### PR TITLE
docs(skills-middleware): fix broken contracts link failing docs build

### DIFF
--- a/docs/docs/specs/097-skills-middleware-integration/plan.md
+++ b/docs/docs/specs/097-skills-middleware-integration/plan.md
@@ -101,7 +101,7 @@ scripts/
 |----------|------|
 | Research | [research.md](./research.md) |
 | Data model | [data-model.md](./data-model.md) |
-| Contracts | [contracts/](./contracts/) |
+| Contracts | [contracts/](./contracts/catalog-api.md) |
 | Quickstart | [quickstart.md](./quickstart.md) |
 
 ## Next steps


### PR DESCRIPTION
## Summary

- The `publish-gh-pages` workflow fails because `plan.md` links to `./contracts/` — a bare directory with no Docusaurus index page
- Docusaurus `onBrokenLinks: 'throw'` treats this as a fatal error
- Changed the link target to `./contracts/catalog-api.md` so it resolves to an actual page

## Test plan

- [x] `npm run build` in `docs/` passes locally with no broken-link errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)