### PR TITLE
fix(docs): escape nested quotes in ADR front matter title

### DIFF
--- a/docs/docs/changes/2026-01-29-caipe-ui-bugfix-flicker-on-new-chat.md
+++ b/docs/docs/changes/2026-01-29-caipe-ui-bugfix-flicker-on-new-chat.md
@@ -1,5 +1,5 @@
 ---
-title: "2026-01-29: Bug Fix: Flicker/Reload on "New Chat" Click"
+title: "2026-01-29: Bug Fix: Flicker/Reload on 'New Chat' Click"
 ---
 
 # Bug Fix: Flicker/Reload on "New Chat" Click


### PR DESCRIPTION
## Summary

- The Docusaurus build in the GH Pages deploy pipeline ([run #22602318285](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/22602318285/job/65486755865)) was failing due to a YAML front matter parsing error in `docs/docs/changes/2026-01-29-caipe-ui-bugfix-flicker-on-new-chat.md`
- The title field contained unescaped nested double quotes ("New Chat" inside an already double-quoted YAML string), which broke the `gray-matter` YAML parser
- Replaced the inner double quotes with single quotes to produce valid YAML

## Test plan

- [x] Verified Docusaurus build succeeds locally after the fix (npx docusaurus build completes with SUCCESS)
- [ ] CI GH Pages build should pass with this change
