### PR TITLE
feat(helm): add Gateway API HTTPRoute support

### DIFF
--- a/charts/ai-platform-engineering/Chart.lock
+++ b/charts/ai-platform-engineering/Chart.lock
@@ -1,40 +1,40 @@
 dependencies:
 - name: supervisor-agent
   repository: ""
-  version: 0.2.0
+  version: 0.2.4
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: agent
   repository: ""
-  version: 0.3.0
+  version: 0.4.2
 - name: slim
   repository: oci://ghcr.io/agntcy/slim/helm
   version: v0.1.8
@@ -43,9 +43,9 @@ dependencies:
   version: v0.1.3
 - name: rag-stack
   repository: file://../rag-stack
-  version: 0.0.5
+  version: 0.0.7
 - name: backstage-plugin-agent-forge
   repository: ""
   version: 0.1.0
-digest: sha256:18f2bb9311e7b5c87d372e33137383a1ddb9760e79591ca1bac5d73d43bdefc3
-generated: "2025-10-31T16:51:23.837712974Z"
+digest: sha256:425c8dc855c7fc66800c9fa887245e864847f2ac4d07717a6d86d6089a470471
+generated: "2026-01-07T11:06:13.268309Z"

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
 - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.5.14
+version: 0.5.15
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
@@ -125,7 +125,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.0.6
+    version: 0.0.7
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack

--- a/charts/rag-stack/Chart.lock
+++ b/charts/rag-stack/Chart.lock
@@ -1,21 +1,24 @@
 dependencies:
 - name: rag-server
   repository: file://./charts/rag-server
-  version: 0.0.1
+  version: 0.0.2
 - name: agent-ontology
   repository: file://./charts/agent-ontology
+  version: 0.0.3
+- name: rag-ingestors
+  repository: file://./charts/rag-ingestors
   version: 0.0.2
 - name: rag-webui
   repository: file://./charts/rag-webui
-  version: 0.0.1
+  version: 0.0.3
 - name: neo4j
   repository: https://helm.neo4j.com/neo4j
   version: 2025.7.1
 - name: rag-redis
   repository: file://./charts/rag-redis
-  version: 0.0.1
+  version: 0.0.3
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm/
   version: 5.0.2
-digest: sha256:e159334dafeab366a557d5c284a3d04f52fcae96d830557ba4cac398a9a05cae
-generated: "2025-10-20T16:24:44.82709-05:00"
+digest: sha256:d68900926e26ae2bc630d8f66bc22505d2be0345324c1acae19aba5511550a98
+generated: "2025-12-19T20:01:49.408155Z"

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: rag-stack
 description: A complete RAG stack including web UI, server, agents, Redis, Neo4j and Milvus
 
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.6"
 
 dependencies:

--- a/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
@@ -237,3 +237,83 @@ Get Neo4j password
     {{- end -}}
     {{- $password -}}
 {{- end -}}
+
+{{/*
+Determine if Gateway API is enabled - global value takes precedence
+*/}}
+{{- define "agent.gatewayApi.enabled" -}}
+{{- if hasKey .Values "global" }}
+{{- if hasKey .Values.global "gatewayApi" }}
+{{- if hasKey .Values.global.gatewayApi "enabled" }}
+{{- .Values.global.gatewayApi.enabled }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get Gateway name from global configuration
+*/}}
+{{- define "agent.gatewayApi.gatewayName" -}}
+{{- $name := "" -}}
+{{- with .Values.global -}}
+{{- with .gatewayApi -}}
+{{- if hasKey . "gatewayName" -}}
+{{- $name = .gatewayName -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $name -}}
+{{- end }}
+
+{{/*
+Get Gateway namespace from global configuration, default to release namespace
+*/}}
+{{- define "agent.gatewayApi.gatewayNamespace" -}}
+{{- $namespace := .Release.Namespace -}}
+{{- with .Values.global -}}
+{{- with .gatewayApi -}}
+{{- if and (hasKey . "gatewayNamespace") .gatewayNamespace -}}
+{{- $namespace = .gatewayNamespace -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $namespace -}}
+{{- end }}
+
+{{/*
+Map Ingress pathType to Gateway API HTTPRoute path match type
+Ingress: Prefix, Exact, ImplementationSpecific
+Gateway API: PathPrefix, Exact, RegularExpression
+*/}}
+{{- define "agent.gatewayApi.pathType" -}}
+{{- $ingressType := . | default "Prefix" -}}
+{{- if eq $ingressType "Prefix" -}}
+PathPrefix
+{{- else if eq $ingressType "Exact" -}}
+Exact
+{{- else if eq $ingressType "ImplementationSpecific" -}}
+PathPrefix
+{{- else -}}
+PathPrefix
+{{- end -}}
+{{- end }}
+
+{{/*
+Determine if ingress should be rendered - enabled when ingress.enabled is true AND gatewayApi is NOT enabled
+*/}}
+{{- define "agent.ingress.shouldRender" -}}
+{{- $ingressEnabled := include "agent.ingress.enabled" . | eq "true" -}}
+{{- $gatewayEnabled := include "agent.gatewayApi.enabled" . | eq "true" -}}
+{{- if and $ingressEnabled (not $gatewayEnabled) -}}
+{{- true -}}
+{{- else -}}
+{{- false -}}
+{{- end -}}
+{{- end }}

--- a/charts/rag-stack/charts/agent-ontology/templates/httproute.yaml
+++ b/charts/rag-stack/charts/agent-ontology/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{- if include "agent.gatewayApi.enabled" . | eq "true" -}}
+{{- $fullName := include "agent.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $gatewayName := include "agent.gatewayApi.gatewayName" . -}}
+{{- $gatewayNamespace := include "agent.gatewayApi.gatewayNamespace" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    {{- if ne $gatewayNamespace .Release.Namespace }}
+    namespace: {{ $gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.ingress.hosts }}
+  hostnames:
+  {{- range .Values.ingress.hosts }}
+  - {{ .host | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  {{- range .paths }}
+  - matches:
+    - path:
+        type: {{ include "agent.gatewayApi.pathType" .pathType }}
+        value: {{ .path }}
+    backendRefs:
+    - name: {{ $fullName }}
+      port: {{ $svcPort }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/rag-stack/charts/agent-ontology/templates/ingress.yaml
+++ b/charts/rag-stack/charts/agent-ontology/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if include "agent.ingress.enabled" . | eq "true" -}}
+{{- if include "agent.ingress.shouldRender" . | eq "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/rag-stack/charts/rag-redis/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-redis/templates/_helpers.tpl
@@ -60,3 +60,83 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine if Gateway API is enabled - global value takes precedence
+*/}}
+{{- define "rag-redis.gatewayApi.enabled" -}}
+{{- if hasKey .Values "global" }}
+{{- if hasKey .Values.global "gatewayApi" }}
+{{- if hasKey .Values.global.gatewayApi "enabled" }}
+{{- .Values.global.gatewayApi.enabled }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get Gateway name from global configuration
+*/}}
+{{- define "rag-redis.gatewayApi.gatewayName" -}}
+{{- $name := "" -}}
+{{- with .Values.global -}}
+{{- with .gatewayApi -}}
+{{- if hasKey . "gatewayName" -}}
+{{- $name = .gatewayName -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $name -}}
+{{- end }}
+
+{{/*
+Get Gateway namespace from global configuration, default to release namespace
+*/}}
+{{- define "rag-redis.gatewayApi.gatewayNamespace" -}}
+{{- $namespace := .Release.Namespace -}}
+{{- with .Values.global -}}
+{{- with .gatewayApi -}}
+{{- if and (hasKey . "gatewayNamespace") .gatewayNamespace -}}
+{{- $namespace = .gatewayNamespace -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $namespace -}}
+{{- end }}
+
+{{/*
+Map Ingress pathType to Gateway API HTTPRoute path match type
+Ingress: Prefix, Exact, ImplementationSpecific
+Gateway API: PathPrefix, Exact, RegularExpression
+*/}}
+{{- define "rag-redis.gatewayApi.pathType" -}}
+{{- $ingressType := . | default "Prefix" -}}
+{{- if eq $ingressType "Prefix" -}}
+PathPrefix
+{{- else if eq $ingressType "Exact" -}}
+Exact
+{{- else if eq $ingressType "ImplementationSpecific" -}}
+PathPrefix
+{{- else -}}
+PathPrefix
+{{- end -}}
+{{- end }}
+
+{{/*
+Determine if ingress should be rendered - enabled when ingress.enabled is true AND gatewayApi is NOT enabled
+*/}}
+{{- define "rag-redis.ingress.shouldRender" -}}
+{{- $ingressEnabled := .Values.ingress.enabled | default false -}}
+{{- $gatewayEnabled := include "rag-redis.gatewayApi.enabled" . | eq "true" -}}
+{{- if and $ingressEnabled (not $gatewayEnabled) -}}
+{{- true -}}
+{{- else -}}
+{{- false -}}
+{{- end -}}
+{{- end }}

--- a/charts/rag-stack/charts/rag-redis/templates/httproute.yaml
+++ b/charts/rag-stack/charts/rag-redis/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{- if include "rag-redis.gatewayApi.enabled" . | eq "true" -}}
+{{- $fullName := include "rag-redis.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $gatewayName := include "rag-redis.gatewayApi.gatewayName" . -}}
+{{- $gatewayNamespace := include "rag-redis.gatewayApi.gatewayNamespace" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "rag-redis.fullname" . }}
+  labels:
+    {{- include "rag-redis.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    {{- if ne $gatewayNamespace .Release.Namespace }}
+    namespace: {{ $gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.ingress.hosts }}
+  hostnames:
+  {{- range .Values.ingress.hosts }}
+  - {{ .host | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  {{- range .paths }}
+  - matches:
+    - path:
+        type: {{ include "rag-redis.gatewayApi.pathType" .pathType }}
+        value: {{ .path }}
+    backendRefs:
+    - name: {{ $fullName }}
+      port: {{ $svcPort }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/rag-stack/charts/rag-redis/templates/ingress.yaml
+++ b/charts/rag-stack/charts/rag-redis/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if include "rag-redis.ingress.shouldRender" . | eq "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/rag-stack/charts/rag-webui/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-webui/templates/_helpers.tpl
@@ -79,3 +79,83 @@ Get Rag Server URL combining host and port
     {{- end -}}
     {{- printf "http://%s:%s" $host ($port | toString) -}}
 {{- end -}}
+
+{{/*
+Determine if Gateway API is enabled - global value takes precedence
+*/}}
+{{- define "rag-webui.gatewayApi.enabled" -}}
+{{- if hasKey .Values "global" }}
+{{- if hasKey .Values.global "gatewayApi" }}
+{{- if hasKey .Values.global.gatewayApi "enabled" }}
+{{- .Values.global.gatewayApi.enabled }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- else }}
+{{- false }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get Gateway name from global configuration
+*/}}
+{{- define "rag-webui.gatewayApi.gatewayName" -}}
+{{- $name := "" -}}
+{{- with .Values.global -}}
+{{- with .gatewayApi -}}
+{{- if hasKey . "gatewayName" -}}
+{{- $name = .gatewayName -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $name -}}
+{{- end }}
+
+{{/*
+Get Gateway namespace from global configuration, default to release namespace
+*/}}
+{{- define "rag-webui.gatewayApi.gatewayNamespace" -}}
+{{- $namespace := .Release.Namespace -}}
+{{- with .Values.global -}}
+{{- with .gatewayApi -}}
+{{- if and (hasKey . "gatewayNamespace") .gatewayNamespace -}}
+{{- $namespace = .gatewayNamespace -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $namespace -}}
+{{- end }}
+
+{{/*
+Map Ingress pathType to Gateway API HTTPRoute path match type
+Ingress: Prefix, Exact, ImplementationSpecific
+Gateway API: PathPrefix, Exact, RegularExpression
+*/}}
+{{- define "rag-webui.gatewayApi.pathType" -}}
+{{- $ingressType := . | default "Prefix" -}}
+{{- if eq $ingressType "Prefix" -}}
+PathPrefix
+{{- else if eq $ingressType "Exact" -}}
+Exact
+{{- else if eq $ingressType "ImplementationSpecific" -}}
+PathPrefix
+{{- else -}}
+PathPrefix
+{{- end -}}
+{{- end }}
+
+{{/*
+Determine if ingress should be rendered - enabled when ingress.enabled is true AND gatewayApi is NOT enabled
+*/}}
+{{- define "rag-webui.ingress.shouldRender" -}}
+{{- $ingressEnabled := .Values.ingress.enabled | default false -}}
+{{- $gatewayEnabled := include "rag-webui.gatewayApi.enabled" . | eq "true" -}}
+{{- if and $ingressEnabled (not $gatewayEnabled) -}}
+{{- true -}}
+{{- else -}}
+{{- false -}}
+{{- end -}}
+{{- end }}

--- a/charts/rag-stack/charts/rag-webui/templates/httproute.yaml
+++ b/charts/rag-stack/charts/rag-webui/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if include "rag-webui.gatewayApi.enabled" . | eq "true" -}}
+{{- $fullName := include "rag-webui.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $gatewayName := include "rag-webui.gatewayApi.gatewayName" . -}}
+{{- $gatewayNamespace := include "rag-webui.gatewayApi.gatewayNamespace" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "rag-webui.fullname" . }}
+  labels:
+    {{- include "rag-webui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    {{- if ne $gatewayNamespace .Release.Namespace }}
+    namespace: {{ $gatewayNamespace }}
+    {{- end }}
+  {{- if .Values.ingress.hosts }}
+  hostnames:
+  {{- range .Values.ingress.hosts }}
+  - {{ .host | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.ingress.hosts }}
+  {{- range .Values.ingress.hosts }}
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: {{ $fullName }}
+      port: {{ $svcPort }}
+  {{- end }}
+  {{- else }}
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: {{ $fullName }}
+      port: {{ $svcPort }}
+  {{- end }}
+{{- end }}

--- a/charts/rag-stack/charts/rag-webui/templates/ingress.yaml
+++ b/charts/rag-stack/charts/rag-webui/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if include "rag-webui.ingress.shouldRender" . | eq "true" -}}
 {{- $fullName := include "rag-webui.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
@@ -28,7 +28,7 @@ spec:
   rules:
     {{- if .Values.ingress.hosts }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ .host | quote }}
       http:
         paths:
           - path: /

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -20,6 +20,13 @@ global:
       host: "rag-redis"
       port: 6379
 
+  # Gateway API configuration
+  # When enabled, HTTPRoutes will be created instead of Ingress resources
+  gatewayApi:
+    enabled: false  # Disabled by default for backwards compatibility
+    gatewayName: ""  # Reference to existing Gateway resource
+    gatewayNamespace: ""  # Optional: Gateway namespace, defaults to release namespace if empty
+
   # Secrets configuration for LLM providers
   # When used as a subchart, global values can override these values
   # When used as a standalone agent, this will be the secret for the LLM provider


### PR DESCRIPTION
# Description

Add support for Kubernetes Gateway API HTTPRoutes as an alternative to Ingress resources. When global.gatewayApi.enabled is true, HTTPRoutes are created instead of Ingress resources (mutually exclusive).

Features:
- Global configuration for gateway name and namespace reference
- HTTPRoute templates for agent-ontology, rag-redis, and rag-webui
- Mutual exclusion logic between Ingress and HTTPRoute
- Support for cross-namespace gateway references
- Disabled by default for backwards compatibility

Also fixes bug in rag-webui ingress template where hostname wasn't extracted correctly from values structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
