### PR TITLE
fix: critical fix for ingestor

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/ingestor.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/ingestor.py
@@ -561,8 +561,8 @@ class IngestorBuilder:
             if not datasources:
                 # No datasources yet - use sync_interval to avoid tight loop
                 # The sync function should create datasources if needed
-                logger.debug(f"No datasources found, will check again after sync_interval ({self._sync_interval}s)")
-                return self._sync_interval
+                logger.debug(f"No datasources found, will check again in 30 seconds")
+                return 30  # 30 seconds
             
             # Find the earliest datasource that will need reloading
             min_time_until_reload = self._sync_interval


### PR DESCRIPTION
# Description

Fixes the case where there are no datasources to sync, and ingestor waits till next cycle


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
