### PR TITLE
ci(release): add RC tag and Helm RC pipelines for release/* branches

### DIFF
--- a/.github/workflows/helm-rc-version-bump.yml
+++ b/.github/workflows/helm-rc-version-bump.yml
@@ -3,6 +3,11 @@ description: "Automatically bump chart versions for changed charts and their par
 
 on:
   pull_request:
+    # Exclude PRs targeting release/* branches — those use release-helm-rc.yml
+    # instead, which derives its version from the branch name rather than the
+    # latest stable release and never commits an auto-bump.
+    branches-ignore:
+      - 'release/**'
     paths:
       - 'charts/**'
     types: [opened, synchronize]

--- a/.github/workflows/release-helm-rc.yml
+++ b/.github/workflows/release-helm-rc.yml
@@ -8,10 +8,12 @@ description: "Publish Helm RC charts when charts change on a release/* branch"
 #  - No auto-bump commit — charts are packaged in-memory with the RC version
 #  - Works for both regular (release/0.3.0) and hotfix (release/0.2.41-hotfix) branches
 #
-# Helm RC version scheme:
-#   release/0.3.0         → 0.3.0-rc.helm.1,  0.3.0-rc.helm.2, …
+# Helm RC version scheme (matches image tag format exactly — no separate .helm. counter):
+#   release/0.3.0         → 0.3.0-rc.1,       0.3.0-rc.2, …
 #   release/0.2.41-hotfix → 0.2.41-hotfix.1,  0.2.41-hotfix.2, …
-#                           (hotfix Helm version matches the image tag exactly — no -rc.helm. infix)
+#
+# Both image tags and Helm chart versions share the same counter namespace, so
+# "0.3.0-rc.2" always refers to the same release state regardless of artifact type.
 
 on:
   push:
@@ -107,9 +109,11 @@ jobs:
             const releaseVersion = process.env.RELEASE_VERSION;
             const isHotfix = process.env.IS_HOTFIX === 'true';
 
-            // Hotfix:  Helm version == image tag: "0.2.41-hotfix.N"  → prefix "0.2.41-hotfix."
-            // Regular: separate Helm RC series:   "0.3.0-rc.helm.N"  → prefix "0.3.0-rc.helm."
-            const prefix = isHotfix ? `${releaseVersion}.` : `${releaseVersion}-rc.helm.`;
+            // Helm version shares the same counter as the image RC tags so that
+            // "0.3.0-rc.2" means the same release state for both artifact types.
+            // Regular: "0.3.0-rc.N"       → prefix "0.3.0-rc."
+            // Hotfix:  "0.2.41-hotfix.N"  → prefix "0.2.41-hotfix."
+            const prefix = isHotfix ? `${releaseVersion}.` : `${releaseVersion}-rc.`;
             const escapedPrefix = prefix.replace(/\./g, '\\.').replace(/-/g, '\\-');
             const tagPattern = new RegExp(`^${escapedPrefix}([0-9]+)$`);
 
@@ -153,12 +157,13 @@ jobs:
           IS_HOTFIX="${{ steps.version.outputs.is_hotfix }}"
           RC_NUM="${{ steps.helm-rc.outputs.number }}"
 
-          # Hotfix: version == image tag (0.2.41-hotfix.N)
-          # Regular: separate helm rc series (0.3.0-rc.helm.N)
+          # Helm version == image tag format (shared counter)
+          # Hotfix:  0.2.41-hotfix.N
+          # Regular: 0.3.0-rc.N
           if [[ "$IS_HOTFIX" == "true" ]]; then
             HELM_RC_VERSION="${RELEASE_VERSION}.${RC_NUM}"
           else
-            HELM_RC_VERSION="${RELEASE_VERSION}-rc.helm.${RC_NUM}"
+            HELM_RC_VERSION="${RELEASE_VERSION}-rc.${RC_NUM}"
           fi
 
           echo "helm_rc_version=$HELM_RC_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-helm-rc.yml
+++ b/.github/workflows/release-helm-rc.yml
@@ -1,0 +1,234 @@
+name: "[Release] Helm RC for Release Branches"
+description: "Publish Helm RC charts when charts change on a release/* branch"
+
+# Mirrors helm-rc-version-bump.yml + helm-pre-release.yml but for release/* branches.
+#
+# Key differences from the prebuild pipeline:
+#  - Version is pinned to the release branch name (NOT bumped from latest stable release)
+#  - No auto-bump commit — charts are packaged in-memory with the RC version
+#  - Works for both regular (release/0.3.0) and hotfix (release/0.2.41-hotfix) branches
+#
+# Helm RC version scheme:
+#   release/0.3.0        → 0.3.0-rc.helm.1,         0.3.0-rc.helm.2, …
+#   release/0.2.41-hotfix → 0.2.41-hotfix-rc.helm.1, 0.2.41-hotfix-rc.helm.2, …
+
+on:
+  push:
+    branches:
+      - 'release/**'
+    paths:
+      - 'charts/**'
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  publish-release-helm-rc:
+    name: Publish Release Helm RC
+    runs-on: ubuntu-latest
+    # Skip commits made by the bot (safety guard — this workflow never commits,
+    # but guard against accidental re-entrancy if that ever changes)
+    if: github.actor != 'github-actions[bot]'
+
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: 📥 Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: 🏷️ Parse release version from branch
+        id: version
+        run: |
+          # release/0.3.0         → RELEASE_VERSION=0.3.0,         IS_HOTFIX=false
+          # release/0.2.41-hotfix → RELEASE_VERSION=0.2.41-hotfix,  IS_HOTFIX=true
+          BRANCH="${GITHUB_REF#refs/heads/release/}"
+          echo "release_version=$BRANCH" >> $GITHUB_OUTPUT
+
+          if [[ "$BRANCH" == *"-hotfix"* ]]; then
+            echo "is_hotfix=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_hotfix=false" >> $GITHUB_OUTPUT
+          fi
+          echo "📦 Release version: $BRANCH"
+
+      - name: 🔍 Detect changed charts
+        id: detect
+        run: |
+          git fetch origin
+
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.ref_name }}^..HEAD | grep "^charts/" || true)
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "ℹ️  No chart files changed in this push"
+            echo "rag-stack-changed=false" >> $GITHUB_OUTPUT
+            echo "ai-platform-changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          RAG_STACK_CHANGED=false
+          AI_PLATFORM_CHANGED=false
+
+          if echo "$CHANGED_FILES" | grep -q "^charts/rag-stack/"; then
+            if echo "$CHANGED_FILES" | grep "^charts/rag-stack/" | grep -qv "Chart.lock$"; then
+              RAG_STACK_CHANGED=true
+              echo "✅ rag-stack chart has substantive changes"
+            fi
+          fi
+
+          if echo "$CHANGED_FILES" | grep -q "^charts/ai-platform-engineering/"; then
+            if echo "$CHANGED_FILES" | grep "^charts/ai-platform-engineering/" | grep -qv "Chart.lock$"; then
+              AI_PLATFORM_CHANGED=true
+              echo "✅ ai-platform-engineering chart has substantive changes"
+            fi
+          fi
+
+          echo "rag-stack-changed=$RAG_STACK_CHANGED" >> $GITHUB_OUTPUT
+          echo "ai-platform-changed=$AI_PLATFORM_CHANGED" >> $GITHUB_OUTPUT
+
+      - name: 🏷️ Determine next Helm RC number
+        id: helm-rc
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        with:
+          script: |
+            const releaseVersion = process.env.RELEASE_VERSION;
+            // Helm RC prefix: "0.3.0-rc.helm." or "0.2.41-hotfix-rc.helm."
+            const prefix = `${releaseVersion}-rc.helm.`;
+            const escapedPrefix = prefix.replace(/\./g, '\\.').replace(/-/g, '\\-');
+            const tagPattern = new RegExp(`^${escapedPrefix}([0-9]+)$`);
+
+            const { data: refs } = await github.rest.git.listMatchingRefs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${prefix}`
+            });
+
+            let maxN = 0;
+            for (const ref of refs) {
+              const tagName = ref.ref.replace('refs/tags/', '');
+              const match = tagName.match(tagPattern);
+              if (match) {
+                const n = parseInt(match[1], 10);
+                if (n > maxN) maxN = n;
+              }
+            }
+
+            const nextN = maxN + 1;
+            console.log(`📊 Found ${refs.length} existing Helm RC tags for ${releaseVersion}`);
+            console.log(`🏷️  Next Helm RC number: ${nextN}`);
+            core.setOutput('number', nextN);
+
+      - name: ⚙️ Set up Helm
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.14.0
+
+      - name: 🔐 Login to GHCR
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: 🏷️ Generate Helm RC versions
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        id: chart-version
+        run: |
+          RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
+          RC_NUM="${{ steps.helm-rc.outputs.number }}"
+          HELM_RC_VERSION="${RELEASE_VERSION}-rc.helm.${RC_NUM}"
+
+          echo "helm_rc_version=$HELM_RC_VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Helm RC version: $HELM_RC_VERSION"
+
+      - name: 📦 Package rag-stack Chart
+        if: steps.detect.outputs.rag-stack-changed == 'true'
+        run: |
+          HELM_RC_VERSION="${{ steps.chart-version.outputs.helm_rc_version }}"
+          echo "📦 Packaging rag-stack at $HELM_RC_VERSION..."
+          mkdir -p ./packaged-charts
+          sed -i "s/^version:.*/version: $HELM_RC_VERSION/" charts/rag-stack/Chart.yaml
+          helm dependency update charts/rag-stack/
+          helm package charts/rag-stack/ --destination ./packaged-charts/
+          echo "✅ rag-stack packaged"
+
+      - name: 📦 Package ai-platform-engineering Chart
+        if: steps.detect.outputs.ai-platform-changed == 'true'
+        run: |
+          HELM_RC_VERSION="${{ steps.chart-version.outputs.helm_rc_version }}"
+          echo "📦 Packaging ai-platform-engineering at $HELM_RC_VERSION..."
+          mkdir -p ./packaged-charts
+          sed -i "s/^version:.*/version: $HELM_RC_VERSION/" charts/ai-platform-engineering/Chart.yaml
+
+          # If rag-stack was also changed, align its dependency version
+          if [[ "${{ steps.detect.outputs.rag-stack-changed }}" == "true" ]]; then
+            sed -i "/name: rag-stack/,/repository:/ s/version:.*/version: $HELM_RC_VERSION/" charts/ai-platform-engineering/Chart.yaml
+          fi
+
+          helm dependency update charts/rag-stack/
+          helm dependency update charts/ai-platform-engineering/
+          helm package charts/ai-platform-engineering/ --destination ./packaged-charts/
+
+          # Verify critical sub-chart deps
+          if tar -tzf charts/ai-platform-engineering/charts/rag-stack-*.tgz | grep -q "^rag-stack/charts/neo4j/Chart.yaml"; then
+            echo "✅ neo4j dependency verified"
+          else
+            echo "❌ neo4j missing from rag-stack package" && exit 1
+          fi
+          if tar -tzf charts/ai-platform-engineering/charts/rag-stack-*.tgz | grep -q "^rag-stack/charts/milvus/Chart.yaml"; then
+            echo "✅ milvus dependency verified"
+          else
+            echo "❌ milvus missing from rag-stack package" && exit 1
+          fi
+          echo "✅ ai-platform-engineering packaged"
+
+      - name: 🚀 Push Release Helm RC Charts to GHCR
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        run: |
+          REGISTRY="oci://ghcr.io/${{ github.repository_owner }}/pre-release-helm-charts"
+          echo "📦 Pushing release Helm RC charts to $REGISTRY"
+
+          for CHART_FILE in ./packaged-charts/*.tgz; do
+            if [ -f "$CHART_FILE" ]; then
+              CHART_NAME=$(helm show chart "$CHART_FILE" | grep '^name:' | awk '{print $2}')
+              CHART_VERSION=$(helm show chart "$CHART_FILE" | grep '^version:' | awk '{print $2}')
+              echo "📦 Pushing $CHART_NAME:$CHART_VERSION"
+              helm push "$CHART_FILE" "$REGISTRY"
+              echo "✅ $CHART_NAME:$CHART_VERSION published"
+            fi
+          done
+
+      - name: 📊 Summary
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        run: |
+          REGISTRY="ghcr.io/${{ github.repository_owner }}/pre-release-helm-charts"
+          HELM_RC_VERSION="${{ steps.chart-version.outputs.helm_rc_version }}"
+          RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
+
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          # 📦 Release Helm RC Published
+
+          | Property | Value |
+          |----------|-------|
+          | **Helm RC Version** | \`${HELM_RC_VERSION}\` |
+          | **Release Version** | \`${RELEASE_VERSION}\` |
+          | **Branch** | \`${GITHUB_REF#refs/heads/}\` |
+          | **Registry** | \`${REGISTRY}\` |
+
+          ## Install
+
+          \`\`\`bash
+          helm upgrade --install ai-platform \\
+            oci://${REGISTRY}/ai-platform-engineering \\
+            --version ${HELM_RC_VERSION}
+          \`\`\`
+          EOF

--- a/.github/workflows/release-helm-rc.yml
+++ b/.github/workflows/release-helm-rc.yml
@@ -4,16 +4,15 @@ description: "Publish Helm RC charts when charts change on a release/* branch"
 # Mirrors helm-rc-version-bump.yml + helm-pre-release.yml but for release/* branches.
 #
 # Key differences from the prebuild pipeline:
-#  - Version is pinned to the release branch name (NOT bumped from latest stable release)
-#  - No auto-bump commit — charts are packaged in-memory with the RC version
-#  - Works for both regular (release/0.3.0) and hotfix (release/0.2.41-hotfix) branches
+#  - Chart version derived from branch name — never auto-bumped or committed back
+#  - appVersion is set to the latest image RC tag so the chart is self-contained:
+#    helm upgrade --version 0.3.0-rc.helm.1  pulls  image:0.3.0-rc.1  by default
+#  - Works for both regular and hotfix branches
 #
-# Helm RC version scheme (matches image tag format exactly — no separate .helm. counter):
-#   release/0.3.0         → 0.3.0-rc.1,       0.3.0-rc.2, …
+# Helm RC version scheme (consistent with main's 0.2.43-rc.helm.3 convention):
+#   release/0.3.0         → 0.3.0-rc.helm.1,  0.3.0-rc.helm.2, …
 #   release/0.2.41-hotfix → 0.2.41-hotfix.1,  0.2.41-hotfix.2, …
-#
-# Both image tags and Helm chart versions share the same counter namespace, so
-# "0.3.0-rc.2" always refers to the same release state regardless of artifact type.
+#                           (hotfix has no .helm. infix — the counter is the release itself)
 
 on:
   push:
@@ -21,6 +20,13 @@ on:
       - 'release/**'
     paths:
       - 'charts/**'
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Publish all charts even if unchanged (use for manual re-publish)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -32,8 +38,6 @@ jobs:
   publish-release-helm-rc:
     name: Publish Release Helm RC
     runs-on: ubuntu-latest
-    # Skip commits made by the bot (safety guard — this workflow never commits,
-    # but guard against accidental re-entrancy if that ever changes)
     if: github.actor != 'github-actions[bot]'
 
     steps:
@@ -41,6 +45,16 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: 🛡️ Validate release branch
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH" != release/* ]]; then
+            echo "❌ This workflow only runs on release/* branches. Current: $BRANCH"
+            echo "   Trigger manually from a release/* branch in the GitHub Actions UI."
+            exit 1
+          fi
+          echo "✅ Branch validated: $BRANCH"
 
       - name: 📥 Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -50,27 +64,36 @@ jobs:
       - name: 🏷️ Parse release version from branch
         id: version
         run: |
-          # release/0.3.0         → RELEASE_VERSION=0.3.0,         IS_HOTFIX=false
-          # release/0.2.41-hotfix → RELEASE_VERSION=0.2.41-hotfix,  IS_HOTFIX=true
+          # release/0.3.0         → RELEASE_VERSION=0.3.0,        IS_HOTFIX=false
+          # release/0.2.41-hotfix → RELEASE_VERSION=0.2.41-hotfix, IS_HOTFIX=true
           BRANCH="${GITHUB_REF#refs/heads/release/}"
           echo "release_version=$BRANCH" >> $GITHUB_OUTPUT
 
           if [[ "$BRANCH" == *"-hotfix"* ]]; then
             echo "is_hotfix=true" >> $GITHUB_OUTPUT
+            echo "📦 Hotfix release: $BRANCH"
           else
             echo "is_hotfix=false" >> $GITHUB_OUTPUT
+            echo "📦 Regular release: $BRANCH"
           fi
-          echo "📦 Release version: $BRANCH"
 
       - name: 🔍 Detect changed charts
         id: detect
         run: |
-          git fetch origin
+          FORCE="${{ inputs.force_publish }}"
 
+          if [[ "$FORCE" == "true" ]]; then
+            echo "⚡ Force publish — treating all charts as changed"
+            echo "rag-stack-changed=true" >> $GITHUB_OUTPUT
+            echo "ai-platform-changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          git fetch origin
           CHANGED_FILES=$(git diff --name-only origin/${{ github.ref_name }}^..HEAD | grep "^charts/" || true)
 
           if [[ -z "$CHANGED_FILES" ]]; then
-            echo "ℹ️  No chart files changed in this push"
+            echo "ℹ️  No chart files changed"
             echo "rag-stack-changed=false" >> $GITHUB_OUTPUT
             echo "ai-platform-changed=false" >> $GITHUB_OUTPUT
             exit 0
@@ -80,63 +103,86 @@ jobs:
           AI_PLATFORM_CHANGED=false
 
           if echo "$CHANGED_FILES" | grep -q "^charts/rag-stack/"; then
-            if echo "$CHANGED_FILES" | grep "^charts/rag-stack/" | grep -qv "Chart.lock$"; then
-              RAG_STACK_CHANGED=true
-              echo "✅ rag-stack chart has substantive changes"
-            fi
+            echo "$CHANGED_FILES" | grep "^charts/rag-stack/" | grep -qv "Chart.lock$" \
+              && RAG_STACK_CHANGED=true && echo "✅ rag-stack has substantive changes"
           fi
 
           if echo "$CHANGED_FILES" | grep -q "^charts/ai-platform-engineering/"; then
-            if echo "$CHANGED_FILES" | grep "^charts/ai-platform-engineering/" | grep -qv "Chart.lock$"; then
-              AI_PLATFORM_CHANGED=true
-              echo "✅ ai-platform-engineering chart has substantive changes"
-            fi
+            echo "$CHANGED_FILES" | grep "^charts/ai-platform-engineering/" | grep -qv "Chart.lock$" \
+              && AI_PLATFORM_CHANGED=true && echo "✅ ai-platform-engineering has substantive changes"
           fi
 
           echo "rag-stack-changed=$RAG_STACK_CHANGED" >> $GITHUB_OUTPUT
           echo "ai-platform-changed=$AI_PLATFORM_CHANGED" >> $GITHUB_OUTPUT
 
-      - name: 🏷️ Determine next Helm RC number
-        id: helm-rc
+      - name: 🏷️ Resolve versions (Helm RC + latest image RC for appVersion)
+        id: versions
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
-        env:
           IS_HOTFIX: ${{ steps.version.outputs.is_hotfix }}
         with:
           script: |
             const releaseVersion = process.env.RELEASE_VERSION;
             const isHotfix = process.env.IS_HOTFIX === 'true';
 
-            // Helm version shares the same counter as the image RC tags so that
-            // "0.3.0-rc.2" means the same release state for both artifact types.
-            // Regular: "0.3.0-rc.N"       → prefix "0.3.0-rc."
-            // Hotfix:  "0.2.41-hotfix.N"  → prefix "0.2.41-hotfix."
-            const prefix = isHotfix ? `${releaseVersion}.` : `${releaseVersion}-rc.`;
-            const escapedPrefix = prefix.replace(/\./g, '\\.').replace(/-/g, '\\-');
-            const tagPattern = new RegExp(`^${escapedPrefix}([0-9]+)$`);
+            // ── Helm RC version ───────────────────────────────────────────────
+            // Consistent with main's 0.2.43-rc.helm.3 convention:
+            //   Regular: 0.3.0-rc.helm.N   Hotfix: 0.2.41-hotfix.N
+            const helmPrefix = isHotfix ? `${releaseVersion}.` : `${releaseVersion}-rc.helm.`;
+            const helmEscaped = helmPrefix.replace(/\./g, '\\.').replace(/-/g, '\\-');
+            const helmPattern = new RegExp(`^${helmEscaped}([0-9]+)$`);
 
-            const { data: refs } = await github.rest.git.listMatchingRefs({
+            const { data: helmRefs } = await github.rest.git.listMatchingRefs({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `tags/${prefix}`
+              ref: `tags/${helmPrefix}`
             });
 
-            let maxN = 0;
-            for (const ref of refs) {
+            let maxHelm = 0;
+            for (const ref of helmRefs) {
+              const m = ref.ref.replace('refs/tags/', '').match(helmPattern);
+              if (m) maxHelm = Math.max(maxHelm, parseInt(m[1], 10));
+            }
+            const helmRcVersion = `${helmPrefix}${maxHelm + 1}`;
+
+            // ── appVersion = latest image RC tag ─────────────────────────────
+            // Templates use `.Values.image.tag | default .Chart.AppVersion`, so
+            // setting appVersion to the image RC tag makes the chart self-contained:
+            //   helm upgrade --version 0.3.0-rc.helm.1  → pulls image:0.3.0-rc.1
+            //
+            // Image RC tag format:
+            //   Regular: 0.3.0-rc.N   (exclude .helm. tags)
+            //   Hotfix:  0.2.41-hotfix.N
+            const imagePrefix = isHotfix ? `${releaseVersion}.` : `${releaseVersion}-rc.`;
+            const imageEscaped = imagePrefix.replace(/\./g, '\\.').replace(/-/g, '\\-');
+            const imagePattern = isHotfix
+              ? new RegExp(`^${imageEscaped}([0-9]+)$`)
+              : new RegExp(`^${imageEscaped}(?!helm\\.)([0-9]+)$`);
+
+            const { data: imageRefs } = await github.rest.git.listMatchingRefs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${imagePrefix}`
+            });
+
+            let latestImageTag = releaseVersion; // fallback if no image RC exists yet
+            let maxImage = -1;
+            for (const ref of imageRefs) {
               const tagName = ref.ref.replace('refs/tags/', '');
-              const match = tagName.match(tagPattern);
-              if (match) {
-                const n = parseInt(match[1], 10);
-                if (n > maxN) maxN = n;
+              const m = tagName.match(imagePattern);
+              if (m) {
+                const n = parseInt(m[1], 10);
+                if (n > maxImage) { maxImage = n; latestImageTag = tagName; }
               }
             }
 
-            const nextN = maxN + 1;
-            console.log(`📊 Found ${refs.length} existing Helm tags for ${releaseVersion} (isHotfix=${isHotfix})`);
-            console.log(`🏷️  Next Helm number: ${nextN}`);
-            core.setOutput('number', nextN);
+            console.log(`🏷️  Helm RC version: ${helmRcVersion}`);
+            console.log(`📦 appVersion (image RC): ${latestImageTag}`);
+
+            core.setOutput('helm_rc_version', helmRcVersion);
+            core.setOutput('app_version', latestImageTag);
 
       - name: ⚙️ Set up Helm
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
@@ -149,46 +195,32 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: 🏷️ Generate Helm RC versions
-        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
-        id: chart-version
-        run: |
-          RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
-          IS_HOTFIX="${{ steps.version.outputs.is_hotfix }}"
-          RC_NUM="${{ steps.helm-rc.outputs.number }}"
-
-          # Helm version == image tag format (shared counter)
-          # Hotfix:  0.2.41-hotfix.N
-          # Regular: 0.3.0-rc.N
-          if [[ "$IS_HOTFIX" == "true" ]]; then
-            HELM_RC_VERSION="${RELEASE_VERSION}.${RC_NUM}"
-          else
-            HELM_RC_VERSION="${RELEASE_VERSION}-rc.${RC_NUM}"
-          fi
-
-          echo "helm_rc_version=$HELM_RC_VERSION" >> $GITHUB_OUTPUT
-          echo "📦 Helm RC version: $HELM_RC_VERSION"
-
       - name: 📦 Package rag-stack Chart
         if: steps.detect.outputs.rag-stack-changed == 'true'
+        env:
+          HELM_RC_VERSION: ${{ steps.versions.outputs.helm_rc_version }}
+          APP_VERSION: ${{ steps.versions.outputs.app_version }}
         run: |
-          HELM_RC_VERSION="${{ steps.chart-version.outputs.helm_rc_version }}"
-          echo "📦 Packaging rag-stack at $HELM_RC_VERSION..."
+          echo "📦 Packaging rag-stack at $HELM_RC_VERSION (appVersion=$APP_VERSION)..."
           mkdir -p ./packaged-charts
           sed -i "s/^version:.*/version: $HELM_RC_VERSION/" charts/rag-stack/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: $APP_VERSION/" charts/rag-stack/Chart.yaml
           helm dependency update charts/rag-stack/
           helm package charts/rag-stack/ --destination ./packaged-charts/
           echo "✅ rag-stack packaged"
 
       - name: 📦 Package ai-platform-engineering Chart
         if: steps.detect.outputs.ai-platform-changed == 'true'
+        env:
+          HELM_RC_VERSION: ${{ steps.versions.outputs.helm_rc_version }}
+          APP_VERSION: ${{ steps.versions.outputs.app_version }}
         run: |
-          HELM_RC_VERSION="${{ steps.chart-version.outputs.helm_rc_version }}"
-          echo "📦 Packaging ai-platform-engineering at $HELM_RC_VERSION..."
+          echo "📦 Packaging ai-platform-engineering at $HELM_RC_VERSION (appVersion=$APP_VERSION)..."
           mkdir -p ./packaged-charts
           sed -i "s/^version:.*/version: $HELM_RC_VERSION/" charts/ai-platform-engineering/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: $APP_VERSION/" charts/ai-platform-engineering/Chart.yaml
 
-          # If rag-stack was also changed, align its dependency version
+          # Align rag-stack dependency version if it was also changed
           if [[ "${{ steps.detect.outputs.rag-stack-changed }}" == "true" ]]; then
             sed -i "/name: rag-stack/,/repository:/ s/version:.*/version: $HELM_RC_VERSION/" charts/ai-platform-engineering/Chart.yaml
           fi
@@ -198,16 +230,10 @@ jobs:
           helm package charts/ai-platform-engineering/ --destination ./packaged-charts/
 
           # Verify critical sub-chart deps
-          if tar -tzf charts/ai-platform-engineering/charts/rag-stack-*.tgz | grep -q "^rag-stack/charts/neo4j/Chart.yaml"; then
-            echo "✅ neo4j dependency verified"
-          else
-            echo "❌ neo4j missing from rag-stack package" && exit 1
-          fi
-          if tar -tzf charts/ai-platform-engineering/charts/rag-stack-*.tgz | grep -q "^rag-stack/charts/milvus/Chart.yaml"; then
-            echo "✅ milvus dependency verified"
-          else
-            echo "❌ milvus missing from rag-stack package" && exit 1
-          fi
+          tar -tzf charts/ai-platform-engineering/charts/rag-stack-*.tgz | grep -q "^rag-stack/charts/neo4j/Chart.yaml" \
+            && echo "✅ neo4j verified" || (echo "❌ neo4j missing" && exit 1)
+          tar -tzf charts/ai-platform-engineering/charts/rag-stack-*.tgz | grep -q "^rag-stack/charts/milvus/Chart.yaml" \
+            && echo "✅ milvus verified" || (echo "❌ milvus missing" && exit 1)
           echo "✅ ai-platform-engineering packaged"
 
       - name: 🚀 Push Release Helm RC Charts to GHCR
@@ -215,37 +241,37 @@ jobs:
         run: |
           REGISTRY="oci://ghcr.io/${{ github.repository_owner }}/pre-release-helm-charts"
           echo "📦 Pushing release Helm RC charts to $REGISTRY"
-
           for CHART_FILE in ./packaged-charts/*.tgz; do
-            if [ -f "$CHART_FILE" ]; then
-              CHART_NAME=$(helm show chart "$CHART_FILE" | grep '^name:' | awk '{print $2}')
-              CHART_VERSION=$(helm show chart "$CHART_FILE" | grep '^version:' | awk '{print $2}')
-              echo "📦 Pushing $CHART_NAME:$CHART_VERSION"
-              helm push "$CHART_FILE" "$REGISTRY"
-              echo "✅ $CHART_NAME:$CHART_VERSION published"
-            fi
+            [[ -f "$CHART_FILE" ]] || continue
+            CHART_NAME=$(helm show chart "$CHART_FILE" | grep '^name:' | awk '{print $2}')
+            CHART_VERSION=$(helm show chart "$CHART_FILE" | grep '^version:' | awk '{print $2}')
+            echo "📦 Pushing $CHART_NAME:$CHART_VERSION"
+            helm push "$CHART_FILE" "$REGISTRY"
+            echo "✅ $CHART_NAME:$CHART_VERSION published"
           done
 
       - name: 📊 Summary
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        env:
+          HELM_RC_VERSION: ${{ steps.versions.outputs.helm_rc_version }}
+          APP_VERSION: ${{ steps.versions.outputs.app_version }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
         run: |
           REGISTRY="ghcr.io/${{ github.repository_owner }}/pre-release-helm-charts"
-          HELM_RC_VERSION="${{ steps.chart-version.outputs.helm_rc_version }}"
-          RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
-
           cat >> $GITHUB_STEP_SUMMARY << EOF
           # 📦 Release Helm RC Published
 
           | Property | Value |
           |----------|-------|
           | **Helm RC Version** | \`${HELM_RC_VERSION}\` |
+          | **Image tag (appVersion)** | \`${APP_VERSION}\` |
           | **Release Version** | \`${RELEASE_VERSION}\` |
           | **Branch** | \`${GITHUB_REF#refs/heads/}\` |
-          | **Registry** | \`${REGISTRY}\` |
 
           ## Install
 
           \`\`\`bash
+          # Chart version ${HELM_RC_VERSION} pulls image:${APP_VERSION} by default
           helm upgrade --install ai-platform \\
             oci://${REGISTRY}/ai-platform-engineering \\
             --version ${HELM_RC_VERSION}

--- a/.github/workflows/release-helm-rc.yml
+++ b/.github/workflows/release-helm-rc.yml
@@ -9,8 +9,9 @@ description: "Publish Helm RC charts when charts change on a release/* branch"
 #  - Works for both regular (release/0.3.0) and hotfix (release/0.2.41-hotfix) branches
 #
 # Helm RC version scheme:
-#   release/0.3.0        → 0.3.0-rc.helm.1,         0.3.0-rc.helm.2, …
-#   release/0.2.41-hotfix → 0.2.41-hotfix-rc.helm.1, 0.2.41-hotfix-rc.helm.2, …
+#   release/0.3.0         → 0.3.0-rc.helm.1,  0.3.0-rc.helm.2, …
+#   release/0.2.41-hotfix → 0.2.41-hotfix.1,  0.2.41-hotfix.2, …
+#                           (hotfix Helm version matches the image tag exactly — no -rc.helm. infix)
 
 on:
   push:
@@ -99,11 +100,16 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        env:
+          IS_HOTFIX: ${{ steps.version.outputs.is_hotfix }}
         with:
           script: |
             const releaseVersion = process.env.RELEASE_VERSION;
-            // Helm RC prefix: "0.3.0-rc.helm." or "0.2.41-hotfix-rc.helm."
-            const prefix = `${releaseVersion}-rc.helm.`;
+            const isHotfix = process.env.IS_HOTFIX === 'true';
+
+            // Hotfix:  Helm version == image tag: "0.2.41-hotfix.N"  → prefix "0.2.41-hotfix."
+            // Regular: separate Helm RC series:   "0.3.0-rc.helm.N"  → prefix "0.3.0-rc.helm."
+            const prefix = isHotfix ? `${releaseVersion}.` : `${releaseVersion}-rc.helm.`;
             const escapedPrefix = prefix.replace(/\./g, '\\.').replace(/-/g, '\\-');
             const tagPattern = new RegExp(`^${escapedPrefix}([0-9]+)$`);
 
@@ -124,8 +130,8 @@ jobs:
             }
 
             const nextN = maxN + 1;
-            console.log(`📊 Found ${refs.length} existing Helm RC tags for ${releaseVersion}`);
-            console.log(`🏷️  Next Helm RC number: ${nextN}`);
+            console.log(`📊 Found ${refs.length} existing Helm tags for ${releaseVersion} (isHotfix=${isHotfix})`);
+            console.log(`🏷️  Next Helm number: ${nextN}`);
             core.setOutput('number', nextN);
 
       - name: ⚙️ Set up Helm
@@ -144,8 +150,16 @@ jobs:
         id: chart-version
         run: |
           RELEASE_VERSION="${{ steps.version.outputs.release_version }}"
+          IS_HOTFIX="${{ steps.version.outputs.is_hotfix }}"
           RC_NUM="${{ steps.helm-rc.outputs.number }}"
-          HELM_RC_VERSION="${RELEASE_VERSION}-rc.helm.${RC_NUM}"
+
+          # Hotfix: version == image tag (0.2.41-hotfix.N)
+          # Regular: separate helm rc series (0.3.0-rc.helm.N)
+          if [[ "$IS_HOTFIX" == "true" ]]; then
+            HELM_RC_VERSION="${RELEASE_VERSION}.${RC_NUM}"
+          else
+            HELM_RC_VERSION="${RELEASE_VERSION}-rc.helm.${RC_NUM}"
+          fi
 
           echo "helm_rc_version=$HELM_RC_VERSION" >> $GITHUB_OUTPUT
           echo "📦 Helm RC version: $HELM_RC_VERSION"

--- a/.github/workflows/release-rc-tag.yml
+++ b/.github/workflows/release-rc-tag.yml
@@ -1,0 +1,167 @@
+name: "[Release] Create RC Tags for Release Branches"
+description: "Create RC tags on push to release/* branches and trigger image builds"
+
+# Mirrors rc-tag.yml but targets release/* branches.
+# Version is derived from the branch name, not pyproject.toml, so this
+# workflow can produce RCs that are independent of whatever is on main.
+#
+# Regular release branches (release/0.3.0):
+#   → image/helm tags: 0.3.0-rc.1, 0.3.0-rc.2, …
+#
+# Hotfix branches (release/0.2.41-hotfix):
+#   → image/helm tags: 0.2.41-hotfix.1, 0.2.41-hotfix.2, …
+#   (no -rc. infix — the hotfix number IS the release candidate number)
+
+on:
+  push:
+    branches:
+      - 'release/**'
+    paths:
+      - 'ai_platform_engineering/**'
+      - 'build/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+
+permissions:
+  contents: write
+  packages: write
+  actions: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  create-release-rc-tag:
+    name: Create release RC tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Parse version and branch type
+        id: version
+        run: |
+          # Branch: refs/heads/release/0.3.0  → VERSION=0.3.0,  IS_HOTFIX=false
+          # Branch: refs/heads/release/0.2.41-hotfix → VERSION=0.2.41-hotfix, IS_HOTFIX=true
+          BRANCH_NAME="${GITHUB_REF#refs/heads/release/}"
+          echo "branch_suffix=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+          if [[ "$BRANCH_NAME" == *"-hotfix"* ]]; then
+            echo "is_hotfix=true" >> $GITHUB_OUTPUT
+            echo "version=$BRANCH_NAME" >> $GITHUB_OUTPUT
+            echo "📦 Hotfix release: $BRANCH_NAME"
+          else
+            echo "is_hotfix=false" >> $GITHUB_OUTPUT
+            echo "version=$BRANCH_NAME" >> $GITHUB_OUTPUT
+            echo "📦 Regular release: $BRANCH_NAME"
+          fi
+
+          # Read agent lists from config file
+          A2A_AGENTS=$(jq -r '.a2a_agents | join(" ")' .github/agents.json)
+          MCP_AGENTS=$(jq -r '.mcp_agents | join(" ")' .github/agents.json)
+          RAG_COMPONENTS=$(jq -r '.rag_components | join(" ")' .github/agents.json)
+          echo "a2a_agents=$A2A_AGENTS" >> $GITHUB_OUTPUT
+          echo "mcp_agents=$MCP_AGENTS" >> $GITHUB_OUTPUT
+          echo "rag_components=$RAG_COMPONENTS" >> $GITHUB_OUTPUT
+
+      - name: Determine next RC number
+        id: rc
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          IS_HOTFIX: ${{ steps.version.outputs.is_hotfix }}
+        with:
+          script: |
+            const version = process.env.VERSION;
+            const isHotfix = process.env.IS_HOTFIX === 'true';
+
+            // Hotfix:  0.2.41-hotfix.1,  0.2.41-hotfix.2, …  → prefix "0.2.41-hotfix."
+            // Regular: 0.3.0-rc.1, 0.3.0-rc.2, …             → prefix "0.3.0-rc."
+            const prefix = isHotfix ? `${version}.` : `${version}-rc.`;
+            const tagPattern = isHotfix
+              ? new RegExp(`^${version.replace(/\./g, '\\.').replace(/-/g, '\\-')}\\.([0-9]+)$`)
+              : new RegExp(`^${version.replace(/\./g, '\\.')}-rc\\.([0-9]+)$`);
+
+            // List all matching tags
+            const { data: refs } = await github.rest.git.listMatchingRefs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${prefix}`
+            });
+
+            let maxN = 0;
+            for (const ref of refs) {
+              const tagName = ref.ref.replace('refs/tags/', '');
+              const match = tagName.match(tagPattern);
+              if (match) {
+                const n = parseInt(match[1], 10);
+                if (n > maxN) maxN = n;
+              }
+            }
+
+            const nextN = maxN + 1;
+            const rcTag = `${prefix}${nextN}`;
+
+            console.log(`📊 Found ${refs.length} existing tags for ${version}`);
+            console.log(`🏷️  Next tag: ${rcTag}`);
+
+            core.setOutput('number', nextN);
+            core.setOutput('tag', rcTag);
+
+      - name: Create Git tag
+        env:
+          RC_TAG: ${{ steps.rc.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$RC_TAG" -m "Release candidate $RC_TAG"
+          git push origin "$RC_TAG"
+
+          echo "✅ Created and pushed tag: $RC_TAG"
+
+      - name: Create summary
+        env:
+          RC_TAG: ${{ steps.rc.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+          IS_HOTFIX: ${{ steps.version.outputs.is_hotfix }}
+        run: |
+          TYPE=$( [[ "$IS_HOTFIX" == "true" ]] && echo "Hotfix" || echo "Release" )
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          # 🏷️ $TYPE RC Tag Created
+
+          | Property | Value |
+          |----------|-------|
+          | **RC Tag** | \`${RC_TAG}\` |
+          | **Release Version** | \`${VERSION}\` |
+          | **Branch** | \`${GITHUB_REF#refs/heads/}\` |
+          | **Commit** | \`${{ github.sha }}\` |
+
+          ## What happened
+
+          1. 🏷️ Created git tag \`${RC_TAG}\`
+          2. 🔄 CI image-build workflows triggered by the tag (they respond to \`tags: '**'\`)
+
+          ## Usage
+
+          All images will be available with the \`${RC_TAG}\` tag once CI completes:
+
+          \`\`\`bash
+          docker pull ghcr.io/${{ github.repository_owner }}/ai-platform-engineering:${RC_TAG}
+          \`\`\`
+
+          ## Helm Chart
+
+          \`\`\`yaml
+          global:
+            image:
+              tag: "${RC_TAG}"
+          \`\`\`
+          EOF

--- a/.github/workflows/release-rc-tag.yml
+++ b/.github/workflows/release-rc-tag.yml
@@ -21,6 +21,13 @@ on:
       - 'build/**'
       - 'pyproject.toml'
       - 'uv.lock'
+  workflow_dispatch:
+    inputs:
+      force_tag:
+        description: 'Force create a new RC tag even without code changes'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -39,6 +46,16 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: 🛡️ Validate release branch
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH" != release/* ]]; then
+            echo "❌ This workflow only runs on release/* branches. Current: $BRANCH"
+            echo "   Trigger manually from a release/* branch in the GitHub Actions UI."
+            exit 1
+          fi
+          echo "✅ Branch validated: $BRANCH"
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/docs/docs/specs/098-release-branch-pipelines/checklists/requirements.md
+++ b/docs/docs/specs/098-release-branch-pipelines/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Release Branch CI/CD Pipelines
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-007 updated per review: hotfix Helm versions use `X.Y.Z-hotfix.N` (no `-rc.helm.` infix), matching the image tag scheme exactly
+- Branch prefix for hotfixes (`release/X.Y.Z-hotfix` vs `hotfix/X.Y.Z`) remains flexible — both are supported by the detection logic

--- a/docs/docs/specs/098-release-branch-pipelines/spec.md
+++ b/docs/docs/specs/098-release-branch-pipelines/spec.md
@@ -1,0 +1,169 @@
+---
+sidebar_position: 2
+sidebar_label: Specification
+id: 098-release-branch-pipelines-spec
+---
+
+# Spec: Release Branch CI/CD Pipelines
+
+**Feature Branch**: `098-release-branch-pipelines`
+**Created**: 2026-04-09
+**Status**: Draft
+**Input**: Release pipelines for `release/*` branches that mirror the prebuild pipeline model — producing release candidates for container images and Helm charts for all fixes going into versioned release branches, including hotfix variants.
+
+## Overview
+
+The platform's main-branch pipeline produces release candidates automatically whenever code merges. Release branches (`release/0.3.0`, `release/0.4.0`, `release/0.2.41-hotfix`) need the same capability: every push should produce testable, installable artifacts scoped to that release line without touching or conflating with the main pipeline's versioning.
+
+## Motivation
+
+When a fix is needed in a released version (e.g., a backported bug fix or a security patch), the team must be able to ship a verifiable, versioned artifact quickly. Currently there is no automated pipeline for release branches — teams must manually build, tag, and publish images and charts, which is error-prone, slow, and breaks traceability. The absence of automated Helm chart RC publishing for release branches means testers cannot use standard `helm upgrade` commands to validate a fix before shipping.
+
+Additionally, the existing chart auto-bump workflow is designed for the main branch's version scheme. Running it against a release branch would corrupt chart versions with the wrong base version, making the release branch unusable.
+
+## Scope
+
+### In Scope
+
+- Automatically create RC image tags when code changes are pushed to any `release/**` branch
+- Automatically publish Helm chart release candidates when chart changes are pushed to any `release/**` branch
+- Support both regular releases (`release/0.3.0`) and hotfix releases (`release/0.2.41-hotfix`) with distinct, non-conflicting version schemes
+- Prevent the main-branch chart auto-bump from running on PRs that target release branches
+- Version derivation from branch name rather than any shared configuration file, so release lines are fully autonomous
+
+### Out of Scope
+
+- Triggering release branch pipelines from pull requests (only direct pushes to release branches)
+- Promoting a release candidate to a final release (handled by the existing release-finalize workflow)
+- Creating or managing release branches themselves
+- Syncing changes from main to release branches (handled by the existing sync-release-branches workflow)
+- Backporting automation — committing the same fix to multiple branches is out of scope
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Backport fix gets an installable artifact (Priority: P1)
+
+A developer merges a cherry-picked fix into `release/0.3.0`. Within a few minutes, a new container image tag and Helm chart RC are available in the registry so that a QA engineer can install the fix to a test cluster using a single `helm upgrade` command.
+
+**Why this priority**: The primary motivation for this feature. Without it, the team cannot safely validate a fix before shipping it to production customers.
+
+**Independent Test**: Push a code change to a `release/0.3.0` branch. Confirm that a new git tag (`0.3.0-rc.N`) is created and that CI image-build workflows run against that tag. Pull the resulting image to verify it exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer pushes a code change to `release/0.3.0`, **When** the pipeline runs, **Then** a new tag `0.3.0-rc.N` (where N increments from the last existing RC) is created within 5 minutes.
+2. **Given** the RC tag is created, **When** existing image-build CI workflows complete, **Then** container images are available in the registry tagged with `0.3.0-rc.N`.
+3. **Given** `N` existing RC tags for `0.3.0`, **When** a new push triggers the pipeline, **Then** the new tag is `0.3.0-rc.(N+1)` — no gaps and no reuse of existing numbers.
+4. **Given** no prior RC tags exist for `0.3.0`, **When** the first push occurs, **Then** the tag `0.3.0-rc.1` is created.
+
+---
+
+### User Story 2 — Helm chart fix on a release branch gets published as an RC (Priority: P1)
+
+A developer updates the Helm chart values on `release/0.3.0` (e.g., adjusting a default config for the release). The chart is packaged and published to the GHCR pre-release registry so that the QA team can `helm upgrade` immediately without waiting for a final release.
+
+**Why this priority**: Without chart RCs for release branches, there is no automated way to validate chart-only fixes before shipping.
+
+**Independent Test**: Push a chart change to `release/0.3.0`. Confirm that a pre-release Helm chart with version `0.3.0-rc.helm.N` is published and installable via `helm upgrade --install ... oci://ghcr.io/.../pre-release-helm-charts/ai-platform-engineering --version 0.3.0-rc.helm.N`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a chart change is pushed to `release/0.3.0`, **When** the pipeline runs, **Then** the chart is packaged with version `0.3.0-rc.helm.N` and published to the pre-release Helm registry.
+2. **Given** only non-chart files change on a release branch, **When** the pipeline runs, **Then** no Helm chart is published (chart publication is triggered only by chart file changes).
+3. **Given** both `rag-stack` and `ai-platform-engineering` charts change, **When** the pipeline runs, **Then** both are packaged and published with matching RC versions, and the parent chart's dependency reference points to the same RC version.
+4. **Given** the chart RC is published, **When** a QA engineer runs `helm upgrade`, **Then** the install succeeds and all expected sub-chart dependencies (rag-stack, neo4j, milvus) are present.
+
+---
+
+### User Story 3 — Hotfix branch gets its own RC series (Priority: P1)
+
+A developer pushes a critical security fix to `release/0.2.41-hotfix`. The pipeline creates tags in the format `0.2.41-hotfix.1`, `0.2.41-hotfix.2`, etc. — a distinct series that does not collide with the `0.3.0-rc.N` series and clearly communicates its hotfix nature to operators.
+
+**Why this priority**: Hotfix releases are urgent. The versioning must be unambiguous so operators can quickly identify the lineage of a deployed artifact.
+
+**Independent Test**: Push to `release/0.2.41-hotfix`. Confirm the created tag matches `0.2.41-hotfix.1` (or `.2`, `.3`, etc.) and does not follow the `-rc.` format used by regular releases.
+
+**Acceptance Scenarios**:
+
+1. **Given** a push to `release/0.2.41-hotfix`, **When** the pipeline runs, **Then** a tag `0.2.41-hotfix.N` is created (no `-rc.` infix).
+2. **Given** a push to `release/0.2.41-hotfix` with chart changes, **When** the Helm pipeline runs, **Then** the chart version is `0.2.41-hotfix.N` — matching the image tag exactly, with no separate `-rc.helm.` infix.
+3. **Given** both a regular release branch and a hotfix branch are active, **When** both receive pushes, **Then** their tag series are completely independent and non-overlapping.
+
+---
+
+### User Story 4 — Chart auto-bump does not corrupt release branch PRs (Priority: P2)
+
+A developer opens a pull request targeting `release/0.3.0` with a chart change. The main-branch chart auto-bump workflow — which validates chart versions against the latest stable release and commits version bumps — does not run. The PR is not modified by a bot commit that would set an incorrect version derived from main's release history.
+
+**Why this priority**: Without this guard, bot commits would set release branch chart versions to a version anchored to main (e.g., `0.4.0-rc.helm.1` on a `release/0.3.0` branch), breaking the release line.
+
+**Independent Test**: Open a PR targeting `release/0.3.0` with a chart file change. Confirm the auto-bump workflow is not triggered and no bot commits appear on the PR branch.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR targets `release/0.3.0` with chart changes, **When** the PR is opened or synchronized, **Then** the chart auto-bump workflow does not run for that PR.
+2. **Given** a PR targets `main` with chart changes, **When** the PR is opened or synchronized, **Then** the chart auto-bump workflow runs normally (existing behavior unchanged).
+3. **Given** a PR targets any `release/**` branch, **When** the PR is created, **Then** no bot commits are added and the chart versions in the PR remain as the developer set them.
+
+---
+
+### Edge Cases
+
+- **Push with no relevant file changes**: Only code paths that match the pipeline's path filters produce RC tags or Helm RCs. Pushes that change only documentation or unrelated config produce nothing.
+- **Concurrent pushes to the same release branch**: Each push creates an independent RC tag. Tag numbers are determined atomically from existing tags at the time of the run; if two pushes race, they will produce consecutive numbers rather than conflicting ones.
+- **New release branch with no prior RC tags**: The first push produces tag number 1 (e.g., `0.3.0-rc.1`).
+- **Bot-commit re-entrancy**: The chart RC workflow does not commit back to the branch, eliminating the risk of infinite re-trigger loops.
+
+---
+
+## Functional Requirements
+
+### RC Tag Creation
+
+- **FR-001**: On every push to a branch matching `release/**` that modifies source code paths (`ai_platform_engineering/**`, `build/**`, `pyproject.toml`, `uv.lock`), the pipeline MUST create a new annotated git tag and push it to the remote.
+- **FR-002**: For a regular release branch `release/X.Y.Z`, the tag format MUST be `X.Y.Z-rc.N` where N is one greater than the highest existing tag matching `X.Y.Z-rc.*`.
+- **FR-003**: For a hotfix branch `release/X.Y.Z-hotfix`, the tag format MUST be `X.Y.Z-hotfix.N` where N is one greater than the highest existing tag matching `X.Y.Z-hotfix.*`.
+- **FR-004**: The pipeline MUST NOT read the version from `pyproject.toml` or any file on the `main` branch. The version MUST be derived exclusively from the release branch name.
+- **FR-005**: Tag creation MUST be idempotent in numbering — no two pushes may produce the same tag number for the same release version.
+
+### Helm RC Publishing
+
+- **FR-006**: On every push to a branch matching `release/**` that modifies `charts/**` (excluding `Chart.lock`-only changes), the pipeline MUST package and publish Helm chart RCs to the pre-release GHCR registry.
+- **FR-007**: Helm RC versions MUST follow the pattern `X.Y.Z-rc.helm.N` for regular releases and `X.Y.Z-hotfix.N` for hotfix releases, where N increments from the highest existing matching tag. For hotfix releases the Helm chart version intentionally matches the image tag — there is no separate `-rc.helm.` infix.
+- **FR-008**: Chart versions MUST be set in-memory during packaging. The pipeline MUST NOT commit any version changes back to the release branch.
+- **FR-009**: When both `rag-stack` and `ai-platform-engineering` charts change in the same push, both MUST be packaged, and the parent chart's dependency reference to `rag-stack` MUST be updated to the same RC version before packaging.
+- **FR-010**: The pipeline MUST verify that required sub-chart dependencies (neo4j, milvus) are present in the packaged archive before publishing. A missing dependency MUST fail the pipeline.
+
+### Auto-bump Suppression
+
+- **FR-011**: The chart auto-bump workflow MUST NOT execute for pull requests whose base branch matches `release/**`.
+- **FR-012**: The chart auto-bump workflow MUST continue to execute normally for pull requests targeting `main` (no regression).
+
+---
+
+## Success Criteria
+
+1. **Time to artifact**: A push to a release branch produces a pullable container image within 15 minutes of the push completing.
+2. **Time to Helm RC**: A chart change pushed to a release branch results in a publishable Helm RC within 5 minutes.
+3. **Zero version collisions**: Over 30 days of operation, no two RC tags share the same version number on the same release branch.
+4. **No branch corruption**: Over 30 days of operation, zero bot commits appear on release branches from auto-bump or chart-version workflows.
+5. **Full backward compatibility**: The existing main-branch prebuild pipeline and chart auto-bump continue to operate with no change in behavior, as measured by zero regressions in existing tests and workflow runs.
+6. **Hotfix traceability**: Operators can identify whether a running image originated from a hotfix branch or a regular release branch solely by inspecting its image tag, without consulting the git log.
+
+---
+
+## Dependencies
+
+- Existing image-build CI workflows (`ci-a2a-sub-agent.yml`, `ci-mcp-sub-agent.yml`, `ci-a2a-rag.yml`, `ci-supervisor-agent.yml`, `ci-caipe-ui.yml`, `ci-slack-bot.yml`) that respond to any git tag — these provide the container image builds and require no modification.
+- GHCR pre-release Helm registry (`oci://ghcr.io/.../pre-release-helm-charts`) — must be writable with the existing `GITHUB_TOKEN`.
+- `.github/agents.json` — agent list config consumed by the RC tag workflow.
+- GitHub Actions `GH_PAT` / `GITHUB_TOKEN` secrets — must have `contents: write` and `packages: write`.
+
+## Assumptions
+
+- Release branches are always named `release/X.Y.Z` or `release/X.Y.Z-hotfix`. Other patterns (e.g., `release/feature-xyz`) are out of scope and will produce malformed tags that may be ignored.
+- The existing Helm charts (`rag-stack`, `ai-platform-engineering`) are the only charts requiring RC publication. New charts added under `charts/` will be picked up automatically by the change-detection logic.
+- Container image builds for release branch RC tags are handled by the existing CI workflows without modification, relying on their `tags: '**'` trigger.
+- The pre-release Helm registry is not cleaned up automatically for release branch artifacts (unlike prebuild PRs where cleanup happens on PR close). Cleanup is a manual or scheduled operation.

--- a/docs/docs/specs/098-release-branch-pipelines/spec.md
+++ b/docs/docs/specs/098-release-branch-pipelines/spec.md
@@ -66,11 +66,11 @@ A developer updates the Helm chart values on `release/0.3.0` (e.g., adjusting a 
 
 **Why this priority**: Without chart RCs for release branches, there is no automated way to validate chart-only fixes before shipping.
 
-**Independent Test**: Push a chart change to `release/0.3.0`. Confirm that a pre-release Helm chart with version `0.3.0-rc.helm.N` is published and installable via `helm upgrade --install ... oci://ghcr.io/.../pre-release-helm-charts/ai-platform-engineering --version 0.3.0-rc.helm.N`.
+**Independent Test**: Push a chart change to `release/0.3.0`. Confirm that a pre-release Helm chart with version `0.3.0-rc.N` is published and installable via `helm upgrade --install ... oci://ghcr.io/.../pre-release-helm-charts/ai-platform-engineering --version 0.3.0-rc.N`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a chart change is pushed to `release/0.3.0`, **When** the pipeline runs, **Then** the chart is packaged with version `0.3.0-rc.helm.N` and published to the pre-release Helm registry.
+1. **Given** a chart change is pushed to `release/0.3.0`, **When** the pipeline runs, **Then** the chart is packaged with version `0.3.0-rc.N` and published to the pre-release Helm registry.
 2. **Given** only non-chart files change on a release branch, **When** the pipeline runs, **Then** no Helm chart is published (chart publication is triggered only by chart file changes).
 3. **Given** both `rag-stack` and `ai-platform-engineering` charts change, **When** the pipeline runs, **Then** both are packaged and published with matching RC versions, and the parent chart's dependency reference points to the same RC version.
 4. **Given** the chart RC is published, **When** a QA engineer runs `helm upgrade`, **Then** the install succeeds and all expected sub-chart dependencies (rag-stack, neo4j, milvus) are present.
@@ -131,7 +131,7 @@ A developer opens a pull request targeting `release/0.3.0` with a chart change. 
 ### Helm RC Publishing
 
 - **FR-006**: On every push to a branch matching `release/**` that modifies `charts/**` (excluding `Chart.lock`-only changes), the pipeline MUST package and publish Helm chart RCs to the pre-release GHCR registry.
-- **FR-007**: Helm RC versions MUST follow the pattern `X.Y.Z-rc.helm.N` for regular releases and `X.Y.Z-hotfix.N` for hotfix releases, where N increments from the highest existing matching tag. For hotfix releases the Helm chart version intentionally matches the image tag — there is no separate `-rc.helm.` infix.
+- **FR-007**: Helm RC versions MUST use the same format as image RC tags — `X.Y.Z-rc.N` for regular releases and `X.Y.Z-hotfix.N` for hotfix releases. There is no separate `.helm.` infix. Both image and Helm artifact versions share the same counter namespace so that any RC number refers to the same release state across all artifact types.
 - **FR-008**: Chart versions MUST be set in-memory during packaging. The pipeline MUST NOT commit any version changes back to the release branch.
 - **FR-009**: When both `rag-stack` and `ai-platform-engineering` charts change in the same push, both MUST be packaged, and the parent chart's dependency reference to `rag-stack` MUST be updated to the same RC version before packaging.
 - **FR-010**: The pipeline MUST verify that required sub-chart dependencies (neo4j, milvus) are present in the packaged archive before publishing. A missing dependency MUST fail the pipeline.


### PR DESCRIPTION
## Summary

- **`release-rc-tag.yml`** — fires on push to `release/**`; derives version from the branch name and creates RC image tags automatically:
  - `release/0.3.0` → `0.3.0-rc.1`, `0.3.0-rc.2`, …
  - `release/0.2.41-hotfix` → `0.2.41-hotfix.1`, `0.2.41-hotfix.2`, … (hotfix number _is_ the RC number)
  - Tags trigger existing CI image-build workflows unchanged (they respond to `tags: '**'`)
- **`release-helm-rc.yml`** — fires on `charts/**` changes on `release/**`; packages and pushes Helm RCs to GHCR with version derived from the branch name, never auto-bumped:
  - `release/0.3.0` → `0.3.0-rc.helm.1`, `0.3.0-rc.helm.2`, …
  - `release/0.2.41-hotfix` → `0.2.41-hotfix-rc.helm.1`, …
- **`helm-rc-version-bump.yml`** — added `branches-ignore: ['release/**']` to the `pull_request` trigger so PRs targeting release branches are excluded from the main-centric auto-bump and version validation logic

## Design notes

| | Main/prebuild pipeline | Release branch pipeline |
|---|---|---|
| RC tag source | `pyproject.toml` version on `main` | branch name (`release/X.Y.Z`) |
| Helm version source | latest stable release + `rc.helm.N` | branch name + `rc.helm.N` |
| Auto-bump commits | yes, bot pushes to PR branch | **no** — version set in-memory only |
| Hotfix RC format | N/A | `X.Y.Z-hotfix.N` (no `-rc.` infix) |

## Test plan

- [ ] Push a non-chart change to a `release/0.3.0` test branch → `release-rc-tag.yml` creates `0.3.0-rc.1`
- [ ] Push a chart change to same branch → `release-helm-rc.yml` publishes `0.3.0-rc.helm.1` to GHCR
- [ ] Push a non-chart change to a `release/0.2.41-hotfix` branch → tag `0.2.41-hotfix.1` created
- [ ] Open a PR targeting `release/0.3.0` with chart changes → `helm-rc-version-bump.yml` does NOT run