### PR TITLE
fix(docker-compose): remove jarvis from all-agents profile

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -888,7 +888,6 @@ services:
     command: python3 -m jarvis_agent.combined_server --fastapi-port 8000 --a2a-port 58000
     profiles:
       - jarvis
-      - all-agents
 
   ####################################################################################################
   #                                      CAIPE UI                                                    #


### PR DESCRIPTION
## Summary

- Remove jarvis agent from the all-agents Docker Compose profile so it does not start automatically with other agents

## Test plan

- Verify jarvis only starts with its own profile: docker compose --profile jarvis up
- Verify all-agents profile no longer includes jarvis: docker compose --profile all-agents config

Made with [Cursor](https://cursor.com)