### PR TITLE
chore(compose): sanitize defaults and simplify stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,8 +274,7 @@ release: setup-venv  ## Bump version and create a release
 	@git add CHANGELOG.md
 	@git commit -m "docs: update changelog"
 	@cz bump --increment $${INCREMENT:-PATCH}
-	@git tag -f stable
-	@echo "Version bumped and stable tag updated successfully."
+	@echo "Version bumped updated successfully."
 
 ## ========== Help ==========
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -156,8 +156,8 @@ services:
       - IAM_MCP_READONLY=${IAM_MCP_READONLY:-true}
       - USE_AWS_CLI_AS_TOOL=${USE_AWS_CLI_AS_TOOL:-true}
       # Multi-account support - format: "name1:id1,name2:id2" or just "id1,id2"
-      - DEFAULT_AWS_ACCOUNT_ID=${DEFAULT_AWS_ACCOUNT_ID:-outshift-common-dev:471112537430}
-      - AWS_ACCOUNT_LIST=${AWS_ACCOUNT_LIST:-eticloud:626007623524,outshift-common-dev:471112537430,outshift-common-staging:637423531539,outshift-common-prod:058264538874,eti-ci:009736724745,cisco-research:509581005347,eticloud-demo:075967417574}
+      - DEFAULT_AWS_ACCOUNT_ID=${DEFAULT_AWS_ACCOUNT_ID:-outshift-common-dev:123456789012}
+      - AWS_ACCOUNT_LIST=${AWS_ACCOUNT_LIST:-account1:123456789012,account2:123456789013}
       - CROSS_ACCOUNT_ROLE_NAME=${CROSS_ACCOUNT_ROLE_NAME:-caipe-read-only}
       - STRANDS_LOG_LEVEL=${STRANDS_LOG_LEVEL:-INFO}
       - FASTMCP_LOG_LEVEL=${FASTMCP_LOG_LEVEL:-ERROR}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -129,6 +129,7 @@ services:
     env_file: [.env]
     ports: ["8012:8000"]
     environment:
+      - AWS_AGENT_BACKEND=${AWS_AGENT_BACKEND:-langgraph}
       - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
       - MCP_MODE=http
       - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
@@ -145,6 +146,8 @@ services:
       - IAM_MCP_READONLY=${IAM_MCP_READONLY:-true}
       - STRANDS_LOG_LEVEL=${STRANDS_LOG_LEVEL:-INFO}
       - FASTMCP_LOG_LEVEL=${FASTMCP_LOG_LEVEL:-ERROR}
+      - DEFAULT_AWS_ACCOUNT_ID=${DEFAULT_AWS_ACCOUNT_ID:-outshift-common-dev:123456789012}
+      - AWS_ACCOUNT_LIST=${AWS_ACCOUNT_LIST:-account1:123456789012,account2:123456789013}
     profiles:
       - aws
       - all-agents
@@ -310,7 +313,7 @@ services:
       - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
     depends_on:
       mcp-confluence:
-        condition: service_healthy
+        condition: service_started
     profiles:
       - confluence
       - all-agents
@@ -324,12 +327,6 @@ services:
       - CONFLUENCE_URL=${CONFLUENCE_URL}
       - CONFLUENCE_USERNAME=${CONFLUENCE_USERNAME}
       - CONFLUENCE_API_TOKEN=${CONFLUENCE_API_TOKEN}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
     profiles:
       - confluence
       - all-agents
@@ -609,24 +606,6 @@ services:
     restart: unless-stopped
     env_file: [.env]
     depends_on: [rag-redis]
-    profiles:
-      - rag
-      - graph_rag
-
-  agent_rag:
-    image: ghcr.io/cnoe-io/caipe-rag-agent-rag:${IMAGE_TAG:-stable}
-    container_name: agent_rag
-    ports: ["8099:8099"]
-    env_file: [.env]
-    environment:
-      - REDIS_URL=redis://rag-redis:6379/0
-      - NEO4J_ADDR=neo4j://neo4j:7687
-      - NEO4J_ONTOLOGY_ADDR=neo4j://neo4j-ontology:7688
-      - NEO4J_USERNAME=neo4j
-      - NEO4J_PASSWORD=dummy_password
-      - RAG_SERVER_URL=http://rag_server:9446
-      - ENABLE_GRAPH_RAG=${ENABLE_GRAPH_RAG:-true}
-    restart: unless-stopped
     profiles:
       - rag
       - graph_rag


### PR DESCRIPTION
### Summary
- Add `AWS_AGENT_BACKEND` env var default for `agent-aws`
- Replace real AWS account defaults with placeholders
- Relax `mcp-confluence` dependency condition and remove `mcp-confluence` healthcheck
- Remove `agent_rag` service from compose
- Stop force-updating `stable` tag in `make release`

### Why
Avoid leaking real account IDs in dev defaults and simplify local compose startup.