### PR TITLE
fix: tweak RAG agent ontology handling

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/agent_ontology/src/agent_ontology/agent.py
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_ontology/src/agent_ontology/agent.py
@@ -3,7 +3,7 @@ import traceback
 
 from common.graph_db.base import GraphDB
 from langgraph.prebuilt import create_react_agent
-from common.agent.tools import fetch_entity
+from common.agent.tools import graph_fetch_entity as fetch_entity
 from agent_ontology.heuristics import HeuristicsProcessor
 from agent_ontology.relation_manager import RelationCandidateManager
 from agent_ontology.prompts import RELATION_PROMPT, SYSTEM_PROMPT_1

--- a/ai_platform_engineering/knowledge_bases/rag/agent_ontology/src/agent_ontology/relation_manager.py
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_ontology/src/agent_ontology/relation_manager.py
@@ -36,7 +36,7 @@ class RelationCandidateManager:
         self.logger.info("Cleaning up relation candidates from the database")
         await self.ontology_graph_db.raw_query(f"MATCH ()-[r]->() WHERE r.heuristics_version_id <> '{self.heuristics_version_id}' DELETE r")
         await self.ontology_graph_db.raw_query(f"MATCH (n) WHERE n.heuristics_version_id <> '{self.heuristics_version_id}' DETACH DELETE n")
-        await self.data_graph_db.raw_query(f"MATCH ()-[r]-() WHERE r.{constants.UPDATED_BY_KEY}={CLIENT_NAME} AND r.{constants.HEURISTICS_VERSION_ID_KEY} <> '{self.heuristics_version_id}' DELETE r")
+        await self.data_graph_db.raw_query(f"MATCH ()-[r]-() WHERE r.{constants.UPDATED_BY_KEY}='{CLIENT_NAME}' AND r.{constants.HEURISTICS_VERSION_ID_KEY} <> '{self.heuristics_version_id}' DELETE r")
 
 
     async def _set_heuristic(self, relation_id: str, candidate: RelationCandidate, recreate: bool = False):


### PR DESCRIPTION
- Fix issue in agent.py (pod not starting looking for fetch_entity function rather than graph_fetch_entity)
- Fix issue in relation_manager.py (missing quotes around CLIENT_NAME causing cypher query to error-out)

Closes #439

# Description

I had been playing around trying to get the rag-stack working in a CAIPE context. These small errors were preventing the agent-ontology pod from functioning.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
