### PR TITLE
fix(supervisor): correctly send final structured output to the UI when user input is required

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor.py
@@ -478,6 +478,19 @@ class AIPlatformEngineerA2AExecutor(AgentExecutor):
                          ]
                      }
         """
+        # Send a final text artifact with the structured content so the UI
+        # replaces any previously-streamed chunks.  Without this, the UI keeps
+        # showing the raw concatenated streaming output because
+        # _handle_user_input_required only used to send a status message (which
+        # the UI doesn't render as the primary content area).
+        if content:
+            final_artifact = new_text_artifact(
+                name='final_result',
+                description='Complete result from Platform Engineer',
+                text=content,
+            )
+            await self._send_artifact(event_queue, task, final_artifact, append=False, last_chunk=True)
+
         # If metadata with form fields is provided, send it as a separate artifact
         # This allows the UI to render a structured form instead of just text
         if metadata and metadata.get("input_fields"):


### PR DESCRIPTION
# Description

Turns out we ignore structured final response when user input is required :)
let's not do that

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
