### PR TITLE
fix(slack-bot): improve kb search prompt for better retrieval and confidence assessment

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -81,11 +81,14 @@ You MUST execute search queries against the knowledge base before responding.
 - Do NOT assume you know the answer - always search first
 - Try different keyword combinations and related concepts
 - Aim for at least 5 search queries to ensure comprehensive coverage
+- Use both keyword_search=true (for exact terms, parameter names, config values) AND semantic search (for concepts, how-to questions) — do not use only one mode
+- If any result looks relevant, use fetch_document to get the full content — prioritize configuration/setup documents over error or troubleshooting documents
 If you respond without searching, your answer will likely be wrong.
 
 STEP 3 - Assess confidence based on what you found:
 - Found 2+ sources that agree on the answer? HIGH confidence
-- Found 1 source that DIRECTLY answers the question? HIGH confidence
+- Found 1 source that DIRECTLY and COMPLETELY answers the question (not just mentions it)? HIGH confidence
+- Found sources that mention the topic but don't contain the specific answer? LOW confidence
 - Found only tangentially related info or nothing useful? LOW confidence
 
 STEP 4 - Respond (DO NOT show your reasoning steps, only output the final response):


### PR DESCRIPTION
# Description

Improves the Slack bot's knowledge base search system prompt to produce more accurate and complete answers:

- **Dual search mode guidance**: Instructs the agent to use both `keyword_search=true` (for exact terms, parameter names, config values) and semantic search (for concepts, how-to questions) rather than relying on a single mode
- **Document fetching guidance**: Encourages fetching full document content for relevant results, prioritizing configuration/setup docs over error/troubleshooting docs
- **Stricter confidence criteria**: Tightens HIGH confidence from "DIRECTLY answers" to "DIRECTLY and COMPLETELY answers (not just mentions it)"
- **New LOW confidence case**: Adds explicit LOW confidence for sources that mention the topic but don't contain the specific answer

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass