### PR TITLE
fix: ExternalSecret validation error in kb-rag-agent

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -49,12 +49,12 @@ dependencies:
   version: 2025.7.1
 - name: kb-rag-stack
   repository: ""
-  version: 0.1.4
+  version: 0.1.5
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm/
   version: 5.0.2
 - name: backstage-plugin-agent-forge
   repository: ""
   version: 0.1.0
-digest: sha256:63c52d59c2862a7d422c6e74b868769cce89d73ac52b2b27632ac7b31dc75417
-generated: "2025-09-26T15:23:34.881024095Z"
+digest: sha256:ccca83369b52452c8ab28a8794f8e1766696228618118b24cabd5a99fd9c152d
+generated: "2025-09-28T18:15:37.921679306-05:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.2.5
+version: 0.2.6
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
@@ -138,7 +138,7 @@ dependencies:
       # - complete
   # KB-RAG Stack - Complete stack including web, server, agent, Redis, and Milvus
   - name: kb-rag-stack
-    version: 0.1.4
+    version: 0.1.5
     tags:
       - kb-rag-stack
       - complete

--- a/helm/charts/kb-rag-stack/Chart.lock
+++ b/helm/charts/kb-rag-stack/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.1.1
 - name: kb-rag-agent
   repository: file://./charts/kb-rag-agent
-  version: 0.1.2
+  version: 0.1.3
 - name: kb-rag-redis
   repository: file://./charts/kb-rag-redis
   version: 0.1.1
-digest: sha256:66ef447edad5fe5b7dea5bcf17c57f29924285076645cf8770c41a0a42a48105
-generated: "2025-09-10T13:50:55.442941389Z"
+digest: sha256:5cb779876acc0f41a8b8fdc9b4d4f240dedac0aaecdad187350bc26bf9241bec
+generated: "2025-09-28T18:15:25.251543747-05:00"

--- a/helm/charts/kb-rag-stack/Chart.yaml
+++ b/helm/charts/kb-rag-stack/Chart.yaml
@@ -3,8 +3,8 @@ name: kb-rag-stack
 description: A complete KB-RAG stack including web, server, agent, Redis, and Milvus
 
 type: application
-version: 0.1.4
-appVersion: "0.1.4"
+version: 0.1.5
+appVersion: "0.1.5"
 
 dependencies:
   - name: kb-rag-web
@@ -14,7 +14,7 @@ dependencies:
     version: "0.1.1"
     repository: "file://./charts/kb-rag-server"
   - name: kb-rag-agent
-    version: "0.1.2"
+    version: "0.1.3"
     repository: "file://./charts/kb-rag-agent"
   - name: kb-rag-redis
     version: "0.1.1"

--- a/helm/charts/kb-rag-stack/charts/kb-rag-agent/Chart.yaml
+++ b/helm/charts/kb-rag-stack/charts/kb-rag-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "0.1.3"

--- a/helm/charts/kb-rag-stack/charts/kb-rag-agent/templates/agent-externalsecret.yaml
+++ b/helm/charts/kb-rag-stack/charts/kb-rag-agent/templates/agent-externalsecret.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "agent.agentSecrets.externalSecrets.enabled" .) "true" }}
+{{- if and (eq (include "agent.agentSecrets.externalSecrets.enabled" .) "true") .Values.agentSecrets.externalSecrets.data }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:


### PR DESCRIPTION
## Fix ExternalSecret validation error in kb-rag-agent

### Problem
When deploying with `tags.complete: "true"`, the kb-rag-agent ExternalSecret fails with:
```
admission webhook "validate.externalsecret.external-secrets.io" denied the request: either data or dataFrom should be specified
```

### Root Cause
The ExternalSecret template in `kb-rag-agent/templates/agent-externalsecret.yaml` was being created even when `agentSecrets.externalSecrets.data` was empty (`[]`), violating the ExternalSecret validation requirement.

### Solution
Added a condition to only create the ExternalSecret when `agentSecrets.externalSecrets.data` is not empty:

```yaml
{{- if and (eq (include "agent.agentSecrets.externalSecrets.enabled" .) "true") .Values.agentSecrets.externalSecrets.data }}
```

### Testing
- Verified the fix resolves the ArgoCD sync failure
- Confirmed kb-rag-agent works properly when data is provided
- No ExternalSecret created when data is empty (preventing validation error)

### Impact
- Fixes `tags.complete` deployment failures
- Maintains backward compatibility
- No breaking changes to existing configurations
