### PR TITLE
fix(ci): replace pull_request_target with pull_request for security

### DIFF
--- a/.github/workflows/helm-pre-release-cleanup.yml
+++ b/.github/workflows/helm-pre-release-cleanup.yml
@@ -2,7 +2,7 @@ name: "[Pre-Release] Helm Chart Cleanup"
 description: "Cleanup pre-release Helm charts when PR is closed or label is removed"
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed, unlabeled]
     paths:
       - charts/**


### PR DESCRIPTION
## Summary

- Replaces `pull_request_target` with `pull_request` in the Helm pre-release cleanup workflow
- Prevents potential security risk where fork PRs could trigger workflows with write access to GHCR

## Security Context

`pull_request_target` runs in the base repo's context with full secrets and write permissions, even for fork PRs. While this specific workflow doesn't checkout PR code, using `pull_request` is the safer default as it:

- Restricts write permissions to same-repo PRs only
- Prevents any potential registry manipulation from fork PRs
- Follows GitHub's security best practices