### PR TITLE
docs: update agent-chat-cli uvx command to use --no-cache flag

### DIFF
--- a/ai_platform_engineering/agents/argocd/README.md
+++ b/ai_platform_engineering/agents/argocd/README.md
@@ -53,7 +53,7 @@ Pick one of the following methods:
 - **Python CLI:**
 
   ```bash
-  uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+  uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
   ```
 
 ---

--- a/ai_platform_engineering/agents/aws/Makefile
+++ b/ai_platform_engineering/agents/aws/Makefile
@@ -144,7 +144,7 @@ run-docker-a2a:   ## Run A2A Docker container
 ## ========== Client Tools ==========
 
 run-a2a-client:   ## Run A2A client
-	@uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+	@uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 
 ## ========== Help ==========
 

--- a/ai_platform_engineering/agents/aws/README.md
+++ b/ai_platform_engineering/agents/aws/README.md
@@ -140,7 +140,7 @@ docker run -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ## 🏗️ Architecture

--- a/ai_platform_engineering/agents/backstage/README.md
+++ b/ai_platform_engineering/agents/backstage/README.md
@@ -79,7 +79,7 @@ docker run --rm -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ---

--- a/ai_platform_engineering/agents/common.mk
+++ b/ai_platform_engineering/agents/common.mk
@@ -142,11 +142,11 @@ run-mcp: setup-venv check-env ## Run MCP server in HTTP mode
 
 run-a2a-client: setup-venv ## Run A2A client script
 	@$(MAKE) check-env
-	@$(venv-run) uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+	@$(venv-run) uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 
 run-mcp-client: setup-venv ## Run MCP client script
 	@$(MAKE) check-env
-	@$(venv-run) uvx https://github.com/cnoe-io/agent-chat-cli.git mcp
+	@$(venv-run) uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git mcp
 
 langgraph-dev: setup-venv ## Run LangGraph dev mode
 	@$(venv-run) langgraph dev

--- a/ai_platform_engineering/agents/confluence/README.md
+++ b/ai_platform_engineering/agents/confluence/README.md
@@ -70,7 +70,7 @@ docker run -p 0.0.0.0:8000:8000 -it\
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ## 🏗️ Architecture

--- a/ai_platform_engineering/agents/github/README.md
+++ b/ai_platform_engineering/agents/github/README.md
@@ -219,7 +219,7 @@ pip install uv
 Now you can use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ## Local Development

--- a/ai_platform_engineering/agents/jira/README.md
+++ b/ai_platform_engineering/agents/jira/README.md
@@ -70,7 +70,7 @@ docker run -p 0.0.0.0:8000:8000 -it\
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ## 🏗️ Architecture

--- a/ai_platform_engineering/agents/pagerduty/README.md
+++ b/ai_platform_engineering/agents/pagerduty/README.md
@@ -80,7 +80,7 @@ docker run --rm -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ---

--- a/ai_platform_engineering/agents/slack/README.md
+++ b/ai_platform_engineering/agents/slack/README.md
@@ -130,7 +130,7 @@ docker run -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ### Alternative: Running Locally

--- a/ai_platform_engineering/agents/splunk/README.md
+++ b/ai_platform_engineering/agents/splunk/README.md
@@ -75,7 +75,7 @@ docker run --rm -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ---
@@ -176,7 +176,7 @@ flowchart TD
 Search for error logs in the last 24 hours from the web application
 ```
 
-### Alert Management  
+### Alert Management
 ```
 Create an alert for when CPU usage exceeds 80% for more than 5 minutes
 ```
@@ -251,4 +251,4 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 📄 License
 
-Apache 2.0 
+Apache 2.0

--- a/ai_platform_engineering/agents/template-claude-agent-sdk/README.md
+++ b/ai_platform_engineering/agents/template-claude-agent-sdk/README.md
@@ -81,7 +81,7 @@ docker run --rm -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ---

--- a/ai_platform_engineering/agents/template/README.md
+++ b/ai_platform_engineering/agents/template/README.md
@@ -80,7 +80,7 @@ docker run --rm -p 0.0.0.0:8000:8000 -it \
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ---

--- a/ai_platform_engineering/agents/webex/Makefile
+++ b/ai_platform_engineering/agents/webex/Makefile
@@ -97,11 +97,11 @@ run-mcp:           ## Run MCP server in SSE mode
 
 run-a2a-client: setup-venv ## Run A2A client script
 	@$(MAKE) check-env
-	@$(venv-run) uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+	@$(venv-run) uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 
 run-mcp-client: setup-venv ## Run MCP client script
 	@$(MAKE) check-env
-	@$(venv-run) uvx https://github.com/cnoe-io/agent-chat-cli.git mcp
+	@$(venv-run) uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git mcp
 
 ## ========== Docker ==========
 

--- a/ai_platform_engineering/agents/webex/README.md
+++ b/ai_platform_engineering/agents/webex/README.md
@@ -52,7 +52,7 @@ docker run -p 0.0.0.0:8000:8000 -it\
 Use the [agent-chat-cli](https://github.com/cnoe-io/agent-chat-cli) to interact with the agent:
 
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 ## 🏗️ Architecture
@@ -132,7 +132,7 @@ Agent: I can help you with Webex tasks such as:
 - Listing messages in rooms or direct messages
 - Listing users in a room
 - Listing rooms you are a member of
-- Listing messages in a thread        
+- Listing messages in a thread
 
 ---
 

--- a/charts/ai-platform-engineering/README.md
+++ b/charts/ai-platform-engineering/README.md
@@ -217,7 +217,7 @@ Your agents will be available at: `http://localhost:[LOCAL_PORT]`
 
 ```bash
 # Install and use the agent chat CLI
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a --host localhost --port [LOCAL_PORT]
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a --host localhost --port [LOCAL_PORT]
 ```
 
 ### Option 2: Ingress Deployment (Domain Access)
@@ -285,7 +285,7 @@ You should see a `405 Method Not Allowed` response, which is expected (the agent
 
 ```bash
 # Use the domain name instead of localhost
-uvx https://github.com/cnoe-io/agent-chat-cli.git a2a --host agent-[AGENT_NAME].local --port 80
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a --host agent-[AGENT_NAME].local --port 80
 ```
 
 ### Uninstall

--- a/docs/docs/changes/2024-10-22-streaming-architecture.md
+++ b/docs/docs/changes/2024-10-22-streaming-architecture.md
@@ -179,7 +179,7 @@ Implement custom streaming handling in the executor for A2A sub-agents while kee
 ### Current State (Not Streaming)
 
 ```bash
-uvx git+https://github.com/cnoe-io/agent-chat-cli a2a \
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a \
   --host 10.99.255.178 --port 8000
 
 # Type: show me komodor clusters

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -122,7 +122,7 @@ Setup CAIPE to run in a docker environment on a laptop or a virtual machine like
 
    **Option B: Using uvx**
    ```bash
-   uvx https://github.com/cnoe-io/agent-chat-cli.git <a2a|mcp>
+   uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
    ```
 
    > 💡 For more connection options and troubleshooting, see the [Quick Start Guide](../quick-start.md).

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -172,7 +172,7 @@ docker run -it --network=host ghcr.io/cnoe-io/agent-chat-cli:stable
 
 **Option B: Using uvx**
 ```bash
-uvx https://github.com/cnoe-io/agent-chat-cli.git <a2a|mcp>
+uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
 ```
 
 **Option C: Using Agent Forge Backstage Plugin**

--- a/docs/docs/getting-started/user-interfaces.md
+++ b/docs/docs/getting-started/user-interfaces.md
@@ -24,7 +24,7 @@ These interfaces empower users to build and manage sophisticated multi-agent sys
    *Or, clone and run the chat client:*
 
    ```bash
-   uvx https://github.com/cnoe-io/agent-chat-cli.git a2a
+   uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
    ```
 
 


### PR DESCRIPTION
## Summary

Updated all documentation and Makefiles to use the new uvx command format with `--no-cache` flag:

```bash
uvx --no-cache git+https://github.com/cnoe-io/agent-chat-cli.git a2a
```

## Changes

- Updated all agent README files (argocd, aws, backstage, confluence, github, jira, pagerduty, slack, splunk, template, template-claude-agent-sdk, webex)
- Updated documentation in `docs/docs/getting-started/` (user-interfaces.md, quick-start.md, docker-compose/setup.md)
- Updated Makefiles (`common.mk`, `webex/Makefile`, `aws/Makefile`)
- Updated Helm chart README
- Updated ADR documentation (`2024-10-22-streaming-architecture.md`)

## Benefits

- Ensures the latest version is always fetched without using cached versions
- Improves reliability and consistency across installations
- Standardizes the command format across all documentation

## Testing

All documentation has been updated consistently. The command format change is backward compatible and improves reliability.