### PR TITLE
fix: correct ingress path templating and consistent rag ingress

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,15 +6,15 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.1
+version: 0.4.2
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.2.1
+    version: 0.2.2
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-jira
     tags:
       - agent-jira
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-slack
     tags:
       - agent-slack
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.3.1
+    version: 0.3.2
     alias: agent-webex
     tags:
       - agent-webex
@@ -125,7 +125,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.0.3
+    version: 0.0.4
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.1"
+appVersion: "0.3.2"

--- a/charts/ai-platform-engineering/charts/agent/templates/ingress.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/ingress.yaml
@@ -31,7 +31,6 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          {{- range .paths }}
           - path: /
             pathType: Prefix
             backend:
@@ -39,7 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-          {{- end }}
     {{- end }}
     {{- else }}
     - http:

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.1"
+appVersion: "0.2.2"

--- a/charts/ai-platform-engineering/charts/supervisor-agent/templates/ingress.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/templates/ingress.yaml
@@ -31,7 +31,6 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          {{- range .paths }}
           - path: /
             pathType: Prefix
             backend:
@@ -39,7 +38,6 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-          {{- end }}
     {{- end }}
     {{- else }}
     - http:

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -3,8 +3,8 @@ name: rag-stack
 description: A complete RAG stack including web UI, server, agents, Redis, Neo4j and Milvus
 
 type: application
-version: 0.0.3
-appVersion: "0.0.3"
+version: 0.0.4
+appVersion: "0.0.4"
 
 dependencies:
   - name: rag-server
@@ -20,7 +20,7 @@ dependencies:
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-webui
-    version: "0.0.1"
+    version: "0.0.2"
     repository: "file://./charts/rag-webui"
     condition: rag-webui.enabled
   - name: neo4j

--- a/charts/rag-stack/charts/rag-webui/Chart.yaml
+++ b/charts/rag-stack/charts/rag-webui/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.0.2"

--- a/charts/rag-stack/charts/rag-webui/templates/ingress.yaml
+++ b/charts/rag-stack/charts/rag-webui/templates/ingress.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.ingress.enabled -}}
+{{- $fullName := include "rag-webui.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -24,18 +26,28 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- if .Values.ingress.hosts }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ . | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          - path: /
+            pathType: Prefix
             backend:
               service:
-                name: {{ include "rag-webui.fullname" $ }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ $.Values.service.port }}
-          {{- end }}
+                  number: {{ $svcPort }}
+    {{- end }}
+    {{- else }}
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

Ingress templating changed to expect:
```
ingress:
  hosts:
    - agent.local
```
Instead of hosts being a map, it is now a list. This means `.path` no longer works and our implementation currently does not require multiple paths so hardcode the default.

Also make rag webui ingress to be consistent

## Type of Change

- [x] Bugfix
- [x] New Feature
- [x] Breaking Change - old ingress will break
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
