### PR TITLE
feat(helm): add command and args to deployment

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,56 +1,56 @@
 apiVersion: v2
-appVersion: 0.1.0
+appVersion: 0.1.1
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
-version: 0.1.2
+version: 0.1.3
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: ai-platform-engineering
     condition: ai-platform-engineering.enabled
   # Backstage plugin agent forge
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: backstage-plugin-agent-forge
     condition: backstage-plugin-agent-forge.enabled
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-argocd
     condition: agent-argocd.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-atlassian
     condition: agent-atlassian.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-backstage
     condition: agent-backstage.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-github
     condition: agent-github.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-pagerduty
     condition: agent-pagerduty.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-slack
     condition: agent-slack.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-confluence
     condition: agent-confluence.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-jira
     condition: agent-jira.enabled
   - name: agent
-    version: 0.1.0
+    version: 0.1.1
     alias: agent-reflection
     condition: agent-reflection.enabled
   # Separate chart for external secrets

--- a/helm/charts/agent/Chart.yaml
+++ b/helm/charts/agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.1.1"

--- a/helm/charts/agent/templates/deployment.yaml
+++ b/helm/charts/agent/templates/deployment.yaml
@@ -40,6 +40,18 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.command }}
+          command:
+            {{- range .Values.image.command }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.image.args }}
+          args:
+            {{- range .Values.image.args }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,6 +6,8 @@ ai-platform-engineering:
   image:
     repository: "ghcr.io/cnoe-io/ai-platform-engineering"
     tag: "stable"
+    command: ["poetry", "run", "ai-platform-engineering"]
+    args: ["platform-engineer"]
   multiAgentConfig:
     protocol: "a2a"
     port: "8000"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,6 +18,8 @@ ai-platform-engineering:
       - pagerduty
       - github
       - slack
+      - komodor
+
 # Backstage plugin agent forge
 backstage-plugin-agent-forge:
   enabled: true
@@ -26,15 +28,18 @@ backstage-plugin-agent-forge:
     repository: "ghcr.io/cnoe-io/backstage-plugin-agent-forge"
     tag: "latest"
   isMultiAgent: true
+  service:
+    port: "3000"
+
 # Agent configurations using aliases from Chart.yaml
 agent-argocd:
-  enabled: true
+  enabled: false
   nameOverride: "agent-argocd"
   image:
     repository: "ghcr.io/cnoe-io/agent-argocd"
 
 agent-pagerduty:
-  enabled: true
+  enabled: false
   nameOverride: "agent-pagerduty"
   image:
     repository: "ghcr.io/cnoe-io/agent-pagerduty"

--- a/scripts/add-new-agent-helm-chart.py
+++ b/scripts/add-new-agent-helm-chart.py
@@ -7,7 +7,6 @@ This script will:
 3. Add new agent sections to values files with empty configurations
 """
 
-import os
 import sys
 import re
 from pathlib import Path
@@ -366,13 +365,13 @@ def main():
     print("\n📝 Manual steps required:")
     for agent_name in new_agents:
         print(f"\nFor agent-{agent_name}:")
-        print(f"  1. Review and update configuration in:")
-        print(f"     - helm/values.yaml")
-        print(f"     - helm/values-existing-secrets.yaml") 
-        print(f"     - helm/values-external-secrets.yaml.example")
-        print(f"  2. Add specific secrets and environment variables")
-    print(f"\n3. Test the configuration with: helm template ./helm")
-    print(f"4. Run: helm dependency update ./helm")
+        print("  1. Review and update configuration in:")
+        print("     - helm/values.yaml")
+        print("     - helm/values-existing-secrets.yaml") 
+        print("     - helm/values-external-secrets.yaml.example")
+        print("  2. Add specific secrets and environment variables")
+    print("\n3. Test the configuration with: helm template ./helm")
+    print("4. Run: helm dependency update ./helm")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Description

- add support for command and args in deployment (required for multi-agent)
- backstage default port 3000
- default all individual agent to `false` so user can choose which agent to enable (multi-agent and backstage is still enabled by default)
- bump both subchart and main chart versions


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
