### PR TITLE
rename platform-engineer to caipe-supervisor

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -55,19 +55,19 @@ if [ "$USE_SLIM" = "true" ]; then
     sleep 5
 fi
 
-# Deploy other services (exclude platform-engineer)
+# Deploy other services (exclude caipe-supervisor)
 OTHER_PROFILES=$(echo "$PROFILES" | sed 's/slim,\?//')
 if [ -n "$OTHER_PROFILES" ]; then
     echo "Starting supporting services with profiles: $OTHER_PROFILES"
-    COMPOSE_PROFILES="$OTHER_PROFILES" docker compose up -d --scale platform-engineer=0
+    COMPOSE_PROFILES="$OTHER_PROFILES" docker compose up -d --scale caipe-supervisor=0
     echo "Waiting for services to be ready..."
     sleep 3
 fi
 
-# Deploy platform-engineer last
-echo "Starting platform-engineer..."
+# Deploy caipe-supervisor  last
+echo "Starting caipe-supervisor..."
 if [ "$1" = "--no-detach" ] || [ "$1" = "-f" ]; then
-    COMPOSE_PROFILES="$PROFILES" docker compose up platform-engineer
+    COMPOSE_PROFILES="$PROFILES" docker compose up caipe-supervisor
 else
-    COMPOSE_PROFILES="$PROFILES" docker compose up -d platform-engineer
+    COMPOSE_PROFILES="$PROFILES" docker compose up -d caipe-supervisor
 fi


### PR DESCRIPTION
# Description

rename platform-engineer to caipe-supervisor


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
