### PR TITLE
fix(slack-bot): disable retryable writes for DocumentDB compatibility

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/mongodb_session.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/mongodb_session.py
@@ -33,7 +33,7 @@ class MongoDBSessionStore:
         self._client = MongoClient(
             uri,
             serverSelectionTimeoutMS=5000,
-            retryWrites=True,
+            retryWrites=False,  # DocumentDB does not support retryable writes — do not change
         )
         self._db = self._client[database]
         self._sessions = self._db["slack_sessions"]


### PR DESCRIPTION
## Summary
- `pymongo` defaults `retryWrites=True`, but AWS DocumentDB does not support retryable writes (returns error code 301)
- The MongoDB URI already has `retryWrites=false` but the `MongoClient` constructor kwarg overrides it
- Fix: explicitly set `retryWrites=False` with a comment to prevent future regressions