### PR TITLE
fix(slack-bot): skip duplicate CAIPE_URL in env map loop

### DIFF
--- a/charts/ai-platform-engineering/charts/slack-bot/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/templates/deployment.yaml
@@ -89,8 +89,10 @@ spec:
             - name: CAIPE_URL
               value: {{ .Values.caipeUrl | quote }}
             {{- range $key, $value := .Values.env }}
+            {{- if ne $key "CAIPE_URL" }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Summary
- The slack-bot deployment template sets `CAIPE_URL` explicitly from `.Values.caipeUrl` (line 89), but the `env` map loop (line 91) also renders it when `CAIPE_URL` exists in the parent chart's default `env` map
- Kubernetes uses the last duplicate env var, so the parent chart default (`http://ai-platform-engineering-supervisor-agent:8000`) silently overrides the user's `caipeUrl` setting
- Fix: skip `CAIPE_URL` in the env map range loop since it's already set from the dedicated value