### PR TITLE
fix: chart was not bumped with prompt config change

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.8
+version: 0.4.9
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent


### PR DESCRIPTION
# Description

Chart was not bumped


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
