### PR TITLE
feat(dynamic-agents): add HITL forms using HumanInTheLoopMiddleware p…

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -168,6 +168,12 @@ class SleepToolConfig(BaseModel):
     )
 
 
+class RequestUserInputToolConfig(BaseModel):
+    """Configuration for the request_user_input built-in tool."""
+
+    enabled: bool = Field(True, description="Whether the tool is enabled")
+
+
 class BuiltinToolsConfig(BaseModel):
     """Configuration for built-in tools available to dynamic agents."""
 
@@ -187,6 +193,45 @@ class BuiltinToolsConfig(BaseModel):
         None,
         description="Configuration for the sleep tool (pauses execution)",
     )
+    request_user_input: RequestUserInputToolConfig | None = Field(
+        None,
+        description="Configuration for the request_user_input tool (requests structured input from user)",
+    )
+
+
+# =============================================================================
+# HITL Input Fields (for request_user_input tool)
+# =============================================================================
+
+
+class InputFieldType(str, Enum):
+    """Field types for user input forms."""
+
+    TEXT = "text"
+    SELECT = "select"
+    MULTISELECT = "multiselect"
+    BOOLEAN = "boolean"
+    NUMBER = "number"
+    URL = "url"
+    EMAIL = "email"
+
+
+class InputField(BaseModel):
+    """Definition of an input field for user forms.
+
+    Used by the request_user_input tool to define form fields.
+    Matches the InputField interface in the UI's MetadataInputForm component.
+    """
+
+    field_name: str = Field(..., description="Unique field identifier (snake_case)")
+    field_label: str | None = Field(None, description="Display label (auto-generated from field_name if not provided)")
+    field_description: str | None = Field(None, description="Help text shown below the field")
+    field_type: InputFieldType = Field(InputFieldType.TEXT, description="Type of input control")
+    field_values: list[str] | None = Field(None, description="Options for select/multiselect fields")
+    required: bool = Field(False, description="Whether the field is required")
+    default_value: str | None = Field(None, description="Pre-populated default value")
+    placeholder: str | None = Field(None, description="Placeholder text for text inputs")
+    value: str | None = Field(None, description="User-provided value (populated when form is submitted)")
 
 
 # =============================================================================

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -26,6 +26,15 @@ class RestartRuntimeRequest(BaseModel):
     session_id: str
 
 
+class ResumeStreamRequest(BaseModel):
+    """Request body for resuming an interrupted stream."""
+
+    agent_id: str
+    conversation_id: str
+    form_data: str  # JSON string of form values, or rejection message
+    trace_id: str | None = None
+
+
 def _can_use_agent(agent: DynamicAgentConfig, user: UserContext) -> bool:
     """Check if user can use the agent."""
     # Admin can use all agents
@@ -141,13 +150,13 @@ async def _generate_sse_events(
         yield f"event: error\ndata: {error_data}\n\n"
 
 
-@router.post("/stream")
-async def chat_stream(
+@router.post("/start-stream")
+async def chat_start_stream(
     request: ChatRequest,
     user: UserContext = Depends(get_current_user),
     mongo: MongoDBService = Depends(get_mongo_service),
 ) -> StreamingResponse:
-    """Stream a chat response from a dynamic agent.
+    """Start streaming a chat response from a dynamic agent.
 
     Uses Server-Sent Events (SSE) for real-time streaming.
 
@@ -155,8 +164,12 @@ async def chat_stream(
     - content: Streaming text chunks
     - tool_start: Tool invocation started
     - tool_end: Tool invocation completed
+    - input_required: Agent requests user input via form (HITL)
     - error: Error occurred
     - done: Streaming complete
+
+    If the agent calls request_user_input, streaming will end with an
+    input_required event. Use /resume-stream to continue after user input.
     """
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
@@ -189,6 +202,121 @@ async def chat_stream(
             message=request.message,
             session_id=request.conversation_id,
             user_id=user.email,
+            user_name=user.name,
+            user_groups=user.groups,
+            trace_id=request.trace_id,
+            mongo=mongo,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering
+        },
+    )
+
+
+async def _generate_resume_sse_events(
+    agent_config: DynamicAgentConfig,
+    mcp_servers: list,
+    session_id: str,
+    user_id: str,
+    form_data: str,
+    user_name: str | None = None,
+    user_groups: list[str] | None = None,
+    trace_id: str | None = None,
+    mongo: MongoDBService | None = None,
+) -> AsyncGenerator[str, None]:
+    """Generate SSE events from agent resume streaming."""
+    # Set conversation context for logging
+    conversation_id_var.set(session_id)
+
+    cache = get_runtime_cache()
+
+    # Set MongoDB service for subagent resolution
+    if mongo:
+        cache.set_mongo_service(mongo)
+
+    try:
+        # Get or create runtime with user context
+        runtime = await cache.get_or_create(
+            agent_config,
+            mcp_servers,
+            session_id,
+            user_email=user_id,
+            user_name=user_name,
+            user_groups=user_groups,
+        )
+
+        # Resume streaming with form data
+        async for event in runtime.resume(session_id, user_id, form_data, trace_id):
+            event_type = event.get("type", "event")
+            event_data = event.get("data", "")
+
+            # Format as SSE
+            if isinstance(event_data, dict):
+                data = json.dumps(event_data)
+            else:
+                data = str(event_data)
+
+            yield f"event: {event_type}\ndata: {data}\n\n"
+
+        # Send done event
+        yield "event: done\ndata: {}\n\n"
+
+    except Exception as e:
+        logger.exception(f"Error resuming stream for agent '{agent_config.name}'")
+        error_data = json.dumps({"error": str(e)})
+        yield f"event: error\ndata: {error_data}\n\n"
+
+
+@router.post("/resume-stream")
+async def chat_resume_stream(
+    request: ResumeStreamRequest,
+    user: UserContext = Depends(get_current_user),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> StreamingResponse:
+    """Resume an interrupted stream after user provides form input.
+
+    Called after the agent emitted an input_required event. The form_data
+    should be a JSON string of the form values, or a rejection message
+    if the user dismissed the form.
+
+    Events:
+    - content: Streaming text chunks
+    - tool_start: Tool invocation started
+    - tool_end: Tool invocation completed
+    - input_required: Agent requests more user input (can happen multiple times)
+    - error: Error occurred
+    - done: Streaming complete
+    """
+    # Set conversation context for logging
+    conversation_id_var.set(request.conversation_id)
+
+    # Get agent config
+    agent = mongo.get_agent(request.agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    # Check access
+    if not _can_use_agent(agent, user):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # Get MCP servers for this agent
+    server_ids = list(agent.allowed_tools.keys())
+    mcp_servers = mongo.get_servers_by_ids(server_ids) if server_ids else []
+
+    logger.info(
+        f"[chat] Resuming stream: agent='{agent.name}', user={user.email}, trace_id={request.trace_id or 'auto'}"
+    )
+
+    return StreamingResponse(
+        _generate_resume_sse_events(
+            agent_config=agent,
+            mcp_servers=mcp_servers,
+            session_id=request.conversation_id,
+            user_id=user.email,
+            form_data=request.form_data,
             user_name=user.name,
             user_groups=user.groups,
             trace_id=request.trace_id,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -3,6 +3,7 @@
 Creates and manages DeepAgent instances with MCP tools.
 """
 
+import json
 import logging
 import re
 import time
@@ -15,6 +16,7 @@ from cnoe_agent_utils.tracing import TracingManager
 from deepagents import create_deep_agent
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Command
 
 from dynamic_agents.config import Settings, get_settings
 from dynamic_agents.models import AgentContext, DynamicAgentConfig, MCPServerConfig, SubAgentRef
@@ -22,6 +24,7 @@ from dynamic_agents.prompts.extension import get_default_extension_prompt
 from dynamic_agents.services.builtin_tools import (
     create_current_datetime_tool,
     create_fetch_url_tool,
+    create_request_user_input_tool,
     create_sleep_tool,
     create_user_info_tool,
 )
@@ -33,6 +36,7 @@ from dynamic_agents.services.mcp_client import (
 from dynamic_agents.services.stream_events import (
     make_content_event,
     make_final_result_event,
+    make_input_required_event,
 )
 from dynamic_agents.services.stream_trackers import (
     SubagentTracker,
@@ -80,6 +84,7 @@ class AgentRuntime:
         self._user_name = user_name
         self._user_groups = user_groups or []
         self._graph = None
+        self._checkpointer = InMemorySaver()  # Store for state access
         self._mcp_client: MultiServerMCPClient | None = None
         self._initialized = False
         self._created_at = time.time()
@@ -181,9 +186,10 @@ class AgentRuntime:
             tools=tools,
             system_prompt=system_prompt,
             context_schema=AgentContext,
-            checkpointer=InMemorySaver(),
+            checkpointer=self._checkpointer,
             name=safe_name,
             subagents=subagents if subagents else None,
+            interrupt_on={"request_user_input": True},
         )
 
         self._initialized = True
@@ -268,6 +274,13 @@ class AgentRuntime:
             sleep_tool = create_sleep_tool(max_seconds=max_seconds)
             tools.append(sleep_tool)
             logger.debug(f"Agent '{self.config.name}': sleep enabled (max_seconds={max_seconds})")
+
+        # request_user_input tool (enabled by default)
+        request_user_input_config = self.config.builtin_tools.request_user_input
+        if request_user_input_config and request_user_input_config.enabled:
+            request_user_input_tool = create_request_user_input_tool()
+            tools.append(request_user_input_tool)
+            logger.debug(f"Agent '{self.config.name}': request_user_input enabled")
 
         return tools
 
@@ -480,6 +493,20 @@ class AgentRuntime:
             ):
                 yield event
 
+        # Check for pending interrupt (agent called request_user_input)
+        logger.info("[stream] Stream loop completed, checking for pending interrupt...")
+        interrupt_data = await self.has_pending_interrupt(session_id)
+        logger.info(f"[stream] has_pending_interrupt result: {interrupt_data}")
+        if interrupt_data:
+            logger.info(f"[stream] Agent '{self.config.name}' has pending interrupt, emitting input_required event")
+            yield make_input_required_event(
+                interrupt_id=interrupt_data["interrupt_id"],
+                prompt=interrupt_data["prompt"],
+                fields=interrupt_data["fields"],
+                agent=self.config.name,
+            )
+            return  # Don't emit final_result, stream paused for user input
+
         # Emit final_result with accumulated content
         final_text = "".join(accumulated_content)
         if final_text:
@@ -626,6 +653,215 @@ class AgentRuntime:
                                     results.append(event)
 
         return results
+
+    async def has_pending_interrupt(self, session_id: str) -> dict[str, Any] | None:
+        """Check if there's a pending interrupt for the given session.
+
+        Uses the HumanInTheLoopMiddleware pattern from deepagents. When interrupt_on
+        is configured for a tool, the middleware intercepts the tool call and creates
+        an interrupt with action_requests containing the tool call info.
+
+        Args:
+            session_id: Conversation/session ID
+
+        Returns:
+            Interrupt data dict if there's a pending request_user_input interrupt, None otherwise.
+            The dict contains: interrupt_id, prompt, fields, tool_call_id
+        """
+        if not self._graph:
+            logger.warning("[has_pending_interrupt] No graph available")
+            return None
+
+        config = {"configurable": {"thread_id": session_id}}
+
+        try:
+            state = await self._graph.aget_state(config)
+            logger.debug(
+                f"[has_pending_interrupt] Got state: has_interrupts={hasattr(state, 'interrupts')}, "
+                f"interrupts_count={len(state.interrupts) if hasattr(state, 'interrupts') and state.interrupts else 0}"
+            )
+
+            # HumanInTheLoopMiddleware stores interrupts in state.interrupts (not state.tasks)
+            if not state or not hasattr(state, "interrupts") or not state.interrupts:
+                logger.debug("[has_pending_interrupt] No interrupts in state")
+                return None
+
+            # Check each interrupt for request_user_input tool call
+            for i, interrupt in enumerate(state.interrupts):
+                interrupt_value = getattr(interrupt, "value", None)
+                logger.debug(f"[has_pending_interrupt] Interrupt {i}: value_type={type(interrupt_value)}")
+
+                if not isinstance(interrupt_value, dict):
+                    continue
+
+                # HumanInTheLoopMiddleware format: {"action_requests": [...], "review_configs": [...]}
+                action_requests = interrupt_value.get("action_requests", [])
+                for action in action_requests:
+                    if action.get("name") == "request_user_input":
+                        # Extract form metadata from tool arguments
+                        args = action.get("args", {})
+                        tool_call_id = action.get("id", str(id(interrupt)))
+                        logger.info(
+                            f"[has_pending_interrupt] Found request_user_input interrupt: tool_call_id={tool_call_id}"
+                        )
+                        return {
+                            "interrupt_id": tool_call_id,
+                            "prompt": args.get("prompt", ""),
+                            "fields": args.get("fields", []),
+                            "tool_call_id": tool_call_id,
+                        }
+
+            logger.debug("[has_pending_interrupt] No request_user_input interrupt found")
+            return None
+        except Exception as e:
+            logger.warning(f"Error checking for pending interrupt: {e}")
+            return None
+
+    async def resume(
+        self,
+        session_id: str,
+        user_id: str,
+        form_data: str,
+        trace_id: str | None = None,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Resume agent execution after user provides form input.
+
+        Uses the HumanInTheLoopMiddleware pattern from deepagents. The form_data
+        is converted to a decision format that the middleware expects.
+
+        Args:
+            session_id: Conversation/session ID
+            user_id: User's email/identifier
+            form_data: JSON string of form values (e.g. {"field_name": "value"}),
+                      or rejection message if user dismissed the form
+            trace_id: Optional trace ID for Langfuse tracing
+
+        Yields:
+            SSE-compatible event dicts
+        """
+        if not self._initialized:
+            await self.initialize()
+
+        # Create config for this session
+        config = self.tracing.create_config(session_id)
+        if "configurable" not in config:
+            config["configurable"] = {}
+        config["configurable"]["thread_id"] = session_id
+
+        # Add agent context
+        config["context"] = AgentContext(
+            user_id=user_id,
+            agent_config_id=self.config.id,
+            session_id=session_id,
+        )
+
+        if "metadata" not in config:
+            config["metadata"] = {}
+        config["metadata"]["user_id"] = user_id
+        config["metadata"]["agent_config_id"] = self.config.id
+        config["metadata"]["agent_name"] = self.config.name
+        if trace_id:
+            config["metadata"]["trace_id"] = trace_id
+
+        self._current_trace_id = config.get("metadata", {}).get("trace_id")
+
+        # Initialize trackers
+        tool_tracker = ToolTracker(agent_name=self.config.name)
+        todo_tracker = TodoTracker(agent_name=self.config.name)
+        subagent_tracker = SubagentTracker(parent_agent_name=self.config.name)
+        accumulated_content: list[str] = []
+
+        logger.info(f"[resume] Resuming stream for agent '{self.config.name}': user={user_id}, conv={session_id}")
+
+        # Check if this is a rejection (dismiss) or submission
+        # Rejection message format: "User dismissed the input form without providing values."
+        is_rejection = form_data.startswith("User dismissed")
+
+        if is_rejection:
+            # User rejected/dismissed the form
+            resume_payload = {"decisions": [{"type": "reject", "message": form_data}]}
+        else:
+            # User submitted the form - parse values and build edited args
+            try:
+                user_values = json.loads(form_data)
+            except json.JSONDecodeError:
+                logger.warning(f"[resume] Invalid form_data JSON: {form_data[:100]}")
+                user_values = {}
+
+            # Get the pending interrupt to find original tool args
+            interrupt_data = await self.has_pending_interrupt(session_id)
+            if interrupt_data:
+                # Build edited args with user values merged into fields
+                original_fields = interrupt_data.get("fields", [])
+                edited_fields = []
+                for field in original_fields:
+                    field_copy = dict(field)
+                    field_name = field.get("field_name", "")
+                    if field_name in user_values:
+                        field_copy["value"] = user_values[field_name]
+                    edited_fields.append(field_copy)
+
+                edited_args = {
+                    "prompt": interrupt_data.get("prompt", ""),
+                    "fields": edited_fields,
+                }
+
+                resume_payload = {
+                    "decisions": [
+                        {
+                            "type": "edit",
+                            "edited_action": {
+                                "name": "request_user_input",
+                                "args": edited_args,
+                            },
+                        }
+                    ]
+                }
+            else:
+                # No interrupt found, just approve (shouldn't happen normally)
+                logger.warning("[resume] No pending interrupt found, using simple approve")
+                resume_payload = {"decisions": [{"type": "approve"}]}
+
+        logger.debug(f"[resume] Resume payload: {resume_payload}")
+
+        # Resume with Command containing the decisions
+        async for chunk in self._graph.astream(
+            Command(resume=resume_payload),
+            config=config,
+            stream_mode=["messages", "updates"],
+            subgraphs=True,
+        ):
+            for event in self._transform_stream_chunk(
+                chunk, tool_tracker, todo_tracker, subagent_tracker, accumulated_content
+            ):
+                yield event
+
+        # Check for another pending interrupt (agent might request more input)
+        interrupt_data = await self.has_pending_interrupt(session_id)
+        if interrupt_data:
+            logger.info(f"[resume] Agent '{self.config.name}' has pending interrupt after resume")
+            yield make_input_required_event(
+                interrupt_id=interrupt_data["interrupt_id"],
+                prompt=interrupt_data["prompt"],
+                fields=interrupt_data["fields"],
+                agent=self.config.name,
+            )
+            return  # Don't emit final_result, stream paused
+
+        # Emit final_result with accumulated content
+        final_text = "".join(accumulated_content)
+        if final_text:
+            logger.info(
+                f"[resume] Completed resume for agent '{self.config.name}': "
+                f"conv={session_id}, content_length={len(final_text)}"
+            )
+            yield make_final_result_event(
+                content=final_text,
+                agent=self.config.name,
+                trace_id=self._current_trace_id,
+                failed_servers=self._failed_servers,
+                missing_tools=self._missing_tools,
+            )
 
     async def cleanup(self) -> None:
         """Cleanup MCP client connections."""

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -4,6 +4,7 @@ This module provides wrapper functions for built-in tools that can be
 configured per-agent with access controls (e.g., domain restrictions).
 """
 
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Literal
@@ -13,7 +14,7 @@ import requests
 from bs4 import BeautifulSoup
 from langchain_core.tools import tool
 
-from dynamic_agents.models import BuiltinToolConfigField, BuiltinToolDefinition
+from dynamic_agents.models import BuiltinToolConfigField, BuiltinToolDefinition, InputField
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,13 @@ def get_builtin_tool_definitions() -> list[BuiltinToolDefinition]:
                     required=False,
                 ),
             ],
+        ),
+        BuiltinToolDefinition(
+            id="request_user_input",
+            name="Request User Input",
+            description="Requests structured input from the user via a form (HITL)",
+            enabled_by_default=True,
+            config_fields=[],
         ),
     ]
 
@@ -361,11 +369,106 @@ def create_sleep_tool(max_seconds: int = 300):
     return sleep
 
 
+def create_request_user_input_tool():
+    """Create a request_user_input tool for HITL forms.
+
+    This tool works with HumanInTheLoopMiddleware via interrupt_on configuration.
+    When the agent calls this tool, the middleware intercepts it and pauses execution.
+    The agent runtime detects the interrupt, sends an SSE event with form metadata,
+    and waits for the user to submit or dismiss the form.
+
+    When resumed, the middleware re-invokes the tool with edited args that have
+    field values populated by the user. The tool then extracts and returns those values.
+
+    Returns:
+        A LangChain tool for collecting structured user input.
+    """
+
+    @tool
+    def request_user_input(
+        prompt: str,
+        fields: list[dict],
+    ) -> str:
+        """Request structured input from the user via a form.
+
+        Use this tool when you need specific information from the user that
+        would benefit from a structured form interface (e.g., configuration values,
+        approval decisions, multi-field input).
+
+        The execution will pause until the user submits or dismisses the form.
+
+        Args:
+            prompt: Message explaining what information is needed and why.
+            fields: List of field definitions. Each field should have:
+                - field_name: Unique identifier (snake_case)
+                - field_label: Display label (optional, auto-generated from field_name)
+                - field_description: Help text (optional)
+                - field_type: One of "text", "select", "multiselect", "boolean", "number", "url", "email"
+                - field_values: Options for select/multiselect (required for those types)
+                - required: Whether field is required (default: false)
+                - default_value: Pre-populated value (optional)
+                - placeholder: Placeholder text (optional)
+                - value: User-provided value (populated when form is submitted)
+
+        Returns:
+            JSON string of submitted values ({"field_name": "value", ...}),
+            or "Waiting for user input" if fields don't have values yet,
+            or error message if validation fails.
+
+        Example:
+            result = request_user_input(
+                prompt="Please provide deployment configuration:",
+                fields=[
+                    {"field_name": "environment", "field_type": "select",
+                     "field_values": ["dev", "staging", "prod"], "required": True},
+                    {"field_name": "replicas", "field_type": "number", "default_value": "3"},
+                    {"field_name": "confirm_deploy", "field_type": "boolean",
+                     "field_label": "Confirm Deployment", "required": True}
+                ]
+            )
+        """
+        # Validate fields against InputField model
+        validated_fields = []
+        for field_dict in fields:
+            try:
+                validated = InputField(**field_dict)
+                validated_fields.append(validated.model_dump())
+            except Exception as e:
+                logger.warning(f"Invalid field definition: {field_dict}, error: {e}")
+                return f"ERROR: Invalid field definition: {e}"
+
+        # Check if any fields have values (user has submitted the form)
+        fields_with_values = [f for f in validated_fields if f.get("value") is not None]
+
+        if not fields_with_values:
+            # No values yet - this is the initial call, middleware will intercept
+            # and pause execution. Return a placeholder that won't be seen.
+            return "Waiting for user input"
+
+        # Check required fields have values
+        required_missing = [f["field_name"] for f in validated_fields if f.get("required") and f.get("value") is None]
+        if required_missing:
+            return f"ERROR: Missing required fields: {', '.join(required_missing)}"
+
+        # Extract values and return as JSON
+        result = {}
+        for f in validated_fields:
+            field_name = f.get("field_name", "")
+            value = f.get("value")
+            if value is not None:
+                result[field_name] = value
+
+        return json.dumps(result)
+
+    return request_user_input
+
+
 __all__ = [
     "create_fetch_url_tool",
     "create_current_datetime_tool",
     "create_user_info_tool",
     "create_sleep_tool",
+    "create_request_user_input_tool",
     "is_domain_allowed",
     "get_builtin_tool_definitions",
 ]

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_events.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_events.py
@@ -18,6 +18,7 @@ TODO_UPDATE = "todo_update"
 SUBAGENT_START = "subagent_start"
 SUBAGENT_END = "subagent_end"
 FINAL_RESULT = "final_result"
+INPUT_REQUIRED = "input_required"
 
 # Deepagents built-in tools (render compactly in UI)
 BUILTIN_TOOLS = frozenset(
@@ -181,5 +182,33 @@ def make_final_result_event(
                     "missing_tools": missing_tools or [],
                 },
             },
+        },
+    }
+
+
+def make_input_required_event(
+    interrupt_id: str,
+    prompt: str,
+    fields: list[dict[str, Any]],
+    agent: str,
+) -> dict[str, Any]:
+    """Input required from user (HITL form).
+
+    Sent when the agent calls request_user_input and execution is paused.
+    The UI should render a form and call resume-stream with the result.
+
+    Args:
+        interrupt_id: Unique ID for this interrupt (used to resume).
+        prompt: Message explaining what information is needed.
+        fields: List of field definitions for the form.
+        agent: The agent name that requested input.
+    """
+    return {
+        "type": INPUT_REQUIRED,
+        "data": {
+            "interrupt_id": interrupt_id,
+            "prompt": prompt,
+            "fields": fields,
+            "agent": agent,
         },
     }

--- a/ui/src/app/api/dynamic-agents/chat/resume-stream/route.ts
+++ b/ui/src/app/api/dynamic-agents/chat/resume-stream/route.ts
@@ -1,15 +1,15 @@
 /**
- * API proxy route for Dynamic Agent chat streaming.
+ * API proxy route for resuming Dynamic Agent chat streaming after HITL form submission.
  *
  * Forwards the browser's POST request to the Dynamic Agents backend
  * and pipes the SSE response back to the client without buffering.
  *
- * The browser cannot hit the backend directly (different host / internal URL),
- * so Next.js acts as a transparent SSE proxy.
- *
- * POST /api/dynamic-agents/chat/stream
- * Body: { message, conversation_id, agent_id }
+ * POST /api/dynamic-agents/chat/resume-stream
+ * Body: { conversation_id, agent_id, form_data }
  * Response: SSE stream (text/event-stream)
+ *
+ * Call this endpoint after the user submits (or dismisses) a HITL form
+ * that was requested via an `input_required` event from /start-stream.
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   }
 
   // Parse the request body
-  let body: { message: string; conversation_id: string; agent_id: string };
+  let body: { conversation_id: string; agent_id: string; form_data: string };
   try {
     body = await request.json();
   } catch {
@@ -48,9 +48,9 @@ export async function POST(request: NextRequest): Promise<Response> {
     );
   }
 
-  if (!body.message || !body.conversation_id || !body.agent_id) {
+  if (!body.conversation_id || !body.agent_id || body.form_data === undefined) {
     return NextResponse.json(
-      { success: false, error: "Missing required fields: message, conversation_id, agent_id" },
+      { success: false, error: "Missing required fields: conversation_id, agent_id, form_data" },
       { status: 400 }
     );
   }
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest): Promise<Response> {
     backendHeaders["Authorization"] = authHeader;
   }
 
-  const backendUrl = `${dynamicAgentsUrl}/api/v1/chat/stream`;
+  const backendUrl = `${dynamicAgentsUrl}/api/v1/chat/resume-stream`;
 
   try {
     const backendResponse = await fetch(backendUrl, {
@@ -79,7 +79,7 @@ export async function POST(request: NextRequest): Promise<Response> {
     if (!backendResponse.ok) {
       const errorText = await backendResponse.text().catch(() => "");
       console.error(
-        `[dynamic-agents/chat/stream] Backend error: ${backendResponse.status} ${backendResponse.statusText}`,
+        `[dynamic-agents/chat/resume-stream] Backend error: ${backendResponse.status} ${backendResponse.statusText}`,
         errorText
       );
       return NextResponse.json(
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       message.includes("ECONNREFUSED") ||
       (err instanceof TypeError && message.includes("fetch"))
     ) {
-      console.error("[dynamic-agents/chat/stream] Backend unreachable:", message);
+      console.error("[dynamic-agents/chat/resume-stream] Backend unreachable:", message);
       return NextResponse.json(
         {
           success: false,
@@ -128,7 +128,7 @@ export async function POST(request: NextRequest): Promise<Response> {
       );
     }
 
-    console.error("[dynamic-agents/chat/stream] Proxy error:", err);
+    console.error("[dynamic-agents/chat/resume-stream] Proxy error:", err);
     return NextResponse.json(
       { success: false, error: message },
       { status: 500 }

--- a/ui/src/app/api/dynamic-agents/chat/start-stream/route.ts
+++ b/ui/src/app/api/dynamic-agents/chat/start-stream/route.ts
@@ -1,0 +1,140 @@
+/**
+ * API proxy route for Dynamic Agent chat streaming (start).
+ *
+ * Forwards the browser's POST request to the Dynamic Agents backend
+ * and pipes the SSE response back to the client without buffering.
+ *
+ * The browser cannot hit the backend directly (different host / internal URL),
+ * so Next.js acts as a transparent SSE proxy.
+ *
+ * POST /api/dynamic-agents/chat/start-stream
+ * Body: { message, conversation_id, agent_id }
+ * Response: SSE stream (text/event-stream)
+ *
+ * The stream may end with an `input_required` event if the agent needs
+ * user input. In that case, use /resume-stream to continue after form submission.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerConfig } from "@/lib/config";
+
+export const runtime = "nodejs";
+// Disable body size limit for streaming responses
+export const maxDuration = 300; // 5 minutes
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const config = getServerConfig();
+
+  if (!config.dynamicAgentsEnabled) {
+    return NextResponse.json(
+      { success: false, error: "Dynamic agents are not enabled" },
+      { status: 403 }
+    );
+  }
+
+  const dynamicAgentsUrl = config.dynamicAgentsUrl;
+  if (!dynamicAgentsUrl) {
+    return NextResponse.json(
+      { success: false, error: "Dynamic agents URL not configured" },
+      { status: 500 }
+    );
+  }
+
+  // Parse the request body
+  let body: { message: string; conversation_id: string; agent_id: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.message || !body.conversation_id || !body.agent_id) {
+    return NextResponse.json(
+      { success: false, error: "Missing required fields: message, conversation_id, agent_id" },
+      { status: 400 }
+    );
+  }
+
+  // Build headers for the backend request
+  const backendHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Accept": "text/event-stream",
+  };
+
+  // Forward the access token if present
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader) {
+    backendHeaders["Authorization"] = authHeader;
+  }
+
+  const backendUrl = `${dynamicAgentsUrl}/api/v1/chat/start-stream`;
+
+  try {
+    const backendResponse = await fetch(backendUrl, {
+      method: "POST",
+      headers: backendHeaders,
+      body: JSON.stringify(body),
+    });
+
+    if (!backendResponse.ok) {
+      const errorText = await backendResponse.text().catch(() => "");
+      console.error(
+        `[dynamic-agents/chat/start-stream] Backend error: ${backendResponse.status} ${backendResponse.statusText}`,
+        errorText
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Backend error: ${backendResponse.status} ${backendResponse.statusText}`,
+        },
+        { status: backendResponse.status }
+      );
+    }
+
+    // Pipe the SSE stream through to the client
+    if (!backendResponse.body) {
+      return NextResponse.json(
+        { success: false, error: "Backend returned no body" },
+        { status: 502 }
+      );
+    }
+
+    // Return a streaming response that pipes the backend SSE through
+    return new Response(backendResponse.body, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+
+    // Handle connection errors to the backend
+    if (
+      message.includes("fetch failed") ||
+      message.includes("ECONNREFUSED") ||
+      (err instanceof TypeError && message.includes("fetch"))
+    ) {
+      console.error("[dynamic-agents/chat/start-stream] Backend unreachable:", message);
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Dynamic agents service is not available. Please ensure it is running.",
+        },
+        { status: 503 }
+      );
+    }
+
+    console.error("[dynamic-agents/chat/start-stream] Proxy error:", err);
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -62,10 +62,14 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // User input form state (HITL - Human-in-the-Loop)
+  // Supports both A2A (contextId-based) and SSE/Dynamic Agents (agentId-based)
   const [pendingUserInput, setPendingUserInput] = useState<{
     messageId: string;
     metadata: UserInputMetadata;
     contextId?: string;
+    // SSE/Dynamic Agent specific fields
+    isSSE?: boolean;
+    agentId?: string;
   } | null>(null);
 
   // Track message IDs where the user explicitly dismissed the input form,
@@ -389,7 +393,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
     if (selectedAgentId) {
       // Dynamic agent: use lightweight SSE client via proxy route
       const dynClient = new DynamicAgentClient({
-        proxyUrl: "/api/dynamic-agents/chat/stream",
+        proxyUrl: "/api/dynamic-agents/chat",
         accessToken,
       });
       abortFn = () => dynClient.abort();
@@ -549,6 +553,46 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
               accumulatedText = metadata.response;
               updateMessage(convId!, assistantMsgId, { content: accumulatedText });
             }
+          }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // DETECT USER INPUT FORM REQUEST (SSE/Dynamic Agents)
+        // ═══════════════════════════════════════════════════════════════
+        if (isSSEEvent && sseEvent.type === "input_required" && sseEvent.inputRequiredData) {
+          console.log(`[ChatPanel] 📝 SSE INPUT REQUIRED - Event #${eventNum}`, sseEvent.inputRequiredData);
+          const { prompt, fields, agent } = sseEvent.inputRequiredData;
+          
+          // Convert SSE InputFieldDefinition[] to UserInputMetadata format
+          const inputFields: InputField[] = fields.map(f => ({
+            field_name: f.field_name,
+            field_label: f.field_label,
+            field_description: f.field_description,
+            field_type: f.field_type,
+            field_values: f.field_values,
+            required: f.required,
+            default_value: f.default_value,
+            placeholder: f.placeholder,
+          }));
+
+          hitlFormRequested = true;
+          setPendingUserInput({
+            messageId: assistantMsgId,
+            metadata: {
+              user_input: true,
+              input_title: `Input Required`,
+              input_description: prompt,
+              input_fields: inputFields,
+            },
+            contextId: convId,
+            isSSE: true,
+            agentId: selectedAgentId,
+          });
+
+          // Update message content with the prompt
+          if (prompt) {
+            accumulatedText = prompt;
+            updateMessage(convId!, assistantMsgId, { content: accumulatedText });
           }
         }
 
@@ -954,6 +998,140 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
   }, [pendingUserInput, activeConversationId, endpoint, accessToken, addMessage, updateMessage,
       appendToMessage, addA2AEvent, setConversationStreaming]);
 
+  // Handle user input form submission via SSE/Dynamic Agents resume
+  const handleUserInputSubmitSSE = useCallback(async (formData: Record<string, string>) => {
+    if (!pendingUserInput || !activeConversationId || !pendingUserInput.agentId) return;
+
+    console.log("[ChatPanel] 📝 SSE HITL form submitted:", formData);
+
+    const turnId = `turn-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const selectionSummary = Object.entries(formData)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join("\n");
+    addMessage(activeConversationId, { role: "user", content: selectionSummary || "Form submitted." }, turnId);
+    const assistantMsgId = addMessage(activeConversationId, { role: "assistant", content: "" }, turnId);
+
+    dismissedInputForMessageRef.current.add(pendingUserInput.messageId);
+    const agentId = pendingUserInput.agentId;
+    setPendingUserInput(null);
+
+    // Create Dynamic Agent client for resume
+    const dynClient = new DynamicAgentClient({
+      proxyUrl: "/api/dynamic-agents/chat",
+      accessToken,
+    });
+
+    // Send form data as JSON string
+    const formDataJson = JSON.stringify(formData);
+
+    setConversationStreaming(activeConversationId, {
+      conversationId: activeConversationId,
+      messageId: assistantMsgId,
+      client: { abort: () => dynClient.abort() } as ReturnType<typeof setConversationStreaming> extends void ? never : Parameters<typeof setConversationStreaming>[1] extends { client: infer C } ? C : never,
+    });
+
+    let accumulatedText = "";
+    let rawStreamContent = "";
+    let eventCounter = 0;
+    let hasReceivedCompleteResult = false;
+    let hitlFormRequested = false;
+
+    try {
+      for await (const event of dynClient.resumeStream(activeConversationId, agentId, formDataJson)) {
+        eventCounter++;
+        const sseEvent = event as SSEAgentEvent;
+
+        // Buffer event for store
+        addSSEEvent(sseEvent, activeConversationId);
+
+        // Handle input_required (agent may request more input)
+        if (sseEvent.type === "input_required" && sseEvent.inputRequiredData) {
+          console.log(`[ChatPanel] 📝 SSE Additional input required:`, sseEvent.inputRequiredData);
+          const { prompt, fields } = sseEvent.inputRequiredData;
+          
+          const inputFields: InputField[] = fields.map(f => ({
+            field_name: f.field_name,
+            field_label: f.field_label,
+            field_description: f.field_description,
+            field_type: f.field_type,
+            field_values: f.field_values,
+            required: f.required,
+            default_value: f.default_value,
+            placeholder: f.placeholder,
+          }));
+
+          hitlFormRequested = true;
+          setPendingUserInput({
+            messageId: assistantMsgId,
+            metadata: {
+              user_input: true,
+              input_title: `Input Required`,
+              input_description: prompt,
+              input_fields: inputFields,
+            },
+            contextId: activeConversationId,
+            isSSE: true,
+            agentId,
+          });
+
+          if (prompt) {
+            accumulatedText = prompt;
+            updateMessage(activeConversationId, assistantMsgId, { content: accumulatedText });
+          }
+          break; // Stream pauses for user input
+        }
+
+        // Handle final_result
+        if (sseEvent.type === "final_result" && sseEvent.content) {
+          accumulatedText = sseEvent.content;
+          rawStreamContent += `\n\n[final_result]\n${sseEvent.content}`;
+          hasReceivedCompleteResult = true;
+          updateMessage(activeConversationId, assistantMsgId, {
+            content: accumulatedText,
+            rawStreamContent,
+            isFinal: true,
+          });
+        }
+
+        // Handle content tokens
+        if (sseEvent.type === "content" && sseEvent.content) {
+          accumulatedText += sseEvent.content;
+          rawStreamContent += sseEvent.content;
+          updateMessage(activeConversationId, assistantMsgId, { content: accumulatedText, rawStreamContent });
+        }
+
+        // Handle errors
+        if (sseEvent.type === "error") {
+          console.error("[ChatPanel] SSE resume error event:", sseEvent.displayContent);
+          appendToMessage(activeConversationId, assistantMsgId,
+            `\n\n**Error:** ${sseEvent.displayContent || "Unknown error"}`);
+          break;
+        }
+      }
+
+      if (!hitlFormRequested && !hasReceivedCompleteResult) {
+        if (accumulatedText.length > 0) {
+          console.log(`[ChatPanel] SSE HITL resume: no final_result - using accumulated content (${accumulatedText.length} chars)`);
+          updateMessage(activeConversationId, assistantMsgId, {
+            content: accumulatedText,
+            rawStreamContent,
+            isFinal: true,
+          });
+        } else {
+          console.log(`[ChatPanel] SSE HITL resume: stream ended with no content`);
+          updateMessage(activeConversationId, assistantMsgId, { rawStreamContent, isFinal: true });
+        }
+      }
+      setConversationStreaming(activeConversationId, null);
+    } catch (error) {
+      console.error("[ChatPanel] SSE HITL resume error:", error);
+      appendToMessage(activeConversationId, assistantMsgId,
+        `\n\n**Error:** ${(error as Error).message || "Failed to resume"}`);
+      setConversationStreaming(activeConversationId, null);
+    }
+  }, [pendingUserInput, activeConversationId, accessToken, addMessage, updateMessage,
+      appendToMessage, addSSEEvent, setConversationStreaming]);
+
   // Handle @mention detection
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
@@ -1176,10 +1354,33 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
                 title={pendingUserInput.metadata.input_title}
                 description={pendingUserInput.metadata.input_description}
                 inputFields={pendingUserInput.metadata.input_fields}
-                onSubmit={handleUserInputSubmit}
+                onSubmit={pendingUserInput.isSSE ? handleUserInputSubmitSSE : handleUserInputSubmit}
                 onCancel={() => {
                   if (pendingUserInput) {
                     dismissedInputForMessageRef.current.add(pendingUserInput.messageId);
+                    // For SSE, send dismissal message to resume the agent
+                    if (pendingUserInput.isSSE && pendingUserInput.agentId && activeConversationId) {
+                      const dynClient = new DynamicAgentClient({
+                        proxyUrl: "/api/dynamic-agents/chat",
+                        accessToken,
+                      });
+                      // Fire-and-forget: resume with rejection message
+                      // The agent will receive "User dismissed the input form without providing values."
+                      (async () => {
+                        try {
+                          const dismissalMessage = "User dismissed the input form without providing values.";
+                          for await (const _event of dynClient.resumeStream(
+                            activeConversationId,
+                            pendingUserInput.agentId!,
+                            dismissalMessage
+                          )) {
+                            // Consume events but don't display - user dismissed
+                          }
+                        } catch (err) {
+                          console.error("[ChatPanel] Error sending SSE form dismissal:", err);
+                        }
+                      })();
+                    }
                   }
                   setPendingUserInput(null);
                 }}

--- a/ui/src/components/dynamic-agents/sse-types.ts
+++ b/ui/src/components/dynamic-agents/sse-types.ts
@@ -82,6 +82,37 @@ export interface FinalResultEventData {
   missing_tools?: string[];
 }
 
+/** Input required data from input_required events (HITL forms) */
+export interface InputRequiredEventData {
+  /** Unique ID for this interrupt (used to resume) */
+  interrupt_id: string;
+  /** Message explaining what information is needed */
+  prompt: string;
+  /** Field definitions for the form */
+  fields: InputFieldDefinition[];
+  /** Agent that requested input */
+  agent: string;
+}
+
+/** Field definition for HITL forms (matches backend InputField model) */
+export interface InputFieldDefinition {
+  field_name: string;
+  field_label?: string;
+  field_description?: string;
+  field_type:
+    | "text"
+    | "select"
+    | "multiselect"
+    | "boolean"
+    | "number"
+    | "url"
+    | "email";
+  field_values?: string[];
+  required?: boolean;
+  default_value?: string;
+  placeholder?: string;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // HITL (Human-in-the-Loop) Types
 // ═══════════════════════════════════════════════════════════════
@@ -118,6 +149,7 @@ export type SSEEventType =
   | "subagent_start" // Subagent invocation started
   | "subagent_end" // Subagent invocation completed
   | "final_result" // Final agent response
+  | "input_required" // Agent requests user input via form (HITL)
   | "warning" // Warning event (e.g., missing tools)
   | "error"; // Error event
 
@@ -159,6 +191,9 @@ export interface SSEAgentEvent {
 
   /** Final result data for final_result events */
   finalResultData?: FinalResultEventData;
+
+  /** Input required data for input_required events (HITL forms) */
+  inputRequiredData?: InputRequiredEventData;
 
   // ─── Content ─────────────────────────────────────────────────
   /** Content text for content/final_result events */
@@ -274,6 +309,15 @@ export function createSSEAgentEvent(
           failed_servers: metadata?.failed_servers as string[] | undefined,
           missing_tools: metadata?.missing_tools as string[] | undefined,
         },
+      };
+    }
+
+    case "input_required": {
+      const inputData = data as InputRequiredEventData;
+      return {
+        ...base,
+        inputRequiredData: inputData,
+        sourceAgent: inputData.agent,
       };
     }
 

--- a/ui/src/lib/dynamic-agent-client.ts
+++ b/ui/src/lib/dynamic-agent-client.ts
@@ -26,11 +26,28 @@ import {
 } from "@/components/dynamic-agents/sse-types";
 
 export interface DynamicAgentClientConfig {
-  /** Proxy route URL (e.g. /api/dynamic-agents/chat/stream) */
+  /** Proxy route URL base (e.g. /api/dynamic-agents/chat) */
   proxyUrl: string;
   /** JWT access token for Bearer authentication */
   accessToken?: string;
 }
+
+/** Callback for when agent requests user input via form */
+export type InputRequiredCallback = (data: {
+  interruptId: string;
+  prompt: string;
+  fields: Array<{
+    field_name: string;
+    field_label?: string;
+    field_description?: string;
+    field_type: string;
+    field_values?: string[];
+    required?: boolean;
+    default_value?: string;
+    placeholder?: string;
+  }>;
+  agent: string;
+}) => void;
 
 interface RawSSEEvent {
   event: string;
@@ -51,6 +68,12 @@ export class DynamicAgentClient {
    * Can be used for feedback integration with Langfuse.
    */
   public lastTraceId: string | null = null;
+
+  /**
+   * Callback for when agent requests user input via form.
+   * Set this to handle HITL form rendering.
+   */
+  public onInputRequired: InputRequiredCallback | null = null;
 
   constructor(config: DynamicAgentClientConfig) {
     this.proxyUrl = config.proxyUrl;
@@ -100,11 +123,12 @@ export class DynamicAgentClient {
     });
 
     let eventCount = 0;
+    const streamUrl = `${this.proxyUrl}/start-stream`;
 
     try {
-      console.log(`[DynamicAgent] Sending to ${this.proxyUrl}`);
+      console.log(`[DynamicAgent] Sending to ${streamUrl}`);
 
-      const response = await fetch(this.proxyUrl, {
+      const response = await fetch(streamUrl, {
         method: "POST",
         headers,
         body,
@@ -133,13 +157,24 @@ export class DynamicAgentClient {
           console.log(`[DynamicAgent] ⚠️ Received warning event:`, rawEvent.data);
         }
 
+        // Handle input_required event (HITL form request)
+        if (rawEvent.event === "input_required") {
+          console.log(`[DynamicAgent] 📝 Input required:`, rawEvent.data);
+          // Continue to yield the event so UI can render form
+        }
+
         const agentEvent = this.mapToAgentEvent(rawEvent);
         if (!agentEvent) continue;
 
         yield agentEvent;
 
         // Check for terminal events
-        if (rawEvent.event === "done" || rawEvent.event === "error") {
+        // input_required is also terminal - stream pauses for user input
+        if (
+          rawEvent.event === "done" ||
+          rawEvent.event === "error" ||
+          rawEvent.event === "input_required"
+        ) {
           break;
         }
       }
@@ -150,6 +185,102 @@ export class DynamicAgentClient {
         console.log(`[DynamicAgent] Stream aborted after ${eventCount} events`);
       } else {
         console.error("[DynamicAgent] Stream error:", error);
+        throw error;
+      }
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  /**
+   * Resume a paused stream after user provides form input.
+   * Call this after receiving an input_required event and user submits the form.
+   *
+   * @param conversationId Conversation/session ID
+   * @param agentId Dynamic agent config ID
+   * @param formData JSON string of form values, or rejection message
+   */
+  async *resumeStream(
+    conversationId: string,
+    agentId: string,
+    formData: string,
+  ): AsyncGenerator<SSEAgentEvent, void, undefined> {
+    // Abort any previous request
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.abortController = new AbortController();
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    };
+    if (this.accessToken) {
+      headers["Authorization"] = `Bearer ${this.accessToken}`;
+    }
+
+    const body = JSON.stringify({
+      conversation_id: conversationId,
+      agent_id: agentId,
+      form_data: formData,
+    });
+
+    let eventCount = 0;
+    const resumeUrl = `${this.proxyUrl}/resume-stream`;
+
+    try {
+      console.log(`[DynamicAgent] Resuming stream at ${resumeUrl}`);
+
+      const response = await fetch(resumeUrl, {
+        method: "POST",
+        headers,
+        body,
+        signal: this.abortController.signal,
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error(
+            "Session expired: Your authentication token has expired. " +
+              "Please save your work and log in again.",
+          );
+        }
+        const errorBody = await response.text().catch(() => "");
+        throw new Error(
+          `HTTP error: ${response.status} ${response.statusText}. ${errorBody || "(empty)"}`,
+        );
+      }
+
+      // Parse SSE stream using getReader (Safari-compatible)
+      for await (const rawEvent of this.parseSSEStream(response)) {
+        eventCount++;
+
+        // Handle input_required event (agent may request more input)
+        if (rawEvent.event === "input_required") {
+          console.log(`[DynamicAgent] 📝 Additional input required:`, rawEvent.data);
+        }
+
+        const agentEvent = this.mapToAgentEvent(rawEvent);
+        if (!agentEvent) continue;
+
+        yield agentEvent;
+
+        // Check for terminal events
+        if (
+          rawEvent.event === "done" ||
+          rawEvent.event === "error" ||
+          rawEvent.event === "input_required"
+        ) {
+          break;
+        }
+      }
+
+      console.log(`[DynamicAgent] Resume stream ended after ${eventCount} events`);
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        console.log(`[DynamicAgent] Resume stream aborted after ${eventCount} events`);
+      } else {
+        console.error("[DynamicAgent] Resume stream error:", error);
         throw error;
       }
     } finally {
@@ -215,7 +346,7 @@ export class DynamicAgentClient {
   private mapToAgentEvent(raw: RawSSEEvent): SSEAgentEvent | null {
     const { event, data } = raw;
 
-    // ─── Structured events: content, tool_*, todo_update, subagent_*, final_result, warning ───
+    // ─── Structured events: content, tool_*, todo_update, subagent_*, final_result, input_required, warning ───
     if (
       event === "content" ||
       event === "tool_start" ||
@@ -224,6 +355,7 @@ export class DynamicAgentClient {
       event === "subagent_start" ||
       event === "subagent_end" ||
       event === "final_result" ||
+      event === "input_required" ||
       event === "warning"
     ) {
       try {


### PR DESCRIPTION
# Description

Implements Human-in-the-Loop (HITL) forms for Dynamic Agents, allowing agents to request structured input from users via forms. This uses deepagents' native `interrupt_on` mechanism with `HumanInTheLoopMiddleware`, matching the pattern used by CAIPE.

## How It Works

1. Agent calls `request_user_input(prompt, fields)` tool
2. `HumanInTheLoopMiddleware` intercepts (via `interrupt_on={"request_user_input": True}`)
3. Backend detects interrupt in `state.interrupts` with `action_requests` format
4. SSE `input_required` event sent to UI with form metadata
5. UI renders form using existing `MetadataInputForm` component
6. User fills form and submits
7. Backend resumes with `Command(resume={"decisions": [{"type": "edit", "edited_action": {...}}]})`
8. Tool re-runs with values populated in fields, returns JSON result
9. Agent continues with the form data

## Changes

### Backend (dynamic-agents)
- **models.py**: Added `InputFieldType` enum, `InputField` model with `value` property, `RequestUserInputToolConfig`
- **builtin_tools.py**: Added `request_user_input` tool definition and `create_request_user_input_tool()` factory
- **stream_events.py**: Added `INPUT_REQUIRED` constant and `make_input_required_event()`
- **agent_runtime.py**:
  - Added `interrupt_on={"request_user_input": True}` to `create_deep_agent()`
  - Added `has_pending_interrupt()` to detect `action_requests` from middleware
  - Added `resume()` method with proper `Command(resume={"decisions": [...]})` format
- **routes/chat.py**: Renamed `/stream` to `/start-stream`, added `/resume-stream` endpoint

### Frontend (ui)
- **sse-types.ts**: Added `InputRequiredEventData`, `InputFieldDefinition`, and `input_required` event type
- **dynamic-agent-client.ts**: Updated to use `/start-stream`, added `resumeStream()` method
- **start-stream/route.ts**: Renamed from `stream/route.ts`
- **resume-stream/route.ts**: New proxy endpoint for resume
- **ChatPanel.tsx**: Added SSE HITL form handling, reuses existing `MetadataInputForm` component

## Example Usage

An agent with `request_user_input` enabled can call:
```python
result = request_user_input(
    prompt="Please provide deployment configuration:",
    fields=[
        {"field_name": "environment", "field_type": "select",
         "field_values": ["dev", "staging", "prod"], "required": True},
        {"field_name": "replicas", "field_type": "number", "default_value": "3"},
        {"field_name": "confirm_deploy", "field_type": "boolean",
         "field_label": "Confirm Deployment", "required": True}
    ]
)
# result = '{"environment": "prod", "replicas": "5", "confirm_deploy": "true"}'
```

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass