### PR TITLE
fix(ui): persist deletion of built-in skills across helm deploys

### DIFF
--- a/ui/src/app/api/agent-configs/route.ts
+++ b/ui/src/app/api/agent-configs/route.ts
@@ -129,23 +129,33 @@ async function deleteAgentConfigFromMongoDB(
   user: { email: string; role?: string }
 ): Promise<void> {
   const collection = await getCollection<AgentConfig>("agent_configs");
-  
+
   const existing = await collection.findOne({ id });
   if (!existing) {
     throw new ApiError("Agent config not found", 404);
   }
-  
+
   // System configs can only be deleted by admins
   if (existing.is_system && !isUserAdmin(user)) {
     throw new ApiError("Only admins can delete system configurations", 403);
   }
-  
+
   // Non-system configs can only be deleted by owner
   if (!existing.is_system && existing.owner_id !== user.email) {
     throw new ApiError("You don't have permission to delete this configuration", 403);
   }
-  
+
   await collection.deleteOne({ id });
+
+  // Track deleted system configs so the seeder doesn't re-insert them
+  if (existing.is_system) {
+    const deletedCollection = await getCollection<{ config_id: string; deleted_at: Date; deleted_by: string }>("deleted_system_configs");
+    await deletedCollection.updateOne(
+      { config_id: id },
+      { $set: { config_id: id, deleted_at: new Date(), deleted_by: user.email } },
+      { upsert: true }
+    );
+  }
 }
 
 async function getAgentConfigsFromMongoDB(ownerEmail: string): Promise<AgentConfig[]> {

--- a/ui/src/app/api/agent-configs/seed/route.ts
+++ b/ui/src/app/api/agent-configs/seed/route.ts
@@ -20,6 +20,13 @@ import { BUILTIN_QUICK_START_TEMPLATES } from "@/types/agent-config";
  * Checks if seeding is needed (returns { needsSeeding: boolean, count: number })
  */
 
+// Load IDs of system configs that were intentionally deleted by admins
+async function getDeletedSystemConfigIds(): Promise<Set<string>> {
+  const deletedCollection = await getCollection<{ config_id: string }>("deleted_system_configs");
+  const docs = await deletedCollection.find({}).toArray();
+  return new Set(docs.map(d => d.config_id));
+}
+
 // Check if seeding is needed
 async function checkSeedingStatus(): Promise<{ needsSeeding: boolean; existingCount: number; templateCount: number }> {
   if (!isMongoDBConfigured) {
@@ -27,14 +34,18 @@ async function checkSeedingStatus(): Promise<{ needsSeeding: boolean; existingCo
   }
 
   const collection = await getCollection<AgentConfig>("agent_configs");
-  
+  const deletedIds = await getDeletedSystemConfigIds();
+
+  // Only count templates that haven't been intentionally deleted
+  const activeTemplateCount = BUILTIN_QUICK_START_TEMPLATES.filter(t => !deletedIds.has(t.id)).length;
+
   // Check how many system templates exist
   const existingSystemConfigs = await collection.countDocuments({ is_system: true });
-  
+
   return {
-    needsSeeding: existingSystemConfigs < BUILTIN_QUICK_START_TEMPLATES.length,
+    needsSeeding: existingSystemConfigs < activeTemplateCount,
     existingCount: existingSystemConfigs,
-    templateCount: BUILTIN_QUICK_START_TEMPLATES.length,
+    templateCount: activeTemplateCount,
   };
 }
 
@@ -45,14 +56,21 @@ async function seedBuiltinTemplates(): Promise<{ seeded: number; skipped: number
   }
 
   const collection = await getCollection<AgentConfig>("agent_configs");
-  
+  const deletedIds = await getDeletedSystemConfigIds();
+
   let seeded = 0;
   let skipped = 0;
 
   for (const template of BUILTIN_QUICK_START_TEMPLATES) {
+    // Skip templates that were intentionally deleted
+    if (deletedIds.has(template.id)) {
+      skipped++;
+      continue;
+    }
+
     // Check if this template already exists
     const existing = await collection.findOne({ id: template.id });
-    
+
     if (existing) {
       skipped++;
       continue;

--- a/ui/src/lib/mongodb.ts
+++ b/ui/src/lib/mongodb.ts
@@ -227,6 +227,9 @@ async function createIndexes(db: Db) {
     safeCreateIndex(db, 'workflow_runs', { owner_id: 1, workflow_id: 1 }),
     safeCreateIndex(db, 'workflow_runs', { owner_id: 1, started_at: -1 }),
 
+    // Deleted system configs (tracks intentionally deleted built-in skills)
+    safeCreateIndex(db, 'deleted_system_configs', { config_id: 1 }, { unique: true }),
+
     // Task configs collection (Task Builder)
     safeCreateIndex(db, 'task_configs', { id: 1 }, { unique: true }),
     safeCreateIndex(db, 'task_configs', { name: 1 }, { unique: true }),


### PR DESCRIPTION
## Summary

- Built-in skills reappear after every helm deploy because the seeder counts existing system configs vs the hardcoded template list, and re-inserts any that are missing
- Fix: when a system config is deleted, record its ID in a `deleted_system_configs` MongoDB collection
- The seeder now checks this collection and skips intentionally deleted templates during both the `needsSeeding` check and the insertion loop
- Added a unique index on `deleted_system_configs.config_id`

## Test plan

- [x] All 281 existing skills/agent-config tests pass
- [ ] Deploy to staging, delete a built-in skill, redeploy, verify it stays deleted
- [ ] Verify new built-in skills (added to `BUILTIN_QUICK_START_TEMPLATES`) still get seeded
- [ ] Verify non-system skill deletion is unaffected