### PR TITLE
fix(rag): use dynamic RAG tool names instead of hardcoded list

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -148,6 +148,13 @@ class AIPlatformEngineerMAS:
         status["rag_enabled"] = False
       return status
 
+
+  def get_rag_tool_names(self) -> set[str]:
+    """Get the set of RAG tool names loaded from the MCP server."""
+    if not self.rag_tools:
+      return set()
+    return {t.name for t in self.rag_tools}
+
   async def _load_rag_tools(self) -> List[Any]:
     """
     Load RAG MCP tools from the server.

--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py
@@ -768,6 +768,13 @@ class PlatformEngineerDeepAgent:
                 status["rag_config_age_seconds"] = time.time() - self.rag_config_timestamp
             return status
     
+
+    def get_rag_tool_names(self) -> set[str]:
+        """Get the set of RAG tool names loaded from the MCP server."""
+        if not self.rag_tools:
+            return set()
+        return {t.name for t in self.rag_tools}
+
     async def _load_rag_tools(self) -> List[Any]:
         """Load RAG MCP tools from the server."""
         if not self.rag_enabled or self.rag_config is None:

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -45,7 +45,8 @@ class AIPlatformEngineerA2ABinding:
   SYSTEM_INSTRUCTION = system_prompt
 
   def __init__(self):
-      self.graph = AIPlatformEngineerMAS().get_graph()
+      self._mas_instance = AIPlatformEngineerMAS()
+      self.graph = self._mas_instance.get_graph()
       self.tracing = TracingManager()
       self._execution_plan_sent = False
 
@@ -711,14 +712,8 @@ class AIPlatformEngineerA2ABinding:
                       logging.debug(f"Resolved tool call: {tool_call_id} -> {tool_name}")
 
 
-                  # This is a hard-coded list for now
-                  # TODO: Fetch the rag tool names from when the deep agent is initialised
-                  rag_tool_names = {
-                      'search', 'fetch_document', 'fetch_datasources_and_entity_types',
-                      'graph_explore_ontology_entity', 'graph_explore_data_entity',
-                      'graph_fetch_data_entity_details', 'graph_shortest_path_between_entity_types',
-                      'graph_raw_query_data', 'graph_raw_query_ontology'
-                  }
+                  # Get RAG tool names dynamically from the MAS instance
+                  rag_tool_names = self._mas_instance.get_rag_tool_names()
 
                   # CRITICAL: Handle ResponseFormat tool in structured response mode
                   # The tool returns JSON with the structured response fields

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py
@@ -1135,14 +1135,8 @@ class AIPlatformEngineerA2ABinding:
                       accumulated_subagent_responses[tool_name].append(tool_content)
                       logging.debug(f"📦 Tracked sub-agent response from {tool_name}: {len(tool_content)} chars")
 
-                  # This is a hard-coded list for now
-                  # TODO: Fetch the rag tool names from when the deep agent is initialised
-                  rag_tool_names = {
-                      'search', 'fetch_document', 'fetch_datasources_and_entity_types',
-                      'graph_explore_ontology_entity', 'graph_explore_data_entity',
-                      'graph_fetch_data_entity_details', 'graph_shortest_path_between_entity_types',
-                      'graph_raw_query_data', 'graph_raw_query_ontology'
-                  }
+                  # Get RAG tool names dynamically from the MAS instance
+                  rag_tool_names = self._mas_instance.get_rag_tool_names()
 
                   # ResponseFormat / PlatformEngineerResponse ToolMessage — extract structured result
                   # This is the last-resort handler; prefer updates stream or AIMessage.


### PR DESCRIPTION
## Summary
- Add `get_rag_tool_names()` method to `deep_agent.py` and `deep_agent_single.py` that returns tool names from the MAS instance's `rag_tools`
- Modify A2A protocol bindings to use dynamic lookup instead of hardcoded `rag_tool_names` sets
- Store `_mas_instance` reference in `agent.py` (already existed in `agent_single.py`)

## Why
The hardcoded RAG tool names were fragile and required manual updates when tools changed. Dynamic lookup ensures the agent always uses the actual tools loaded from the MCP server.

## Files Changed
- `ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py`
- `ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py`
- `ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py`
- `ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py`