### PR TITLE
fix: don't build the webui image in main docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -692,9 +692,7 @@ services:
     depends_on: [rag_server, neo4j, neo4j-ontology, rag-redis]
 
   rag_webui:
-    build:
-      context: ai_platform_engineering/knowledge_bases/rag
-      dockerfile: ./build/Dockerfile.webui
+    image: ghcr.io/cnoe-io/caipe-rag-webui:${IMAGE_TAG:-stable}
     container_name: rag-webui
     environment:
       - RAG_SERVER_URL=http://rag_server:9446


### PR DESCRIPTION
# Description

Make webui pull the image instead of building one

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
