### PR TITLE
feat(helm): Add promptConfig override support

### DIFF
--- a/charts/ai-platform-engineering/Chart.lock
+++ b/charts/ai-platform-engineering/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: backstage-plugin-agent-forge
   repository: ""
   version: 0.1.0
-digest: sha256:e02d568ddcb165ada5b9ef33091dc777411b723440929bb87d6a89d710061b48
-generated: "2025-10-08T16:29:50.42541278Z"
+digest: sha256:0bb0ae712cf7adcd0d75e957895ce1d3d608cabd63e59d43da40ed2004a10892
+generated: "2025-10-20T14:49:03.407133-05:00"

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.0
+version: 0.3.1
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/templates/prompt-config.yaml
+++ b/charts/ai-platform-engineering/templates/prompt-config.yaml
@@ -10,4 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   prompt_config.yaml: |
+{{- if .Values.promptConfig }}
+{{ .Values.promptConfig | nindent 4 }}
+{{- else }}
 {{ .Files.Get "data/prompt_config.yaml" | nindent 4 }}
+{{- end }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -32,6 +32,11 @@ global:
   rag:
     enableGraphRag: true
 
+# Optional: Override the default prompt_config.yaml
+# If not set, uses the default from data/prompt_config.yaml
+# You can provide your custom prompt configuration here
+promptConfig: ""
+
 ######### Supervisor agent configuration #########
 supervisor-agent:
   nameOverride: "supervisor-agent"


### PR DESCRIPTION
## Summary
This PR adds the ability to override the default `prompt_config.yaml` in the Helm chart without modifying the chart source.

## Changes
- Added `promptConfig` value in `values.yaml` to allow custom prompt configuration
- Updated `prompt-config.yaml` template to use custom config if provided, falling back to default
- Bumped chart version from 0.3.0 to 0.3.1
- Updated `Chart.lock` with `helm dependency update`

## Usage
Users can now override `prompt_config.yaml` using:

### Option 1: Using `--set-file`
```bash
helm install ai-platform-engineering . --set-file promptConfig=./custom-prompt-config.yaml
```

### Option 2: Using a custom values file
```yaml
# custom-values.yaml
promptConfig: |
  agent_name: "Custom AI Platform Engineer"
  agent_description: |
    Custom description
  # ... rest of config
```

```bash
helm install ai-platform-engineering . -f custom-values.yaml
```

## Backward Compatibility
- ✅ Fully backward compatible
- If `promptConfig` is not specified, uses the default from `data/prompt_config.yaml`
- No breaking changes to existing deployments

## Testing
```bash
# Test template rendering
helm template ai-platform-engineering . --set-file promptConfig=./test-config.yaml
```