### PR TITLE
fix(supervisor): replace orphaned-tool-call RemoveMessage with synthetic ToolMessages

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -118,9 +118,19 @@ class AIPlatformEngineerA2ABinding:
       """
       CRITICAL: Repair orphaned tool calls in message history.
 
-      Bedrock/Anthropic requires ToolMessages to appear IMMEDIATELY after
-      the AIMessage with tool_use. If we can't properly repair the ordering,
-      we remove the problematic AIMessages entirely.
+      Bedrock/Anthropic requires a ToolMessage (tool_result) to appear immediately
+      after the AIMessage that contains the matching tool_use block. When a session
+      is interrupted mid-tool-call, the checkpoint holds an AIMessage with unresolved
+      tool_call_ids and no corresponding ToolMessages.
+
+      Strategy: inject a synthetic ToolMessage for each orphaned tool_call_id via
+      aupdate_state(..., as_node="tools"). This keeps the AIMessage intact (Bedrock
+      adjacency requirement satisfied) and routes the graph tools→model, so the new
+      user query is processed correctly.
+
+      Do NOT remove the AIMessage and replace with a placeholder (old approach):
+      that caused the graph to set checkpoint.next=END, leaking the placeholder text
+      directly to users instead of processing the new query.
 
       This is essential for recovery when:
       - A sub-agent call fails mid-stream (e.g., context overflow)
@@ -131,8 +141,6 @@ class AIPlatformEngineerA2ABinding:
           config: Runnable configuration with thread_id
       """
       try:
-          from langchain_core.messages import RemoveMessage
-
           state = await self.graph.aget_state(config)
           if not state or not state.values:
               return
@@ -196,60 +204,51 @@ class AIPlatformEngineerA2ABinding:
               f"IDs: {list(orphaned.keys())}, Names: {orphaned_names}"
           )
 
-          # STRATEGY: Remove ONLY the AIMessages that have orphaned tool calls.
-          # This preserves earlier conversation history while eliminating the problematic
-          # messages that would cause Bedrock validation errors.
+          # STRATEGY: Inject synthetic ToolMessages for each orphaned tool call.
           #
-          # We cannot simply append ToolMessages at the end because Bedrock requires
-          # tool_result immediately after tool_use. And we cannot remove ALL messages
-          # because that triggers IndexError when LangGraph's should_continue runs.
+          # Keep the AIMessage intact and append a synthetic ToolMessage for each
+          # unresolved tool_call_id. This satisfies Bedrock's requirement that every
+          # tool_use block is immediately followed by a matching tool_result, and it
+          # routes the graph to the `tools` node next (tools→model) so the model
+          # processes the new user query correctly.
+          #
+          # Previous approach (remove AIMessage + inject placeholder with
+          # as_node="model") was broken: a placeholder AIMessage with no tool_calls
+          # caused LangGraph to set checkpoint next-node=END, so the new query was
+          # never processed and the placeholder text leaked to users.
 
-          # Get the IDs of AIMessages that have orphaned tool calls
-          ai_msg_ids_to_remove = set()
+          synthetic_tool_msgs = []
           for tool_call_id, (msg_idx, tool_name, ai_msg_id) in orphaned.items():
-              if ai_msg_id:
-                  ai_msg_ids_to_remove.add(ai_msg_id)
-                  logging.info(
-                      f"🔧 Will remove AIMessage with orphaned tool_call: "
-                      f"msg_id={ai_msg_id[:20] if ai_msg_id else 'None'}..., "
-                      f"tool={tool_name}, tool_call_id={tool_call_id[:20]}..."
+              synthetic_tool_msgs.append(
+                  ToolMessage(
+                      content=f"Tool '{tool_name}' did not complete (session was interrupted).",
+                      tool_call_id=tool_call_id,
+                      name=tool_name,
                   )
-
-          if ai_msg_ids_to_remove:
-              # Remove only the problematic AIMessages
-              remove_messages = [RemoveMessage(id=msg_id) for msg_id in ai_msg_ids_to_remove]
-              await self.graph.aupdate_state(config, {"messages": remove_messages})
+              )
               logging.info(
-                  f"✅ Supervisor: Removed {len(ai_msg_ids_to_remove)} AIMessage(s) with orphaned tool calls. "
-                  f"Earlier conversation history preserved."
+                  f"🔧 Adding synthetic ToolMessage for orphaned tool: "
+                  f"{tool_name} (tool_call_id={tool_call_id[:20]}...)"
+              )
+
+          if synthetic_tool_msgs:
+              await self.graph.aupdate_state(
+                  config,
+                  {"messages": synthetic_tool_msgs},
+                  as_node="tools",
+              )
+              logging.info(
+                  f"✅ Supervisor: Repaired {len(synthetic_tool_msgs)} orphaned tool call(s) "
+                  f"with synthetic ToolMessages. Graph will route to model node next."
               )
           else:
-              # No message IDs found - fall back to just logging
               logging.warning(
-                  f"⚠️ Supervisor: Found orphaned tool calls but no message IDs to remove. "
-                  f"Orphaned tools: {orphaned_names}"
+                  f"⚠️ Supervisor: Found orphaned tool calls but could not build synthetic "
+                  f"ToolMessages. Orphaned tools: {orphaned_names}"
               )
 
       except Exception as e:
           logging.error(f"Supervisor: Error repairing orphaned tool calls: {e}", exc_info=True)
-          # If repair fails, try a fallback: clear the thread state entirely
-          # This loses history but allows future queries to work
-          try:
-              logging.warning("⚠️ Attempting fallback: clearing corrupted thread state")
-              # Get the thread_id from config
-              thread_id = config.get("configurable", {}).get("thread_id")
-              if thread_id and hasattr(self.graph, 'checkpointer') and self.graph.checkpointer:
-                  # Try to clear the checkpoint for this thread
-                  logging.info(f"Clearing checkpoint for thread_id: {thread_id}")
-                  # We can't easily delete checkpoints, so we'll just add a fresh HumanMessage
-                  # to reset the conversation flow
-                  from langchain_core.messages import HumanMessage
-                  reset_msg = HumanMessage(content="[System: Previous conversation was interrupted. Starting fresh.]")
-                  await self.graph.aupdate_state(config, {"messages": [reset_msg]})
-                  logging.info("✅ Added reset message to recover from corrupted state")
-          except Exception as fallback_err:
-              logging.error(f"Fallback recovery also failed: {fallback_err}")
-              # At this point, the conversation is corrupted - user will need to start a new thread
 
   def _deserialize_a2a_event(self, data: Any):
       """Try to deserialize a dict payload into known A2A models."""

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_binding_e2e.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_binding_e2e.py
@@ -11,18 +11,17 @@ Coverage
    - all tool calls already resolved
    - no AIMessages in history
 
-2. _repair_orphaned_tool_calls — repair paths
-   - single orphan → RemoveMessage for that AIMessage ID
-   - multiple orphans on same AIMessage → exactly one RemoveMessage
-   - multiple orphans on different AIMessages → one RemoveMessage each
-   - orphan with no msg ID → no aupdate_state (logs warning only)
+2. _repair_orphaned_tool_calls — repair paths (synthetic ToolMessage strategy)
+   - single orphan → synthetic ToolMessage injected via as_node="tools"
+   - multiple orphans on same AIMessage → one ToolMessage per orphaned tool_call_id
+   - multiple orphans on different AIMessages → one ToolMessage per tool_call_id
    - Bedrock additional_kwargs storage location detected
    - Bedrock content-block storage location detected
+   - history preserved — only orphaned tool calls get synthetic ToolMessages
 
 3. _repair_orphaned_tool_calls — exception handling
-   - aget_state raises → fallback HumanMessage injected
-   - aupdate_state raises → fallback HumanMessage injected
-   - fallback itself raises → swallowed, no crash
+   - aget_state raises → caught and logged, no crash
+   - aupdate_state raises → caught and logged, no crash
 
 4. _extract_tool_call_ids helper
    - standard tool_calls list
@@ -36,7 +35,7 @@ Coverage
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -167,14 +166,14 @@ class TestRepairOrphanedToolCallsNoOp:
 
 
 # ===========================================================================
-# 2. Repair paths — RemoveMessage strategy
+# 2. Repair paths — synthetic ToolMessage strategy
 # ===========================================================================
 
 class TestRepairOrphanedToolCallsRepair:
 
     @pytest.mark.asyncio
-    async def test_single_orphan_removes_ai_message(self):
-        """One orphaned tool call → RemoveMessage for its AIMessage ID."""
+    async def test_single_orphan_injects_synthetic_tool_message(self):
+        """One orphaned tool call → synthetic ToolMessage injected via as_node='tools'."""
 
         binding = _make_binding()
         ai_msg = _make_ai_message(["tc-1"], ["jira_search"], msg_id="ai-msg-orphan")
@@ -187,12 +186,13 @@ class TestRepairOrphanedToolCallsRepair:
         call_args = binding.graph.aupdate_state.call_args
         messages = call_args[0][1]["messages"]
         assert len(messages) == 1
-        assert isinstance(messages[0], RemoveMessage)
-        assert messages[0].id == "ai-msg-orphan"
+        assert isinstance(messages[0], ToolMessage)
+        assert messages[0].tool_call_id == "tc-1"
+        assert call_args[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_multiple_orphans_same_ai_message_one_remove(self):
-        """Two orphaned tool calls on same AIMessage → exactly one RemoveMessage."""
+    async def test_multiple_orphans_same_ai_message_two_tool_messages(self):
+        """Two orphaned tool calls on same AIMessage → two synthetic ToolMessages."""
 
         binding = _make_binding()
         ai_msg = _make_ai_message(["tc-1", "tc-2"], ["tool_a", "tool_b"], msg_id="ai-multi")
@@ -201,14 +201,16 @@ class TestRepairOrphanedToolCallsRepair:
 
         await binding._repair_orphaned_tool_calls(CONFIG)
 
-        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert len(messages) == 1
-        assert isinstance(messages[0], RemoveMessage)
-        assert messages[0].id == "ai-multi"
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        injected_ids = {m.tool_call_id for m in messages}
+        assert injected_ids == {"tc-1", "tc-2"}
+        assert all(isinstance(m, ToolMessage) for m in messages)
+        assert call_args[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_multiple_orphans_different_ai_messages_one_remove_each(self):
-        """Orphans on two separate AIMessages → two RemoveMessages."""
+    async def test_multiple_orphans_different_ai_messages_one_tool_message_each(self):
+        """Orphans on two separate AIMessages → one synthetic ToolMessage per tool call."""
 
         binding = _make_binding()
         ai1 = _make_ai_message(["tc-1"], ["tool_a"], msg_id="ai-first")
@@ -218,14 +220,16 @@ class TestRepairOrphanedToolCallsRepair:
 
         await binding._repair_orphaned_tool_calls(CONFIG)
 
-        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        ids_removed = {m.id for m in messages}
-        assert ids_removed == {"ai-first", "ai-second"}
-        assert all(isinstance(m, RemoveMessage) for m in messages)
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        injected_ids = {m.tool_call_id for m in messages}
+        assert injected_ids == {"tc-1", "tc-2"}
+        assert all(isinstance(m, ToolMessage) for m in messages)
+        assert call_args[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_partial_orphans_only_orphaned_ai_message_removed(self):
-        """One AI message resolved, one orphaned → only orphaned one removed."""
+    async def test_partial_orphans_only_orphaned_repaired(self):
+        """One AI message resolved, one orphaned → only synthetic ToolMessage for the orphan."""
 
         binding = _make_binding()
         ai_resolved = _make_ai_message(["tc-resolved"], ["tool_ok"], msg_id="ai-ok")
@@ -238,34 +242,18 @@ class TestRepairOrphanedToolCallsRepair:
 
         await binding._repair_orphaned_tool_calls(CONFIG)
 
-        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        ids_removed = {m.id for m in messages}
-        assert "ai-bad" in ids_removed
-        assert "ai-ok" not in ids_removed
-
-    @pytest.mark.asyncio
-    async def test_orphan_without_msg_id_no_update_state(self):
-        """AIMessage with no id → can't build RemoveMessage, no aupdate_state call."""
-        ai_msg = AIMessage(content="", tool_calls=[
-            {"id": "tc-noid", "name": "tool_x", "args": {}, "type": "tool_call"}
-        ])
-        # Don't set id (AIMessage id defaults to auto-generated, but we clear it)
-        ai_msg.id = None
-
-        binding = _make_binding()
-        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
-        binding.graph.aupdate_state = AsyncMock()
-
-        await binding._repair_orphaned_tool_calls(CONFIG)
-
-        binding.graph.aupdate_state.assert_not_awaited()
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        assert len(messages) == 1
+        assert isinstance(messages[0], ToolMessage)
+        assert messages[0].tool_call_id == "tc-orphan"
+        assert call_args[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
     async def test_bedrock_additional_kwargs_tooluse_detected(self):
         """Bedrock stores tool_call IDs in additional_kwargs['tool_use']."""
 
         binding = _make_binding()
-        # No standard tool_calls — only additional_kwargs Bedrock storage
         ai_msg = AIMessage(
             content="",
             additional_kwargs={"tool_use": [{"id": "bedrock-tc-1", "name": "bedrock_tool"}]},
@@ -277,8 +265,10 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         binding.graph.aupdate_state.assert_awaited_once()
-        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert any(isinstance(m, RemoveMessage) and m.id == "ai-bedrock" for m in messages)
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        assert any(isinstance(m, ToolMessage) and m.tool_call_id == "bedrock-tc-1" for m in messages)
+        assert call_args[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
     async def test_bedrock_content_block_tool_use_detected(self):
@@ -295,14 +285,16 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         binding.graph.aupdate_state.assert_awaited_once()
-        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert any(isinstance(m, RemoveMessage) and m.id == "ai-block" for m in messages)
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        assert any(isinstance(m, ToolMessage) and m.tool_call_id == "block-tc-1" for m in messages)
+        assert call_args[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_history_preserved_only_orphaned_removed(self):
+    async def test_history_preserved_only_orphaned_repaired(self):
         """
-        Earlier clean conversation (HumanMessage + AI + ToolMessage) must be
-        preserved; only the orphaned AIMessage is removed.
+        Earlier clean conversation is preserved; only the orphaned tool call
+        gets a synthetic ToolMessage, not the already-resolved one.
         """
 
         binding = _make_binding()
@@ -318,10 +310,11 @@ class TestRepairOrphanedToolCallsRepair:
 
         await binding._repair_orphaned_tool_calls(CONFIG)
 
-        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        removed_ids = {m.id for m in messages if isinstance(m, RemoveMessage)}
-        assert removed_ids == {"ai-orphan"}
-        assert "ai-old" not in removed_ids
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        injected_ids = {m.tool_call_id for m in messages if isinstance(m, ToolMessage)}
+        assert injected_ids == {"tc-orphan"}
+        assert "tc-old" not in injected_ids
 
 
 # ===========================================================================
@@ -331,43 +324,25 @@ class TestRepairOrphanedToolCallsRepair:
 class TestRepairExceptionHandling:
 
     @pytest.mark.asyncio
-    async def test_aget_state_exception_triggers_fallback(self):
-        """If aget_state raises, fallback HumanMessage injected."""
+    async def test_aget_state_exception_is_caught(self):
+        """If aget_state raises, the error is caught and logged — method does not raise."""
         binding = _make_binding()
         binding.graph.aget_state = AsyncMock(side_effect=RuntimeError("checkpoint error"))
         binding.graph.aupdate_state = AsyncMock()
-        binding.graph.checkpointer = MagicMock()
 
         # Should not raise
         await binding._repair_orphaned_tool_calls(CONFIG)
-
-        # Fallback: a HumanMessage was injected
-        if binding.graph.aupdate_state.await_count > 0:
-            call_msgs = binding.graph.aupdate_state.call_args[0][1]["messages"]
-            assert any(isinstance(m, HumanMessage) for m in call_msgs)
+        binding.graph.aupdate_state.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_aupdate_state_exception_triggers_fallback(self):
-        """If aupdate_state raises during repair, fallback path attempted."""
+    async def test_aupdate_state_exception_is_caught(self):
+        """If aupdate_state raises during repair, the error is caught — method does not raise."""
         binding = _make_binding()
         ai_msg = _make_ai_message(["tc-1"], ["tool_x"], msg_id="ai-err")
         binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
         binding.graph.aupdate_state = AsyncMock(side_effect=RuntimeError("write error"))
-        binding.graph.checkpointer = MagicMock()
 
         # Must not crash
-        await binding._repair_orphaned_tool_calls(CONFIG)
-
-    @pytest.mark.asyncio
-    async def test_fallback_exception_is_swallowed(self):
-        """If both repair and fallback raise, the method still returns cleanly."""
-        binding = _make_binding()
-        ai_msg = _make_ai_message(["tc-1"], ["tool_x"], msg_id="ai-err2")
-        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
-        binding.graph.aupdate_state = AsyncMock(side_effect=RuntimeError("all writes fail"))
-        binding.graph.checkpointer = MagicMock()
-
-        # Even with double failure, no exception escapes
         await binding._repair_orphaned_tool_calls(CONFIG)
 
 

--- a/tests/test_supervisor_streaming_json_and_orphaned_tools.py
+++ b/tests/test_supervisor_streaming_json_and_orphaned_tools.py
@@ -110,7 +110,7 @@ class TestExtractToolCallIds:
 # ---------------------------------------------------------------------------
 
 class TestRepairOrphanedToolCalls:
-    """Test that _repair_orphaned_tool_calls finds orphans in all Bedrock formats."""
+    """Test that _repair_orphaned_tool_calls injects synthetic ToolMessages for orphans."""
 
     def _make_binding(self):
         """Create a minimal AIPlatformEngineerA2ABinding with mocked graph."""
@@ -127,7 +127,7 @@ class TestRepairOrphanedToolCalls:
 
     @pytest.mark.asyncio
     async def test_no_orphans_when_tool_message_present(self):
-        """No removal when every tool_call has a matching ToolMessage."""
+        """No repair when every tool_call has a matching ToolMessage."""
         binding = self._make_binding()
         tid = "tooluse_abc"
         messages = [
@@ -144,12 +144,11 @@ class TestRepairOrphanedToolCalls:
         binding.graph.aupdate_state.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_removes_orphan_in_tool_calls(self):
-        """Removes AIMessage when tool_call has no ToolMessage (standard format)."""
+    async def test_injects_synthetic_tool_msg_for_standard_format(self):
+        """Injects synthetic ToolMessage (as_node='tools') for orphan in standard tool_calls."""
         binding = self._make_binding()
         tid = "tooluse_orphan_standard"
-        msg_id = "msg-orphan-std"
-        ai_msg = _make_ai_message_with_tool_calls(tid, msg_id=msg_id)
+        ai_msg = _make_ai_message_with_tool_calls(tid)
         messages = [HumanMessage(content="hi"), ai_msg]
 
         state = MagicMock()
@@ -160,13 +159,16 @@ class TestRepairOrphanedToolCalls:
         await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
 
         binding.graph.aupdate_state.assert_called_once()
-        removed = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert len(removed) == 1
-        assert removed[0].id == msg_id
+        call_kwargs = binding.graph.aupdate_state.call_args
+        injected = call_kwargs[0][1]["messages"]
+        assert len(injected) == 1
+        assert isinstance(injected[0], ToolMessage)
+        assert injected[0].tool_call_id == tid
+        assert call_kwargs[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_removes_orphan_in_additional_kwargs(self):
-        """Removes AIMessage with orphaned tool_use stored in additional_kwargs."""
+    async def test_injects_synthetic_tool_msg_for_additional_kwargs(self):
+        """Injects synthetic ToolMessage for orphan stored in additional_kwargs."""
         binding = self._make_binding()
         tid = "tooluse_orphan_addkwargs"
         ai_msg = _make_ai_message_with_additional_kwargs(tid)
@@ -180,10 +182,14 @@ class TestRepairOrphanedToolCalls:
         await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
 
         binding.graph.aupdate_state.assert_called_once()
+        call_kwargs = binding.graph.aupdate_state.call_args
+        injected = call_kwargs[0][1]["messages"]
+        assert all(isinstance(m, ToolMessage) for m in injected)
+        assert call_kwargs[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_removes_orphan_in_content_block(self):
-        """Removes AIMessage with orphaned tool_use stored in content block."""
+    async def test_injects_synthetic_tool_msg_for_content_block(self):
+        """Injects synthetic ToolMessage for orphan stored in content block."""
         binding = self._make_binding()
         tid = "tooluse_orphan_contentblock"
         ai_msg = _make_ai_message_with_content_block(tid)
@@ -197,6 +203,10 @@ class TestRepairOrphanedToolCalls:
         await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
 
         binding.graph.aupdate_state.assert_called_once()
+        call_kwargs = binding.graph.aupdate_state.call_args
+        injected = call_kwargs[0][1]["messages"]
+        assert all(isinstance(m, ToolMessage) for m in injected)
+        assert call_kwargs[1].get("as_node") == "tools"
 
 
 # ---------------------------------------------------------------------------
@@ -550,8 +560,8 @@ class TestRepairOrphanedToolCallsEdgeCases:
         binding.graph.aupdate_state.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_multiple_orphans_all_removed(self):
-        """Multiple orphaned AIMessages should all be removed."""
+    async def test_multiple_orphans_all_repaired(self):
+        """Multiple orphaned tool calls each get their own synthetic ToolMessage."""
         binding = self._make_binding()
         msg1 = _make_ai_message_with_tool_calls("tooluse_a", msg_id="msg-a")
         msg2 = _make_ai_message_with_additional_kwargs("tooluse_b", msg_id="msg-b")
@@ -565,14 +575,17 @@ class TestRepairOrphanedToolCallsEdgeCases:
         await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
 
         binding.graph.aupdate_state.assert_called_once()
-        removed = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        removed_ids = {r.id for r in removed}
-        assert "msg-a" in removed_ids
-        assert "msg-b" in removed_ids
+        call_kwargs = binding.graph.aupdate_state.call_args
+        injected = call_kwargs[0][1]["messages"]
+        injected_ids = {m.tool_call_id for m in injected}
+        assert "tooluse_a" in injected_ids
+        assert "tooluse_b" in injected_ids
+        assert all(isinstance(m, ToolMessage) for m in injected)
+        assert call_kwargs[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
-    async def test_partial_orphan_only_orphaned_removed(self):
-        """AIMessage with 2 tool calls, one resolved and one orphaned — only orphaned AIMessage removed."""
+    async def test_partial_orphan_only_orphaned_repaired(self):
+        """AIMessage with 2 tool calls, one resolved and one orphaned — only one synthetic ToolMessage injected."""
         binding = self._make_binding()
         ai_msg = AIMessage(
             id="msg-partial",
@@ -596,17 +609,19 @@ class TestRepairOrphanedToolCallsEdgeCases:
         await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
 
         binding.graph.aupdate_state.assert_called_once()
-        removed = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert len(removed) == 1
-        assert removed[0].id == "msg-partial"
+        call_kwargs = binding.graph.aupdate_state.call_args
+        injected = call_kwargs[0][1]["messages"]
+        assert len(injected) == 1
+        assert isinstance(injected[0], ToolMessage)
+        assert injected[0].tool_call_id == "tooluse_orphaned"
+        assert call_kwargs[1].get("as_node") == "tools"
 
     @pytest.mark.asyncio
     async def test_aget_state_raises_exception(self):
-        """aget_state raising should trigger fallback path without propagating."""
+        """aget_state raising should be caught and not propagate."""
         binding = self._make_binding()
         binding.graph.aget_state = AsyncMock(side_effect=RuntimeError("checkpoint error"))
         binding.graph.aupdate_state = AsyncMock()
-        binding.graph.checkpointer = None
 
         await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
         # Should not raise; the except block handles it


### PR DESCRIPTION
## Summary

Ports the orphaned-tool-call repair fix (originally targeting the now-deleted agent_single.py) to agent.py, the unified single/distributed binding since PR #1151.

### Root cause

When a session is interrupted mid-tool-call, the checkpoint holds an AIMessage with unresolved tool_call_ids. The old strategy removed that AIMessage and injected a placeholder via as_node="model". Because the placeholder had no tool_calls, LangGraph set checkpoint.next=END. The next astream(new_input) honoured that checkpoint, skipped the model, and returned the placeholder text directly to users.

### Fix

- Keep the AIMessage intact
- Inject a synthetic ToolMessage per orphaned tool_call_id via aupdate_state(..., as_node="tools")
- as_node="tools" routes the graph tools→model so the new user query is processed correctly
- Bedrock adjacency requirement satisfied: tool_result immediately follows tool_use

### Changes

- agent.py: Replace RemoveMessage strategy with synthetic ToolMessage injection
- tests/test_agent_binding_e2e.py: Update repair path tests to assert ToolMessage injection with as_node="tools"
- tests/test_supervisor_streaming_json_and_orphaned_tools.py: Update repair path tests

## Test plan

- [x] 721 tests pass (make test)
- [x] Lint clean (make lint)
- [x] Verify as_node="tools" is used (not "model" or "agent")
- [x] Verify RemoveMessage is not used in repair path
- [x] All Bedrock storage locations covered (tool_calls, additional_kwargs, content blocks)