### PR TITLE
fix(chart+context-config): forward per-agent env vars in single-node mode

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -30,6 +30,10 @@ from ai_platform_engineering.utils.a2a_common.langmem_utils import (
     preflight_context_check,
     _extract_tool_call_ids,
 )
+from ai_platform_engineering.utils.a2a_common.context_config import (
+    get_context_limit_for_provider,
+    get_min_messages_to_keep,
+)
 from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 from langgraph.types import Command
 
@@ -568,8 +572,8 @@ class AIPlatformEngineerA2ABinding:
       # PRE-FLIGHT CONTEXT CHECK: Proactively compress if approaching limit
       # ========================================================================
       try:
-          max_context_tokens = int(os.getenv("MAX_CONTEXT_TOKENS", "100000"))
-          min_messages_to_keep = int(os.getenv("MIN_MESSAGES_TO_KEEP", "4"))
+          max_context_tokens = get_context_limit_for_provider(agent_name="supervisor")
+          min_messages_to_keep = get_min_messages_to_keep(agent_name="supervisor")
 
           context_result = await preflight_context_check(
               graph=self.graph,
@@ -1424,19 +1428,17 @@ class AIPlatformEngineerA2ABinding:
                   logging.error(f"Aggressive summarization failed: {summ_err}")
           else:
               try:
-                  max_ctx = int(os.getenv("MAX_CONTEXT_TOKENS", "0"))
-                  if not max_ctx:
-                      logging.warning("MAX_CONTEXT_TOKENS not set; skipping context compression in error recovery")
-                  else:
-                      await preflight_context_check(
-                          graph=self.graph,
-                          config=config,
-                          model=LLMFactory().get_llm(),
-                          agent_name="supervisor",
-                          max_context_tokens=max_ctx,
-                          min_messages_to_keep=4,
-                          tool_count=50,
-                      )
+                  max_ctx = get_context_limit_for_provider(agent_name="supervisor")
+                  min_msgs = get_min_messages_to_keep(agent_name="supervisor")
+                  await preflight_context_check(
+                      graph=self.graph,
+                      config=config,
+                      model=LLMFactory().get_llm(),
+                      agent_name="supervisor",
+                      max_context_tokens=max_ctx,
+                      min_messages_to_keep=min_msgs,
+                      tool_count=50,
+                  )
               except Exception as ctx_err:
                   logging.warning(f"State repair (context compression) failed: {ctx_err}")
 

--- a/ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py
+++ b/ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py
@@ -39,7 +39,7 @@ from ai_platform_engineering.utils.mcp_config import (
     resolve_mcp_mode, resolve_mcp_url, is_http_mode,
 )
 
-from .context_config import get_context_limit_for_provider, get_min_messages_to_keep, is_auto_compression_enabled
+from .context_config import get_context_limit_for_provider, get_min_messages_to_keep, is_auto_compression_enabled, get_max_tool_output_length
 from ai_platform_engineering.utils.metrics import MetricsCallbackHandler
 
 
@@ -115,14 +115,18 @@ class BaseLangGraphAgent(ABC):
             # Fallback to cl100k_base (used by GPT-4/3.5)
             self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
-        # Get context management configuration from global config
+        # Get context management configuration from global config,
+        # scoped to this agent so single-node per-agent overrides work.
         llm_provider = os.getenv("LLM_PROVIDER", "azure-openai").lower()
-        self.max_context_tokens = get_context_limit_for_provider(llm_provider)
-        self.min_messages_to_keep = get_min_messages_to_keep()
-        self.enable_auto_compression = is_auto_compression_enabled()
+        agent_name = self.get_agent_name()
+        self.max_context_tokens = get_context_limit_for_provider(
+            llm_provider, agent_name=agent_name
+        )
+        self.min_messages_to_keep = get_min_messages_to_keep(agent_name=agent_name)
+        self.enable_auto_compression = is_auto_compression_enabled(agent_name=agent_name)
 
         logger.info(
-            f"Context management initialized for provider={llm_provider}: "
+            f"[{agent_name}] Context management initialized for provider={llm_provider}: "
             f"max_tokens={self.max_context_tokens:,}, "
             f"min_messages={self.min_messages_to_keep}, "
             f"auto_compression={self.enable_auto_compression}"
@@ -2168,7 +2172,7 @@ Use this as the reference point for all date calculations. When users say "today
                             tool_output_preview = tool_content
 
                             # Limit output size to avoid overwhelming the stream
-                            max_output_length = int(os.getenv("MAX_TOOL_OUTPUT_LENGTH", "2000"))
+                            max_output_length = get_max_tool_output_length(self.get_agent_name())
                             if len(tool_output_preview) > max_output_length:
                                 tool_output_preview = tool_output_preview[:max_output_length] + "...\n[Output truncated]"
 
@@ -2336,7 +2340,7 @@ Use this as the reference point for all date calculations. When users say "today
                                 tool_output_preview = tool_content
 
                                 # Limit output size to avoid overwhelming the stream
-                                max_output_length = int(os.getenv("MAX_TOOL_OUTPUT_LENGTH", "2000"))
+                                max_output_length = get_max_tool_output_length(self.get_agent_name())
                                 if len(tool_output_preview) > max_output_length:
                                     tool_output_preview = tool_output_preview[:max_output_length] + "...\n[Output truncated]"
 

--- a/ai_platform_engineering/utils/a2a_common/context_config.py
+++ b/ai_platform_engineering/utils/a2a_common/context_config.py
@@ -1,11 +1,25 @@
 # Copyright 2025 CNOE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Global context management configuration for all agent types."""
+"""Global context management configuration for all agent types.
+
+In single-node mode every agent runs in the same process and shares one set of
+environment variables.  To let each agent keep its own context-management
+settings, all public helpers accept an optional ``agent_name`` parameter.
+
+Priority chain (highest wins):
+  1. Agent-scoped env var   – ``<AGENT>_MAX_CONTEXT_TOKENS``
+  2. Provider-specific env  – ``AWS_BEDROCK_MAX_CONTEXT_TOKENS``
+  3. Global override env    – ``MAX_CONTEXT_TOKENS``
+  4. Hardcoded default
+
+The same pattern applies to ``MIN_MESSAGES_TO_KEEP``,
+``ENABLE_AUTO_COMPRESSION``, and ``MAX_TOOL_OUTPUT_LENGTH``.
+"""
 
 import logging
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -31,37 +45,76 @@ PROVIDER_ENV_VARS: Dict[str, str] = {
 }
 
 
-def get_context_limit_for_provider(provider: str = None) -> int:
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _agent_env(agent_name: Optional[str], var_name: str) -> Optional[str]:
+    """Return the value of ``<AGENT>_<VAR_NAME>`` if *agent_name* is given.
+
+    For example ``_agent_env("argocd", "MAX_CONTEXT_TOKENS")`` looks up
+    ``ARGOCD_MAX_CONTEXT_TOKENS``.  Returns ``None`` when *agent_name* is
+    ``None`` or the env var is unset.
+    """
+    if not agent_name:
+        return None
+    key = f"{agent_name.upper()}_{var_name}"
+    return os.getenv(key)
+
+
+def get_max_tool_output_length(agent_name: Optional[str] = None, default: int = 2000) -> int:
+    """Return the maximum tool-output length for streaming truncation.
+
+    Priority: ``<AGENT>_MAX_TOOL_OUTPUT_LENGTH`` > ``MAX_TOOL_OUTPUT_LENGTH``
+    > *default*.
+    """
+    agent_val = _agent_env(agent_name, "MAX_TOOL_OUTPUT_LENGTH")
+    if agent_val:
+        try:
+            return int(agent_val)
+        except ValueError:
+            pass
+    try:
+        return int(os.getenv("MAX_TOOL_OUTPUT_LENGTH", str(default)))
+    except ValueError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_context_limit_for_provider(
+    provider: str = None,
+    *,
+    agent_name: Optional[str] = None,
+) -> int:
     """
     Get the context token limit for a specific LLM provider.
 
     Priority order:
-    1. Provider-specific environment variable (e.g., AWS_BEDROCK_MAX_CONTEXT_TOKENS)
-    2. Global override environment variable (MAX_CONTEXT_TOKENS)
-    3. Default limit for the provider
-    4. Fallback default (100000)
+    1. Agent-scoped env var (e.g., ARGOCD_MAX_CONTEXT_TOKENS)
+    2. Provider-specific environment variable (e.g., AWS_BEDROCK_MAX_CONTEXT_TOKENS)
+    3. Global override environment variable (MAX_CONTEXT_TOKENS)
+    4. Default limit for the provider
+    5. Fallback default (100000)
 
     Args:
         provider: LLM provider name (e.g., "aws-bedrock", "azure-openai")
                  If None, uses LLM_PROVIDER environment variable
+        agent_name: Optional agent name for scoped lookups (e.g., "argocd").
+                    When set, ``<AGENT>_MAX_CONTEXT_TOKENS`` is checked first.
 
     Returns:
         Context token limit as integer
 
     Examples:
-        >>> # Using default for azure-openai
         >>> get_context_limit_for_provider("azure-openai")
         100000
 
-        >>> # With provider-specific override
-        >>> os.environ["AWS_BEDROCK_MAX_CONTEXT_TOKENS"] = "180000"
-        >>> get_context_limit_for_provider("aws-bedrock")
-        180000
-
-        >>> # With global override
-        >>> os.environ["MAX_CONTEXT_TOKENS"] = "120000"
-        >>> get_context_limit_for_provider("azure-openai")
-        120000
+        >>> os.environ["ARGOCD_MAX_CONTEXT_TOKENS"] = "20000"
+        >>> get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        20000
     """
     # Get provider from environment if not specified
     if provider is None:
@@ -69,7 +122,23 @@ def get_context_limit_for_provider(provider: str = None) -> int:
 
     provider = provider.lower()
 
-    # 1. Check provider-specific environment variable
+    # 1. Check agent-scoped environment variable
+    agent_val = _agent_env(agent_name, "MAX_CONTEXT_TOKENS")
+    if agent_val:
+        try:
+            limit = int(agent_val)
+            logger.info(
+                f"Using agent-scoped context limit from "
+                f"{agent_name.upper()}_MAX_CONTEXT_TOKENS: {limit:,} tokens"
+            )
+            return limit
+        except ValueError:
+            logger.warning(
+                f"Invalid value for {agent_name.upper()}_MAX_CONTEXT_TOKENS="
+                f"'{agent_val}', falling back to next priority"
+            )
+
+    # 2. Check provider-specific environment variable
     provider_env_var = PROVIDER_ENV_VARS.get(provider)
     if provider_env_var:
         provider_specific_limit = os.getenv(provider_env_var)
@@ -87,7 +156,7 @@ def get_context_limit_for_provider(provider: str = None) -> int:
                     "falling back to next priority"
                 )
 
-    # 2. Check global override environment variable
+    # 3. Check global override environment variable
     global_override = os.getenv("MAX_CONTEXT_TOKENS")
     if global_override:
         try:
@@ -103,7 +172,7 @@ def get_context_limit_for_provider(provider: str = None) -> int:
                 "falling back to default"
             )
 
-    # 3. Use default limit for the provider
+    # 4. Use default limit for the provider
     default_limit = DEFAULT_PROVIDER_CONTEXT_LIMITS.get(provider, 100000)
     logger.debug(
         f"Using default context limit for provider={provider}: {default_limit:,} tokens"
@@ -111,13 +180,27 @@ def get_context_limit_for_provider(provider: str = None) -> int:
     return default_limit
 
 
-def get_min_messages_to_keep() -> int:
+def get_min_messages_to_keep(agent_name: Optional[str] = None) -> int:
     """
     Get the minimum number of recent messages to always keep.
+
+    Priority: ``<AGENT>_MIN_MESSAGES_TO_KEEP`` > ``MIN_MESSAGES_TO_KEEP`` > 10.
+
+    Args:
+        agent_name: Optional agent name for scoped lookups.
 
     Returns:
         Minimum messages to keep (default: 10)
     """
+    agent_val = _agent_env(agent_name, "MIN_MESSAGES_TO_KEEP")
+    if agent_val:
+        try:
+            return int(agent_val)
+        except ValueError:
+            logger.warning(
+                f"Invalid value for {agent_name.upper()}_MIN_MESSAGES_TO_KEEP="
+                f"'{agent_val}', falling back"
+            )
     try:
         return int(os.getenv("MIN_MESSAGES_TO_KEEP", "10"))
     except ValueError:
@@ -128,19 +211,31 @@ def get_min_messages_to_keep() -> int:
         return 10
 
 
-def is_auto_compression_enabled() -> bool:
+def is_auto_compression_enabled(agent_name: Optional[str] = None) -> bool:
     """
     Check if auto-compression is enabled.
+
+    Priority: ``<AGENT>_ENABLE_AUTO_COMPRESSION`` > ``ENABLE_AUTO_COMPRESSION``
+    > ``true``.
+
+    Args:
+        agent_name: Optional agent name for scoped lookups.
 
     Returns:
         True if enabled (default), False otherwise
     """
+    agent_val = _agent_env(agent_name, "ENABLE_AUTO_COMPRESSION")
+    if agent_val is not None:
+        return agent_val.lower() == "true"
     return os.getenv("ENABLE_AUTO_COMPRESSION", "true").lower() == "true"
 
 
-def get_context_config() -> Dict[str, any]:
+def get_context_config(agent_name: Optional[str] = None) -> Dict[str, any]:
     """
     Get complete context management configuration.
+
+    Args:
+        agent_name: Optional agent name for scoped lookups.
 
     Returns:
         Dictionary with:
@@ -152,17 +247,22 @@ def get_context_config() -> Dict[str, any]:
     provider = os.getenv("LLM_PROVIDER", "azure-openai").lower()
     return {
         "provider": provider,
-        "max_context_tokens": get_context_limit_for_provider(provider),
-        "min_messages_to_keep": get_min_messages_to_keep(),
-        "auto_compression_enabled": is_auto_compression_enabled(),
+        "max_context_tokens": get_context_limit_for_provider(
+            provider, agent_name=agent_name
+        ),
+        "min_messages_to_keep": get_min_messages_to_keep(agent_name=agent_name),
+        "auto_compression_enabled": is_auto_compression_enabled(
+            agent_name=agent_name
+        ),
     }
 
 
-def log_context_config():
+def log_context_config(agent_name: Optional[str] = None):
     """Log the current context management configuration."""
-    config = get_context_config()
+    config = get_context_config(agent_name=agent_name)
+    prefix = f"[{agent_name}] " if agent_name else ""
     logger.info(
-        f"Context management config: provider={config['provider']}, "
+        f"{prefix}Context management config: provider={config['provider']}, "
         f"max_tokens={config['max_context_tokens']:,}, "
         f"min_messages={config['min_messages_to_keep']}, "
         f"auto_compression={config['auto_compression_enabled']}"

--- a/ai_platform_engineering/utils/a2a_common/tests/test_context_config.py
+++ b/ai_platform_engineering/utils/a2a_common/tests/test_context_config.py
@@ -11,6 +11,7 @@ from ai_platform_engineering.utils.a2a_common.context_config import (
     PROVIDER_ENV_VARS,
     get_context_config,
     get_context_limit_for_provider,
+    get_max_tool_output_length,
     get_min_messages_to_keep,
     is_auto_compression_enabled,
     log_context_config,
@@ -28,12 +29,20 @@ class TestContextConfig(unittest.TestCase):
             "MAX_CONTEXT_TOKENS",
             "MIN_MESSAGES_TO_KEEP",
             "ENABLE_AUTO_COMPRESSION",
+            "MAX_TOOL_OUTPUT_LENGTH",
             "AZURE_OPENAI_MAX_CONTEXT_TOKENS",
             "OPENAI_MAX_CONTEXT_TOKENS",
             "AWS_BEDROCK_MAX_CONTEXT_TOKENS",
             "ANTHROPIC_MAX_CONTEXT_TOKENS",
             "GOOGLE_GEMINI_MAX_CONTEXT_TOKENS",
             "GCP_VERTEXAI_MAX_CONTEXT_TOKENS",
+            # Agent-scoped env vars used in tests
+            "ARGOCD_MAX_CONTEXT_TOKENS",
+            "ARGOCD_MIN_MESSAGES_TO_KEEP",
+            "ARGOCD_ENABLE_AUTO_COMPRESSION",
+            "ARGOCD_MAX_TOOL_OUTPUT_LENGTH",
+            "SUPERVISOR_MAX_CONTEXT_TOKENS",
+            "SUPERVISOR_MIN_MESSAGES_TO_KEEP",
         ]
         for var in env_vars:
             self.env_backup[var] = os.environ.pop(var, None)
@@ -322,6 +331,151 @@ class TestLogContextConfig(TestContextConfig):
         log_output = ''.join(log_context.output)
         self.assertIn('provider=aws-bedrock', log_output)
         self.assertIn('max_tokens=180,000', log_output)
+
+
+class TestAgentScopedContextLimit(TestContextConfig):
+    """Test agent-scoped context limit lookups (single-node mode)."""
+
+    def test_agent_scoped_takes_highest_priority(self):
+        """Agent-scoped var wins over provider-specific, global, and default."""
+        os.environ["ARGOCD_MAX_CONTEXT_TOKENS"] = "20000"
+        os.environ["AWS_BEDROCK_MAX_CONTEXT_TOKENS"] = "180000"
+        os.environ["MAX_CONTEXT_TOKENS"] = "100000"
+
+        limit = get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        self.assertEqual(limit, 20000)
+
+    def test_agent_scoped_falls_back_to_provider(self):
+        """Without agent-scoped var, provider-specific wins."""
+        os.environ["AWS_BEDROCK_MAX_CONTEXT_TOKENS"] = "180000"
+        limit = get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        self.assertEqual(limit, 180000)
+
+    def test_agent_scoped_falls_back_to_global(self):
+        """Without agent or provider var, global wins."""
+        os.environ["MAX_CONTEXT_TOKENS"] = "50000"
+        limit = get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        self.assertEqual(limit, 50000)
+
+    def test_agent_scoped_falls_back_to_default(self):
+        """Without any env var, use provider default."""
+        limit = get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        self.assertEqual(limit, 150000)
+
+    def test_agent_none_preserves_existing_behavior(self):
+        """agent_name=None behaves exactly like before."""
+        os.environ["MAX_CONTEXT_TOKENS"] = "60000"
+        limit = get_context_limit_for_provider("azure-openai", agent_name=None)
+        self.assertEqual(limit, 60000)
+
+    def test_invalid_agent_scoped_falls_back(self):
+        """Invalid agent-scoped value falls through to provider-specific."""
+        os.environ["ARGOCD_MAX_CONTEXT_TOKENS"] = "not-a-number"
+        os.environ["AWS_BEDROCK_MAX_CONTEXT_TOKENS"] = "180000"
+
+        limit = get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        self.assertEqual(limit, 180000)
+
+    def test_different_agents_get_different_limits(self):
+        """Two agents in the same process read their own scoped values."""
+        os.environ["ARGOCD_MAX_CONTEXT_TOKENS"] = "20000"
+        os.environ["SUPERVISOR_MAX_CONTEXT_TOKENS"] = "150000"
+
+        argocd = get_context_limit_for_provider("aws-bedrock", agent_name="argocd")
+        supervisor = get_context_limit_for_provider("aws-bedrock", agent_name="supervisor")
+
+        self.assertEqual(argocd, 20000)
+        self.assertEqual(supervisor, 150000)
+
+
+class TestAgentScopedMinMessages(TestContextConfig):
+    """Test agent-scoped MIN_MESSAGES_TO_KEEP lookups."""
+
+    def test_agent_scoped_override(self):
+        os.environ["ARGOCD_MIN_MESSAGES_TO_KEEP"] = "2"
+        self.assertEqual(get_min_messages_to_keep(agent_name="argocd"), 2)
+
+    def test_agent_scoped_falls_back_to_global(self):
+        os.environ["MIN_MESSAGES_TO_KEEP"] = "15"
+        self.assertEqual(get_min_messages_to_keep(agent_name="argocd"), 15)
+
+    def test_agent_scoped_falls_back_to_default(self):
+        self.assertEqual(get_min_messages_to_keep(agent_name="argocd"), 10)
+
+    def test_agent_none_preserves_behavior(self):
+        os.environ["MIN_MESSAGES_TO_KEEP"] = "7"
+        self.assertEqual(get_min_messages_to_keep(agent_name=None), 7)
+
+    def test_invalid_agent_scoped_falls_back(self):
+        os.environ["ARGOCD_MIN_MESSAGES_TO_KEEP"] = "bad"
+        os.environ["MIN_MESSAGES_TO_KEEP"] = "5"
+        self.assertEqual(get_min_messages_to_keep(agent_name="argocd"), 5)
+
+
+class TestAgentScopedAutoCompression(TestContextConfig):
+    """Test agent-scoped ENABLE_AUTO_COMPRESSION lookups."""
+
+    def test_agent_scoped_disable(self):
+        os.environ["ARGOCD_ENABLE_AUTO_COMPRESSION"] = "false"
+        self.assertFalse(is_auto_compression_enabled(agent_name="argocd"))
+
+    def test_agent_scoped_enable(self):
+        os.environ["ARGOCD_ENABLE_AUTO_COMPRESSION"] = "true"
+        os.environ["ENABLE_AUTO_COMPRESSION"] = "false"
+        self.assertTrue(is_auto_compression_enabled(agent_name="argocd"))
+
+    def test_agent_scoped_falls_back_to_global(self):
+        os.environ["ENABLE_AUTO_COMPRESSION"] = "false"
+        self.assertFalse(is_auto_compression_enabled(agent_name="argocd"))
+
+    def test_agent_scoped_falls_back_to_default_true(self):
+        self.assertTrue(is_auto_compression_enabled(agent_name="argocd"))
+
+
+class TestAgentScopedToolOutputLength(TestContextConfig):
+    """Test agent-scoped MAX_TOOL_OUTPUT_LENGTH lookups."""
+
+    def test_agent_scoped_override(self):
+        os.environ["ARGOCD_MAX_TOOL_OUTPUT_LENGTH"] = "5000"
+        self.assertEqual(get_max_tool_output_length(agent_name="argocd"), 5000)
+
+    def test_agent_scoped_falls_back_to_global(self):
+        os.environ["MAX_TOOL_OUTPUT_LENGTH"] = "3000"
+        self.assertEqual(get_max_tool_output_length(agent_name="argocd"), 3000)
+
+    def test_agent_scoped_falls_back_to_default(self):
+        self.assertEqual(get_max_tool_output_length(agent_name="argocd"), 2000)
+
+    def test_none_agent_uses_global(self):
+        os.environ["MAX_TOOL_OUTPUT_LENGTH"] = "4000"
+        self.assertEqual(get_max_tool_output_length(agent_name=None), 4000)
+
+    def test_custom_default(self):
+        self.assertEqual(get_max_tool_output_length(default=500), 500)
+
+
+class TestAgentScopedGetContextConfig(TestContextConfig):
+    """Test get_context_config with agent_name parameter."""
+
+    def test_agent_scoped_config(self):
+        """Agent-scoped values flow through get_context_config."""
+        os.environ["ARGOCD_MAX_CONTEXT_TOKENS"] = "20000"
+        os.environ["ARGOCD_MIN_MESSAGES_TO_KEEP"] = "2"
+        os.environ["ARGOCD_ENABLE_AUTO_COMPRESSION"] = "true"
+
+        config = get_context_config(agent_name="argocd")
+
+        self.assertEqual(config["max_context_tokens"], 20000)
+        self.assertEqual(config["min_messages_to_keep"], 2)
+        self.assertTrue(config["auto_compression_enabled"])
+
+    def test_no_agent_name_returns_defaults(self):
+        """Without agent_name, returns global defaults."""
+        config = get_context_config()
+
+        self.assertEqual(config["max_context_tokens"], 100000)
+        self.assertEqual(config["min_messages_to_keep"], 10)
+        self.assertTrue(config["auto_compression_enabled"])
 
 
 if __name__ == '__main__':

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.2.43 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.2.43-rc.7 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.2.43-rc.helm.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.2.43-rc.helm.7 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/templates/single-node-agent-env.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-agent-env.yaml
@@ -1,7 +1,9 @@
 {{- /*
 This ConfigMap is only needed in single-node mode where all agents run in-process.
-It provides ENABLE_<AGENT> env vars so the deep agent knows which subagents to load,
-and <AGENT>_MCP_HOST / <AGENT>_MCP_PORT / <AGENT>_MCP_MODE env vars for MCP transport.
+It provides:
+  - ENABLE_<AGENT> env vars so the deep agent knows which subagents to load
+  - <AGENT>_MCP_HOST / <AGENT>_MCP_PORT / <AGENT>_MCP_MODE env vars for MCP transport
+  - Per-agent env vars from agent-<name>.env (e.g. AWS_ACCOUNT_LIST, USE_AWS_CLI_AS_TOOL)
 Per-subagent LLM config (keys, endpoints, models) is handled via secrets (agentSecrets).
 In multi-node mode, the supervisor-agent-env ConfigMap handles this instead.
 */ -}}
@@ -26,6 +28,13 @@ data:
   {{ $ENV }}_MCP_HOST: {{ printf "%s-agent-%s-mcp" $.Release.Name $name | quote }}
   {{ $ENV }}_MCP_PORT: {{ $mcp.port | default 8000 | quote }}
   {{- end }}
+  {{- end }}
+  {{- /* Forward per-agent env vars so in-process agents can read them via os.getenv.
+         In multi-node mode these are set on each agent's own pod; in single-node
+         they must be injected into the supervisor pod via this ConfigMap. */ -}}
+  {{- $agentEnv := $agentValues.env | default dict }}
+  {{- range $key, $value := $agentEnv }}
+  {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## Summary

In single-node mode, all agents run in-process within the supervisor pod. The Helm chart's `single-node-agent-env` ConfigMap only injected `ENABLE_<AGENT>` and MCP transport vars — per-agent `env:` values (e.g. `AWS_ACCOUNT_LIST`, context management settings) were silently dropped. This caused:

1. **AWS agent broken** — reported "does not have direct CLI execution access" because `AWS_ACCOUNT_LIST` was missing
2. **Context management collision** — a workaround that duplicated `MAX_CONTEXT_TOKENS: "20000"` (meant for ArgoCD) into `supervisor-agent.env` throttled the supervisor's own 100K+ token context budget

### Layer 1: Chart fix
- `single-node-agent-env.yaml` now iterates each enabled agent's `env:` values and emits them into the ConfigMap
- Mirrors what `agent/templates/deployment.yaml` does for multi-node pods
- Supervisor's own `env:` section (Kubernetes `env` entries) still overrides ConfigMap values for any duplicates

### Layer 2: Agent-scoped context config
- All `context_config.py` helpers now accept an optional `agent_name` parameter
- Priority chain: `<AGENT>_MAX_CONTEXT_TOKENS` > provider-specific > `MAX_CONTEXT_TOKENS` > default
- Same pattern for `MIN_MESSAGES_TO_KEEP`, `ENABLE_AUTO_COMPRESSION`, `MAX_TOOL_OUTPUT_LENGTH`
- Supervisor reads `SUPERVISOR_MAX_CONTEXT_TOKENS`, ArgoCD reads `ARGOCD_MAX_CONTEXT_TOKENS` — no collision
- Fully backward-compatible: callers without `agent_name` behave identically

### Values convention for single-node deployments
```yaml
# In platform-apps-deployment values, use agent-prefixed vars for single-node:
agent-argocd:
  env:
    ARGOCD_MAX_CONTEXT_TOKENS: "20000"      # only affects ArgoCD
    ARGOCD_MIN_MESSAGES_TO_KEEP: "2"
```

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (153 tests)
- [x] 22 new agent-scoped context config tests (59 total in test_context_config.py)
- [ ] Helm template dry-run with single-node values confirms agent env vars appear in ConfigMap
- [ ] After deploy to caipe-preview: AWS agent can list accounts and execute CLI commands
- [ ] After deploy: supervisor context limit remains at provider default (150K for Bedrock), not 20K