### PR TITLE
ci: use latest semver release tag instead of stable in quick-sanity workflow

### DIFF
--- a/.github/workflows/tests-quick-sanity-integration-on-stable-tag.yml
+++ b/.github/workflows/tests-quick-sanity-integration-on-stable-tag.yml
@@ -1,5 +1,5 @@
-name: "[Tests][Stable Tag] Quick Sanity Integration"
-description: "Run quick sanity integration tests on stable tag"
+name: "[Tests][Release Tag] Quick Sanity Integration"
+description: "Run quick sanity integration tests on the latest release tag"
 
 on:
   push:
@@ -32,6 +32,25 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Resolve latest release tag
+        id: resolve-tag
+        run: |
+          set -euo pipefail
+          # Find the latest semver release tag (exclude rc/pre-release and the 'stable' alias)
+          LATEST_TAG=$(git tag --sort=-version:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "ERROR: No semver release tag found" >&2
+            exit 1
+          fi
+          echo "Resolved latest release tag: $LATEST_TAG"
+          echo "IMAGE_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
+          echo "image_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create .env from GitHub Secrets
         run: |
@@ -110,7 +129,8 @@ jobs:
       - name: Start services
         run: |
           set -euo pipefail
-          IMAGE_TAG=stable docker compose -f docker-compose.yaml --profile=p2p up -d
+          echo "Starting services with IMAGE_TAG=$IMAGE_TAG"
+          docker compose -f docker-compose.yaml --profile=p2p up -d
 
       - name: Stream service logs (background)
         run: |
@@ -119,7 +139,7 @@ jobs:
           echo "::group::Service logs"
 
           # Stream logs to console AND file for artifact upload
-          ( IMAGE_TAG=stable docker compose -f docker-compose.yaml --profile=p2p logs -f --no-color --timestamps \
+          ( docker compose -f docker-compose.yaml --profile=p2p logs -f --no-color --timestamps \
               | tee -a compose-live.log ) &
           echo $! > logs.pid
         shell: bash
@@ -159,7 +179,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: compose-logs-stable
+          name: compose-logs-release-${{ steps.resolve-tag.outputs.image_tag }}
           path: compose-live.log
           if-no-files-found: warn
 
@@ -167,6 +187,6 @@ jobs:
         if: always()
         run: |
           echo "::group::Clean-up workspace"
-          IMAGE_TAG=stable docker compose -f docker-compose.yaml --profile=p2p down -v --remove-orphans || true
+          docker compose -f docker-compose.yaml --profile=p2p down -v --remove-orphans || true
           docker rmi -f $(docker images -aq) || true
           echo "::endgroup::"


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `IMAGE_TAG=stable` in the **[Tests][Stable Tag] Quick Sanity Integration** workflow with a dynamic step that resolves the latest semver release tag (e.g. `0.2.19`) at runtime
- Renames the workflow to **[Tests][Release Tag] Quick Sanity Integration** to reflect the new behavior

## Problem

The `stable` git tag is a mutable alias that only gets updated *after* the `[Tests][Latest Tag]` workflow succeeds. When the quick-sanity workflow is triggered by a push to main, it uses `IMAGE_TAG=stable` to pull Docker images — but `stable` may lag or briefly point to an older release, causing flaky failures unrelated to the merged code.

Run [#431](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/22168858188) is an example of this: the 6m 9s runtime (vs normal ~3m 40s) suggests a transient startup issue, not a code regression.

## Solution

Add a **"Resolve latest release tag"** step that:
1. Fetches all tags (`fetch-depth: 0`, `fetch-tags: true`)
2. Greps for the latest strict semver tag (`X.Y.Z` — no rc/pre-release, no `stable` alias)
3. Exports it as `IMAGE_TAG` env var for all subsequent steps
4. Fails fast with a clear error if no release tag is found

## Changes

| File | What changed |
|------|-------------|
| `tests-quick-sanity-integration-on-stable-tag.yml` | Dynamic tag resolution, removed all `IMAGE_TAG=stable` hardcodes, versioned artifact name, updated workflow name |

## Test plan

- [x] Workflow YAML is valid (no syntax errors)
- [ ] Manual `workflow_dispatch` run should show `Resolved latest release tag: 0.2.19` and pull the `0.2.19` Docker images

Made with [Cursor](https://cursor.com)