### PR TITLE
feat(helm): add missing agent deployments for aws, splunk, webex, komodor

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.2.2
+version: 0.2.3
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
@@ -46,6 +46,22 @@ dependencies:
     version: 0.2.0
     alias: agent-slack
     condition: global.enabledSubAgents.slack
+  - name: agent
+    version: 0.2.0
+    alias: agent-aws
+    condition: global.enabledSubAgents.aws
+  - name: agent
+    version: 0.2.0
+    alias: agent-splunk
+    condition: global.enabledSubAgents.splunk
+  - name: agent
+    version: 0.2.0
+    alias: agent-webex
+    condition: global.enabledSubAgents.webex
+  - name: agent
+    version: 0.2.0
+    alias: agent-komodor
+    condition: global.enabledSubAgents.komodor
   # AGNTCY Slim dataplane service
   - name: slim
     version: v0.1.8

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,6 +24,10 @@ dependencies:
     condition: global.enabledSubAgents.argocd
   - name: agent
     version: 0.2.0
+    alias: agent-aws
+    condition: global.enabledSubAgents.aws
+  - name: agent
+    version: 0.2.0
     alias: agent-backstage
     condition: global.enabledSubAgents.backstage
   - name: agent
@@ -40,6 +44,10 @@ dependencies:
     condition: global.enabledSubAgents.jira
   - name: agent
     version: 0.2.0
+    alias: agent-komodor
+    condition: global.enabledSubAgents.komodor
+  - name: agent
+    version: 0.2.0
     alias: agent-pagerduty
     condition: global.enabledSubAgents.pagerduty
   - name: agent
@@ -48,20 +56,12 @@ dependencies:
     condition: global.enabledSubAgents.slack
   - name: agent
     version: 0.2.0
-    alias: agent-aws
-    condition: global.enabledSubAgents.aws
-  - name: agent
-    version: 0.2.0
     alias: agent-splunk
     condition: global.enabledSubAgents.splunk
   - name: agent
     version: 0.2.0
     alias: agent-webex
     condition: global.enabledSubAgents.webex
-  - name: agent
-    version: 0.2.0
-    alias: agent-komodor
-    condition: global.enabledSubAgents.komodor
   # AGNTCY Slim dataplane service
   - name: slim
     version: v0.1.8

--- a/helm/values-existing-secrets.yaml
+++ b/helm/values-existing-secrets.yaml
@@ -42,6 +42,22 @@ agent-jira:
   agentSecrets:
     secretName: "existing-atlassian-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
+agent-aws:
+  agentSecrets:
+    secretName: "existing-aws-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
+
+agent-splunk:
+  agentSecrets:
+    secretName: "existing-splunk-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
+
+agent-webex:
+  agentSecrets:
+    secretName: "existing-webex-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
+
+agent-komodor:
+  agentSecrets:
+    secretName: "existing-komodor-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
+
 kb-rag-stack:
   kb-rag-agent:
     agentSecrets:

--- a/helm/values-external-secrets.yaml
+++ b/helm/values-external-secrets.yaml
@@ -280,6 +280,78 @@ agent-jira:
           key: dev/confluence # Use your key path
           property: ATLASSIAN_VERIFY_SSL
 
+agent-aws:
+  agentSecrets:
+    secretName: "external-aws-secret"
+    externalSecrets:
+      data:
+      - secretKey: AWS_ACCESS_KEY_ID
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/aws # Use your key path
+          property: AWS_ACCESS_KEY_ID
+      - secretKey: AWS_SECRET_ACCESS_KEY
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/aws # Use your key path
+          property: AWS_SECRET_ACCESS_KEY
+      - secretKey: AWS_REGION
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/aws # Use your key path
+          property: AWS_REGION
+
+agent-splunk:
+  agentSecrets:
+    secretName: "external-splunk-secret"
+    externalSecrets:
+      data:
+      - secretKey: SPLUNK_TOKEN
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/splunk # Use your key path
+          property: SPLUNK_TOKEN
+      - secretKey: SPLUNK_API_URL
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/splunk # Use your key path
+          property: SPLUNK_API_URL
+
+agent-webex:
+  agentSecrets:
+    secretName: "external-webex-secret"
+    externalSecrets:
+      data:
+      - secretKey: WEBEX_TOKEN
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/webex # Use your key path
+          property: WEBEX_TOKEN
+
+agent-komodor:
+  agentSecrets:
+    secretName: "external-komodor-secret"
+    externalSecrets:
+      data:
+      - secretKey: KOMODOR_TOKEN
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/komodor # Use your key path
+          property: KOMODOR_TOKEN
+      - secretKey: KOMODOR_API_URL
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/komodor # Use your key path
+          property: KOMODOR_API_URL
+
 kb-rag-stack:
   kb-rag-agent:
     agentSecrets:

--- a/helm/values-secrets.yaml.example
+++ b/helm/values-secrets.yaml.example
@@ -72,6 +72,30 @@ agent-jira:
       ATLASSIAN_API_URL: ""
       ATLASSIAN_VERIFY_SSL: "true"
 
+agent-aws:
+  agentSecrets:
+    data:
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      AWS_REGION: ""
+
+agent-splunk:
+  agentSecrets:
+    data:
+      SPLUNK_TOKEN: ""
+      SPLUNK_API_URL: ""
+
+agent-webex:
+  agentSecrets:
+    data:
+      WEBEX_TOKEN: ""
+
+agent-komodor:
+  agentSecrets:
+    data:
+      KOMODOR_TOKEN: ""
+      KOMODOR_API_URL: ""
+
 kb-rag-stack:
   kb-rag-agent:
     agentSecrets:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -121,6 +121,58 @@ agent-slack:
     port: 8000
     pullPolicy: "Always"
 
+agent-aws:
+  nameOverride: "agent-aws"
+  image:
+    repository: "ghcr.io/cnoe-io/agent-aws"
+    pullPolicy: "Always"
+  mcp:
+    image:
+      repository: "ghcr.io/cnoe-io/mcp-aws"
+      tag: "stable"
+      pullPolicy: "Always"
+    mode: "http" # Options: stdio, http
+    port: 8000
+
+agent-splunk:
+  nameOverride: "agent-splunk"
+  image:
+    repository: "ghcr.io/cnoe-io/agent-splunk"
+    pullPolicy: "Always"
+  mcp:
+    image:
+      repository: "ghcr.io/cnoe-io/mcp-splunk"
+      tag: "stable"
+      pullPolicy: "Always"
+    mode: "http" # Options: stdio, http
+    port: 8000
+
+agent-webex:
+  nameOverride: "agent-webex"
+  image:
+    repository: "ghcr.io/cnoe-io/agent-webex"
+    pullPolicy: "Always"
+  mcp:
+    image:
+      repository: "ghcr.io/cnoe-io/mcp-webex"
+      tag: "stable"
+      pullPolicy: "Always"
+    mode: "http" # Options: stdio, http
+    port: 8000
+
+agent-komodor:
+  nameOverride: "agent-komodor"
+  image:
+    repository: "ghcr.io/cnoe-io/agent-komodor"
+    pullPolicy: "Always"
+  mcp:
+    image:
+      repository: "ghcr.io/cnoe-io/mcp-komodor"
+      tag: "stable"
+      pullPolicy: "Always"
+    mode: "http" # Options: stdio, http
+    port: 8000
+
 # Backstage plugin agent forge
 backstage-plugin-agent-forge:
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,12 +2,16 @@
 global:
   enabledSubAgents:
     argocd: false
+    aws: false
     backstage: false
     confluence: false
     github: false
     jira: false
+    komodor: false
     pagerduty: false
     slack: false
+    splunk: false
+    webex: false
   createLlmSecret: false # if true, llm secret will be created by the parent chart. Otherwise, expect existing llm secret
   llmSecrets:
     create: false # do not create llm secret in subcharts (use global or existing llm secret)


### PR DESCRIPTION
## Summary
Adds missing agent deployment configurations and bumps helm chart version to 0.2.3.

## Changes
- **Chart.yaml**: Bump version to 0.2.3 and add agent dependencies for aws, splunk, webex, komodor
- **values.yaml**: Add agent configurations following existing pattern

## Details
- Each new agent follows the same structure as existing agents (argocd, backstage, etc.)
- Uses  conditions for conditional deployment
- Enables deployment of these agents as separate pods instead of only within supervisor-agent

## Testing
- Helm template validation passes
- Follows existing agent configuration patterns
- Ready for deployment with enabledSubAgents configuration

Fixes missing agent deployments when enabledSubAgents are configured in override.yaml.