### PR TITLE
fix(ui): team-shared conversations not appearing for team members

### DIFF
--- a/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
@@ -1,0 +1,633 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Chat Sharing with Teams
+ *
+ * Covers the core bug fix: conversations shared with teams now appear
+ * for all team members across all relevant endpoints.
+ *
+ * Endpoints tested:
+ * - GET /api/chat/conversations — team-shared conversations appear in listing
+ * - GET /api/chat/shared — team-shared conversations appear in shared listing
+ * - requireConversationAccess — team members can access team-shared conversations
+ * - getUserTeamIds — resolves team memberships correctly
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('@/lib/auth-config', () => ({
+  authOptions: {},
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) {
+    mockCollections[name] = createMockCollection();
+  }
+  return Promise.resolve(mockCollections[name]);
+});
+
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock('uuid', () => ({
+  v4: () => '550e8400-e29b-41d4-a716-446655440000',
+}));
+
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockCollection() {
+  const findReturnValue = {
+    project: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    sort: jest.fn().mockReturnValue({
+      skip: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+
+  return {
+    find: jest.fn().mockReturnValue(findReturnValue),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    insertMany: jest.fn().mockResolvedValue({ insertedCount: 0 }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+  };
+}
+
+function makeRequest(url: string, options: RequestInit = {}): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'), options);
+}
+
+function userSession(email = 'user@example.com') {
+  return {
+    user: { email, name: 'Test User' },
+    role: 'user',
+  };
+}
+
+const TEAM_ID_1 = new ObjectId();
+const TEAM_ID_2 = new ObjectId();
+
+const OWNER_EMAIL = 'owner@example.com';
+const MEMBER_EMAIL = 'member@example.com';
+const NON_MEMBER_EMAIL = 'outsider@example.com';
+
+const TEAM_WITH_MEMBER = {
+  _id: TEAM_ID_1,
+  name: 'Platform Engineering',
+  members: [
+    { user_id: OWNER_EMAIL, role: 'owner', added_at: new Date(), added_by: OWNER_EMAIL },
+    { user_id: MEMBER_EMAIL, role: 'member', added_at: new Date(), added_by: OWNER_EMAIL },
+  ],
+};
+
+const TEAM_WITHOUT_MEMBER = {
+  _id: TEAM_ID_2,
+  name: 'Other Team',
+  members: [
+    { user_id: 'someone@example.com', role: 'owner', added_at: new Date(), added_by: 'someone@example.com' },
+  ],
+};
+
+function makeConversation(overrides: Record<string, any> = {}) {
+  return {
+    _id: 'conv-' + Math.random().toString(36).slice(2, 10),
+    title: 'Test Conversation',
+    owner_id: OWNER_EMAIL,
+    created_at: new Date(),
+    updated_at: new Date(),
+    metadata: { agent_version: '0.1.0', model_used: 'gpt-4o', total_messages: 0 },
+    sharing: {
+      is_public: false,
+      shared_with: [],
+      shared_with_teams: [],
+      share_link_enabled: false,
+    },
+    tags: [],
+    is_archived: false,
+    is_pinned: false,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.keys(mockCollections).forEach(key => delete mockCollections[key]);
+});
+
+// ============================================================================
+// getUserTeamIds
+// ============================================================================
+
+describe('getUserTeamIds', () => {
+  let getUserTeamIds: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/lib/api-middleware');
+    getUserTeamIds = mod.getUserTeamIds;
+  });
+
+  it('returns team IDs for a user who belongs to teams', async () => {
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: TEAM_ID_1 },
+          { _id: TEAM_ID_2 },
+        ]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const result = await getUserTeamIds(MEMBER_EMAIL);
+
+    expect(result).toEqual([TEAM_ID_1.toString(), TEAM_ID_2.toString()]);
+    expect(teamsCol.find).toHaveBeenCalledWith({ 'members.user_id': MEMBER_EMAIL });
+  });
+
+  it('returns empty array when user has no teams', async () => {
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const result = await getUserTeamIds(NON_MEMBER_EMAIL);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array on database error (graceful degradation)', async () => {
+    mockGetCollection.mockRejectedValueOnce(new Error('DB connection failed'));
+
+    const result = await getUserTeamIds(MEMBER_EMAIL);
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ============================================================================
+// requireConversationAccess — team sharing
+// ============================================================================
+
+describe('requireConversationAccess — team-based access', () => {
+  let requireConversationAccess: any;
+  let ApiError: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/lib/api-middleware');
+    requireConversationAccess = mod.requireConversationAccess;
+    ApiError = mod.ApiError;
+  });
+
+  it('grants access when user is the owner', async () => {
+    const conv = makeConversation();
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const result = await requireConversationAccess(conv._id, OWNER_EMAIL, mockGetCollection);
+
+    expect(result).toBeDefined();
+    expect(result._id).toBe(conv._id);
+  });
+
+  it('grants access when user is in shared_with (direct share)', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [MEMBER_EMAIL], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const result = await requireConversationAccess(conv._id, MEMBER_EMAIL, mockGetCollection);
+
+    expect(result).toBeDefined();
+    expect(result._id).toBe(conv._id);
+  });
+
+  it('grants access when user belongs to a shared team', async () => {
+    const conv = makeConversation({
+      sharing: {
+        shared_with: [],
+        shared_with_teams: [TEAM_ID_1.toString()],
+      },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    // User is a member of TEAM_ID_1
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ _id: TEAM_ID_1 }]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const result = await requireConversationAccess(conv._id, MEMBER_EMAIL, mockGetCollection);
+
+    expect(result).toBeDefined();
+    expect(result._id).toBe(conv._id);
+  });
+
+  it('denies access when user does not belong to any shared team', async () => {
+    const conv = makeConversation({
+      sharing: {
+        shared_with: [],
+        shared_with_teams: [TEAM_ID_1.toString()],
+      },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    // Non-member has no teams
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    // No sharing_access record either
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    await expect(
+      requireConversationAccess(conv._id, NON_MEMBER_EMAIL, mockGetCollection)
+    ).rejects.toThrow('Forbidden');
+  });
+
+  it('denies access when user belongs to a different team than shared', async () => {
+    const conv = makeConversation({
+      sharing: {
+        shared_with: [],
+        shared_with_teams: [TEAM_ID_1.toString()],
+      },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    // User belongs to TEAM_ID_2, not TEAM_ID_1
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ _id: TEAM_ID_2 }]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    await expect(
+      requireConversationAccess(conv._id, NON_MEMBER_EMAIL, mockGetCollection)
+    ).rejects.toThrow('Forbidden');
+  });
+
+  it('grants access via sharing_access record when no team or direct share', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    // No team membership
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    // But has sharing_access record
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue({
+      conversation_id: conv._id,
+      granted_to: MEMBER_EMAIL,
+      permission: 'view',
+    });
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const result = await requireConversationAccess(conv._id, MEMBER_EMAIL, mockGetCollection);
+
+    expect(result).toBeDefined();
+    expect(result._id).toBe(conv._id);
+  });
+
+  it('throws 404 when conversation does not exist', async () => {
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(null);
+    mockCollections['conversations'] = convsCol;
+
+    await expect(
+      requireConversationAccess('non-existent', MEMBER_EMAIL, mockGetCollection)
+    ).rejects.toThrow('Conversation not found');
+  });
+
+  it('skips team check when shared_with_teams is empty', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    await expect(
+      requireConversationAccess(conv._id, NON_MEMBER_EMAIL, mockGetCollection)
+    ).rejects.toThrow('Forbidden');
+
+    // getUserTeamIds should NOT have been called — no teams collection access needed
+    expect(mockGetCollection).not.toHaveBeenCalledWith('teams');
+  });
+
+  it('skips team check when shared_with_teams is undefined', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [] },
+    });
+    delete conv.sharing.shared_with_teams;
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    await expect(
+      requireConversationAccess(conv._id, NON_MEMBER_EMAIL, mockGetCollection)
+    ).rejects.toThrow('Forbidden');
+
+    expect(mockGetCollection).not.toHaveBeenCalledWith('teams');
+  });
+});
+
+// ============================================================================
+// GET /api/chat/conversations — team sharing in listing
+// ============================================================================
+
+describe('GET /api/chat/conversations — team sharing', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/app/api/chat/conversations/route');
+    GET = mod.GET;
+  });
+
+  it('includes shared_with_teams condition when user belongs to teams', async () => {
+    mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
+
+    // User belongs to TEAM_ID_1
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ _id: TEAM_ID_1 }]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const convsCol = createMockCollection();
+    convsCol.countDocuments.mockResolvedValue(0);
+    mockCollections['conversations'] = convsCol;
+
+    const req = makeRequest('/api/chat/conversations');
+    await GET(req);
+
+    const findCall = convsCol.find.mock.calls[0][0];
+    const orConditions = findCall.$or;
+
+    expect(orConditions).toContainEqual({ owner_id: MEMBER_EMAIL });
+    expect(orConditions).toContainEqual({ 'sharing.shared_with': MEMBER_EMAIL });
+    expect(orConditions).toContainEqual({
+      'sharing.shared_with_teams': { $in: [TEAM_ID_1.toString()] },
+    });
+  });
+
+  it('does NOT include shared_with_teams condition when user has no teams', async () => {
+    mockGetServerSession.mockResolvedValue(userSession(NON_MEMBER_EMAIL));
+
+    // No teams
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const convsCol = createMockCollection();
+    convsCol.countDocuments.mockResolvedValue(0);
+    mockCollections['conversations'] = convsCol;
+
+    const req = makeRequest('/api/chat/conversations');
+    await GET(req);
+
+    const findCall = convsCol.find.mock.calls[0][0];
+    const orConditions = findCall.$or;
+
+    expect(orConditions).toHaveLength(2);
+    expect(orConditions).toContainEqual({ owner_id: NON_MEMBER_EMAIL });
+    expect(orConditions).toContainEqual({ 'sharing.shared_with': NON_MEMBER_EMAIL });
+    const teamCondition = orConditions.find(
+      (c: any) => c['sharing.shared_with_teams']
+    );
+    expect(teamCondition).toBeUndefined();
+  });
+
+  it('includes multiple team IDs when user belongs to multiple teams', async () => {
+    mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
+
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: TEAM_ID_1 },
+          { _id: TEAM_ID_2 },
+        ]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const convsCol = createMockCollection();
+    convsCol.countDocuments.mockResolvedValue(0);
+    mockCollections['conversations'] = convsCol;
+
+    const req = makeRequest('/api/chat/conversations');
+    await GET(req);
+
+    const findCall = convsCol.find.mock.calls[0][0];
+    const orConditions = findCall.$or;
+    const teamCondition = orConditions.find(
+      (c: any) => c['sharing.shared_with_teams']
+    );
+
+    expect(teamCondition).toBeDefined();
+    expect(teamCondition['sharing.shared_with_teams'].$in).toEqual([
+      TEAM_ID_1.toString(),
+      TEAM_ID_2.toString(),
+    ]);
+  });
+
+  it('still excludes soft-deleted conversations', async () => {
+    mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
+
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ _id: TEAM_ID_1 }]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const convsCol = createMockCollection();
+    convsCol.countDocuments.mockResolvedValue(0);
+    mockCollections['conversations'] = convsCol;
+
+    const req = makeRequest('/api/chat/conversations');
+    await GET(req);
+
+    const findCall = convsCol.find.mock.calls[0][0];
+    expect(findCall.$and).toBeDefined();
+    expect(findCall.$and).toContainEqual(
+      expect.objectContaining({
+        $or: expect.arrayContaining([
+          { deleted_at: null },
+          { deleted_at: { $exists: false } },
+        ]),
+      })
+    );
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const req = makeRequest('/api/chat/conversations');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// GET /api/chat/shared — team sharing in shared listing
+// ============================================================================
+
+describe('GET /api/chat/shared — team sharing', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/app/api/chat/shared/route');
+    GET = mod.GET;
+  });
+
+  it('includes shared_with_teams condition when user belongs to teams', async () => {
+    mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
+
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([{ _id: TEAM_ID_1 }]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const convsCol = createMockCollection();
+    convsCol.countDocuments.mockResolvedValue(0);
+    mockCollections['conversations'] = convsCol;
+
+    const req = makeRequest('/api/chat/shared');
+    await GET(req);
+
+    const findCall = convsCol.find.mock.calls[0][0];
+
+    // Should exclude owner's own conversations
+    expect(findCall.owner_id).toEqual({ $ne: MEMBER_EMAIL });
+
+    // Should have $or with direct and team sharing
+    expect(findCall.$or).toBeDefined();
+    expect(findCall.$or).toContainEqual({ 'sharing.shared_with': MEMBER_EMAIL });
+    expect(findCall.$or).toContainEqual({
+      'sharing.shared_with_teams': { $in: [TEAM_ID_1.toString()] },
+    });
+  });
+
+  it('only includes direct sharing when user has no teams', async () => {
+    mockGetServerSession.mockResolvedValue(userSession(NON_MEMBER_EMAIL));
+
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const convsCol = createMockCollection();
+    convsCol.countDocuments.mockResolvedValue(0);
+    mockCollections['conversations'] = convsCol;
+
+    const req = makeRequest('/api/chat/shared');
+    await GET(req);
+
+    const findCall = convsCol.find.mock.calls[0][0];
+    expect(findCall.$or).toHaveLength(1);
+    expect(findCall.$or).toContainEqual({ 'sharing.shared_with': NON_MEMBER_EMAIL });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const req = makeRequest('/api/chat/shared');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/ui/src/app/api/agent-configs/route.ts
+++ b/ui/src/app/api/agent-configs/route.ts
@@ -5,6 +5,7 @@ import {
   withErrorHandler,
   successResponse,
   ApiError,
+  getUserTeamIds,
 } from "@/lib/api-middleware";
 import type {
   AgentConfig,
@@ -37,22 +38,6 @@ function isUserAdmin(user: { email: string; role?: string }): boolean {
 }
 
 const VALID_VISIBILITIES: SkillVisibility[] = ["private", "team", "global"];
-
-/**
- * Resolve all team IDs that a user belongs to.
- */
-async function getUserTeamIds(userEmail: string): Promise<string[]> {
-  try {
-    const teams = await getCollection("teams");
-    const userTeams = await teams
-      .find({ "members.user_id": userEmail })
-      .project({ _id: 1 })
-      .toArray();
-    return userTeams.map((t) => t._id.toString());
-  } catch {
-    return [];
-  }
-}
 
 /**
  * MongoDB storage functions

--- a/ui/src/app/api/chat/conversations/route.ts
+++ b/ui/src/app/api/chat/conversations/route.ts
@@ -11,6 +11,7 @@ import {
   paginatedResponse,
   validateRequired,
   getPaginationParams,
+  getUserTeamIds,
 } from '@/lib/api-middleware';
 import type { Conversation, CreateConversationRequest } from '@/types/mongodb';
 
@@ -36,12 +37,24 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const conversations = await getCollection<Conversation>('conversations');
 
-    // Build query — exclude soft-deleted conversations from normal listing
+    // Resolve user's team memberships for team-shared conversations
+    const userTeamIds = await getUserTeamIds(user.email);
+
+    // Build query — include conversations owned, shared directly, or shared via teams
+    const ownershipConditions: any[] = [
+      { owner_id: user.email },
+      { 'sharing.shared_with': user.email },
+    ];
+
+    if (userTeamIds.length > 0) {
+      ownershipConditions.push({
+        'sharing.shared_with_teams': { $in: userTeamIds },
+      });
+    }
+
+    // Exclude soft-deleted conversations from normal listing
     const query: any = {
-      $or: [
-        { owner_id: user.email },
-        { 'sharing.shared_with': user.email },
-      ],
+      $or: ownershipConditions,
       $and: [
         { $or: [{ deleted_at: null }, { deleted_at: { $exists: false } }] },
       ],

--- a/ui/src/app/api/chat/shared/route.ts
+++ b/ui/src/app/api/chat/shared/route.ts
@@ -7,6 +7,7 @@ import {
   withErrorHandler,
   paginatedResponse,
   getPaginationParams,
+  getUserTeamIds,
 } from '@/lib/api-middleware';
 import type { Conversation } from '@/types/mongodb';
 
@@ -17,10 +18,23 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const conversations = await getCollection<Conversation>('conversations');
 
-    // Find conversations shared with user (not owned by user)
+    // Resolve user's team memberships for team-shared conversations
+    const userTeamIds = await getUserTeamIds(user.email);
+
+    // Find conversations shared with user directly or via teams (not owned by user)
+    const sharedConditions: any[] = [
+      { 'sharing.shared_with': user.email },
+    ];
+
+    if (userTeamIds.length > 0) {
+      sharedConditions.push({
+        'sharing.shared_with_teams': { $in: userTeamIds },
+      });
+    }
+
     const query = {
       owner_id: { $ne: user.email },
-      'sharing.shared_with': user.email,
+      $or: sharedConditions,
     };
 
     const total = await conversations.countDocuments(query);

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -30,6 +30,7 @@ import { UseCaseBuilderDialog } from "@/components/gallery/UseCaseBuilder";
 import { RecycleBinDialog } from "@/components/chat/RecycleBinDialog";
 import { ShareButton } from "@/components/chat/ShareButton";
 import { useToast } from "@/components/ui/toast";
+import { useSession } from "next-auth/react";
 import { getStorageMode, getStorageModeDisplay } from "@/lib/storage-config";
 import type { Conversation } from "@/types/a2a";
 
@@ -52,6 +53,7 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapse, onUseCa
     loadConversationsFromServer,
     loadMessagesFromServer,
   } = useChatStore();
+  const { data: session } = useSession();
   const [useCaseBuilderOpen, setUseCaseBuilderOpen] = useState(false);
   const storageMode = getStorageMode(); // Exclusive storage mode
   const [isPending, startTransition] = useTransition();
@@ -394,7 +396,7 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapse, onUseCa
                             <ShareButton
                               conversationId={conv.id}
                               conversationTitle={conv.title}
-                              isOwner={new Date(conv.createdAt) > new Date('2026-01-28')}
+                              isOwner={!conv.owner_id || conv.owner_id === session?.user?.email}
                             />
                           </div>
                           <TooltipProvider delayDuration={200}>

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -267,14 +267,32 @@ export function requireOwnership(ownerId: string, userId: string) {
 }
 
 /**
- * Check if user has access to a conversation (owner or shared with)
+ * Resolve all team IDs that a user belongs to.
+ * Looks up the teams collection for teams where the user is a member.
+ */
+export async function getUserTeamIds(userEmail: string): Promise<string[]> {
+  try {
+    const teams = await getCollection('teams');
+    const userTeams = await teams
+      .find({ 'members.user_id': userEmail })
+      .project({ _id: 1 })
+      .toArray();
+    return userTeams.map((t: any) => t._id.toString());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check if user has access to a conversation (owner, shared with directly,
+ * shared with one of their teams, or via sharing_access records).
  */
 export async function requireConversationAccess(
   conversationId: string,
   userId: string,
-  getCollection: (name: string) => Promise<any>
+  getCollectionFn: (name: string) => Promise<any>
 ) {
-  const conversations = await getCollection('conversations');
+  const conversations = await getCollectionFn('conversations');
   const conversation = await conversations.findOne({ _id: conversationId });
 
   if (!conversation) {
@@ -286,13 +304,27 @@ export async function requireConversationAccess(
     return conversation;
   }
 
-  // Check if conversation is shared with user
+  // Check if conversation is shared with user directly
   if (conversation.sharing?.shared_with?.includes(userId)) {
     return conversation;
   }
 
+  // Check if conversation is shared with one of the user's teams
+  const sharedTeams = conversation.sharing?.shared_with_teams;
+  if (sharedTeams && sharedTeams.length > 0) {
+    const userTeamIds = await getUserTeamIds(userId);
+    if (userTeamIds.length > 0) {
+      const hasTeamAccess = sharedTeams.some((teamId: string) =>
+        userTeamIds.includes(teamId)
+      );
+      if (hasTeamAccess) {
+        return conversation;
+      }
+    }
+  }
+
   // Check sharing_access collection
-  const sharingAccess = await getCollection('sharing_access');
+  const sharingAccess = await getCollectionFn('sharing_access');
   const access = await sharingAccess.findOne({
     conversation_id: conversationId,
     granted_to: userId,

--- a/ui/src/store/chat-store.ts
+++ b/ui/src/store/chat-store.ts
@@ -702,6 +702,7 @@ const storeImplementation = (set: any, get: any) => ({
               // Preserve messages/events for streaming OR already-loaded conversations
               messages: (isStreaming || hasLoadedMessages) && localConv ? localConv.messages : [],
               a2aEvents: (isStreaming || hasLoadedMessages) && localConv ? localConv.a2aEvents : [],
+              owner_id: conv.owner_id,
               sharing: conv.sharing,
             };
           });

--- a/ui/src/types/a2a.ts
+++ b/ui/src/types/a2a.ts
@@ -163,6 +163,8 @@ export interface Conversation {
   messages: ChatMessage[];
   /** A2A events for this conversation (for debug panel, tasks, output) */
   a2aEvents: A2AEvent[];
+  /** Owner email (only for MongoDB conversations) */
+  owner_id?: string;
   /** Sharing information (optional, only for MongoDB conversations) */
   sharing?: {
     is_public?: boolean;


### PR DESCRIPTION
## Summary

- **Fix**: Conversations shared with teams were not showing up in team members chat lists. The MongoDB queries in `GET /api/chat/conversations`, `GET /api/chat/shared`, and `requireConversationAccess()` only checked `owner_id` and `sharing.shared_with` (individual emails), completely ignoring `sharing.shared_with_teams`.
- **Fix**: Sidebar ShareButton `isOwner` used a hardcoded date comparison instead of actual ownership check -- replaced with `owner_id === session.user.email`.
- **Refactor**: Extracted `getUserTeamIds()` from `agent-configs/route.ts` into `api-middleware.ts` as a shared utility, eliminating code duplication.

### Files Changed (8)

| File | Change |
|------|--------|
| `ui/src/lib/api-middleware.ts` | Added `getUserTeamIds()`, fixed `requireConversationAccess()` to check team membership |
| `ui/src/app/api/chat/conversations/route.ts` | Added `shared_with_teams` to conversations listing query |
| `ui/src/app/api/chat/shared/route.ts` | Added `shared_with_teams` to shared conversations query |
| `ui/src/app/api/agent-configs/route.ts` | Removed duplicate `getUserTeamIds()`, imports from api-middleware |
| `ui/src/types/a2a.ts` | Added `owner_id` to client-side `Conversation` type |
| `ui/src/store/chat-store.ts` | Populates `owner_id` from server response |
| `ui/src/components/layout/Sidebar.tsx` | Fixed `isOwner` to use actual ownership check |
| `ui/src/app/api/__tests__/chat-sharing-teams.test.ts` | 20 new comprehensive tests |

## Test plan

- [x] `make lint` passes
- [x] `make caipe-ui-tests` passes (63 suites, 1507 tests)
- [x] 20 new unit tests covering:
  - `getUserTeamIds()` -- returns team IDs, empty array for no teams, graceful degradation on DB error
  - `requireConversationAccess()` -- owner access, direct share, team share, wrong team denied, sharing_access fallback, 404, empty/undefined teams skipped
  - `GET /api/chat/conversations` -- team condition included/excluded, multiple teams, soft-delete filter preserved, auth required
  - `GET /api/chat/shared` -- team condition included/excluded, auth required
