### PR TITLE
fix: make it work with newer claude models that do not support prefilling

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -9,7 +9,6 @@ import asyncio
 import time
 import httpx
 import traceback
-import json
 
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.graph.state import CompiledStateGraph


### PR DESCRIPTION
# Description

Currently, when we switch our model to `AWS_BEDROCK_MODEL_ID="global.anthropic.claude-sonnet-4-6"` with `USE_STRUCTURED_RESPONSE=true`, we get the following error:
```
An error occurred (ValidationException) when calling the ConverseStream operation: The model returned the following errors: This model does not support assistant message prefill. The conversation must end with a user message. 
```
back from AWS Bedrock at the last stage where we call `generate_structured_response`.

This is due to the change from anthropic for newer models:

> Prefilling is deprecated and not supported on Claude Opus 4.6, Claude Sonnet 4.6, and Claude Sonnet 4.5. Use [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) or system prompt instructions instead.

on [their official docs page](https://platform.claude.com/docs/en/build-with-claude/working-with-messages#putting-words-in-claudes-mouth).

There is also an open PR to langchain-aws to add official support for this: https://github.com/langchain-ai/langchain-aws/pull/884.

For now this will be a "hack" to make our code work for both models.



## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
