### PR TITLE
fix: docker-compose: NGINX_ENVSUBST_TEMPLATE_SUFFIX formatting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -696,7 +696,7 @@ services:
     container_name: rag-webui
     environment:
       - RAG_SERVER_URL=http://rag_server:9446
-      - NGINX_ENVSUBST_TEMPLATE_SUFFIX=".conf"
+      - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf
     depends_on: [rag_server]
     ports: ["9447:80"]
   # RAG Dependencies


### PR DESCRIPTION
# Fix for WebUI not working

In the main docker-compose we use the list format for env vars rather than dictionary format. So no quotes are needed.

In the original docker-compose, this was a dictionary: https://github.com/cnoe-io/ai-platform-engineering/blob/main/ai_platform_engineering/knowledge_bases/rag/docker-compose.yaml#L114-L115


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
