### PR TITLE
fix(deps): bump gh CLI from 2.63.2 to 2.89.0 in Dockerfile.a2a

### DIFF
--- a/build/agents/Dockerfile.a2a
+++ b/build/agents/Dockerfile.a2a
@@ -96,7 +96,7 @@ RUN ARCH=$(uname -m) && \
     else \
         GH_ARCH="amd64"; \
     fi && \
-    GH_VERSION="2.63.2" && \
+    GH_VERSION="2.89.0" && \
     curl -sfL --retry 5 --retry-delay 3 "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" -o gh.tar.gz && \
     tar -xzf gh.tar.gz && \
     mv gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh && \


### PR DESCRIPTION
## Summary

- `GH_VERSION="2.63.2"` in `build/agents/Dockerfile.a2a` references a non-existent GitHub CLI release, causing `curl` to exit with code 22 (HTTP error) and failing the build for all agent images (`agent-petstore`, `agent-jira`, `agent-splunk`, and others)
- Bumped to `2.89.0`, the current latest stable release — already the version used in the `caipe-supervisor` stage-2 step

## Test plan

- [ ] Re-run `docker compose -f docker-compose.dev.yaml build` with agent profiles and confirm all agent images build successfully