### PR TITLE
fix: helm chart push on merge

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -71,7 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     # Publish only on merge to main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: check-version-bump
 
     steps:
       - name: 📥 Checkout repository


### PR DESCRIPTION
# Description

Remove `needs: check-version-bump` as this is causing the push step to be skipped during merge to main.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
