### PR TITLE
fix: allow multiple ports for agents

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,56 +1,56 @@
 apiVersion: v2
-appVersion: 0.1.4
+appVersion: 0.1.5
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
-version: 0.1.6
+version: 0.1.7
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: ai-platform-engineering
     condition: ai-platform-engineering.enabled
   # Backstage plugin agent forge
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: backstage-plugin-agent-forge
     condition: backstage-plugin-agent-forge.enabled
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-argocd
     condition: agent-argocd.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-atlassian
     condition: agent-atlassian.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-backstage
     condition: agent-backstage.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-github
     condition: agent-github.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-pagerduty
     condition: agent-pagerduty.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-slack
     condition: agent-slack.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-confluence
     condition: agent-confluence.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-jira
     condition: agent-jira.enabled
   - name: agent
-    version: 0.1.4
+    version: 0.1.5
     alias: agent-reflection
     condition: agent-reflection.enabled
   # Separate chart for external secrets

--- a/helm/charts/agent/Chart.yaml
+++ b/helm/charts/agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.4"
+appVersion: "0.1.5"

--- a/helm/charts/agent/templates/deployment.yaml
+++ b/helm/charts/agent/templates/deployment.yaml
@@ -53,9 +53,17 @@ spec:
             {{- end }}
           {{- end }}
           ports:
+            {{- if .Values.service.ports }}
+            {{- range .Values.service.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+            {{- else }}
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- end }}
           envFrom:
             {{- if include "agent.externalSecrets.enabled" . | eq "true" }}
             {{- range include "agent.externalSecrets.secretNames" . | splitList "," }}

--- a/helm/charts/agent/templates/service.yaml
+++ b/helm/charts/agent/templates/service.yaml
@@ -7,9 +7,18 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    {{- if .Values.service.ports }}
+    {{- range .Values.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+      name: {{ .name }}
+    {{- end }}
+    {{- else }}
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+    {{- end }}
   selector:
     {{- include "agent.selectorLabels" . | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,7 +29,13 @@ backstage-plugin-agent-forge:
     tag: "latest"
   isBackstagePlugin: true
   service:
-    port: "3000"
+    ports:
+      - name: frontend
+        port: 3000
+        protocol: TCP
+      - name: backend
+        port: 7007
+        protocol: TCP
 
 # Agent configurations using aliases from Chart.yaml
 agent-argocd:


### PR DESCRIPTION
# Description

Backstage-plugin runs both frontend and backend in the same pod. We need to allow two ports to be exposed.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
