### PR TITLE
env variable to configure agent url for agent forge

### DIFF
--- a/build/agent-forge/Dockerfile
+++ b/build/agent-forge/Dockerfile
@@ -30,4 +30,24 @@ RUN yarn install || \
 
 EXPOSE 3000
 
+# Add entrypoint script to substitute env variables
+COPY <<'EOF' /app/entrypoint.sh
+#!/bin/bash
+set -e
+
+# Default value if not provided
+AGENT_FORGE_BASE_URL=${AGENT_FORGE_BASE_URL:-http://localhost:8000}
+
+# Find and update app-config.yaml - only replace baseUrl under agentForge block
+if [ -f "app-config.yaml" ]; then
+  sed -i '/^agentForge:/,/^[^ ]/ s|baseUrl:.*|baseUrl: '"${AGENT_FORGE_BASE_URL}"'|' app-config.yaml
+fi
+
+# Execute the main command
+exec "$@"
+EOF
+
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["yarn", "start"]


### PR DESCRIPTION
# Description

added env variable to configure agent url for agent forge

## Type of Change

- [ ] Bugfix
- [ x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
