### PR TITLE
fix: remove a2a from nexigraph images

### DIFF
--- a/.github/workflows/nexigraph-docker-build.yml
+++ b/.github/workflows/nexigraph-docker-build.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=a2a-latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=branch,prefix=a2a-
-            type=ref,event=tag,prefix=a2a-
-            type=sha,format=short,prefix=a2a-
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
# Description

Remove a2a prefix from nexigraph images


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
