### PR TITLE
chore: Fix GITHUB_PERSONAL_ACCESS_TOKEN in secret examples

### DIFF
--- a/deploy/secrets-examples/github-secret.yaml.example
+++ b/deploy/secrets-examples/github-secret.yaml.example
@@ -5,4 +5,4 @@ metadata:
   namespace: ai-platform-engineering
 type: Opaque
 data:
-  GITHUB_TOKEN:
+  GITHUB_PERSONAL_ACCESS_TOKEN:

--- a/helm/values-secrets.yaml.example
+++ b/helm/values-secrets.yaml.example
@@ -42,7 +42,7 @@ agent-pagerduty:
 agent-github:
   agentSecrets:
     data:
-      GITHUB_TOKEN: ""
+      GITHUB_PERSONAL_ACCESS_TOKEN: ""
 
 agent-atlassian:
   agentSecrets:


### PR DESCRIPTION
# Description

Currently the secret values templates use `GITHUB_TOKEN` for the GitHub agent but it should be `GITHUB_PERSONAL_ACCESS_TOKEN`. If the former is used then the agent will not function correctly.


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
