### PR TITLE
feat: Only build a2a/mcp images if any used code changes

### DIFF
--- a/.github/workflows/agent-a2a-docker-build.yml
+++ b/.github/workflows/agent-a2a-docker-build.yml
@@ -26,6 +26,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: 'every'
           filters: |
             shared:
               - 'ai_platform_engineering/utils/a2a/a2a_remote_agent_connect.py'

--- a/.github/workflows/agent-a2a-docker-build.yml
+++ b/.github/workflows/agent-a2a-docker-build.yml
@@ -13,15 +13,121 @@ on:
   workflow_dispatch:
 
 jobs:
+  determine-agents:
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.set-matrix.outputs.agents }}
+      should_build: ${{ steps.set-matrix.outputs.should_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            shared:
+              - 'ai_platform_engineering/utils/a2a/a2a_remote_agent_connect.py'
+              - 'ai_platform_engineering/utils/agntcy/agntcy_remote_agent_connect.py'
+            argocd:
+              - 'ai_platform_engineering/agents/argocd/**'
+              - '!ai_platform_engineering/agents/argocd/mcp/**'
+              - '!ai_platform_engineering/agents/argocd/build/Dockerfile.mcp'
+            aws:
+              - 'ai_platform_engineering/agents/aws/**'
+              - '!ai_platform_engineering/agents/aws/mcp/**'
+              - '!ai_platform_engineering/agents/aws/build/Dockerfile.mcp'
+            backstage:
+              - 'ai_platform_engineering/agents/backstage/**'
+              - '!ai_platform_engineering/agents/backstage/mcp/**'
+              - '!ai_platform_engineering/agents/backstage/build/Dockerfile.mcp'
+            confluence:
+              - 'ai_platform_engineering/agents/confluence/**'
+              - '!ai_platform_engineering/agents/confluence/mcp/**'
+              - '!ai_platform_engineering/agents/confluence/build/Dockerfile.mcp'
+            github:
+              - 'ai_platform_engineering/agents/github/**'
+              - '!ai_platform_engineering/agents/github/mcp/**'
+              - '!ai_platform_engineering/agents/github/build/Dockerfile.mcp'
+            jira:
+              - 'ai_platform_engineering/agents/jira/**'
+              - '!ai_platform_engineering/agents/jira/mcp/**'
+              - '!ai_platform_engineering/agents/jira/build/Dockerfile.mcp'
+            komodor:
+              - 'ai_platform_engineering/agents/komodor/**'
+              - '!ai_platform_engineering/agents/komodor/mcp/**'
+              - '!ai_platform_engineering/agents/komodor/build/Dockerfile.mcp'
+            pagerduty:
+              - 'ai_platform_engineering/agents/pagerduty/**'
+              - '!ai_platform_engineering/agents/pagerduty/mcp/**'
+              - '!ai_platform_engineering/agents/pagerduty/build/Dockerfile.mcp'
+            slack:
+              - 'ai_platform_engineering/agents/slack/**'
+              - '!ai_platform_engineering/agents/slack/mcp/**'
+              - '!ai_platform_engineering/agents/slack/build/Dockerfile.mcp'
+            splunk:
+              - 'ai_platform_engineering/agents/splunk/**'
+              - '!ai_platform_engineering/agents/splunk/mcp/**'
+              - '!ai_platform_engineering/agents/splunk/build/Dockerfile.mcp'
+            template:
+              - 'ai_platform_engineering/agents/template/**'
+              - '!ai_platform_engineering/agents/template/mcp/**'
+              - '!ai_platform_engineering/agents/template/build/Dockerfile.mcp'
+            webex:
+              - 'ai_platform_engineering/agents/webex/**'
+              - '!ai_platform_engineering/agents/webex/mcp/**'
+              - '!ai_platform_engineering/agents/webex/build/Dockerfile.mcp'
+            weather:
+              - 'ai_platform_engineering/agents/weather/**'
+              - '!ai_platform_engineering/agents/weather/mcp/**'
+              - '!ai_platform_engineering/agents/weather/build/Dockerfile.mcp'
+
+      - name: Set matrix based on changes
+        id: set-matrix
+        uses: actions/github-script@v7
+        env:
+          BUILD_ALL: ${{ steps.filter.outputs.shared == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+          CHANGED_ARGOCD: ${{ steps.filter.outputs.argocd }}
+          CHANGED_AWS: ${{ steps.filter.outputs.aws }}
+          CHANGED_BACKSTAGE: ${{ steps.filter.outputs.backstage }}
+          CHANGED_CONFLUENCE: ${{ steps.filter.outputs.confluence }}
+          CHANGED_GITHUB: ${{ steps.filter.outputs.github }}
+          CHANGED_JIRA: ${{ steps.filter.outputs.jira }}
+          CHANGED_KOMODOR: ${{ steps.filter.outputs.komodor }}
+          CHANGED_PAGERDUTY: ${{ steps.filter.outputs.pagerduty }}
+          CHANGED_SLACK: ${{ steps.filter.outputs.slack }}
+          CHANGED_SPLUNK: ${{ steps.filter.outputs.splunk }}
+          CHANGED_TEMPLATE: ${{ steps.filter.outputs.template }}
+          CHANGED_WEBEX: ${{ steps.filter.outputs.webex }}
+          CHANGED_WEATHER: ${{ steps.filter.outputs.weather }}
+        with:
+          script: |
+            const allAgents = [
+              'argocd','aws','backstage','confluence','github','jira','komodor','pagerduty','slack','splunk','template','webex','weather'
+            ];
+            const buildAll = process.env.BUILD_ALL === 'true';
+            let selected;
+            if (buildAll) {
+              selected = allAgents;
+            } else {
+              const env = process.env;
+              selected = allAgents.filter(a => env['CHANGED_' + a.toUpperCase()] === 'true');
+            }
+            core.setOutput('agents', JSON.stringify(selected));
+            core.setOutput('should_build', String(selected.length > 0));
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: determine-agents
+    if: needs.determine-agents.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
 
     strategy:
       matrix:
-        agent: [argocd, aws, backstage, confluence, github, jira, komodor, pagerduty, slack, splunk, template, webex, weather]
+        agent: ${{ fromJson(needs.determine-agents.outputs.agents) }}
       fail-fast: false
 
 

--- a/.github/workflows/agent-mcp-docker-build.yml
+++ b/.github/workflows/agent-mcp-docker-build.yml
@@ -25,6 +25,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: 'every'
           filters: |
             argocd:
               - 'ai_platform_engineering/agents/argocd/mcp/**'

--- a/.github/workflows/agent-mcp-docker-build.yml
+++ b/.github/workflows/agent-mcp-docker-build.yml
@@ -12,15 +12,85 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  determine-agents:
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.set-matrix.outputs.agents }}
+      should_build: ${{ steps.set-matrix.outputs.should_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect changed paths (MCP)
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            argocd:
+              - 'ai_platform_engineering/agents/argocd/mcp/**'
+              - 'ai_platform_engineering/agents/argocd/build/Dockerfile.mcp'
+            backstage:
+              - 'ai_platform_engineering/agents/backstage/mcp/**'
+              - 'ai_platform_engineering/agents/backstage/build/Dockerfile.mcp'
+            confluence:
+              - 'ai_platform_engineering/agents/confluence/mcp/**'
+              - 'ai_platform_engineering/agents/confluence/build/Dockerfile.mcp'
+            jira:
+              - 'ai_platform_engineering/agents/jira/mcp/**'
+              - 'ai_platform_engineering/agents/jira/build/Dockerfile.mcp'
+            komodor:
+              - 'ai_platform_engineering/agents/komodor/mcp/**'
+              - 'ai_platform_engineering/agents/komodor/build/Dockerfile.mcp'
+            pagerduty:
+              - 'ai_platform_engineering/agents/pagerduty/mcp/**'
+              - 'ai_platform_engineering/agents/pagerduty/build/Dockerfile.mcp'
+            slack:
+              - 'ai_platform_engineering/agents/slack/mcp/**'
+              - 'ai_platform_engineering/agents/slack/build/Dockerfile.mcp'
+            splunk:
+              - 'ai_platform_engineering/agents/splunk/mcp/**'
+              - 'ai_platform_engineering/agents/splunk/build/Dockerfile.mcp'
+
+      - name: Set matrix based on changes (MCP)
+        id: set-matrix
+        uses: actions/github-script@v7
+        env:
+          BUILD_ALL: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+          CHANGED_ARGOCD: ${{ steps.filter.outputs.argocd }}
+          CHANGED_BACKSTAGE: ${{ steps.filter.outputs.backstage }}
+          CHANGED_CONFLUENCE: ${{ steps.filter.outputs.confluence }}
+          CHANGED_JIRA: ${{ steps.filter.outputs.jira }}
+          CHANGED_KOMODOR: ${{ steps.filter.outputs.komodor }}
+          CHANGED_PAGERDUTY: ${{ steps.filter.outputs.pagerduty }}
+          CHANGED_SLACK: ${{ steps.filter.outputs.slack }}
+          CHANGED_SPLUNK: ${{ steps.filter.outputs.splunk }}
+        with:
+          script: |
+            const allAgents = [
+              'argocd','backstage','confluence','jira','komodor','pagerduty','slack','splunk'
+            ];
+            const buildAll = process.env.BUILD_ALL === 'true';
+            let selected;
+            if (buildAll) {
+              selected = allAgents;
+            } else {
+              const env = process.env;
+              selected = allAgents.filter(a => env['CHANGED_' + a.toUpperCase()] === 'true');
+            }
+            core.setOutput('agents', JSON.stringify(selected));
+            core.setOutput('should_build', String(selected.length > 0));
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: determine-agents
+    if: needs.determine-agents.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
 
     strategy:
       matrix:
-        agent: [argocd, backstage, confluence, jira, komodor, pagerduty, slack, splunk]
+        agent: ${{ fromJson(needs.determine-agents.outputs.agents) }}
       fail-fast: false
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,33 @@ env:
   IMAGE_NAME: cnoe-io/ai-platform-engineering
 
 jobs:
+  determine-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.filter.outputs.core }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            core:
+              - 'build/**'
+              - 'ai_platform_engineering/multi_agents/**'
+              - 'ai_platform_engineering/utils/**'
+              - 'ai_platform_engineering/common/**'
+              - 'ai_platform_engineering/knowledge_bases/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'ai_platform_engineering/__init__.py'
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: determine-changes
+    if: needs.determine-changes.outputs.should_build == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
# Description

Currently a2a and mcp image builds are triggered for ANY file change. Only do this if relevant files change that would actually modify the docker image.


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
