### PR TITLE
chore(charts): update chart version and remove RAG warning from prompts

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.13
+version: 0.4.14
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml
@@ -209,7 +209,6 @@ system_prompt_template: |
 
   **Agent Routing:**
   - Use RAG agent for: concepts, documentation, runbooks, best practices, AND parameter discovery (organization names, repository owners, service configurations, etc.)
-  - **CRITICAL**: For research/knowledge queries ("research about X"), don't rely on RAG alone - also search ArgoCD, GitHub, Confluence, Jira, and other relevant agents
   - Use operational agents for: real-time data, status, health, create/update operations
   - For incidents: Use specialized agents (Incident Investigator, Incident Documenter, MTTR Analyst, Uptime Analyst)
   - When sub-agents need missing parameters: Query RAG first to discover the correct values before asking the user

--- a/charts/ai-platform-engineering/data/prompt_config.deep_agent_jarvis.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.deep_agent_jarvis.yaml
@@ -247,7 +247,6 @@ system_prompt_template: |
 
   **Agent Routing:**
   - Use RAG agent for: concepts, documentation, runbooks, best practices, AND parameter discovery (organization names, repository owners, service configurations, etc.)
-  - **CRITICAL**: For research/knowledge queries ("research about X"), don't rely on RAG alone - also search ArgoCD, GitHub, Confluence, Jira, and other relevant agents
   - Use operational agents for: real-time data, status, health, create/update operations
   - For incidents: Use specialized agents (Incident Investigator, Incident Documenter, MTTR Analyst, Uptime Analyst)
   - When sub-agents need missing parameters: Query RAG first to discover the correct values before asking the user


### PR DESCRIPTION
## Changes

- Bump chart version from 0.4.13 to 0.4.14
- Remove CRITICAL warning about not relying on RAG alone for research queries from both prompt configs

### Prompt Config Updates

Removed the following line from both `deep_agent` and `deep_agent_jarvis` prompt configs:
- `**CRITICAL**: For research/knowledge queries ("research about X"), don't rely on RAG alone - also search ArgoCD, GitHub, Confluence, Jira, and other relevant agents`

This simplifies the prompt configuration by removing redundant multi-agent search instructions that were already removed from TODO rules in a previous PR.

## Files Changed

- `charts/ai-platform-engineering/Chart.yaml` - Version bump to 0.4.14
- `charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml` - Removed RAG warning
- `charts/ai-platform-engineering/data/prompt_config.deep_agent_jarvis.yaml` - Removed RAG warning