### PR TITLE
fix(ui): use bulk API for initial datasource job fetching

### DIFF
--- a/ui/src/components/rag/IngestView.tsx
+++ b/ui/src/components/rag/IngestView.tsx
@@ -338,8 +338,34 @@ export default function IngestView() {
       
       previousDataSourceIds.current = currentIds
       
-      for (const ds of newDataSources) {
-        await fetchJobsForDataSource(ds.datasource_id)
+      if (newDataSources.length === 0) return
+      
+      // Use bulk API instead of per-datasource fetches to reduce server load
+      // Batch in chunks of 100 (server limit)
+      const datasourceIds = newDataSources.map(ds => ds.datasource_id)
+      const BATCH_SIZE = 100
+      const chunks: string[][] = []
+      for (let i = 0; i < datasourceIds.length; i += BATCH_SIZE) {
+        chunks.push(datasourceIds.slice(i, i + BATCH_SIZE))
+      }
+      
+      // Fetch all chunks in parallel
+      try {
+        const results = await Promise.all(chunks.map(chunk => getJobsBatch(chunk)))
+        
+        setDataSourceJobs(prev => {
+          const updated = { ...prev }
+          for (const result of results) {
+            for (const [datasourceId, fetchedJobs] of Object.entries(result.jobs)) {
+              // Sort by created_at descending (newest first)
+              const sortedJobs = [...fetchedJobs].sort((a, b) => b.created_at - a.created_at)
+              updated[datasourceId] = sortedJobs
+            }
+          }
+          return updated
+        })
+      } catch (error) {
+        console.error('Failed to batch fetch jobs for new datasources:', error)
       }
     }
     if (dataSources.length > 0) {
@@ -423,8 +449,31 @@ export default function IngestView() {
       setDataSources(datasources)
       
       // Optionally refresh jobs for all datasources (on manual refresh)
-      if (alsoRefreshJobs) {
-        await Promise.all(datasources.map(ds => fetchJobsForDataSource(ds.datasource_id)))
+      // Batch in chunks of 100 (server limit)
+      if (alsoRefreshJobs && datasources.length > 0) {
+        try {
+          const datasourceIds = datasources.map(ds => ds.datasource_id)
+          const BATCH_SIZE = 100
+          const chunks: string[][] = []
+          for (let i = 0; i < datasourceIds.length; i += BATCH_SIZE) {
+            chunks.push(datasourceIds.slice(i, i + BATCH_SIZE))
+          }
+          
+          const results = await Promise.all(chunks.map(chunk => getJobsBatch(chunk)))
+          
+          setDataSourceJobs(prev => {
+            const updated = { ...prev }
+            for (const result of results) {
+              for (const [datasourceId, fetchedJobs] of Object.entries(result.jobs)) {
+                const sortedJobs = [...fetchedJobs].sort((a, b) => b.created_at - a.created_at)
+                updated[datasourceId] = sortedJobs
+              }
+            }
+            return updated
+          })
+        } catch (error) {
+          console.error('Failed to batch refresh jobs:', error)
+        }
       }
     } catch (error) {
       console.error('Failed to fetch data sources', error)


### PR DESCRIPTION
## Summary

- Fix performance issue where datasources page made individual API calls per datasource on initial load
- Use the existing bulk `/v1/jobs/batch` API instead of sequential `/v1/jobs/datasource/{id}` calls
- Chunk requests into batches of 100 (server limit) and fetch in parallel

## Problem

When loading the datasources page with 900+ datasources, the UI was making 900+ sequential HTTP requests to fetch job status. This caused significant server strain and slow page loads.

## Solution

- Initial page load now uses `getJobsBatch` with chunked parallel requests
- Manual refresh also uses the bulk API
- With 900+ datasources: **900+ sequential requests → ~10 parallel batched requests**

## Testing

- Build passes
- Verified with 927 datasources - jobs now load correctly using batched API