### PR TITLE
fix(ui): skip Bearer token for internal rag-server URLs

### DIFF
--- a/ui/src/app/api/rag/[...path]/route.ts
+++ b/ui/src/app/api/rag/[...path]/route.ts
@@ -3,27 +3,27 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-config';
 
 /**
- * RAG API Proxy with JWT Bearer Token Authentication
+ * RAG API Proxy
  *
- * Proxies requests from /api/rag/* to the RAG server with JWT authentication.
- * The RAG server validates the JWT token and fetches user claims (email, groups)
- * from the OIDC userinfo endpoint, caching them in Redis.
+ * Proxies requests from /api/rag/* to the RAG server.
  *
- * Authentication:
- * - Authorization: Bearer {access_token} (OIDC JWT access token)
+ * Authentication strategy depends on whether the RAG server is internal or external:
  *
- * The RAG server uses the access_token to:
- * 1. Authenticate the request (validate JWT signature, expiry, audience)
- * 2. Fetch user claims from OIDC userinfo endpoint (cached in Redis)
- * 3. Determine user role based on group membership
+ * - Internal cluster URL (svc.cluster.local, localhost, private IP):
+ *   No Authorization header is sent. The RAG server's trusted-network middleware
+ *   (TRUSTED_NETWORK_CIDRS=10.0.0.0/8) authenticates requests from the Next.js
+ *   pod by source IP and grants TRUSTED_NETWORK_DEFAULT_ROLE.
+ *   Sending a Bearer token here causes persistent 401s: the Duo OIDC access_token
+ *   is signed with a key that is not published in Duo's public JWKS, so the
+ *   rag-server can never validate it via the standard JWKS flow.
  *
- * This is the standards-compliant OAuth approach - only the access_token is
- * passed downstream, and user claims are fetched server-side from the
- * authoritative source (OIDC provider's userinfo endpoint).
+ * - External URL (public hostname):
+ *   Authorization: Bearer {access_token} is forwarded so the RAG server can
+ *   authenticate and fetch per-user claims from the OIDC userinfo endpoint.
  *
  * Example:
- *   /api/rag/healthz -> RAG_SERVER_URL/healthz (with Bearer token)
- *   /api/rag/v1/query -> RAG_SERVER_URL/v1/query (with Bearer token)
+ *   /api/rag/healthz              -> RAG_SERVER_URL/healthz
+ *   /api/rag/v1/mcp/custom-tools  -> RAG_SERVER_URL/v1/mcp/custom-tools
  */
 
 function getRagServerUrl(): string {
@@ -33,30 +33,44 @@ function getRagServerUrl(): string {
 }
 
 /**
- * Get auth headers from the current session
- * 
- * Extracts JWT access token from session and sends to RAG server.
- * The RAG server uses this token to authenticate and fetch user claims
- * from the OIDC userinfo endpoint (with caching).
- * 
- * @returns Headers object with Authorization Bearer token for RAG server
+ * Returns true when the RAG server URL resolves to an in-cluster or loopback
+ * address. In that case the Next.js pod (10.x.x.x) is already inside the
+ * rag-server's trusted network — no Bearer token needed or wanted.
+ */
+function isInternalRagServer(): boolean {
+  const url = getRagServerUrl();
+  return (
+    url.includes('svc.cluster.local') ||
+    url.includes('localhost') ||
+    /http:\/\/10\.\d+\.\d+\.\d+/.test(url) ||
+    /http:\/\/172\.(1[6-9]|2\d|3[01])\.\d+\.\d+/.test(url) ||
+    /http:\/\/192\.168\.\d+\.\d+/.test(url)
+  );
+}
+
+/**
+ * Build request headers for the upstream RAG server.
+ *
+ * For internal URLs the Authorization header is intentionally omitted —
+ * the rag-server's trusted-network check handles auth by source IP.
  */
 async function getRbacHeaders(): Promise<Record<string, string>> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
 
+  if (isInternalRagServer()) {
+    // Internal service: rely on trusted-network auth in the rag-server.
+    // Sending a Bearer token that fails JWKS validation causes 401 on every call.
+    return headers;
+  }
+
   try {
     const session = await getServerSession(authOptions);
-    
-    // Pass JWT access token as Bearer token
-    // RAG server validates JWT and fetches user claims from OIDC userinfo endpoint
     if (session?.accessToken) {
       headers['Authorization'] = `Bearer ${session.accessToken}`;
     }
   } catch (error) {
-    // If session retrieval fails, continue without auth headers
-    // RAG server may still allow access from trusted networks or anonymous users
     console.debug('[RAG Proxy] Could not retrieve session, proceeding without auth headers:', error);
   }
 


### PR DESCRIPTION
## Summary

- The Duo OIDC access_token has a key ID absent from Duo's public JWKS. Forwarding it as Authorization: Bearer to an in-cluster rag-server causes persistent 401s on every REST call (/v1/mcp/custom-tools, /v1/datasources, etc.) — the rag-server cannot validate the token.
- The rag-server already handles this: when no auth header is present and the request comes from a trusted CIDR (TRUSTED_NETWORK_CIDRS=10.0.0.0/8), it grants TRUSTED_NETWORK_DEFAULT_ROLE. The Next.js pod always has a 10.x.x.x address.
- Add isInternalRagServer() to detect cluster-local and private-IP RAG server URLs. For those targets getRbacHeaders() omits the Authorization header, letting trusted-network auth handle it. External deployments continue to receive the Bearer token.

## Observed failure (caipe prod)

Token validation failed for provider 'ui': Key ID 'ce989860...' not found in JWKS (repeated every 2 min)
caipe-ui logs: API Error: Error [ApiError]: Unauthorized

## Test plan

- [ ] Deploy to preview; verify Knowledge Bases tab loads without 401 errors in rag-server logs
- [ ] Confirm supervisor RAG tool calls still work (unaffected — MCP calls never sent a token)
- [ ] Verify an external RAG server deployment (non-cluster URL) still receives Authorization: Bearer

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>