### PR TITLE
fix: deploy script to include GraphRAG services and exclude by default

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -142,7 +142,12 @@ fi
 
 # Add RAG services if enabled
 if [ "$ENABLE_RAG" = "true" ]; then
-    SHOULD_RUN="$SHOULD_RUN rag_server agent_rag agent_ontology rag_webui neo4j neo4j-ontology rag-redis milvus-standalone etcd milvus-minio"
+    SHOULD_RUN="$SHOULD_RUN rag_server agent_rag rag_webui rag-redis milvus-standalone etcd milvus-minio"
+fi
+
+# Add GraphRAG services if enabled
+if [ "$ENABLE_GRAPH_RAG" = "true" ]; then
+    SHOULD_RUN="$SHOULD_RUN rag_server agent_rag rag_webui rag-redis milvus-standalone etcd milvus-minio agent_ontology neo4j neo4j-ontology"
 fi
 
 if [ "$ENABLE_TRACING" = "true" ]; then


### PR DESCRIPTION
# Description

Remove Graph RAG services form deploy.sh, add a separate `ENABLE_GRAPH_RAG`

Removes `agent_ontology neo4j neo4j-ontology` from normal RAG mode


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
