### PR TITLE
fix(ui): force dynamic rendering for runtime env injection

### DIFF
--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Inter, JetBrains_Mono, Source_Sans_3, IBM_Plex_Sans } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/components/auth-provider";
@@ -46,35 +47,44 @@ const DEFAULT_TAGLINE = "Multi-Agent Collaboration & Workflow Automation";
 const DEFAULT_DESCRIPTION = "AI agents and native apps collaborating across tools and teams to get work done.";
 const DEFAULT_APP_NAME = "CAIPE";
 
-// Get branding from environment variables
-const tagline = process.env.NEXT_PUBLIC_TAGLINE || DEFAULT_TAGLINE;
-const description = process.env.NEXT_PUBLIC_DESCRIPTION || DEFAULT_DESCRIPTION;
-const appName = process.env.NEXT_PUBLIC_APP_NAME || DEFAULT_APP_NAME;
-const fullDescription = `${tagline} - ${description}`;
+/**
+ * Dynamic metadata — reads process.env at request time so branding
+ * reflects runtime env vars, not build-time values.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  const tagline = process.env.NEXT_PUBLIC_TAGLINE || DEFAULT_TAGLINE;
+  const description = process.env.NEXT_PUBLIC_DESCRIPTION || DEFAULT_DESCRIPTION;
+  const appName = process.env.NEXT_PUBLIC_APP_NAME || DEFAULT_APP_NAME;
+  const fullDescription = `${tagline} - ${description}`;
 
-export const metadata: Metadata = {
-  title: `${appName} UI`,
-  description: fullDescription,
-  icons: {
-    icon: [
-      { url: "/favicon.ico", sizes: "any" },
-      { url: "/icon.ico", sizes: "any" },
-    ],
-    shortcut: "/favicon.ico",
-    apple: "/favicon.ico",
-  },
-  openGraph: {
+  return {
     title: `${appName} UI`,
     description: fullDescription,
-    url: "https://caipe.example.com",
-  },
-};
+    icons: {
+      icon: [
+        { url: "/favicon.ico", sizes: "any" },
+        { url: "/icon.ico", sizes: "any" },
+      ],
+      shortcut: "/favicon.ico",
+      apple: "/favicon.ico",
+    },
+    openGraph: {
+      title: `${appName} UI`,
+      description: fullDescription,
+      url: "https://caipe.example.com",
+    },
+  };
+}
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Force dynamic rendering so PublicEnvScript reads process.env at request
+  // time instead of capturing empty values at build time.
+  await headers();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>


### PR DESCRIPTION
## Summary

- **Root cause**: PR #779 introduced `PublicEnvScript` as a Server Component to inject `NEXT_PUBLIC_*` env vars into `window.__RUNTIME_ENV__` at request time. However, the root layout was **statically rendered at build time**, so `PublicEnvScript` captured an empty `process.env` and injected `window.__RUNTIME_ENV__={}` into the HTML. This broke SSO, branding, and all other runtime config in production (Docker/K8s) where env vars are only available at runtime, not build time.

- **Fix**: Call `await headers()` in `RootLayout` to force dynamic rendering, ensuring `PublicEnvScript` reads `process.env` at every request. Also convert static `metadata` export to `generateMetadata()` so the page title reflects runtime branding (e.g. the configured app name instead of the default).

## Test plan

- [ ] Verify `window.__RUNTIME_ENV__` contains all `NEXT_PUBLIC_*` vars (browser console)
- [ ] Verify SSO login/logout flow works in production deployment
- [ ] Verify `UserMenu` appears in the top-right after login
- [ ] Verify page title reflects runtime `NEXT_PUBLIC_APP_NAME` value
- [ ] Verify branding (logo, tagline, spinner color) loads correctly from runtime env


Made with [Cursor](https://cursor.com)