### PR TITLE
fix(docs): replace broken relative spec link with GitHub URL

### DIFF
--- a/docs/docs/evaluations/slack-streaming-conformance.md
+++ b/docs/docs/evaluations/slack-streaming-conformance.md
@@ -1,6 +1,6 @@
 # Slack Streaming Conformance Benchmark
 
-> **Spec**: [099-slack-streaming-conformance](../../.specify/specs/099-slack-streaming-conformance/spec.md)  
+> **Spec**: [099-slack-streaming-conformance](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/specs/099-slack-streaming-conformance/spec.md)  
 > **Benchmark Definition**: [`tests/STREAMING_CONFORMANCE.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/tests/STREAMING_CONFORMANCE.md)  
 > **Runner**: `tests/simulate_slack_stream.py --suite --report`
 


### PR DESCRIPTION
## Summary

- Fixes the Docusaurus build failure introduced by a relative link in `docs/docs/evaluations/slack-streaming-conformance.md`

The link `../../.specify/specs/099-slack-streaming-conformance/spec.md` resolves outside the Docusaurus content root (`docs/docs/`), so Docusaurus reports it as a broken link and fails the build. Replaced with the absolute GitHub URL.

Fixes [Publish Docs GH Pages run #24313871269](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/24313871269).

## Test plan

- [ ] Docusaurus build passes in CI