### PR TITLE
fix: Add 'graph_rag' profile to docker-compose services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -572,6 +572,7 @@ services:
     depends_on: [rag-redis]
     profiles:
       - rag
+      - graph_rag
 
   agent_rag:
     image: ghcr.io/cnoe-io/caipe-rag-agent-rag:${IMAGE_TAG:-stable}
@@ -589,6 +590,7 @@ services:
     restart: unless-stopped
     profiles:
       - rag
+      - graph_rag
 
   agent_ontology:
     image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-stable}
@@ -606,7 +608,7 @@ services:
     restart: unless-stopped
     depends_on: [rag_server, neo4j, neo4j-ontology, rag-redis]
     profiles:
-      - donotstart
+      - graph_rag
 
   rag_webui:
     image: ghcr.io/cnoe-io/caipe-rag-webui:${IMAGE_TAG:-stable}
@@ -618,6 +620,7 @@ services:
     ports: ["9447:80"]
     profiles:
       - rag
+      - graph_rag
 
   # RAG Dependencies
   neo4j:
@@ -637,7 +640,7 @@ services:
       - NEO4J_apoc_import_file_enabled=true
       - NEO4J_apoc_import_file_use__neo4j__config=true
     profiles:
-      - rag
+      - graph_rag
 
   neo4j-ontology:
     image: neo4j:latest
@@ -656,7 +659,7 @@ services:
       - NEO4J_apoc_import_file_enabled=true
       - NEO4J_apoc_import_file_use__neo4j__config=true
     profiles:
-      - rag
+      - graph_rag
 
   rag-redis:
     image: redis
@@ -668,6 +671,7 @@ services:
     restart: unless-stopped
     profiles:
       - rag
+      - graph_rag
 
   milvus-standalone:
     image: milvusdb/milvus:v2.6.0
@@ -691,6 +695,7 @@ services:
     depends_on: [etcd, milvus-minio]
     profiles:
       - rag
+      - graph_rag
 
   etcd:
     image: quay.io/coreos/etcd:v3.5.18
@@ -710,6 +715,7 @@ services:
       retries: 3
     profiles:
       - rag
+      - graph_rag
 
   milvus-minio:
     image: minio/minio:RELEASE.2024-05-28T17-19-04Z
@@ -728,6 +734,7 @@ services:
       retries: 3
     profiles:
       - rag
+      - graph_rag
 
   # Langfuse Tracing Services
   langfuse-worker:


### PR DESCRIPTION
Added 'graph_rag' profile to multiple services in docker-compose.

# Description

Add a `graph_rag` profile so the normal `rag` profile doesnt startup neo4j and agent_ontology

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
