### PR TITLE
fix(ui): persist user input on the UI after refresh or page return

### DIFF
--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -55,6 +55,10 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
     metadata: UserInputMetadata;
   } | null>(null);
 
+  // Track message IDs where the user explicitly dismissed the input form,
+  // so we don't re-show it after the restore effect runs.
+  const dismissedInputForMessageRef = useRef<Set<string>>(new Set());
+
   // Auto-scroll state
   const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
   const [showScrollButton, setShowScrollButton] = useState(false);
@@ -218,6 +222,71 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeConversationId, conversation?.messages?.length]);
+
+  // ═══════════════════════════════════════════════════════════════
+  // RESTORE PENDING USER INPUT FORM after page refresh / navigation.
+  // During live streaming, pendingUserInput is set when a UserInputMetaData
+  // artifact arrives.  That state is ephemeral — lost on refresh.  Here we
+  // reconstruct it from the persisted A2A events so the form re-appears.
+  // ═══════════════════════════════════════════════════════════════
+  useEffect(() => {
+    // Clear dismissed-form tracking when switching conversations
+    dismissedInputForMessageRef.current.clear();
+    setPendingUserInput(null);
+  }, [activeConversationId]);
+
+  useEffect(() => {
+    if (pendingUserInput || isThisConversationStreaming) return;
+    if (!conversation || conversation.messages.length === 0) return;
+
+    const messages = conversation.messages;
+    const lastMsg = messages[messages.length - 1];
+
+    // Only restore if the last message is from the assistant (user hasn't replied yet)
+    if (lastMsg.role !== "assistant") return;
+
+    // Don't restore if user explicitly dismissed the form for this message
+    if (dismissedInputForMessageRef.current.has(lastMsg.id)) return;
+
+    // Gather events from both conversation-level and message-level sources
+    const eventsToCheck = [
+      ...(conversation.a2aEvents || []),
+      ...(lastMsg.events || []),
+    ];
+
+    for (const event of eventsToCheck) {
+      if (event.artifact?.name !== "UserInputMetaData") continue;
+
+      let metadata: UserInputMetadata | null = null;
+
+      // Extract from DataPart (primary format)
+      if (event.artifact?.parts) {
+        for (const part of event.artifact.parts) {
+          if (part.kind === "data" && part.data) {
+            metadata = part.data as UserInputMetadata;
+            break;
+          }
+        }
+      }
+
+      // Fallback: artifact.metadata.metadata (legacy format)
+      if (!metadata && event.artifact?.metadata) {
+        const artMeta = event.artifact.metadata as Record<string, unknown>;
+        if (artMeta.metadata && typeof artMeta.metadata === "object") {
+          metadata = artMeta.metadata as UserInputMetadata;
+        }
+      }
+
+      if (metadata?.input_fields && metadata.input_fields.length > 0) {
+        console.log(
+          `[ChatPanel] 📝 Restoring pending user input form from persisted events (${metadata.input_fields.length} fields)`
+        );
+        setPendingUserInput({ messageId: lastMsg.id, metadata });
+        return;
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeConversationId, conversation?.messages?.length, isThisConversationStreaming]);
 
   const handleCopy = async (content: string, id: string) => {
     await navigator.clipboard.writeText(content);
@@ -852,7 +921,12 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
                 description={pendingUserInput.metadata.input_description}
                 inputFields={pendingUserInput.metadata.input_fields}
                 onSubmit={handleUserInputSubmit}
-                onCancel={() => setPendingUserInput(null)}
+                onCancel={() => {
+                  if (pendingUserInput) {
+                    dismissedInputForMessageRef.current.add(pendingUserInput.messageId);
+                  }
+                  setPendingUserInput(null);
+                }}
                 disabled={isThisConversationStreaming}
               />
             )}


### PR DESCRIPTION
# Description

Currently the user input box on the UI isn't persisted if the user leaves the chat or refreshes the page (see below screenshots)

Upon user request that requires additional input:
<img width="2056" height="1251" alt="Screenshot 2026-02-19 at 14 29 25" src="https://github.com/user-attachments/assets/2c5d5ecb-cb28-4774-8e28-beeadbf513c3" />

Although user hasn't submitted the form, it disappears upon page refresh:
<img width="2056" height="1260" alt="Screenshot 2026-02-19 at 14 29 33" src="https://github.com/user-attachments/assets/51985fda-d6bc-4a54-9cdf-94dc6de0ad6a" />

Fix the bug by persisting the user input box

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
