### PR TITLE
fix(docs): escape angle bracket in plan.md to fix MDX build failure

### DIFF
--- a/docs/docs/specs/098-unify-single-distributed-binding/plan.md
+++ b/docs/docs/specs/098-unify-single-distributed-binding/plan.md
@@ -161,7 +161,7 @@ In addition to per-agent distribution, this branch now includes RAG tool reliabi
 ### Updated Technical Context
 
 **Testing**: pytest (sync tests; no pytest-asyncio — use `asyncio.run()` wrappers)
-**Performance Goals**: RAG queries complete within 60s; streaming latency <500ms per chunk
+**Performance Goals**: RAG queries complete within 60s; streaming latency &lt;500ms per chunk
 **Constraints**: Context window ~128K tokens; recursion limit configurable (default 500)
 
 ### Phase B: RAG Reliability (US-6) — COMPLETED


### PR DESCRIPTION
## Summary

- Escapes `<500ms` → `&lt;500ms` in `docs/docs/specs/098-unify-single-distributed-binding/plan.md` line 164

MDX (used by Docusaurus) treats `<` as a JSX tag opener. `<500ms` looks like a tag starting with the digit `5`, which is invalid JSX — causing the Docusaurus build to fail with:

```
Error: MDX compilation failed for file "...plan.md"
Cause: Unexpected character `5` (U+0035) before name, expected a character that can start a name, such as a letter, `$`, or `_`
```

This is the only change — no `.grype.yaml`, no other modifications.

Fixes the failing [Publish Docs GH Pages run](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/24313548436/job/70987233362).

## Test plan

- [ ] Docusaurus build passes in CI