### PR TITLE
fix(ci): sync appVersion with chart version bump

### DIFF
--- a/.github/workflows/helm-pre-release.yml
+++ b/.github/workflows/helm-pre-release.yml
@@ -233,8 +233,9 @@ jobs:
 
           mkdir -p ./packaged-charts
 
-          # Update Chart.yaml with pre-release version
+          # Update Chart.yaml with pre-release version and matching appVersion
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.rag-stack-version }}/" charts/rag-stack/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: ${{ steps.version.outputs.rag-stack-version }}/" charts/rag-stack/Chart.yaml
 
           # Update dependencies and package
           helm dependency update charts/rag-stack/
@@ -249,8 +250,9 @@ jobs:
 
           mkdir -p ./packaged-charts
 
-          # Update Chart.yaml with pre-release version
+          # Update Chart.yaml with pre-release version and matching appVersion
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.ai-platform-version }}/" charts/ai-platform-engineering/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: ${{ steps.version.outputs.ai-platform-version }}/" charts/ai-platform-engineering/Chart.yaml
 
           # If rag-stack was also changed, update its dependency version
           if [[ "${{ steps.detect.outputs.rag-stack-changed }}" == "true" ]]; then

--- a/.github/workflows/helm-rc-version-bump.yml
+++ b/.github/workflows/helm-rc-version-bump.yml
@@ -85,10 +85,13 @@ jobs:
 
           # Valid patterns:
           # 1. Exact match: <release_version> (e.g., 0.2.8)
-          # 2. RC pattern: <release_version>-rc.helm.<number> (e.g., 0.2.8-rc.helm.1)
-          VALID_PATTERN="^${RELEASE_VERSION}(-rc\.helm\.[0-9]+)?$"
+          # 2. Chart version RC pattern: <release_version>-rc.helm.<number> (e.g., 0.2.8-rc.helm.1)
+          # 3. appVersion RC pattern: <release_version>-rc.<number> (e.g., 0.2.8-rc.1)
+          VALID_VERSION_PATTERN="^${RELEASE_VERSION}(-rc\.helm\.[0-9]+)?$"
+          VALID_APP_VERSION_PATTERN="^${RELEASE_VERSION}(-rc\.[0-9]+)?$"
 
-          echo "📋 Valid version pattern: $VALID_PATTERN"
+          echo "📋 Valid version pattern: $VALID_VERSION_PATTERN"
+          echo "📋 Valid appVersion pattern: $VALID_APP_VERSION_PATTERN"
           echo ""
 
           VALIDATION_FAILED=false
@@ -105,7 +108,7 @@ jobs:
             echo "   appVersion: $APP_VERSION"
 
             # Validate chart version
-            if [[ ! "$CHART_VERSION" =~ $VALID_PATTERN ]]; then
+            if [[ ! "$CHART_VERSION" =~ $VALID_VERSION_PATTERN ]]; then
               echo "   ❌ ERROR: Chart version '$CHART_VERSION' does not match release pattern"
               echo "      Expected: '$RELEASE_VERSION' or '$RELEASE_VERSION-rc.helm.<number>'"
               VALIDATION_FAILED=true
@@ -116,9 +119,9 @@ jobs:
 
             # Validate appVersion if it exists and is not empty
             if [[ -n "$APP_VERSION" && "$APP_VERSION" != "null" ]]; then
-              if [[ ! "$APP_VERSION" =~ $VALID_PATTERN ]]; then
+              if [[ ! "$APP_VERSION" =~ $VALID_APP_VERSION_PATTERN ]]; then
                 echo "   ❌ ERROR: appVersion '$APP_VERSION' does not match release pattern"
-                echo "      Expected: '$RELEASE_VERSION' or '$RELEASE_VERSION-rc.helm.<number>'"
+                echo "      Expected: '$RELEASE_VERSION' or '$RELEASE_VERSION-rc.<number>'"
                 VALIDATION_FAILED=true
                 FAILED_CHARTS="$FAILED_CHARTS $CHART_NAME(appVersion:$APP_VERSION)"
               else
@@ -353,13 +356,23 @@ jobs:
               NEW_VERSION="${RELEASE_VERSION}-rc.helm.${NEW_RC}"
             else
               # No rc.helm suffix, start with 1
+              NEW_RC=1
               NEW_VERSION="${RELEASE_VERSION}-rc.helm.1"
             fi
 
-            echo "  📦 $CHART_NAME: $CURRENT_VERSION → $NEW_VERSION"
+            # Derive appVersion from chart version: strip "helm." to get <release>-rc.<N>
+            NEW_APP_VERSION="${RELEASE_VERSION}-rc.${NEW_RC}"
+
+            echo "  📦 $CHART_NAME: $CURRENT_VERSION → $NEW_VERSION (appVersion → $NEW_APP_VERSION)"
 
             # Update the version
             yq -i ".version = \"$NEW_VERSION\"" "$CHART_FILE"
+
+            # Update appVersion if it exists in the chart
+            EXISTING_APP_VERSION=$(yq '.appVersion // ""' "$CHART_FILE" | tr -d '"')
+            if [[ -n "$EXISTING_APP_VERSION" && "$EXISTING_APP_VERSION" != "null" ]]; then
+              yq -i ".appVersion = \"$NEW_APP_VERSION\"" "$CHART_FILE"
+            fi
 
             BUMPED_CHARTS="$BUMPED_CHARTS $CHART_NAME"
           done


### PR DESCRIPTION
## Summary

Ensures `appVersion` stays in sync with chart version bumps across both RC and pre-release workflows, so image tags (which default to `appVersion`) always match the chart RC iteration.

## Changes

### \`helm-rc-version-bump.yml\` (RC auto-bump on main/PRs)
When bumping chart \`version\` to \`<release>-rc.helm.N\`, also updates \`appVersion\` to \`<release>-rc.N\`:

| Field | Before | After |
|-------|--------|-------|
| \`version\` | \`0.2.43-rc.helm.4\` → \`0.2.43-rc.helm.5\` | \`0.2.43-rc.helm.5\` |
| \`appVersion\` | \`0.2.43\` (unchanged ❌) | \`0.2.43-rc.5\` ✅ |

Also updates the validation step to accept \`<release>-rc.<number>\` as a valid \`appVersion\` pattern (separate from the chart version pattern \`<release>-rc.helm.<number>\`).

### \`helm-pre-release.yml\` (prebuild PR packaging)
When packaging charts with a pre-release version (e.g. \`0.2.44-feat-xxx-29\`), also sets \`appVersion\` to the same value so image tags default correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)