### PR TITLE
feat(rag): Refactor Confluence ingestor to use json-based configuration

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/server.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/server.py
@@ -59,6 +59,7 @@ class WebIngestorCommand(str, Enum):
 class ConfluenceIngestRequest(BaseModel):
     url: str = Field(..., description="Confluence page URL (e.g., 'https://domain.atlassian.net/wiki/spaces/SPACE/pages/PAGE_ID/Title')")
     description: str = Field("", description="Description for this data source")
+    get_child_pages: bool = Field(False, description="Whether to ingest direct child pages of this page")
 
 class ConfluenceReloadRequest(BaseModel):
     datasource_id: str = Field(..., description="ID of the Confluence datasource to reload")

--- a/ai_platform_engineering/knowledge_bases/rag/webui/src/api/index.ts
+++ b/ai_platform_engineering/knowledge_bases/rag/webui/src/api/index.ts
@@ -41,13 +41,15 @@ export const ingestUrl = async (params: {
     sitemap_max_urls?: number;
     description?: string;
     ingest_type?: string;
+    get_child_pages?: boolean;
 }): Promise<{ datasource_id: string | null; job_id: string | null; message: string }> => {
     // Route to appropriate endpoint based on ingest_type
     if (params.ingest_type === 'confluence') {
         // Use dedicated confluence endpoint
         const response = await api.post('/v1/ingest/confluence/page', {
             url: params.url,
-            description: params.description || ''
+            description: params.description || '',
+            get_child_pages: params.get_child_pages || false
         });
         return response.data;
     } else {

--- a/ai_platform_engineering/knowledge_bases/rag/webui/src/ui/IngestView.tsx
+++ b/ai_platform_engineering/knowledge_bases/rag/webui/src/ui/IngestView.tsx
@@ -25,6 +25,7 @@ export default function IngestView() {
   const [checkForSiteMap, setCheckForSiteMap] = useState(true)
   const [sitemapMaxUrls, setSitemapMaxUrls] = useState(2000)
   const [description, setDescription] = useState('')
+  const [includeSubPages, setIncludeSubPages] = useState(false)
 
   // DataSources state
   const [dataSources, setDataSources] = useState<DataSourceInfo[]>([])
@@ -100,6 +101,12 @@ export default function IngestView() {
     setCurrentPage(1)
   }, [selectedSourceType])
 
+  // Reset includeSubPages when ingestType changes
+  useEffect(() => {
+    if (ingestType !== 'confluence') {
+      setIncludeSubPages(false)
+    }
+  }, [ingestType])
 
   useEffect(() => {
     fetchDataSources()
@@ -234,6 +241,7 @@ export default function IngestView() {
         sitemap_max_urls: sitemapMaxUrls,
         description: description,
         ingest_type: ingestType,
+        get_child_pages: ingestType === 'confluence' ? includeSubPages : undefined,
       })
       const { datasource_id, job_id, message } = response
       alert(`✅ ${message}`)
@@ -365,6 +373,19 @@ export default function IngestView() {
                   className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
                 <span className="text-sm text-slate-600">Check for sitemap</span>
+              </label>
+            </div>
+          )}
+          {ingestType === 'confluence' && (
+            <div className="mt-2 ml-2">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={includeSubPages}
+                  onChange={(e) => setIncludeSubPages(e.target.checked)}
+                  className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-sm text-slate-600">Include child pages</span>
               </label>
             </div>
           )}


### PR DESCRIPTION
Refactor Confluence ingestor to use page_configs with structured metadata, add comprehensive job failure tracking, and support child page ingestion. Switches from colon-delimited CONFLUENCE_SPACES format to JSON-based configuration for better extensibility.

* common/src/common/models/server.py (ConfluenceIngestRequest): Add get_child_pages field
* ingestors/src/ingestors/confluence/ingestor.py (parse_confluence_spaces_json, track_fetch_failures, process_page_ingestion, reload_datasource, periodic_reload): Refactor to use loader.load_pages and track failures at job level
* ingestors/src/ingestors/confluence/loader.py (fetch_child_pages, load_pages): Add child page loading and unified page fetch logic
* ingestors/src/ingestors/confluence/README.md: Updated to reflect new json config
* server/src/server/restapi.py (ingest_confluence_page, reload_datasource): Add get_child_pages parameter handling
* webui/src/api/index.ts (ConfluenceIngestRequest): Add includeSubPages field
* webui/src/ui/IngestView.tsx: Add includeSubPages checkbox and display failure count in job status

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)


## Type of Change

- [ ] Bugfix
- [ x] New Feature
- [ x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ x] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ x] Functionality is documented
- [ x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
