### PR TITLE
fix(docs): resolve MDX compilation and broken link errors breaking GH Pages build

### DIFF
--- a/docs/docs/changes/2026-01-29-caipe-ui-hybrid-storage-quickstart.md
+++ b/docs/docs/changes/2026-01-29-caipe-ui-hybrid-storage-quickstart.md
@@ -330,4 +330,4 @@ export const isMongoDBConfigured = false;
 - 🎭 **Demos**: localStorage mode (no infrastructure)
 - 🚀 **Production**: MongoDB mode (persistent, scalable)
 
-For more details, see [HYBRID-STORAGE.md](./HYBRID-STORAGE.md)
+For more details, see the hybrid storage documentation in the UI source code.

--- a/docs/docs/changes/2026-01-30-caipe-ui-session-cookie-fix.md
+++ b/docs/docs/changes/2026-01-30-caipe-ui-session-cookie-fix.md
@@ -202,7 +202,7 @@ console.log('[Auth] JWT keys:', Object.keys(token));
 
 ## ✅ Status
 
-**FIXED**: Session cookie size reduced from 8KB to <1KB
+**FIXED**: Session cookie size reduced from 8KB to less than 1KB
 
 **Action Required**:
 1. ✅ Code updated

--- a/docs/docs/knowledge_bases/authentication.md
+++ b/docs/docs/knowledge_bases/authentication.md
@@ -338,9 +338,9 @@ OIDC_EMAIL_CLAIM=username  # If your provider uses username claim
 
 ## References
 
-- [RAG Server Source Code](../../../ai_platform_engineering/knowledge_bases/rag/)
-- [UI Authentication Config](../../../ui/src/lib/auth-config.ts)
-- [Helm Chart Values](../../../charts/rag-stack/charts/rag-server/values.yaml)
+- [RAG Server Source Code](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/)
+- [UI Authentication Config](https://github.com/cnoe-io/ai-platform-engineering/blob/main/ui/src/lib/auth-config.ts)
+- [Helm Chart Values](https://github.com/cnoe-io/ai-platform-engineering/blob/main/charts/rag-stack/charts/rag-server/values.yaml)
 - [NextAuth Documentation](https://next-auth.js.org/)
 
 ## Version Compatibility


### PR DESCRIPTION
## Summary

- Replace `<1KB` with `less than 1KB` in session-cookie-fix ADR — MDX interprets `<` followed by a digit as an invalid JSX tag, causing `Unexpected character '1' (U+0031)` compilation error
- Fix broken link to non-existent `HYBRID-STORAGE.md` in hybrid storage ADR
- Convert relative source-code links in `knowledge_bases/authentication.md` to absolute GitHub URLs (relative paths pointing outside `docs/` break Docusaurus link validation)

## Context

The [Publish Docs GH Pages workflow](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/21843793496/job/63034680687) is failing on every push to `main` with:

```
Error: MDX compilation failed for file "docs/docs/changes/2026-01-30-caipe-ui-session-cookie-fix.md"
Cause: Unexpected character `1` (U+0031) before name
```

## Test plan

- [x] `make docs-build` passes locally with `[SUCCESS] Generated static files in "build"`
- [ ] GH Pages workflow passes after merge


Made with [Cursor](https://cursor.com)