### PR TITLE
fix(ci): add tag support to agent-forge workflow and prevent docs deployment on tags

### DIFF
--- a/.github/workflows/ci-agent-forge-plugin.yml
+++ b/.github/workflows/ci-agent-forge-plugin.yml
@@ -55,6 +55,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=sha,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -6,7 +6,6 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-    tags: ["*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary

This PR fixes two CI workflow issues:

1. **Agent Forge Build Workflow**: Added missing `type=ref,event=tag` to Docker metadata tags configuration to support non-semver tags like `stable`.

2. **Docs Deployment Workflow**: Removed `tags: ["*"]` trigger to prevent deployment failures on tag pushes due to GitHub Pages environment protection rules.

## Changes

### `.github/workflows/ci-agent-forge-plugin.yml`
- Added `type=ref,event=tag` to Docker metadata tags configuration
- Fixes build failure: `ERROR: failed to build: tag is needed when pushing to registry`
- Now supports both semver tags (v1.2.3) and non-semver tags (stable, latest)

### `.github/workflows/publish-gh-pages.yml`
- Removed `tags: ["*"]` trigger
- Prevents deployment failures on tag pushes
- Docs now only deploy from main branch or manual triggers

## Testing

- [x] Workflow syntax validated
- [x] Changes follow conventional commit format
- [x] DCO sign-off included

## Related Issues

Fixes deployment failures seen in:
- https://github.com/cnoe-io/ai-platform-engineering/actions/runs/19533977706
- https://github.com/cnoe-io/ai-platform-engineering/actions/runs/19533974224