### PR TITLE
feat: add Grype container scan on version tag push

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -13,6 +13,12 @@ on:
   push:
     tags:
       - "[0-9]*.[0-9]*.[0-9]*"  # matches 0.2.3, 0.2.3-rc.1, 0.2.3.rc, etc. — excludes 'stable' and branch names
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to scan (e.g. 0.2.3)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -30,6 +36,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Run Grype scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0


### PR DESCRIPTION
## Summary

Adds `security-scan.yml`: runs [anchore/scan-action](https://github.com/anchore/scan-action) (Grype) on version tag pushes as a safe alternative to `aquasecurity/trivy-action` following its [March 2026 supply chain compromise](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release).

## Triggers

- **Tag push**: automatically runs on any version tag matching `[0-9]*.[0-9]*.[0-9]*` (e.g. `0.2.42`, `0.2.42-rc.7`) — excludes `stable` and non-version tags
- **Manual**: `workflow_dispatch` allows running on-demand against any user-specified tag via the GitHub Actions UI

## What it scans

Scans the entire repository directory (`path: "."`) so Grype picks up all package manifests and dependencies across the codebase.

Results are uploaded to GitHub Code Scanning (Security tab) as SARIF.

## Hardening

- All actions pinned to commit SHAs
- `step-security/harden-runner` with `egress-policy: audit`
- Minimal permissions (`contents: read`, `security-events: write`)

## Test plan

- [ ] Push a version tag (e.g. `0.2.43-rc.1`) and verify the workflow triggers
- [ ] Push `stable` tag and verify the workflow does NOT trigger
- [ ] Manually trigger via Actions UI with a tag and verify it scans that tag's code
- [ ] Check Security > Code scanning for uploaded SARIF results

Generated with [Claude Code](https://claude.com/claude-code)
