### PR TITLE
Potential fix for code scanning alert no. 1832: Artifact poisoning

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -32,7 +32,7 @@ jobs:
           name: coverage-reports-main
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./main-coverage/
+          path: ${{ runner.temp }}/coverage/main-coverage/
         continue-on-error: true
 
       # RAG tests disabled - uncomment when re-enabled
@@ -51,7 +51,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Check for main coverage
-          if [ -f "./main-coverage/coverage.xml" ]; then
+          if [ -f "${{ runner.temp }}/coverage/main-coverage/coverage.xml" ]; then
             echo "### Main Tests Coverage" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "Main test suite coverage data available" >> $GITHUB_STEP_SUMMARY
@@ -60,7 +60,7 @@ jobs:
           fi
 
           # Check for RAG coverage
-          if [ -f "./rag-coverage/coverage.xml" ]; then
+          if [ -f "${{ runner.temp }}/coverage/rag-coverage/coverage.xml" ]; then
             echo "### RAG Tests Coverage" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "RAG test suite coverage data available" >> $GITHUB_STEP_SUMMARY
@@ -68,13 +68,9 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ ! -f "./main-coverage/coverage.xml" ] && [ ! -f "./rag-coverage/coverage.xml" ]; then
+          if [ ! -f "${{ runner.temp }}/coverage/main-coverage/coverage.xml" ] && [ ! -f "${{ runner.temp }}/coverage/rag-coverage/coverage.xml" ]; then
             echo "❌ No coverage data available" >> $GITHUB_STEP_SUMMARY
           fi
-
-      - name: Install coverage parsing dependencies
-        run: |
-          npm install --ignore-scripts xml2js
 
       - name: Comment PR with coverage
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
Potential fix for [https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/1832](https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/1832)

Best fix: keep untrusted artifacts out of the workspace and remove unnecessary `npm install` in this privileged workflow.

Concretely in `.github/workflows/coverage-comment.yml`:

1. Change artifact download path from `./main-coverage/` to a temp directory under `${{ runner.temp }}`.
2. Update all coverage file checks to read from that temp location.
3. Remove the `Install coverage parsing dependencies` step (`npm install --ignore-scripts xml2js`) to eliminate the flagged sink and reduce attack surface.  
   - This does not change current behavior in the shown snippet because no demonstrated step here depends on that install for the summary generation.
   - If the later (omitted) `github-script` truly needs `xml2js`, the safe approach would be to avoid dynamic install in this job and use built-in parsing or a pinned prebuilt action/container. But with only shown code, the direct secure fix is to remove the install step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
