### PR TITLE
fix(ui): allow anonymous admin access when SSO is disabled (SDPL-1463)

### DIFF
--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -49,8 +49,8 @@ export async function getAuthenticatedUser(
   if (!session || !session.user?.email) {
     const { allowAnonymous = false } = options;
     if (allowAnonymous && !getConfig('ssoEnabled')) {
-      const fallbackUser = { email: 'anonymous@local', name: 'Anonymous', role: 'user' };
-      return { user: fallbackUser, session: { role: 'user', canViewAdmin: false } };
+      const fallbackUser = { email: 'anonymous@local', name: 'Anonymous', role: 'admin' };
+      return { user: fallbackUser, session: { role: 'admin', canViewAdmin: true } };
     }
     throw new ApiError('Unauthorized', 401);
   }
@@ -85,7 +85,8 @@ export async function getAuthenticatedUser(
 /**
  * Require authentication for API route
  * Use this as a wrapper for protected endpoints.
- * No session → 401 (never uses anonymous fallback).
+ * When SSO is disabled, all requests are treated as anonymous admin (local dev mode).
+ * When SSO is enabled, no session → 401.
  */
 export async function withAuth<T>(
   request: NextRequest,
@@ -95,7 +96,7 @@ export async function withAuth<T>(
     session: any
   ) => Promise<T>
 ): Promise<T> {
-  const { user, session } = await getAuthenticatedUser(request, { allowAnonymous: false });
+  const { user, session } = await getAuthenticatedUser(request, { allowAnonymous: true });
   return handler(request, user, session);
 }
 


### PR DESCRIPTION
## Summary

- `withAuth` in `api-middleware.ts` now passes `allowAnonymous: true` to `getAuthenticatedUser`
- Anonymous fallback user gets `role: 'admin'` and `canViewAdmin: true` when SSO is disabled (previously `role: 'user'`, `canViewAdmin: false`)
- When `NEXT_PUBLIC_SSO_ENABLED=false`, all API routes accept unauthenticated requests as anonymous admin — no OIDC session required

The `allowAnonymous` guard already existed in `getAuthenticatedUser` (with an SSO-disabled check), so this is a minimal two-line change to wire it up.

JIRA: [SDPL-1463](https://splunk.atlassian.net/browse/SDPL-1463)

## Test plan

- [ ] Set `NEXT_PUBLIC_SSO_ENABLED=false` in `.env`, start the UI — all API routes respond without requiring a session
- [ ] Verify anonymous user has admin role (can access admin endpoints)
- [ ] Set `NEXT_PUBLIC_SSO_ENABLED=true` — unauthenticated requests still return 401 as before