### PR TITLE
fix(github-mcp): bump Go builder image to 1.25-alpine

### DIFF
--- a/ai_platform_engineering/agents/github/build/Dockerfile.mcp
+++ b/ai_platform_engineering/agents/github/build/Dockerfile.mcp
@@ -1,5 +1,5 @@
 # ---------- Stage 1: Build Go binary ----------
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
## Summary

- Bumps `FROM golang:1.24-alpine` → `FROM golang:1.25-alpine` in `ai_platform_engineering/agents/github/build/Dockerfile.mcp`
- `mcp_github/go.mod` requires `go >= 1.25.0` but the builder image was still on 1.24, causing `ci-mcp-sub-agent` to fail on all release branch RC builds with:
  `go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`

## Test plan

- [ ] Merge and verify `ci-mcp-sub-agent` passes on the next RC build
- [ ] Confirm `github` MCP agent image is published successfully