### PR TITLE
fix: OIDC group display, task builder tools, and supervisor response format

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/auth.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/auth.py
@@ -273,13 +273,17 @@ def extract_groups_from_claims(claims: dict[str, Any], settings: Settings) -> li
 def check_admin_role(groups: list[str], settings: Settings) -> bool:
     """Check if user is in admin group.
 
-    Uses OIDC_REQUIRED_ADMIN_GROUP if set, otherwise falls back to
-    pattern matching for common admin group names.
+    Uses OIDC_REQUIRED_ADMIN_GROUP if set (supports comma-separated for multiple groups),
+    otherwise falls back to pattern matching for common admin group names.
     """
     if settings.oidc_required_admin_group:
-        # Match against configured admin group (case-insensitive)
-        admin_group_lower = settings.oidc_required_admin_group.lower()
-        return any(group.lower() == admin_group_lower or f"cn={admin_group_lower}" in group.lower() for group in groups)
+        # Support comma-separated list of admin groups
+        admin_groups = [g.strip().lower() for g in settings.oidc_required_admin_group.split(",") if g.strip()]
+        return any(
+            any(user_group.lower() == admin_group or f"cn={admin_group}" in user_group.lower()
+                for admin_group in admin_groups)
+            for user_group in groups
+        )
 
     # Fallback: pattern matching for common admin group names
     admin_patterns = ["admin", "platform-admin", "administrators"]

--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent_single.py
@@ -1053,6 +1053,10 @@ class PlatformEngineerDeepAgent:
         self._graph_generation = 0
         self._initialized = False
         self._subagent_tools: Dict[str, List[str]] = {}
+        # Skills status tracking (mirrors deep_agent.py for FR-016 compatibility)
+        self._skills_loaded_count: Optional[int] = None
+        self._skills_merged_at: Optional[str] = None
+        self._last_built_catalog_generation: Optional[int] = None
 
         # RAG-related instance variables
         self.rag_enabled = ENABLE_RAG
@@ -1124,6 +1128,28 @@ class PlatformEngineerDeepAgent:
         """Return tool names per subagent, captured at graph build time."""
         with self._graph_lock:
             return dict(self._subagent_tools)
+
+    def get_skills_status(self) -> dict:
+        """Snapshot of skills load metadata for operators (FR-016)."""
+        from ai_platform_engineering.skills_middleware.catalog import get_catalog_cache_generation
+
+        with self._graph_lock:
+            cache_gen = get_catalog_cache_generation()
+            last_built = self._last_built_catalog_generation
+            if last_built is None:
+                sync_status = "unknown"
+            elif last_built == cache_gen:
+                sync_status = "in_sync"
+            else:
+                sync_status = "supervisor_stale"
+            return {
+                "graph_generation": self._graph_generation,
+                "skills_loaded_count": self._skills_loaded_count,
+                "skills_merged_at": self._skills_merged_at,
+                "catalog_cache_generation": cache_gen,
+                "last_built_catalog_generation": last_built,
+                "sync_status": sync_status,
+            }
 
     async def _load_rag_tools(self) -> List[Any]:
         """Load RAG MCP tools from the server."""
@@ -1386,8 +1412,13 @@ This format is required so the UI can display agent stickers next to each task.
 
         # Load skills catalog and build StateBackend files for SkillsMiddleware (FR-015)
         try:
+            from datetime import datetime, timezone
+            from ai_platform_engineering.skills_middleware.catalog import get_catalog_cache_generation
             skills = get_merged_skills(include_content=True)
             self._skills_files, self._skills_sources = build_skills_files(skills)
+            self._skills_loaded_count = len(skills)
+            self._skills_merged_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            self._last_built_catalog_generation = get_catalog_cache_generation()
             logger.info(f"📚 Loaded {len(skills)} skills for supervisor ({len(self._skills_sources)} sources)")
         except Exception as e:
             logger.warning(f"Failed to load skills catalog: {e}")

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py
@@ -19,6 +19,7 @@ from ai_platform_engineering.multi_agents.platform_engineer.deep_agent_single im
     AIPlatformEngineerMAS,
     USE_STRUCTURED_RESPONSE,
 )
+from ai_platform_engineering.skills_middleware.mas_registry import set_mas_instance
 from ai_platform_engineering.multi_agents.platform_engineer.prompts import (
     system_prompt
 )
@@ -73,6 +74,7 @@ class AIPlatformEngineerA2ABinding:
 
       await self._mas_instance.ensure_initialized()
       self.graph = self._mas_instance.get_graph()
+      set_mas_instance(self._mas_instance)
       self._initialized = True
       logging.info("✅ AIPlatformEngineerA2ABinding initialized with MCP tools")
 

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent_single.py
@@ -1415,6 +1415,10 @@ class AIPlatformEngineerA2ABinding:
           }
           accumulated_ai_content.clear()
           final_ai_message = None
+          # Preserve a ResponseFormat result that was already captured before the
+          # recursion limit was hit — the task completed successfully, the graph
+          # just kept running past the ResponseFormat tool call.
+          _saved_response_format = response_format_result if is_recursion_limit else None
           response_format_result = None
 
           try:
@@ -1470,6 +1474,15 @@ class AIPlatformEngineerA2ABinding:
                       )
               except Exception as ctx_err:
                   logging.warning(f"State repair (context compression) failed: {ctx_err}")
+
+          # If a ResponseFormat result was captured before the recursion limit was
+          # hit, restore it now — the task actually completed successfully.
+          if _saved_response_format and not response_format_result:
+              response_format_result = _saved_response_format
+              logging.info(
+                  "✅ Restored pre-recursion ResponseFormat result — task completed "
+                  f"before limit (content_len={len(response_format_result.get('content', ''))})"
+              )
 
           # ==============================================================
           # Decision: retry once, or go straight to wrap-up?
@@ -1609,10 +1622,14 @@ class AIPlatformEngineerA2ABinding:
                       f"I encountered an error and need to wrap up: {error_str[:500]}\n\n"
                       "I will now summarize what was accomplished so far and provide my final response."
                   )
+                  # The deepagents graph uses "model" as its main node, not "agent".
+                  # Detect the correct node name at runtime to avoid KeyError.
+                  _graph_nodes = set(getattr(self.graph, 'nodes', {}).keys())
+                  _agent_node = "model" if "model" in _graph_nodes else "agent"
                   await self.graph.aupdate_state(
                       config,
                       {"messages": [AIMessage(content=error_summary)]},
-                      as_node="agent",
+                      as_node=_agent_node,
                   )
 
                   async for item_type, item in self.graph.astream(

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main_single.py
@@ -150,7 +150,17 @@ a2a_server = A2AStarletteApplication(
     http_handler=request_handler
 )
 
-app = a2a_server.build()
+_a2a_app = a2a_server.build()
+
+# Wrap in FastAPI to expose skills catalog API (GET /skills, etc.) alongside A2A server.
+# The A2A Starlette app is mounted at "/" so all A2A paths (/.well-known/*, /message/stream,
+# etc.) are forwarded to it after FastAPI's own routes are checked first.
+from fastapi import FastAPI as _FastAPI  # noqa: E402
+from ai_platform_engineering.skills_middleware.router import router as skills_router  # noqa: E402
+
+app = _FastAPI()
+app.include_router(skills_router)
+app.mount("/", _a2a_app)
 
 ################################################################################
 # Eager initialisation — load MCP tools at startup, not on first request

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main_single.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main_single.py
@@ -17,9 +17,6 @@ from ai_platform_engineering.utils.logging_config import configure_logging
 from ai_platform_engineering.utils.metrics import PrometheusMetricsMiddleware, agent_metrics
 
 from starlette.middleware.cors import CORSMiddleware
-from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.routing import Route
 
 # Import single-node specific executor (uses original class name for compatibility)
 from ai_platform_engineering.multi_agents.platform_engineer.protocol_bindings.a2a.agent_executor_single import (
@@ -160,7 +157,6 @@ from ai_platform_engineering.skills_middleware.router import router as skills_ro
 
 app = _FastAPI()
 app.include_router(skills_router)
-app.mount("/", _a2a_app)
 
 ################################################################################
 # Eager initialisation — load MCP tools at startup, not on first request
@@ -181,21 +177,27 @@ app.add_event_handler("startup", _startup_initialize)
 
 ################################################################################
 # /tools endpoint – returns tool names per subagent from the running MAS
+# Must be registered BEFORE app.mount("/", _a2a_app) so it is matched first.
 ################################################################################
 
 
-async def _tools_endpoint(request: Request) -> JSONResponse:
+@app.get("/tools")
+async def _tools_endpoint():
     """Return dynamically discovered tool names grouped by subagent."""
     try:
         if not _binding._initialized:
             await _binding.ensure_initialized()
-        return JSONResponse({"tools": _binding._mas_instance.get_subagent_tools()})
+        return {"tools": _binding._mas_instance.get_subagent_tools()}
     except Exception as e:
         logger.warning(f"/tools endpoint error: {e}")
-        return JSONResponse({"tools": {}, "error": str(e)}, status_code=500)
+        from fastapi import HTTPException
+        raise HTTPException(status_code=500, detail=str(e))
 
 
-app.routes.append(Route("/tools", _tools_endpoint, methods=["GET"]))
+# Mount A2A Starlette app AFTER all FastAPI routes so FastAPI routes take
+# precedence. The "/" mount is a catch-all and would swallow /tools if it
+# were registered before @app.get("/tools") above.
+app.mount("/", _a2a_app)
 
 ################################################################################
 # Add authentication middleware if enabled

--- a/ai_platform_engineering/utils/deepagents_custom/self_service_middleware.py
+++ b/ai_platform_engineering/utils/deepagents_custom/self_service_middleware.py
@@ -48,7 +48,7 @@ class SelfServiceWorkflowMiddleware(AgentMiddleware):
     Hooks used:
       * ``before_model`` — captures ``user_email`` from graph state.
       * ``wrap_model_call`` / ``awrap_model_call`` — appends the workflow
-        list to ``request.system_prompt`` before the LLM is invoked.
+        list to ``request.system_message`` before the LLM is invoked.
     """
 
     def __init__(self) -> None:
@@ -97,7 +97,15 @@ class SelfServiceWorkflowMiddleware(AgentMiddleware):
 
     def _inject_workflows(self, request: ModelRequest) -> None:
         section = self._build_workflow_prompt_section(user_email=self._user_email)
-        if section and hasattr(request, "system_prompt") and request.system_prompt:
+        if not section:
+            return
+        # ModelRequest uses `system_message` (SystemMessage object), not `system_prompt`
+        if hasattr(request, "system_message") and request.system_message is not None:
+            from langchain_core.messages import SystemMessage
+            existing = request.system_message.content or ""
+            request.system_message = SystemMessage(content=existing + section)
+        elif hasattr(request, "system_prompt") and request.system_prompt:
+            # Fallback for any future API that uses a plain string
             request.system_prompt = request.system_prompt + section
 
     def wrap_model_call(

--- a/ai_platform_engineering/utils/deepagents_custom/self_service_middleware.py
+++ b/ai_platform_engineering/utils/deepagents_custom/self_service_middleware.py
@@ -101,9 +101,8 @@ class SelfServiceWorkflowMiddleware(AgentMiddleware):
             return
         # ModelRequest uses `system_message` (SystemMessage object), not `system_prompt`
         if hasattr(request, "system_message") and request.system_message is not None:
-            from langchain_core.messages import SystemMessage
-            existing = request.system_message.content or ""
-            request.system_message = SystemMessage(content=existing + section)
+            from deepagents.middleware._utils import append_to_system_message
+            request.system_message = append_to_system_message(request.system_message, section)
         elif hasattr(request, "system_prompt") and request.system_prompt:
             # Fallback for any future API that uses a plain string
             request.system_prompt = request.system_prompt + section

--- a/ai_platform_engineering/utils/mongodb_client.py
+++ b/ai_platform_engineering/utils/mongodb_client.py
@@ -100,6 +100,7 @@ def get_task_configs_from_mongodb() -> Optional[dict]:
                     "is_system": 1,
                     "visibility": 1,
                     "metadata": 1,
+                    "shared_with_teams": 1,
                 },
             )
         )
@@ -124,6 +125,7 @@ def get_task_configs_from_mongodb() -> Optional[dict]:
                     "owner_id": doc.get("owner_id", "system"),
                     "is_system": doc.get("is_system", True),
                     "visibility": doc.get("visibility", "global"),
+                    "shared_with_teams": doc.get("shared_with_teams", []),
                 }
                 allowed_tools = metadata.get("allowed_tools")
                 if allowed_tools:
@@ -142,12 +144,43 @@ def get_task_configs_from_mongodb() -> Optional[dict]:
         return None
 
 
+def _get_user_team_ids(user_email: str) -> list:
+    """Return the list of team IDs that *user_email* belongs to.
+
+    Mirrors the TypeScript ``getUserTeamIds`` in ``ui/src/lib/api-middleware.ts``:
+    queries the ``teams`` collection for documents where
+    ``members.user_id == user_email`` and returns their ``_id`` values as strings.
+
+    Returns an empty list if MongoDB is unavailable or the user is in no teams.
+    """
+    client = get_mongodb_client()
+    if client is None:
+        return []
+    database = os.getenv("MONGODB_DATABASE", "caipe")
+    try:
+        db = client[database]
+        teams = db["teams"]
+        user_teams = list(
+            teams.find(
+                {"members.user_id": user_email},
+                {"_id": 1},
+            )
+        )
+        return [str(t["_id"]) for t in user_teams]
+    except PyMongoError as e:
+        logger.warning(f"Failed to resolve team IDs for {user_email}: {e}")
+        return []
+
+
 def get_task_configs_for_user(user_email: Optional[str] = None) -> Optional[dict]:
     """Return task configs visible to *user_email*.
 
-    Fetches the full (cached) config set, then filters:
-      - ``is_system=True`` or ``visibility="global"`` configs are always included.
-      - When *user_email* is provided, configs owned by that user are included.
+    Fetches the full (cached) config set, then filters to match the same
+    visibility rules as the Next.js UI route (``task-configs/route.ts``):
+      - ``is_system=True`` or ``visibility="global"`` — always included.
+      - ``owner_id == user_email`` — user's own private/team configs.
+      - ``visibility="team"`` and ``shared_with_teams`` intersects with the
+        user's team memberships (resolved via the ``teams`` collection).
       - When *user_email* is ``None``, only system/global configs are returned.
 
     The returned dict has the same shape as :func:`get_task_configs_from_mongodb`
@@ -156,6 +189,8 @@ def get_task_configs_for_user(user_email: Optional[str] = None) -> Optional[dict
     all_configs = get_task_configs_from_mongodb()
     if not all_configs:
         return None
+
+    user_team_ids: Optional[set] = None  # lazy-loaded on first team-config hit
 
     filtered: dict = {}
     for name, entry in all_configs.items():
@@ -167,6 +202,13 @@ def get_task_configs_for_user(user_email: Optional[str] = None) -> Optional[dict
             filtered[name] = entry
         elif user_email and owner_id == user_email:
             filtered[name] = entry
+        elif user_email and visibility == "team":
+            shared_with = entry.get("shared_with_teams") or []
+            if shared_with:
+                if user_team_ids is None:
+                    user_team_ids = set(_get_user_team_ids(user_email))
+                if user_team_ids.intersection(shared_with):
+                    filtered[name] = entry
 
     return filtered if filtered else None
 

--- a/build/agents/Dockerfile.a2a
+++ b/build/agents/Dockerfile.a2a
@@ -62,10 +62,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install AWS CLI v2 (architecture-aware) with retry logic
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-        curl -sfL --retry 5 --retry-delay 3 "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+        AWS_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"; \
     else \
-        curl -sfL --retry 5 --retry-delay 3 "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+        AWS_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"; \
     fi && \
+    for i in 1 2 3 4 5; do \
+        curl -sL --connect-timeout 30 --max-time 300 --retry 3 --retry-all-errors --retry-delay 5 "$AWS_URL" -o "awscliv2.zip" && break; \
+        echo "Download attempt $i/5 failed, retrying..."; \
+        sleep $((i * 10)); \
+    done && \
+    [ -s awscliv2.zip ] || (echo "Failed to download AWS CLI after 5 attempts" && exit 1) && \
     unzip -q awscliv2.zip && \
     ./aws/install && \
     rm -rf awscliv2.zip aws

--- a/tests/test_agent_single_error_recovery.py
+++ b/tests/test_agent_single_error_recovery.py
@@ -27,15 +27,11 @@ Usage:
     pytest tests/test_agent_single_error_recovery.py -v
 """
 
-import ast
 import inspect
 import os
 import sys
-import textwrap
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, call
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from unittest.mock import AsyncMock, MagicMock
 
 # ---------------------------------------------------------------------------
 # sys.path fix: standalone agent packages live at

--- a/tests/test_agent_single_error_recovery.py
+++ b/tests/test_agent_single_error_recovery.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+Unit tests for agent_single.py error-recovery fixes.
+
+Fix A — Preserve ResponseFormat result across recursion-limit exceptions
+  When the deepagents graph hits its recursion limit AFTER a ResponseFormat
+  tool call has already been captured (i.e. the task finished but the graph
+  kept running), the exception handler was unconditionally wiping
+  `response_format_result = None`, discarding the valid result.
+
+  Fix: save `_saved_response_format = response_format_result` before the
+  reset when `is_recursion_limit`, then restore it after Phase-1 state
+  repair — so the caller receives the correct structured response instead
+  of the generic fallback "I ran into an issue…" message.
+
+Fix B — Phase-2 wrap-up: detect correct graph node name
+  Phase-2 recovery called `graph.aupdate_state(…, as_node="agent")`, but
+  the deepagents library names its main node "model", not "agent".  This
+  caused:
+      Phase 2 wrap-up failed: Node agent does not exist
+
+  Fix: detect the correct node name at runtime via
+      `set(getattr(self.graph, 'nodes', {}).keys())`
+  and fall back to "agent" when "model" is absent (standard LangGraph).
+
+Usage:
+    pytest tests/test_agent_single_error_recovery.py -v
+"""
+
+import ast
+import inspect
+import os
+import sys
+import textwrap
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+# ---------------------------------------------------------------------------
+# sys.path fix: standalone agent packages live at
+#   ai_platform_engineering/agents/<name>/  (each is its own Python package)
+# In deployed containers this is handled by sitecustomize.py; in the local
+# test environment we add the directories explicitly.
+# ---------------------------------------------------------------------------
+_AGENTS_BASE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "ai_platform_engineering",
+    "agents",
+)
+if os.path.isdir(_AGENTS_BASE):
+    for _agent_dir in os.listdir(_AGENTS_BASE):
+        _agent_path = os.path.join(_AGENTS_BASE, _agent_dir)
+        if os.path.isdir(_agent_path) and _agent_path not in sys.path:
+            sys.path.insert(0, _agent_path)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to construct minimal binding instances
+# ---------------------------------------------------------------------------
+
+def _make_binding():
+    """
+    Return an AIPlatformEngineerA2ABinding constructed without __init__,
+    matching the pattern used in test_supervisor_streaming_json_and_orphaned_tools.py.
+    """
+    from ai_platform_engineering.multi_agents.platform_engineer.protocol_bindings.a2a.agent_executor_single import (
+        AIPlatformEngineerA2ABinding,
+    )
+    binding = AIPlatformEngineerA2ABinding.__new__(AIPlatformEngineerA2ABinding)
+    binding.graph = MagicMock()
+    binding.graph.nodes = {"__start__": None, "model": None, "tools": None}
+    binding.graph.aget_state = AsyncMock(return_value=MagicMock(values={"messages": []}))
+    binding.graph.aupdate_state = AsyncMock()
+    binding.graph.astream = AsyncMock(return_value=_empty_aiter())
+    binding._mas_instance = MagicMock()
+    binding._mas_instance.get_rag_tool_names = MagicMock(return_value=set())
+    binding._in_self_service_workflow = False
+    return binding
+
+
+async def _empty_aiter():
+    """Async generator that yields nothing."""
+    return
+    yield  # make it an async generator
+
+
+# ---------------------------------------------------------------------------
+# Source-level (AST) tests — verify the fix exists in the source
+# ---------------------------------------------------------------------------
+
+class TestSourceLevelFixes:
+    """
+    Parse agent_single.py with ast and assert the two fixes are present.
+    These are fast, zero-dependency checks that the patches weren't
+    accidentally reverted.
+    """
+
+    def _get_source(self) -> str:
+        from ai_platform_engineering.multi_agents.platform_engineer.protocol_bindings.a2a import agent_single
+        return inspect.getsource(agent_single)
+
+    # ── Fix A: _saved_response_format ────────────────────────────────────────
+
+    def test_saved_response_format_variable_exists_in_source(self):
+        """The variable _saved_response_format must be assigned in stream()."""
+        src = self._get_source()
+        assert "_saved_response_format" in src, (
+            "_saved_response_format not found in agent_single.py — "
+            "Fix A (preserve ResponseFormat on recursion limit) may have been reverted"
+        )
+
+    def test_saved_response_format_is_conditional_on_recursion_limit(self):
+        """_saved_response_format should only be set when is_recursion_limit is True."""
+        src = self._get_source()
+        # The assignment must be guarded by is_recursion_limit
+        assert "is_recursion_limit" in src
+        # Ensure the save and restore pattern is present
+        assert "_saved_response_format = response_format_result if is_recursion_limit" in src, (
+            "Expected pattern '_saved_response_format = response_format_result if is_recursion_limit' "
+            "not found in agent_single.py"
+        )
+
+    def test_restore_of_saved_response_format_is_present(self):
+        """The restore block must exist after Phase-1 state repair."""
+        src = self._get_source()
+        assert "response_format_result = _saved_response_format" in src, (
+            "Restore of _saved_response_format not found — the fix may be incomplete"
+        )
+
+    # ── Fix B: dynamic node name detection ───────────────────────────────────
+
+    def test_dynamic_agent_node_detection_present(self):
+        """
+        The Phase-2 wrap-up must detect the graph node name at runtime
+        rather than hard-coding 'agent'.
+        """
+        src = self._get_source()
+        assert "_agent_node" in src, (
+            "_agent_node variable not found in agent_single.py — "
+            "Fix B (dynamic node name) may have been reverted"
+        )
+
+    def test_model_node_preferred_over_agent(self):
+        """The detection logic must prefer 'model' when present in graph.nodes."""
+        src = self._get_source()
+        assert '"model" if "model" in _graph_nodes else "agent"' in src, (
+            'Expected node detection: "model" if "model" in _graph_nodes else "agent"'
+        )
+
+    def test_as_node_uses_dynamic_variable(self):
+        """aupdate_state must be called with as_node=_agent_node, not as_node='agent'."""
+        src = self._get_source()
+        assert 'as_node=_agent_node' in src, (
+            "as_node= must reference _agent_node, not the hardcoded string 'agent'"
+        )
+        # The old hardcoded as_node="agent" must NOT exist in the Phase-2 block.
+        # We check there's no raw as_node="agent" string (allowing for the comment).
+        lines_with_as_node_agent = [
+            line for line in src.splitlines()
+            if 'as_node="agent"' in line and not line.strip().startswith("#")
+        ]
+        assert not lines_with_as_node_agent, (
+            f"Found hardcoded as_node=\"agent\" in non-comment lines: {lines_with_as_node_agent}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the node-name detection logic (Fix B)
+# ---------------------------------------------------------------------------
+
+class TestPhase2WrapupNodeDetection:
+    """
+    Verify that _agent_node resolves to the correct value for different
+    graph node layouts.
+    """
+
+    def _detect_agent_node(self, graph_nodes: dict) -> str:
+        """Replicate the detection logic from agent_single.py (graph.nodes is a dict)."""
+        _graph_nodes = set(graph_nodes.keys())
+        return "model" if "model" in _graph_nodes else "agent"
+
+    def test_deepagents_graph_resolves_to_model(self):
+        """deepagents graph has 'model' as its main node."""
+        nodes = {
+            "__start__": None, "model": None, "tools": None,
+            "TodoListMiddleware.after_model": None,
+            "SummarizationMiddleware.before_model": None,
+            "PatchToolCallsMiddleware.before_agent": None,
+        }
+        assert self._detect_agent_node(nodes) == "model"
+
+    def test_standard_langgraph_resolves_to_agent(self):
+        """Standard LangGraph supervisor has 'agent' as its main node."""
+        nodes = {"__start__": None, "agent": None, "tools": None}
+        assert self._detect_agent_node(nodes) == "agent"
+
+    def test_empty_nodes_falls_back_to_agent(self):
+        """Gracefully falls back to 'agent' when nodes is empty."""
+        assert self._detect_agent_node({}) == "agent"
+
+    def test_graph_with_both_model_and_agent_prefers_model(self):
+        """If both exist, 'model' wins (deepagents takes priority)."""
+        nodes = {"model": None, "agent": None, "tools": None}
+        assert self._detect_agent_node(nodes) == "model"
+
+    def test_aupdate_state_called_with_model_for_deepagents_graph(self):
+        """
+        When graph.nodes contains 'model', aupdate_state should be called
+        with as_node='model' during Phase-2 wrap-up.
+        """
+        binding = _make_binding()
+        # Verify that when graph.nodes contains 'model', _agent_node → 'model'
+        _graph_nodes = set(getattr(binding.graph, 'nodes', {}).keys())
+        _agent_node = "model" if "model" in _graph_nodes else "agent"
+        assert _agent_node == "model"
+
+    def test_aupdate_state_called_with_agent_for_standard_graph(self):
+        """When graph.nodes contains 'agent' but not 'model', _agent_node → 'agent'."""
+        binding = _make_binding()
+        binding.graph.nodes = {"__start__": None, "agent": None, "tools": None}
+        _graph_nodes = set(getattr(binding.graph, 'nodes', {}).keys())
+        _agent_node = "model" if "model" in _graph_nodes else "agent"
+        assert _agent_node == "agent"
+
+    def test_getattr_fallback_when_nodes_missing(self):
+        """When graph has no .nodes attribute, falls back to 'agent' safely."""
+        binding = _make_binding()
+        del binding.graph.nodes  # simulate graph without .nodes
+        _graph_nodes = set(getattr(binding.graph, 'nodes', {}).keys())
+        _agent_node = "model" if "model" in _graph_nodes else "agent"
+        assert _agent_node == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _saved_response_format preservation logic (Fix A)
+# ---------------------------------------------------------------------------
+
+class TestResponseFormatPreservationOnRecursionLimit:
+    """
+    Verify the _saved_response_format save/restore logic.
+
+    We test the branching conditions directly since driving the full
+    stream() generator requires a complex graph fixture.  The source-level
+    tests above guarantee the logic is wired into the right location.
+    """
+
+    def _run_save_restore(
+        self,
+        response_format_result,
+        is_recursion_limit: bool,
+    ):
+        """
+        Simulate the save-and-restore block from agent_single.py:
+
+            _saved_response_format = response_format_result if is_recursion_limit else None
+            response_format_result = None
+            # ... Phase-1 state repair ...
+            if _saved_response_format and not response_format_result:
+                response_format_result = _saved_response_format
+
+        Returns the final response_format_result.
+        """
+        # Step 1: save
+        _saved_response_format = response_format_result if is_recursion_limit else None
+        response_format_result = None
+
+        # Step 2: restore (Phase-1 did not set a new result)
+        if _saved_response_format and not response_format_result:
+            response_format_result = _saved_response_format
+
+        return response_format_result
+
+    # ── Recursion limit with a pre-captured result ────────────────────────────
+
+    def test_result_is_restored_when_recursion_limit_and_pre_captured_result(self):
+        pre = {"content": "Webex message sent.", "is_task_complete": True, "require_user_input": False}
+        result = self._run_save_restore(pre, is_recursion_limit=True)
+        assert result == pre
+
+    def test_restored_result_has_correct_content(self):
+        pre = {"content": "Done.", "is_task_complete": True, "require_user_input": False}
+        result = self._run_save_restore(pre, is_recursion_limit=True)
+        assert result["content"] == "Done."
+        assert result["is_task_complete"] is True
+
+    # ── Non-recursion error must NOT restore ─────────────────────────────────
+
+    def test_result_is_not_restored_for_non_recursion_errors(self):
+        """Context overflow and other errors should NOT restore a stale result."""
+        pre = {"content": "Old result.", "is_task_complete": True, "require_user_input": False}
+        result = self._run_save_restore(pre, is_recursion_limit=False)
+        assert result is None
+
+    def test_result_is_not_restored_for_context_overflow(self):
+        pre = {"content": "Pre-overflow result.", "is_task_complete": True, "require_user_input": False}
+        result = self._run_save_restore(pre, is_recursion_limit=False)
+        assert result is None
+
+    # ── No pre-captured result ────────────────────────────────────────────────
+
+    def test_none_pre_result_stays_none_on_recursion_limit(self):
+        """If ResponseFormat was never captured before the limit, result stays None."""
+        result = self._run_save_restore(None, is_recursion_limit=True)
+        assert result is None
+
+    # ── Fallback message is NOT returned when result is preserved ─────────────
+
+    def test_fallback_message_not_needed_when_result_is_restored(self):
+        """
+        Verify that once _saved_response_format is restored, the code path
+        that would yield the fallback error string is skipped.
+
+        The fallback is only yielded when `not response_format_result` after
+        all recovery attempts.  We confirm the restored result is truthy.
+        """
+        pre = {"content": "Task complete.", "is_task_complete": True, "require_user_input": False}
+        result = self._run_save_restore(pre, is_recursion_limit=True)
+
+        fallback_message = (
+            "I ran into an issue while processing your request. "
+            "Please ask me to continue or try your question again."
+        )
+        # result is truthy → fallback would not be emitted
+        assert result  # truthy
+        assert result.get("content") != fallback_message
+
+    # ── Idempotency: Phase-1 result takes priority ────────────────────────────
+
+    def test_phase1_result_overrides_saved_result(self):
+        """
+        If Phase-1 recovery somehow produced a new response_format_result,
+        the saved value should NOT clobber it (the `not response_format_result`
+        guard prevents this).
+        """
+        pre = {"content": "Saved.", "is_task_complete": True, "require_user_input": False}
+        _saved_response_format = pre if True else None  # is_recursion_limit=True
+        response_format_result = None
+
+        # Simulate Phase-1 producing a new result
+        response_format_result = {"content": "Phase-1 recovery.", "is_task_complete": True, "require_user_input": False}
+
+        # Restore guard
+        if _saved_response_format and not response_format_result:
+            response_format_result = _saved_response_format
+
+        assert response_format_result["content"] == "Phase-1 recovery."
+
+
+# ---------------------------------------------------------------------------
+# Integration: _repair_orphaned_tool_calls is still called during recovery
+# ---------------------------------------------------------------------------
+
+class TestRepairIsCalledOnRecursionLimit:
+    """
+    _repair_orphaned_tool_calls must still be invoked even when
+    is_recursion_limit is True (Phase-1 state repair is always attempted).
+    """
+
+    def test_repair_method_is_defined_on_binding(self):
+        binding = _make_binding()
+        assert hasattr(binding, '_repair_orphaned_tool_calls') or True
+        # The method must exist in the class
+        from ai_platform_engineering.multi_agents.platform_engineer.protocol_bindings.a2a.agent_executor_single import (
+            AIPlatformEngineerA2ABinding,
+        )
+        assert hasattr(AIPlatformEngineerA2ABinding, '_repair_orphaned_tool_calls')

--- a/tests/test_task_config_user_scoping.py
+++ b/tests/test_task_config_user_scoping.py
@@ -8,11 +8,14 @@ Run with: PYTHONPATH=. uv run pytest tests/test_task_config_user_scoping.py -v
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).parents[1]))
 
-from ai_platform_engineering.utils.mongodb_client import get_task_configs_for_user
+from ai_platform_engineering.utils.mongodb_client import (
+    _get_user_team_ids,
+    get_task_configs_for_user,
+)
 
 
 SAMPLE_CONFIGS = {
@@ -138,3 +141,261 @@ class TestGetTaskConfigsForUserDefaults:
         result = get_task_configs_for_user(user_email=None)
         assert result is not None
         assert "Old Task" in result
+
+
+# ============================================================================
+# Team-visibility tests (visibility="team" + shared_with_teams)
+# ============================================================================
+
+TEAM_CONFIGS = {
+    # System / global — always visible
+    "Global Task": {
+        "tasks": [{"display_text": "G", "llm_prompt": "global op", "subagent": "caipe"}],
+        "owner_id": "system",
+        "is_system": True,
+        "visibility": "global",
+        "shared_with_teams": [],
+    },
+    # Shared with team-a and team-b
+    "Team AB Workflow": {
+        "tasks": [{"display_text": "T", "llm_prompt": "team op", "subagent": "caipe"}],
+        "owner_id": "alice@example.com",
+        "is_system": False,
+        "visibility": "team",
+        "shared_with_teams": ["team-a", "team-b"],
+    },
+    # Shared with team-c only
+    "Team C Workflow": {
+        "tasks": [{"display_text": "C", "llm_prompt": "team c op", "subagent": "caipe"}],
+        "owner_id": "charlie@example.com",
+        "is_system": False,
+        "visibility": "team",
+        "shared_with_teams": ["team-c"],
+    },
+    # Private — only owner sees it
+    "Owner-Only Task": {
+        "tasks": [{"display_text": "O", "llm_prompt": "private op", "subagent": "caipe"}],
+        "owner_id": "alice@example.com",
+        "is_system": False,
+        "visibility": "private",
+        "shared_with_teams": [],
+    },
+}
+
+
+@patch(
+    "ai_platform_engineering.utils.mongodb_client.get_task_configs_from_mongodb",
+    return_value=TEAM_CONFIGS,
+)
+class TestTeamVisibilityFiltering:
+    """Tests for visibility='team' filtering in get_task_configs_for_user."""
+
+    def test_member_of_team_a_sees_team_ab_workflow(self, mock_get):
+        """User in team-a can see Team AB Workflow."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=["team-a"],
+        ):
+            result = get_task_configs_for_user(user_email="alice@example.com")
+        assert "Team AB Workflow" in result
+
+    def test_member_of_team_b_sees_team_ab_workflow(self, mock_get):
+        """User in team-b can also see Team AB Workflow."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=["team-b"],
+        ):
+            result = get_task_configs_for_user(user_email="bob@example.com")
+        assert "Team AB Workflow" in result
+
+    def test_member_of_team_c_sees_team_c_workflow(self, mock_get):
+        """User in team-c sees Team C Workflow but not Team AB Workflow."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=["team-c"],
+        ):
+            result = get_task_configs_for_user(user_email="carol@example.com")
+        assert "Team C Workflow" in result
+        assert "Team AB Workflow" not in result
+
+    def test_user_not_in_any_team_does_not_see_team_workflows(self, mock_get):
+        """User with no team memberships cannot see any team-scoped workflows."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=[],
+        ):
+            result = get_task_configs_for_user(user_email="stranger@example.com")
+        assert "Team AB Workflow" not in result
+        assert "Team C Workflow" not in result
+        assert "Global Task" in result
+
+    def test_no_email_does_not_trigger_team_lookup(self, mock_get):
+        """When user_email is None no team IDs should be fetched."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+        ) as mock_team_ids:
+            result = get_task_configs_for_user(user_email=None)
+        mock_team_ids.assert_not_called()
+        assert "Team AB Workflow" not in result
+        assert "Team C Workflow" not in result
+        assert "Global Task" in result
+
+    def test_team_lookup_is_lazy_called_at_most_once(self, mock_get):
+        """_get_user_team_ids is called at most once even with multiple team configs."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=["team-a"],
+        ) as mock_team_ids:
+            get_task_configs_for_user(user_email="dave@example.com")
+        # Both Team AB Workflow and Team C Workflow are team-scoped; IDs resolved once
+        assert mock_team_ids.call_count == 1
+
+    def test_team_workflow_with_empty_shared_with_teams_is_excluded_for_non_owner(self, mock_get):
+        """A team-visibility config with shared_with_teams=[] is not shown to a non-owner."""
+        mock_get.return_value = {
+            "Empty Teams Config": {
+                "tasks": [{"display_text": "E", "llm_prompt": "empty", "subagent": "caipe"}],
+                "owner_id": "alice@example.com",
+                "is_system": False,
+                "visibility": "team",
+                "shared_with_teams": [],
+            }
+        }
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=["team-a"],
+        ):
+            # bob is in team-a but shared_with_teams is empty → not visible to bob
+            result = get_task_configs_for_user(user_email="bob@example.com")
+        assert result is None  # no visible configs at all for non-owner
+
+    def test_owner_sees_own_team_workflow_without_team_membership(self, mock_get):
+        """Owner of a team workflow sees it via owner_id match, not team lookup."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=[],
+        ) as mock_team_ids:
+            result = get_task_configs_for_user(user_email="alice@example.com")
+        # alice@example.com owns "Team AB Workflow" — seen via owner_id branch
+        assert "Team AB Workflow" in result
+        # Team lookup should NOT have been called for alice's own config (owner branch matches first)
+        # (it may still be called for "Team C Workflow" which alice doesn't own)
+
+    def test_global_and_system_always_visible_regardless_of_teams(self, mock_get):
+        """Global task visible to every user, even those with no teams."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=[],
+        ):
+            result = get_task_configs_for_user(user_email="anyone@example.com")
+        assert "Global Task" in result
+
+    def test_private_task_hidden_from_non_owner_team_member(self, mock_get):
+        """Owner-Only Task is not visible to a team member who is not the owner."""
+        with patch(
+            "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
+            return_value=["team-a", "team-b"],
+        ):
+            result = get_task_configs_for_user(user_email="bob@example.com")
+        assert "Owner-Only Task" not in result
+
+
+# ============================================================================
+# _get_user_team_ids unit tests
+# ============================================================================
+
+
+class TestGetUserTeamIds:
+    """Unit tests for _get_user_team_ids using a mocked MongoDB client."""
+
+    def _make_mock_client(self, team_docs: list) -> MagicMock:
+        """Return a mock MongoClient whose teams.find() returns team_docs."""
+        mock_find = MagicMock(return_value=iter(team_docs))
+        mock_teams_coll = MagicMock()
+        mock_teams_coll.find = mock_find
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(return_value=mock_teams_coll)
+        mock_client = MagicMock()
+        mock_client.__getitem__ = MagicMock(return_value=mock_db)
+        return mock_client
+
+    def test_returns_team_ids_as_strings(self):
+        """Team _id values are converted to str."""
+        from bson import ObjectId
+
+        oid = ObjectId()
+        mock_client = self._make_mock_client([{"_id": oid}])
+        with (
+            patch("ai_platform_engineering.utils.mongodb_client.get_mongodb_client", return_value=mock_client),
+            patch.dict("os.environ", {"MONGODB_DATABASE": "caipe"}),
+        ):
+            result = _get_user_team_ids("alice@example.com")
+        assert result == [str(oid)]
+
+    def test_returns_multiple_team_ids(self):
+        """Multiple team memberships return all IDs."""
+        from bson import ObjectId
+
+        oids = [ObjectId(), ObjectId(), ObjectId()]
+        mock_client = self._make_mock_client([{"_id": o} for o in oids])
+        with (
+            patch("ai_platform_engineering.utils.mongodb_client.get_mongodb_client", return_value=mock_client),
+            patch.dict("os.environ", {"MONGODB_DATABASE": "caipe"}),
+        ):
+            result = _get_user_team_ids("alice@example.com")
+        assert result == [str(o) for o in oids]
+
+    def test_returns_empty_when_user_not_in_any_team(self):
+        """User in no teams returns empty list."""
+        mock_client = self._make_mock_client([])
+        with (
+            patch("ai_platform_engineering.utils.mongodb_client.get_mongodb_client", return_value=mock_client),
+            patch.dict("os.environ", {"MONGODB_DATABASE": "caipe"}),
+        ):
+            result = _get_user_team_ids("stranger@example.com")
+        assert result == []
+
+    def test_returns_empty_when_mongodb_unavailable(self):
+        """No MongoDB connection → empty list (no exception raised)."""
+        with patch("ai_platform_engineering.utils.mongodb_client.get_mongodb_client", return_value=None):
+            result = _get_user_team_ids("alice@example.com")
+        assert result == []
+
+    def test_returns_empty_on_pymongo_error(self):
+        """PyMongoError during find is caught and returns empty list."""
+        from pymongo.errors import PyMongoError
+
+        mock_teams_coll = MagicMock()
+        mock_teams_coll.find = MagicMock(side_effect=PyMongoError("connection reset"))
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(return_value=mock_teams_coll)
+        mock_client = MagicMock()
+        mock_client.__getitem__ = MagicMock(return_value=mock_db)
+
+        with (
+            patch("ai_platform_engineering.utils.mongodb_client.get_mongodb_client", return_value=mock_client),
+            patch.dict("os.environ", {"MONGODB_DATABASE": "caipe"}),
+        ):
+            result = _get_user_team_ids("alice@example.com")
+        assert result == []
+
+    def test_queries_teams_collection_by_member_user_id(self):
+        """Confirms the correct query filter is used: members.user_id == email."""
+        mock_find = MagicMock(return_value=iter([]))
+        mock_teams_coll = MagicMock()
+        mock_teams_coll.find = mock_find
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(return_value=mock_teams_coll)
+        mock_client = MagicMock()
+        mock_client.__getitem__ = MagicMock(return_value=mock_db)
+
+        with (
+            patch("ai_platform_engineering.utils.mongodb_client.get_mongodb_client", return_value=mock_client),
+            patch.dict("os.environ", {"MONGODB_DATABASE": "caipe"}),
+        ):
+            _get_user_team_ids("bob@example.com")
+
+        mock_find.assert_called_once_with(
+            {"members.user_id": "bob@example.com"},
+            {"_id": 1},
+        )

--- a/tests/test_task_config_user_scoping.py
+++ b/tests/test_task_config_user_scoping.py
@@ -274,7 +274,7 @@ class TestTeamVisibilityFiltering:
         with patch(
             "ai_platform_engineering.utils.mongodb_client._get_user_team_ids",
             return_value=[],
-        ) as mock_team_ids:
+        ):
             result = get_task_configs_for_user(user_email="alice@example.com")
         # alice@example.com owns "Team AB Workflow" — seen via owner_id branch
         assert "Team AB Workflow" in result

--- a/ui/src/app/api/__tests__/agents-tools-route.test.ts
+++ b/ui/src/app/api/__tests__/agents-tools-route.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for GET /api/agents/tools
+ *
+ * The route proxies to the supervisor's /tools endpoint using the
+ * internal (server-side) A2A URL, not the browser-facing public URL.
+ *
+ * Covers:
+ * - Happy path: supervisor returns tool map → 200 with { success: true, data: { tools } }
+ * - Supervisor returns non-2xx → 502 with { success: false, error }
+ * - Fetch throws (network error / timeout) → 502 with { success: false, error }
+ * - Auth forwarding: accessToken from session is sent as Bearer header
+ * - No auth: request proceeds without Authorization header when session is null
+ * - getInternalA2AUrl() is used (not getServerConfig().caipeUrl)
+ * - Supervisor response missing `tools` key defaults to {}
+ */
+
+// ============================================================================
+// Mocks — must be declared before any imports that reference them
+// ============================================================================
+
+const mockNextResponseJson = jest.fn(
+  (data: unknown, init?: { status?: number }) => ({
+    _isNextResponse: true,
+    json: async () => data,
+    status: init?.status ?? 200,
+  }),
+);
+
+jest.mock("next/server", () => ({
+  NextRequest: Request,
+  NextResponse: { json: (...args: unknown[]) => mockNextResponseJson(...args) },
+}));
+
+jest.mock("next-auth", () => ({ getServerSession: jest.fn() }));
+const mockGetServerSession =
+  jest.requireMock<{ getServerSession: jest.Mock }>("next-auth")
+    .getServerSession;
+
+jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
+
+const mockGetInternalA2AUrl = jest.fn().mockReturnValue("http://test-supervisor:8000");
+jest.mock("@/lib/config", () => ({
+  getInternalA2AUrl: (...args: unknown[]) => mockGetInternalA2AUrl(...args),
+}));
+
+jest.spyOn(console, "error").mockImplementation(() => {});
+jest.spyOn(console, "warn").mockImplementation(() => {});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Build a minimal mock fetch response */
+function makeFetchResponse(opts: {
+  ok: boolean;
+  status: number;
+  body?: unknown;
+}) {
+  return Promise.resolve({
+    ok: opts.ok,
+    status: opts.status,
+    json: async () => opts.body ?? {},
+  });
+}
+
+// ============================================================================
+// Subject under test
+// ============================================================================
+
+import { GET } from "../agents/tools/route";
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("GET /api/agents/tools", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetInternalA2AUrl.mockReturnValue("http://test-supervisor:8000");
+    mockGetServerSession.mockResolvedValue(null);
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      makeFetchResponse({ ok: true, status: 200, body: { tools: {} } }),
+    );
+  });
+
+  // ── URL construction ──────────────────────────────────────────────────────
+
+  it("calls getInternalA2AUrl() to build the supervisor URL", async () => {
+    await GET();
+    expect(mockGetInternalA2AUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches from <internalUrl>/tools", async () => {
+    mockGetInternalA2AUrl.mockReturnValue("http://internal-svc:9000");
+    await GET();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://internal-svc:9000/tools",
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT use getServerConfig() or caipeUrl", async () => {
+    // getServerConfig is not exported from our mock — if the route tried to
+    // call it the mock would throw 'not a function'.
+    await expect(GET()).resolves.not.toThrow();
+    // And the fetch target should be the internal URL, not a public one
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("test-supervisor"),
+      expect.any(Object),
+    );
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it("returns 200 with success:true and the tools map on a successful response", async () => {
+    const tools = { argocd: ["list_apps", "sync_app"], github: ["get_pr"] };
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      makeFetchResponse({ ok: true, status: 200, body: { tools } }),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { tools } });
+  });
+
+  it("defaults tools to {} when supervisor response omits the tools key", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      makeFetchResponse({ ok: true, status: 200, body: {} }),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body).toEqual({ success: true, data: { tools: {} } });
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  it("returns 502 with success:false when supervisor returns a non-2xx status", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      makeFetchResponse({ ok: false, status: 503, body: {} }),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("503");
+  });
+
+  it("returns 502 with the status code in the error message", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      makeFetchResponse({ ok: false, status: 401, body: {} }),
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.error).toMatch(/401/);
+  });
+
+  it("returns 502 when fetch throws a network error", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("ECONNREFUSED");
+  });
+
+  it("returns 502 with 'Supervisor unreachable' when a non-Error is thrown", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue("timeout");
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toBe("Supervisor unreachable");
+  });
+
+  // ── Auth forwarding ───────────────────────────────────────────────────────
+
+  it("forwards the OAuth2 access token as a Bearer header when a session exists", async () => {
+    mockGetServerSession.mockResolvedValue({ accessToken: "tok-abc123" });
+
+    await GET();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer tok-abc123",
+    });
+  });
+
+  it("sends no Authorization header when session is null", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    await GET();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers).not.toHaveProperty("Authorization");
+  });
+
+  it("sends no Authorization header when session has no accessToken", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { email: "a@b.com" } });
+
+    await GET();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers).not.toHaveProperty("Authorization");
+  });
+
+  it("continues without auth (no throw) when getServerSession rejects", async () => {
+    mockGetServerSession.mockRejectedValue(new Error("session store unavailable"));
+
+    await expect(GET()).resolves.toBeDefined();
+    // fetch should still be called — auth failure is non-fatal
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Accept header ─────────────────────────────────────────────────────────
+
+  it("always sends Accept: application/json", async () => {
+    await GET();
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers).toMatchObject({ Accept: "application/json" });
+  });
+});

--- a/ui/src/app/unauthorized/__tests__/page.test.tsx
+++ b/ui/src/app/unauthorized/__tests__/page.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Tests for /unauthorized page
+ *
+ * The page renders the OIDC required group name in two places:
+ *   1. <code> inside "Required Group Membership" box
+ *   2. <strong> inside the "Contact your IT administrator" bullet
+ *
+ * Before this fix the page imported REQUIRED_GROUP from the server-side
+ * auth-config module — which is always `undefined` in a "use client"
+ * component — so it rendered the hardcoded fallback string regardless
+ * of the actual OIDC_REQUIRED_GROUP env var.
+ *
+ * After the fix it reads `config.oidcRequiredGroup` from window.__APP_CONFIG__
+ * (the runtime-injected client config object).
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that reference them
+// ---------------------------------------------------------------------------
+
+const mockSignOut = jest.fn();
+jest.mock("next-auth/react", () => ({
+  signOut: (...args: unknown[]) => mockSignOut(...args),
+}));
+
+// framer-motion — render children without animation overhead
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...rest}>{children}</div>
+    ),
+  },
+}));
+
+// lucide-react — lightweight stub so tests don't depend on SVG rendering
+jest.mock("lucide-react", () => ({
+  ShieldX: () => <span data-testid="icon-shield-x" />,
+  LogOut: () => <span data-testid="icon-logout" />,
+  Mail: () => <span data-testid="icon-mail" />,
+}));
+
+// shadcn Button — pass-through
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, asChild, ...rest }: React.HTMLAttributes<HTMLButtonElement> & { asChild?: boolean; onClick?: () => void }) => {
+    if (asChild) {
+      return <div {...rest}>{children}</div>;
+    }
+    return (
+      <button onClick={onClick} {...rest}>
+        {children}
+      </button>
+    );
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Config mock — patched per test via mockReturnValue / mockImplementation
+// ---------------------------------------------------------------------------
+
+const mockConfig = {
+  oidcRequiredGroup: "backstage-access",
+  supportEmail: "support@example.com",
+  appName: "CAIPE",
+  tagline: "AI Platform Engineering",
+};
+
+jest.mock("@/lib/config", () => ({
+  config: new Proxy(
+    {},
+    {
+      get: (_target, key: string) => mockConfig[key as keyof typeof mockConfig],
+    },
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Subject under test — imported AFTER mocks are set up
+// ---------------------------------------------------------------------------
+
+import UnauthorizedPage from "../page";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UnauthorizedPage", () => {
+  beforeEach(() => {
+    // Reset to safe defaults before each test
+    mockConfig.oidcRequiredGroup = "backstage-access";
+    mockConfig.supportEmail = "support@example.com";
+    mockConfig.appName = "CAIPE";
+    mockConfig.tagline = "AI Platform Engineering";
+    mockSignOut.mockReset();
+  });
+
+  // ── Group name rendering ──────────────────────────────────────────────────
+
+  describe("required group display", () => {
+    it("renders the default group name in the code block", () => {
+      render(<UnauthorizedPage />);
+      expect(screen.getByRole("code")).toHaveTextContent("backstage-access");
+    });
+
+    it("renders a custom group name from config.oidcRequiredGroup in the code block", () => {
+      mockConfig.oidcRequiredGroup = "my-org-platform-users";
+      render(<UnauthorizedPage />);
+      expect(screen.getByRole("code")).toHaveTextContent("my-org-platform-users");
+    });
+
+    it("renders the group name in the <strong> contact-admin bullet", () => {
+      mockConfig.oidcRequiredGroup = "acme-engineers";
+      render(<UnauthorizedPage />);
+      // The strong element inside the list item contains the group name
+      const strongs = screen.getAllByText("acme-engineers");
+      const strongEl = strongs.find((el) => el.tagName === "STRONG");
+      expect(strongEl).toBeTruthy();
+    });
+
+    it("renders the group name in BOTH places consistently", () => {
+      mockConfig.oidcRequiredGroup = "platform-team";
+      render(<UnauthorizedPage />);
+      const all = screen.getAllByText("platform-team");
+      // code block + strong element = 2 occurrences
+      expect(all.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("renders empty string gracefully (no crash) when oidcRequiredGroup is ''", () => {
+      mockConfig.oidcRequiredGroup = "";
+      expect(() => render(<UnauthorizedPage />)).not.toThrow();
+    });
+  });
+
+  // ── No server-side import regression ─────────────────────────────────────
+
+  it("does NOT import REQUIRED_GROUP from @/lib/auth-config", () => {
+    // If the page still imported from auth-config the jest.mock('@/lib/config')
+    // override above would have no effect and the group name would be undefined.
+    // We verify that the rendered output uses our mocked value, not undefined.
+    mockConfig.oidcRequiredGroup = "sentinel-value-12345";
+    render(<UnauthorizedPage />);
+    expect(screen.getByRole("code")).toHaveTextContent("sentinel-value-12345");
+    expect(screen.getByRole("code")).not.toHaveTextContent("undefined");
+    expect(screen.getByRole("code")).not.toHaveTextContent("backstage-access");
+  });
+
+  // ── Static content ────────────────────────────────────────────────────────
+
+  it("renders Access Denied heading", () => {
+    render(<UnauthorizedPage />);
+    expect(
+      screen.getByRole("heading", { name: /access denied/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the sign-out button", () => {
+    render(<UnauthorizedPage />);
+    expect(
+      screen.getByRole("button", { name: /sign out/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a contact-support mailto link", () => {
+    mockConfig.supportEmail = "help@mycompany.com";
+    mockConfig.appName = "MyApp";
+    render(<UnauthorizedPage />);
+    const link = screen.getByRole("link", { name: /contact support/i });
+    expect(link).toHaveAttribute(
+      "href",
+      expect.stringContaining("help@mycompany.com"),
+    );
+    expect(link).toHaveAttribute("href", expect.stringContaining("MyApp"));
+  });
+
+  it("renders appName and tagline in the footer", () => {
+    mockConfig.appName = "TestApp";
+    mockConfig.tagline = "Tagline Text";
+    render(<UnauthorizedPage />);
+    expect(screen.getByText(/TestApp.*Tagline Text/)).toBeInTheDocument();
+  });
+
+  // ── Interactions ──────────────────────────────────────────────────────────
+
+  it("calls signOut with callbackUrl '/login' when sign-out button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<UnauthorizedPage />);
+    await user.click(screen.getByRole("button", { name: /sign out/i }));
+    expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/login" });
+  });
+});

--- a/ui/src/app/unauthorized/page.tsx
+++ b/ui/src/app/unauthorized/page.tsx
@@ -5,10 +5,10 @@ import { signOut } from "next-auth/react";
 import { motion } from "framer-motion";
 import { ShieldX, LogOut, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { REQUIRED_GROUP } from "@/lib/auth-config";
 import { config } from "@/lib/config";
 
 export default function UnauthorizedPage() {
+  const requiredGroup = config.oidcRequiredGroup;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
@@ -44,7 +44,7 @@ export default function UnauthorizedPage() {
           <div className="bg-muted/50 rounded-lg p-4 mb-6 border border-border">
             <p className="text-xs text-muted-foreground mb-1">Required Group Membership</p>
             <code className="text-sm font-mono text-foreground bg-background px-2 py-1 rounded">
-              {REQUIRED_GROUP}
+              {requiredGroup}
             </code>
           </div>
 
@@ -54,7 +54,7 @@ export default function UnauthorizedPage() {
             <ul className="text-sm text-muted-foreground space-y-2">
               <li className="flex items-start gap-2">
                 <span className="text-primary mt-0.5">•</span>
-                Contact your IT administrator to request access to the <strong>{REQUIRED_GROUP}</strong> group
+                Contact your IT administrator to request access to the <strong>{requiredGroup}</strong> group
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-primary mt-0.5">•</span>

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -146,6 +146,7 @@ describe('getServerConfig', () => {
         'jiraTicketEnabled', 'jiraTicketProject', 'jiraTicketLabel',
         'githubTicketEnabled', 'githubTicketRepo', 'githubTicketLabel',
         'ticketEnabled', 'ticketProvider',
+        'oidcRequiredGroup',
       ];
       expect(Object.keys(cfg).sort()).toEqual(expectedKeys.sort());
     });
@@ -828,6 +829,7 @@ describe('getClientConfigScript (XSS safety)', () => {
       'jiraTicketEnabled', 'jiraTicketProject', 'jiraTicketLabel',
       'githubTicketEnabled', 'githubTicketRepo', 'githubTicketLabel',
       'ticketEnabled', 'ticketProvider',
+      'oidcRequiredGroup',
     ];
     expect(Object.keys(parsed).sort()).toEqual(expectedKeys.sort());
   });

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -19,6 +19,7 @@ import {
   getConfig,
   getLogoFilterClass,
   getClientConfigScript,
+  getInternalA2AUrl,
   config,
 } from '../config';
 import type { Config } from '../config';
@@ -721,6 +722,94 @@ describe('getServerConfig', () => {
       process.env.NEXT_PUBLIC_GRADIENT_FROM = '#aabbcc';
       expect(getServerConfig().gradientFrom).toBe('#aabbcc');
     });
+  });
+
+  // ---------- oidcRequiredGroup ----------
+
+  describe('oidcRequiredGroup', () => {
+    beforeEach(() => {
+      delete process.env.OIDC_REQUIRED_GROUP;
+    });
+
+    it('defaults to "backstage-access" when OIDC_REQUIRED_GROUP is not set', () => {
+      expect(getServerConfig().oidcRequiredGroup).toBe('backstage-access');
+    });
+
+    it('reads a custom value from OIDC_REQUIRED_GROUP', () => {
+      process.env.OIDC_REQUIRED_GROUP = 'my-org-platform-users';
+      expect(getServerConfig().oidcRequiredGroup).toBe('my-org-platform-users');
+    });
+
+    it('falls back to the default when OIDC_REQUIRED_GROUP is an empty string', () => {
+      // config.ts uses || so an empty string is treated as absent
+      process.env.OIDC_REQUIRED_GROUP = '';
+      expect(getServerConfig().oidcRequiredGroup).toBe('backstage-access');
+    });
+  });
+});
+
+// ==========================================================================
+// getInternalA2AUrl — server-side internal supervisor URL
+// ==========================================================================
+
+describe('getInternalA2AUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    clearEnv('A2A_BASE_URL');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns the default internal URL when A2A_BASE_URL is not set', () => {
+    expect(getInternalA2AUrl()).toBe('http://caipe-supervisor:8000');
+  });
+
+  it('returns the A2A_BASE_URL value when set', () => {
+    process.env.A2A_BASE_URL = 'http://docker-internal:9090';
+    expect(getInternalA2AUrl()).toBe('http://docker-internal:9090');
+  });
+
+  it('strips a trailing slash from the URL', () => {
+    process.env.A2A_BASE_URL = 'http://svc:8000/';
+    expect(getInternalA2AUrl()).toBe('http://svc:8000');
+  });
+
+  it('accepts NEXT_PUBLIC_A2A_BASE_URL as a fallback when A2A_BASE_URL is absent', () => {
+    process.env.NEXT_PUBLIC_A2A_BASE_URL = 'https://public-fallback:8000';
+    expect(getInternalA2AUrl()).toBe('https://public-fallback:8000');
+  });
+
+  it('A2A_BASE_URL takes precedence over NEXT_PUBLIC_A2A_BASE_URL', () => {
+    process.env.A2A_BASE_URL = 'http://internal:8000';
+    process.env.NEXT_PUBLIC_A2A_BASE_URL = 'https://external:8000';
+    expect(getInternalA2AUrl()).toBe('http://internal:8000');
+  });
+
+  // ── Critical separation test ──────────────────────────────────────────────
+  // When A2A_BASE_URL (internal) and NEXT_PUBLIC_A2A_BASE_URL (external) are
+  // both set, they must remain independent — the route.ts uses getInternalA2AUrl()
+  // while the browser receives NEXT_PUBLIC_A2A_BASE_URL via window.__APP_CONFIG__.
+
+  it('getInternalA2AUrl and getServerConfig().caipeUrl are independent when both env vars are set', () => {
+    process.env.A2A_BASE_URL = 'http://caipe-supervisor.caipe.svc.cluster.local:8000';
+    process.env.NEXT_PUBLIC_A2A_BASE_URL = 'https://caipe-devnet.cisco.com';
+
+    expect(getInternalA2AUrl()).toBe(
+      'http://caipe-supervisor.caipe.svc.cluster.local:8000',
+    );
+    expect(getServerConfig().caipeUrl).toBe('https://caipe-devnet.cisco.com');
+  });
+
+  it('getServerConfig().caipeUrl does NOT use A2A_BASE_URL', () => {
+    process.env.A2A_BASE_URL = 'http://docker-internal:8000';
+    delete process.env.NEXT_PUBLIC_A2A_BASE_URL;
+    // caipeUrl should fall back to its own default, not pick up A2A_BASE_URL
+    expect(getServerConfig().caipeUrl).toBe('http://localhost:8000');
   });
 });
 

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -131,15 +131,17 @@ export function isAdminUser(groups: string[]): boolean {
   });
 }
 
-// Helper to check if user can access dynamic agents
-// If OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP is set, user must be in that group
-// If not set, falls back to requiring admin group membership
+// Helper to check if user can access dynamic agents.
+// Admins always have access. If OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP is set,
+// members of that group also have access. Otherwise only admins.
 export function canAccessDynamicAgents(groups: string[]): boolean {
+  // Admins always get dynamic agents access
+  if (isAdminUser(groups)) return true;
   if (REQUIRED_DYNAMIC_AGENTS_GROUP) {
     const requiredLower = REQUIRED_DYNAMIC_AGENTS_GROUP.toLowerCase();
     return groups.some(g => g.toLowerCase() === requiredLower || g.toLowerCase().includes(`cn=${requiredLower}`));
   }
-  return isAdminUser(groups);
+  return false;
 }
 
 // Helper to check if user can view admin dashboard (read-only)
@@ -439,12 +441,11 @@ export const authOptions: NextAuthOptions = {
       // admin view group is configured (all authenticated users can view).
       session.canViewAdmin = (token.canViewAdmin as boolean)
         ?? (REQUIRED_ADMIN_VIEW_GROUP === '' ? true : false);
-      // For pre-upgrade JWTs that lack canAccessDynamicAgents:
-      // - If OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP is unset, fall back to admin check
-      //   (same logic as canAccessDynamicAgents() at sign-in time)
-      // - If it IS set, deny access — user must re-login to get the right claim
-      session.canAccessDynamicAgents = (token.canAccessDynamicAgents as boolean)
-        ?? (REQUIRED_DYNAMIC_AGENTS_GROUP === '' ? session.role === 'admin' : false);
+      // Admins always get dynamic agents access, regardless of what the JWT says.
+      // This covers both pre-upgrade tokens (missing field) and tokens computed
+      // before canAccessDynamicAgents() was updated to include the admin check.
+      session.canAccessDynamicAgents = (token.canAccessDynamicAgents === true)
+        || (session.role === 'admin');
 
       // If token refresh failed, mark session as invalid and DON'T include tokens
       if (token.error === "RefreshTokenExpired" || token.error === "RefreshTokenError") {

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -439,8 +439,12 @@ export const authOptions: NextAuthOptions = {
       // admin view group is configured (all authenticated users can view).
       session.canViewAdmin = (token.canViewAdmin as boolean)
         ?? (REQUIRED_ADMIN_VIEW_GROUP === '' ? true : false);
+      // For pre-upgrade JWTs that lack canAccessDynamicAgents:
+      // - If OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP is unset, fall back to admin check
+      //   (same logic as canAccessDynamicAgents() at sign-in time)
+      // - If it IS set, deny access — user must re-login to get the right claim
       session.canAccessDynamicAgents = (token.canAccessDynamicAgents as boolean)
-        ?? (REQUIRED_DYNAMIC_AGENTS_GROUP === '' ? false : false);
+        ?? (REQUIRED_DYNAMIC_AGENTS_GROUP === '' ? session.role === 'admin' : false);
 
       // If token refresh failed, mark session as invalid and DON'T include tokens
       if (token.error === "RefreshTokenExpired" || token.error === "RefreshTokenError") {

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -132,16 +132,16 @@ export function isAdminUser(groups: string[]): boolean {
 }
 
 // Helper to check if user can access dynamic agents.
-// Admins always have access. If OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP is set,
-// members of that group also have access. Otherwise only admins.
+// If OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP is set, only that group has access
+// (admin group membership does NOT automatically grant access in this case).
+// If unset, falls back to admin-only access.
 export function canAccessDynamicAgents(groups: string[]): boolean {
-  // Admins always get dynamic agents access
-  if (isAdminUser(groups)) return true;
   if (REQUIRED_DYNAMIC_AGENTS_GROUP) {
     const requiredLower = REQUIRED_DYNAMIC_AGENTS_GROUP.toLowerCase();
     return groups.some(g => g.toLowerCase() === requiredLower || g.toLowerCase().includes(`cn=${requiredLower}`));
   }
-  return false;
+  // No explicit group configured → admins only
+  return isAdminUser(groups);
 }
 
 // Helper to check if user can view admin dashboard (read-only)

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -31,8 +31,10 @@ export const ENABLE_REFRESH_TOKEN = process.env.OIDC_ENABLE_REFRESH_TOKEN !== "f
 // If not set, will auto-detect from common claim names
 export const GROUP_CLAIM = process.env.OIDC_GROUP_CLAIM || "";
 
-// Required group for authorization
-export const REQUIRED_GROUP = process.env.OIDC_REQUIRED_GROUP || "backstage-access";
+// Required group for authorization.
+// Use ?? (nullish coalescing) so that setting OIDC_REQUIRED_GROUP="" disables
+// the group check. || would treat "" as falsy and fall back to "backstage-access".
+export const REQUIRED_GROUP = process.env.OIDC_REQUIRED_GROUP ?? "backstage-access";
 
 // Required admin group for admin access
 export const REQUIRED_ADMIN_GROUP = process.env.OIDC_REQUIRED_ADMIN_GROUP || "";

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -142,6 +142,8 @@ export interface Config {
   ticketEnabled: boolean;
   /** Derived: which provider to use ('jira' takes precedence when both enabled) */
   ticketProvider: 'jira' | 'github' | null;
+  /** OIDC group required for UI access (injected server-side so the unauthorized page shows the real group) */
+  oidcRequiredGroup: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,6 +212,7 @@ const DEFAULT_CONFIG: Config = {
   githubTicketLabel: 'caipe-reported',
   ticketEnabled: false,
   ticketProvider: null,
+  oidcRequiredGroup: 'backstage-access',
 };
 
 // ---------------------------------------------------------------------------
@@ -362,6 +365,7 @@ export function getServerConfig(): Config {
     githubTicketLabel,
     ticketEnabled,
     ticketProvider,
+    oidcRequiredGroup: process.env.OIDC_REQUIRED_GROUP || 'backstage-access',
   };
 }
 


### PR DESCRIPTION
## Summary

This PR bundles three related fixes discovered and diagnosed during deployment on kind-based demo environments.

### Fix 1: Unauthorized page shows hardcoded group name (original issue)

`unauthorized/page.tsx` imported `REQUIRED_GROUP` directly from `auth-config.ts`, a server-side module. Client components can't access server env vars, so it always rendered the hardcoded fallback \`backstage-access\` regardless of the actual \`OIDC_REQUIRED_GROUP\` env var.

- Switched to reading from `window.__APP_CONFIG__` (the runtime config object already injected by the server)
- Changed `||` to `??` so an empty-string env var doesn't fall back to the hardcoded default
- Added support for comma-separated `OIDC_REQUIRED_DYNAMIC_AGENTS_GROUP` values

### Fix 2: Task builder tools endpoint (502 on `/api/agents/tools`)

`/api/agents/tools` uses the internal k8s URL to reach the supervisor, but the browser health check uses the external URL — these were previously mutually exclusive. Also, in multi-node mode the supervisor has no `/tools` endpoint.

- Added `getInternalA2AUrl()` using server-only `A2A_BASE_URL` env var, separate from the browser-facing `NEXT_PUBLIC_A2A_BASE_URL`
- `/api/agents/tools/route.ts` now uses the internal URL for the supervisor fetch

### Fix 3: Supervisor returns "I ran into an issue" after successful tasks (single-node mode)

Two bugs in `agent_single.py` error recovery path, triggered when the deepagents graph hit its recursion limit after a task was already complete:

1. **`Node agent does not exist`**: Phase 2 wrap-up called `as_node="agent"` but the deepagents library names its main node `"model"`. Fixed to detect the correct node name at runtime.

2. **Valid result discarded**: When the recursion limit was hit *after* `ResponseFormat` was already captured (task completed successfully, graph just kept running), the exception handler unconditionally reset `response_format_result = None`. Fixed to preserve the pre-recursion result so successful tasks return the correct response instead of the fallback error message.

## Test plan

- [ ] Authenticated user not in required group sees the actual group name on `/unauthorized`
- [ ] Task builder loads agents (14 agents) via `/api/agents/tools` without 502
- [ ] Single-node supervisor: Webex send message completes with success response, not "I ran into an issue"
- [ ] Multi-node supervisor: unaffected (uses different graph with an `agent` node)