### PR TITLE
feat(github): use GitHub App auth for MCP server, keep PAT for gh CLI

### DIFF
--- a/ai_platform_engineering/agents/github/agent_github/tools.py
+++ b/ai_platform_engineering/agents/github/agent_github/tools.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 
 # Import git tool from utils (shared with GitLab agent)
 from ai_platform_engineering.utils.agent_tools import git
-from ai_platform_engineering.utils.github_app_token_provider import get_github_token
+from ai_platform_engineering.utils.github_app_token_provider import get_github_pat
 from ai_platform_engineering.utils.token_sanitizer import sanitize_output
 
 logger = logging.getLogger(__name__)
@@ -195,10 +195,9 @@ class GHCLITool(BaseTool):
             logger.warning(f"gh CLI command blocked: {command} - {error_msg}")
             return f"❌ {error_msg}"
 
-        # Get token (auto-refreshed if using GitHub App mode)
-        github_token = get_github_token()
+        github_token = get_github_pat()
         if not github_token:
-            return "❌ Error: No GitHub auth configured. Set GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY + GITHUB_APP_INSTALLATION_ID for App auth, or GITHUB_PERSONAL_ACCESS_TOKEN for PAT auth."
+            return "❌ Error: No GitHub PAT configured. Set GITHUB_PERSONAL_ACCESS_TOKEN for gh CLI auth."
 
         # Build full command
         command_parts = ["gh"] + shlex.split(command)

--- a/ai_platform_engineering/utils/github_app_token_provider.py
+++ b/ai_platform_engineering/utils/github_app_token_provider.py
@@ -387,6 +387,18 @@ def get_github_token() -> Optional[str]:
     return token
 
 
+def get_github_pat() -> Optional[str]:
+    """Get the GitHub PAT directly, bypassing GitHub App mode.
+
+    Use this for tools that specifically need a PAT (e.g., gh CLI)
+    rather than an auto-refreshing App installation token.
+
+    Returns:
+        PAT string, or None if no PAT is configured
+    """
+    return os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN") or os.getenv("GITHUB_TOKEN")
+
+
 def is_github_app_mode() -> bool:
     """
     Check if GitHub App authentication is configured and active.


### PR DESCRIPTION
## Summary

- Add `get_github_pat()` function to `github_app_token_provider.py` that returns the PAT directly, bypassing GitHub App mode
- Update `tools.py` (gh CLI tool) to use `get_github_pat()` instead of `get_github_token()`, so the CLI always authenticates with the PAT
- The MCP server path (`get_mcp_config()`) continues using `get_github_token()` which prefers GitHub App installation tokens when `GITHUB_APP_*` env vars are configured

This separates auth concerns: MCP server uses auto-refreshing GitHub App tokens, gh CLI uses PAT.

Companion PR in platform-apps-deployment adds the ExternalSecrets config to pull GitHub App credentials from Vault.

## Test plan

- [ ] Verify MCP server uses GitHub App token when `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID` are set
- [ ] Verify gh CLI uses PAT from `GITHUB_PERSONAL_ACCESS_TOKEN`
- [ ] Verify fallback still works if GitHub App vars are not set (MCP falls back to PAT)

Made with [Cursor](https://cursor.com)