### PR TITLE
fix: do not include agentForge CI in the finalise and fix arm64 build

### DIFF
--- a/.github/workflows/ci-agent-forge-plugin.yml
+++ b/.github/workflows/ci-agent-forge-plugin.yml
@@ -113,20 +113,10 @@ jobs:
   build-and-push:
     needs: prepare
     if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm64
-      fail-fast: false
-
-    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout main repository
@@ -157,12 +147,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set platform tag suffix
-        id: platform
-        run: |
-          PLATFORM="${{ matrix.platform }}"
-          SUFFIX="${PLATFORM//\//-}"
-          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata for Docker
         id: meta
@@ -170,12 +159,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest-${{ steps.platform.outputs.suffix }},enable=${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
-            type=raw,value=${{ needs.prepare.outputs.tag_version }}-${{ steps.platform.outputs.suffix }},enable=${{ needs.prepare.outputs.tag_version != '' }}
-            type=sha,format=short,suffix=-${{ steps.platform.outputs.suffix }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ needs.prepare.outputs.tag_version }},enable=${{ needs.prepare.outputs.tag_version != '' }}
+            type=sha,format=short
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -187,48 +173,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
-          platforms: ${{ matrix.platform }}
-
-  # Create multi-arch manifest after platform builds complete
-  create-manifest:
-    needs: [prepare, build-and-push]
-    if: needs.prepare.outputs.should_build == 'true' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push manifest
-        run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          TAG_VERSION="${{ needs.prepare.outputs.tag_version }}"
-
-          # Create manifest for version tag if provided
-          if [ -n "$TAG_VERSION" ]; then
-            echo "Creating manifest for $TAG_VERSION..."
-            docker manifest create "${IMAGE}:${TAG_VERSION}" \
-              "${IMAGE}:${TAG_VERSION}-linux-amd64" \
-              "${IMAGE}:${TAG_VERSION}-linux-arm64"
-            docker manifest push "${IMAGE}:${TAG_VERSION}"
-          fi
-
-          # Create manifest for latest if on main or workflow_dispatch
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Creating manifest for latest..."
-            docker manifest create "${IMAGE}:latest" \
-              "${IMAGE}:latest-linux-amd64" \
-              "${IMAGE}:latest-linux-arm64"
-            docker manifest push "${IMAGE}:latest"
-          fi
-
-          echo "✅ Multi-arch manifests created"
+          platforms: linux/amd64,linux/arm64
 
   # Retag unchanged agent forge from previous version when tag_version is provided
   # If source image doesn't exist (still building), falls back to full build
@@ -337,6 +282,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        if: steps.retag-or-build.outputs.needs_build == 'true'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-buildx-action@v3
@@ -352,12 +301,12 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
-    needs: [prepare, build-and-push, create-manifest, retag-unchanged]
+    needs: [prepare, build-and-push, retag-unchanged]
     # Only notify for final releases (non-RC tags) - RC builds don't need release finalization
     if: |
       always() &&
@@ -371,15 +320,13 @@ jobs:
         run: |
           # Determine overall conclusion
           BUILD_RESULT="${{ needs.build-and-push.result }}"
-          MANIFEST_RESULT="${{ needs.create-manifest.result }}"
           RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
-          if [[ "$MANIFEST_RESULT" == "skipped" ]]; then MANIFEST_RESULT="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MANIFEST_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -55,7 +55,6 @@ jobs:
             "[CI][MCP] Sub-Agents MCP Docker Build and Push"
             "[CI][A2A] CAIPE RAG Build and Push"
             "[CI][A2A] Supervisor Agent Docker Build and Push"
-            "[CI][AgentForge] Build and Push"
           )
 
           ALL_PASSED=true


### PR DESCRIPTION
# Description

We don't really need agentForge for the release to be published so still trigger but don't make it as a condition. Our github also doesn't have arm64 runner so change to using normal.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
