### PR TITLE
fix: remove a2a-stable tag reference

### DIFF
--- a/deploy/eks/dev-eks-cluster-using-existing-secrets.yaml.example
+++ b/deploy/eks/dev-eks-cluster-using-existing-secrets.yaml.example
@@ -63,7 +63,6 @@ agent-backstage:
       pullPolicy: "Always"
     mode: "http" # Options: stdio, http
     port: 8000
-agent-backstage:
   agentSecrets:
     secretName: "backstage-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
@@ -79,7 +78,6 @@ agent-confluence:
       pullPolicy: "Always"
     mode: "http" # Options: stdio, http
     port: 8000
-agent-confluence:
   agentSecrets:
     secretName: "agent-confluence-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
@@ -90,7 +88,6 @@ agent-github:
     pullPolicy: "Always"
   mcp:
     useRemoteMcpServer: true
-agent-github:
   agentSecrets:
     secretName: "github-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
@@ -106,7 +103,6 @@ agent-jira:
       pullPolicy: "Always"
     mode: "http" # Options: stdio, http
     port: 8000
-agent-jira:
   agentSecrets:
     secretName: "atlassian-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
@@ -138,6 +134,8 @@ agent-slack:
     mode: "http" # Options: stdio, http
     port: 8000
     pullPolicy: "Always"
+  agentSecrets:
+    secretName: "slack-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
 # Backstage plugin agent forge
 backstage-plugin-agent-forge:
@@ -155,6 +153,8 @@ backstage-plugin-agent-forge:
       - name: backend
         port: 7007
         protocol: TCP
+  agentSecrets:
+    secretName: "backstage-secret" # Specify an existing Kubernetes secret name, or leave empty to auto-generate from values-secrets.yaml
 
 graphrag:
   enabled: true

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -4,37 +4,37 @@ dependencies:
   version: 0.1.1
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: agent
   repository: ""
-  version: 0.2.1
+  version: 0.2.2
 - name: slim
   repository: oci://ghcr.io/agntcy/slim/helm
   version: v0.1.8
@@ -49,12 +49,12 @@ dependencies:
   version: 2025.7.1
 - name: kb-rag-stack
   repository: ""
-  version: 0.1.5
+  version: 0.1.6
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm/
   version: 5.0.2
 - name: backstage-plugin-agent-forge
   repository: ""
   version: 0.1.0
-digest: sha256:ccca83369b52452c8ab28a8794f8e1766696228618118b24cabd5a99fd9c152d
-generated: "2025-09-28T18:15:37.921679306-05:00"
+digest: sha256:4855a3b7793d1df4dea7c8ba4d45d76d288a45375d770025439d2cd75fec2582
+generated: "2025-09-29T13:49:26.117868631Z"

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -57,4 +57,4 @@ dependencies:
   repository: ""
   version: 0.1.0
 digest: sha256:4855a3b7793d1df4dea7c8ba4d45d76d288a45375d770025439d2cd75fec2582
-generated: "2025-09-29T13:49:26.117868631Z"
+generated: "2025-09-29T13:52:53.724194215Z"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.1.1
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-jira
     tags:
       - agent-jira
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-slack
     tags:
       - agent-slack
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.2.1
+    version: 0.2.2
     alias: agent-webex
     tags:
       - agent-webex
@@ -138,7 +138,7 @@ dependencies:
       # - complete
   # KB-RAG Stack - Complete stack including web, server, agent, Redis, and Milvus
   - name: kb-rag-stack
-    version: 0.1.5
+    version: 0.1.6
     tags:
       - kb-rag-stack
       - complete

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.2.6
+version: 0.2.7
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/helm/charts/agent/Chart.yaml
+++ b/helm/charts/agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.1"
+appVersion: "0.2.2"

--- a/helm/charts/agent/values.yaml
+++ b/helm/charts/agent/values.yaml
@@ -17,7 +17,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "a2a-stable"
+  tag: "stable"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/helm/charts/kb-rag-stack/Chart.lock
+++ b/helm/charts/kb-rag-stack/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.1.1
 - name: kb-rag-agent
   repository: file://./charts/kb-rag-agent
-  version: 0.1.3
+  version: 0.1.4
 - name: kb-rag-redis
   repository: file://./charts/kb-rag-redis
   version: 0.1.1
-digest: sha256:5cb779876acc0f41a8b8fdc9b4d4f240dedac0aaecdad187350bc26bf9241bec
-generated: "2025-09-28T18:15:25.251543747-05:00"
+digest: sha256:26667face6686f1924dd1e8a4dea191d0ee8c868792ad1ea7ddde86998f892cc
+generated: "2025-09-29T13:48:54.605465826Z"

--- a/helm/charts/kb-rag-stack/Chart.yaml
+++ b/helm/charts/kb-rag-stack/Chart.yaml
@@ -3,8 +3,8 @@ name: kb-rag-stack
 description: A complete KB-RAG stack including web, server, agent, Redis, and Milvus
 
 type: application
-version: 0.1.5
-appVersion: "0.1.5"
+version: 0.1.6
+appVersion: "0.1.6"
 
 dependencies:
   - name: kb-rag-web
@@ -14,7 +14,7 @@ dependencies:
     version: "0.1.1"
     repository: "file://./charts/kb-rag-server"
   - name: kb-rag-agent
-    version: "0.1.3"
+    version: "0.1.4"
     repository: "file://./charts/kb-rag-agent"
   - name: kb-rag-redis
     version: "0.1.1"

--- a/helm/charts/kb-rag-stack/charts/kb-rag-agent/Chart.yaml
+++ b/helm/charts/kb-rag-stack/charts/kb-rag-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.3"
+appVersion: "0.1.4"

--- a/helm/charts/kb-rag-stack/charts/kb-rag-agent/values.yaml
+++ b/helm/charts/kb-rag-stack/charts/kb-rag-agent/values.yaml
@@ -13,7 +13,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "a2a-stable"
+  tag: "stable"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/helm/values-external-secrets.yaml
+++ b/helm/values-external-secrets.yaml
@@ -180,9 +180,18 @@ agent-backstage:
     secretName: "external-backstage-secret"
     externalSecrets:
       data:
-      - secretKey: BACKSTAGE_API_KEY
+      - secretKey: BACKSTAGE_API_TOKEN
         remoteRef:
           conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/backstage # Use your key path
+          property: BACKSTAGE_API_TOKEN
+      - secretKey: BACKSTAGE_URL
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/backstage # Use your key path
+          property: BACKSTAGE_URL
 
 agent-slack:
   agentSecrets:
@@ -297,12 +306,12 @@ agent-aws:
           decodingStrategy: None
           key: dev/aws # Use your key path
           property: AWS_SECRET_ACCESS_KEY
-      - secretKey: AWS_REGION
+      - secretKey: AWS_DEFAULT_REGION
         remoteRef:
           conversionStrategy: Default
           decodingStrategy: None
           key: dev/aws # Use your key path
-          property: AWS_REGION
+          property: AWS_DEFAULT_REGION
 
 agent-splunk:
   agentSecrets:
@@ -327,6 +336,18 @@ agent-webex:
     secretName: "external-webex-secret"
     externalSecrets:
       data:
+      - secretKey: WEBEX_BOT_TOKEN
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/webex # Use your key path
+          property: WEBEX_BOT_TOKEN
+      - secretKey: WEBEX_WEBHOOK_SECRET
+        remoteRef:
+          conversionStrategy: Default
+          decodingStrategy: None
+          key: dev/webex # Use your key path
+          property: WEBEX_WEBHOOK_SECRET
       - secretKey: WEBEX_TOKEN
         remoteRef:
           conversionStrategy: Default


### PR DESCRIPTION
# Description

Get rid of `a2a-stable` tags as we no longer use them. Also correct required secret keys for each agent in our example.


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
