### PR TITLE
fix: pin kb-rag services to sha-b098b8d for workshop4

### DIFF
--- a/workshop/docker-compose.mission4.yaml
+++ b/workshop/docker-compose.mission4.yaml
@@ -52,7 +52,7 @@ services:
   #                                          KB-RAG SERVICES                                         #
   ####################################################################################################
   kb-rag-agent:
-    image: ghcr.io/cnoe-io/kb-rag-agent-a2a:0.1.15
+    image: ghcr.io/cnoe-io/kb-rag-agent-a2a:sha-b098b8d
     pull_policy: always
     container_name: kb-rag-agent
     restart: unless-stopped
@@ -66,7 +66,7 @@ services:
     ports:
       - "8020:8000"
   kb-rag-server:
-    image: ghcr.io/cnoe-io/kb-rag-server:0.1.15
+    image: ghcr.io/cnoe-io/kb-rag-server:sha-b098b8d
     pull_policy: always
     container_name: kb-rag-server
     restart: unless-stopped
@@ -79,7 +79,7 @@ services:
     ports:
       - "9446:9446"
   kb-rag-web:
-    image: ghcr.io/cnoe-io/kb-rag-web:0.1.15
+    image: ghcr.io/cnoe-io/kb-rag-web:sha-b098b8d
     pull_policy: always
     container_name: kb-rag-web
     restart: unless-stopped


### PR DESCRIPTION
# Description

Pin Workshop 4 kb-rag services to `sha-b098b8d`


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
