### PR TITLE
test(integration): improve error logging for keyword assertion failures

### DIFF
--- a/integration/a2a_client_integration_test.py
+++ b/integration/a2a_client_integration_test.py
@@ -452,7 +452,15 @@ class TestAgentCommunication:
 
         logger.info(f"✅ Prompt '{prompt_id}' ({category}) successful - response: {response}")
         if expected_keywords:
-            assert len(found_keywords) > 0, f"None of expected keywords {expected_keywords} found in response for {prompt_id}"
+            if len(found_keywords) == 0:
+                # Log detailed failure information for debugging
+                logger.error(f"❌ Prompt '{prompt_id}' failed - response (first 500 chars): {response[:500]}")
+                logger.error(f"❌ Expected keywords: {expected_keywords}")
+                logger.error(f"❌ Response length: {len(response)}")
+                # Check if this looks like a notification/intermediate message
+                if len(response) < 100 and ("calling" in response_lower or "supervisor" in response_lower or "agent" in response_lower):
+                    logger.warning(f"⚠️ Response appears to be an intermediate notification, not final result")
+            assert len(found_keywords) > 0, f"None of expected keywords {expected_keywords} found in response for {prompt_id}. Response (first 500 chars): {response[:500]}"
             logger.info(f"✅ Prompt '{prompt_id}' ({category}) successful - found keywords: {found_keywords}")
         else:
             logger.info(f"✅ Prompt '{prompt_id}' ({category}) successful - response length: {len(response)}")


### PR DESCRIPTION
## Summary

Enhanced error logging in integration tests to help diagnose test failures,
particularly when running against stable Docker images that may not have
the latest code fixes.

## Problem

When integration tests fail with keyword assertion errors, it's difficult to
diagnose the root cause because:
- The actual response content is not fully logged
- It's unclear if the response is an intermediate notification vs final result
- No indication of response length or format

This is especially problematic when:
- Testing against stable Docker images (pre-built, may be outdated)
- Agent responses don't match expected format
- Only intermediate notifications are returned instead of final results

## Solution

Added detailed error logging when expected keywords are not found:

1. **Response Preview**: Logs first 500 characters of actual response
2. **Expected Keywords**: Shows which keywords were expected but not found
3. **Response Length**: Displays total response length
4. **Notification Detection**: Warns if response appears to be an intermediate
   notification (short response with words like 'calling', 'supervisor', 'agent')
5. **Enhanced Assertion Message**: Includes response preview in assertion error

## Example Output

When a test fails, you'll now see:
```
❌ Prompt 'github_info' failed - response (first 500 chars): 🔧 Supervisor: Calling Agent Write_Todos...
❌ Expected keywords: ['github', 'ai-platform-engineering', 'cnoe-io', ...]
❌ Response length: 42
⚠️ Response appears to be an intermediate notification, not final result
```

## Benefits

- Easier debugging of test failures in CI environments
- Better understanding of what the agent is actually returning
- Helps identify when stable images need to be rebuilt
- Makes it clear when responses are incomplete or malformed

## Testing

This change only affects error logging - no functional changes to test logic.
The enhanced logging will be visible when tests fail, making it easier to
diagnose issues.