### PR TITLE
fix(docs): add gitlab agent to sidebar navigation

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -214,6 +214,10 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'doc',
+          id: 'agents/gitlab',
+        },
+        {
+          type: 'doc',
           id: 'agents/jira',
         },
         {


### PR DESCRIPTION
## Summary
- Added missing gitlab agent entry to docs sidebar configuration
- The `docs/docs/agents/gitlab.md` file exists but was not accessible from the navigation

## Test plan
- [ ] Verify docs build succeeds
- [ ] Verify gitlab agent appears in sidebar under "Agents & MCP Servers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)