### PR TITLE
fix(ci): correct workflow ID in trigger script

### DIFF
--- a/.github/workflows/tests-quick-sanity-integration-on-latest-tag.yml
+++ b/.github/workflows/tests-quick-sanity-integration-on-latest-tag.yml
@@ -217,7 +217,7 @@ jobs:
             const { data: workflowRuns } = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'quick-sanity-integration-tests-stable.yml',
+              workflow_id: 'tests-quick-sanity-integration-on-stable-tag.yml',
               status: 'in_progress',
               per_page: 1
             });
@@ -227,7 +227,7 @@ jobs:
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                workflow_id: 'quick-sanity-integration-tests-stable.yml',
+                workflow_id: 'tests-quick-sanity-integration-on-stable-tag.yml',
                 ref: 'main'
               });
               console.log('Triggered stable integration tests workflow');


### PR DESCRIPTION
## Summary

Fixed incorrect workflow ID in the GitHub Actions script that triggers the stable integration tests workflow.

## Problem

The script was trying to trigger a workflow with ID `quick-sanity-integration-tests-stable.yml`, but the actual workflow file is named `tests-quick-sanity-integration-on-stable-tag.yml`. This caused the error:

```
HttpError: Workflow does not have 'workflow_dispatch' trigger
```

## Solution

Updated the workflow ID in both places in the script:
- `listWorkflowRuns` call
- `createWorkflowDispatch` call

Changed from: `quick-sanity-integration-tests-stable.yml`
Changed to: `tests-quick-sanity-integration-on-stable-tag.yml`

## Verification

The stable tag workflow already has `workflow_dispatch` enabled, so once the correct workflow ID is used, the trigger will work correctly.