### PR TITLE
feat(slack-bot): refactor overthink mode with OverthinkConfig model

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -27,6 +27,7 @@ from a2a_client import A2AClient
 from utils.session_manager import SessionManager
 from utils.scoring import submit_feedback_score
 from utils.interaction_tracker import InteractionTracker
+from utils.config_models import get_escalation_config
 
 app = App(token=os.environ.get("SLACK_INTEGRATION_BOT_TOKEN", os.environ.get("SLACK_BOT_TOKEN", "")))
 APP_NAME = os.environ.get("SLACK_INTEGRATION_APP_NAME", os.environ.get("APP_NAME", "CAIPE"))
@@ -157,6 +158,9 @@ def handle_mention(event, say, client):
 
     team_id = event.get("team")
 
+    default_config = channel_config.default if channel_config.default else {}
+    esc_config = get_escalation_config(default_config)
+
     result = ai.stream_a2a_response(
       a2a_client=a2a_client,
       slack_client=client,
@@ -168,6 +172,7 @@ def handle_mention(event, say, client):
       context_id=context_id,
       metadata=request_metadata if request_metadata else None,
       session_manager=session_manager,
+      escalation_config=esc_config,
     )
 
     # Track interaction for platform statistics
@@ -264,6 +269,8 @@ def handle_qanda_message(event, say, client):
       final_message = f"The user email is {user_email}\n\n{final_message}"
       request_metadata["user_email"] = user_email
 
+    esc_config = get_escalation_config(default_config)
+
     result = ai.stream_a2a_response(
       a2a_client=a2a_client,
       slack_client=client,
@@ -276,6 +283,7 @@ def handle_qanda_message(event, say, client):
       metadata=request_metadata,
       session_manager=session_manager,
       overthink_mode=channel_config.qanda.overthink,
+      escalation_config=esc_config,
     )
 
     if isinstance(result, dict) and result.get("skipped"):
@@ -520,6 +528,7 @@ def handle_message_events(body, say, client):
     if not default_config or not isinstance(default_config, dict):
       raise ValueError(f"Channel {channel_id} is missing required 'default' config")
 
+    esc_config = get_escalation_config(default_config)
     ai.handle_ai_alert_processing(
       a2a_client,
       client,
@@ -529,6 +538,7 @@ def handle_message_events(body, say, client):
       default_config,
       session_manager,
       custom_prompt=channel_config.ai_alerts.custom_prompt,
+      escalation_config=esc_config,
     )
 
     # Track alert interaction for platform statistics
@@ -767,6 +777,82 @@ def handle_caipe_retry(ack, body, client):
     )
   except Exception as e:
     logger.exception(f"Error handling retry: {e}")
+
+
+# =============================================================================
+# Escalation Action Handlers
+# =============================================================================
+@app.action("caipe_escalation_get_help")
+def handle_escalation_get_help(ack, body, client):
+    ack()
+    try:
+        from utils.escalation import execute_escalation
+
+        user_id = body.get("user", {}).get("id")
+        action = body.get("actions", [{}])[0]
+        parts = action.get("value", "").split("|")
+        channel_id = parts[0] if len(parts) > 0 else None
+        thread_ts = parts[1] if len(parts) > 1 else None
+        if not channel_id or not thread_ts:
+            return
+
+        # Track escalation in feedback
+        submit_feedback_score(
+            thread_ts=thread_ts, user_id=user_id, channel_id=channel_id,
+            feedback_value="escalation_requested", slack_client=client,
+            session_manager=session_manager, config=config,
+        )
+
+        client.chat_postEphemeral(
+            channel=channel_id, user=user_id, thread_ts=thread_ts,
+            text="Got it! Connecting you with a human...",
+        )
+
+        # Get escalation config for this channel
+        channel_config = config.channels.get(channel_id)
+        if not channel_config:
+            return
+        esc_config = get_escalation_config(channel_config.default or {})
+        if not esc_config:
+            return
+
+        # Determine the parent message ts (root of thread)
+        message = body.get("message", {})
+        parent_ts = message.get("thread_ts") or thread_ts
+
+        execute_escalation(
+            slack_client=client, a2a_client=a2a_client,
+            channel_id=channel_id, thread_ts=thread_ts,
+            parent_ts=parent_ts, user_id=user_id,
+            escalation_config=esc_config,
+        )
+    except Exception as e:
+        logger.exception(f"Error handling escalation: {e}")
+
+
+@app.action("caipe_delete_message")
+def handle_delete_message(ack, body, client):
+    ack()
+    try:
+        user_id = body.get("user", {}).get("id")
+        channel_id = body.get("channel", {}).get("id")
+        message = body.get("message", {})
+        message_ts = message.get("ts")
+        thread_ts = message.get("thread_ts") or message_ts
+
+        if not channel_id or not message_ts:
+            return
+
+        submit_feedback_score(
+            thread_ts=thread_ts, user_id=user_id, channel_id=channel_id,
+            feedback_value="message_deleted", slack_client=client,
+            session_manager=session_manager, config=config,
+        )
+
+        client.chat_delete(channel=channel_id, ts=message_ts)
+        logger.info(f"[{thread_ts}] Message {message_ts} deleted by <@{user_id}>")
+    except Exception as e:
+        logger.exception(f"Error handling message delete: {e}")
 
 
 def _open_feedback_modal(ack, body, client, feedback_type):

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -141,7 +141,13 @@ def handle_mention(event, say, client):
       session_manager.clear_skipped(thread_ts)
 
     if is_humble_followup:
-      mention_prompt = config.defaults.humble_followup_prompt
+      # Use per-channel followup prompt from overthink config, fall back to global default
+      followup = (
+        channel_config.qanda.overthink.followup_prompt
+        or channel_config.ai_alerts.overthink.followup_prompt
+        or config.defaults.humble_followup_prompt
+      )
+      mention_prompt = followup
     elif channel_config.custom_prompt:
       mention_prompt = channel_config.custom_prompt
     else:
@@ -282,7 +288,7 @@ def handle_qanda_message(event, say, client):
       context_id=context_id,
       metadata=request_metadata,
       session_manager=session_manager,
-      overthink_mode=channel_config.qanda.overthink,
+      overthink_config=channel_config.qanda.overthink if channel_config.qanda.overthink.enabled else None,
       escalation_config=esc_config,
     )
 
@@ -528,8 +534,9 @@ def handle_message_events(body, say, client):
     if not default_config or not isinstance(default_config, dict):
       raise ValueError(f"Channel {channel_id} is missing required 'default' config")
 
+    alerts_overthink = channel_config.ai_alerts.overthink
     esc_config = get_escalation_config(default_config)
-    ai.handle_ai_alert_processing(
+    result = ai.handle_ai_alert_processing(
       a2a_client,
       client,
       event,
@@ -538,8 +545,14 @@ def handle_message_events(body, say, client):
       default_config,
       session_manager,
       custom_prompt=channel_config.ai_alerts.custom_prompt,
+      overthink_config=alerts_overthink if alerts_overthink.enabled else None,
       escalation_config=esc_config,
     )
+
+    if isinstance(result, dict) and result.get("skipped"):
+      reason = result.get("reason", "unknown")
+      logger.info(f"[{alert_ts}] Overthink: skipped alert processing ({reason})")
+      session_manager.set_skipped(alert_ts, True)
 
     # Track alert interaction for platform statistics
     interaction_tracker.record_interaction(

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
@@ -131,3 +131,71 @@ C123:
         )
         with pytest.raises(Exception, match="Cannot enable both"):
             Config.from_env()
+
+
+class TestOverthinkConfig:
+    def test_overthink_config_with_custom_markers(self, monkeypatch):
+        monkeypatch.setenv(
+            "SLACK_INTEGRATION_BOT_CONFIG",
+            """
+C123:
+  name: "#test-channel"
+  ai_enabled: true
+  qanda:
+    enabled: true
+    overthink:
+      enabled: true
+      skip_markers: ["NO_ACTION", "IRRELEVANT"]
+      pass_marker: "ACTIONABLE"
+      custom_prompt: "Custom overthink: {message_text}"
+      followup_prompt: "Custom followup: {message_text}"
+  ai_alerts:
+    enabled: true
+    overthink:
+      enabled: true
+      skip_markers: ["SKIP"]
+      pass_marker: "PROCESS"
+  default:
+    project_key: TEST
+""",
+        )
+        cfg = Config.from_env()
+        qanda = cfg.channels["C123"].qanda
+        assert qanda.overthink.enabled is True
+        assert qanda.overthink.skip_markers == ["NO_ACTION", "IRRELEVANT"]
+        assert qanda.overthink.pass_marker == "ACTIONABLE"
+        assert qanda.overthink.custom_prompt == "Custom overthink: {message_text}"
+        assert qanda.overthink.followup_prompt == "Custom followup: {message_text}"
+
+        alerts = cfg.channels["C123"].ai_alerts
+        assert alerts.overthink.enabled is True
+        assert alerts.overthink.skip_markers == ["SKIP"]
+        assert alerts.overthink.pass_marker == "PROCESS"
+
+    def test_overthink_defaults_when_enabled_minimal(self, monkeypatch):
+        monkeypatch.setenv(
+            "SLACK_INTEGRATION_BOT_CONFIG",
+            """
+C123:
+  name: "#test-channel"
+  ai_enabled: true
+  qanda:
+    enabled: true
+    overthink:
+      enabled: true
+  ai_alerts:
+    enabled: false
+  default:
+    project_key: TEST
+""",
+        )
+        cfg = Config.from_env()
+        cfg.apply_defaults_to_channels()
+        qanda = cfg.channels["C123"].qanda
+        assert qanda.overthink.enabled is True
+        assert qanda.overthink.skip_markers == ["DEFER", "LOW_CONFIDENCE"]
+        assert qanda.overthink.pass_marker == "CONFIDENCE: HIGH"
+        # apply_defaults sets the default overthink prompt
+        assert qanda.custom_prompt == cfg.defaults.overthink_qanda_prompt
+        # apply_defaults sets the default followup prompt
+        assert qanda.overthink.followup_prompt == cfg.defaults.humble_followup_prompt

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -11,6 +11,7 @@ This module handles all interactions with the CAIPE supervisor, including:
 """
 
 import os
+import re
 import time
 
 APP_NAME = os.environ.get("SLACK_INTEGRATION_APP_NAME", os.environ.get("APP_NAME", "CAIPE"))
@@ -83,7 +84,7 @@ class StreamBuffer:
       self.slack_client.chat_appendStream(
         channel=self.channel_id,
         ts=self.stream_ts,
-        chunks=[{"type": "markdown_text", "text": text}],
+        chunks=[{"type": "markdown_text", "text": _normalize_paragraph_breaks(text)}],
       )
       self._flushed_any = True
       return True
@@ -128,6 +129,7 @@ def stream_a2a_response(
   triggered_by_user_id=None,
   additional_footer=None,
   overthink_mode=False,
+  escalation_config=None,
 ):
   """
   Stream an A2A response to Slack.
@@ -500,6 +502,12 @@ def stream_a2a_response(
               blocks=form_blocks,
               text="Action required",
             )
+          # Stop any active stream before returning to prevent orphaned streams
+          if stream_ts:
+            try:
+              slack_client.chat_stopStream(channel=channel_id, ts=stream_ts)
+            except Exception as e:
+              logger.debug(f"[{thread_ts}] Failed to stop stream before HITL form: {e}")
           return form_blocks
 
       elif parsed.event_type == EventType.OTHER_ARTIFACT:
@@ -569,10 +577,21 @@ def stream_a2a_response(
     elif task_error:
       # No useful content AND we had an error - return retry marker for caller to handle
       logger.error(f"[{thread_ts}] No content received and task had error: {task_error}")
-      # Clean up: stop active stream or delete progress message
+      # Clean up: stop active stream with error blocks, or delete progress message
       if stream_ts:
         try:
-          slack_client.chat_stopStream(channel=channel_id, ts=stream_ts)
+          error_blocks = slack_formatter.format_error_message(str(task_error))
+          error_blocks.extend(
+            _build_stream_final_blocks(
+              channel_id, thread_ts, response_ts,
+              triggered_by_user_id=triggered_by_user_id,
+              additional_footer=additional_footer,
+              escalation_config=escalation_config,
+            )
+          )
+          slack_client.chat_stopStream(
+            channel=channel_id, ts=stream_ts, blocks=error_blocks
+          )
         except Exception as e:
           logger.debug(f"[{thread_ts}] Failed to stop stream {stream_ts}: {e}")
       if response_ts:
@@ -636,7 +655,7 @@ def stream_a2a_response(
       already_streamed = streaming_final_answer
       needs_final = not already_streamed
       if needs_final and final_text:
-        stop_chunks.append({"type": "markdown_text", "text": final_text})
+        stop_chunks.append({"type": "markdown_text", "text": _normalize_paragraph_breaks(final_text)})
 
       stop_blocks = _build_stream_final_blocks(
         channel_id,
@@ -644,6 +663,7 @@ def stream_a2a_response(
         response_ts,
         triggered_by_user_id=triggered_by_user_id,
         additional_footer=additional_footer,
+        escalation_config=escalation_config,
       )
       logger.info(f"[{thread_ts}] SLACK stopStream: chunks={len(stop_chunks)}, blocks={len(stop_blocks)}")
       slack_client.chat_stopStream(
@@ -668,6 +688,7 @@ def stream_a2a_response(
         response_ts,
         triggered_by_user_id=triggered_by_user_id,
         additional_footer=additional_footer,
+        escalation_config=escalation_config,
       )
     else:
       if thread_deleted:
@@ -688,11 +709,24 @@ def stream_a2a_response(
         response_ts,
         triggered_by_user_id=triggered_by_user_id,
         additional_footer=additional_footer,
+        escalation_config=escalation_config,
       )
 
   except Exception as e:
     logger.exception(f"[{thread_ts}] Error during streaming: {e}")
     error_blocks = slack_formatter.format_error_message(str(e))
+    # Append feedback blocks so users can still rate even on errors
+    try:
+      error_blocks.extend(
+        _build_stream_final_blocks(
+          channel_id, thread_ts, response_ts,
+          triggered_by_user_id=triggered_by_user_id,
+          additional_footer=additional_footer,
+          escalation_config=escalation_config,
+        )
+      )
+    except Exception:
+      logger.warning(f"[{thread_ts}] Failed to build feedback blocks for error response")
     if stream_ts:
       # Stop the plan stream with error in blocks
       try:
@@ -740,6 +774,46 @@ def _build_progress_blocks(current_tool, plan_steps=None):
     if len(plan_text) <= 2000:
       blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": plan_text}]})
   return blocks
+
+
+# Lines starting with a list marker or blank lines should keep single newlines
+_LIST_PREFIX = re.compile(r'^(\s*[-*+]|\s*\d+[.)]\s)', re.MULTILINE)
+
+
+def _normalize_paragraph_breaks(text: str) -> str:
+  """Ensure paragraph breaks render in Slack's markdown_text streaming format.
+
+  Slack's markdown_text (used by appendStream/stopStream) treats single \\n
+  as a soft wrap rather than a visible line break.  Double \\n\\n produces a
+  paragraph break.  This helper converts lone \\n to \\n\\n while preserving:
+    - existing double+ newlines
+    - newlines inside fenced code blocks (``` ... ```)
+    - single newlines between list items (- , * , 1. , etc.)
+  """
+  # Split on fenced code blocks so we only touch prose sections
+  parts = re.split(r'(```[\s\S]*?```)', text)
+  result = []
+  for i, part in enumerate(parts):
+    if i % 2 == 1:
+      # Inside a code fence — leave unchanged
+      result.append(part)
+    else:
+      # Normalize lone newlines, but skip lines that look like list items
+      lines = part.split('\n')
+      normalized = []
+      for j, line in enumerate(lines):
+        normalized.append(line)
+        if j < len(lines) - 1:
+          next_line = lines[j + 1] if j + 1 < len(lines) else ''
+          # Keep single \n if current or next line is a list item or blank
+          is_list = _LIST_PREFIX.match(line) or _LIST_PREFIX.match(next_line)
+          is_blank = line.strip() == '' or next_line.strip() == ''
+          if is_list or is_blank:
+            normalized.append('\n')
+          else:
+            normalized.append('\n\n')
+      result.append(''.join(normalized))
+  return ''.join(result)
 
 
 def _check_overthink_skip(final_text: str, thread_ts: str) -> dict | None:
@@ -814,6 +888,7 @@ def _post_final_response(
   original_ts,
   triggered_by_user_id=None,
   additional_footer=None,
+  escalation_config=None,
 ):
   """Post final response as a regular message (fallback for bot messages)."""
   text_chunks = slack_formatter.split_text_into_blocks(final_text)
@@ -827,13 +902,14 @@ def _post_final_response(
       }
     )
 
-  # Build footer with optional user attribution and additional text
-  footer_text = _build_footer_text(triggered_by_user_id=triggered_by_user_id, additional_footer=additional_footer)
-  final_blocks.append(
-    {
-      "type": "context",
-      "elements": [{"type": "mrkdwn", "text": footer_text}],
-    }
+  # Append feedback + footer blocks (actions, context_actions, footer)
+  final_blocks.extend(
+    _build_stream_final_blocks(
+      channel_id, thread_ts, original_ts,
+      triggered_by_user_id=triggered_by_user_id,
+      additional_footer=additional_footer,
+      escalation_config=escalation_config,
+    )
   )
 
   slack_client.chat_postMessage(
@@ -852,51 +928,65 @@ def _build_stream_final_blocks(
   original_ts,
   triggered_by_user_id=None,
   additional_footer=None,
+  escalation_config=None,
 ):
   """Build the feedback + footer blocks used by both stream types."""
   final_blocks = []
 
-  # Add refinement buttons
-  final_blocks.append(
+  # Add refinement buttons (and optional escalation)
+  action_value = f"{channel_id}|{thread_ts}|{original_ts or ''}"
+  action_elements = [
     {
-      "type": "actions",
-      "elements": [
-        {
-          "type": "button",
-          "text": {"type": "plain_text", "text": "Not enough detail"},
-          "action_id": "caipe_feedback_more_detail",
-          "value": f"{channel_id}|{thread_ts}|{original_ts or ''}",
-        },
-        {
-          "type": "button",
-          "text": {"type": "plain_text", "text": "Too verbose"},
-          "action_id": "caipe_feedback_less_verbose",
-          "value": f"{channel_id}|{thread_ts}|{original_ts or ''}",
-        },
-      ],
-    }
-  )
+      "type": "button",
+      "text": {"type": "plain_text", "text": "More detail"},
+      "action_id": "caipe_feedback_more_detail",
+      "value": action_value,
+    },
+    {
+      "type": "button",
+      "text": {"type": "plain_text", "text": "Briefer"},
+      "action_id": "caipe_feedback_less_verbose",
+      "value": action_value,
+    },
+  ]
+  if escalation_config:
+    action_elements.append(
+      {
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Get help"},
+        "action_id": "caipe_escalation_get_help",
+        "value": action_value,
+        "style": "danger",
+      }
+    )
+  final_blocks.append({"type": "actions", "elements": action_elements})
 
-  # Add thumbs up/down feedback buttons
-  final_blocks.append(
+  # Add thumbs up/down feedback buttons (and optional trash icon)
+  context_elements = [
     {
-      "type": "context_actions",
-      "elements": [
-        {
-          "type": "feedback_buttons",
-          "action_id": "caipe_feedback",
-          "positive_button": {
-            "text": {"type": "plain_text", "text": "\U0001f44d"},
-            "value": f"positive|{original_ts or ''}",
-          },
-          "negative_button": {
-            "text": {"type": "plain_text", "text": "\U0001f44e"},
-            "value": f"negative|{original_ts or ''}",
-          },
-        },
-      ],
-    }
-  )
+      "type": "feedback_buttons",
+      "action_id": "caipe_feedback",
+      "positive_button": {
+        "text": {"type": "plain_text", "text": "\U0001f44d"},
+        "value": f"positive|{original_ts or ''}",
+      },
+      "negative_button": {
+        "text": {"type": "plain_text", "text": "\U0001f44e"},
+        "value": f"negative|{original_ts or ''}",
+      },
+    },
+  ]
+  if escalation_config and escalation_config.delete_admins:
+    context_elements.append(
+      {
+        "type": "icon_button",
+        "action_id": "caipe_delete_message",
+        "icon": {"type": "known", "name": "trash"},
+        "value": action_value,
+        "accessibility_label": "Delete this response",
+      }
+    )
+  final_blocks.append({"type": "context_actions", "elements": context_elements})
 
   # Build footer
   footer_text = _build_footer_text(triggered_by_user_id=triggered_by_user_id, additional_footer=additional_footer)
@@ -930,6 +1020,7 @@ def handle_ai_alert_processing(
   channel_config,
   session_manager,
   custom_prompt=None,
+  escalation_config=None,
 ):
   """AI-powered alert processing."""
   alert_text = event.get("text", "")
@@ -976,7 +1067,7 @@ def handle_ai_alert_processing(
 
   context_id = session_manager.get_context_id(thread_ts)
 
-  stream_a2a_response(
+  result = stream_a2a_response(
     a2a_client=a2a_client,
     slack_client=slack_client,
     channel_id=channel_id,
@@ -991,7 +1082,8 @@ def handle_ai_alert_processing(
       "jira_config": channel_config,
     },
     session_manager=session_manager,
+    escalation_config=escalation_config,
   )
 
   logger.info(f"[{thread_ts}] AI processed alert from {bot_username}")
-  return None
+  return result

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -128,7 +128,7 @@ def stream_a2a_response(
   session_manager=None,
   triggered_by_user_id=None,
   additional_footer=None,
-  overthink_mode=False,
+  overthink_config=None,
   escalation_config=None,
 ):
   """
@@ -140,12 +140,13 @@ def stream_a2a_response(
 
   Returns:
       List of Slack blocks for the final response, or dict with retry_needed=True on recoverable errors,
-      or dict with skipped=True if overthink_mode filtered the response
+      or dict with skipped=True if overthink filtered the response
   """
   from .hitl_handler import parse_form_data, format_hitl_form_blocks
 
   # Streaming requires a valid user_id (starts with U or W), bot_ids (B) don't work
   can_stream = user_id and user_id[0] in ("U", "W")
+  overthink_mode = bool(overthink_config and overthink_config.enabled)
 
   # In overthink mode, process silently - don't show "working" message
   # Only post if we have a confident response
@@ -559,15 +560,17 @@ def stream_a2a_response(
 
     # Overthink mode: check for skip markers before posting
     if overthink_mode and final_text:
-      skip_result = _check_overthink_skip(final_text, thread_ts)
+      skip_markers = overthink_config.skip_markers if overthink_config else None
+      skip_result = _check_overthink_skip(final_text, thread_ts, skip_markers=skip_markers)
       if skip_result:
         # No progress message to delete in overthink mode (silent processing)
         return skip_result
 
-      # Strip the [CONFIDENCE: HIGH] marker before posting
-      if "[CONFIDENCE: HIGH]" in final_text:
-        final_text = final_text.replace("[CONFIDENCE: HIGH]", "").rstrip()
-        logger.info(f"[{thread_ts}] Stripped [CONFIDENCE: HIGH] marker from response")
+      # Strip the pass marker before posting
+      pass_marker = f"[{overthink_config.pass_marker}]" if overthink_config else "[CONFIDENCE: HIGH]"
+      if pass_marker in final_text:
+        final_text = final_text.replace(pass_marker, "").rstrip()
+        logger.info(f"[{thread_ts}] Stripped {pass_marker} marker from response")
 
     # Handle graceful degradation: if we have content, show it even if there was an error
     if final_text and final_text != "I've completed your request.":
@@ -816,25 +819,32 @@ def _normalize_paragraph_breaks(text: str) -> str:
   return ''.join(result)
 
 
-def _check_overthink_skip(final_text: str, thread_ts: str) -> dict | None:
+def _check_overthink_skip(
+  final_text: str,
+  thread_ts: str,
+  skip_markers: list[str] | None = None,
+) -> dict | None:
   """Check if response should be skipped in overthink mode.
 
+  Args:
+      final_text: The full response text to check.
+      thread_ts: Thread timestamp for logging.
+      skip_markers: List of marker strings to check for (e.g. ["DEFER", "LOW_CONFIDENCE"]).
+          The code looks for ``[MARKER]`` in the text. Defaults to ["DEFER", "LOW_CONFIDENCE"].
+
   Returns:
-      None if response should be posted normally
-      {"skipped": True, "reason": "..."} if response should be skipped
+      None if response should be posted normally.
+      {"skipped": True, "reason": "<marker_lower>"} if a skip marker was found.
   """
-  # Check for DEFER marker anywhere in response
-  if "[DEFER]" in final_text:
-    logger.info(f"[{thread_ts}] Overthink: skipping response (DEFER - human action needed)")
-    return {"skipped": True, "reason": "defer"}
+  markers = skip_markers or ["DEFER", "LOW_CONFIDENCE"]
+  for marker in markers:
+    if f"[{marker}]" in final_text:
+      reason = marker.lower()
+      logger.info(f"[{thread_ts}] Overthink: skipping response ({marker})")
+      logger.debug(f"[{thread_ts}] Skipped response: {final_text}")
+      return {"skipped": True, "reason": reason}
 
-  # Check for LOW_CONFIDENCE marker anywhere in response
-  if "[LOW_CONFIDENCE]" in final_text:
-    logger.info(f"[{thread_ts}] Overthink: skipping response (LOW_CONFIDENCE - no good sources)")
-    logger.debug(f"[{thread_ts}] LOW_CONFIDENCE response: {final_text}")
-    return {"skipped": True, "reason": "low_confidence"}
-
-  # Response has content, allow posting
+  # No skip markers found — allow posting
   return None
 
 
@@ -1020,6 +1030,7 @@ def handle_ai_alert_processing(
   channel_config,
   session_manager,
   custom_prompt=None,
+  overthink_config=None,
   escalation_config=None,
 ):
   """AI-powered alert processing."""
@@ -1082,6 +1093,7 @@ def handle_ai_alert_processing(
       "jira_config": channel_config,
     },
     session_manager=session_manager,
+    overthink_config=overthink_config,
     escalation_config=escalation_config,
   )
 

--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -155,6 +155,49 @@ User's follow-up message:
         )
     )
 
+    overthink_ai_alerts_prompt: str = Field(
+        default_factory=lambda: os.environ.get(
+            "SLACK_INTEGRATION_PROMPT_OVERTHINK_AI_ALERTS",
+            """You are an automated alert classifier. Analyze this alert and decide whether to take action.
+
+STEP 1 - Quick filter (no search needed):
+- Is this a routine informational notification (oncall changes, deployments, status updates)? Respond with [DEFER] and stop
+- Is this a test/development alert with no production impact? Respond with [DEFER] and stop
+- Otherwise, continue to Step 2
+
+STEP 2 - Search for context (MANDATORY - DO NOT SKIP):
+Search for related incidents, runbooks, and existing tickets.
+- Look for duplicate or related tickets that may already be tracking this issue
+- Check if this is a known pattern or recurring alert
+- Aim for at least 3 search queries
+
+STEP 3 - Assess confidence:
+- HIGH: Alert clearly matches a ticketable pattern (error, failure, security, user-impacting)
+- LOW: Ambiguous severity, might be noise, or insufficient context to determine action
+
+STEP 4 - Respond:
+- If LOW confidence:
+  - Explain why this alert is ambiguous
+  - Final line must be [LOW_CONFIDENCE]
+- If HIGH confidence:
+  - Create a Jira ticket with appropriate fields
+  - Explain your reasoning
+  - Final line must be [CONFIDENCE: HIGH]
+
+JIRA CONFIGURATION:
+Project: {jira_project}
+{jira_config_str}
+
+ALERT DETAILS:
+Bot: {bot_username}
+Channel ID: {channel_id}
+Text: {alert_text}
+Timestamp: {timestamp}
+Blocks: {alert_blocks}
+Attachments: {alert_attachments}""",
+        )
+    )
+
     default_ai_alerts_prompt: str = Field(
         default_factory=lambda: os.environ.get(
             "SLACK_INTEGRATION_PROMPT_AI_ALERTS",
@@ -230,6 +273,16 @@ def get_escalation_config(default_config: Dict[str, Any]) -> Optional["Escalatio
     return EscalationConfig(**raw)
 
 
+class OverthinkConfig(BaseModel):
+    """Overthink mode configuration — shared by Q&A and AI alerts."""
+
+    enabled: bool = False
+    skip_markers: List[str] = Field(default_factory=lambda: ["DEFER", "LOW_CONFIDENCE"])
+    pass_marker: str = "CONFIDENCE: HIGH"
+    custom_prompt: Optional[str] = None
+    followup_prompt: Optional[str] = None
+
+
 class IncludeBotsConfig(BaseModel):
     """Configuration for including bot messages"""
 
@@ -241,7 +294,7 @@ class QandaConfig(BaseModel):
     """Q&A mode configuration"""
 
     enabled: bool = False
-    overthink: bool = False
+    overthink: OverthinkConfig = Field(default_factory=OverthinkConfig)
     include_bots: IncludeBotsConfig = Field(default_factory=IncludeBotsConfig)
     custom_prompt: Optional[str] = None
 
@@ -250,6 +303,7 @@ class AIAlertsConfig(BaseModel):
     """AI alerts configuration"""
 
     enabled: bool = False
+    overthink: OverthinkConfig = Field(default_factory=OverthinkConfig)
     custom_prompt: Optional[str] = None
 
 
@@ -305,18 +359,25 @@ class Config(BaseModel):
     def apply_defaults_to_channels(self):
         """Apply global defaults to channel configs (e.g., default prompts with style)"""
         for channel_config in self.channels.values():
+            # --- Q&A prompt resolution ---
             custom_prompt = channel_config.qanda.custom_prompt
+            overthink = channel_config.qanda.overthink
 
-            if channel_config.qanda.overthink:
-                if custom_prompt:
+            if overthink.enabled:
+                # Use overthink-specific prompt from config, or channel custom_prompt, or global default
+                overthink_prompt = overthink.custom_prompt or self.defaults.overthink_qanda_prompt
+                if custom_prompt and not overthink.custom_prompt:
                     channel_config.qanda.custom_prompt = (
-                        self.defaults.overthink_qanda_prompt
+                        overthink_prompt
                         + "\n\n---\n\n"
                         + "Additional channel-specific instructions (lower priority than the above overthink logic):\n"
                         + custom_prompt
                     )
                 else:
-                    channel_config.qanda.custom_prompt = self.defaults.overthink_qanda_prompt
+                    channel_config.qanda.custom_prompt = overthink_prompt
+                # Set default followup prompt if not configured
+                if not overthink.followup_prompt:
+                    overthink.followup_prompt = self.defaults.humble_followup_prompt
             elif not custom_prompt:
                 channel_config.qanda.custom_prompt = self.defaults.default_qanda_prompt
             else:
@@ -324,3 +385,21 @@ class Config(BaseModel):
                     channel_config.qanda.custom_prompt = (
                         custom_prompt + "\n\n" + self.defaults.response_style_instruction
                     )
+
+            # --- AI alerts prompt resolution ---
+            alerts_overthink = channel_config.ai_alerts.overthink
+            if alerts_overthink.enabled:
+                alerts_prompt = alerts_overthink.custom_prompt or self.defaults.overthink_ai_alerts_prompt
+                alerts_custom = channel_config.ai_alerts.custom_prompt
+                if alerts_custom and not alerts_overthink.custom_prompt:
+                    channel_config.ai_alerts.custom_prompt = (
+                        alerts_prompt
+                        + "\n\n---\n\n"
+                        + "Additional channel-specific instructions:\n"
+                        + alerts_custom
+                    )
+                else:
+                    channel_config.ai_alerts.custom_prompt = alerts_prompt
+                # Set default followup prompt if not configured
+                if not alerts_overthink.followup_prompt:
+                    alerts_overthink.followup_prompt = self.defaults.humble_followup_prompt

--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -199,6 +199,37 @@ INSTRUCTIONS:
     )
 
 
+class VictorOpsEscalation(BaseModel):
+    """VictorOps on-call escalation configuration"""
+
+    enabled: bool = False
+    team: str = ""
+
+
+class EmojiEscalation(BaseModel):
+    """Emoji reaction escalation configuration"""
+
+    enabled: bool = False
+    name: str = "eyes"
+
+
+class EscalationConfig(BaseModel):
+    """Escalation workflows triggered by the 'Get help' button"""
+
+    victorops: VictorOpsEscalation = Field(default_factory=VictorOpsEscalation)
+    users: List[str] = Field(default_factory=list)
+    emoji: EmojiEscalation = Field(default_factory=EmojiEscalation)
+    delete_admins: List[str] = Field(default_factory=list)
+
+
+def get_escalation_config(default_config: Dict[str, Any]) -> Optional["EscalationConfig"]:
+    """Extract and parse escalation config from a channel's default dict."""
+    raw = default_config.get("escalation")
+    if not raw:
+        return None
+    return EscalationConfig(**raw)
+
+
 class IncludeBotsConfig(BaseModel):
     """Configuration for including bot messages"""
 

--- a/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
@@ -1,0 +1,133 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Escalation workflows triggered by the 'Get help' button.
+
+Supports three configurable actions (all fire if enabled):
+1. VictorOps on-call ping — queries AI for the on-call email, resolves Slack user, @-mentions them
+2. Direct user/group ping — @-mentions configured Slack users or groups
+3. Emoji reaction — adds a configured emoji to the parent message
+"""
+
+import re
+
+from loguru import logger
+
+from utils.config_models import EscalationConfig
+
+
+def execute_escalation(
+    slack_client,
+    a2a_client,
+    channel_id,
+    thread_ts,
+    parent_ts,
+    user_id,
+    escalation_config: EscalationConfig,
+):
+    """Run all configured escalation actions. Returns list of result summaries."""
+    results = []
+
+    if escalation_config.victorops.enabled and escalation_config.victorops.team:
+        result = _ping_victorops_oncall(
+            a2a_client, slack_client, channel_id, thread_ts,
+            escalation_config.victorops.team,
+        )
+        results.append(result)
+
+    if escalation_config.users:
+        result = _ping_users(slack_client, channel_id, thread_ts, escalation_config.users)
+        results.append(result)
+
+    if escalation_config.emoji.enabled:
+        result = _add_emoji_reaction(
+            slack_client, channel_id, parent_ts, escalation_config.emoji.name,
+        )
+        results.append(result)
+
+    return results
+
+
+def _ping_victorops_oncall(a2a_client, slack_client, channel_id, thread_ts, team):
+    """Query the AI for VictorOps on-call, resolve to Slack user, and ping them."""
+    try:
+        prompt = (
+            f"RESPOND IN 1 WORD THAT IS USER EMAIL. "
+            f"WHO IS ON CALL FOR TEAM {team}?"
+        )
+        oncall_email = None
+        for event_data in a2a_client.send_message_stream(message_text=prompt):
+            # Look for text content in any event
+            if isinstance(event_data, dict):
+                result = event_data.get("result", {})
+                parts = []
+                # Check artifact parts
+                if "artifact" in result:
+                    parts = result["artifact"].get("parts", [])
+                # Check message parts
+                elif "parts" in result:
+                    parts = result["parts"]
+                for part in parts:
+                    if part.get("kind") == "text" and part.get("text", "").strip():
+                        text = part["text"].strip()
+                        # Extract email pattern from response
+                        email_match = re.search(r'[\w.+-]+@[\w-]+\.[\w.]+', text)
+                        if email_match:
+                            oncall_email = email_match.group(0)
+
+        if not oncall_email:
+            slack_client.chat_postMessage(
+                channel=channel_id, thread_ts=thread_ts,
+                text=f"Could not determine on-call for team *{team}*. Please check VictorOps manually.",
+            )
+            return "victorops: could not determine on-call"
+
+        # Resolve email to Slack user ID
+        try:
+            user_resp = slack_client.users_lookupByEmail(email=oncall_email)
+            oncall_slack_id = user_resp["user"]["id"]
+            slack_client.chat_postMessage(
+                channel=channel_id, thread_ts=thread_ts,
+                text=f"<@{oncall_slack_id}> — a user requested human help in this thread (on-call for *{team}*)",
+            )
+            return f"victorops: pinged {oncall_email} (<@{oncall_slack_id}>)"
+        except Exception:
+            slack_client.chat_postMessage(
+                channel=channel_id, thread_ts=thread_ts,
+                text=f"On-call for *{team}* is *{oncall_email}* but could not find their Slack account.",
+            )
+            return f"victorops: found {oncall_email} but no Slack account"
+
+    except Exception as e:
+        logger.exception(f"[{thread_ts}] VictorOps escalation failed: {e}")
+        slack_client.chat_postMessage(
+            channel=channel_id, thread_ts=thread_ts,
+            text=f"Could not determine on-call for team *{team}*. Please check VictorOps manually.",
+        )
+        return f"victorops: error — {e}"
+
+
+def _ping_users(slack_client, channel_id, thread_ts, user_ids):
+    """Directly @-mention configured users/groups in the thread."""
+    try:
+        mentions = " ".join(f"<@{uid}>" for uid in user_ids)
+        slack_client.chat_postMessage(
+            channel=channel_id, thread_ts=thread_ts,
+            text=f"{mentions} — a user requested human assistance in this thread",
+        )
+        return f"users: pinged {len(user_ids)} user(s)"
+    except Exception as e:
+        logger.exception(f"[{thread_ts}] User ping escalation failed: {e}")
+        return f"users: error — {e}"
+
+
+def _add_emoji_reaction(slack_client, channel_id, parent_ts, emoji_name):
+    """Add an emoji reaction to the parent message."""
+    try:
+        slack_client.reactions_add(
+            name=emoji_name, channel=channel_id, timestamp=parent_ts,
+        )
+        return f"emoji: added :{emoji_name}:"
+    except Exception as e:
+        logger.exception(f"[{parent_ts}] Emoji escalation failed: {e}")
+        return f"emoji: error — {e}"


### PR DESCRIPTION
## Summary

- **OverthinkConfig model**: New Pydantic model replacing `overthink: bool` with configurable `skip_markers`, `pass_marker`, `custom_prompt`, and `followup_prompt`
- **AI alerts overthink**: Added overthink support for AI alerts (previously only Q&A), with dedicated `overthink_ai_alerts_prompt`
- **Configurable markers**: Skip markers (default: `["DEFER", "LOW_CONFIDENCE"]`) and pass marker (default: `"CONFIDENCE: HIGH"`) are now per-channel configurable
- **Per-channel followup prompt**: Humble followup on @mention uses `followup_prompt` from overthink config instead of global default
- **Updated `apply_defaults_to_channels`**: Handles prompt resolution for both Q&A and AI alerts overthink

## Depends on

- #1123 (escalation workflows + feedback/streaming fixes)

## Test plan

- [ ] `make lint` passes
- [ ] `make test-supervisor` — TestOverthinkConfig tests pass
- [ ] Verify overthink mode works with custom skip/pass markers in config
- [ ] Verify AI alerts overthink correctly skips low-confidence alerts