### PR TITLE
fix(slack-bot): add missing default field in test fixture

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
@@ -49,6 +49,7 @@ C456:
     enabled: "true"
   ai_alerts:
     enabled: "false"
+  default: {}
 """
         monkeypatch.delenv("SLACK_INTEGRATION_BOT_CONFIG", raising=False)
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:


### PR DESCRIPTION
## Summary

- Cherry-pick of #1164 into `main`
- `test_config_loaded_from_file_path` YAML fixture was missing the `default` key that `ChannelConfig` requires on `release/0.2.41-hotfix`
- On `main`, `ChannelConfig` has no `default` field (replaced by `other: OtherConfig`), so adding `default: {}` to the fixture is harmless — pydantic ignores unknown keys by default
- Keeps the test fixture consistent across branches

## Test plan

- [ ] CI Slack Bot unit tests pass