### PR TITLE
feat: upgrade Jira agent to API v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.1.12 (2025-09-17)
 
 ### BREAKING CHANGE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,184 @@
-## 0.1.11 (2025-08-26)
+## Unreleased
+
+### BREAKING CHANGE
+
+- test command now runs both general and RAG module tests
+- Redis service port name changed from 'http' to 'redis'
+
+### Feat
+
+- idpbuilder values
+- add OAuth2 authentication support for A2A protocol
+- add integration test workflows and improve agent Docker build automation
+- updating collection name from rag-default to rag-united
+- backend data management improvements for milvus and redis
+- adding addtional config in web UI frontend
+- add prebuild docker image github actions
+- Only build images if relevant change
+- Adding streamable http to Webex agent
+- Adding initial, optional Webex agent
+- Adding streamable http to Webex agent
+- Adding initial, optional Webex agent
+- major helm chart refactor
+- implement memory-optimized batch processing for URL loading
+- update agents documentation and sidebar
+- enhance coverage reporting with detailed metrics and tables
+- **tests**: add comprehensive test suite with memory monitoring and scale tests
+- add AWS agent to include cost explorer MCP (#251)
+- add kb-rag-web to helm chart
+- add the aws agent to platform engineer (#246)
+- Addition of Agent Splunk (#247)
+- use a2a card to dynamically create client
+- added redis db management backend
+- added reranking
+- frontend now supports RAG config
+- add multiple llm provider support for graphrag
 
 ### Fix
 
+- updates
+- adding generic to custom parser to scrap sites like wikipedia
+- updating docker compose for the workshop
+- **gha**: update for tags
+- gha litellm typo fix
+- **mcp-docker-build**: add webex mcp
+- update sidebars.ts
+- updated loader.py
+- updated rag_api
+- dividing rag_api for added flexibility and readiness
+- adding init file
+- changed variable name from UNIFLIED_COLLECTION_NAME TO DEFAULT_COLLECTION_NAME
+- renaming: rag_united --> rag_default
+- docker compose
+- **graph-rag**: lint
+- **graph-rag**: heuristics improvements, use graph db to store relation candidates
+- correct mcp image builds - use OR not AND
+- improve the prebuild github actions
+- add litellm to mcp as well
+- fixed conflicts between main
+- also modify supervisor agent
+- AND not OR
+- lint
+- fix slim to work
+- Add queue closed error protection to prevent crashes during shutdown
+- unit tests and quick sanity
+- ruff linter
+- minor formatting in splunk
+- added webex to platform engineer
+- adding logs to webex mcp
+- adding webex to workflows
+- updating docker compose
+- adding init files to webex client
+- **docker-compose.dev**: add p2p-tracing profile to nexigraph
+- no default env in kb-rag-server chart
+- kb-agent-rag requires milvus secret
+- smaller milvus res
+- remove excessive resource requests
+- remove node selector and limit eph storage
+- further cleanup
+- remove unsued env
+- bring latest milvus vals and template milvus uri
+- try more delay
+- revert wrong change
+- default llmSecrets in kb-rag-server
+- correct liveness and readiness port for kb-rag-agent
+- kb-rag-server also requires llm secret
+- copy working milvus values
+- move milvus to the parent chart
+- milvus is INSIDE kb-rag-stack...
+- remove deprecated isMultiAgent
+- correct appVersion
+- properly fix kb-rag-agent secrets
+- modify kb-rag-stack for the same change
+- resolve unit test failures and improve memory optimization
+- mcp_splunk symlink to be in-repo relative
+- **rag**: restructure package to use rag.server.* namespace
+- **docker**: update Dockerfile for new package structure
+- **rag**: update coverage configuration for new package structure
+- **helm**: bump chart version to 0.1.18
+- **rag**: restructure KB-RAG package with proper scoping
+- **ci**: resolve KB-RAG Stack Helm chart test failures
+- **ci**: resolve Helm chart test failures in GitHub Actions
+- **docs**: resolve broken links causing Docusaurus build failures
+- **ci**: add proper download links for coverage artifacts
+- correct XML attribute access for coverage parsing
+- handle missing main coverage and improve coverage reporting
+- update remaining uv.lock files and add coverage debugging
+- update uv.lock files to resolve Docker build issues
+- add debugging and error handling for coverage XML parsing
+- update uv.lock files to resolve Docker build issues
+- remove stray 'p' character causing JavaScript ReferenceError
+- add --index-strategy unsafe-best-match for PyTorch CPU installation
+- use --extra-index-url instead of --index-url for PyTorch CPU installation
+- update a2a-sdk dependency format and workspace configuration
+- resolve a2a-sdk dependency issue in CI
+- install CPU-only PyTorch in RAG tests to avoid NVIDIA packages
+- Pin all a2a-sdk versions to 0.2.16
+- Add missing fs import in GitHub Actions workflow
+- Resolve Docker build workspace member issues
+- Exclude RAG module tests from main test suite
+- Remove Poetry dependencies and migrate RAG module to UV
+- unit tests and linting
+- lint
+- **rag**: replace incorrect ascrape method with proper LangChain async methods
+- optimize memory usage by streaming page processing (#253)
+- **kb-rag-redis**: correct service port configuration to match deployment (#252)
+- add milvus to parent chart
+- updates
+- updates
+- update kb-rag-server
+- update kb-rag-server
+- **kb-rag-agent**: restore
+- **kb-rag-stack**: add condition: agent.enabled
+- remove kb-rag-agent dedicated chart
+- updates
+- just add a new subchart for now
+- default no SA
+- **aws**: ruff lint
+- broken links
+- updates
+- remove debug line
+- **aws-agent**: ruff lint
+- fixed readme and created agent container
+- add try/except when agent is unreachable
+- docker compose dev
+- docker compose dev
+- docker compose dev
+- docker compose dev
+- add misc utils - run coroutine in sync
+- cleanup how we do agent enabled
+- ruff lint
+- **graph-rag**: qa agent now fetches properties before raw query
+- created was being updated regardless
+- ruff linter
+- clean kb-rag workflow to reduce space usage
+- ruff linter
+- ruff linter
+- added dockerignore
+- updated docker compose
+- update uv lock
+- include in pyproject
+- get rid of non existing func
+- much simpler fix :)()(
+- ruff linter
+- **workshop**: mission4: rag-agent docker port -> 8020
+- **workshop**: mission4: rag-agent docker port -> 8020
+- **workshop**: mission4: switch to main tag for github agent
+- **workshop**: mission7
+- **workshop**: mission7
+- **github**: add load_dotenv
+- updates sidebars.ts for docs
+- png to svg
+- png to svg
+- **workshop**: mission4: add restart policy to docker compose
+- updating port number for kb-rag
+- typo for logger message
+- **workshop**: switch mission4 to a different env file
 - **weather**: add self.mcp_api_key
+
+### Refactor
+
+- create kb-rag-stack
 
 ## 0.1.10 (2025-08-26)
 

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/attachments.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/attachments.py
@@ -67,7 +67,7 @@ async def upload_attachment(issue_key: str, attachment: JiraAttachment) -> JiraA
         # Use the Jira API to upload the file
         with open(attachment.filename, "rb") as file:
             response = await make_api_request(
-                f"/rest/api/2/issue/{issue_key}/attachments", method="POST", files={"file": file}
+                f"/rest/api/3/issue/{issue_key}/attachments", method="POST", files={"file": file}
             )
 
         if response:
@@ -87,7 +87,7 @@ async def upload_attachment(issue_key: str, attachment: JiraAttachment) -> JiraA
 async def get_issue_attachments(issue_key: str) -> list[JiraAttachment]:
     """Retrieve all attachments for a Jira issue."""
     logger.debug(f"Fetching attachments for issue {issue_key}")
-    response = await make_api_request(f"/rest/api/2/issue/{issue_key}?fields=attachment")
+    response = await make_api_request(f"/rest/api/3/issue/{issue_key}?fields=attachment")
     issue_data = response.json()
 
     if not isinstance(issue_data, dict):

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/issues.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/issues.py
@@ -78,7 +78,7 @@ async def get_issue(
     }
 
     success, response = await make_api_request(
-        path=f"rest/api/2/issue/{issue_key}",
+        path=f"rest/api/3/issue/{issue_key}",
         method="GET",
         params=params,
     )
@@ -108,7 +108,7 @@ async def get_project_issues(
     }
 
     success, response = await make_api_request(
-        path="rest/api/2/search",
+        path="rest/api/3/search",
         method="GET",
         params=params,
     )

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/links.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/links.py
@@ -17,7 +17,7 @@ async def get_link_types() -> str:
     Returns:
         JSON string representing a list of issue link type objects.
     """
-    response = await make_api_request("/rest/api/2/issueLinkType")
+    response = await make_api_request("/rest/api/3/issueLinkType")
     if not response or response.status_code != 200:
         raise ValueError("Failed to fetch issue link types. Response: {response}")
     link_types_data = response.json().get("issueLinkTypes", [])

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/search.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/search.py
@@ -49,7 +49,7 @@ async def search(
     }
 
     success, response = await make_api_request(
-        path="rest/api/2/search",
+        path="rest/api/3/search",
         method="GET",
         params=params,
     )
@@ -82,7 +82,7 @@ async def search_fields(
     }
 
     success, response = await make_api_request(
-        path="rest/api/2/field/search",
+        path="rest/api/3/field/search",
         method="GET",
         params=params,
     )

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/transitions.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/transitions.py
@@ -24,7 +24,7 @@ async def get_transitions(
         JSON string representing a list of available transitions.
     """
     success, response = await make_api_request(
-        path=f"rest/api/2/issue/{issue_key}/transitions",
+        path=f"rest/api/3/issue/{issue_key}/transitions",
         method="GET",
     )
 
@@ -91,7 +91,7 @@ async def transition_issue(
         }
 
     success, response = await make_api_request(
-        path=f"rest/api/2/issue/{issue_key}/transitions",
+        path=f"rest/api/3/issue/{issue_key}/transitions",
         method="POST",
         data=payload,
     )

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/users.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/users.py
@@ -44,15 +44,15 @@ async def handle_user_operations(
     if action == "get_user_profile":
         logger.debug(f"Fetching user profile for identifier: {identifier}")
         params = {"accountId": identifier}
-        path = "rest/api/2/user"
+        path = "rest/api/3/user"
     elif action == "get_user":
         logger.debug(f"Fetching details for user {identifier}")
         params = {"accountId": identifier}
-        path = "rest/api/2/user"
+        path = "rest/api/3/user"
     elif action == "search_users":
         logger.debug(f"Searching for users with query: {query}")
         params = {"query": query}
-        path = "rest/api/2/user/search"
+        path = "rest/api/3/user/search"
     else:
         raise ValueError(f"Invalid action: {action}")
 
@@ -101,7 +101,7 @@ async def get_current_user_account_id() -> str:
     """Get the account ID of the current user."""
     logger.debug("Fetching current user account ID")
     success, response = await make_api_request(
-        path="rest/api/2/myself",
+        path="rest/api/3/myself",
         method="GET",
     )
     if not success:

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/worklog.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/worklog.py
@@ -18,7 +18,7 @@ async def get_worklog(
     logger.debug(f"Parameters: issue_key={issue_key}")
 
     success, response = await make_api_request(
-        path=f"rest/api/2/issue/{issue_key}/worklog",
+        path=f"rest/api/3/issue/{issue_key}/worklog",
         method="GET",
     )
 
@@ -52,7 +52,7 @@ async def add_worklog(
     }
 
     success, response = await make_api_request(
-        path=f"rest/api/2/issue/{issue_key}/worklog",
+        path=f"rest/api/3/issue/{issue_key}/worklog",
         method="POST",
         json=worklog_data,
     )

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,7 +28,7 @@ supervisor-agent:
     pullPolicy: "Always"
     args: ["platform-engineer"]
   env:
-    EXTERNAL_URL: "http://localhost:8000"  # Agent url for the client
+    EXTERNAL_URL: "https://cnoe.localtest.me:8443/agent-forge"  # Agent url for the client
   multiAgentConfig:
     protocol: "a2a"
     port: "8000"
@@ -123,7 +123,7 @@ agent-slack:
 
 # Backstage plugin agent forge
 backstage-plugin-agent-forge:
-  enabled: true
+  enabled: false  # idpbuilder has backstage chart with agent-forge added
   nameOverride: "backstage-plugin-agent-forge"
   image:
     repository: "ghcr.io/cnoe-io/backstage-plugin-agent-forge"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,7 +28,7 @@ supervisor-agent:
     pullPolicy: "Always"
     args: ["platform-engineer"]
   env:
-    EXTERNAL_URL: "https://cnoe.localtest.me:8443/agent-forge"  # Agent url for the client
+    EXTERNAL_URL: "http://localhost:8000"  # Agent url for the client
   multiAgentConfig:
     protocol: "a2a"
     port: "8000"
@@ -123,7 +123,7 @@ agent-slack:
 
 # Backstage plugin agent forge
 backstage-plugin-agent-forge:
-  enabled: false  # idpbuilder has backstage chart with agent-forge added
+  enabled: true
   nameOverride: "backstage-plugin-agent-forge"
   image:
     repository: "ghcr.io/cnoe-io/backstage-plugin-agent-forge"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.1.11"
+version = "0.1.12"
 description = "AI Platform Engineering Multi-Agent Systems"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.1.11"
+version = "0.1.12"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

This PR upgrades the Jira agent from API v2 to v3 across all modules to ensure compatibility with the latest Jira API version.

## Changes Made

- **Attachments**: Updated endpoints from `/rest/api/2/` to `/rest/api/3/`
- **Issues**: Migrated issue retrieval and project search endpoints
- **Links**: Updated issue link type endpoints  
- **Search**: Upgraded search and field search endpoints
- **Transitions**: Updated issue transition endpoints
- **Users**: Migrated user profile, search, and current user endpoints
- **Worklog**: Updated worklog retrieval and creation endpoints

## Impact

- Ensures forward compatibility with Jira Cloud instances
- Maintains existing functionality while using the latest API version
- No breaking changes to the agent interface

## Files Modified

- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/attachments.py`
- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/issues.py`
- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/links.py`
- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/search.py`
- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/transitions.py`
- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/users.py`
- `ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/worklog.py`