### PR TITLE
fix(supervisor): repair streaming failures from json scoping and orphaned tool calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Claude Code Instructions
+
+## Git Workflow
+
+- Always work on a **new branch** — never commit directly to `main`
+- Branch naming: `fix/<short-description>` or `feat/<short-description>`
+- After making changes, **create a PR** using `gh pr create`
+
+## Commit Style
+
+Use **Conventional Commits** format:
+```
+<type>(<scope>): <short description>
+
+<body>
+
+Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
+```
+
+Types: `fix`, `feat`, `chore`, `docs`, `refactor`, `test`, `ci`
+
+**DCO is required** — every commit must include:
+```
+Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
+```
+
+Example commit:
+```
+fix(a2a): remove redundant json import causing UnboundLocalError
+
+The import json inside stream() shadowed the module-level import,
+making json a local variable and crashing when USE_STRUCTURED_RESPONSE=true.
+
+Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
+```
+
+## Author Identity
+
+- **Name**: Sri Aradhyula
+- **Email**: sraradhy@cisco.com
+
+## PR Guidelines
+
+- Keep PR title short (under 70 chars), conventional commit style
+- Body should include: Summary bullets + Test plan checklist

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -60,6 +60,8 @@ class AIPlatformEngineerA2ABinding:
       - A sub-agent call fails mid-stream (e.g., context overflow)
       - A tool call is interrupted
       - Network issues cause incomplete responses
+      - LangMem summarization removes ToolMessages but leaves AIMessages
+        with tool_use data in additional_kwargs (Bedrock-specific)
 
       Args:
           config: Runnable configuration with thread_id
@@ -90,6 +92,42 @@ class AIPlatformEngineerA2ABinding:
                       if tc_id:
                           tool_calls_info[tc_id] = (idx, tc_name, msg_id)
 
+                  # Bedrock stores tool_use data in additional_kwargs which the
+                  # Converse API adapter reads when building the request. The
+                  # standard tool_calls attribute may be empty while
+                  # additional_kwargs still contains tool_use blocks, causing
+                  # Bedrock to complain about missing toolResult.
+                  add_kwargs = getattr(msg, 'additional_kwargs', {}) or {}
+                  for key in ('tool_use', 'toolUse'):
+                      tool_use_data = add_kwargs.get(key)
+                      if tool_use_data:
+                          items = tool_use_data if isinstance(tool_use_data, list) else [tool_use_data]
+                          for tu in items:
+                              if isinstance(tu, dict):
+                                  tu_id = tu.get('id') or tu.get('toolUseId')
+                                  tu_name = tu.get('name', 'unknown')
+                                  if tu_id and tu_id not in tool_calls_info:
+                                      tool_calls_info[tu_id] = (idx, tu_name, msg_id)
+                                      logging.debug(
+                                          f"Found tool_use in additional_kwargs: "
+                                          f"id={tu_id[:20]}..., name={tu_name}"
+                                      )
+
+                  # Also check content blocks for Bedrock tool_use (Converse API
+                  # format stores tool_use as content blocks)
+                  msg_content = getattr(msg, 'content', None)
+                  if isinstance(msg_content, list):
+                      for block in msg_content:
+                          if isinstance(block, dict) and block.get('type') == 'tool_use':
+                              tu_id = block.get('id')
+                              tu_name = block.get('name', 'unknown')
+                              if tu_id and tu_id not in tool_calls_info:
+                                  tool_calls_info[tu_id] = (idx, tu_name, msg_id)
+                                  logging.debug(
+                                      f"Found tool_use in content blocks: "
+                                      f"id={tu_id[:20]}..., name={tu_name}"
+                                  )
+
               # Track resolved tool calls
               if isinstance(msg, ToolMessage):
                   tc_id = getattr(msg, 'tool_call_id', None)
@@ -101,6 +139,12 @@ class AIPlatformEngineerA2ABinding:
                       if tc_id not in resolved_tool_calls}
 
           if not orphaned:
+              logging.debug(
+                  f"No orphaned tool calls found. "
+                  f"Tracked {len(tool_calls_info)} tool_call IDs, "
+                  f"{len(resolved_tool_calls)} resolved. "
+                  f"Message types: {[type(m).__name__ for m in messages]}"
+              )
               return
 
           orphaned_names = [info[1] for info in orphaned.values()]
@@ -585,7 +629,6 @@ class AIPlatformEngineerA2ABinding:
                                   continue  # Skip tool notification, already handled
                           else:
                               # Fallback: try to get any string value from args
-                              import json
                               for key, val in tool_args.items():
                                   if isinstance(val, str) and len(val) > 10:
                                       response_format_content = val
@@ -1097,6 +1140,15 @@ class AIPlatformEngineerA2ABinding:
               }
               return
 
+          # Attempt to repair orphaned tool calls before fallback stream.
+          # The primary stream failed with a Bedrock validation error, so
+          # the state likely has an AIMessage with tool_use that has no
+          # corresponding ToolMessage. Repair now to give fallback a chance.
+          try:
+              await self._repair_orphaned_tool_calls(config)
+          except Exception as repair_err:
+              logging.error(f"⚠️ Pre-fallback repair failed: {repair_err}")
+
           # Signal to executor to clear accumulated content before fallback stream
           # This prevents duplication from partial content streamed before the exception
           yield {
@@ -1105,7 +1157,8 @@ class AIPlatformEngineerA2ABinding:
               "clear_accumulators": True,
               "content": "🔄 Switching to fallback streaming mode...",
           }
-          async for item_type, item in self.graph.astream(inputs, config, stream_mode=['messages', 'custom', 'updates']):
+          try:
+            async for item_type, item in self.graph.astream(inputs, config, stream_mode=['messages', 'custom', 'updates']):
 
               # Handle custom A2A event payloads emitted via get_stream_writer()
               if isinstance(item, dict):
@@ -1217,6 +1270,69 @@ class AIPlatformEngineerA2ABinding:
                       logging.info(f"🎯 AIMessage content preview: {content_preview}...")
                       accumulated_ai_content.append(str(message.content))
                   final_ai_message = message
+          except Exception as fallback_err:
+              fallback_error_str = str(fallback_err)
+              logging.error(
+                  f"❌ Fallback stream also failed: {fallback_error_str}"
+              )
+
+              is_bedrock_tool_error = (
+                  "Expected toolResult" in fallback_error_str
+                  or "toolResult blocks" in fallback_error_str
+              )
+
+              if is_bedrock_tool_error:
+                  # The state has a persistent orphaned tool_use that neither
+                  # _repair_orphaned_tool_calls nor summarization could fix.
+                  # Force-repair by removing ALL AIMessages that Bedrock flags.
+                  try:
+                      import re as _re
+                      ids_found = _re.findall(
+                          r'tooluse_[A-Za-z0-9_-]+', fallback_error_str
+                      )
+                      if ids_found:
+                          logging.warning(
+                              f"🔧 Force-repairing Bedrock orphaned IDs: {ids_found}"
+                          )
+                          from langchain_core.messages import RemoveMessage
+                          state = await self.graph.aget_state(config)
+                          msgs = (
+                              state.values.get("messages", [])
+                              if state and state.values else []
+                          )
+                          to_remove = []
+                          for msg in msgs:
+                              if not isinstance(msg, AIMessage):
+                                  continue
+                              msg_id = getattr(msg, 'id', None)
+                              if not msg_id:
+                                  continue
+                              # Check all possible locations for the orphaned ID
+                              msg_str = str(getattr(msg, 'tool_calls', []))
+                              msg_str += str(getattr(msg, 'additional_kwargs', {}))
+                              msg_str += str(getattr(msg, 'content', ''))
+                              if any(tid in msg_str for tid in ids_found):
+                                  to_remove.append(RemoveMessage(id=msg_id))
+                          if to_remove:
+                              await self.graph.aupdate_state(
+                                  config, {"messages": to_remove}
+                              )
+                              logging.info(
+                                  f"✅ Force-removed {len(to_remove)} AIMessage(s) "
+                                  f"with Bedrock orphaned tool_use IDs"
+                              )
+                  except Exception as force_err:
+                      logging.error(f"Force-repair failed: {force_err}")
+
+              yield {
+                  "is_task_complete": False,
+                  "require_user_input": False,
+                  "content": (
+                      "⚠️ I encountered a conversation state issue. "
+                      "I've repaired the state - please try your question again."
+                  ),
+              }
+              return
 
       # After EITHER primary or fallback streaming completes, parse the final response to extract is_task_complete
       logging.info(f"🔍 POST-STREAM PARSING: final_ai_message={final_ai_message is not None}, accumulated_chunks={len(accumulated_ai_content)}, response_format_args={response_format_args is not None}")
@@ -1232,7 +1348,6 @@ class AIPlatformEngineerA2ABinding:
               logging.info(f"🎯 POST-STREAM: Parsing accumulated tool_call_chunks JSON ({len(partial_str)} chars)")
               logging.debug(f"🎯 POST-STREAM: Partial JSON preview: {partial_str[:500]}...")
               try:
-                  import json
                   parsed = json.loads(partial_str)
                   if isinstance(parsed, dict):
                       response_format_args.update(parsed)

--- a/ai_platform_engineering/utils/a2a_common/langmem_utils.py
+++ b/ai_platform_engineering/utils/a2a_common/langmem_utils.py
@@ -36,12 +36,52 @@ from langchain_core.messages import BaseMessage, SystemMessage, AIMessage, ToolM
 logger = logging.getLogger(__name__)
 
 
+def _extract_tool_call_ids(msg: BaseMessage) -> set:
+    """
+    Extract all tool call IDs from an AIMessage, checking all locations where
+    Bedrock/Anthropic may store them: tool_calls, additional_kwargs, and
+    content blocks.
+    """
+    ids = set()
+    if not isinstance(msg, AIMessage):
+        return ids
+
+    for tc in (getattr(msg, 'tool_calls', None) or []):
+        tc_id = tc.get('id') if isinstance(tc, dict) else getattr(tc, 'id', None)
+        if tc_id:
+            ids.add(tc_id)
+
+    add_kwargs = getattr(msg, 'additional_kwargs', {}) or {}
+    for key in ('tool_use', 'toolUse'):
+        data = add_kwargs.get(key)
+        if data:
+            items = data if isinstance(data, list) else [data]
+            for tu in items:
+                if isinstance(tu, dict):
+                    tu_id = tu.get('id') or tu.get('toolUseId')
+                    if tu_id:
+                        ids.add(tu_id)
+
+    content = getattr(msg, 'content', None)
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get('type') == 'tool_use':
+                tu_id = block.get('id')
+                if tu_id:
+                    ids.add(tu_id)
+
+    return ids
+
+
 def _find_safe_summarization_boundary(messages: List[BaseMessage], min_keep: int) -> int:
     """
     Find a safe index to split messages for summarization.
 
     Ensures we don't split in the middle of tool call/result pairs, which would
     cause LLM validation errors like "Expected toolResult blocks for the following Ids".
+
+    Checks tool_calls, additional_kwargs, and content blocks (Bedrock stores
+    tool_use data in all three locations).
 
     Args:
         messages: List of messages to analyze
@@ -63,15 +103,9 @@ def _find_safe_summarization_boundary(messages: List[BaseMessage], min_keep: int
     for i in range(cut_index, len(messages)):
         msg = messages[i]
 
-        # Check for tool calls in AI messages
         if isinstance(msg, AIMessage):
-            tool_calls = getattr(msg, 'tool_calls', None) or []
-            for tc in tool_calls:
-                tc_id = tc.get('id') if isinstance(tc, dict) else getattr(tc, 'id', None)
-                if tc_id:
-                    pending_tool_calls.add(tc_id)
+            pending_tool_calls.update(_extract_tool_call_ids(msg))
 
-        # Check for tool results
         if isinstance(msg, ToolMessage):
             tc_id = getattr(msg, 'tool_call_id', None)
             if tc_id and tc_id in pending_tool_calls:
@@ -87,14 +121,11 @@ def _find_safe_summarization_boundary(messages: List[BaseMessage], min_keep: int
         msg = messages[i]
 
         if isinstance(msg, AIMessage):
-            tool_calls = getattr(msg, 'tool_calls', None) or []
-            for tc in tool_calls:
-                tc_id = tc.get('id') if isinstance(tc, dict) else getattr(tc, 'id', None)
-                if tc_id and tc_id in pending_tool_calls:
-                    # Found the tool call, need to keep it
-                    # Move cut point before this message
-                    cut_index = i
-                    pending_tool_calls.discard(tc_id)
+            msg_tc_ids = _extract_tool_call_ids(msg)
+            matched = msg_tc_ids & pending_tool_calls
+            if matched:
+                cut_index = i
+                pending_tool_calls -= matched
 
         if not pending_tool_calls:
             break
@@ -103,23 +134,19 @@ def _find_safe_summarization_boundary(messages: List[BaseMessage], min_keep: int
     while cut_index > 0:
         last_msg = messages[cut_index - 1]
         if isinstance(last_msg, AIMessage):
-            tool_calls = getattr(last_msg, 'tool_calls', None) or []
-            if tool_calls:
-                # This AI message has tool calls - check if results are in summarize section
+            tc_ids = _extract_tool_call_ids(last_msg)
+            if tc_ids:
                 has_all_results = True
-                for tc in tool_calls:
-                    tc_id = tc.get('id') if isinstance(tc, dict) else getattr(tc, 'id', None)
-                    if tc_id:
-                        # Look for matching ToolMessage in messages[:cut_index]
-                        found = False
-                        for j in range(cut_index):
-                            if isinstance(messages[j], ToolMessage):
-                                if getattr(messages[j], 'tool_call_id', None) == tc_id:
-                                    found = True
-                                    break
-                        if not found:
-                            has_all_results = False
-                            break
+                for tc_id in tc_ids:
+                    found = False
+                    for j in range(cut_index):
+                        if isinstance(messages[j], ToolMessage):
+                            if getattr(messages[j], 'tool_call_id', None) == tc_id:
+                                found = True
+                                break
+                    if not found:
+                        has_all_results = False
+                        break
 
                 if not has_all_results:
                     cut_index -= 1


### PR DESCRIPTION
## Summary

- **Bug 1 (critical, `0.2.21`)**: Remove `import json` inside `stream()` at lines 632 and 1352 — these shadow the module-level import, making Python treat `json` as a local variable throughout the entire function. With `USE_STRUCTURED_RESPONSE=true` the import path is never reached, causing `UnboundLocalError: cannot access local variable 'json'` when the `ResponseFormat` ToolMessage is processed
- **Bug 2**: `_repair_orphaned_tool_calls()` only checked `msg.tool_calls`, missing tool-use IDs stored in `additional_kwargs` and content blocks (Bedrock Converse API format) — adds checks for both so the pre-fallback repair actually finds and removes orphaned AIMessages
- **Bug 3**: Fallback `astream()` was not wrapped in `try/except`, so when the fallback also failed the exception propagated to `agent_executor:838` as "Execution error" and state was never repaired — wraps the fallback with force-repair that extracts IDs from the Bedrock error and removes them via `aupdate_state`
- **Root cause prevention**: `langmem_utils._find_safe_summarization_boundary()` now uses `_extract_tool_call_ids()` that checks all three Bedrock storage locations, preventing summarization from splitting `tool_use`/`toolResult` pairs in the first place

## Observed symptoms

- After a few turns the UI and supervisor show `🔄 Switching to fallback streaming mode...`
- New pod (`0.2.21`, `USE_STRUCTURED_RESPONSE=true`): `UnboundLocalError: cannot access local variable 'json'` → fallback triggers → `Execution error` at `agent_executor:838` → `ResponseFormat` AIMessage left orphaned in state
- Old pods: `ValidationException: Expected toolResult blocks at messages.0.content` after LangMem summarization compresses context

## Test plan

- [ ] Deploy to `caipe-preview` and verify no `UnboundLocalError` with `USE_STRUCTURED_RESPONSE=true`
- [ ] Confirm `🔄 Switching to fallback streaming mode...` no longer appears after several turns with sub-agent calls
- [ ] Trigger a long conversation (>80K tokens) to exercise LangMem summarization and verify no orphaned tool-use errors
- [ ] Verify the supervisor recovers cleanly when a fallback does occur (sees `✅ Force-removed N AIMessage(s)` in logs, not `Execution error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)