### PR TITLE
fix(rag): rename fetch_datasources_and_entity_types to list_datasources_and_entity_types in prompt

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.2.43 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.2.43-rc.7 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.2.43-rc.helm.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.2.43-rc.helm.7 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/data/prompt_config.rag.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.rag.yaml
@@ -163,7 +163,7 @@ start_rag_prompt: |
   **Knowledge Base Access:**
   Text docs (wikis, Confluence, PDFs, Slack/Webex) + Graph entities (structured data: AWS, ArgoCD, infrastructure)
 
-  **Start:** Call `fetch_datasources_and_entity_types` to discover available datasources and entity types
+  **Start:** Call `list_datasources_and_entity_types` to discover available datasources and entity types
 
   **BE PERSISTENT - MINIMUM 3 APPROACHES:**
   ❌ NEVER give up after 1 search! ✅ Try 3+ different strategies:


### PR DESCRIPTION
## Summary

The RAG server tool was renamed to `list_datasources_and_entity_types` in the Python implementation (`tools.py:251`, `restapi.py:352`) but `prompt_config.rag.yaml` still referenced the old name `fetch_datasources_and_entity_types`, causing the RAG agent to call a non-existent tool at the start of every knowledge base session.

One-line fix to align the prompt with the actual tool name.

The other changes originally in this PR (speed rule, jokes/trivia skip exception, fetch_document cap) have been superseded by later PRs (#1069, #1151) and are dropped.

## Test plan

- [ ] RAG agent starts a session and successfully calls `list_datasources_and_entity_types`