### PR TITLE
docs(blog): publish CNCF sandbox post and link PR 904

### DIFF
--- a/docs/blog/2026-03-04-cncf-sandbox-application.md
+++ b/docs/blog/2026-03-04-cncf-sandbox-application.md
@@ -1,15 +1,13 @@
 ---
-title: "CNCF Sandbox Application Draft"
-description: Draft application for CAIPE to join the CNCF Sandbox
+title: "CNCF Sandbox application for CAIPE"
+description: Application for Community AI Platform Engineering (CAIPE) to join the CNCF Sandbox, merged via the upstream pull request.
 authors: [sriaradhyula]
 tags: [articles]
-draft: true
 ---
 
 # [Sandbox] CAIPE (Community AI Platform Engineering)
 
-> Draft application for [CNCF Sandbox](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+CAIPE).
-> Copy each section into the corresponding field of the GitHub issue form.
+> Application for [CNCF Sandbox](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+CAIPE). This post tracks the text merged in [cnoe-io/ai-platform-engineering#904](https://github.com/cnoe-io/ai-platform-engineering/pull/904); copy each section into the corresponding field of the GitHub issue form when submitting.
 
 <!-- truncate -->
 


### PR DESCRIPTION
## Summary

- Remove `draft: true` from the CNCF Sandbox application blog post so it appears on the live Docusaurus blog.
- Refresh title and description for published content and link [PR #904](https://github.com/cnoe-io/ai-platform-engineering/pull/904) (already merged) for provenance.

## Test plan

- [ ] `cd docs && npm ci && npx docusaurus build` succeeds
- [ ] Blog listing shows the post at `/blog`

Made with [Cursor](https://cursor.com)