### PR TITLE
fix: release manual to directly trigger helm release

### DIFF
--- a/.github/workflows/helm-release-version-sync.yml
+++ b/.github/workflows/helm-release-version-sync.yml
@@ -246,18 +246,3 @@ jobs:
             echo "✅ Tag '$TAG' now points to commit with synced versions"
           fi
 
-      - name: 🚀 Trigger Helm chart publish
-        if: steps.check.outputs.skip != 'true' && steps.version.outputs.mode == 'tag_push'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "🚀 Triggering Helm chart publish workflow..."
-          echo "   (skipped when called via workflow_call — the caller handles this)"
-
-          OUTPUT=$(gh workflow run helm.yml --ref main -f publish_all=true 2>&1) || {
-            echo "❌ Failed to trigger Helm publish workflow"
-            echo "   Error: $OUTPUT"
-            echo "   Run manually: gh workflow run helm.yml --ref main -f publish_all=true"
-            exit 1
-          }
-          echo "✅ Helm publish workflow triggered successfully"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -17,6 +17,13 @@ on:
         options:
           - 'true'
           - 'false'
+  workflow_call:
+    inputs:
+      publish_all:
+        description: 'Publish all charts (bypass change detection)'
+        required: false
+        default: 'false'
+        type: string
 
 permissions:
   contents: read
@@ -145,8 +152,8 @@ jobs:
   publish:
     name: Push Helm Charts to GHCR
     runs-on: ubuntu-latest
-    # Publish on merge to main or workflow_dispatch
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    # Publish on merge to main, workflow_dispatch, or workflow_call
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
 
     steps:
       - name: 📥 Checkout repository
@@ -166,8 +173,8 @@ jobs:
       - name: 🔍 Detect Changed Charts
         id: detect
         run: |
-          # Check if publish_all is set (workflow_dispatch)
-          PUBLISH_ALL="${{ github.event.inputs.publish_all }}"
+          # Check if publish_all is set (workflow_dispatch or workflow_call)
+          PUBLISH_ALL="${{ inputs.publish_all }}"
 
           if [[ "$PUBLISH_ALL" == "true" ]]; then
             echo "📦 publish_all=true, will publish all charts"

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -23,10 +23,19 @@ jobs:
       version: ${{ github.event.inputs.version }}
     secrets: inherit
 
+  # Then: Publish Helm charts to GHCR
+  publish-helm-charts:
+    name: Publish Helm Charts
+    needs: sync-chart-versions
+    uses: ./.github/workflows/helm.yml
+    with:
+      publish_all: 'true'
+    secrets: inherit
+
   # Then: Create the release
   release:
     name: Create Release
-    needs: sync-chart-versions
+    needs: [sync-chart-versions, publish-helm-charts]
     runs-on: ubuntu-latest
     steps:
       - name: 🔒 Harden runner
@@ -225,21 +234,6 @@ jobs:
             exit 1
           fi
           echo "📝 Images will be tagged with $NEW_VERSION when builds complete"
-
-      - name: 🚀 Trigger Helm chart publish
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          NEW_VERSION="${{ github.event.inputs.version }}"
-          echo "🚀 Triggering Helm chart publish for $NEW_VERSION..."
-
-          OUTPUT=$(gh workflow run helm.yml --ref main -f publish_all=true 2>&1) || {
-            echo "❌ Failed to trigger Helm publish workflow"
-            echo "   Error: $OUTPUT"
-            echo "   You may need to run it manually: gh workflow run helm.yml --ref main -f publish_all=true"
-            exit 1
-          }
-          echo "✅ Helm publish workflow triggered successfully"
 
       - name: 🚀 Create GitHub Release (Draft)
         env:


### PR DESCRIPTION
# Description

I seems our GITHUB_TOKEN in manual release doesn't have permission to trigger the helm chart workflow anymore:
```
Run echo "🚀 Triggering Helm chart publish workflow..."
🚀 Triggering Helm chart publish workflow...
could not create workflow dispatch event: HTTP 401: Bad credentials (https://api.github.com/repos/cnoe-io/ai-platform-engineering/actions/workflows/168172413/dispatches)
Try authenticating with:  gh auth login
⚠️ Failed to trigger Helm publish workflow (may need to be run manually) 
```
although it was working until 5 days ago. Make manual trigger to call helm publish directly.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
