### PR TITLE
docs(quickstart): replace vidcast embed with asciinema recording

### DIFF
--- a/docs/docs/getting-started/helm/setup.md
+++ b/docs/docs/getting-started/helm/setup.md
@@ -24,6 +24,10 @@ The interactive script will ask for your LLM provider, API key, optional compone
 
 > **Want to inspect the script first?** View it at [`setup-caipe.sh`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/setup-caipe.sh) before running.
 
+<iframe src="https://asciinema.org/a/845278/iframe" width="100%" height="600" style={{border: 'none', borderRadius: '8px', overflow: 'hidden'}} scrolling="no" allowFullScreen />
+
+> [View full screen recording on asciinema](https://asciinema.org/a/845278)
+
 ---
 
 ## Step 1: Clone the repository (optional but recommended)

--- a/docs/docs/getting-started/kind/setup.md
+++ b/docs/docs/getting-started/kind/setup.md
@@ -22,6 +22,10 @@ The interactive script will ask for your LLM provider, API key, and optional com
 
 > **Want to inspect the script first?** View it at [`setup-caipe.sh`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/setup-caipe.sh) before running.
 
+<iframe src="https://asciinema.org/a/845278/iframe" width="100%" height="600" style={{border: 'none', borderRadius: '8px', overflow: 'hidden'}} scrolling="no" allowFullScreen />
+
+> [View full screen recording on asciinema](https://asciinema.org/a/845278)
+
 ---
 
 ## Step 1: Prerequisites

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -28,6 +28,6 @@ The script asks for your LLM provider, API key, and optional components (RAG, tr
 | [**IDP Builder**](idpbuilder/setup.md) | Full platform stack with Backstage, ArgoCD, Gitea |
 | [**EKS**](eks/setup.md) | AWS production deployment |
 
-<div style={{paddingBottom: '56.25%', position: 'relative', display: 'block', width: '100%'}}>
-  <iframe src="https://app.vidcast.io/share/embed/40364232-f609-43d7-9578-07aef9c25893?mute=1&autoplay=1&disableCopyDropdown=1" width="100%" height="100%" title="CAIPE Getting Started with Docker Compose Demo" loading="lazy" allow="fullscreen *;autoplay *;" style={{position: 'absolute', top: 0, left: 0, border: 'solid', borderRadius: '12px'}}></iframe>
-</div>
+<iframe src="https://asciinema.org/a/845278/iframe" width="100%" height="600" style={{border: 'none', borderRadius: '8px', overflow: 'hidden'}} scrolling="no" allowFullScreen />
+
+> [View full screen recording on asciinema](https://asciinema.org/a/845278)


### PR DESCRIPTION
## Summary

- Replace the Vidcast iframe embed on the Quick Start page with an asciinema recording (https://asciinema.org/a/845278)
- Lighter, terminal-native demo that matches the `curl | bash` setup flow

## Test plan

- [ ] Verify the asciinema SVG badge renders on the docs site
- [ ] Clicking the badge opens the asciinema player


Made with [Cursor](https://cursor.com)