### PR TITLE
fix(agents): wrap subagent MCP tools with error handling for resilience

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -34,6 +34,9 @@ from dynamic_agents.services.mcp_client import (
     filter_tools_by_allowed,
     get_tools_with_resilience,
 )
+from dynamic_agents.services.tool_error_handling import (
+    wrap_tools_with_error_handling,
+)
 from dynamic_agents.services.stream_events import (
     make_input_required_event,
     transform_stream_chunk,
@@ -356,6 +359,9 @@ class AgentRuntime:
                 mcp_client = MultiServerMCPClient(connections, tool_name_prefix=True)
                 all_tools = await mcp_client.get_tools()
                 mcp_tools, _ = filter_tools_by_allowed(all_tools, subagent_config.allowed_tools)
+                mcp_tools = wrap_tools_with_error_handling(
+                    mcp_tools, agent_name=subagent_config.name,
+                )
                 tools.extend(mcp_tools)
 
         # 2. Add built-in tools based on subagent's config

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/tool_error_handling.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/tool_error_handling.py
@@ -1,0 +1,176 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone utility to wrap tools with error handling for subagent resilience.
+
+When MCP tools (or any tools) are passed to subagents via SubAgentMiddleware,
+tool failures raise exceptions that propagate through LangGraph's ToolNode
+(which only catches ToolInvocationError by default).  This crashes the entire
+subagent graph and marks the deterministic task step as failed — even when the
+LLM could have recovered by trying a different approach.
+
+This module provides ``wrap_tools_with_error_handling`` to catch tool exceptions
+and return error strings to the LLM, giving it a chance to self-correct.
+
+NOTE: This is a copy of ai_platform_engineering/utils/deepagents_custom/tool_error_handling.py
+kept in sync manually because dynamic_agents has its own venv and cannot import
+from the parent ai_platform_engineering package.
+"""
+
+import asyncio
+import logging
+from functools import wraps
+
+from langchain_core.tools import BaseTool, StructuredTool
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_OUTPUT_CHARS = 15_000
+
+
+def _format_tool_error(tool_name: str, exc: Exception) -> str:
+    """Build an informative but concise error string for the LLM."""
+    error_text = str(exc).strip()
+    if not error_text:
+        error_text = type(exc).__name__
+    return (
+        f"Tool '{tool_name}' failed: {error_text}\n"
+        f"You can retry with different arguments or use a different approach."
+    )
+
+
+def _truncate(result: str, tool_name: str, max_chars: int = MAX_TOOL_OUTPUT_CHARS) -> str:
+    if isinstance(result, str) and len(result) > max_chars:
+        logger.warning(f"Tool '{tool_name}' output truncated from {len(result)} to {max_chars} chars")
+        return result[:max_chars] + f"\n... [truncated, {len(result) - max_chars} chars omitted]"
+    return result
+
+
+def wrap_tools_with_error_handling(
+    tools: list[BaseTool],
+    agent_name: str = "subagent",
+) -> list[BaseTool]:
+    """Wrap tools with error handling so exceptions become LLM-visible messages.
+
+    This prevents MCP tool failures from crashing subagent graphs. The LLM
+    receives the error text and can decide to retry or take a different path.
+
+    Args:
+        tools: LangChain tools (typically from MultiServerMCPClient.get_tools())
+        agent_name: Label used in log messages
+
+    Returns:
+        New list of tools with error-handling wrappers applied.
+    """
+    wrapped: list[BaseTool] = []
+
+    for tool in tools:
+        try:
+            tool_name = tool.name
+            has_sync = hasattr(tool, "func") and tool.func is not None
+            has_async = hasattr(tool, "coroutine") and tool.coroutine is not None
+
+            if has_async and not has_sync:
+                original_coro = tool.coroutine
+
+                async def _safe_coro(
+                    *args,
+                    _orig=original_coro,
+                    _name=tool_name,
+                    **kwargs,
+                ):
+                    try:
+                        result = await _orig(*args, **kwargs)
+                        if isinstance(result, str):
+                            result = _truncate(result, _name)
+                        return result
+                    except Exception as e:
+                        msg = _format_tool_error(_name, e)
+                        logger.warning(f"[{agent_name}] {msg}")
+                        return msg
+
+                def _sync_fallback(
+                    *args,
+                    _async_fn=_safe_coro,
+                    _name=tool_name,
+                    **kwargs,
+                ):
+                    try:
+                        try:
+                            loop = asyncio.get_running_loop()
+                        except RuntimeError:
+                            loop = None
+
+                        if loop and loop.is_running():
+                            import nest_asyncio
+                            nest_asyncio.apply()
+                            return loop.run_until_complete(_async_fn(*args, **kwargs))
+                        return asyncio.run(_async_fn(*args, **kwargs))
+                    except Exception as e:
+                        msg = _format_tool_error(_name, e)
+                        logger.warning(f"[{agent_name}] sync fallback: {msg}")
+                        return msg
+
+                new_tool = StructuredTool(
+                    name=tool.name,
+                    description=tool.description or "",
+                    args_schema=tool.args_schema,
+                    func=_sync_fallback,
+                    coroutine=_safe_coro,
+                    response_format=getattr(tool, "response_format", "content"),
+                    metadata=tool.metadata,
+                )
+                wrapped.append(new_tool)
+            else:
+                original_run = getattr(tool, "_run", None)
+                original_arun = getattr(tool, "_arun", None)
+
+                if original_run:
+                    @wraps(original_run)
+                    def _safe_run(
+                        *args,
+                        _orig=original_run,
+                        _name=tool_name,
+                        **kwargs,
+                    ):
+                        try:
+                            result = _orig(*args, **kwargs)
+                            if isinstance(result, str):
+                                result = _truncate(result, _name)
+                            return result
+                        except Exception as e:
+                            msg = _format_tool_error(_name, e)
+                            logger.warning(f"[{agent_name}] {msg}")
+                            return msg
+
+                    tool._run = _safe_run  # type: ignore[method-assign]
+
+                if original_arun:
+                    @wraps(original_arun)
+                    async def _safe_arun(
+                        *args,
+                        _orig=original_arun,
+                        _name=tool_name,
+                        **kwargs,
+                    ):
+                        try:
+                            result = await _orig(*args, **kwargs)
+                            if isinstance(result, str):
+                                result = _truncate(result, _name)
+                            return result
+                        except Exception as e:
+                            msg = _format_tool_error(_name, e)
+                            logger.warning(f"[{agent_name}] {msg}")
+                            return msg
+
+                    tool._arun = _safe_arun  # type: ignore[method-assign]
+
+                wrapped.append(tool)
+        except Exception as e:
+            logger.error(f"Failed to wrap tool {tool.name}: {e}", exc_info=True)
+            wrapped.append(tool)
+
+    logger.info(
+        f"[{agent_name}] Wrapped {len(wrapped)} tools with error handling"
+    )
+    return wrapped

--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py
@@ -56,6 +56,9 @@ from ai_platform_engineering.utils.deepagents_custom.tools import (
     tool_result_to_file,
     wait,
 )
+from ai_platform_engineering.utils.deepagents_custom.tool_error_handling import (
+    wrap_tools_with_error_handling,
+)
 
 # Skills middleware: upstream SkillsMiddleware + custom catalog layer
 from deepagents.middleware.skills import SkillsMiddleware
@@ -674,6 +677,7 @@ async def create_github_subagent_def(prompt_config: dict = None) -> dict:
             # Retry with the base class helper that suppresses these.
             mcp_tools = await agent._load_mcp_tools_with_cleanup_handling(client, name)
         mcp_tools = agent._filter_mcp_tools(mcp_tools)
+        mcp_tools = wrap_tools_with_error_handling(mcp_tools, agent_name=name)
         logger.info(f"{name}: {len(mcp_tools)} MCP tools loaded via local go run")
     except (ValueError, FileNotFoundError) as e:
         logger.warning(f"{name}: Cannot start local MCP server: {e}")

--- a/ai_platform_engineering/utils/deepagents_custom/__init__.py
+++ b/ai_platform_engineering/utils/deepagents_custom/__init__.py
@@ -67,6 +67,11 @@ from ai_platform_engineering.utils.deepagents_custom.exceptions import (
     ToolError,
 )
 
+# Export tool error handling
+from ai_platform_engineering.utils.deepagents_custom.tool_error_handling import (
+    wrap_tools_with_error_handling,
+)
+
 __all__ = [
     # Official deepagents
     "create_deep_agent",
@@ -94,4 +99,6 @@ __all__ = [
     # Exceptions
     "AgentStopRequestedError",
     "ToolError",
+    # Tool error handling
+    "wrap_tools_with_error_handling",
 ]

--- a/ai_platform_engineering/utils/deepagents_custom/tool_error_handling.py
+++ b/ai_platform_engineering/utils/deepagents_custom/tool_error_handling.py
@@ -1,0 +1,172 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone utility to wrap tools with error handling for subagent resilience.
+
+When MCP tools (or any tools) are passed to subagents via SubAgentMiddleware,
+tool failures raise exceptions that propagate through LangGraph's ToolNode
+(which only catches ToolInvocationError by default).  This crashes the entire
+subagent graph and marks the deterministic task step as failed — even when the
+LLM could have recovered by trying a different approach.
+
+This module provides ``wrap_tools_with_error_handling`` to catch tool exceptions
+and return error strings to the LLM, giving it a chance to self-correct.
+"""
+
+import asyncio
+import logging
+from functools import wraps
+
+from langchain_core.tools import BaseTool, StructuredTool
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_OUTPUT_CHARS = 15_000
+
+
+def _format_tool_error(tool_name: str, exc: Exception) -> str:
+    """Build an informative but concise error string for the LLM."""
+    error_text = str(exc).strip()
+    if not error_text:
+        error_text = type(exc).__name__
+    return (
+        f"Tool '{tool_name}' failed: {error_text}\n"
+        f"You can retry with different arguments or use a different approach."
+    )
+
+
+def _truncate(result: str, tool_name: str, max_chars: int = MAX_TOOL_OUTPUT_CHARS) -> str:
+    if isinstance(result, str) and len(result) > max_chars:
+        logger.warning(f"Tool '{tool_name}' output truncated from {len(result)} to {max_chars} chars")
+        return result[:max_chars] + f"\n... [truncated, {len(result) - max_chars} chars omitted]"
+    return result
+
+
+def wrap_tools_with_error_handling(
+    tools: list[BaseTool],
+    agent_name: str = "subagent",
+) -> list[BaseTool]:
+    """Wrap tools with error handling so exceptions become LLM-visible messages.
+
+    This prevents MCP tool failures from crashing subagent graphs. The LLM
+    receives the error text and can decide to retry or take a different path.
+
+    Args:
+        tools: LangChain tools (typically from MultiServerMCPClient.get_tools())
+        agent_name: Label used in log messages
+
+    Returns:
+        New list of tools with error-handling wrappers applied.
+    """
+    wrapped: list[BaseTool] = []
+
+    for tool in tools:
+        try:
+            tool_name = tool.name
+            has_sync = hasattr(tool, "func") and tool.func is not None
+            has_async = hasattr(tool, "coroutine") and tool.coroutine is not None
+
+            if has_async and not has_sync:
+                original_coro = tool.coroutine
+
+                async def _safe_coro(
+                    *args,
+                    _orig=original_coro,
+                    _name=tool_name,
+                    **kwargs,
+                ):
+                    try:
+                        result = await _orig(*args, **kwargs)
+                        if isinstance(result, str):
+                            result = _truncate(result, _name)
+                        return result
+                    except Exception as e:
+                        msg = _format_tool_error(_name, e)
+                        logger.warning(f"[{agent_name}] {msg}")
+                        return msg
+
+                def _sync_fallback(
+                    *args,
+                    _async_fn=_safe_coro,
+                    _name=tool_name,
+                    **kwargs,
+                ):
+                    try:
+                        try:
+                            loop = asyncio.get_running_loop()
+                        except RuntimeError:
+                            loop = None
+
+                        if loop and loop.is_running():
+                            import nest_asyncio
+                            nest_asyncio.apply()
+                            return loop.run_until_complete(_async_fn(*args, **kwargs))
+                        return asyncio.run(_async_fn(*args, **kwargs))
+                    except Exception as e:
+                        msg = _format_tool_error(_name, e)
+                        logger.warning(f"[{agent_name}] sync fallback: {msg}")
+                        return msg
+
+                new_tool = StructuredTool(
+                    name=tool.name,
+                    description=tool.description or "",
+                    args_schema=tool.args_schema,
+                    func=_sync_fallback,
+                    coroutine=_safe_coro,
+                    response_format=getattr(tool, "response_format", "content"),
+                    metadata=tool.metadata,
+                )
+                wrapped.append(new_tool)
+            else:
+                original_run = getattr(tool, "_run", None)
+                original_arun = getattr(tool, "_arun", None)
+
+                if original_run:
+                    @wraps(original_run)
+                    def _safe_run(
+                        *args,
+                        _orig=original_run,
+                        _name=tool_name,
+                        **kwargs,
+                    ):
+                        try:
+                            result = _orig(*args, **kwargs)
+                            if isinstance(result, str):
+                                result = _truncate(result, _name)
+                            return result
+                        except Exception as e:
+                            msg = _format_tool_error(_name, e)
+                            logger.warning(f"[{agent_name}] {msg}")
+                            return msg
+
+                    tool._run = _safe_run  # type: ignore[method-assign]
+
+                if original_arun:
+                    @wraps(original_arun)
+                    async def _safe_arun(
+                        *args,
+                        _orig=original_arun,
+                        _name=tool_name,
+                        **kwargs,
+                    ):
+                        try:
+                            result = await _orig(*args, **kwargs)
+                            if isinstance(result, str):
+                                result = _truncate(result, _name)
+                            return result
+                        except Exception as e:
+                            msg = _format_tool_error(_name, e)
+                            logger.warning(f"[{agent_name}] {msg}")
+                            return msg
+
+                    tool._arun = _safe_arun  # type: ignore[method-assign]
+
+                wrapped.append(tool)
+        except Exception as e:
+            logger.error(f"Failed to wrap tool {tool.name}: {e}", exc_info=True)
+            wrapped.append(tool)
+
+    logger.info(
+        f"[{agent_name}] Wrapped {len(wrapped)} tools with error handling"
+    )
+    return wrapped


### PR DESCRIPTION
## Summary

- Add `wrap_tools_with_error_handling()` utility that catches exceptions during tool execution and returns error messages to the LLM, preventing subagent graph crashes
- Apply wrapper in `create_github_subagent_def` (single-node deep agent) and `_build_subagent_tools` (dynamic agents)
- Include a local copy in the `dynamic_agents` package since it runs in an isolated venv

**Problem**: MCP tool failures (e.g. `get_file_contents` returning "path not found") raised exceptions that crashed entire subagent graphs via LangGraph's `ToolNode` (which only catches `ToolInvocationError` by default). The `DeterministicTaskMiddleware` would then mark the whole task step as failed, preventing the LLM from recovering.

**Fix**: Wrap all MCP tools passed to subagents so exceptions become LLM-visible error messages. The LLM can then retry with different arguments or take a different approach.

## Test plan

- [ ] Run single-node deep agent with a self-service workflow that uses GitHub subagent
- [ ] Trigger a GitHub MCP tool error (e.g. request a nonexistent file) and verify the subagent recovers instead of crashing
- [ ] Run dynamic agents with MCP tools and verify error resilience
- [ ] Verify existing tool functionality is not affected by the wrapper

Made with [Cursor](https://cursor.com)