### PR TITLE
fix: always pull and expose external url

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,7 +4,7 @@ name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
-version: 0.1.7
+version: 0.1.8
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: agent

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,8 +6,11 @@ ai-platform-engineering:
   image:
     repository: "ghcr.io/cnoe-io/ai-platform-engineering"
     tag: "stable"
+    pullPolicy: "Always"
     command: ["poetry", "run", "ai-platform-engineering"]
     args: ["platform-engineer"]
+  env:
+    EXTERNAL_URL: "http://localhost:8000"  # Agent url for the client
   multiAgentConfig:
     protocol: "a2a"
     port: "8000"
@@ -20,6 +23,7 @@ ai-platform-engineering:
       - jira
       - pagerduty
       - slack
+
 # Backstage plugin agent forge
 backstage-plugin-agent-forge:
   enabled: true
@@ -27,6 +31,7 @@ backstage-plugin-agent-forge:
   image:
     repository: "ghcr.io/cnoe-io/backstage-plugin-agent-forge"
     tag: "latest"
+    pullPolicy: "Always"
   isBackstagePlugin: true
   service:
     ports:
@@ -43,39 +48,53 @@ agent-argocd:
   nameOverride: "agent-argocd"
   image:
     repository: "ghcr.io/cnoe-io/agent-argocd"
+    pullPolicy: "Always"
 
 agent-backstage:
   enabled: false
   nameOverride: "agent-backstage"
   image:
     repository: "ghcr.io/cnoe-io/agent-backstage"
+    pullPolicy: "Always"
 
 agent-confluence:
   enabled: false
   nameOverride: "agent-confluence"
   image:
     repository: "ghcr.io/cnoe-io/agent-confluence"
+    pullPolicy: "Always"
 
 agent-github:
   enabled: false
   nameOverride: "agent-github"
   image:
     repository: "ghcr.io/cnoe-io/agent-github"
+    pullPolicy: "Always"
 
 agent-jira:
   enabled: false
   nameOverride: "agent-jira"
   image:
     repository: "ghcr.io/cnoe-io/agent-jira"
+    pullPolicy: "Always"
 
 agent-pagerduty:
   enabled: false
   nameOverride: "agent-pagerduty"
   image:
     repository: "ghcr.io/cnoe-io/agent-pagerduty"
+    pullPolicy: "Always"
 
 agent-slack:
   enabled: false
   nameOverride: "agent-slack"
   image:
     repository: "ghcr.io/cnoe-io/agent-slack"
+    pullPolicy: "Always"
+
+agent-reflection:
+  enabled: false
+  nameOverride: "agent-reflection"
+  image:
+    repository: "ghcr.io/cnoe-io/agent-reflection"
+    pullPolicy: "Always"


### PR DESCRIPTION
# Description

- add `agent-reflection` to values file
- expose external url for multiagent
- always pull image as stable images get updated regularly

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
