### PR TITLE
ci(security): use Code Scanning PR diff mode instead of fail-build

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,11 +1,27 @@
 ---
 name: "Grype Scan"
-description: "Anchore Grype vulnerability scan — filesystem on PRs/main (blocking on critical), filesystem + all containers on tags (informational)"
+description: "Anchore Grype vulnerability scan — filesystem on all events, containers on tags. Blocking gate is GitHub Code Scanning PR diff mode, not fail-build."
 
 # Trigger matrix:
-#   pull_request / push to main  → filesystem scan only, fail-build: true on critical+ (blocks merge)
+#   pull_request / push to main  → filesystem scan only; fail-build: false — GitHub Code Scanning
+#                                  PR diff mode is the gate (only NEW alerts block the PR)
 #   push tag                     → filesystem scan + all container images, fail-build: false (informational)
 #   workflow_dispatch            → both jobs, fail-build: false
+#
+# Why fail-build: false everywhere?
+#   Grype's fail-build hard-fails on any CVE at or above severity-cutoff, including CVEs in
+#   upstream libraries that have no available fix yet. That forces contributors to take the
+#   blame for vulnerabilities they didn't introduce and can't resolve.
+#
+#   GitHub Code Scanning's PR diff mode only surfaces alerts that are *new* in the PR — CVEs
+#   already present on the base branch (e.g., in a transitive dep that predates the PR) are
+#   silently excluded from the PR check. This means:
+#     - A PR that introduces a new vulnerable dependency → new alert → PR blocked
+#     - An upstream CVE already present on main → not new → PR not blocked, alert visible in
+#       the Security tab so maintainers can track and upgrade when a fix is released
+#
+#   To activate this: require the "Code scanning results / Grype" check under
+#   Settings → Branches → Branch protection rules for main.
 
 on:
   pull_request:
@@ -45,8 +61,7 @@ jobs:
         id: scan
         with:
           path: "."
-          # Block on critical vulns for PRs/main; informational on tags and manual dispatch
-          fail-build: "${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}"
+          fail-build: false  # Gate is GitHub Code Scanning PR diff — see top-level comment
           severity-cutoff: critical
           output-format: sarif
 


### PR DESCRIPTION
## Summary

- Sets `fail-build: false` on the Grype filesystem scan (was a dynamic expression that was `true` on PRs/main)
- Moves the blocking gate to **GitHub Code Scanning's PR diff mode**
- Adds a detailed comment block at the top of the workflow explaining the rationale

## How it works after this change

GitHub Code Scanning compares the SARIF results uploaded for a PR against the results already present on the base branch (`main`). Only **new** alerts — CVEs introduced by the PR that weren't already on `main` — surface as a blocking PR check.

| CVE scenario | Old behaviour | New behaviour |
|---|---|---|
| Upstream dep CVE already on `main` (e.g. fastmcp, nltk) | Blocks PR | Not blocked — not new; visible in Security tab |
| PR introduces a new dep with a known CVE | Blocks PR | Blocks PR — alert is new |
| PR upgrades a dep to a vulnerable version | Blocks PR | Blocks PR — alert is new |

The PR owner sees exactly which package and CVE triggered the alert, making it clear whether it's in their code or an upstream library.

## Required follow-up (repo settings, not code)

After merging, require the **"Code scanning results / Grype"** check in:

> Settings → Branches → Branch protection rules for `main` → Require status checks → add `Code scanning results / Grype`

Without that, the check runs but doesn't block merges.

## Test plan

- [ ] Merge this PR and verify the Grype workflow completes without failing on main
- [ ] Open a test PR that does NOT change any deps — verify no new Grype alerts appear
- [ ] Enable "Code scanning results / Grype" as a required check in branch protection