### PR TITLE
fix: add MAX_SEARCH_RESULTS and WARN_SEARCH_RESULTS for argocd agent

### DIFF
--- a/ai_platform_engineering/agents/argocd/mcp/mcp_argocd/tools/search.py
+++ b/ai_platform_engineering/agents/argocd/mcp/mcp_argocd/tools/search.py
@@ -10,6 +10,7 @@ on names, descriptions, labels, annotations, etc.
 from typing import Dict, Any, List
 import re
 import logging
+import os
 from mcp_argocd.tools.api_v1_applications import (
     list_applications,
     _get_argocd_base_url,
@@ -22,9 +23,9 @@ from mcp_argocd.tools.api_v1_clusters import cluster_service__list
 # Configure logging
 logger = logging.getLogger(__name__)
 
-# Safety limits to prevent OOM
-MAX_SEARCH_RESULTS = 1000  # Never return more than 1000 items total across all resource types
-WARN_SEARCH_RESULTS = 500  # Log warning if search returns more than this
+# Safety limits to prevent OOM and SSE timeout issues (configurable via env vars)
+MAX_SEARCH_RESULTS = int(os.getenv("MAX_SEARCH_RESULTS", "1000"))
+WARN_SEARCH_RESULTS = int(os.getenv("WARN_SEARCH_RESULTS", "500"))
 
 
 async def search_argocd_resources(


### PR DESCRIPTION
# Description

We are trying to work around the following intermittent error when our argocd mcp search results return a large dataset:

httpx.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)

Added the ability to tune the MAX_SEARCH_RESULTS on deployment to try and avoid this error. 

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)


## Type of Change

- [x ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)



## Checklist

- [ x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ x] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
