### PR TITLE
Potential fix for code scanning alert no. 71: Incomplete URL substring sanitization

### DIFF
--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/utils/urls.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/utils/urls.py
@@ -31,7 +31,7 @@ def is_atlassian_cloud_url(url: str) -> bool:
         return False
 
     # The standard check for Jira cloud domains
-    cloud_domains = ("atlassian.net", "jira.com", "jira-dev.com")
+    cloud_domains = ("atlassian.net")
     return any(
         hostname == domain or hostname.endswith(f".{domain}")
         for domain in cloud_domains

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/utils/urls.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/utils/urls.py
@@ -31,8 +31,8 @@ def is_atlassian_cloud_url(url: str) -> bool:
         return False
 
     # The standard check for Jira cloud domains
-    return (
-        ".atlassian.net" in hostname
-        or ".jira.com" in hostname
-        or ".jira-dev.com" in hostname
+    cloud_domains = ("atlassian.net", "jira.com", "jira-dev.com")
+    return any(
+        hostname == domain or hostname.endswith(f".{domain}")
+        for domain in cloud_domains
     )


### PR DESCRIPTION
Potential fix for [https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/71](https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/71)

Use hostname-aware suffix validation instead of substring matching. Specifically, treat a hostname as Atlassian Cloud only when it is exactly one of the allowed base domains or ends with `.` + allowed base domain. This preserves intended behavior (allowing subdomains) while preventing arbitrary-position matches.

In `ai_platform_engineering/agents/jira/mcp/mcp_jira/utils/urls.py`, replace the return expression at lines 34–38 with a boundary-safe check using `hostname == domain or hostname.endswith(f".{domain}")` across an allowlist tuple:
- `atlassian.net`
- `jira.com`
- `jira-dev.com`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
