### PR TITLE
feat: use Github app to bypass branch protection rule during release

### DIFF
--- a/.github/workflows/helm-release-version-sync.yml
+++ b/.github/workflows/helm-release-version-sync.yml
@@ -22,12 +22,19 @@ jobs:
     name: Sync Chart Versions
     runs-on: ubuntu-latest
     steps:
+      - name: 🔑 Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: 📥 Checkout repository
         uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 🏷️ Determine version and mode
         id: version
@@ -249,7 +256,7 @@ jobs:
       - name: 🚀 Trigger Helm chart publish
         if: steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "🚀 Triggering Helm chart publish workflow..."
 

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -34,12 +34,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: 🔑 Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: 📥 Checkout repository (with synced Chart.yaml files)
         uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: ✅ Validate version format
         run: |
@@ -173,7 +180,7 @@ jobs:
 
       - name: 🔄 Trigger fresh CI builds for release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEW_VERSION="${{ github.event.inputs.version }}"
           echo "🔄 Triggering fresh CI builds for release $NEW_VERSION..."
@@ -229,7 +236,7 @@ jobs:
 
       - name: 🚀 Create GitHub Release (Draft)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEW_VERSION="${{ github.event.inputs.version }}"
           echo "🔄 Creating DRAFT GitHub Release for $NEW_VERSION..."


### PR DESCRIPTION
# Description

Created a new Github App called `caipe-release-bot` and added it to this repo + gave right to bypass branch protection rule. This is required during release CI as the bot needs to modify the app and chart versions and push the commits directly to main. Modify the CI to use this Github App and its `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are also stored in secrets.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
