### PR TITLE
feat(ui): add preferences modal with categorized feature flags

### DIFF
--- a/ui/src/components/__tests__/user-menu.test.tsx
+++ b/ui/src/components/__tests__/user-menu.test.tsx
@@ -93,6 +93,17 @@ jest.mock("lucide-react", () => ({
   KeyRound: () => <span data-testid="icon-keyround" />,
   Search: () => <span data-testid="icon-search" />,
   X: () => <span data-testid="icon-x" />,
+  SlidersHorizontal: () => <span data-testid="icon-sliders" />,
+}));
+
+jest.mock("@/store/feature-flag-store", () => ({
+  useFeatureFlagStore: () => ({ initialize: jest.fn() }),
+  isFeatureEnabled: jest.fn(() => false),
+}));
+
+jest.mock("@/components/preferences-modal", () => ({
+  PreferencesModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="preferences-modal">Preferences</div> : null,
 }));
 
 jest.mock("@/components/ui/button", () => ({

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -14,6 +14,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useChatStore } from "@/store/chat-store";
 import { A2ASDKClient, type ParsedA2AEvent, type HITLDecision, toStoreEvent } from "@/lib/a2a-sdk-client";
+import { isFeatureEnabled, useFeatureFlagStore } from "@/store/feature-flag-store";
 import { cn, deduplicateByKey } from "@/lib/utils";
 import { ChatMessage as ChatMessageType, A2AEvent } from "@/types/a2a";
 import { getConfig } from "@/lib/config";
@@ -30,6 +31,8 @@ interface ChatPanelProps {
 
 export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatPanelProps) {
   const { data: session } = useSession();
+  const autoScrollEnabled = useFeatureFlagStore((s) => s.flags.autoScroll ?? true);
+  const showTimestamps = useFeatureFlagStore((s) => s.flags.showTimestamps ?? false);
 
   // Derive the user's first name for message labels (falls back to "You")
   const userDisplayName = useMemo(() => {
@@ -146,14 +149,14 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
 
   // Auto-scroll when new messages arrive (only if user hasn't scrolled up)
   useEffect(() => {
-    if (!isUserScrolledUp) {
+    if (autoScrollEnabled && !isUserScrolledUp) {
       scrollToBottom("smooth");
     }
-  }, [conversation?.messages?.length, isUserScrolledUp, scrollToBottom]);
+  }, [conversation?.messages?.length, isUserScrolledUp, scrollToBottom, autoScrollEnabled]);
 
   // Auto-scroll during streaming only if user is near the bottom
   useEffect(() => {
-    if (isThisConversationStreaming && !isUserScrolledUp) {
+    if (autoScrollEnabled && isThisConversationStreaming && !isUserScrolledUp) {
       scrollToBottom("instant");
     }
   }, [conversation?.messages?.at(-1)?.content, isThisConversationStreaming, isUserScrolledUp, scrollToBottom]);
@@ -360,12 +363,13 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
     // Add assistant message placeholder with same turnId
     const assistantMsgId = addMessage(convId, { role: "assistant", content: "" }, turnId);
 
-    // Create A2A SDK client for this request
-    // Include user email so agents know who is making the request
+    // Create A2A SDK client for this request.
+    // Only include userEmail when cross-thread memory is enabled so the
+    // backend can scope fact extraction and recall to this user.
     const client = new A2ASDKClient({
       endpoint,
       accessToken,
-      userEmail: session?.user?.email ?? undefined,
+      userEmail: isFeatureEnabled("memory") ? (session?.user?.email ?? undefined) : undefined,
     });
 
     // ═══════════════════════════════════════════════════════════════
@@ -1070,6 +1074,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
                           isRecovering={recoveringMessageId === msg.id}
                           conversationId={conversationId}
                           userDisplayName={userDisplayName}
+                          showTimestamp={showTimestamps}
                         />
                       );
                     })}
@@ -1504,22 +1509,16 @@ interface ChatMessageProps {
   onCopy: (content: string, id: string) => void;
   isCopied: boolean;
   isStreaming?: boolean;
-  // Whether this is the latest answer (should be expanded by default)
   isLatestAnswer?: boolean;
-  // Stop handler for streaming messages
   onStop?: () => void;
-  // Retry prompt - called to regenerate the response
   onRetry?: () => void;
-  // Feedback props
   feedback?: Feedback;
   onFeedbackChange?: (feedback: Feedback) => void;
   onFeedbackSubmit?: (feedback: Feedback) => void;
-  // Conversation ID for Langfuse feedback tracking
   conversationId?: string;
-  // Crash recovery: true when polling tasks/get for this message's interrupted task
   isRecovering?: boolean;
-  // Display name for user messages (first name from session, falls back to "You")
   userDisplayName?: string;
+  showTimestamp?: boolean;
 }
 
 /**
@@ -1540,11 +1539,11 @@ const ChatMessage = React.memo(function ChatMessage({
   conversationId,
   isRecovering = false,
   userDisplayName = "You",
+  showTimestamp = false,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
-  // Show Thinking expanded by default — content is truncated to 2000 chars during
-  // streaming to prevent freezes, so it's safe to keep expanded.
-  const [showRawStream, setShowRawStream] = useState(true);
+  const showThinkingDefault = useFeatureFlagStore((s) => s.flags.showThinking ?? true);
+  const [showRawStream, setShowRawStream] = useState(showThinkingDefault);
   const [isHovered, setIsHovered] = useState(false);
   // Collapse final answer for assistant messages - auto-collapse older answers, keep latest expanded
   const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -1614,19 +1613,33 @@ const ChatMessage = React.memo(function ChatMessage({
             : "text-muted-foreground justify-between"
         )}>
           {isUser ? (
-            <span className="text-xs font-medium">
-              {/* Priority: message-level senderName (from MongoDB, the actual sender)
-                  → session-based userDisplayName (backward compat for legacy messages)
-                  → "You" (no session / no data) */}
-              {message.senderName
-                ? message.senderName.split(" ")[0]
-                : userDisplayName}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium">
+                {message.senderName
+                  ? message.senderName.split(" ")[0]
+                  : userDisplayName}
+              </span>
+              {showTimestamp && (
+                <span className="text-[10px] text-muted-foreground/60 font-normal">
+                  {message.timestamp instanceof Date
+                    ? message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+                    : new Date(message.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                </span>
+              )}
+            </div>
           ) : (
             <>
-              <span className="text-xs font-medium">{getConfig('appName')}</span>
               <div className="flex items-center gap-2">
-                {/* Collapse button - shown when not streaming and content is long */}
+                <span className="text-xs font-medium">{getConfig('appName')}</span>
+                {showTimestamp && (
+                  <span className="text-[10px] text-muted-foreground/60 font-normal">
+                    {message.timestamp instanceof Date
+                      ? message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+                      : new Date(message.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
                 {!isStreaming && displayContent && displayContent.length > 300 && (
                   <button
                     onClick={() => setIsCollapsed(!isCollapsed)}

--- a/ui/src/components/preferences-modal.tsx
+++ b/ui/src/components/preferences-modal.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, { useState } from "react";
+import { Brain, Bug, Eye, ArrowDownToLine, Clock, Info, ExternalLink, Settings } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  useFeatureFlagStore,
+  FEATURE_FLAGS,
+  CATEGORY_LABELS,
+  type FeatureFlag,
+  type FeatureFlagCategory,
+  type FeatureFlagIcon,
+} from "@/store/feature-flag-store";
+
+const FLAG_ICONS: Record<FeatureFlagIcon, React.ReactNode> = {
+  Brain: <Brain className="h-4 w-4" />,
+  Bug: <Bug className="h-4 w-4" />,
+  Eye: <Eye className="h-4 w-4" />,
+  ArrowDownToLine: <ArrowDownToLine className="h-4 w-4" />,
+  Clock: <Clock className="h-4 w-4" />,
+};
+
+const CATEGORY_ORDER: FeatureFlagCategory[] = ["ai", "chat", "developer"];
+
+interface PreferencesModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function FlagRow({ flag }: { flag: FeatureFlag }) {
+  const { flags, toggle } = useFeatureFlagStore();
+  const [showInfo, setShowInfo] = useState(false);
+  const enabled = flags[flag.id] ?? flag.defaultValue;
+
+  return (
+    <div className="rounded-lg border border-border hover:border-border/80 transition-colors">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span className={cn(
+          "shrink-0 p-1.5 rounded-lg transition-colors",
+          enabled ? "text-primary bg-primary/10" : "text-muted-foreground bg-muted/50"
+        )}>
+          {FLAG_ICONS[flag.icon]}
+        </span>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium">{flag.label}</span>
+            <button
+              onClick={() => setShowInfo(!showInfo)}
+              className={cn(
+                "p-0.5 rounded transition-colors",
+                showInfo
+                  ? "text-primary"
+                  : "text-muted-foreground/40 hover:text-muted-foreground"
+              )}
+              aria-label={`Info about ${flag.label}`}
+            >
+              <Info className="h-3 w-3" />
+            </button>
+          </div>
+          <span className="text-xs text-muted-foreground">{flag.description}</span>
+        </div>
+
+        <button
+          onClick={() => toggle(flag.id)}
+          className="shrink-0"
+          role="switch"
+          aria-checked={enabled}
+          aria-label={`Toggle ${flag.label}`}
+        >
+          <div
+            className={cn(
+              "relative w-10 h-6 rounded-full transition-colors",
+              enabled ? "bg-primary" : "bg-muted-foreground/30"
+            )}
+          >
+            <div
+              className={cn(
+                "absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform",
+                enabled ? "translate-x-[18px]" : "translate-x-0.5"
+              )}
+            />
+          </div>
+        </button>
+      </div>
+
+      {showInfo && (
+        <div className="px-4 pb-3">
+          <div className="p-2.5 rounded-lg bg-muted/40 border border-border/50 text-xs text-muted-foreground leading-relaxed">
+            {flag.detail}
+            {flag.docsUrl && (
+              <a
+                href={flag.docsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 mt-1.5 text-primary hover:underline font-medium"
+              >
+                Learn more
+                <ExternalLink className="h-2.5 w-2.5" />
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PreferencesModal({ open, onOpenChange }: PreferencesModalProps) {
+  const flagsByCategory = CATEGORY_ORDER
+    .map((cat) => ({
+      category: cat,
+      label: CATEGORY_LABELS[cat],
+      flags: FEATURE_FLAGS.filter((f) => f.category === cat),
+    }))
+    .filter((g) => g.flags.length > 0);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] p-0">
+        <DialogHeader className="p-6 pb-4 border-b border-border">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl gradient-primary-br">
+              <Settings className="h-5 w-5 text-white" />
+            </div>
+            <div>
+              <DialogTitle>Your Preferences</DialogTitle>
+              <DialogDescription>
+                Personal settings for your account only
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="p-6 overflow-y-auto max-h-[60vh] space-y-6">
+          {flagsByCategory.map(({ category, label, flags }) => (
+            <div key={category}>
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                {label}
+              </h3>
+              <div className="space-y-2">
+                {flags.map((flag) => (
+                  <FlagRow key={flag.id} flag={flag} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="p-4 border-t border-border bg-muted/20">
+          <p className="text-[11px] text-center text-muted-foreground">
+            These preferences apply to your account only and sync across devices.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/settings-panel.tsx
+++ b/ui/src/components/settings-panel.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api-client";
 import { getConfig } from "@/lib/config";
+import { isFeatureEnabled } from "@/store/feature-flag-store";
 
 // Font size options
 const fontSizes = [
@@ -112,6 +113,14 @@ type GradientTheme = typeof gradientThemes[number]["id"];
 
 // Sync status type for UI indicator
 type SyncStatus = 'idle' | 'syncing' | 'synced' | 'error';
+
+/** @deprecated Use `isFeatureEnabled("memory")` from `@/store/feature-flag-store` */
+export const MEMORY_ENABLED_KEY = "caipe-feature-flags";
+
+/** @deprecated Use `isFeatureEnabled("memory")` from `@/store/feature-flag-store` */
+export function isMemoryEnabled(): boolean {
+  return isFeatureEnabled("memory");
+}
 
 export function SettingsPanel() {
   const [open, setOpen] = useState(false);
@@ -269,6 +278,7 @@ export function SettingsPanel() {
     setTheme(themeId);
     syncToServer({ theme: themeId });
   };
+
 
   if (!mounted) return null;
 

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -3,7 +3,9 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { motion, AnimatePresence } from "framer-motion";
-import { LogIn, LogOut, ChevronDown, Shield, Users, Hash, Code, ChevronRight, Layers, ExternalLink, Clock, RefreshCw, Bug, Settings, Copy, Check, KeyRound, Lightbulb, FileText, Tag, Wrench, Sparkles, ChevronUp, Search, X } from "lucide-react";
+import { LogIn, LogOut, ChevronDown, Shield, Users, Hash, Code, ChevronRight, Layers, ExternalLink, Clock, RefreshCw, Bug, Settings, Copy, Check, KeyRound, Lightbulb, FileText, Tag, Wrench, Sparkles, ChevronUp, Search, X, SlidersHorizontal } from "lucide-react";
+import { useFeatureFlagStore } from "@/store/feature-flag-store";
+import { PreferencesModal } from "@/components/preferences-modal";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { config } from "@/lib/config";
@@ -272,7 +274,9 @@ function ChangelogSection({ release, defaultOpen, onScopeClick }: {
 
 export function UserMenu() {
   const { data: session, status, update } = useSession();
+  const { initialize } = useFeatureFlagStore();
   const [open, setOpen] = useState(false);
+  const [prefsOpen, setPrefsOpen] = useState(false);
   const [systemOpen, setSystemOpen] = useState(false);
   const [systemTab, setSystemTab] = useState("oidc");
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -306,6 +310,8 @@ export function UserMenu() {
       setChangelogLoading(false);
     }
   }, []);
+
+  useEffect(() => { initialize(); }, [initialize]);
 
   // Close on outside click - MUST be called before any returns (Rules of Hooks)
   useEffect(() => {
@@ -565,6 +571,23 @@ export function UserMenu() {
               </div>
             )}
 
+            {/* Preferences */}
+            <div className="border-b border-border">
+              <button
+                onClick={() => {
+                  setPrefsOpen(true);
+                  setOpen(false);
+                }}
+                className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex items-center gap-2">
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                  <span>Preferences</span>
+                </div>
+                <ChevronRight className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
             {/* Actions */}
             <div className="p-1.5">
               <button
@@ -581,6 +604,9 @@ export function UserMenu() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Preferences Modal */}
+      <PreferencesModal open={prefsOpen} onOpenChange={setPrefsOpen} />
 
       {/* System Dialog — tabbed: OIDC Token, Debug, Built With */}
       <Dialog open={systemOpen} onOpenChange={(open) => { setSystemOpen(open); if (!open) setSystemTab("oidc"); }}>

--- a/ui/src/store/feature-flag-store.ts
+++ b/ui/src/store/feature-flag-store.ts
@@ -1,0 +1,208 @@
+import { create } from "zustand";
+import { apiClient } from "@/lib/api-client";
+
+const STORAGE_KEY = "caipe-feature-flags";
+
+export type FeatureFlagIcon = "Brain" | "Bug" | "Eye" | "ArrowDownToLine" | "Clock";
+export type FeatureFlagCategory = "ai" | "chat" | "developer";
+
+export const CATEGORY_LABELS: Record<FeatureFlagCategory, string> = {
+  ai: "AI & Memory",
+  chat: "Chat Behavior",
+  developer: "Developer",
+};
+
+export interface FeatureFlag {
+  id: string;
+  label: string;
+  description: string;
+  /** Longer explanation shown in the info tooltip */
+  detail: string;
+  icon: FeatureFlagIcon;
+  category: FeatureFlagCategory;
+  defaultValue: boolean;
+  /** MongoDB preferences field name used for server sync */
+  preferencesKey: string;
+  /** URL to documentation page (opened when the info button is clicked) */
+  docsUrl?: string;
+}
+
+export const FEATURE_FLAGS: FeatureFlag[] = [
+  {
+    id: "memory",
+    label: "Cross-Thread Memory",
+    description: "Remember facts about you across conversations",
+    detail:
+      "When enabled, the assistant extracts and recalls facts about you (e.g. your clusters, team, preferences) across separate conversations. Disabling this makes every chat start fresh.",
+    icon: "Brain",
+    category: "ai",
+    defaultValue: true,
+    preferencesKey: "memory_enabled",
+    docsUrl: "/docs/features/cross-thread-memory",
+  },
+  {
+    id: "showThinking",
+    label: "Show Thinking",
+    description: "Expand the raw stream panel by default",
+    detail:
+      "Controls whether the \"Thinking...\" panel is expanded or collapsed when the assistant starts streaming a response. You can always toggle it per-message.",
+    icon: "Eye",
+    category: "chat",
+    defaultValue: true,
+    preferencesKey: "show_thinking_enabled",
+  },
+  {
+    id: "autoScroll",
+    label: "Auto-Scroll",
+    description: "Scroll to newest message automatically",
+    detail:
+      "When enabled, the chat view scrolls to the bottom as new messages arrive and during streaming. Disable to keep your scroll position while reading older messages.",
+    icon: "ArrowDownToLine",
+    category: "chat",
+    defaultValue: true,
+    preferencesKey: "auto_scroll_enabled",
+  },
+  {
+    id: "showTimestamps",
+    label: "Show Timestamps",
+    description: "Display time next to each message",
+    detail:
+      "Shows a small timestamp (e.g. 2:34 PM) next to each message in the chat. Useful for tracking response times and reviewing conversation history.",
+    icon: "Clock",
+    category: "chat",
+    defaultValue: false,
+    preferencesKey: "show_timestamps_enabled",
+  },
+  {
+    id: "debug",
+    label: "Debug Mode",
+    description: "Verbose logging in browser console",
+    detail:
+      "Enables detailed diagnostic output in the browser developer console to help troubleshoot agent interactions and streaming issues.",
+    icon: "Bug",
+    category: "developer",
+    defaultValue: false,
+    preferencesKey: "debug_mode_enabled",
+  },
+];
+
+interface FeatureFlagState {
+  flags: Record<string, boolean>;
+  initialized: boolean;
+
+  initialize: () => void;
+  toggle: (id: string) => void;
+  isEnabled: (id: string) => boolean;
+}
+
+function getDefaults(): Record<string, boolean> {
+  const defaults: Record<string, boolean> = {};
+  for (const flag of FEATURE_FLAGS) {
+    defaults[flag.id] = flag.defaultValue;
+  }
+  return defaults;
+}
+
+function readFromLocalStorage(): Record<string, boolean> {
+  if (typeof window === "undefined") return getDefaults();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return getDefaults();
+    const parsed = JSON.parse(raw) as Record<string, boolean>;
+    const merged = getDefaults();
+    for (const flag of FEATURE_FLAGS) {
+      if (typeof parsed[flag.id] === "boolean") {
+        merged[flag.id] = parsed[flag.id];
+      }
+    }
+    return merged;
+  } catch {
+    return getDefaults();
+  }
+}
+
+function writeToLocalStorage(flags: Record<string, boolean>): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(flags));
+}
+
+let syncTimer: ReturnType<typeof setTimeout> | null = null;
+
+function syncToServer(flags: Record<string, boolean>): void {
+  if (syncTimer) clearTimeout(syncTimer);
+  syncTimer = setTimeout(() => {
+    const prefs: Record<string, string> = {};
+    for (const flag of FEATURE_FLAGS) {
+      prefs[flag.preferencesKey] = String(flags[flag.id] ?? flag.defaultValue);
+    }
+    apiClient.updatePreferences(prefs).catch(() => {
+      /* server unavailable -- localStorage still works */
+    });
+  }, 500);
+}
+
+export const useFeatureFlagStore = create<FeatureFlagState>((set, get) => ({
+  flags: getDefaults(),
+  initialized: false,
+
+  initialize: () => {
+    if (get().initialized) return;
+    const flags = readFromLocalStorage();
+    set({ flags, initialized: true });
+
+    apiClient
+      .getSettings()
+      .then((settings) => {
+        if (!settings?.preferences) return;
+        const prefs = settings.preferences;
+        const updated = { ...get().flags };
+        let changed = false;
+        for (const flag of FEATURE_FLAGS) {
+          const serverVal = prefs[flag.preferencesKey as keyof typeof prefs];
+          if (typeof serverVal === "string") {
+            const boolVal = serverVal === "true";
+            if (updated[flag.id] !== boolVal) {
+              updated[flag.id] = boolVal;
+              changed = true;
+            }
+          }
+        }
+        if (changed) {
+          writeToLocalStorage(updated);
+          set({ flags: updated });
+        }
+      })
+      .catch(() => {
+        /* server unavailable */
+      });
+  },
+
+  toggle: (id: string) => {
+    const current = get().flags;
+    const next = { ...current, [id]: !current[id] };
+    writeToLocalStorage(next);
+    set({ flags: next });
+    syncToServer(next);
+  },
+
+  isEnabled: (id: string) => {
+    const val = get().flags[id];
+    if (typeof val === "boolean") return val;
+    const flag = FEATURE_FLAGS.find((f) => f.id === id);
+    return flag?.defaultValue ?? false;
+  },
+}));
+
+/**
+ * Read a feature flag outside of React components.
+ *
+ * Prefers the Zustand store when initialized, otherwise falls back to
+ * localStorage so it works before React hydration (e.g. inside the
+ * A2ASDKClient constructor).
+ */
+export function isFeatureEnabled(id: string): boolean {
+  const store = useFeatureFlagStore.getState();
+  if (store.initialized) return store.isEnabled(id);
+  const flags = readFromLocalStorage();
+  return flags[id] ?? getDefaults()[id] ?? false;
+}

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -117,6 +117,11 @@ export interface UserSettings {
     context_panel_visible: boolean;
     debug_mode: boolean;
     code_theme: string;
+    memory_enabled: string;
+    debug_mode_enabled: string;
+    show_thinking_enabled: string;
+    auto_scroll_enabled: string;
+    show_timestamps_enabled: string;
   };
   notifications: {
     email_enabled: boolean;
@@ -143,6 +148,11 @@ export const DEFAULT_USER_SETTINGS: Omit<UserSettings, '_id' | 'user_id' | 'upda
     context_panel_visible: true,
     debug_mode: false,
     code_theme: 'onedark',
+    memory_enabled: 'true',
+    debug_mode_enabled: 'false',
+    show_thinking_enabled: 'true',
+    auto_scroll_enabled: 'true',
+    show_timestamps_enabled: 'false',
   },
   notifications: {
     email_enabled: true,


### PR DESCRIPTION
## Summary

- Replace inline feature toggles in the user dropdown with a dedicated **Preferences modal** organized by category (AI & Memory, Chat Behavior, Developer)
- Add three new user-level feature flags: **Show Thinking** (default expanded/collapsed), **Auto-Scroll**, and **Show Timestamps** (HH:MM per message)
- Each flag includes an info button with detailed explanation and optional docs link
- Settings persist via `localStorage` with MongoDB server sync

<img width="287" height="163" alt="Screenshot 2026-03-03 at 9 23 28 AM" src="https://github.com/user-attachments/assets/0066a4dd-3918-4a73-97f0-3d19ad63f8c9" />

<img width="495" height="657" alt="Screenshot 2026-03-03 at 9 23 21 AM" src="https://github.com/user-attachments/assets/d3b0ff27-5f60-41a9-b474-86f8472fe04c" />


## Test plan

- [x] `tsc --noEmit` passes
- [x] All 1815 UI tests pass (`make caipe-ui-tests`)
- [ ] Verify Preferences menu item opens modal from user dropdown
- [ ] Toggle Show Thinking off → new streaming responses should start collapsed
- [ ] Toggle Auto-Scroll off → chat should not scroll on new messages
- [ ] Toggle Show Timestamps on → HH:MM appears next to each message
- [ ] Verify settings persist across page reload (localStorage)

Made with [Cursor](https://cursor.com)