### PR TITLE
feat: Return trace_id to clients for Langfuse feedback

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor.py
@@ -713,8 +713,9 @@ class AIPlatformEngineerA2AExecutor(AgentExecutor):
             trace_id = str(uuid.uuid4()).replace('-', '').lower()
             logger.info(f"Generated ROOT trace_id: {trace_id}")
 
-        # Initialize state with trace_id for client feedback/scoring
-        state = StreamState(trace_id=trace_id)
+        # Initialize state
+        state = StreamState()
+        state.trace_id = trace_id  # For client feedback/scoring
 
         try:
             async for event in self.agent.stream(query, context_id, trace_id):


### PR DESCRIPTION
# Description

Expose trace_id through A2A protocol responses to enable client-side feedback and scoring via Langfuse. Changes include:

- Add trace_id field to StreamState dataclass
- Include trace_id in TaskStatusUpdateEvent metadata on completion
- Include trace_id in artifact metadata for final results
- Pass trace_id through _send_completion method

# Validation

```bash
>>>  python3 << 'EOF'
import requests, uuid
r = requests.post("http://localhost:8000", json={"jsonrpc": "2.0", "id": 1, "method": "message/send", "params": {"message": {"messageId": str(uuid.uuid4()), "role": "user",
"parts": [{"text": "What's 2+2?", "kind": "text"}], "kind": "message"}}}, headers={"Accept": "application/json"}, timeout=120).json().get("result", {})
for a in r.get("artifacts", []):
        if a.get("name") == "final_result":
                for p in a.get("parts", []):
                        if t := p.get("text"): print(t)
                if tid := a.get("metadata", {}).get("trace_id"): print(f"\n✅ found trace_id at result.artifacts[final_result].metadata.trace_id: {tid}")
        if tid := r.get("status", {}).get("metadata", {}).get("trace_id"): print(f"✅ found trace_id at result.status.metadata.trace_id: {tid}")
EOF

2 + 2 = 4

✅ found trace_id at result.artifacts[final_result].metadata.trace_id: a26d1cc30d36413480d9b4c30da93edc
```

<img width="1044" height="958" alt="Screenshot 2026-02-13 at 2 11 57 PM" src="https://github.com/user-attachments/assets/66cf836a-bc6a-45d3-b881-a5a3980db62e" />
