### PR TITLE
fix(a2a): move execution plan state to per-request StreamState to prevent cross-user leakage

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_executor.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_executor.py
@@ -905,40 +905,43 @@ class TestIsFinalAnswerTagging(unittest.IsolatedAsyncioTestCase):
 
     def test_last_plan_step_active_returns_true(self):
         executor = _make_executor()
-        executor._execution_plan_emitted = True
-        executor._latest_execution_plan = [
+        state = StreamState()
+        state.execution_plan_emitted = True
+        state.latest_execution_plan = [
             {'step_id': 's1', 'status': 'completed'},
             {'step_id': 's2', 'status': 'completed'},
             {'step_id': 's3', 'status': 'in_progress'},
         ]
-        executor._current_plan_step_id = 's3'
-        self.assertTrue(executor._is_last_plan_step_active())
+        state.current_plan_step_id = 's3'
+        self.assertTrue(executor._is_last_plan_step_active(state))
 
     def test_intermediate_step_active_returns_false(self):
         executor = _make_executor()
-        executor._execution_plan_emitted = True
-        executor._latest_execution_plan = [
+        state = StreamState()
+        state.execution_plan_emitted = True
+        state.latest_execution_plan = [
             {'step_id': 's1', 'status': 'completed'},
             {'step_id': 's2', 'status': 'in_progress'},
             {'step_id': 's3', 'status': 'pending'},
         ]
-        executor._current_plan_step_id = 's2'
-        self.assertFalse(executor._is_last_plan_step_active())
+        state.current_plan_step_id = 's2'
+        self.assertFalse(executor._is_last_plan_step_active(state))
 
     def test_no_plan_returns_false(self):
         executor = _make_executor()
-        self.assertFalse(executor._is_last_plan_step_active())
+        state = StreamState()
+        self.assertFalse(executor._is_last_plan_step_active(state))
 
     async def test_streaming_chunk_tagged_as_final_answer_when_last_step_active(self):
         executor = _make_executor()
-        executor._execution_plan_emitted = True
-        executor._latest_execution_plan = [
+
+        state = StreamState()
+        state.execution_plan_emitted = True
+        state.latest_execution_plan = [
             {'step_id': 's1', 'status': 'completed'},
             {'step_id': 's2', 'status': 'in_progress'},
         ]
-        executor._current_plan_step_id = 's2'
-
-        state = StreamState()
+        state.current_plan_step_id = 's2'
         task = _make_task()
         eq = _make_event_queue()
 
@@ -950,14 +953,14 @@ class TestIsFinalAnswerTagging(unittest.IsolatedAsyncioTestCase):
 
     async def test_streaming_chunk_not_tagged_when_intermediate_step(self):
         executor = _make_executor()
-        executor._execution_plan_emitted = True
-        executor._latest_execution_plan = [
+
+        state = StreamState()
+        state.execution_plan_emitted = True
+        state.latest_execution_plan = [
             {'step_id': 's1', 'status': 'in_progress'},
             {'step_id': 's2', 'status': 'pending'},
         ]
-        executor._current_plan_step_id = 's1'
-
-        state = StreamState()
+        state.current_plan_step_id = 's1'
         task = _make_task()
         eq = _make_event_queue()
 


### PR DESCRIPTION
## Summary

- **Root cause**: `AIPlatformEngineerA2AExecutor` is a singleton, but stored execution plan state (`_execution_plan_emitted`, `_execution_plan_artifact_id`, `_latest_execution_plan`) as instance variables. When two users sent concurrent requests, the second `execute()` call would reset/overwrite the first user's plan state, causing cross-user leakage (e.g., User A sees User B's TODO execution plan steps).
- **Fix**: Moved all three execution plan tracking fields from the singleton executor instance into the per-request `StreamState` dataclass. Each `execute()` call now gets its own isolated `StreamState`, so concurrent requests cannot interfere with each other's plan tracking.
- Updated `_ensure_execution_plan_completed()` to accept `state` parameter instead of reading `self._*` fields.

## Test plan

- [ ] Verify existing tests pass (pre-existing async test infra issue unrelated)
- [ ] Manual test: two concurrent self-service workflow requests should not leak execution plan steps between users
- [ ] Verify single-user workflow still shows correct execution plan progression

Made with [Cursor](https://cursor.com)