### PR TITLE
fix(agent-confluence): make agent-confluence use the same env var names as official confluence MCP

### DIFF
--- a/ai_platform_engineering/agents/confluence/mcp/mcp_confluence/api/client.py
+++ b/ai_platform_engineering/agents/confluence/mcp/mcp_confluence/api/client.py
@@ -62,7 +62,7 @@ async def make_api_request(
 
     # Use the utility function to retrieve the token if not provided
     token = token or get_env()
-    email = str(os.getenv("ATLASSIAN_EMAIL") or os.getenv("CONFLUENCE_EMAIL") or os.getenv("CONFLUENCE_USER"))
+    email = str(os.getenv("ATLASSIAN_EMAIL") or os.getenv("CONFLUENCE_EMAIL") or os.getenv("CONFLUENCE_USER") or os.getenv("CONFLUENCE_USERNAME"))
     url = str(os.getenv("CONFLUENCE_API_URL") or os.getenv("ATLASSIAN_API_URL") or os.getenv("CONFLUENCE_URL"))
     if not token:
         logger.error("No API token available. Request cannot proceed.")


### PR DESCRIPTION
# Description

The official confluence mcp only accepts `CONFLUENCE_USER` but our agent currently doesn't accept this variable name.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
