### PR TITLE
Fix: updating docker compose and loader for the workshop

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/server/loader/loader.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/loader/loader.py
@@ -149,8 +149,9 @@ class Loader:
         if not self.use_hybrid_approach:
             return self.use_custom_parser
 
-        # Use custom parser only for Docusaurus and MkDocs
-        custom_parser_generators = {"docusaurus", "mkdocs"}
+        # Use custom parser for Docusaurus, MkDocs, and generic sites
+        # The custom parser has good fallback logic for generic sites (removes nav/header elements)
+        custom_parser_generators = {"docusaurus", "mkdocs", "generic"}
         return generator in custom_parser_generators
 
     async def get_sitemaps(self, url: str) -> List[str]:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -860,9 +860,10 @@ services:
     ports:
       - "8010:8000"
   kb-rag-server:
-    build:
-      context: ai_platform_engineering/knowledge_bases/rag
-      dockerfile: build/Dockerfile.server
+    image: ghcr.io/cnoe-io/kb-rag-server:latest
+    # build:
+    #   context: ai_platform_engineering/knowledge_bases/rag
+    #   dockerfile: build/Dockerfile.server
     container_name: kb-rag-server
     profiles:
       - kb-rag
@@ -876,9 +877,10 @@ services:
     environment:
       - REDIS_URL=redis://kb-rag-redis:6379/0
   kb-rag-web:
-    build:
-      context: ai_platform_engineering/knowledge_bases/rag
-      dockerfile: build/Dockerfile.web
+    image: ghcr.io/cnoe-io/kb-rag-web:latest
+    # build:
+    #   context: ai_platform_engineering/knowledge_bases/rag
+    #   dockerfile: build/Dockerfile.web
     container_name: kb-rag-web
     profiles:
       - kb-rag


### PR DESCRIPTION
# Description

Updated docker compose to pull latest images from github packages. 

Updated loader in kb-rag-server to scrap sites like wikipedia 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
