### PR TITLE
fix(ui): detect stale system templates in seed status check

### DIFF
--- a/ui/src/app/api/agent-configs/seed/route.ts
+++ b/ui/src/app/api/agent-configs/seed/route.ts
@@ -49,6 +49,8 @@ async function checkSeedingStatus(): Promise<{ needsSeeding: boolean; existingCo
 
   const collection = await getCollection<AgentConfig>("agent_configs");
   const enabledIds = enabledTemplates.map((t) => t.id);
+  const allSystemIds = BUILTIN_QUICK_START_TEMPLATES.map((t) => t.id);
+  const disabledIds = allSystemIds.filter((id) => !new Set(enabledIds).has(id));
 
   // Count how many of the enabled templates already exist
   const existingCount = await collection.countDocuments({
@@ -56,8 +58,13 @@ async function checkSeedingStatus(): Promise<{ needsSeeding: boolean; existingCo
     id: { $in: enabledIds },
   });
 
+  // Count system templates that should be removed
+  const staleCount = disabledIds.length > 0
+    ? await collection.countDocuments({ is_system: true, id: { $in: disabledIds } })
+    : 0;
+
   return {
-    needsSeeding: existingCount < enabledTemplates.length,
+    needsSeeding: existingCount < enabledTemplates.length || staleCount > 0,
     existingCount,
     templateCount: enabledTemplates.length,
   };


### PR DESCRIPTION
# Description

When `BUILTIN_SKILL_IDS` is set to a subset (or a value matching no
templates like `"none"`), `checkSeedingStatus` returns
`needsSeeding=false` if all enabled templates already exist — even when
non-whitelisted system templates remain in MongoDB. The store sees
`false`, skips the POST, and the removal logic in `seedBuiltinTemplates`
never runs.

Fix: also query for system templates whose IDs are not in the enabled
set, and include `staleCount > 0` in the `needsSeeding` condition.

* ui/src/app/api/agent-configs/seed/route.ts (checkSeedingStatus):
  Query for stale system templates and factor them into needsSeeding.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass