### PR TITLE
fix(feedback): fix DM scoring name, align Langfuse scores across Slack and UI

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_langfuse_feedback.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_langfuse_feedback.py
@@ -100,8 +100,8 @@ class TestFeedbackClient:
 class TestScoringUtility:
     """Tests for submit_feedback_score utility function."""
 
-    def test_submit_dual_scores(self):
-        """Test that submit_feedback_score creates two scores."""
+    def test_submit_triple_scores(self):
+        """Test that submit_feedback_score creates three scores."""
         # Setup mocks
         mock_client = MagicMock()
         mock_client.submit_feedback.return_value = True
@@ -132,9 +132,9 @@ class TestScoringUtility:
             feedback_client=mock_client,
         )
 
-        # Verify two scores were submitted
+        # Verify three scores were submitted
         assert result is True
-        assert mock_client.submit_feedback.call_count == 2
+        assert mock_client.submit_feedback.call_count == 3
 
         # Check first score (channel-specific)
         first_call = mock_client.submit_feedback.call_args_list[0][1]
@@ -142,11 +142,62 @@ class TestScoringUtility:
         assert first_call["value"] == "thumbs_up"
         assert first_call["trace_id"] == "trace_456"
 
-        # Check second score (aggregate)
+        # Check second score (all slack channels)
         second_call = mock_client.submit_feedback.call_args_list[1][1]
         assert second_call["score_name"] == "all slack channels"
         assert second_call["value"] == "thumbs_up"
         assert second_call["trace_id"] == "trace_456"
+
+        # Check third score (all clients)
+        third_call = mock_client.submit_feedback.call_args_list[2][1]
+        assert third_call["score_name"] == "all"
+        assert third_call["value"] == "thumbs_up"
+        assert third_call["trace_id"] == "trace_456"
+
+    def test_submit_dm_feedback_uses_dm_score_name(self):
+        """Test that DM feedback uses 'DM' as channel-specific score name."""
+        mock_client = MagicMock()
+        mock_client.submit_feedback.return_value = True
+
+        mock_slack_client = MagicMock()
+        mock_slack_client.users_info.return_value = {
+            "user": {"profile": {"email": "test@example.com"}}
+        }
+
+        session_manager = SessionManager(InMemorySessionStore())
+        session_manager.set_trace_id("thread_123", "trace_456")
+        session_manager.set_context_id("thread_123", "context_789")
+
+        # DM channel IDs start with "D"
+        mock_config = MagicMock()
+        mock_config.channels = {}  # DM channels are not in config
+
+        result = submit_feedback_score(
+            thread_ts="thread_123",
+            user_id="U123",
+            channel_id="D123456",
+            feedback_value="thumbs_up",
+            slack_client=mock_slack_client,
+            session_manager=session_manager,
+            config=mock_config,
+            feedback_client=mock_client,
+        )
+
+        assert result is True
+        assert mock_client.submit_feedback.call_count == 3
+
+        # Channel-specific score should be "DM", not "feedback"
+        first_call = mock_client.submit_feedback.call_args_list[0][1]
+        assert first_call["score_name"] == "DM"
+        assert first_call["channel_name"] == "DM"
+
+        # All slack channels score
+        second_call = mock_client.submit_feedback.call_args_list[1][1]
+        assert second_call["score_name"] == "all slack channels"
+
+        # All clients score
+        third_call = mock_client.submit_feedback.call_args_list[2][1]
+        assert third_call["score_name"] == "all"
 
     def test_submit_feedback_no_trace_id(self):
         """Test submit_feedback_score returns False when trace_id is missing."""

--- a/ai_platform_engineering/integrations/slack_bot/utils/scoring.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/scoring.py
@@ -27,9 +27,10 @@ def submit_feedback_score(
     """
     Submit a feedback score to Langfuse with full context.
 
-    Submits TWO scores:
-      1. Channel-specific score (name: channel name)
-      2. Aggregated score (name: "all slack channels")
+    Submits THREE scores:
+      1. Channel-specific score (name: channel name, or "DM" for direct messages)
+      2. Aggregated Slack score (name: "all slack channels")
+      3. Aggregated cross-client score (name: "all") — shared with the web UI
     """
     if feedback_client is None:
         logger.debug("Langfuse feedback scoring disabled, skipping")
@@ -57,8 +58,9 @@ def submit_feedback_score(
     except Exception as e:
         logger.warning(f"Could not get user email: {e}")
 
-    # Get channel name from config
+    # Get channel name from config; DMs won't be in config.channels
     channel_name = None
+    is_dm = channel_id.startswith("D") if channel_id else False
     if channel_id in config.channels:
         channel_name = config.channels[channel_id].name
 
@@ -72,7 +74,9 @@ def submit_feedback_score(
         slack_permalink = None
 
     # Score 1: Channel-specific score
-    channel_score_name = f"{channel_name}" if channel_name else "feedback"
+    # For DMs, use "DM" as the score name; for unknown channels, fall back to "all slack channels"
+    channel_score_name = channel_name if channel_name else ("DM" if is_dm else "all slack channels")
+    display_channel_name = channel_name or ("DM" if is_dm else None)
     success_channel = feedback_client.submit_feedback(
         trace_id=trace_id,
         score_name=channel_score_name,
@@ -82,12 +86,12 @@ def submit_feedback_score(
         comment=comment,
         session_id=context_id,
         channel_id=channel_id,
-        channel_name=channel_name,
+        channel_name=display_channel_name,
         slack_permalink=slack_permalink,
     )
 
     # Score 2: Aggregated score for all Slack channels
-    success_all = feedback_client.submit_feedback(
+    success_all_slack = feedback_client.submit_feedback(
         trace_id=trace_id,
         score_name="all slack channels",
         value=feedback_value,
@@ -96,8 +100,22 @@ def submit_feedback_score(
         comment=comment,
         session_id=context_id,
         channel_id=channel_id,
-        channel_name=channel_name,
+        channel_name=display_channel_name,
         slack_permalink=slack_permalink,
     )
 
-    return success_channel and success_all
+    # Score 3: Aggregated score across all clients (Slack + Web UI)
+    success_all = feedback_client.submit_feedback(
+        trace_id=trace_id,
+        score_name="all",
+        value=feedback_value,
+        user_id=user_id,
+        user_email=user_email,
+        comment=comment,
+        session_id=context_id,
+        channel_id=channel_id,
+        channel_name=display_channel_name,
+        slack_permalink=slack_permalink,
+    )
+
+    return success_channel and success_all_slack and success_all

--- a/ui/src/app/api/feedback/route.ts
+++ b/ui/src/app/api/feedback/route.ts
@@ -107,8 +107,8 @@ export async function POST(request: NextRequest): Promise<NextResponse<FeedbackR
 
     if (langfuse) {
       // Map feedback to categorical values matching the Slack bot's scoring format.
-      // This ensures consistent Langfuse dashboards across both clients.
-      const scoreValue = body.feedbackType === "like" ? "thumbs_up" : (body.reason || "thumbs_down");
+      // Always use thumbs_up/thumbs_down as the value; reason goes in comment.
+      const scoreValue = body.feedbackType === "like" ? "thumbs_up" : "thumbs_down";
 
       // Build structured metadata (same shape as Slack bot's langfuse_client.py)
       const metadata: Record<string, string> = {
@@ -118,22 +118,26 @@ export async function POST(request: NextRequest): Promise<NextResponse<FeedbackR
       if (body.messageId) metadata.message_id = body.messageId;
       if (body.conversationId) metadata.session_id = body.conversationId;
 
-      const comment = body.additionalFeedback || body.reason || undefined;
+      // Combine reason + additional feedback into the comment field
+      const commentParts: string[] = [];
+      if (body.reason) commentParts.push(body.reason);
+      if (body.additionalFeedback) commentParts.push(body.additionalFeedback);
+      const comment = commentParts.length > 0 ? commentParts.join(": ") : undefined;
 
-      // Score 1: UI-specific score
+      // Score 1: Web UI-specific score (parallel to Slack bot's per-channel scores)
       langfuse.score({
         traceId: langfuseTraceId,
-        name: "caipe-ui",
+        name: "all web",
         value: scoreValue,
         dataType: "CATEGORICAL",
         comment,
         metadata,
       });
 
-      // Score 2: Aggregated score across all clients (matches Slack bot's "all slack channels")
+      // Score 2: Aggregated score across all clients (Slack + Web)
       langfuse.score({
         traceId: langfuseTraceId,
-        name: "all channels",
+        name: "all",
         value: scoreValue,
         dataType: "CATEGORICAL",
         comment,


### PR DESCRIPTION
# Description

Fixes two bugs in the Langfuse feedback scoring system and introduces a unified scoring taxonomy across Slack bot and web UI clients.

**Bug 1: DM feedback sent wrong score name**
When a user hit thumbs up/down in a DM with CAIPE, the channel-specific score was named `"feedback"` instead of something meaningful. This happened because DM channel IDs (starting with `D`) aren't in `config.channels`, so `channel_name` was `None` and the fallback was `"feedback"`. Now DMs correctly use `"DM"` as the score name.

**Bug 2: UI Langfuse score inconsistencies**
- Score values for dislikes sent the reason string (e.g. `"Inaccurate"`) as the value instead of `"thumbs_down"` — now consistent with the Slack bot
- Score names were mismatched (`"all channels"` vs `"all slack channels"`) — now uses a unified taxonomy
- Reason + additional feedback now go in the `comment` field (matching Slack bot behavior)

**New unified scoring taxonomy:**

| Score name | Source | Purpose |
|---|---|---|
| `#channel-name` | Slack | Per-channel breakdown |
| `DM` | Slack | Direct message feedback |
| `all slack channels` | Slack | All Slack feedback |
| `all web` | Web UI | All web UI feedback |
| `all` | Both | Everything combined |

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass