### PR TITLE
feat: use skills example config and also fix docker-compose generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ APP_NAME ?= ai-platform-engineering
 .PHONY: \
 	setup-venv start-venv clean-pyc clean-venv clean-build-artifacts clean \
 	build install build-docker run run-ai-platform-engineer langgraph-dev \
-	generate-compose generate-compose-dev generate-compose-all clean-compose \
+	generate-docker-compose generate-docker-compose-dev generate-docker-compose-all clean-docker-compose \
 	lint lint-fix test test-compose-generator test-compose-generator-coverage \
 	test-rag-unit test-rag-coverage test-rag-memory test-rag-scale test-rag-all validate lock-all help
 
@@ -64,21 +64,26 @@ OUTPUT_DIR ?= docker-compose
 A2A_TRANSPORT ?= p2p
 DEV ?= false
 
-generate-docker-compose:  ## Generate docker-compose files from personas (make generate-compose PERSONAS="p2p-basic argocd" DEV=true)
+generate-docker-compose:  ## Generate docker-compose files from personas (make generate-docker-compose PERSONAS="p2p-basic argocd" DEV=true)
 	@echo "Generating docker-compose files for personas: $(PERSONAS)..."
 	@mkdir -p $(OUTPUT_DIR)
 	@chmod +x scripts/generate-docker-compose.py
 	@for persona in $(PERSONAS); do \
-		echo "Generating docker-compose.$$persona.yaml..."; \
+		if [ "$(DEV)" = "true" ]; then \
+			OUTPUT_FILE="$(OUTPUT_DIR)/docker-compose.$$persona.dev.yaml"; \
+		else \
+			OUTPUT_FILE="$(OUTPUT_DIR)/docker-compose.$$persona.yaml"; \
+		fi; \
 		A2A_TRANSPORT=$(A2A_TRANSPORT) ./scripts/generate-docker-compose.py \
 			--persona $$persona \
-			--output $(OUTPUT_DIR)/docker-compose.$$persona.yaml \
+			--output $$OUTPUT_FILE \
 			$(if $(filter true,$(DEV)),--dev,); \
+		echo "✓ Generated: $$(realpath $$OUTPUT_FILE)"; \
 	done
 	@echo "✓ Generated compose files in $(OUTPUT_DIR)/"
 
-generate-docker-compose-dev:  ## Generate dev docker-compose files with local code mounts (make generate-compose-dev PERSONAS="p2p-basic")
-	@$(MAKE) generate-compose DEV=true
+generate-docker-compose-dev:  ## Generate dev docker-compose files with local code mounts (make generate-docker-compose-dev PERSONAS="p2p-basic")
+	@$(MAKE) generate-docker-compose DEV=true
 
 generate-docker-compose-all:  ## Generate docker-compose files for all personas
 	@echo "Generating docker-compose files for all personas..."

--- a/ai_platform_engineering/agents/splunk/build/Dockerfile.mcp
+++ b/ai_platform_engineering/agents/splunk/build/Dockerfile.mcp
@@ -44,4 +44,4 @@ USER appuser
 EXPOSE 8000
 
 # Run the HTTP/SSE MCP server
-CMD ["python", "mcp_splunk/server.py"] 
+CMD ["python", "mcp_splunk/server.py"]

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -160,16 +160,16 @@ docker compose -f docker-compose.argocd.yaml --profile a2a-over-slim up
 
 ```bash
 # Generate a single persona
-make generate-compose PERSONAS="argocd"
+make generate-docker-compose PERSONAS="argocd"
 
 # Generate multiple personas
-make generate-compose PERSONAS="argocd github aws"
+make generate-docker-compose PERSONAS="argocd github aws"
 
 # Generate with dev mode (local code mounts)
-make generate-compose-dev PERSONAS="argocd"
+make generate-docker-compose-dev PERSONAS="argocd"
 
 # Generate all personas
-make generate-compose-all
+make generate-docker-compose-all
 ```
 
 ### Using the Script Directly

--- a/docker-compose/docker-compose.argocd.yaml
+++ b/docker-compose/docker-compose.argocd.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="argocd"
+#   make generate-docker-compose PERSONAS="argocd"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona argocd

--- a/docker-compose/docker-compose.aws.yaml
+++ b/docker-compose/docker-compose.aws.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="aws"
+#   make generate-docker-compose PERSONAS="aws"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona aws

--- a/docker-compose/docker-compose.backstage.yaml
+++ b/docker-compose/docker-compose.backstage.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="backstage"
+#   make generate-docker-compose PERSONAS="backstage"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona backstage

--- a/docker-compose/docker-compose.caipe-basic.yaml
+++ b/docker-compose/docker-compose.caipe-basic.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="caipe-basic"
+#   make generate-docker-compose PERSONAS="caipe-basic"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona caipe-basic

--- a/docker-compose/docker-compose.caipe-complete-with-tracing.yaml
+++ b/docker-compose/docker-compose.caipe-complete-with-tracing.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="caipe-complete-with-tracing"
+#   make generate-docker-compose PERSONAS="caipe-complete-with-tracing"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona caipe-complete-with-tracing

--- a/docker-compose/docker-compose.confluence.yaml
+++ b/docker-compose/docker-compose.confluence.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="confluence"
+#   make generate-docker-compose PERSONAS="confluence"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona confluence

--- a/docker-compose/docker-compose.devops-engineer.yaml
+++ b/docker-compose/docker-compose.devops-engineer.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="devops-engineer"
+#   make generate-docker-compose PERSONAS="devops-engineer"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona devops-engineer

--- a/docker-compose/docker-compose.github.yaml
+++ b/docker-compose/docker-compose.github.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="github"
+#   make generate-docker-compose PERSONAS="github"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona github

--- a/docker-compose/docker-compose.incident-engineer.yaml
+++ b/docker-compose/docker-compose.incident-engineer.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="incident-engineer"
+#   make generate-docker-compose PERSONAS="incident-engineer"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona incident-engineer

--- a/docker-compose/docker-compose.jira.yaml
+++ b/docker-compose/docker-compose.jira.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="jira"
+#   make generate-docker-compose PERSONAS="jira"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona jira

--- a/docker-compose/docker-compose.komodor.yaml
+++ b/docker-compose/docker-compose.komodor.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="komodor"
+#   make generate-docker-compose PERSONAS="komodor"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona komodor

--- a/docker-compose/docker-compose.pagerduty.yaml
+++ b/docker-compose/docker-compose.pagerduty.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="pagerduty"
+#   make generate-docker-compose PERSONAS="pagerduty"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona pagerduty

--- a/docker-compose/docker-compose.petstore.yaml
+++ b/docker-compose/docker-compose.petstore.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="petstore"
+#   make generate-docker-compose PERSONAS="petstore"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona petstore

--- a/docker-compose/docker-compose.platform-engineer.yaml
+++ b/docker-compose/docker-compose.platform-engineer.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="platform-engineer"
+#   make generate-docker-compose PERSONAS="platform-engineer"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona platform-engineer

--- a/docker-compose/docker-compose.product-owner.yaml
+++ b/docker-compose/docker-compose.product-owner.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="product-owner"
+#   make generate-docker-compose PERSONAS="product-owner"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona product-owner

--- a/docker-compose/docker-compose.rag-only.yaml
+++ b/docker-compose/docker-compose.rag-only.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="rag-only"
+#   make generate-docker-compose PERSONAS="rag-only"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona rag-only

--- a/docker-compose/docker-compose.slack.yaml
+++ b/docker-compose/docker-compose.slack.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="slack"
+#   make generate-docker-compose PERSONAS="slack"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona slack

--- a/docker-compose/docker-compose.slim-tracing.yaml
+++ b/docker-compose/docker-compose.slim-tracing.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="slim-tracing"
+#   make generate-docker-compose PERSONAS="slim-tracing"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona slim-tracing

--- a/docker-compose/docker-compose.splunk.yaml
+++ b/docker-compose/docker-compose.splunk.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="splunk"
+#   make generate-docker-compose PERSONAS="splunk"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona splunk

--- a/docker-compose/docker-compose.weather.yaml
+++ b/docker-compose/docker-compose.weather.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="weather"
+#   make generate-docker-compose PERSONAS="weather"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona weather

--- a/docker-compose/docker-compose.webex.yaml
+++ b/docker-compose/docker-compose.webex.yaml
@@ -7,7 +7,7 @@
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="webex"
+#   make generate-docker-compose PERSONAS="webex"
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona webex

--- a/docs/docs/usecases/incident-engineer.md
+++ b/docs/docs/usecases/incident-engineer.md
@@ -49,7 +49,7 @@ cd docker-compose
 docker compose -f docker-compose.incident-engineer.yaml --profile a2a-p2p up
 
 # Or generate it fresh with dev mode
-make generate-compose PERSONAS="incident-engineer" DEV=true
+make generate-docker-compose PERSONAS="incident-engineer" DEV=true
 ```
 
 The Incident Engineer persona includes:

--- a/docs/docs/usecases/platform-engineer.md
+++ b/docs/docs/usecases/platform-engineer.md
@@ -48,7 +48,7 @@ docker compose -f docker-compose.devops-engineer.yaml --profile a2a-p2p up
 docker compose -f docker-compose.caipe-basic.yaml --profile a2a-p2p up
 
 # Generate fresh compose files
-make generate-compose PERSONAS="platform-engineer devops-engineer"
+make generate-docker-compose PERSONAS="platform-engineer devops-engineer"
 ```
 
 ### Available Personas

--- a/docs/docs/usecases/product-owner.md
+++ b/docs/docs/usecases/product-owner.md
@@ -32,10 +32,10 @@ docker compose -f docker-compose.product-owner.yaml --profile a2a-p2p up
 docker compose -f docker-compose.product-owner.yaml --profile a2a-over-slim up
 
 # Generate fresh compose file
-make generate-compose PERSONAS="product-owner"
+make generate-docker-compose PERSONAS="product-owner"
 
 # Or in dev mode with local code
-make generate-compose PERSONAS="product-owner" DEV=true
+make generate-docker-compose PERSONAS="product-owner" DEV=true
 ```
 
 ### What's Included

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -45,14 +45,14 @@ persona:
 
 ### Using Personas
 
-Personas can be used with the `generate-compose.py` script to generate tailored docker-compose configurations:
+Personas can be used with the `generate-docker-compose.py` script to generate tailored docker-compose configurations:
 
 ```bash
 # Generate compose for a specific persona
-./scripts/generate-compose.py --persona devops-engineer
+./scripts/generate-docker-compose.py --persona devops-engineer
 
 # Generate for multiple personas
-./scripts/generate-compose.py --persona argocd full-platform
+./scripts/generate-docker-compose.py --persona argocd full-platform
 ```
 
 ### Available Agents

--- a/prompt_config.yaml
+++ b/prompt_config.yaml
@@ -59,3 +59,49 @@ agent_prompts:
   rag:
     system_prompt: |
       The RAG agent now encompasses everything about ai_platform_engineering. All our documentation lies there. So if there's any question about ai_platform_engineering, then route to kb-rag.
+
+agent_skill_examples:
+  general:
+    - "What can you do?"
+  argocd:
+    - "Get the status of applications"
+    - "Sync an application to the latest version"
+  aws:
+    - "Check EKS cluster health status"
+    - "Create S3 bucket"
+  backstage:
+    - "Search for services by owner"
+    - "Get details for a specific service"
+  confluence:
+    - "Search for pages about deployment"
+    - "Find recent pages in a space"
+  github:
+    - "Show open pull requests for a repository"
+    - "Get recent commits from a repository"
+  jira:
+    - "Search for high priority issues"
+    - "Find issues with a specific label"
+  pagerduty:
+    - "Show currently triggered incidents"
+    - "Who is on-call right now?"
+  slack:
+    - "Send a message to a channel"
+    - "Find channels by name"
+  splunk:
+    - "Search for errors in the last hour"
+    - "Check active alerts and detectors"
+  komodor:
+    - "Show health risks for clusters"
+    - "Trigger a root cause analysis"
+  webex:
+    - "Send a message to a room"
+    - "Get recent messages from a room"
+  petstore:
+    - "Find available pets by status"
+    - "Check store inventory levels"
+  weather:
+    - "What's the weather like today?"
+    - "Show the forecast for the next 5 days in London"
+  rag:
+    - "Give me information about SRE team onboarding"
+    - "How do I configure agents?"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,7 +53,7 @@ The `--dev` flag generates a docker-compose file similar to `docker-compose.dev.
   - `slim`: SLIM dataplane transport
 
 ```bash
-A2A_TRANSPORT=slim ./scripts/generate-compose.py --persona devops-engineer
+A2A_TRANSPORT=slim ./scripts/generate-docker-compose.py --persona devops-engineer
 ```
 
 ### Supported Agents

--- a/scripts/generate-docker-compose.py
+++ b/scripts/generate-docker-compose.py
@@ -320,8 +320,8 @@ def generate_agent_service(
     # Use local build in dev mode
     if dev_mode and agent_name != 'rag':
         service['build'] = {
-            'context': '..',
-            'dockerfile': f'ai_platform_engineering/agents/{agent_name}/build/Dockerfile'
+            'context': f'../ai_platform_engineering/agents/{agent_name}',
+            'dockerfile': 'build/Dockerfile.a2a'
         }
         del service['image']
 
@@ -391,11 +391,11 @@ def generate_mcp_service(
     # Add local code mounts and build context in dev mode
     if dev_mode:
         service['volumes'] = [
-            f'../ai_platform_engineering/agents/{agent_name}/mcp:/app/mcp'
+            f'../ai_platform_engineering/agents/{agent_name}/mcp/mcp_{agent_name}:/app/mcp_{agent_name}'
         ]
         service['build'] = {
-            'context': '..',
-            'dockerfile': f'ai_platform_engineering/agents/{agent_name}/mcp/build/Dockerfile'
+            'context': f'../ai_platform_engineering/agents/{agent_name}',
+            'dockerfile': 'build/Dockerfile.mcp'
         }
         del service['image']
 
@@ -970,7 +970,7 @@ def generate_banner(personas: List[str], dev_mode: bool, filename: str = None) -
 # Transports: a2a-p2p, a2a-over-slim
 #
 # To regenerate this file, run:
-#   make generate-compose PERSONAS="{personas_str}"{dev_flag}
+#   make generate-docker-compose PERSONAS="{personas_str}"{dev_flag}
 #
 # Or manually:
 #   ./scripts/generate-docker-compose.py --persona {personas_str}{dev_arg}


### PR DESCRIPTION
# Description

1. New Feature: add `agent_skill_examples` to prompt_config and use that to override sub-agent example if exists.
2. Fix generate docker compose path errors and naming inconsistencies.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
