### PR TITLE
fix(slack-bot): silence unhandled reaction event warnings

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -758,6 +758,16 @@ def handle_wrong_answer_submission(ack, body, client, view):
         logger.exception(f"Error handling wrong answer submission: {e}")
 
 
+@app.event("reaction_added")
+def handle_reaction_added(event, logger):
+    pass
+
+
+@app.event("reaction_removed")
+def handle_reaction_removed(event, logger):
+    pass
+
+
 @app.error
 def custom_error_handler(error, body, logger):
     logger.exception(f"Error: {error}, Request body: {body}")


### PR DESCRIPTION
## Summary

- Add no-op handlers for `reaction_added` and `reaction_removed` events to suppress Bolt framework warnings.

## Test plan

- [ ] Verify no more "Unhandled request" warnings for reaction events in logs