### PR TITLE
fix: Ability to disable graph-rag

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/agent_rag/src/agent_rag/prompts.py
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_rag/src/agent_rag/prompts.py
@@ -1,34 +1,60 @@
 """Default prompts used by the agent."""
 
-SYSTEM_PROMPT = """
-You are a helpful AI assistant that tries to answer questions. 
+SYSTEM_PROMPT_COMBINED = """
+You are a Retrieval-Augmented Question Answering agent. 
 
 You have access to:
-1. Vector database that contains information about all documents and graph entities.
-2. Graph database (type: {graphdb_type}, query language: {query_language}) that contains information about all entities and their relationships.
+1. A **Vector database** for semantic similarity search 
+2. A **Graph database** (type: {graphdb_type}, query language: {query_language}) that contains information about all entities and their relationships.
 
-These databases contain information about the world. Use the tools you have to repeatedly to query the databases and answer the questions to the best of your ability.
+## Your Task:
+- Break down the question into smaller sub-questions if needed.
+- Use the `search` tool to find relevant documents and graph entities in the database.
+- Decide whether the question is asking for:
+  - Semantic/contextual information asking questions e.g. "What is ...", "Explain ...", "How to ..." (then use search results)
+  - Structural/Numerical information with lots of data e.g. "How many <entities>" or "Which <entities> have ...". (then use graph database tools)
+  - Or a combination of both (then use both tools iteratively)
+- If no results are found, consider lowering the similarity threshold slowly (to a min 0.3)
+- If neither database has the answer, apologize and say you don't know.
 
-To answer a query, follow these instructions:
-1. Reason whether the question is asking questions involving lots of data such as "How many <entities>" or "Which <entities> have ...". If so, use the graph database tools to answer the question.
-2. Use the `search` tool to find relevant documents and graph entities in the Vector database. If no results are found, consider lowering the similarity threshold slowly (to a min 0.3)
-    1a. If the answer is in the documents found, use the information from the documents to answer the question.
-3. Use the graph database tools if the entities returned from the search are relavant to the question.
-
-How to use the graph database tools:
-1. Find the properties of the entity types using `get_entity_properties` tool.
+## How to use the graph database tools:
+1. Find the properties of entity types using `get_entity_properties` tool.
 2. Once the entity_types and its properties are established, and the query does not ask for specific entities or relations, use `raw_query` directly.
-3. If query has multiple entity types, Use the `get_relation_path_between_entity_types` tool to find both direct AND indirect relations between the entity types.
-4. Use `raw_query` and `fetch_entity_details` to traverse the graph with information from the previous steps.
-    a. DO NOT guess the properties and relation names, only use what is provided from the search.
-    b. Use the `entity_primary_key` property from the `search` results to find specific entities for the raw query.
-5. If the raw_query returns null values, you may be using the wrong property or relation name. Go back to step 1 and re-establish the properties and relations of the entity types.
-6. If the raw_query returns an empty result, try to use the `search` tool to find relevant entities and documents.
+4. If query has multiple entity types, Use the `get_relation_path_between_entity_types` tool to find both direct AND indirect relations between the entity types.
+5. Use `raw_query` and `fetch_entity_details` to traverse the graph with information from the previous steps.
 
-ALWAYS provide references to the documents and graph entities you used to answer the question.
-Think step by step, provide your thoughts and observations with each tool call. Only use knowledge from the tools provided. DO NOT invent answers or provide general answers.
-If you don't have the answer, just apologize and say you don't know.
+## Important Notes when using `raw_query` tool:
+a. DO NOT assume the properties and relation names, only use what is provided from the search and `get_entity_properties` tool.
+b. Always use backticks to format property names, and use exact names, including case sensitivity.
+c. Use the `entity_primary_key` property from the `search` results to find the right entity to then use in `raw_query`.
+d. If the `raw_query` returns an error, carefully read the error message and adjust the query accordingly. Common errors include:
+    - Syntax errors: Check for typos, missing commas, or incorrect syntax.
+    - Invalid property or relation names: Ensure you are using the correct names as per the schema.
+    - Incorrect use of backticks: Make sure to use backticks around property and relation names.
+e. If the `raw_query` returns null values, you may be using the wrong property or relation name. Go back to step 1 and re-establish the properties and relations of the entity types.
+f. If the `raw_query` returns an empty result, try to use the `search` tool to find relevant entities and documents.
+
+
+### Answer Format
+ - ALWAYS provide references to the documents and graph entities you used to answer the question. Provide them in a "References" section at the end of your answer.
+ - Only use knowledge from the tools provided. DO NOT invent answers or provide general answers.
+ - For graph entities, use the format `{ui_url}?entity_type=<entity_type>&entity_primary_key=<entity_primary_key>`.
 
 The entity types available in the graph database are:
 {entities}
+"""
+
+SYSTEM_PROMPT_RAG_ONLY= """
+You are a Retrieval-Augmented Question Answering agent.
+
+You have access to a **Vector database** for semantic similarity search.
+
+## Your Task:
+- Use the `search` tool to find relevant documents in the database.
+- If no results are found, consider lowering the similarity threshold slowly (to a min 0.3)
+- If the database has no answer, apologize and say you don't know.
+
+## Answer Format
+    - ALWAYS provide references to the documents you used to answer the question. Provide them in a "References" section at the end of your answer.
+    - Only use knowledge from the tools provided. DO NOT invent answers or provide general answers.
 """

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-ontology
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-ontology
@@ -29,6 +29,10 @@ FROM python:3.13-slim-bookworm
 # Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
 # will fail.
 
+# Create a non-root user
+RUN groupadd --gid 1001 app && \
+    useradd --uid 1001 --gid app --shell /bin/bash --create-home app
+
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
 
@@ -36,6 +40,9 @@ WORKDIR /app/agent_ontology
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/agent_ontology/.venv/bin:$PATH"
+
+# Use a non-root user to run the application
+USER app
 
 # Run the application by default
 CMD ["python3", "src/agent_ontology/restapi.py"]

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-rag
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-rag
@@ -29,6 +29,10 @@ FROM python:3.13-slim-bookworm
 # Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
 # will fail.
 
+# Create a non-root user
+RUN groupadd --gid 1001 app && \
+    useradd --uid 1001 --gid app --shell /bin/bash --create-home app
+
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
 
@@ -36,6 +40,9 @@ WORKDIR /app/agent_rag
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/agent_rag/.venv/bin:$PATH"
+
+# Use a non-root user to run the application
+USER app
 
 # Run the application by default
 CMD ["python3", "src/agent_rag"]

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.connectors
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.connectors
@@ -29,6 +29,10 @@ FROM python:3.13-slim-bookworm
 # Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
 # will fail.
 
+# Create a non-root user
+RUN groupadd --gid 1001 app && \
+    useradd --uid 1001 --gid app --shell /bin/bash --create-home app
+
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
 
@@ -36,6 +40,9 @@ WORKDIR /app/connectors
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/connectors/.venv/bin:$PATH"
+
+# Use a non-root user to run the application
+USER app
 
 # Run the application by default
 CMD ["python3", "src/connectors/test_dummy/client.py"]

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server
@@ -29,6 +29,10 @@ FROM python:3.13-slim-bookworm
 # Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
 # will fail.
 
+# Create a non-root user
+RUN groupadd --gid 1001 app && \
+    useradd --uid 1001 --gid app --shell /bin/bash --create-home app
+
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
 
@@ -36,6 +40,9 @@ WORKDIR /app/server
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/server/.venv/bin:$PATH"
+
+# Use a non-root user to run the application
+USER app
 
 # Run the application by default
 CMD ["python3", "src/server"]

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.webui
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.webui
@@ -15,7 +15,10 @@ RUN npm run build
 
 # ---------- Stage 2: Serve with nginx ----------
 FROM nginx:alpine
+
 COPY --from=build /app/webui/dist /usr/share/nginx/html
 COPY webui/nginx.conf /etc/nginx/conf.d/default.conf
+
+
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"] 

--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/graph_db/base.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/graph_db/base.py
@@ -209,8 +209,14 @@ class GraphDB(ABC):
         raise NotImplementedError("Subclasses must implement this method.")
 
     @abstractmethod
-    async def raw_query(self, query: str, readonly=False, max_results=10000) -> dict:
+    async def raw_query(self, query: str, return_everything: bool = False, readonly=False, max_results=10000) -> dict:
         """
         Does a raw query to graph database
+        
+        :param query: The raw query string to execute
+        :param return_everything: If True, return complete result data, otherwise return simplified format
+        :param readonly: If True, execute query in read-only mode
+        :param max_results: Maximum number of results to return
+        :return: Dictionary containing query results
         """
         raise NotImplementedError("Subclasses must implement this method.")

--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/graph_db/neo4j/graph_db.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/graph_db/neo4j/graph_db.py
@@ -800,7 +800,7 @@ class Neo4jDB(GraphDB):
             vals.append(result.get("values", ""))
         return vals
 
-    async def raw_query(self, query: str, readonly=False, max_results=10000) -> dict:
+    async def raw_query(self, query: str, return_everything: bool = False, readonly=False, max_results=10000) -> dict:
         if readonly:
             session = self.driver.session(default_access_mode=neo4j.READ_ACCESS, database=self.database)
         else:
@@ -809,12 +809,17 @@ class Neo4jDB(GraphDB):
             res = await session.run(query) # type: ignore
             # d = await res.data()
             rec = await res.fetch(max_results)
-            print(rec)
+            logger.debug(f"Query returned {len(rec)} records")
             d = await res.consume()
-            print(d)
-            return {
-                "results":rec
-            }
+            if return_everything:
+                return {
+                    "results":rec,
+                    "summary":d
+                }
+            else:
+                return {
+                    "results":rec
+                }
 
     async def _create_full_text_index(self, index_name: str, labels: list, props: list, analyzer: str = 'simple'):
         props = [f"n.`{prop}`" for prop in props]

--- a/ai_platform_engineering/knowledge_bases/rag/docker-compose.yaml
+++ b/ai_platform_engineering/knowledge_bases/rag/docker-compose.yaml
@@ -12,19 +12,19 @@ services:
         NEO4J_PASSWORD: dummy_password
         MILVUS_URI: http://milvus-standalone:19530
         ONTOLOGY_AGENT_RESTAPI_ADDR: http://agent_ontology:8098
+        GRAPH_RAG_ENABLED: ${GRAPH_RAG_ENABLED:-true}
         CLEANUP_INTERVAL: 86400
     restart: unless-stopped
     env_file:
       - ../../../.env
     depends_on:
-      - neo4j
-      - neo4j-ontology
       - rag-redis
     build:
       context: .
       dockerfile: ./build/Dockerfile.server
     profiles:
       - apps
+      - rag_only
 
   agent_rag:
     ports:
@@ -39,14 +39,14 @@ services:
         NEO4J_USERNAME: neo4j
         NEO4J_PASSWORD: dummy_password
         RAG_SERVER_URL: http://rag_server:9446
+        GRAPH_RAG_ENABLED: ${GRAPH_RAG_ENABLED:-true}
     restart: unless-stopped
-    depends_on:
-      - neo4j
     build:
       context: .
       dockerfile: ./build/Dockerfile.agent-rag
     profiles:
       - apps
+      - rag_only
 
   agent_ontology:
     ports:
@@ -84,6 +84,7 @@ services:
       - "9447:80"
     profiles:
       - apps
+      - rag_only
 
 #####################
 # Dependent services
@@ -141,6 +142,7 @@ services:
     profiles:
       - deps
       - apps
+      - rag_only
 
   milvus-standalone:
     container_name: milvus-standalone
@@ -149,6 +151,7 @@ services:
     profiles:
       - deps
       - apps
+      - rag_only
     security_opt:
       - seccomp:unconfined
     environment:
@@ -177,6 +180,7 @@ services:
     profiles:
       - deps
       - apps
+      - rag_only
     environment:
       - ETCD_AUTO_COMPACTION_MODE=revision
       - ETCD_AUTO_COMPACTION_RETENTION=1000
@@ -197,6 +201,7 @@ services:
     profiles:
       - deps
       - apps
+      - rag_only
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/ai_platform_engineering/knowledge_bases/rag/webui/src/ui/Graph/OntologyGraph/OntologyGraph.tsx
+++ b/ai_platform_engineering/knowledge_bases/rag/webui/src/ui/Graph/OntologyGraph/OntologyGraph.tsx
@@ -538,7 +538,7 @@ export default function OntologyGraph({
                         className="btn bg-yellow-500 hover:bg-yellow-600 text-white disabled:bg-gray-400 disabled:cursor-not-allowed"
                         disabled={isLoading || isAgentActive}
                         title={isAgentActive ? "Agent is currently active - please wait" : nodes.length === 0 ? "Detect Ontology" : "Re-Detect the Ontology"}>
-                        {isLoading ? 'Processing...' : nodes.length === 0 ? 'Detect Ontology' : 'Re-evaluate Ontology'}
+                        {isLoading ? 'Processing...' : nodes.length === 0 ? 'Detect Ontology' : 'Re-detect Ontology'}
                     </button>
                 </div>
                 {error && <p className="text-red-500 mt-2">{error}</p>}
@@ -550,22 +550,44 @@ export default function OntologyGraph({
                     </div>
                 )}
                 <div style={{ height: '65vh' }} className="flex-grow rounded-lg shadow-md bg-white">
-                    {nodes.length === 0 && !isLoading ? (
-                        // Welcome Screen when no ontology data
+                    {nodes.length === 0 ? (
+                        // Welcome Screen when no ontology data or loading
                         <div className="h-full p-8 flex items-center justify-center">
                             <div className="text-center space-y-4 max-w-md">
-                                <div className="text-6xl text-indigo-500 mb-4">🌐</div>
-                                <h3 className="text-2xl font-bold text-gray-800">Ontology Graph</h3>
-                                <p className="text-gray-600">
-                                    No ontology data found. <br/> Use 🔌 Graph connectors to ingest entities, and click detect ontology to see entity relationships and confidence scores.
-                                </p>
-                                <button
-                                    onClick={() => setShowRegenerateConfirm(true)}
-                                    className="btn bg-yellow-500 hover:bg-yellow-600 text-white disabled:bg-gray-400 disabled:cursor-not-allowed"
-                                    disabled={isLoading || isAgentActive}
-                                    title={isAgentActive ? "Agent is currently active - please wait" : nodes.length === 0 ? "Detect Ontology" : "Re-Detect the Ontology"}>
-                                    {isLoading ? 'Processing...' : nodes.length === 0 ? 'Detect Ontology' : 'Re-evaluate Ontology'}
-                                </button>
+                                {isLoading ? (
+                                    // Loading state
+                                    <>
+                                        <div className="text-6xl mb-4">
+                                            <div className="animate-spin">⚙️</div>
+                                        </div>
+                                        <h3 className="text-2xl font-bold text-gray-800">Loading Ontology...</h3>
+                                        <p className="text-gray-600">
+                                            {isAgentProcessing || isAgentEvaluating 
+                                                ? 'The ontology agent is analyzing data and discovering relationships. This may take a few moments...'
+                                                : 'Fetching ontology data...'
+                                            }
+                                        </p>
+                                        <div className="w-full bg-gray-200 rounded-full h-2.5">
+                                            <div className="bg-indigo-600 h-2.5 rounded-full animate-pulse" style={{width: '60%'}}></div>
+                                        </div>
+                                    </>
+                                ) : (
+                                    // Welcome state when no data
+                                    <>
+                                        <div className="text-6xl text-indigo-500 mb-4">🌐</div>
+                                        <h3 className="text-2xl font-bold text-gray-800">Ontology Graph</h3>
+                                        <p className="text-gray-600">
+                                            No ontology data found. <br/> Use 🔌 Graph connectors to ingest entities, and click detect ontology to see entity relationships and confidence scores.
+                                        </p>
+                                        <button
+                                            onClick={() => setShowRegenerateConfirm(true)}
+                                            className="btn bg-yellow-500 hover:bg-yellow-600 text-white disabled:bg-gray-400 disabled:cursor-not-allowed"
+                                            disabled={isLoading || isAgentActive}
+                                            title={isAgentActive ? "Agent is currently active - please wait" : "Detect Ontology"}>
+                                            Detect Ontology
+                                        </button>
+                                    </>
+                                )}
                             </div>
                         </div>
                     ) : (


### PR DESCRIPTION
# Description

- Ability to disable GraphRAG (From server, agent and UI)
- System prompt tweaks for RAG agent
- Tweaks to `raw_graph_query` to allow for more context/feedback when LLM queries the graph
- Add non root user to containers

docker-compose can be run with ONLY RAG like so:
```
 GRAPH_RAG_ENABLED=false docker compose --profile rag_only up
 ```

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
