### PR TITLE
fix: Docker Compose dev file not starting properly

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -18,33 +18,33 @@ services:
     # 'condition: service_started' just waits for the container to start (faster but less reliable).
     depends_on:
       agent-argocd-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-aws-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-backstage-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-confluence-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-github-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-jira-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-komodor-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-pagerduty-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-petstore-p2p:
-        condition: service_healthy
+        condition: service_started
       agent_rag:
-        condition: service_healthy
+        condition: service_started
       agent-slack-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-splunk-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-weather-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-webex-p2p:
-        condition: service_healthy
+        condition: service_started
     env_file:
       - .env
     ports:
@@ -134,7 +134,7 @@ services:
       agent-argocd-p2p:
         condition: service_started
       agent-aws-p2p:
-        condition: service_healthy
+        condition: service_started
       agent-backstage-p2p:
         condition: service_started
       agent-confluence-p2p:


### PR DESCRIPTION
# Description

A recent change modified the `docker-compose.dev.yml` file to use the `service_healthy` condition for the services starting instead of the existing `service_started`. When you use the compose file as-is the supervisor never starts due to the other services not having health checks.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
