### PR TITLE
fix(auth): Fix shared key authentication not loading middleware

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py
@@ -111,7 +111,7 @@ app = a2a_server.build()
 ################################################################################
 A2A_AUTH_OAUTH2 = os.getenv('A2A_AUTH_OAUTH2', 'false').lower() == 'true'
 
-A2A_AUTH_SHARED_KEY = os.getenv('A2A_AUTH_SHARED_KEY', 'false').lower() == 'true'
+A2A_AUTH_SHARED_KEY = os.getenv('A2A_AUTH_SHARED_KEY')
 
 # Add CORSMiddleware to allow requests from any origin (disables CORS restrictions)
 app.add_middleware(


### PR DESCRIPTION
# Fix: Shared Key Authentication Middleware Not Loading

## Problem

Shared key authentication was completely non-functional due to a logic error introduced in commit 856badd1. The authentication middleware would never load, regardless of configuration, leaving all endpoints unprotected.

## Root Cause

Line 114 in `main.py` was checking if `A2A_AUTH_SHARED_KEY` equals the string `"true"`:

```python
A2A_AUTH_SHARED_KEY = os.getenv('A2A_AUTH_KEY', 'false').lower() == 'true'
```

When users set the actual secret key (e.g., `A2A_AUTH_SHARED_KEY=abc123...`), this check would always return `False`, preventing the middleware from loading.

## Solution

This PR reverts line 114 to the correct implementation from commit 821d68e9:

```python
A2A_AUTH_SHARED_KEY = os.getenv('A2A_AUTH_SHARED_KEY')
```

Now the middleware loads when a key is set (any truthy value) and uses that key for authentication validation.

## Changes

- **File**: `ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py`
- **Line**: 114
- **Change**: Remove boolean comparison, just read the env var value

## Testing

Verified the fix with:

1. ✅ Requests without authentication → `401 Unauthorized`
2. ✅ Requests with valid Bearer token → Success
3. ✅ Requests with invalid token → `401 Unauthorized`
4. ✅ Public endpoints still accessible without auth

## Impact

- **Severity**: Critical security fix
- **Breaking Changes**: None
- **Backward Compatibility**: Fully compatible - restores intended behavior

## Related Issues

This fixes the authentication bypass that was preventing shared key authentication from working as documented.

---

**Note**: This is a simple one-line revert that restores the correct behavior from commit 821d68e9 which was accidentally broken in commit 856badd1.

Fixes #398