### PR TITLE
docs(skills): add dco-ai-attribution skill and update agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,22 @@ Each component has its own environment variables - see `env.example` in `ui/` an
 - **Configuration & code details** - Document in component READMEs
 - **Agent instructions** - Keep this file (`AGENTS.md`) up-to-date
 
+## DCO and AI Attribution Policy
+
+**Skill**: [`skills/dco-ai-attribution/SKILL.md`](./skills/dco-ai-attribution/SKILL.md)  
+**Authority**: Linux kernel [AI Coding Assistants policy](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst)
+
+AI agents operating in this repository **must** follow these rules on every commit:
+
+1. **Never generate `Signed-off-by`** — this is a human-only DCO certification. Do not add, suggest, or insert this trailer on behalf of the AI.
+2. **Always suggest `Assisted-by`** when code was materially AI-assisted:
+   ```
+   Assisted-by: Claude:claude-sonnet-4-6
+   ```
+3. **Always remind the human** to add their own `Signed-off-by` before the commit is finalized.
+
+Full pre-commit checklist and examples: [`skills/dco-ai-attribution/SKILL.md`](./skills/dco-ai-attribution/SKILL.md)
+
 ## Git Guidelines
 
 - **Sign off commits** - Use `git commit --signoff` (DCO requirement)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,12 @@
 
 ## Commit Style -- Conventional Commits + DCO
 
-Every commit must use [Conventional Commits](https://www.conventionalcommits.org/) format and include a **DCO sign-off** (`git commit -s`):
+Every commit must use [Conventional Commits](https://www.conventionalcommits.org/) format and include a **DCO sign-off** (`git commit -s`).
+
+For AI-assisted commits, follow the [dco-ai-attribution](./skills/dco-ai-attribution/SKILL.md) skill:
+- AI must **never** add `Signed-off-by` — only the human author can certify the DCO
+- Always append `Assisted-by: Claude:<model-version>` when code was materially AI-assisted
+- See `agents.md` for the canonical policy reference used by AI coding agents
 
 ```
 <type>(<scope>): <short description>
@@ -102,6 +107,7 @@ PYTHONPATH=. uv run pytest tests/<test_file>.py::<TestClass> -v
 
 The `skills/` directory contains reusable tools organized by category:
 
+- **dco-ai-attribution**: DCO compliance and AI attribution rules for AI-assisted commits (see [skills/dco-ai-attribution/SKILL.md](./skills/dco-ai-attribution/SKILL.md))
 - **persistence**: Test LangGraph backends (Redis, PostgreSQL, MongoDB) and fact extraction
 - **debugging**: (future) Debugging and troubleshooting tools
 - **monitoring**: (future) Observability and metrics helpers

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,7 @@ Reusable tools and utilities organized by category.
 
 ```
 skills/
+├── dco-ai-attribution/   # DCO compliance and AI attribution for commits
 ├── persistence/          # LangGraph persistence testing (Redis, Postgres, MongoDB)
 ├── integration-testing/  # End-to-end multi-agent integration testing
 ├── quality-gates/        # Pre-commit validation (lint, test, UI tests)
@@ -15,6 +16,13 @@ skills/
 ```
 
 ## Available Skills
+
+### 📋 [dco-ai-attribution](./dco-ai-attribution/)
+DCO compliance and AI attribution rules for commits that include AI-assisted code.
+
+**When to apply**: Whenever an AI agent helps write or refactor code that will be committed.
+
+See [dco-ai-attribution/SKILL.md](./dco-ai-attribution/SKILL.md) for the full policy, `Assisted-by` trailer format, and pre-commit checklist.
 
 ### 📊 [persistence](./persistence/)
 Test and manage LangGraph persistence backends and fact extraction.

--- a/skills/dco-ai-attribution/SKILL.md
+++ b/skills/dco-ai-attribution/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: dco-ai-attribution
+description: >
+  DCO compliance and AI attribution guidelines for commits that include AI-assisted code.
+  Enforces the Linux kernel coding-assistants policy: AI must never add Signed-off-by;
+  humans certify the DCO; Assisted-by trailer documents AI tool usage. Apply whenever
+  a user is committing AI-assisted code in any project.
+---
+
+# DCO and AI Attribution for AI-Assisted Commits
+
+These rules are derived from the Linux kernel's official
+[AI Coding Assistants](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst)
+policy. They apply to all projects where the DCO governs contributions.
+
+---
+
+## Core rule: AI must never add Signed-off-by
+
+`Signed-off-by` is a human-only legal certification of the DCO. An AI agent must not
+generate, suggest, or insert a `Signed-off-by` line on behalf of itself.
+
+The human submitter is always responsible for:
+1. Reviewing all AI-generated code before committing
+2. Ensuring the contribution is license-compatible with the target project
+3. Adding their own `Signed-off-by` to certify the DCO
+4. Taking full legal and ethical responsibility for the contribution
+
+---
+
+## Attribution: Assisted-by trailer
+
+Format:
+  Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+
+Examples:
+  Assisted-by: Claude:claude-sonnet-4-6
+  Assisted-by: Claude:claude-sonnet-4-6 clang-tidy
+  Assisted-by: Claude:claude-3-opus coccinelle sparse
+
+---
+
+## Complete commit message example
+
+  fix(auth): validate JWT expiry before returning user context
+
+  The expiry check was skipped when the token lacked an explicit 'exp'
+  claim, allowing stale tokens to authenticate.
+
+  Assisted-by: Claude:claude-sonnet-4-6
+  Signed-off-by: Sri Aradhyula <sraradhy@example.com>
+
+---
+
+## Pre-commit checklist
+
+- [ ] I have read and understood every line of AI-generated code
+- [ ] I can explain what the code does and why it is correct
+- [ ] The code is license-compatible with the target project
+- [ ] I have added my own Signed-off-by trailer
+- [ ] I have added an Assisted-by trailer (AI tool + model version)
+- [ ] No AI-generated Signed-off-by line is present
+
+---
+
+## How this skill was developed
+
+Written with Claude Code (claude-sonnet-4-6). Policy content derived from the Linux
+kernel's coding-assistants.rst, authored by the kernel community (GPL-2.0).
+
+  Assisted-by: Claude:claude-sonnet-4-6


### PR DESCRIPTION
## Summary

- Adds `skills/dco-ai-attribution/SKILL.md` — implements the Linux kernel [AI Coding Assistants policy](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst): AI must never add `Signed-off-by`; `Assisted-by` trailer documents AI tool usage
- Updates `AGENTS.md` with a standing **DCO and AI Attribution Policy** section so all AI coding agents load the rules at context time
- Updates `CLAUDE.md` to register the skill under Reusable Skills and adds an attribution note in the Commit Style section
- Updates `skills/README.md` with the new skill entry and directory listing

## Test plan

- [ ] Verify `skills/dco-ai-attribution/SKILL.md` renders with YAML frontmatter intact
- [ ] Confirm `AGENTS.md` DCO section link resolves to the correct skill file
- [ ] Confirm `CLAUDE.md` skill link resolves correctly
- [ ] Verify no AI-generated `Signed-off-by` is present in this commit

Assisted-by: Claude:claude-sonnet-4-6