### PR TITLE
fix(docker): include vault_utils.py in supervisor image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ ai_platform_engineering/agents/*/agent_*/**
 !ai_platform_engineering/agents/*/agent_*/agent_langgraph.py
 !ai_platform_engineering/agents/*/agent_*/agent_strands.py
 !ai_platform_engineering/agents/*/agent_*/tools.py
+!ai_platform_engineering/agents/*/agent_*/vault_utils.py
 !ai_platform_engineering/agents/*/agent_*/models.py
 !ai_platform_engineering/agents/*/agent_*/state.py
 !ai_platform_engineering/agents/*/agent_*/protocol_bindings/**


### PR DESCRIPTION
## Summary

- Add `vault_utils.py` to the `.dockerignore` allowlist so it's included in the supervisor Docker image

## Root cause

The `.dockerignore` excludes all files under `agent_*/**` then re-includes specific files (tools.py, agent.py, models.py, etc). `vault_utils.py` was added in PR #898 but not added to this allowlist, so it never makes it into the Docker image. This causes the aigateway subagent to fail in single-node mode with `No module named 'vault_utils'`, breaking the "Create LLM API Key" workflow.

## Test plan

- [ ] Verify `vault_utils.py` exists in the built Docker image
- [ ] Verify aigateway subagent loads without import errors
- [ ] Verify "Create LLM API Key" workflow sends Webex notification

Made with [Cursor](https://cursor.com)