### PR TITLE
fix(ui): default canViewAdmin to true for pre-upgrade JWT sessions

### DIFF
--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -417,7 +417,10 @@ export const authOptions: NextAuthOptions = {
       // Set role from token (OIDC group check only here)
       // MongoDB fallback check happens in API middleware (server-side only)
       session.role = (token.role as 'admin' | 'user') || 'user';
-      session.canViewAdmin = (token.canViewAdmin as boolean) ?? false;
+      // For pre-upgrade JWTs that lack canViewAdmin, default to true when no
+      // admin view group is configured (all authenticated users can view).
+      session.canViewAdmin = (token.canViewAdmin as boolean)
+        ?? (REQUIRED_ADMIN_VIEW_GROUP === '' ? true : false);
 
       // If token refresh failed, mark session as invalid and DON'T include tokens
       if (token.error === "RefreshTokenExpired" || token.error === "RefreshTokenError") {


### PR DESCRIPTION
## Summary

- Fixes admin tab access lost after upgrading to 0.2.21 for users with existing sessions
- Pre-upgrade JWT tokens lack the `canViewAdmin` field introduced in #833
- The session callback fallback treated missing field as "no access"
- Now defaults to `true` when `OIDC_REQUIRED_ADMIN_VIEW_GROUP` is not configured (the default), matching the intended behavior that all authenticated users can view the admin dashboard readonly

## Root Cause

In `auth-config.ts` session callback, the `?? false` fallback meant old JWTs without `canViewAdmin` were treated as no admin view access. The fix uses the `REQUIRED_ADMIN_VIEW_GROUP` constant to determine the correct default: `true` when no view group is configured.

## Impact

- Users who were already logged in before the 0.2.21 upgrade lost readonly admin access
- Workaround was to log out and log back in (new JWT includes `canViewAdmin`)
- This fix eliminates the need for re-login after upgrade

## Test plan

- [x] TypeScript compiles cleanly
- [x] 44 auth/admin-role unit tests pass
- [ ] Deploy to staging, verify existing sessions regain Admin tab access without re-login
- [ ] Verify new logins continue to work correctly
- [ ] Verify that setting `OIDC_REQUIRED_ADMIN_VIEW_GROUP` still restricts access properly

Made with [Cursor](https://cursor.com)