### PR TITLE
refactor(ui): proxy write operations to dynamic-agents backend

### DIFF
--- a/ai_platform_engineering/dynamic_agents/ARCHITECTURE.md
+++ b/ai_platform_engineering/dynamic_agents/ARCHITECTURE.md
@@ -1056,16 +1056,16 @@ Stores MCP server configurations.
          │                                    │  │   dynamic_agents        │   │
          │ CRUD Operations                    │  │                         │   │
          ▼                                    │  │  • Agent configs        │   │
-┌─────────────────┐   REST API               │  │  • Owner tracking       │   │
+┌─────────────────┐   GET (reads)            │  │  • Owner tracking       │   │
 │  Next.js API    │ ──────────────────────► │  │  • Visibility rules     │   │
 │  Routes         │                          │  │  • Subagent refs        │   │
-└─────────────────┘                          │  └─────────────────────────┘   │
+└────────┬────────┘                          │  └─────────────────────────┘   │
          │                                    │                                 │
-         │ Proxy (some routes)               │  ┌─────────────────────────┐   │
+         │ POST/PUT/DELETE (writes)          │  ┌─────────────────────────┐   │
          ▼                                    │  │   mcp_servers           │   │
-┌─────────────────┐   REST API               │  │                         │   │
-│  Dynamic Agents │ ──────────────────────► │  │  • Connection configs   │   │
-│  Service        │                          │  │  • Transport types      │   │
+┌─────────────────┐                          │  │                         │   │
+│  Dynamic Agents │   Writes to MongoDB      │  │  • Connection configs   │   │
+│  Backend (proxy)│ ──────────────────────► │  │  • Transport types      │   │
 └────────┬────────┘                          │  │  • Enabled status       │   │
          │                                    │  └─────────────────────────┘   │
          │                                    │                                 │
@@ -1079,9 +1079,14 @@ Stores MCP server configurations.
 └─────────────────┘                          │  └─────────────────────────┘   │
                                               └─────────────────────────────────┘
 
-Note: The UI also stores conversations in MongoDB with an `agent_id` field
+Note: The UI stores conversations in MongoDB with an `agent_id` field
 that references the Dynamic Agent used for that conversation. This is stored
 by the UI, not the Dynamic Agents service.
+
+Write operations (POST/PUT/DELETE) go through the Dynamic Agents backend to ensure:
+• Consistent datetime handling (timezone-aware)
+• Proper validation and business logic
+• Config-driven entity protection (403 on edit/delete)
 ```
 
 ---
@@ -1269,6 +1274,53 @@ interface Conversation {
 
 ## API Flow
 
+### UI API Route Pattern
+
+The Next.js UI routes follow a hybrid pattern for interacting with Dynamic Agents data:
+
+- **Reads (GET)**: Direct MongoDB access for fast queries with visibility filtering
+- **Writes (POST, PUT, DELETE)**: Proxy to Dynamic Agents Python backend for consistent data handling
+
+This architecture ensures:
+1. **Data consistency**: The Python backend handles datetime serialization, validation, and defaults
+2. **Single source of truth**: All write operations go through the backend's business logic
+3. **Performance**: Read operations remain fast with direct MongoDB queries
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         UI API Route Pattern                                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+    Browser
+       │
+       ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         Next.js API Routes                                   │
+│                                                                              │
+│  /api/dynamic-agents          /api/mcp-servers                               │
+│  ┌─────────────────────────┐  ┌─────────────────────────┐                   │
+│  │ GET  → Direct MongoDB   │  │ GET  → Direct MongoDB   │                   │
+│  │ POST → Proxy to backend │  │ POST → Proxy to backend │                   │
+│  │ PUT  → Proxy to backend │  │ PUT  → Proxy to backend │                   │
+│  │ DELETE→ Proxy to backend│  │ DELETE→ Proxy to backend│                   │
+│  └────────────┬────────────┘  └────────────┬────────────┘                   │
+│               │                            │                                 │
+└───────────────┼────────────────────────────┼────────────────────────────────┘
+                │ Writes                     │ Reads
+                ▼                            ▼
+┌───────────────────────────────┐   ┌─────────────────────────────────────────┐
+│   Dynamic Agents Backend      │   │              MongoDB                    │
+│   (Python FastAPI)            │   │                                         │
+│                               │   │  ┌─────────────────────────┐           │
+│   /api/v1/agents/*            │   │  │   dynamic_agents        │           │
+│   /api/v1/mcp-servers/*       │   │  └─────────────────────────┘           │
+│              │                │   │                                         │
+│              ▼                │   │  ┌─────────────────────────┐           │
+│         MongoDB writes ───────┼───┼─►│   mcp_servers           │           │
+│                               │   │  └─────────────────────────┘           │
+└───────────────────────────────┘   └─────────────────────────────────────────┘
+```
+
 ### Admin Operations Flow
 
 ```
@@ -1299,24 +1351,26 @@ interface Conversation {
 │                      Next.js API Routes                                      │
 │                                                                              │
 │  /api/dynamic-agents                    /api/mcp-servers                     │
-│  • GET: List agents (via MongoDB)       • GET: List servers (via MongoDB)   │
-│  • POST: Create (via MongoDB)           • POST: Create (via MongoDB)        │
-│  • PUT: Update (via MongoDB)            • PUT: Update (via MongoDB)         │
-│  • DELETE: Remove (via MongoDB)         • DELETE: Remove (via MongoDB)      │
+│  • GET: List agents (Direct MongoDB)    • GET: List servers (Direct MongoDB) │
+│  • POST: Create → Backend proxy         • POST: Create → Backend proxy       │
+│  • PUT: Update → Backend proxy          • PUT: Update → Backend proxy        │
+│  • DELETE: Remove → Backend proxy       • DELETE: Remove → Backend proxy     │
 │                                                                              │
 │  /api/mcp-servers/probe                                                      │
-│  • POST: Probe server → proxies to Dynamic Agents service                   │
+│  • POST: Probe server → Backend proxy                                        │
 └─────────────────────────────────────────────────────────────────────────────┘
                   │                                │
-                  ▼                                ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                         MongoDB                                              │
-│                                                                              │
-│  ┌─────────────────────────┐  ┌─────────────────────────┐                   │
-│  │   dynamic_agents        │  │   mcp_servers           │                   │
-│  └─────────────────────────┘  └─────────────────────────┘                   │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
+          ┌───────┴────────┐              ┌────────┴───────┐
+          │ Reads          │              │ Writes         │
+          ▼                │              ▼                │
+┌─────────────────────┐    │   ┌─────────────────────────┐ │
+│     MongoDB         │    │   │  Dynamic Agents Backend │ │
+│                     │    │   │  (Python FastAPI)       │ │
+│ • dynamic_agents    │    │   │                         │ │
+│ • mcp_servers       │◄───┼───│  Writes to MongoDB      │ │
+└─────────────────────┘    │   └─────────────────────────┘ │
+                           │                               │
+                           └───────────────────────────────┘
 
 ### Visibility Access Control
 

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -1,11 +1,11 @@
 /**
  * API routes for Dynamic Agents management.
- * 
- * These routes proxy to the dynamic-agents backend service.
- * For MVP, they directly access MongoDB (same pattern as other admin routes).
+ *
+ * - GET: Direct MongoDB access for reads
+ * - POST, PUT, DELETE: Proxy to dynamic-agents backend for writes
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getCollection } from "@/lib/mongodb";
 import {
   withAuth,
@@ -17,86 +17,34 @@ import {
   paginatedResponse,
   getUserTeamIds,
 } from "@/lib/api-middleware";
-import type {
-  DynamicAgentConfig,
-  DynamicAgentConfigCreate,
-  DynamicAgentConfigUpdate,
-  SubAgentRef,
-  VisibilityType,
-} from "@/types/dynamic-agent";
-import type { Collection } from "mongodb";
+import type { DynamicAgentConfig } from "@/types/dynamic-agent";
 
 const COLLECTION_NAME = "dynamic_agents";
-
-/**
- * Validate that subagents have compatible visibility with the parent agent.
- * 
- * Rules:
- * - Private agent → can use private, team, or global subagents
- * - Team agent → can use team or global subagents  
- * - Global agent → can only use global subagents
- */
-async function validateSubagentVisibility(
-  parentVisibility: VisibilityType,
-  subagents: SubAgentRef[],
-  collection: Collection<DynamicAgentConfig>
-): Promise<{ valid: boolean; error?: string }> {
-  if (!subagents || subagents.length === 0) {
-    return { valid: true };
-  }
-
-  for (const subagent of subagents) {
-    const subagentConfig = await collection.findOne({ _id: subagent.agent_id });
-    if (!subagentConfig) {
-      return { valid: false, error: `Subagent "${subagent.agent_id}" not found` };
-    }
-
-    const subVis = subagentConfig.visibility;
-
-    // Global parent can only use global subagents
-    if (parentVisibility === "global" && subVis !== "global") {
-      return {
-        valid: false,
-        error: `Global agents can only use global subagents. "${subagentConfig.name}" is ${subVis}.`,
-      };
-    }
-
-    // Team parent can use team or global subagents
-    if (parentVisibility === "team" && subVis === "private") {
-      return {
-        valid: false,
-        error: `Team agents can only use team or global subagents. "${subagentConfig.name}" is private.`,
-      };
-    }
-
-    // Private parent can use any visibility (private, team, or global)
-    // No restrictions needed
-  }
-
-  return { valid: true };
-}
+const DYNAMIC_AGENTS_URL =
+  process.env.DYNAMIC_AGENTS_URL || "http://localhost:8100";
 
 /**
  * GET /api/dynamic-agents
  * List dynamic agents visible to the current user.
- * 
+ *
  * Query params:
  * - enabled_only=true: Only return enabled agents (useful for subagent selection)
  */
 export const GET = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
-    const collection = await getCollection<DynamicAgentConfig>(COLLECTION_NAME);
+    const collection =
+      await getCollection<DynamicAgentConfig>(COLLECTION_NAME);
     const { page, pageSize, skip } = getPaginationParams(request);
     const { searchParams } = new URL(request.url);
     const enabledOnly = searchParams.get("enabled_only") === "true";
 
     // Build visibility filter
     let query: any = {};
-    
+
     if (session.role !== "admin") {
       // Non-admins see: their own, global, or team-shared agents
       const userTeams = await getUserTeamIds(user.email);
-      
+
       query = {
         $and: [
           // enabled: true OR enabled field doesn't exist (defaults to true)
@@ -119,7 +67,12 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
 
     const [items, total] = await Promise.all([
-      collection.find(query).sort({ created_at: -1 }).skip(skip).limit(pageSize).toArray(),
+      collection
+        .find(query)
+        .sort({ created_at: -1 })
+        .skip(skip)
+        .limit(pageSize)
+        .toArray(),
       collection.countDocuments(query),
     ]);
 
@@ -130,83 +83,44 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 /**
  * POST /api/dynamic-agents
  * Create a new dynamic agent configuration.
+ * Proxies to dynamic-agents backend.
  * Requires admin role.
  */
 export const POST = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     requireAdmin(session);
 
-    const body: DynamicAgentConfigCreate = await request.json();
+    const body = await request.json();
 
-    // Validate required fields
-    if (!body.id) {
-      throw new ApiError("Missing required field: id", 400);
-    }
-
-    if (!body.name || !body.system_prompt) {
-      throw new ApiError("Missing required fields: name, system_prompt", 400);
-    }
-
-    if (!body.model_id || !body.model_provider) {
-      throw new ApiError("Missing required fields: model_id, model_provider", 400);
-    }
-
-    // Validate ID format (alphanumeric and underscores only)
-    if (!/^[a-z0-9_]+$/.test(body.id)) {
-      throw new ApiError("Invalid ID format: must be lowercase alphanumeric with underscores", 400);
-    }
-
-    const collection = await getCollection<DynamicAgentConfig>(COLLECTION_NAME);
-
-    // Check for ID clash
-    const existing = await collection.findOne({ _id: body.id });
-    if (existing) {
-      throw new ApiError(`Agent with ID "${body.id}" already exists`, 409);
-    }
-
-    // Validate subagent visibility compatibility
-    if (body.subagents && body.subagents.length > 0) {
-      const parentVisibility = body.visibility || "private";
-      const validationResult = await validateSubagentVisibility(
-        parentVisibility,
-        body.subagents,
-        collection
-      );
-      if (!validationResult.valid) {
-        throw new ApiError(validationResult.error!, 400);
-      }
-    }
-
-    const now = new Date().toISOString();
-
-    const newAgent: DynamicAgentConfig = {
-      _id: body.id,
-      name: body.name,
-      description: body.description,
-      system_prompt: body.system_prompt,
-      allowed_tools: body.allowed_tools || {},
-      builtin_tools: body.builtin_tools,
-      model_id: body.model_id,
-      model_provider: body.model_provider,
-      visibility: body.visibility || "private",
-      shared_with_teams: body.shared_with_teams,
-      subagents: body.subagents || [],
-      enabled: body.enabled ?? true,
-      owner_id: user.email,
-      is_system: false,
-      created_at: now,
-      updated_at: now,
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
     };
+    if (session.accessToken) {
+      headers["Authorization"] = `Bearer ${session.accessToken}`;
+    }
 
-    await collection.insertOne(newAgent as any);
+    const response = await fetch(`${DYNAMIC_AGENTS_URL}/api/v1/agents`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
 
-    return successResponse(newAgent, 201);
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(
+        data.detail || "Failed to create agent",
+        response.status
+      );
+    }
+
+    return successResponse(data.data, 201);
   });
 });
 
 /**
  * PUT /api/dynamic-agents?id=<agent_id>
  * Update a dynamic agent configuration.
+ * Proxies to dynamic-agents backend.
  * Requires admin role.
  */
 export const PUT = withErrorHandler(async (request: NextRequest) => {
@@ -220,59 +134,37 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     requireAdmin(session);
 
-    const body: DynamicAgentConfigUpdate = await request.json();
-    const collection = await getCollection<DynamicAgentConfig>(COLLECTION_NAME);
+    const body = await request.json();
 
-    // Check if agent exists
-    const existing = await collection.findOne({ _id: id });
-    if (!existing) {
-      throw new ApiError("Agent not found", 404);
-    }
-
-    // Determine final values for visibility validation
-    const finalVisibility = body.visibility ?? existing.visibility;
-    const finalSubagents = body.subagents ?? existing.subagents;
-
-    // Validate subagent visibility compatibility
-    if (finalSubagents && finalSubagents.length > 0) {
-      const validationResult = await validateSubagentVisibility(
-        finalVisibility,
-        finalSubagents,
-        collection
-      );
-      if (!validationResult.valid) {
-        throw new ApiError(validationResult.error!, 400);
-      }
-    }
-
-    // Build update
-    const updateFields: any = {
-      updated_at: new Date().toISOString(),
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
     };
+    if (session.accessToken) {
+      headers["Authorization"] = `Bearer ${session.accessToken}`;
+    }
 
-    // Only include fields that were provided
-    if (body.name !== undefined) updateFields.name = body.name;
-    if (body.description !== undefined) updateFields.description = body.description;
-    if (body.system_prompt !== undefined) updateFields.system_prompt = body.system_prompt;
-    if (body.allowed_tools !== undefined) updateFields.allowed_tools = body.allowed_tools;
-    if (body.builtin_tools !== undefined) updateFields.builtin_tools = body.builtin_tools;
-    if (body.model_id !== undefined) updateFields.model_id = body.model_id;
-    if (body.model_provider !== undefined) updateFields.model_provider = body.model_provider;
-    if (body.visibility !== undefined) updateFields.visibility = body.visibility;
-    if (body.shared_with_teams !== undefined) updateFields.shared_with_teams = body.shared_with_teams;
-    if (body.subagents !== undefined) updateFields.subagents = body.subagents;
-    if (body.enabled !== undefined) updateFields.enabled = body.enabled;
+    const response = await fetch(`${DYNAMIC_AGENTS_URL}/api/v1/agents/${id}`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify(body),
+    });
 
-    await collection.updateOne({ _id: id }, { $set: updateFields });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(
+        data.detail || "Failed to update agent",
+        response.status
+      );
+    }
 
-    const updated = await collection.findOne({ _id: id });
-    return successResponse(updated);
+    return successResponse(data.data);
   });
 });
 
 /**
  * DELETE /api/dynamic-agents?id=<agent_id>
  * Delete a dynamic agent configuration.
+ * Proxies to dynamic-agents backend.
  * Requires admin role. System agents cannot be deleted.
  */
 export const DELETE = withErrorHandler(async (request: NextRequest) => {
@@ -286,20 +178,23 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     requireAdmin(session);
 
-    const collection = await getCollection<DynamicAgentConfig>(COLLECTION_NAME);
-
-    // Check if agent exists
-    const existing = await collection.findOne({ _id: id });
-    if (!existing) {
-      throw new ApiError("Agent not found", 404);
+    const headers: HeadersInit = {};
+    if (session.accessToken) {
+      headers["Authorization"] = `Bearer ${session.accessToken}`;
     }
 
-    // System agents cannot be deleted
-    if (existing.is_system) {
-      throw new ApiError("System agents cannot be deleted", 400);
-    }
+    const response = await fetch(`${DYNAMIC_AGENTS_URL}/api/v1/agents/${id}`, {
+      method: "DELETE",
+      headers,
+    });
 
-    await collection.deleteOne({ _id: id });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(
+        data.detail || "Failed to delete agent",
+        response.status
+      );
+    }
 
     return successResponse({ deleted: id });
   });

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -1,8 +1,11 @@
 /**
  * API routes for MCP Server management.
+ *
+ * - GET: Direct MongoDB access for reads
+ * - POST, PUT, DELETE: Proxy to dynamic-agents backend for writes
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getCollection } from "@/lib/mongodb";
 import {
   withAuth,
@@ -13,13 +16,11 @@ import {
   getPaginationParams,
   paginatedResponse,
 } from "@/lib/api-middleware";
-import type {
-  MCPServerConfig,
-  MCPServerConfigCreate,
-  MCPServerConfigUpdate,
-} from "@/types/dynamic-agent";
+import type { MCPServerConfig } from "@/types/dynamic-agent";
 
 const COLLECTION_NAME = "mcp_servers";
+const DYNAMIC_AGENTS_URL =
+  process.env.DYNAMIC_AGENTS_URL || "http://localhost:8100";
 
 /**
  * GET /api/mcp-servers
@@ -45,60 +46,44 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 /**
  * POST /api/mcp-servers
  * Create a new MCP server configuration.
+ * Proxies to dynamic-agents backend.
  * Requires admin role.
  */
 export const POST = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     requireAdmin(session);
 
-    const body: MCPServerConfigCreate = await request.json();
+    const body = await request.json();
 
-    // Validate required fields
-    if (!body.id || !body.name || !body.transport) {
-      throw new ApiError("Missing required fields: id, name, transport", 400);
-    }
-
-    // Validate transport-specific fields
-    if (body.transport === "stdio" && !body.command) {
-      throw new ApiError("'command' is required for stdio transport", 400);
-    }
-    if ((body.transport === "sse" || body.transport === "http") && !body.endpoint) {
-      throw new ApiError("'endpoint' is required for sse/http transport", 400);
-    }
-
-    const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
-
-    // Check if ID already exists
-    const existing = await collection.findOne({ _id: body.id });
-    if (existing) {
-      throw new ApiError(`MCP server with ID '${body.id}' already exists`, 409);
-    }
-
-    const now = new Date().toISOString();
-
-    const newServer: MCPServerConfig = {
-      _id: body.id,
-      name: body.name,
-      description: body.description,
-      transport: body.transport,
-      endpoint: body.endpoint,
-      command: body.command,
-      args: body.args,
-      env: body.env,
-      enabled: body.enabled ?? true,
-      created_at: now,
-      updated_at: now,
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
     };
+    if (session.accessToken) {
+      headers["Authorization"] = `Bearer ${session.accessToken}`;
+    }
 
-    await collection.insertOne(newServer as any);
+    const response = await fetch(`${DYNAMIC_AGENTS_URL}/api/v1/mcp-servers`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
 
-    return successResponse(newServer, 201);
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(
+        data.detail || "Failed to create MCP server",
+        response.status
+      );
+    }
+
+    return successResponse(data.data, 201);
   });
 });
 
 /**
  * PUT /api/mcp-servers?id=<server_id>
  * Update an MCP server configuration.
+ * Proxies to dynamic-agents backend.
  * Requires admin role.
  */
 export const PUT = withErrorHandler(async (request: NextRequest) => {
@@ -112,39 +97,40 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     requireAdmin(session);
 
-    const body: MCPServerConfigUpdate = await request.json();
-    const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
+    const body = await request.json();
 
-    // Check if server exists
-    const existing = await collection.findOne({ _id: id });
-    if (!existing) {
-      throw new ApiError("MCP server not found", 404);
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+    };
+    if (session.accessToken) {
+      headers["Authorization"] = `Bearer ${session.accessToken}`;
     }
 
-    // Build update
-    const updateFields: any = {
-      updated_at: new Date().toISOString(),
-    };
+    const response = await fetch(
+      `${DYNAMIC_AGENTS_URL}/api/v1/mcp-servers/${id}`,
+      {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify(body),
+      }
+    );
 
-    if (body.name !== undefined) updateFields.name = body.name;
-    if (body.description !== undefined) updateFields.description = body.description;
-    if (body.transport !== undefined) updateFields.transport = body.transport;
-    if (body.endpoint !== undefined) updateFields.endpoint = body.endpoint;
-    if (body.command !== undefined) updateFields.command = body.command;
-    if (body.args !== undefined) updateFields.args = body.args;
-    if (body.env !== undefined) updateFields.env = body.env;
-    if (body.enabled !== undefined) updateFields.enabled = body.enabled;
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(
+        data.detail || "Failed to update MCP server",
+        response.status
+      );
+    }
 
-    await collection.updateOne({ _id: id }, { $set: updateFields });
-
-    const updated = await collection.findOne({ _id: id });
-    return successResponse(updated);
+    return successResponse(data.data);
   });
 });
 
 /**
  * DELETE /api/mcp-servers?id=<server_id>
  * Delete an MCP server configuration.
+ * Proxies to dynamic-agents backend.
  * Requires admin role.
  */
 export const DELETE = withErrorHandler(async (request: NextRequest) => {
@@ -158,15 +144,26 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     requireAdmin(session);
 
-    const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
-
-    // Check if server exists
-    const existing = await collection.findOne({ _id: id });
-    if (!existing) {
-      throw new ApiError("MCP server not found", 404);
+    const headers: HeadersInit = {};
+    if (session.accessToken) {
+      headers["Authorization"] = `Bearer ${session.accessToken}`;
     }
 
-    await collection.deleteOne({ _id: id });
+    const response = await fetch(
+      `${DYNAMIC_AGENTS_URL}/api/v1/mcp-servers/${id}`,
+      {
+        method: "DELETE",
+        headers,
+      }
+    );
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(
+        data.detail || "Failed to delete MCP server",
+        response.status
+      );
+    }
 
     return successResponse({ deleted: id });
   });


### PR DESCRIPTION

# Description

Refactor UI API routes for dynamic-agents and mcp-servers to proxy POST, PUT, DELETE operations to the Python backend instead of direct MongoDB access. This ensures consistent datetime handling and prevents timezone-aware vs naive datetime comparison errors.

- GET operations remain direct MongoDB for performance
- POST/PUT/DELETE now proxy to /api/v1/agents/* and /api/v1/mcp-servers/*
- Auth token forwarded via Authorization header
- Updated ARCHITECTURE.md to document the new API pattern


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
