### PR TITLE
fix: prevent auto-redirect to shared/public conversations leaking context_id across users

### DIFF
--- a/ui/src/app/(app)/chat/[uuid]/__tests__/page.test.tsx
+++ b/ui/src/app/(app)/chat/[uuid]/__tests__/page.test.tsx
@@ -39,6 +39,10 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
 }));
 
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { email: "test@example.com" } }, status: "authenticated" }),
+}));
+
 jest.mock("@/lib/config", () => ({
   getConfig: jest.fn((key: string) => {
     if (key === "caipeUrl") return "http://localhost:8000";

--- a/ui/src/app/(app)/chat/[uuid]/page.tsx
+++ b/ui/src/app/(app)/chat/[uuid]/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { motion } from "framer-motion";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { ChatPanel } from "@/components/chat/ChatPanel";
@@ -18,6 +19,7 @@ import type { Conversation as LocalConversation } from "@/types/a2a";
 function ChatUUIDPage() {
   const params = useParams();
   const router = useRouter();
+  const { data: session } = useSession();
   const uuid = params.uuid as string;
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -104,6 +106,21 @@ function ChatUUIDPage() {
       if (localConv) {
         setConversation(localConv);
         setActiveConversation(uuid);
+
+        // Derive access level from store data when the conversation was loaded
+        // by loadConversationsFromServer (which skips the per-conversation API
+        // call that normally returns access_level). Without this, shared/public
+        // conversations appear writable — users can send A2A requests with the
+        // shared conversation's UUID as context_id even though MongoDB rejects
+        // the subsequent message save (403 shared_readonly).
+        if (localConv.owner_id && session?.user?.email && localConv.owner_id !== session.user.email) {
+          if (localConv.sharing?.is_public) {
+            setAccessLevel('shared_readonly');
+          } else if (localConv.sharing?.shared_with?.includes(session.user.email) ||
+                     (localConv.sharing?.shared_with_teams?.length ?? 0) > 0) {
+            setAccessLevel('shared_readonly');
+          }
+        }
 
         const hasMessages = localConv.messages && localConv.messages.length > 0;
 

--- a/ui/src/app/(app)/chat/__tests__/page.test.tsx
+++ b/ui/src/app/(app)/chat/__tests__/page.test.tsx
@@ -19,6 +19,10 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
 }));
 
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { email: "test@example.com" } }, status: "authenticated" }),
+}));
+
 jest.mock("@/lib/config", () => ({
   getConfig: jest.fn((key: string) => {
     if (key === "logoUrl") return "/logo.svg";

--- a/ui/src/app/(app)/chat/page.tsx
+++ b/ui/src/app/(app)/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { useChatStore } from "@/store/chat-store";
 import { getStorageMode } from "@/lib/storage-config";
 import { AuthGuard } from "@/components/auth-guard";
@@ -13,15 +14,19 @@ import { CAIPESpinner } from "@/components/ui/caipe-spinner";
  *
  * Priority order:
  *  1. activeConversationId from the store (remembers the user's last selection
- *     across tab switches — e.g. Chat → Skills → Chat).
- *  2. The most recent conversation in the list (first visit / active was deleted).
+ *     across tab switches — e.g. Chat → Skills → Chat), only if owned.
+ *  2. The most recent OWNED conversation (first visit / active was deleted).
  *  3. Create a brand-new conversation (empty history).
  *
- * This ensures the URL always contains a conversation UUID, which is required
- * for proper ChatPanel/ContextPanel rendering and MongoDB persistence.
+ * Only conversations owned by the current user are considered for auto-redirect.
+ * Shared/public conversations are excluded to prevent cross-user context_id
+ * collisions — the conversations API returns owned + shared + public in a
+ * single list, and auto-selecting a public conversation would cause multiple
+ * users to unknowingly share the same A2A context_id.
  */
 function ChatRedirectPage() {
   const router = useRouter();
+  const { data: session } = useSession();
   const redirected = useRef(false);
 
   const createConversation = useChatStore((s) => s.createConversation);
@@ -41,24 +46,34 @@ function ChatRedirectPage() {
       // Re-read from the store after potential server load
       const state = useChatStore.getState();
       const { conversations: currentConversations, activeConversationId } = state;
+      const userEmail = session?.user?.email;
 
-      // 1. Resume the last active conversation if it still exists
+      // Only consider conversations OWNED by the current user for auto-redirect.
+      // The API returns shared/public conversations in the same list; picking one
+      // of those would silently drop the user into someone else's conversation,
+      // causing all their messages to share the same A2A context_id.
+      // In localStorage mode, owner_id is unset — include those conversations.
+      const ownedConversations = userEmail
+        ? currentConversations.filter((c) => !c.owner_id || c.owner_id === userEmail)
+        : currentConversations;
+
+      // 1. Resume the last active conversation if it still exists and is owned
       if (activeConversationId) {
-        const stillExists = currentConversations.some((c) => c.id === activeConversationId);
-        if (stillExists) {
+        const stillOwned = ownedConversations.some((c) => c.id === activeConversationId);
+        if (stillOwned) {
           redirected.current = true;
           router.replace(`/chat/${activeConversationId}`);
           return;
         }
       }
 
-      // 2. Fall back to the most recent conversation (sorted by updatedAt)
-      if (currentConversations.length > 0) {
-        const latestId = currentConversations[0].id;
+      // 2. Fall back to the most recent OWNED conversation (sorted by updatedAt)
+      if (ownedConversations.length > 0) {
+        const latestId = ownedConversations[0].id;
         redirected.current = true;
         router.replace(`/chat/${latestId}`);
       } else {
-        // 3. No conversations — create a new one
+        // 3. No owned conversations — create a new one
         const newId = createConversation();
         redirected.current = true;
         router.replace(`/chat/${newId}`);

--- a/ui/src/app/api/__tests__/chat-sharing-public.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-public.test.ts
@@ -158,7 +158,7 @@ describe('requireConversationAccess — public (is_public) access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation._id).toBe(conv._id);
-    expect(result.access_level).toBe('shared');
+    expect(result.access_level).toBe('shared_readonly');
   });
 
   it('denies access when is_public is false and user has no other access', async () => {
@@ -214,7 +214,7 @@ describe('requireConversationAccess — public (is_public) access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation.sharing.is_public).toBe(true);
-    expect(result.access_level).toBe('shared');
+    expect(result.access_level).toBe('shared_readonly');
   });
 
   it('does not check teams or sharing_access when is_public is true', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
@@ -186,7 +186,7 @@ describe('requireConversationAccess — readonly sharing permissions', () => {
   });
 
   describe('public shares', () => {
-    it('returns shared (comment) by default for public conversations', async () => {
+    it('returns shared_readonly (view) by default for public conversations', async () => {
       const conv = makeConversation({
         sharing: { is_public: true, shared_with: [], shared_with_teams: [] },
       });
@@ -196,7 +196,7 @@ describe('requireConversationAccess — readonly sharing permissions', () => {
 
       const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
 
-      expect(result.access_level).toBe('shared');
+      expect(result.access_level).toBe('shared_readonly');
     });
 
     it('returns shared_readonly when public_permission is view', async () => {

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -360,9 +360,11 @@ export async function requireConversationAccess(
     return { conversation, access_level: 'owner' };
   }
 
-  // Check if conversation is public (shared with everyone)
+  // Check if conversation is public (shared with everyone).
+  // Default to read-only ('view') so non-owners cannot send messages in
+  // public conversations — prevents cross-user context_id collisions.
   if (conversation.sharing?.is_public) {
-    const perm = conversation.sharing?.public_permission ?? 'comment';
+    const perm = conversation.sharing?.public_permission ?? 'view';
     return {
       conversation,
       access_level: perm === 'comment' ? 'shared' : 'shared_readonly',


### PR DESCRIPTION
# Description

## Current Issue
- GET `/api/chat/conversations` returns owned + shared + public conversations in one list.
- `ChatRedirectPage` picked the most recent one for auto-redirect regardless of public or not
- `ChatUUIDPage` then skipped the per-conversation API call (since it was already in the Zustand store), so accessLevel stayed null and the input box appeared writable.
- Users unknowingly sent A2A requests with the public conversation's UUID as context_id, polluting the shared thread in LangGraph, while MongoDB silently rejected the message saves (403 read-only) -- so no messages ever appeared in the chat history.
- Note: The user wouldn't have seen the previous message from public shared ones and wouldn't have had any knowledge that they were using that chat context because `loadConversationsFromServer` (called by ChatRedirectPage) fetches the list of conversations from GET /api/chat/conversations, which returns conversation metadata (title, id, owner, sharing info), but not the messages themselves.

## Fix
- `ChatRedirectPage` now only auto-redirects to owned conversations
- `ChatUUIDPage` now derives `shared_readonly` from store data when the API call is skipped
- api-middleware.ts defaults public_permission to view instead of comment (server-side safety net)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
