### PR TITLE
fix(.env.example): remove it to fix linter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,5 +59,5 @@ BACKSTAGE_URL=<your-backstage-url>
 # Set ENABLE_TRACING=true to enable trace collection
 ENABLE_TRACING=false
 # replace with your Langfuse public and secret keys from langfuse settings
-LANGFUSE_PUBLIC_KEY=pk-lf-1234567890
-LANGFUSE_SECRET_KEY=sk-lf-1234567890
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=


### PR DESCRIPTION
- GIT_LEAKS is tripping on sample keys. Removing them

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
