### PR TITLE
fix(executor): prevent structured response metadata from leaking into Slack output

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -663,9 +663,13 @@ def stream_a2a_response(
             # For plan flows: only streaming_final_answer means the answer was streamed
             #   (pre-plan chatter sets streamed_any_text but isn't the answer).
             # For no-plan flows: streamed_any_text means the answer was streamed.
+            # Exception: when a clean final_result was received, always prefer it —
+            # the streamed content may include raw LLM output with structured
+            # response metadata (is_task_complete, was_task_successful, …).
             stop_chunks = []
             already_streamed = streaming_final_answer or (not plan_steps and streamed_any_text)
-            needs_final = not already_streamed
+            has_authoritative_final = bool(final_result_text and final_result_text.strip())
+            needs_final = not already_streamed or (has_authoritative_final and streaming_final_answer)
             if needs_final and final_text:
                 stop_chunks.append({"type": "markdown_text", "text": final_text})
 

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor.py
@@ -263,11 +263,34 @@ class AIPlatformEngineerA2AExecutor(AgentExecutor):
             ]
         }
 
+    _STRUCTURED_RESPONSE_RE = re.compile(
+        r"(?:Returning structured response:\s*)?"
+        r"is_task_complete=\w+\s+"
+        r"require_user_input=\w+\s+"
+        r"(?:was_task_successful=\w+\s+)?"
+        r"content='",
+        re.DOTALL,
+    )
+
+    def _strip_structured_response_wrapper(self, content: str) -> str:
+        """Strip leaked structured response metadata wrapper, returning only the content value."""
+        m = self._STRUCTURED_RESPONSE_RE.search(content)
+        if not m:
+            return content
+        inner = content[m.end():]
+        # The content value ends with a trailing single-quote (may be truncated)
+        if inner.endswith("'"):
+            inner = inner[:-1]
+        logger.info(f"Stripped structured response wrapper ({m.end()} header chars)")
+        return inner
+
     def _extract_final_answer(self, content: str) -> str:
         """
         Extract content after [FINAL ANSWER] marker.
         If marker not found, return original content.
+        Also strips leaked structured response metadata wrappers.
         """
+        content = self._strip_structured_response_wrapper(content)
         marker = "[FINAL ANSWER]"
         if marker in content:
             # Extract everything after the marker

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_executor_single.py
@@ -266,11 +266,34 @@ class AIPlatformEngineerA2AExecutor(AgentExecutor):
             ]
         }
 
+    _STRUCTURED_RESPONSE_RE = re.compile(
+        r"(?:Returning structured response:\s*)?"
+        r"is_task_complete=\w+\s+"
+        r"require_user_input=\w+\s+"
+        r"(?:was_task_successful=\w+\s+)?"
+        r"content='",
+        re.DOTALL,
+    )
+
+    def _strip_structured_response_wrapper(self, content: str) -> str:
+        """Strip leaked structured response metadata wrapper, returning only the content value."""
+        m = self._STRUCTURED_RESPONSE_RE.search(content)
+        if not m:
+            return content
+        inner = content[m.end():]
+        # The content value ends with a trailing single-quote (may be truncated)
+        if inner.endswith("'"):
+            inner = inner[:-1]
+        logger.info(f"Stripped structured response wrapper ({m.end()} header chars)")
+        return inner
+
     def _extract_final_answer(self, content: str) -> str:
         """
         Extract content after [FINAL ANSWER] marker.
         If marker not found, return original content.
+        Also strips leaked structured response metadata wrappers.
         """
+        content = self._strip_structured_response_wrapper(content)
         marker = "[FINAL ANSWER]"
         if marker in content:
             # Extract everything after the marker

--- a/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py
+++ b/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py
@@ -353,6 +353,7 @@ class A2ARemoteAgentConnectTool(BaseTool):
 
     accumulated_text: list[str] = []
     tool_errors: list[str] = []  # Track tool errors to bubble them up
+    artifacts_streamed = False  # True once any artifact-update is forwarded to the supervisor
 
     async for chunk in self._client.send_message_streaming(streaming_request):
       try:
@@ -421,6 +422,7 @@ class A2ARemoteAgentConnectTool(BaseTool):
                 # Artifacts are always streamed so supervisor can forward them to clients
                 if text or data:
                   writer({"type": "artifact-update", "result": result, "source_agent": self.name})
+                  artifacts_streamed = True
                   content_type = "DataPart" if data else "TextPart"
                   artifact_name = artifact.get('name', '')
                   logger.debug(f"✅ Streamed artifact-update event: {artifact_name} ({content_type})")
@@ -505,7 +507,12 @@ class A2ARemoteAgentConnectTool(BaseTool):
         "type": "a2a_event",
         "data": "⚠️ Remote agent returned no content."
       })
-    else:
+    elif not artifacts_streamed:
+      # Only write the accumulated response when no artifact-update events
+      # were forwarded.  When artifacts were streamed individually, the
+      # executor already received each chunk — re-sending the full blob
+      # duplicates content and can leak structured response metadata
+      # (is_task_complete, was_task_successful, …) into user-visible output.
       writer({
         "type": "a2a_event",
         "data": final_response


### PR DESCRIPTION
## Summary

- **Root cause**: `A2ARemoteAgentConnectTool._arun()` re-sent the full accumulated sub-agent text (streaming chunks + final result) as a single `a2a_event` after individual `artifact-update` events had already been forwarded. This was a latent bug exposed by #1025, which fixed plan step attribution and plan merging — the corrected `_is_last_plan_step_active()` now properly tags streaming chunks with `is_final_answer=True`, causing the Slack bot to render the duplicate raw LLM output (including `is_task_complete`, `was_task_successful`, etc.) as the user-visible answer.
- **Three-layer fix**:
  1. Skip the redundant `a2a_event` write in `a2a_remote_agent_connect` when artifacts were already streamed individually
  2. Add `_strip_structured_response_wrapper()` to both executor variants so `_extract_final_answer()` detects and strips the metadata pattern from accumulated content
  3. In the Slack bot, always prefer the authoritative `final_result_text` for `stopStream` even when content was already streamed live

## Related PRs

- Exposed by #1025 (`fix(executor): plan step attribution, false final answer, and sub-agent source bugs`) — merged in 0.2.42

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (153 tests)
- [ ] Manual: ask "what is CAIPE?" in Slack → verify response shows clean content without metadata fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)