### PR TITLE
fix(helm): make grafana dashboard label configurable

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.5.13
+version: 0.5.14
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/templates/grafana-dashboard-configmap.yaml
+++ b/charts/ai-platform-engineering/templates/grafana-dashboard-configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ai-platform-engineering.labels" . | nindent 4 }}
-    grafana_dashboard: "1"
+    {{- with .Values.metrics.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.metrics.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -61,6 +61,10 @@ metrics:
     metricRelabelings: []
   grafanaDashboard:
     enabled: true
+    # Labels for Grafana sidecar dashboard discovery
+    # Override to match your Grafana sidecar configuration (e.g., grafana_dashboard: "local")
+    labels:
+      grafana_dashboard: "1"
 
 # Extra Kubernetes resources to deploy
 extraDeploy: []


### PR DESCRIPTION
# Description

Allow grafana cm label to be configurable fully

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
