### PR TITLE
fix(rag): remove unconditional fetch_document call-to-action from search tool description

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_ai_plan_streaming.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_ai_plan_streaming.py
@@ -435,9 +435,12 @@ class TestToolEndNoTaskUpdate:
 
 
 class TestStreamWithoutPlanStreamsMarkdown:
-    """When no plan exists, STREAMING_RESULT streams markdown_text normally."""
+    """When no plan exists, STREAMING_RESULT is buffered (not streamed live) to avoid
+    leaking intermediate tool outputs or response metadata into Slack.
+    The clean FINAL_RESULT is delivered via stopStream instead."""
 
-    def test_markdown_streamed_without_plan(self):
+    def test_no_plan_streaming_result_buffered_final_result_in_stop_chunks(self):
+        """No-plan flow: STREAMING_RESULT events are buffered; FINAL_RESULT goes in stopStream."""
         events = [
             _task_event(),
             _streaming_result("Hello "),
@@ -458,24 +461,61 @@ class TestStreamWithoutPlanStreamsMarkdown:
             user_id="U123",
         )
 
-        # appendStream should have been called with markdown_text chunks
-        # (StreamBuffer may batch multiple tokens into fewer API calls)
+        # STREAMING_RESULT events should NOT be streamed via appendStream (no live markdown)
         markdown_texts = []
         for c in mock_slack.chat_appendStream.call_args_list:
             chunks = c.kwargs.get("chunks", [])
             for chunk in chunks:
                 if chunk.get("type") == "markdown_text":
                     markdown_texts.append(chunk["text"])
+        assert len(markdown_texts) == 0, (
+            "No-plan STREAMING_RESULT events must not be streamed live to avoid metadata leak"
+        )
 
-        combined = "".join(markdown_texts)
-        assert "Hello " in combined
-        assert "world" in combined
-        assert len(markdown_texts) >= 1
-
-        # stopStream should NOT carry final text since text was already streamed
+        # stopStream MUST carry the clean FINAL_RESULT text
         stop_call = mock_slack.chat_stopStream.call_args
         chunks = stop_call.kwargs.get("chunks")
-        assert chunks is None, "stopStream should not duplicate already-streamed text"
+        assert chunks is not None, "stopStream should carry the FINAL_RESULT text"
+        assert any("Hello world" in c.get("text", "") for c in chunks), (
+            "stopStream chunks should contain the FINAL_RESULT text"
+        )
+
+    def test_no_plan_fallback_to_buffered_streaming_when_no_final_result(self):
+        """No-plan flow without FINAL_RESULT: buffered STREAMING_RESULT used as fallback."""
+        events = [
+            _task_event(),
+            _streaming_result("Fallback "),
+            _streaming_result("content"),
+        ]
+        mock_a2a = Mock()
+        mock_a2a.send_message_stream.return_value = iter(events)
+        mock_slack = _mock_slack()
+
+        stream_a2a_response(
+            a2a_client=mock_a2a,
+            slack_client=mock_slack,
+            channel_id="C1",
+            thread_ts="t1",
+            message_text="hi",
+            team_id="T1",
+            user_id="U123",
+        )
+
+        # No live streaming
+        markdown_texts = []
+        for c in mock_slack.chat_appendStream.call_args_list:
+            chunks = c.kwargs.get("chunks", [])
+            for chunk in chunks:
+                if chunk.get("type") == "markdown_text":
+                    markdown_texts.append(chunk["text"])
+        assert len(markdown_texts) == 0
+
+        # stopStream should use the buffered streaming content as fallback
+        stop_call = mock_slack.chat_stopStream.call_args
+        chunks = stop_call.kwargs.get("chunks")
+        assert chunks is not None, "stopStream should carry buffered content as fallback"
+        combined = "".join(c.get("text", "") for c in chunks)
+        assert "Fallback" in combined and "content" in combined
 
 
 class TestStreamBuffer:

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -276,6 +276,7 @@ def stream_a2a_response(
     trace_id = None  # Langfuse trace ID for feedback scoring
     # streamed_any_text is tracked by stream_buf.has_flushed
     streaming_final_answer = False  # Latch: once last plan step streams, keep streaming
+    no_plan_streaming_chunks: list[str] = []  # Buffer for no-plan flows; fallback if FINAL_RESULT absent
 
     try:
         for event_data in a2a_client.send_message_stream(
@@ -367,14 +368,19 @@ def stream_a2a_response(
                                 _set_typing_status(f"is {title}...")
                             continue
 
-                    # Stream markdown (no plan, or final answer)
-                    _start_stream_if_needed()
-                    if stream_buf:
-                        text = parsed.text_content
-                        if needs_separator and stream_buf.has_flushed:
-                            text = "\n\n" + text
-                            needs_separator = False
-                        stream_buf.append(text)
+                    # Stream markdown only for plan-based final-answer steps.
+                    # No-plan flows buffer silently and wait for FINAL_RESULT to avoid
+                    # leaking intermediate tool outputs or response metadata to Slack.
+                    if streaming_final_answer or plan_steps:
+                        _start_stream_if_needed()
+                        if stream_buf:
+                            text = parsed.text_content
+                            if needs_separator and stream_buf.has_flushed:
+                                text = "\n\n" + text
+                                needs_separator = False
+                            stream_buf.append(text)
+                    else:
+                        no_plan_streaming_chunks.append(parsed.text_content)
 
                 # Update progress for non-streaming fallback (bot users)
                 if throttler and throttler.should_update():
@@ -569,6 +575,20 @@ def stream_a2a_response(
             final_result_text, partial_result_text, final_message_text, last_artifacts, thread_ts
         )
 
+        # For no-plan flows where FINAL_RESULT never arrived, fall back to buffered streaming content.
+        # This preserves backward compatibility with agents that don't emit final_result artifacts.
+        if (
+            not final_result_text
+            and no_plan_streaming_chunks
+            and (not final_text or final_text == "I've completed your request.")
+        ):
+            buffered = "".join(no_plan_streaming_chunks).strip()
+            if buffered:
+                logger.info(
+                    f"[{thread_ts}] Falling back to buffered no-plan streaming content: {len(buffered)} chars"
+                )
+                final_text = buffered
+
         # Overthink mode: check for skip markers before posting
         if overthink_mode and final_text:
             skip_result = _check_overthink_skip(final_text, thread_ts)
@@ -662,9 +682,10 @@ def stream_a2a_response(
             # Skip final_text if the answer was already streamed live.
             # For plan flows: only streaming_final_answer means the answer was streamed
             #   (pre-plan chatter sets streamed_any_text but isn't the answer).
-            # For no-plan flows: streamed_any_text means the answer was streamed.
+            # For no-plan flows: we no longer stream intermediate chunks to avoid leaking
+            #   tool outputs or metadata, so the final answer is always sent via stop_chunks.
             stop_chunks = []
-            already_streamed = streaming_final_answer or (not plan_steps and streamed_any_text)
+            already_streamed = streaming_final_answer
             needs_final = not already_streamed
             if needs_final and final_text:
                 stop_chunks.append({"type": "markdown_text", "text": final_text})

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/tools.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/tools.py
@@ -116,7 +116,7 @@ class AgentTools:
 
     labels = [ps.label for ps in config.parallel_searches]
     keys_str = ", ".join(f'"{lbl}"' for lbl in labels)
-    return_section = f"Returns:\n    dict with keys: {keys_str}\n    Each key maps to a list of results with text_content (truncated to 500 chars), metadata, and score.\n    Use fetch_document with document_id to get full content."
+    return_section = f"Returns:\n    dict with keys: {keys_str}\n    Each key maps to a list of results with text_content (highlighted snippet), metadata, and score."
 
     base = config.description or "Search for relevant documents in the knowledge base."
     return (

--- a/ai_platform_engineering/multi_agents/agent_registry.py
+++ b/ai_platform_engineering/multi_agents/agent_registry.py
@@ -221,6 +221,7 @@ class AgentRegistry:
             subagents.append({
                 "name": sanitized_name,
                 "description": description,
+                "system_prompt": prompt,
                 "graph": subagent_graph  # CustomSubAgent with pre-created graph
             })
         return subagents

--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -333,7 +333,7 @@ class AIPlatformEngineerMAS:
     # break SkillsMiddleware which needs StateBackend access.
     all_tools = all_agents + [
         reflect_on_output,
-        format_markdown,
+        *([format_markdown] if not USE_STRUCTURED_RESPONSE else []),  # Redundant in structured mode: LLM streams full response twice (as args + in PlatformEngineerResponse), adding ~8s latency
         fetch_url,
         get_current_date,
         *([request_user_input] if not USE_STRUCTURED_RESPONSE else []),  # Only in unstructured mode; structured mode uses PlatformEngineerResponse.metadata instead

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_binding_e2e.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_binding_e2e.py
@@ -1,0 +1,438 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E unit tests for AIPlatformEngineerA2ABinding (distributed-mode, agent.py).
+
+Coverage
+--------
+1. _repair_orphaned_tool_calls — no-op paths
+   - empty state / no values / no messages
+   - all tool calls already resolved
+   - no AIMessages in history
+
+2. _repair_orphaned_tool_calls — repair paths
+   - single orphan → RemoveMessage for that AIMessage ID
+   - multiple orphans on same AIMessage → exactly one RemoveMessage
+   - multiple orphans on different AIMessages → one RemoveMessage each
+   - orphan with no msg ID → no aupdate_state (logs warning only)
+   - Bedrock additional_kwargs storage location detected
+   - Bedrock content-block storage location detected
+
+3. _repair_orphaned_tool_calls — exception handling
+   - aget_state raises → fallback HumanMessage injected
+   - aupdate_state raises → fallback HumanMessage injected
+   - fallback itself raises → swallowed, no crash
+
+4. _extract_tool_call_ids helper
+   - standard tool_calls list
+   - Bedrock additional_kwargs['tool_use']
+   - Bedrock additional_kwargs['toolUse']
+   - content blocks with type='tool_use'
+   - non-AIMessage returns empty set
+   - deduplication across storage locations
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ai_message(tool_call_ids: list[str], tool_names: list[str] | None = None,
+                     msg_id: str = "ai-msg-1") -> AIMessage:
+    """Build an AIMessage with tool_calls."""
+    names = tool_names or ["unknown"] * len(tool_call_ids)
+    tool_calls = [
+        {"id": tc_id, "name": name, "args": {}, "type": "tool_call"}
+        for tc_id, name in zip(tool_call_ids, names)
+    ]
+    return AIMessage(content="", tool_calls=tool_calls, id=msg_id)
+
+
+def _make_tool_message(tool_call_id: str) -> ToolMessage:
+    return ToolMessage(content="ok", tool_call_id=tool_call_id)
+
+
+def _make_state(messages: list) -> MagicMock:
+    state = MagicMock()
+    state.values = {"messages": messages}
+    return state
+
+
+def _make_empty_state() -> MagicMock:
+    state = MagicMock()
+    state.values = {}
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Factory: creates a binding bypassing __init__ heavy deps
+# ---------------------------------------------------------------------------
+
+def _make_binding():
+    """
+    Instantiate AIPlatformEngineerA2ABinding without triggering __init__,
+    which would attempt to connect to real agents and load the graph.
+    """
+    with patch(
+        "ai_platform_engineering.multi_agents.platform_engineer"
+        ".protocol_bindings.a2a.agent.AIPlatformEngineerMAS"
+    ), patch(
+        "ai_platform_engineering.multi_agents.platform_engineer"
+        ".protocol_bindings.a2a.agent.TracingManager"
+    ), patch(
+        "ai_platform_engineering.multi_agents.platform_engineer"
+        ".protocol_bindings.a2a.agent.set_mas_instance"
+    ):
+        from ai_platform_engineering.multi_agents.platform_engineer.protocol_bindings.a2a.agent import (
+            AIPlatformEngineerA2ABinding,
+        )
+        binding = AIPlatformEngineerA2ABinding.__new__(AIPlatformEngineerA2ABinding)
+        binding.graph = AsyncMock()
+        binding.tracing = MagicMock()
+        binding._execution_plan_sent = False
+        return binding
+
+
+CONFIG = {"configurable": {"thread_id": "test-thread-1"}}
+
+
+# ===========================================================================
+# 1. No-op paths
+# ===========================================================================
+
+class TestRepairOrphanedToolCallsNoOp:
+
+    @pytest.mark.asyncio
+    async def test_none_state_is_noop(self):
+        """aget_state returns None → no aupdate_state call."""
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(return_value=None)
+        await binding._repair_orphaned_tool_calls(CONFIG)
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_values_is_noop(self):
+        """state.values is empty → no aupdate_state call."""
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(return_value=_make_empty_state())
+        await binding._repair_orphaned_tool_calls(CONFIG)
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_messages_is_noop(self):
+        """messages list is empty → no aupdate_state call."""
+        binding = _make_binding()
+        state = MagicMock()
+        state.values = {"messages": []}
+        binding.graph.aget_state = AsyncMock(return_value=state)
+        await binding._repair_orphaned_tool_calls(CONFIG)
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_all_resolved_is_noop(self):
+        """Every AIMessage tool_call has a matching ToolMessage → no repair needed."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["jira_search"], msg_id="ai-1")
+        tm = _make_tool_message("tc-1")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg, tm]))
+        await binding._repair_orphaned_tool_calls(CONFIG)
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_ai_messages_is_noop(self):
+        """Only HumanMessages in history → no tool calls to repair."""
+        binding = _make_binding()
+        state = _make_state([HumanMessage(content="hello"), HumanMessage(content="world")])
+        binding.graph.aget_state = AsyncMock(return_value=state)
+        await binding._repair_orphaned_tool_calls(CONFIG)
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multiple_resolved_tool_calls_noop(self):
+        """Multiple tool calls all resolved → no repair."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1", "tc-2"], ["tool_a", "tool_b"], msg_id="ai-1")
+        tm1 = _make_tool_message("tc-1")
+        tm2 = _make_tool_message("tc-2")
+        binding.graph.aget_state = AsyncMock(
+            return_value=_make_state([ai_msg, tm1, tm2])
+        )
+        await binding._repair_orphaned_tool_calls(CONFIG)
+        binding.graph.aupdate_state.assert_not_awaited()
+
+
+# ===========================================================================
+# 2. Repair paths — RemoveMessage strategy
+# ===========================================================================
+
+class TestRepairOrphanedToolCallsRepair:
+
+    @pytest.mark.asyncio
+    async def test_single_orphan_removes_ai_message(self):
+        """One orphaned tool call → RemoveMessage for its AIMessage ID."""
+
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["jira_search"], msg_id="ai-msg-orphan")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        binding.graph.aupdate_state.assert_awaited_once()
+        call_args = binding.graph.aupdate_state.call_args
+        messages = call_args[0][1]["messages"]
+        assert len(messages) == 1
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == "ai-msg-orphan"
+
+    @pytest.mark.asyncio
+    async def test_multiple_orphans_same_ai_message_one_remove(self):
+        """Two orphaned tool calls on same AIMessage → exactly one RemoveMessage."""
+
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1", "tc-2"], ["tool_a", "tool_b"], msg_id="ai-multi")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(messages) == 1
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == "ai-multi"
+
+    @pytest.mark.asyncio
+    async def test_multiple_orphans_different_ai_messages_one_remove_each(self):
+        """Orphans on two separate AIMessages → two RemoveMessages."""
+
+        binding = _make_binding()
+        ai1 = _make_ai_message(["tc-1"], ["tool_a"], msg_id="ai-first")
+        ai2 = _make_ai_message(["tc-2"], ["tool_b"], msg_id="ai-second")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai1, ai2]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        ids_removed = {m.id for m in messages}
+        assert ids_removed == {"ai-first", "ai-second"}
+        assert all(isinstance(m, RemoveMessage) for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_partial_orphans_only_orphaned_ai_message_removed(self):
+        """One AI message resolved, one orphaned → only orphaned one removed."""
+
+        binding = _make_binding()
+        ai_resolved = _make_ai_message(["tc-resolved"], ["tool_ok"], msg_id="ai-ok")
+        tm = _make_tool_message("tc-resolved")
+        ai_orphaned = _make_ai_message(["tc-orphan"], ["tool_bad"], msg_id="ai-bad")
+        binding.graph.aget_state = AsyncMock(
+            return_value=_make_state([ai_resolved, tm, ai_orphaned])
+        )
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        ids_removed = {m.id for m in messages}
+        assert "ai-bad" in ids_removed
+        assert "ai-ok" not in ids_removed
+
+    @pytest.mark.asyncio
+    async def test_orphan_without_msg_id_no_update_state(self):
+        """AIMessage with no id → can't build RemoveMessage, no aupdate_state call."""
+        ai_msg = AIMessage(content="", tool_calls=[
+            {"id": "tc-noid", "name": "tool_x", "args": {}, "type": "tool_call"}
+        ])
+        # Don't set id (AIMessage id defaults to auto-generated, but we clear it)
+        ai_msg.id = None
+
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bedrock_additional_kwargs_tooluse_detected(self):
+        """Bedrock stores tool_call IDs in additional_kwargs['tool_use']."""
+
+        binding = _make_binding()
+        # No standard tool_calls — only additional_kwargs Bedrock storage
+        ai_msg = AIMessage(
+            content="",
+            additional_kwargs={"tool_use": [{"id": "bedrock-tc-1", "name": "bedrock_tool"}]},
+            id="ai-bedrock",
+        )
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        binding.graph.aupdate_state.assert_awaited_once()
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert any(isinstance(m, RemoveMessage) and m.id == "ai-bedrock" for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_bedrock_content_block_tool_use_detected(self):
+        """Bedrock stores tool_call IDs in content blocks with type='tool_use'."""
+
+        binding = _make_binding()
+        ai_msg = AIMessage(
+            content=[{"type": "tool_use", "id": "block-tc-1", "name": "block_tool", "input": {}}],
+            id="ai-block",
+        )
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        binding.graph.aupdate_state.assert_awaited_once()
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert any(isinstance(m, RemoveMessage) and m.id == "ai-block" for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_history_preserved_only_orphaned_removed(self):
+        """
+        Earlier clean conversation (HumanMessage + AI + ToolMessage) must be
+        preserved; only the orphaned AIMessage is removed.
+        """
+
+        binding = _make_binding()
+        history = [
+            HumanMessage(content="earlier query"),
+            _make_ai_message(["tc-old"], ["old_tool"], msg_id="ai-old"),
+            _make_tool_message("tc-old"),
+            HumanMessage(content="new query"),
+            _make_ai_message(["tc-orphan"], ["new_tool"], msg_id="ai-orphan"),
+        ]
+        binding.graph.aget_state = AsyncMock(return_value=_make_state(history))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        removed_ids = {m.id for m in messages if isinstance(m, RemoveMessage)}
+        assert removed_ids == {"ai-orphan"}
+        assert "ai-old" not in removed_ids
+
+
+# ===========================================================================
+# 3. Exception handling
+# ===========================================================================
+
+class TestRepairExceptionHandling:
+
+    @pytest.mark.asyncio
+    async def test_aget_state_exception_triggers_fallback(self):
+        """If aget_state raises, fallback HumanMessage injected."""
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(side_effect=RuntimeError("checkpoint error"))
+        binding.graph.aupdate_state = AsyncMock()
+        binding.graph.checkpointer = MagicMock()
+
+        # Should not raise
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+        # Fallback: a HumanMessage was injected
+        if binding.graph.aupdate_state.await_count > 0:
+            call_msgs = binding.graph.aupdate_state.call_args[0][1]["messages"]
+            assert any(isinstance(m, HumanMessage) for m in call_msgs)
+
+    @pytest.mark.asyncio
+    async def test_aupdate_state_exception_triggers_fallback(self):
+        """If aupdate_state raises during repair, fallback path attempted."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["tool_x"], msg_id="ai-err")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock(side_effect=RuntimeError("write error"))
+        binding.graph.checkpointer = MagicMock()
+
+        # Must not crash
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+    @pytest.mark.asyncio
+    async def test_fallback_exception_is_swallowed(self):
+        """If both repair and fallback raise, the method still returns cleanly."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["tool_x"], msg_id="ai-err2")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock(side_effect=RuntimeError("all writes fail"))
+        binding.graph.checkpointer = MagicMock()
+
+        # Even with double failure, no exception escapes
+        await binding._repair_orphaned_tool_calls(CONFIG)
+
+
+# ===========================================================================
+# 4. _extract_tool_call_ids helper
+# ===========================================================================
+
+class TestExtractToolCallIds:
+
+    def _get_extract_fn(self):
+        from ai_platform_engineering.utils.a2a_common.langmem_utils import _extract_tool_call_ids
+        return _extract_tool_call_ids
+
+    def test_standard_tool_calls_list(self):
+        extract = self._get_extract_fn()
+        msg = _make_ai_message(["id-1", "id-2"], ["tool_a", "tool_b"])
+        assert extract(msg) == {"id-1", "id-2"}
+
+    def test_bedrock_additional_kwargs_tool_use(self):
+        extract = self._get_extract_fn()
+        msg = AIMessage(
+            content="",
+            additional_kwargs={"tool_use": [{"id": "bk-1", "name": "t"}]},
+        )
+        assert "bk-1" in extract(msg)
+
+    def test_bedrock_additional_kwargs_tool_use_camel(self):
+        extract = self._get_extract_fn()
+        msg = AIMessage(
+            content="",
+            additional_kwargs={"toolUse": [{"toolUseId": "bk-2", "name": "t"}]},
+        )
+        assert "bk-2" in extract(msg)
+
+    def test_content_block_tool_use(self):
+        extract = self._get_extract_fn()
+        msg = AIMessage(
+            content=[{"type": "tool_use", "id": "blk-1", "name": "t", "input": {}}],
+        )
+        assert "blk-1" in extract(msg)
+
+    def test_non_ai_message_returns_empty(self):
+        extract = self._get_extract_fn()
+        assert extract(HumanMessage(content="hi")) == set()
+        assert extract(ToolMessage(content="ok", tool_call_id="x")) == set()
+
+    def test_deduplication_across_storage_locations(self):
+        """Same ID in both tool_calls and content block → returned once."""
+        extract = self._get_extract_fn()
+        msg = AIMessage(
+            content=[{"type": "tool_use", "id": "dup-1", "name": "t", "input": {}}],
+            tool_calls=[{"id": "dup-1", "name": "t", "args": {}, "type": "tool_call"}],
+        )
+        ids = extract(msg)
+        assert ids == {"dup-1"}
+
+    def test_empty_tool_calls_returns_empty(self):
+        extract = self._get_extract_fn()
+        msg = AIMessage(content="plain text", tool_calls=[])
+        assert extract(msg) == set()
+
+    def test_none_tool_call_id_skipped(self):
+        extract = self._get_extract_fn()
+        msg = AIMessage(
+            content="",
+            additional_kwargs={"tool_use": [{"id": None, "name": "t"}]},
+        )
+        assert None not in extract(msg)


### PR DESCRIPTION
## Problem

After `6d825e70` (feat(rag): improve MCP search tools and UI), the supervisor was calling `fetch_document` for every search result on every query, adding ~20s of unnecessary latency per request (observed: 10+ sequential `fetch_document` calls x ~2s each).

## Root Cause Analysis

### Before 6d825e70

Each search result was built by naively truncating raw chunk text to 500 chars and appending a **conditional inline marker** directly to results that were actually cut off:

```python
text = page_content[:500]
if len(page_content) > 500:
    text += "... [truncated, use fetch_document with document_id to get full content]"
```

The model had a **per-result signal**: it could see exactly which results were truncated and knew precisely which ones warranted a fetch_document call. It only fetched when it saw the marker.

### After 6d825e70

The per-result truncation logic was replaced with format_search_result() from the new snippet_utils.py. This function does query-aware snippet extraction with term highlighting — a genuine improvement to result quality. The inline [truncated] marker was removed as **collateral damage** — the commit message makes no mention of this behavioral change.

With the inline per-result signal gone, the model treats the unconditional standing instruction in the tool description as "always call fetch_document for every result". The snippets look complete and well-formatted — the model has no way to know 90% of each document is missing — so it fetches everything.

## Options Considered

**Option A — Prompt config rule only**
Add a fetch_document — Use Sparingly rule to prompt_config.deep_agent.yaml.
Rejected as primary fix: Prompt instructions are soft signals. The model tends to trust a tool own description over system prompt rules. Two contradictory signals are unreliable.

**Option B — Replace instruction with softer wording**
Change to "Only use fetch_document if the snippet is clearly insufficient."
Rejected: The model cannot judge sufficiency from a snippet. The new format_search_result output looks complete and well-formatted by design — there is no visible signal indicating the snippet is partial.

**Option C — Remove the call-to-action entirely (this PR)**
Remove the unconditional instruction from the tool description entirely. The fetch_document tool still exists and is still described in its own docstring. The model will use it when a user explicitly requests full document content. It will not call it reflexively after every search.
Chosen: Matches the intended behavior of the original inline marker — conditional use, not unconditional.

**Option D — Disable fetch_document entirely**
Set fetch_document_enabled: false in RAG server config.
Rejected: Too aggressive. Legitimate use cases exist.

**Option E — Restore conditional inline marker in snippet_utils.py**
Re-add [content truncated] to format_search_result output when the full document is significantly larger than the snippet.
Deferred: More invasive change to snippet_utils.py. Could be a follow-up if the model still over-fetches in edge cases.

## The Fix

One line in _make_search_description():

- Before: Each result includes text_content (truncated to 500 chars) ... Use fetch_document with document_id to get full content.
- After: Each result includes text_content (highlighted snippet) — accurate description of what format_search_result() actually returns.

## Related

- 6d825e70 — commit that introduced the regression (collateral damage from snippet refactor)
- PR #1074 — companion fix excluding format_markdown tool in structured response mode (same class of problem: unnecessary tool calls adding latency)
- Supervisor prompt_config.deep_agent.yaml also has a fetch_document — Use Sparingly rule added as secondary belt-and-suspenders guard

## Test Plan

- [ ] Send "show me deployment options in caipe" — verify fetch_document called 0-2 times instead of 10+
- [ ] Send "what is ArgoCD?" — verify no fetch_document calls (search snippets sufficient)
- [ ] Explicitly ask "give me the full content of document X" — verify fetch_document is still called when needed
- [ ] Verify response quality is unchanged