### PR TITLE
feat(rag-server): add MCPAuthMiddleware to enforce auth on /mcp routes

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/rbac.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/rbac.py
@@ -498,15 +498,20 @@ def is_trusted_request(request: Request) -> bool:
     return False
 
   # Option 1: Check source IP against CIDR ranges
-  if TRUSTED_NETWORK_CIDRS and request.client:
-    try:
-      client_ip = ipaddress.ip_address(request.client.host)
-      for cidr in TRUSTED_NETWORK_CIDRS:
-        if client_ip in cidr:
-          logger.debug(f"Request from trusted network: {client_ip} in {cidr}")
-          return True
-    except ValueError as e:
-      logger.warning(f"Invalid client IP address: {request.client.host} - {e}")
+  # Prefer X-Forwarded-For (real client IP set by Istio ingress) over the direct
+  # connection IP (request.client.host), which is always the ingress gateway.
+  if TRUSTED_NETWORK_CIDRS:
+    xff = request.headers.get("X-Forwarded-For")
+    raw_ip = xff.split(",")[0].strip() if xff else (request.client.host if request.client else None)
+    if raw_ip:
+      try:
+        client_ip = ipaddress.ip_address(raw_ip)
+        for cidr in TRUSTED_NETWORK_CIDRS:
+          if client_ip in cidr:
+            logger.debug(f"Request from trusted network: {client_ip} in {cidr}")
+            return True
+      except ValueError as e:
+        logger.warning(f"Invalid client IP address: {raw_ip} - {e}")
 
   # Option 2: Check for trusted header
   if TRUSTED_NETWORK_TOKEN:

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -9,8 +9,9 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastmcp import FastMCP
 from server.tools import AgentTools
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import StreamingResponse
+from starlette.responses import PlainTextResponse, StreamingResponse
 from starlette.background import BackgroundTask
 from typing import List, Optional
 import logging
@@ -35,7 +36,7 @@ from common.models.server import (
 )
 from common.models.rag import DataSourceInfo, IngestorInfo, valid_metadata_keys
 from common.models.rbac import Role, UserContext, UserInfoResponse
-from server.rbac import get_user_or_anonymous, require_role, has_permission, get_permissions, is_trusted_request, UserInfoCache, set_userinfo_cache, get_auth_manager
+from server.rbac import get_user_or_anonymous, require_role, has_permission, get_permissions, is_trusted_request, UserInfoCache, set_userinfo_cache, get_auth_manager, _authenticate_from_token
 from common.graph_db.neo4j.graph_db import Neo4jDB
 from common.graph_db.base import GraphDB
 from common.constants import DATASOURCE_ID_KEY, WEBLOADER_INGESTOR_REDIS_QUEUE, WEBLOADER_INGESTOR_NAME, WEBLOADER_INGESTOR_TYPE, CONFLUENCE_INGESTOR_REDIS_QUEUE, CONFLUENCE_INGESTOR_NAME, CONFLUENCE_INGESTOR_TYPE, DEFAULT_DATA_LABEL, DEFAULT_SCHEMA_LABEL
@@ -216,6 +217,50 @@ async def combined_lifespan(app: FastAPI):
 
 
 # Initialize FastAPI app
+class MCPAuthMiddleware(BaseHTTPMiddleware):
+  """
+  Middleware that enforces authentication on /mcp* routes.
+
+  FastMCP routes are registered outside FastAPI's dependency injection system
+  so they cannot use Depends()-based auth guards. This middleware intercepts
+  requests to /mcp* paths and applies the same auth logic as require_authenticated_user():
+    1. Valid Bearer JWT -> allowed through
+    2. Trusted network (CIDR / X-Trust-Token) -> allowed through
+    3. Anything else -> 401
+
+  Non-MCP routes are unaffected and continue to use their own Depends() guards.
+  """
+
+  async def dispatch(self, request: Request, call_next):
+    if not request.url.path.startswith("/mcp"):
+      return await call_next(request)
+
+    # Allow OPTIONS (CORS preflight) without auth
+    if request.method == "OPTIONS":
+      return await call_next(request)
+
+    auth_header = request.headers.get("Authorization")
+    if auth_header:
+      if not auth_header.startswith("Bearer "):
+        return self._unauthorized("Invalid Authorization header format. Expected 'Bearer <token>'.", request)
+      auth_manager = get_auth_manager()
+      user = await _authenticate_from_token(request, auth_manager)
+      if user:
+        return await call_next(request)
+      return self._unauthorized("Invalid or expired token.", request)
+
+    if is_trusted_request(request):
+      return await call_next(request)
+
+    return self._unauthorized("Missing or malformed Authorization header.", request)
+
+  def _unauthorized(self, reason: str, request: Request):
+    accept = request.headers.get("accept", "")
+    if "text/event-stream" in accept:
+      return PlainTextResponse(f"error unauthorized: {reason}", status_code=401, media_type="text/event-stream")
+    return JSONResponse({"error": "unauthorized", "reason": reason}, status_code=401)
+
+
 if mcp_enabled:
   app = FastAPI(
     title="CAIPE RAG API",
@@ -224,6 +269,7 @@ if mcp_enabled:
     lifespan=combined_lifespan,
     routes=[*mcp_app.routes],  # Include MCP routes
   )
+  app.add_middleware(MCPAuthMiddleware)
 else:
   app = FastAPI(
     title="CAIPE RAG API",


### PR DESCRIPTION
# Description

FastMCP routes are registered via mcp.http_app() and included in the FastAPI app through routes=[*mcp_app.routes]. This bypasses FastAPI's Depends() injection system, meaning the RBAC guards on REST endpoints do not apply to MCP routes — leaving /mcp* paths unauthenticated even when OIDC is fully configured.

Add MCPAuthMiddleware (BaseHTTPMiddleware) that intercepts all /mcp* requests and applies the same logic as require_authenticated_user():
  1. Valid Bearer JWT -> allowed through
  2. Trusted network (CIDR / X-Trust-Token) -> allowed through
  3. Anything else -> 401

Reuses existing get_auth_manager(), _authenticate_from_token(), and is_trusted_request() from rbac.py — no new auth logic introduced. The middleware is only added when mcp_enabled=true.

This also updates the trusted network CIDR logic to check X-Forwarded-For first to support stacks where requests are routed through Istio which sits in the trusted network.

# Validation

_workflow demonstrating the new functionality by deploying the prebuild image to our dev environment_

Using this script to validate auth for the RAG MCP server:

```bash
#!/bin/bash
# Validates that MCPAuthMiddleware correctly blocks unauthenticated /mcp requests.
# Usage: ./validate-mcp-auth.sh [before|patch|after]
set -euo pipefail

TOKEN=$(cat <TOKENPATH> | jq -r '.access_token')
MCP_URL='<URL>'
MCP_PAYLOAD='{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
IMAGE='ghcr.io/cnoe-io/prebuild/caipe-rag-server:rag-mcp-auth-middleware-2'
PHASE=${1:-before}

mcp_call() {
    local desc=$1; shift
    echo -n "  $desc: "
    curl -s -w ' STATUS:%{http_code}' -H 'Accept: application/json, text/event-stream' \
        -H 'Content-Type: application/json' -X POST "$MCP_URL" \
        --data-raw "$MCP_PAYLOAD" "$@" | grep -o '"message":"[^"]*"\|error[^,}]*\|STATUS:[0-9]*' | tr '\n' ' '
    echo
}

case "$PHASE" in
before)
    echo "=== BEFORE patch (expect: no token → 200 BUG, with token → 200) ==="
    mcp_call "no token  "
    mcp_call "with token" -H "Authorization: Bearer $TOKEN"
    ;;
patch)
    echo "=== Patching rag-server image ==="
    kubectl patch deployment rag-server --type='json' \
        -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/image\",\"value\":\"$IMAGE\"}]"
    kubectl rollout status deployment/rag-server -n sdp-ai
    echo "Done. Run: $0 after"
    ;;
after)
    echo "=== AFTER patch (expect: no token → 401 FIXED, with token → 200) ==="
    mcp_call "no token  "
    mcp_call "with token" -H "Authorization: Bearer $TOKEN"
    ;;
*)
    echo "Usage: $0 [before|patch|after]"
    exit 1
    ;;
esac
```

Running this script:

```
>>>  kubectl get deployment rag-server -o jsonpath='{.spec.template.spec.containers[0].image}'
ghcr.io/cnoe-io/caipe-rag-server:0.2.22

>>> ./validate-mcp-auth.sh before
=== BEFORE patch (expect: no token → 200 BUG, with token → 200) ===
  no token  : STATUS:200
  with token: STATUS:200

>>> ./validate-mcp-auth.sh patch
=== Patching rag-server image ===
deployment.apps/rag-server patched
Waiting for deployment "rag-server" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "rag-server" rollout to finish: 1 old replicas are pending termination...
deployment "rag-server" successfully rolled out
Done. Run: ./validate-mcp-auth.sh after

>>> kubectl get deployment rag-server -n sdp-ai -o jsonpath='{.spec.template.spec.containers[0].image}'
ghcr.io/cnoe-io/prebuild/caipe-rag-server:rag-mcp-auth-middleware-2

>>> ./validate-mcp-auth.sh after
=== AFTER patch (expect: no token → 401 FIXED, with token → 200) ===
  no token  : error unauthorized: Missing or malformed Authorization header. STATUS:401
  with token: STATUS:200
```

and in the rag-server logs we can see

```text
rag-server 2026-02-25 20:49:48,074 - [rag.server.auth] DEBUG - Fetching fresh JWKS for provider 'ui' (auth.py:136)                                                                                                   │
│ rag-server 2026-02-25 20:49:48,074 - [rag.server.auth] DEBUG - Provider 'ui': Attempting discovery with explicit URL: <AUTH_SERVER>/.well-known/openid-configurat │
│ rag-server 2026-02-25 20:49:48,392 - [rag.server.auth] INFO - OIDC provider 'ui' JWKS URI: h<AUTH_SERVER>/v1/keys (auth.py:94)                                     │
│ rag-server 2026-02-25 20:49:48,392 - [rag.server.auth] DEBUG - Fetching JWKS from <AUTH_SERVER>/v1/keys (auth.py:97)                                              │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.auth] DEBUG - Token validated successfully for provider 'ui' (auth.py:194)                                                                                          │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.auth] INFO - Token validated successfully by provider 'ui' (auth.py:385)                                                                                            │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Access token validated by provider 'ui' (rbac.py:565)                                                                                                 │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Access token claims keys: ['ver', 'jti', 'iss', 'aud', 'iat', 'exp', 'cid', 'uid', 'scp', 'auth_time', 'sub', 'groups'] (rbac.py:566)                 │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Client credentials check: has_client_id=False, has_user_claims=False (rbac.py:356)                                                                    │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Not detected as client credentials token (rbac.py:376)                                                                                                │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Regular user token detected (not client credentials) (rbac.py:590)                                                                                    │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Extracted sub from access_token: <EMAIL>... (rbac.py:598)                                                                                    │
│ rag-server 2026-02-25 20:49:48,687 - [rag.server.rbac] DEBUG - Checking Redis cache for userinfo... (rbac.py:609)                                                                                                    │
│ rag-server 2026-02-25 20:49:48,688 - [rag.server.rbac] DEBUG - Userinfo cache hit for sub=<EMAIL>..., email=<EMAIL>, groups_count=<GROUPCOUNT> (rbac.py:153)                                                 │
│ rag-server 2026-02-25 20:49:48,688 - [rag.server.rbac] INFO - Userinfo found in cache: email=<EMAIL>, groups_count=<GROUPCOUNT> (rbac.py:615)                                                                         │
│ rag-server 2026-02-25 20:49:48,688 - [rag.server.rbac] INFO - User info resolution complete: email=<EMAIL>, groups_count=<GROUPCOUNT>, source=cache (rbac.py:644)                                                     │
│ rag-server 2026-02-25 20:49:48,688 - [rag.server.rbac] INFO - Role determination: Assigned ADMIN role based on group membership: ['<ADMIN GROUP>'] (rbac.py:309)                                        │
│ rag-server 2026-02-25 20:49:48,688 - [rag.server.rbac] INFO - Role determined: email=<EMAIL>, role=admin, groups=[<GROUPS>] │
│ rag-server 2026-02-25 20:49:48,688 - [rag.server.rbac] INFO - User authenticated successfully: email=<EMAIL>, role=admin, groups_count=<GROUPCOUNT>, source=cache (rbac.py:660)                                       │
│ rag-server INFO:     100.64.231.60:51826 - "POST /mcp HTTP/1.1" 200 OK
```