### PR TITLE
feat: bump to 0.2.18 and improve MCP tools error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,22 +45,22 @@ SLIM_ENDPOINT=http://slim-dataplane:46357
 # =============================================================================
 
 # LLM provider <aws-bedrock|azure-openai|openai>
-LLM_PROVIDER='azure-openai'
+LLM_PROVIDER=azure-openai
 
 
 # --- AWS Bedrock details ---
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
-AWS_BEDROCK_MODEL_ID="us.amazon.nova-pro-v1:0"
-AWS_BEDROCK_PROVIDER="amazon"
+AWS_BEDROCK_MODEL_ID=us.amazon.nova-pro-v1:0
+AWS_BEDROCK_PROVIDER=amazon
 
 
 # --- Azure OpenAI details ---
 AZURE_OPENAI_API_KEY=
-AZURE_OPENAI_API_VERSION='2025-03-01-preview'
-AZURE_OPENAI_DEPLOYMENT='gpt-4o'
-AZURE_OPENAI_ENDPOINT='https://resource_group_name.openai.azure.com'
+AZURE_OPENAI_API_VERSION=2025-03-01-preview
+AZURE_OPENAI_DEPLOYMENT=gpt-4o
+AZURE_OPENAI_ENDPOINT=https://resource_group_name.openai.azure.com
 
 
 # --- OpenAI details ---
@@ -133,6 +133,10 @@ PETSTORE_API_KEY=
 # MULTI-AGENT CONNECTIVITY SETTINGS
 # =============================================================================
 
+# Exclude non-agent ENABLE_* flags from the agent registry/connectivity checks.
+# These flags control UI/features, but they are not addressable A2A agents.
+EXCLUDE_FROM_AGENT_REGISTRY=CAIPE_UI,AGENT_FORGE
+
 # Initial Connectivity Check
 SKIP_AGENT_CONNECTIVITY_CHECK=false
 AGENT_CONNECTIVITY_TIMEOUT=5.0
@@ -165,7 +169,8 @@ TRUSTED_NETWORK_DEFAULT_ROLE=admin
 
 # Feature Flags
 NEXT_PUBLIC_SSO_ENABLED=false
-NEXT_PUBLIC_RAG_ENABLED=true  # Set to false to disable RAG Knowledge Bases
+# Set to true only when running the `rag` compose profile (or a reachable RAG server).
+NEXT_PUBLIC_RAG_ENABLED=false
 NEXT_PUBLIC_ENABLE_SUBAGENT_CARDS=true
 NEXT_PUBLIC_MONGODB_ENABLED=false
 
@@ -182,8 +187,10 @@ OIDC_REQUIRED_ADMIN_GROUP=
 OIDC_ENABLE_REFRESH_TOKEN=true
 
 # MongoDB Configuration (for persistent chat history)
-MONGODB_URI=mongodb://admin:changeme@mongodb:27017
-MONGODB_DATABASE=caipe
+# Enable only when running the `caipe-ui-with-mongodb` compose profile.
+# For docker-compose.yaml (container-to-container DNS): use `caipe-ui-mongodb` as the hostname.
+# MONGODB_URI=mongodb://admin:changeme@caipe-ui-mongodb:27017
+# MONGODB_DATABASE=caipe
 MONGODB_ROOT_USERNAME=admin
 MONGODB_ROOT_PASSWORD=changeme
 
@@ -205,4 +212,3 @@ ANTHROPIC_API_KEY=
 
 # OpenAI (for evaluation webhook - only if not already defined)
 #OPENAI_API_KEY=
-

--- a/ai_platform_engineering/multi_agents/agent_registry.py
+++ b/ai_platform_engineering/multi_agents/agent_registry.py
@@ -41,6 +41,8 @@ DEFAULT_REGISTRY_EXCLUSIONS = frozenset({
     "GRAPH_RAG",            # Graph RAG capability flag
     "RAG",                  # RAG capability flag
     "SUBAGENT_CARDS",       # UI feature flag for sub-agent cards
+    "CAIPE_UI",             # UI enable flag — not an A2A agent
+    "AGENT_FORGE",          # Backstage plugin service flag — not an A2A agent
 })
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
   #                                 CAIPE Supervisor Deep Agent                                      #
   ####################################################################################################
   caipe-supervisor:
-    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.2.18}
     container_name: caipe-supervisor
     volumes:
       - ${PROMPT_CONFIG_PATH:-./charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml}:/app/prompt_config.yaml
@@ -118,7 +118,7 @@ services:
   ####################################################################################################
   # AWS Agent
   agent-aws:
-    image: ghcr.io/cnoe-io/agent-aws:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-aws:${IMAGE_TAG:-0.2.18}
     container_name: agent-aws
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.aws_agent.yaml:/app/prompt_config.aws_agent.yaml
@@ -150,7 +150,7 @@ services:
 
   # Petstore Agent
   agent-petstore:
-    image: ghcr.io/cnoe-io/agent-template:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-template:${IMAGE_TAG:-0.2.18}
     container_name: agent-petstore
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.petstore_agent.yaml:/app/prompt_config.petstore_agent.yaml
@@ -173,10 +173,12 @@ services:
 
   # GitHub
   agent-github:
-    image: ghcr.io/cnoe-io/agent-github:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-github:${IMAGE_TAG:-0.2.18}
     container_name: agent-github
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.github_agent.yaml:/app/prompt_config.github_agent.yaml
+      # Temporary: allow local hotfixes without rebuilding the image (Podman/Docker).
+      - ./ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py:/app/ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py:ro
     env_file: [.env]
     ports: ["8001:8000"]
     environment:
@@ -188,6 +190,7 @@ services:
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
       - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse-web:3000}
       - GH_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}  # gh CLI authentication
+      - USE_GH_CLI_AS_TOOL=${USE_GH_CLI_AS_TOOL:-true}
     # Docker socket mount is only needed when MCP_MODE=stdio
     # For local Github Offical MCP server execution.
     # Uncomment this when MCP_MODE=stdio is supported
@@ -198,7 +201,7 @@ services:
 
   # Weather Agent
   agent-weather:
-    image: ghcr.io/cnoe-io/agent-weather:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-weather:${IMAGE_TAG:-0.2.18}
     container_name: agent-weather
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.weather_agent.yaml:/app/prompt_config.weather_agent.yaml
@@ -216,7 +219,7 @@ services:
 
   # Backstage Agent
   agent-backstage:
-    image: ghcr.io/cnoe-io/agent-backstage:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-backstage:${IMAGE_TAG:-0.2.18}
     container_name: agent-backstage
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.backstage_agent.yaml:/app/prompt_config.backstage_agent.yaml
@@ -236,7 +239,7 @@ services:
       - all-agents
 
   mcp-backstage:
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.2.18}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -256,7 +259,7 @@ services:
 
   # ArgoCD Agents
   agent-argocd:
-    image: ghcr.io/cnoe-io/agent-argocd:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-argocd:${IMAGE_TAG:-0.2.18}
     container_name: agent-argocd
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.argocd_agent.yaml:/app/prompt_config.argocd_agent.yaml
@@ -276,7 +279,7 @@ services:
       - all-agents
 
   mcp-argocd:
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.2.18}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -296,7 +299,7 @@ services:
 
   # Confluence Agents
   agent-confluence:
-    image: ghcr.io/cnoe-io/agent-confluence:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-confluence:${IMAGE_TAG:-0.2.18}
     container_name: agent-confluence
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.confluence_agent.yaml:/app/prompt_config.confluence_agent.yaml
@@ -330,7 +333,7 @@ services:
 
   # Jira Agent
   agent-jira:
-    image: ghcr.io/cnoe-io/agent-jira:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-jira:${IMAGE_TAG:-0.2.18}
     container_name: agent-jira
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.jira_agent.yaml:/app/prompt_config.jira_agent.yaml
@@ -350,7 +353,7 @@ services:
       - all-agents
 
   mcp-jira:
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.2.18}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -370,7 +373,7 @@ services:
 
   # Komodor Agent
   agent-komodor:
-    image: ghcr.io/cnoe-io/agent-komodor:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-komodor:${IMAGE_TAG:-0.2.18}
     container_name: agent-komodor
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.komodor_agent.yaml:/app/prompt_config.komodor_agent.yaml
@@ -389,7 +392,7 @@ services:
       - komodor
 
   mcp-komodor:
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.2.18}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -408,7 +411,7 @@ services:
 
   # PagerDuty Agent
   agent-pagerduty:
-    image: ghcr.io/cnoe-io/agent-pagerduty:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-pagerduty:${IMAGE_TAG:-0.2.18}
     container_name: agent-pagerduty
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.pagerduty_agent.yaml:/app/prompt_config.pagerduty_agent.yaml
@@ -428,7 +431,7 @@ services:
       - all-agents
 
   mcp-pagerduty:
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.2.18}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -448,7 +451,7 @@ services:
 
   # Slack Agent
   agent-slack:
-    image: ghcr.io/cnoe-io/agent-slack:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-slack:${IMAGE_TAG:-0.2.18}
     container_name: agent-slack
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.slack_agent.yaml:/app/prompt_config.slack_agent.yaml
@@ -468,7 +471,7 @@ services:
       - all-agents
 
   mcp-slack:
-    image: ghcr.io/cnoe-io/mcp-slack:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-slack:${IMAGE_TAG:-0.2.18}
     container_name: mcp-slack
     env_file: [.env]
     ports: ["18007:8000"]
@@ -488,7 +491,7 @@ services:
 
   # Splunk
   agent-splunk:
-    image: ghcr.io/cnoe-io/agent-splunk:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-splunk:${IMAGE_TAG:-0.2.18}
     container_name: agent-splunk
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.splunk_agent.yaml:/app/prompt_config.splunk_agent.yaml
@@ -508,7 +511,7 @@ services:
       - all-agents
 
   mcp-splunk:
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.2.18}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -528,7 +531,7 @@ services:
 
   # Webex
   agent-webex:
-    image: ghcr.io/cnoe-io/agent-webex:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/agent-webex:${IMAGE_TAG:-0.2.18}
     container_name: agent-webex
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.webex_agent.yaml:/app/prompt_config.webex_agent.yaml
@@ -548,7 +551,7 @@ services:
       - all-agents
 
   mcp-webex:
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.2.18}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -638,7 +641,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.2.18}
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -684,7 +687,7 @@ services:
   #                                      RAG Services                                                #
   ####################################################################################################
   rag_server:
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.2.18}
     container_name: rag_server
     ports: ["9446:9446"]
     environment:
@@ -712,7 +715,7 @@ services:
       - graph_rag
 
   agent_ontology:
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.2.18}
     container_name: agent_ontology
     ports: ["8098:8098"]
     environment:
@@ -731,7 +734,7 @@ services:
 
 
   rag_web_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.2.15}
+    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.2.18}
     container_name: web-ingestor
     environment:
       - INGESTOR_TYPE=webloader


### PR DESCRIPTION
- Bump image versions from 0.2.18 to 0.2.18 in docker-compose.yaml
- Add graceful error handling for MCP tools loading failures
- Add CAIPE_UI and AGENT_FORGE to agent registry exclusions
- Update .env.example with improved defaults and comments
- Add volume mount for local base_langgraph_agent.py hotfixes

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
