### PR TITLE
fix(ci): handle docs-only changes gracefully in CAIPE UI workflow

### DIFF
--- a/.github/actions/determine-release-tag/action.yml
+++ b/.github/actions/determine-release-tag/action.yml
@@ -35,8 +35,11 @@ runs:
         done
 
         if [ -z "$RUN_ID" ]; then
-          echo "❌ Could not find rc-tag.yml run for this commit"
-          exit 1
+          echo "⚠️  No rc-tag.yml run found for this commit"
+          echo "📝 This is expected for documentation-only or non-release changes"
+          echo "🏷️  Will build with 'latest' tag instead of RC tag"
+          echo "tag=" >> $GITHUB_OUTPUT
+          exit 0
         fi
 
         echo "⏳ Waiting for workflow run $RUN_ID to complete..."


### PR DESCRIPTION
## Summary

Fixes the `ci-caipe-ui` workflow failure that occurs when documentation-only changes are merged to `main`.

**Root Cause:**
- The `ci-caipe-ui.yml` workflow triggers on any changes to `ui/**` paths (including docs)
- The `rc-tag.yml` workflow only triggers on code changes (`ai_platform_engineering/**`, `build/**`, etc.)
- When docs-only PRs merge, `ci-caipe-ui` waits for an RC tag that never comes, causing failure

**Solution:**
- Updated `determine-release-tag` action to handle missing RC tag runs gracefully
- Instead of failing, it now exits successfully and proceeds with `latest` tag
- Added informative messages explaining this is expected behavior for non-release changes

## Changes

- Modified `.github/actions/determine-release-tag/action.yml`:
  - Changed exit code from `1` to `0` when no RC tag workflow is found
  - Added clear messaging about expected behavior
  - Allows workflow to proceed with empty tag (defaults to `latest`)

## Testing

This fix addresses the failure seen in:
- Run: https://github.com/cnoe-io/ai-platform-engineering/actions/runs/21396443979
- PR #713 (docs-only changes that still triggered UI workflow)

## Impact

- ✅ Documentation PRs will no longer fail CI unnecessarily
- ✅ UI builds will still succeed with `latest` tag for docs changes
- ✅ RC tagging workflow continues to work normally for code changes
- ✅ No breaking changes to existing behavior

## Related

- Closes the issue with PR #713's failing CI
- Improves developer experience for documentation contributions
