### PR TITLE
fix: backstage is using ES256

### DIFF
--- a/ai_platform_engineering/utils/auth/oauth2_middleware.py
+++ b/ai_platform_engineering/utils/auth/oauth2_middleware.py
@@ -25,7 +25,9 @@ A2A_AUTH_OAUTH2 = os.getenv('A2A_AUTH_OAUTH2', 'false').lower() == 'true'
 
 if A2A_AUTH_OAUTH2:
   CLOCK_SKEW_LEEWAY = 10
-  ALGORITHMS = ["RS256"]
+  # Support multiple JWT signing algorithms (RS256, ES256, etc.)
+  # Can be configured via ALLOWED_ALGORITHMS env var (comma-separated)
+  ALGORITHMS = os.environ.get("ALLOWED_ALGORITHMS", "RS256,ES256").split(",")
   JWKS_URI = os.environ["JWKS_URI"]
   AUDIENCE = os.environ["AUDIENCE"]  # expected 'aud' claim in token
   ISSUER = os.environ["ISSUER"]
@@ -35,6 +37,7 @@ if A2A_AUTH_OAUTH2:
 
   print("\n" + "="*40)
   print(f"JWKS_URI: {JWKS_URI}")
+  print(f"ALLOWED_ALGORITHMS: {ALGORITHMS}")
   print("="*40 + "\n")
 
 


### PR DESCRIPTION
# Description

Backstage token uses ES256. Make alg configurable and default allow both ES256 and RS256.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
