### PR TITLE
fix(aws): omit --profile flag when no AWS_ACCOUNT_LIST profiles are configured

### DIFF
--- a/ai_platform_engineering/agents/aws/agent_aws/tools.py
+++ b/ai_platform_engineering/agents/aws/agent_aws/tools.py
@@ -421,17 +421,24 @@ class AWSCLITool(BaseTool):
         else:
             output_fmt = output_format if output_format in ["json", "text", "table", "yaml"] else "json"
 
-        # Build profile flag - always required
-        profile_flag = f"--profile {profile}"
+        # Build profile flag — omit when no AWS_ACCOUNT_LIST is configured so
+        # that env var credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+        # are used directly.  Adding --profile when no ~/.aws/config exists
+        # causes "The config profile (X) could not be found" errors.
+        configured_profiles = get_configured_profiles()
+        if configured_profiles and profile:
+            profile_prefix = f"--profile {profile} "
+        else:
+            profile_prefix = ""
 
         # Only add --region if not already in command
         if "--region" in command:
-            full_command = f"aws {profile_flag} {command} --output {output_fmt}"
+            full_command = f"aws {profile_prefix}{command} --output {output_fmt}"
         else:
-            full_command = f"aws {profile_flag} {command} --region {aws_region} --output {output_fmt}"
+            full_command = f"aws {profile_prefix}{command} --region {aws_region} --output {output_fmt}"
 
         # Log which account is being queried
-        logger.info(f"Querying account: {profile}")
+        logger.info(f"Querying account: {profile or '(env var credentials)'}")
 
         logger.info(f"Executing AWS CLI command: {full_command}")
         if jq_filter:
@@ -845,13 +852,16 @@ class EKSKubectlTool(BaseTool):
 
             logger.debug(f"Created temporary kubeconfig: {kubeconfig_path}")
 
-            # Build aws eks update-kubeconfig command
+            # Build aws eks update-kubeconfig command.
+            # Omit --profile when no AWS_ACCOUNT_LIST profiles are configured so
+            # env var credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) are used.
             update_cmd_parts = [
                 "aws", "eks", "update-kubeconfig",
                 "--name", cluster_name,
                 "--kubeconfig", kubeconfig_path,
-                "--profile", profile
             ]
+            if get_configured_profiles() and profile:
+                update_cmd_parts.extend(["--profile", profile])
 
             if region:
                 update_cmd_parts.extend(["--region", region])


### PR DESCRIPTION
## Summary

- `AWSCLITool`: only prepend `--profile` to the AWS CLI command when `get_configured_profiles()` returns profiles. Without this, single-account deployments using env var credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) hit `The config profile (X) could not be found` errors because no `~/.aws/config` exists.
- `EKSKubectlTool`: same fix for `aws eks update-kubeconfig` — omit `--profile` when no profiles are configured.
- Log message updated: shows `(env var credentials)` when no profile is active.

## Test plan

- [ ] Single-account deployment with env var credentials — confirm AWS CLI commands run without profile errors
- [ ] Multi-account deployment with `AWS_ACCOUNT_LIST` set — confirm `--profile` is still included as before

> Split from #1051.