### PR TITLE
fix(confluence-ingestor): accept CONFLUENCE_API_TOKEN as fallback for CONFLUENCE_TOKEN

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/confluence/ingestor.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/confluence/ingestor.py
@@ -46,9 +46,9 @@ CONFLUENCE_USERNAME = os.environ.get("CONFLUENCE_USERNAME")
 if not CONFLUENCE_USERNAME:
     raise ValueError("CONFLUENCE_USERNAME environment variable is required")
 
-CONFLUENCE_TOKEN = os.environ.get("CONFLUENCE_TOKEN")
+CONFLUENCE_TOKEN = os.environ.get("CONFLUENCE_TOKEN") or os.environ.get("CONFLUENCE_API_TOKEN")
 if not CONFLUENCE_TOKEN:
-    raise ValueError("CONFLUENCE_TOKEN environment variable is required")
+    raise ValueError("CONFLUENCE_TOKEN (or CONFLUENCE_API_TOKEN) environment variable is required")
 
 CONFLUENCE_SSL_VERIFY = (
     os.environ.get("CONFLUENCE_SSL_VERIFY", "true").lower() == "true"


### PR DESCRIPTION
## Summary

- The Confluence RAG ingestor reads `CONFLUENCE_TOKEN` but the existing `agent-confluence-secret` stores the Atlassian API token under `CONFLUENCE_API_TOKEN`
- This mismatch caused the ingestor to crash on startup with `ValueError: CONFLUENCE_TOKEN environment variable is required`
- Fix: accept either `CONFLUENCE_TOKEN` or `CONFLUENCE_API_TOKEN` so the ingestor can reuse the existing agent secret without duplication

## Change

```python
# Before
CONFLUENCE_TOKEN = os.environ.get("CONFLUENCE_TOKEN")

# After
CONFLUENCE_TOKEN = os.environ.get("CONFLUENCE_TOKEN") or os.environ.get("CONFLUENCE_API_TOKEN")
```

## Test plan

- [ ] Deploy the Confluence ingestor in caipe-preview using `envFrom: agent-confluence-secret` (which provides `CONFLUENCE_API_TOKEN`)
- [ ] Verify ingestor starts without `ValueError`
- [ ] Verify SRE space pages are ingested into the RAG knowledge base


Made with [Cursor](https://cursor.com)