### PR TITLE
fix(deps): regenerate uv.lock to fix Docker build

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ dev = [
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.3" },
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", specifier = "==9.0.2" },
     { name = "ruff", specifier = "==0.14.8" },
 ]
 unittest = [{ name = "pytest-asyncio", specifier = "==1.3.0" }]


### PR DESCRIPTION
## Summary

- `uv.lock` had `pytest` specifier recorded as `>=9.0.2` instead of the resolved pinned form `==9.0.2`
- This caused `uv lock --check` to report the lock as stale
- The Dockerfile runs `uv sync --locked` which asserts the lock is up-to-date — that assertion failed, producing exit code 1

## Root cause

The `fix(deps)` upgrade commit (#1173) left one specifier in `uv.lock` unnormalized. Running `uv lock` locally reconciles it in a single-line diff.

## Test plan

- [ ] Docker build `caipe-supervisor` target completes successfully
- [ ] `uv lock --check` exits 0