### PR TITLE
fix(slack-bot): add missing default field in test fixture

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
@@ -49,6 +49,7 @@ C456:
     enabled: "true"
   ai_alerts:
     enabled: "false"
+  default: {}
 """
         monkeypatch.delenv("SLACK_INTEGRATION_BOT_CONFIG", raising=False)
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:


### PR DESCRIPTION
## Summary

- `ChannelConfig.default` is a required `Dict[str, Any]` field on `release/0.2.41-hotfix`
- `test_config_loaded_from_file_path` omitted it from the YAML fixture, causing a pydantic `ValidationError`
- Adds `default: {}` to the fixture — the test only asserts on `name`, so an empty dict is sufficient
- Not broken on `main` (that branch replaced `default` with `other: OtherConfig` which has a default value)

## Test plan

- [ ] CI Slack Bot build passes on `release/0.2.41-hotfix`