### PR TITLE
Add pod annotations and extraDeploy options

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.3
+version: 0.3.4
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
@@ -125,7 +125,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.0.1
+    version: 0.0.2
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack

--- a/charts/ai-platform-engineering/templates/extra-deploy.yaml
+++ b/charts/ai-platform-engineering/templates/extra-deploy.yaml
@@ -1,0 +1,8 @@
+{{- /*
+Render additional Kubernetes resources from extraDeploy array.
+This allows users to add custom resources like VirtualServices, DestinationRules, etc.
+*/ -}}
+{{- range .Values.extraDeploy }}
+---
+{{- toYaml . }}
+{{- end }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -32,6 +32,9 @@ global:
   rag:
     enableGraphRag: true
 
+# Extra Kubernetes resources to deploy
+extraDeploy: []
+
 # Prompt Configuration
 # Choose between predefined prompt configurations or provide your own custom configuration
 #

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: rag-stack
 description: A complete RAG stack including web UI, server, agents, Redis, Neo4j and Milvus
 
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.0.1"
 
 dependencies:

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -40,6 +40,7 @@ global:
 # Default values for rag-stack.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
 agentExports:
   data:
     enabled: true
@@ -51,7 +52,7 @@ rag-server:
   image:
     repository: "ghcr.io/cnoe-io/caipe-rag-server"
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   service:
     type: ClusterIP
@@ -59,6 +60,8 @@ rag-server:
 
   logLevel: DEBUG
   cleanupInterval: 86400 # 24 hours
+
+  podAnnotations: {}
 
   resources:
     requests:
@@ -83,6 +86,8 @@ agent-rag:
     port: 8099
 
   logLevel: DEBUG
+
+  podAnnotations: {}
 
   resources:
     requests:
@@ -127,6 +132,8 @@ agent-ontology:
   logLevel: DEBUG
   syncInterval: 86400 # 24 hours
 
+  podAnnotations: {}
+
   resources:
     requests:
       cpu: 100m
@@ -160,13 +167,15 @@ rag-webui:
   image:
     repository: "ghcr.io/cnoe-io/caipe-rag-webui"
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   service:
     type: ClusterIP
     port: 80
 
   nginxEnvsubstTemplateSuffix: ".conf"
+
+  podAnnotations: {}
 
   ingress:
     enabled: true
@@ -209,6 +218,9 @@ neo4j:
       cpu: "1"
       memory: "2Gi"
 
+  podSpec:
+    annotations: {}
+
   volumes:
     data:
       mode: "dynamic"
@@ -237,6 +249,9 @@ neo4j-ontology:
       cpu: "1"
       memory: "2Gi"
 
+  podSpec:
+    annotations: {}
+
   volumes:
     data:
       mode: "dynamic"
@@ -255,6 +270,8 @@ rag-redis:
   service:
     type: ClusterIP
     port: 6379
+
+  podAnnotations: {}
 
   persistence:
     enabled: true
@@ -284,15 +301,28 @@ milvus:
   woodpecker:
     enabled: true   # Default is false, we need true
 
-  # Performance overrides only for compute nodes
-  queryNode:
+  mixCoordinator:
+    annotations: {}
+
+  proxy:
+    annotations: {}
+
+  dataNode:
+    annotations: {}
     resources:
       limits:
         cpu: 200m
         memory: 256Mi
 
-  dataNode:
+  queryNode:
+    annotations: {}
     resources:
       limits:
         cpu: 200m
         memory: 256Mi
+
+  etcd:
+    podAnnotations: {}
+
+  minio:
+    podAnnotations: {}

--- a/docs/ISTIO.md
+++ b/docs/ISTIO.md
@@ -1,0 +1,121 @@
+# Istio Configuration
+
+When running in an Istio service mesh, you need to configure port exclusions to allow direct communication between certain components that need to bypass mTLS.
+
+## Configuration
+
+Add the following `podAnnotations` to your values file for components that need Istio port exclusions:
+
+### Supervisor Agent
+
+```yaml
+supervisor-agent:
+  podAnnotations:
+    traffic.sidecar.istio.io/excludeInboundPorts: "15020"
+    traffic.sidecar.istio.io/excludeOutboundPorts: "8098,8099,9446,19530,2379,2380,7687,7474,6379"
+```
+
+### RAG Stack Components
+
+```yaml
+rag-stack:
+  rag-server:
+    podAnnotations:
+      traffic.sidecar.istio.io/excludeInboundPorts: "9446,9091,15020"
+      traffic.sidecar.istio.io/excludeOutboundPorts: "19530,2379,2380,9091,53100,21123,21124,22222,9000,7687,7474,6379,8098,8099,8000"
+
+  agent-rag:
+    podAnnotations:
+      traffic.sidecar.istio.io/excludeInboundPorts: "8099,15020"
+      traffic.sidecar.istio.io/excludeOutboundPorts: "19530,2379,2380,9091,53100,21123,21124,22222,9000,7687,7474,6379,9446"
+
+  agent-ontology:
+    podAnnotations:
+      traffic.sidecar.istio.io/excludeInboundPorts: "8098,15020"
+      traffic.sidecar.istio.io/excludeOutboundPorts: "19530,2379,2380,9091,53100,21123,21124,22222,9000,7687,7474,6379"
+
+  rag-redis:
+    podAnnotations:
+      traffic.sidecar.istio.io/excludeInboundPorts: "6379,15020"
+
+  rag-webui:
+    podAnnotations:
+      traffic.sidecar.istio.io/excludeOutboundPorts: "9446"
+```
+
+### Milvus Components
+
+```yaml
+  milvus:
+    mixCoordinator:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "53100,9091,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "53100,21123,21124,22222,19530,2379,2380,9091,9000"
+
+    proxy:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "19530,19529,9091,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "53100,21123,21124,22222,19530,2379,2380,9091,9000"
+
+    dataNode:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "21124,9091,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "53100,21123,21124,22222,19530,2379,2380,9091,9000"
+
+    queryNode:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "21123,9091,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "53100,21123,21124,22222,19530,2379,2380,9091,9000"
+
+    etcd:
+      podAnnotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "2379,2380,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "2379,2380,15020"
+
+    minio:
+      podAnnotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "9000,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "9000"
+```
+
+### Neo4j
+
+```yaml
+  neo4j:
+    podSpec:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "7687,7474,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "7687,7474"
+
+  neo4j-ontology:
+    podSpec:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "7687,7474,15020"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "7687,7474"
+```
+
+## Manual Patch Required
+
+**Note:** The Milvus `streamingNode` component does NOT support component-specific annotations in the Milvus Helm chart. After deployment, you must manually patch it:
+
+```bash
+kubectl patch deployment caipe-milvus-streamingnode -n <namespace> --type=merge -p='{"spec":{"template":{"metadata":{"annotations":{"traffic.sidecar.istio.io/excludeInboundPorts":"22222,21123,9091,15020","traffic.sidecar.istio.io/excludeOutboundPorts":"53100,21123,21124,22222,19530,2379,2380,9091,9000"}}}}}'
+```
+
+## Port Reference
+
+- **15020**: Istio sidecar metrics/health port
+- **6379**: Redis
+- **7474**: Neo4j HTTP
+- **7687**: Neo4j Bolt
+- **8098**: Agent Ontology
+- **8099**: Agent RAG
+- **9000**: MinIO
+- **9091**: Milvus metrics
+- **9446**: RAG Server
+- **2379, 2380**: etcd client and peer ports
+- **19530**: Milvus proxy
+- **21123**: Milvus query node
+- **21124**: Milvus data node
+- **22222**: Milvus streaming node
+- **53100**: Milvus mix coordinator


### PR DESCRIPTION
# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)


## Type of Change

- [ ] Bugfix
- [x] New Feature: Update helm charts to include pod annotations and extra Deploy. This allows users to add any pod annotations (like for istio deploys) in their values files, and include any extra k8s resources in the extraDeploy field. This streamlines the helm diff by letting helm manage all the resources
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
