### PR TITLE
ci: add uv installation to integration test workflows

### DIFF
--- a/.github/workflows/tests-detailed-sanity-integration.yml
+++ b/.github/workflows/tests-detailed-sanity-integration.yml
@@ -100,6 +100,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Run detailed integration tests
         run: |
           make detailed-test

--- a/.github/workflows/tests-quick-sanity-integration-dev.yml
+++ b/.github/workflows/tests-quick-sanity-integration-dev.yml
@@ -102,6 +102,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Start services
         run: |
           set -euo pipefail

--- a/.github/workflows/tests-quick-sanity-integration-on-latest-tag.yml
+++ b/.github/workflows/tests-quick-sanity-integration-on-latest-tag.yml
@@ -105,6 +105,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Start services
         run: |
           set -euo pipefail

--- a/.github/workflows/tests-quick-sanity-integration-on-stable-tag.yml
+++ b/.github/workflows/tests-quick-sanity-integration-on-stable-tag.yml
@@ -102,6 +102,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Start services
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

This PR adds `uv` installation to all integration test workflows to fix the `make: uv: No such file or directory` error.

## Changes

Added `uv` installation step to 4 workflows:
- `tests-quick-sanity-integration-dev.yml`
- `tests-quick-sanity-integration-on-stable-tag.yml`
- `tests-quick-sanity-integration-on-latest-tag.yml`
- `tests-detailed-sanity-integration.yml`

Each workflow now includes:
```yaml
- name: Install uv
  run: |
    curl -LsSf https://astral.sh/uv/install.sh | sh
    echo "$HOME/.cargo/bin" >> $GITHUB_PATH
```

## Problem

The workflows were failing with:
```
make: uv: No such file or directory
make: *** [Makefile:190: quick-sanity] Error 127
```

This happened because `make quick-sanity` and other targets use `uv run` commands, but `uv` wasn't installed in the CI environment.

## Solution

Install `uv` using the official installer script and add it to PATH before running make targets.

## Testing

This will be tested when the PR is merged and workflows run.