### PR TITLE
ci: standardize workflow trigger conditions

### DIFF
--- a/.github/workflows/agent-a2a-docker-build.yml
+++ b/.github/workflows/agent-a2a-docker-build.yml
@@ -106,17 +106,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-agents, set-all-agents]
     if: |
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) ||
       (needs.determine-agents.outputs.should_build == 'true' &&
        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'prebuild/'))) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true') ||
-      startsWith(github.ref, 'refs/tags/')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true')
     permissions:
       contents: read
       packages: write
 
     strategy:
       matrix:
-        agent: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true') || startsWith(github.ref, 'refs/tags/')) && fromJson(needs.set-all-agents.outputs.all_agents) || (needs.determine-agents.outputs.agents && fromJson(needs.determine-agents.outputs.agents)) || fromJson('[]') }}
+        agent: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true')) && fromJson(needs.set-all-agents.outputs.all_agents) || (needs.determine-agents.outputs.agents && fromJson(needs.determine-agents.outputs.agents)) || fromJson('[]') }}
       fail-fast: false
 
 

--- a/.github/workflows/agent-mcp-docker-build.yml
+++ b/.github/workflows/agent-mcp-docker-build.yml
@@ -98,18 +98,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-agents, set-all-agents]
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) ||
       (needs.determine-agents.outputs.should_build == 'true' &&
        (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/'))) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true') ||
-      startsWith(github.ref, 'refs/tags/')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true')
     permissions:
       contents: read
       packages: write
 
     strategy:
       matrix:
-        agent: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true') || startsWith(github.ref, 'refs/tags/')) && fromJson(needs.set-all-agents.outputs.all_agents) || (needs.determine-agents.outputs.agents && fromJson(needs.determine-agents.outputs.agents)) || fromJson('[]') }}
+        agent: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true')) && fromJson(needs.set-all-agents.outputs.all_agents) || (needs.determine-agents.outputs.agents && fromJson(needs.determine-agents.outputs.agents)) || fromJson('[]') }}
       fail-fast: false
 
     env:


### PR DESCRIPTION
## Summary
Standardizes the trigger conditions across agent build workflows to improve consistency and maintainability.

## Changes
- Consolidates trigger logic for main branch and tags in both workflows
- Simplifies conditional expressions for better readability
- Ensures consistent behavior across agent-a2a and agent-mcp build workflows

## Testing
- Workflow syntax validated
- Logic tested for main branch, tag, and PR scenarios

Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>