### PR TITLE
fix: correctly handle aws bedrock streaming format

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -105,10 +105,27 @@ class AIPlatformEngineerA2ABinding:
                       "content": "",
                   }
               elif isinstance(message, AIMessageChunk):
+                  # Normalize content to string (AWS Bedrock returns list, OpenAI returns string)
+                  content = message.content
+                  if isinstance(content, list):
+                      # If content is a list (AWS Bedrock), extract text from content blocks
+                      text_parts = []
+                      for item in content:
+                          if isinstance(item, dict):
+                              # Extract text from Bedrock content block: {"type": "text", "text": "..."}
+                              text_parts.append(item.get('text', ''))
+                          elif isinstance(item, str):
+                              text_parts.append(item)
+                          else:
+                              text_parts.append(str(item))
+                      content = ''.join(text_parts)
+                  elif not isinstance(content, str):
+                      content = str(content) if content else ''
+
                   yield {
                       "is_task_complete": False,
                       "require_user_input": False,
-                      "content": message.content,
+                      "content": content,
                   }
 
       except Exception as e:


### PR DESCRIPTION
# Description

For streaming, AWS Bedrock returns a list of json (it may also be because that's how Anthropic models handle streaming) like such: 
```
message.content = [{"type": "text", "text": "Hello"}]  # List of dicts
```
where as Azure OpenAI returns a plain text:
```
message.content = "Hello"  # Plain string
```
So we need to check the response type and handle gracefully for both cases.

Tested locally using both AWS Bedrock and Azure OpenAI and confirmed both work now.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
