### PR TITLE
fix(build): add retry logic to npm install for transient registry errors

### DIFF
--- a/build/Dockerfile.caipe-ui
+++ b/build/Dockerfile.caipe-ui
@@ -16,11 +16,24 @@ RUN npm config set fetch-retries 5 && \
     npm config set fetch-retry-maxtimeout 120000 && \
     npm config set fetch-timeout 300000
 
-# Install dependencies with appropriate package manager
-RUN if [ -f package-lock.json ]; then npm ci; \
-    elif [ -f yarn.lock ]; then yarn install --frozen-lockfile; \
-    elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i --frozen-lockfile; \
-    else npm i; fi
+# Install dependencies with retry wrapper for transient registry errors (E403/ETIMEDOUT)
+RUN set -e; \
+    install_deps() { \
+      if [ -f package-lock.json ]; then npm ci; \
+      elif [ -f yarn.lock ]; then yarn install --frozen-lockfile; \
+      elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i --frozen-lockfile; \
+      else npm i; fi; \
+    }; \
+    max_attempts=3; attempt=1; \
+    until install_deps; do \
+      if [ "$attempt" -ge "$max_attempts" ]; then \
+        echo "npm install failed after $max_attempts attempts"; exit 1; \
+      fi; \
+      attempt=$((attempt + 1)); \
+      echo "Attempt $((attempt - 1)) failed, retrying ($attempt/$max_attempts) in 15s..."; \
+      sleep 15; \
+      npm cache clean --force; \
+    done
 
 # ---------- Stage 2: Build application ----------
 FROM node:20-alpine AS build


### PR DESCRIPTION
## Summary

- The CAIPE UI Docker build [failed](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/22408840780/job/64876411265) with `npm error code E403` / `403 Forbidden - GET https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz` during `npm ci`
- Investigation confirmed `strip-ansi@6.0.1` is still published on npm (returns HTTP 200, integrity hash matches lockfile). The 403 was a **transient npm CDN issue** on the GitHub Actions runner
- All 6 lockfile references to `strip-ansi@6.0.1` are dev dependencies (jest tooling: cliui, string-length, string-width-cjs, strip-ansi-cjs, wrap-ansi-cjs, yargs)
- Wraps the npm install Dockerfile step in a retry loop (3 attempts, 15s delay, cache clean between retries) to survive transient registry errors

## Test plan

- [ ] CI builds this branch successfully (the `prebuild/` prefix triggers the Docker build workflow)
- [ ] Verify the retry logic does not mask persistent failures (exits after 3 attempts)
- [ ] Confirm no functional change to the built image (same deps, same build output)
