### PR TITLE
feat(rag): individual graph tool toggles

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/rag.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/rag.py
@@ -1,5 +1,5 @@
 # This file contains models for the RAG server
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import List, Optional, Dict, Any
 
 # ============================================================================
@@ -67,7 +67,31 @@ class MCPBuiltinToolsConfig(BaseModel):
     search_enabled: bool = True
     fetch_document_enabled: bool = True
     fetch_datasources_enabled: bool = True
-    graph_tools_enabled: bool = True  # Only active when graph_rag_enabled=True on server
+    # Individual graph tool toggles (only active when graph_rag_enabled=True on server)
+    graph_explore_ontology_entity_enabled: bool = True
+    graph_explore_data_entity_enabled: bool = True
+    graph_fetch_data_entity_details_enabled: bool = True
+    graph_shortest_path_between_entity_types_enabled: bool = True
+    graph_raw_query_data_enabled: bool = True
+    graph_raw_query_ontology_enabled: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_graph_tools_enabled(cls, data: Any) -> Any:
+        """Backward compat: if old 'graph_tools_enabled' key is present,
+        fan it out to the six individual flags and drop it."""
+        if isinstance(data, dict) and "graph_tools_enabled" in data:
+            val = data.pop("graph_tools_enabled")
+            for key in (
+                "graph_explore_ontology_entity_enabled",
+                "graph_explore_data_entity_enabled",
+                "graph_fetch_data_entity_details_enabled",
+                "graph_shortest_path_between_entity_types_enabled",
+                "graph_raw_query_data_enabled",
+                "graph_raw_query_ontology_enabled",
+            ):
+                data.setdefault(key, val)
+        return data
 
 
 class ParallelSearch(BaseModel):

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/tools.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/tools.py
@@ -67,17 +67,18 @@ class AgentTools:
         if builtin_config.fetch_datasources_enabled:
             mcp.tool(self.list_datasources_and_entity_types)
 
-        if graph_rag_enabled and builtin_config.graph_tools_enabled:
+        if graph_rag_enabled:
             graph_tools = [
-                self.graph_explore_ontology_entity,
-                self.graph_explore_data_entity,
-                self.graph_fetch_data_entity_details,
-                self.graph_shortest_path_between_entity_types,
-                self.graph_raw_query_data,
-                self.graph_raw_query_ontology,
+                (builtin_config.graph_explore_ontology_entity_enabled, self.graph_explore_ontology_entity),
+                (builtin_config.graph_explore_data_entity_enabled, self.graph_explore_data_entity),
+                (builtin_config.graph_fetch_data_entity_details_enabled, self.graph_fetch_data_entity_details),
+                (builtin_config.graph_shortest_path_between_entity_types_enabled, self.graph_shortest_path_between_entity_types),
+                (builtin_config.graph_raw_query_data_enabled, self.graph_raw_query_data),
+                (builtin_config.graph_raw_query_ontology_enabled, self.graph_raw_query_ontology),
             ]
-            for tool in graph_tools:
-                mcp.tool(tool)
+            for enabled, tool in graph_tools:
+                if enabled:
+                    mcp.tool(tool)
 
         logger.info(f"Registered MCP tools: {list((await mcp.get_tools()).keys())}")
 

--- a/ui/src/components/rag/MCPToolsView.tsx
+++ b/ui/src/components/rag/MCPToolsView.tsx
@@ -561,7 +561,9 @@ function BuiltinConfigSection({ config, canEdit, onUpdate }: BuiltinConfigSectio
     }
   };
 
-  const items: { key: keyof MCPBuiltinToolsConfig; label: string; description: string }[] = [
+  type ToolItem = { key: keyof MCPBuiltinToolsConfig; label: string; description: string };
+
+  const generalTools: ToolItem[] = [
     {
       key: "search_enabled",
       label: "search",
@@ -577,12 +579,67 @@ function BuiltinConfigSection({ config, canEdit, onUpdate }: BuiltinConfigSectio
       label: "list_datasources_and_entity_types",
       description: "List available datasources and graph entity types",
     },
+  ];
+
+  const graphTools: ToolItem[] = [
     {
-      key: "graph_tools_enabled",
-      label: "Graph tools",
-      description: "Explore ontology, entity relationships, and run raw graph queries (requires Graph RAG)",
+      key: "graph_explore_ontology_entity_enabled",
+      label: "graph_explore_ontology_entity",
+      description: "Explore an ontology entity and its neighborhood",
+    },
+    {
+      key: "graph_explore_data_entity_enabled",
+      label: "graph_explore_data_entity",
+      description: "Explore a data entity and its neighborhood",
+    },
+    {
+      key: "graph_fetch_data_entity_details_enabled",
+      label: "graph_fetch_data_entity_details",
+      description: "Fetch details of a single data entity with all properties and relations",
+    },
+    {
+      key: "graph_shortest_path_between_entity_types_enabled",
+      label: "graph_shortest_path_between_entity_types",
+      description: "Find shortest relationship paths between two entity types",
+    },
+    {
+      key: "graph_raw_query_data_enabled",
+      label: "graph_raw_query_data",
+      description: "Execute a raw read-only query on the data graph",
+    },
+    {
+      key: "graph_raw_query_ontology_enabled",
+      label: "graph_raw_query_ontology",
+      description: "Execute a raw read-only query on the ontology graph",
     },
   ];
+
+  const renderToggleRow = ({ key, label, description }: ToolItem) => (
+    <div key={key} className="flex items-center justify-between gap-4 py-1">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-mono">{label}</p>
+        <p className="text-xs text-muted-foreground truncate">{description}</p>
+      </div>
+      <button
+        onClick={() => toggle(key)}
+        disabled={!canEdit || saving}
+        className={cn(
+          "relative w-10 rounded-full transition-colors shrink-0",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          local[key] ? "bg-primary" : "bg-muted"
+        )}
+        style={{ height: "22px" }}
+        title={canEdit ? undefined : "Admin access required"}
+      >
+        <span
+          className={cn(
+            "absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-all",
+            local[key] ? "left-[calc(100%-18px)]" : "left-0.5"
+          )}
+        />
+      </button>
+    </div>
+  );
 
   return (
     <div className="rounded-xl border border-border/50 bg-card/50 p-4 space-y-3">
@@ -591,32 +648,14 @@ function BuiltinConfigSection({ config, canEdit, onUpdate }: BuiltinConfigSectio
         {saving && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
       </div>
       <div className="space-y-2">
-        {items.map(({ key, label, description }) => (
-          <div key={key} className="flex items-center justify-between gap-4 py-1">
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-mono">{label}</p>
-              <p className="text-xs text-muted-foreground truncate">{description}</p>
-            </div>
-            <button
-              onClick={() => toggle(key)}
-              disabled={!canEdit || saving}
-              className={cn(
-                "relative w-10 rounded-full transition-colors shrink-0",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-                local[key] ? "bg-primary" : "bg-muted"
-              )}
-              style={{ height: "22px" }}
-              title={canEdit ? undefined : "Admin access required"}
-            >
-              <span
-                className={cn(
-                  "absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-all",
-                  local[key] ? "left-[calc(100%-18px)]" : "left-0.5"
-                )}
-              />
-            </button>
-          </div>
-        ))}
+        {generalTools.map(renderToggleRow)}
+      </div>
+      <div className="border-t border-border/40 pt-3 space-y-2">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Graph RAG Tools</p>
+          <p className="text-xs text-muted-foreground/70">Requires Graph RAG to be enabled</p>
+        </div>
+        {graphTools.map(renderToggleRow)}
       </div>
     </div>
   );
@@ -789,7 +828,12 @@ export default function MCPToolsView() {
     search_enabled: true,
     fetch_document_enabled: true,
     fetch_datasources_enabled: true,
-    graph_tools_enabled: true,
+    graph_explore_ontology_entity_enabled: true,
+    graph_explore_data_entity_enabled: true,
+    graph_fetch_data_entity_details_enabled: true,
+    graph_shortest_path_between_entity_types_enabled: true,
+    graph_raw_query_data_enabled: true,
+    graph_raw_query_ontology_enabled: true,
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/ui/src/lib/rag-api.ts
+++ b/ui/src/lib/rag-api.ts
@@ -402,7 +402,12 @@ export interface MCPBuiltinToolsConfig {
   search_enabled: boolean;
   fetch_document_enabled: boolean;
   fetch_datasources_enabled: boolean;
-  graph_tools_enabled: boolean;
+  graph_explore_ontology_entity_enabled: boolean;
+  graph_explore_data_entity_enabled: boolean;
+  graph_fetch_data_entity_details_enabled: boolean;
+  graph_shortest_path_between_entity_types_enabled: boolean;
+  graph_raw_query_data_enabled: boolean;
+  graph_raw_query_ontology_enabled: boolean;
 }
 
 export async function getMCPTools(): Promise<MCPToolConfig[]> {


### PR DESCRIPTION
# Description

Replace the single `graph_tools_enabled` toggle with six individual per-tool flags so admins can enable/disable each graph tool independently. Includes backward-compat migration for existing configs stored in Redis.

UI now shows a "Graph RAG Tools" subsection with its own header and divider.

## Type of Change

- [x] New Feature

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass