### PR TITLE
fix(docs): escape email in MDX to fix Docusaurus build

### DIFF
--- a/docs/docs/changes/2026-02-10-ui-scroll-performance-fixes.md
+++ b/docs/docs/changes/2026-02-10-ui-scroll-performance-fixes.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-02-10
 **Status**: Implemented
-**Author**: Sri Aradhyula <sraradhy@cisco.com>
+**Author**: Sri Aradhyula `<sraradhy@cisco.com>`
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Wraps `<sraradhy@cisco.com>` in backticks on line 5 of `docs/docs/changes/2026-02-10-ui-scroll-performance-fixes.md` to prevent MDX from interpreting the `<...@...>` as a JSX tag
- Fixes the Docusaurus GH Pages build failure (#587): `Unexpected character '@' (U+0040) in name`

## Root Cause

Docusaurus uses MDX which treats `<...>` as JSX syntax. The `@` character inside angle brackets is not valid in a JSX tag name, causing a compilation error. Wrapping in backticks renders it as inline code, bypassing MDX parsing.

## Test Plan

- [ ] GH Pages workflow passes after merge

Made with [Cursor](https://cursor.com)