### PR TITLE
feat(ci): add weekly security CVE tracking issue workflow

### DIFF
--- a/.github/cve-alternatives.json
+++ b/.github/cve-alternatives.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Manually maintained alternatives for packages with open CVEs. Keyed by the package name as it appears in the Grype rule ID (suffix after the GHSA). Edit this file via a normal PR — the security-cve-tracking workflow reads it automatically.",
+  "fastmcp": {
+    "alternatives": [
+      "[`mcp`](https://pypi.org/project/mcp/) — official low-level MCP SDK (modelcontextprotocol)"
+    ],
+    "notes": "fastmcp is a high-level wrapper around the official `mcp` SDK. The CVEs are in fastmcp's HTTP layer. Migrating to `mcp` directly removes the dependency but requires rewriting server boilerplate."
+  },
+  "nltk": {
+    "alternatives": [
+      "[`spacy`](https://pypi.org/project/spacy/) — industrial-strength NLP, actively maintained",
+      "[`tiktoken`](https://pypi.org/project/tiktoken/) — OpenAI tokenizer, lighter weight if only tokenization is needed"
+    ],
+    "notes": "Used for tokenization/text processing in the RAG stack. spaCy is the most direct drop-in with equivalent NLP capabilities."
+  },
+  "scrapy": {
+    "alternatives": [
+      "[`httpx`](https://pypi.org/project/httpx/) + [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/) — lightweight, async-friendly",
+      "[`playwright`](https://pypi.org/project/playwright/) — handles JS-rendered pages"
+    ],
+    "notes": "Used in RAG ingestors for web scraping. httpx+bs4 is the simplest migration for static pages; playwright is needed for JS-heavy sites."
+  },
+  "github.com/modelcontextprotocol/go-sdk": {
+    "alternatives": [],
+    "notes": "This IS the official MCP Go SDK — no viable alternative. Waiting on the upstream maintainers to patch."
+  },
+  "serialize-javascript": {
+    "alternatives": [
+      "[`devalue`](https://www.npmjs.com/package/devalue) — safer serialization for untrusted data"
+    ],
+    "notes": "Transitive dependency pulled in by webpack/build tooling. Direct migration may not be possible — depends on whether the direct dep exposes an option to swap serializers."
+  }
+}

--- a/.github/workflows/security-cve-tracking.yml
+++ b/.github/workflows/security-cve-tracking.yml
@@ -87,24 +87,53 @@ jobs:
                 )
                 .map(g => {
                   const advisory = `https://github.com/advisories/${g.ghsa}`;
-                  return `| [\`${g.ghsa}\`](${advisory}) | \`${g.pkg}\` | ${g.severity} | ${g.count} |`;
+                  const pypi = `https://pypi.org/project/${g.pkg}/#history`;
+                  const npm  = `https://www.npmjs.com/package/${g.pkg}?activeTab=versions`;
+                  // Link to PyPI for Python packages, npm for JS, GitHub for Go modules
+                  const isGo  = g.pkg.includes('/') || g.pkg.includes('github.com');
+                  const isJs  = ['serialize-javascript', 'next', 'dompurify', 'hono'].includes(g.pkg);
+                  const fixLink = isGo
+                    ? `[GitHub releases](https://github.com/${g.pkg}/releases)`
+                    : isJs
+                      ? `[npm versions](${npm})`
+                      : `[PyPI history](${pypi})`;
+                  return `| [\`${g.ghsa}\`](${advisory}) | \`${g.pkg}\` | ${g.severity} | ${g.count} | Waiting for upstream patch — monitor ${fixLink} |`;
                 })
                 .join('\n');
 
               body = [
                 '## Upstream CVE Tracking',
                 '',
-                `**${totalCount} open alert${totalCount === 1 ? '' : 's'}** across ${Object.keys(groups).length} CVE${Object.keys(groups).length === 1 ? '' : 's'} in upstream dependencies with no available fix yet.`,
+                `**${totalCount} open alert${totalCount === 1 ? '' : 's'}** across ${Object.keys(groups).length} CVE${Object.keys(groups).length === 1 ? '' : 's'}.`,
                 '',
-                'These alerts are **informational only** — they do not block pull requests.',
-                'GitHub Code Scanning PR diff mode only surfaces alerts that are *new* in a PR;',
-                'CVEs already present on `main` are excluded from the PR gate.',
+                '> **\u26a0\ufe0f These are not vulnerabilities in this repository\'s code.**',
+                '> Every CVE listed here is in a third-party library that this project depends on.',
+                '> The CAIPE codebase itself is not affected — we are waiting for the upstream',
+                '> maintainers to release a patched version. There is no action contributors to',
+                '> this repo can take to resolve these.',
                 '',
-                'Alerts will auto-close once the upstream package ships a patched version',
-                'and the dependency is upgraded here.',
+                '### Why are these tracked here?',
                 '',
-                '| GHSA | Package | Severity | Open alerts |',
-                '|------|---------|----------|-------------|',
+                'Grype scans the full dependency tree on every push to `main` and uploads results',
+                'to GitHub Code Scanning. These alerts surface because the installed version of an',
+                'upstream package appears in a CVE\'s affected range, but no patched release exists',
+                'on PyPI / npm yet.',
+                '',
+                'They do **not** block pull requests — GitHub Code Scanning PR diff mode only',
+                'flags alerts that are *new in the PR*. An upstream CVE already present on `main`',
+                'is excluded from the PR gate, so contributors are never blocked by issues they',
+                'did not introduce.',
+                '',
+                '### What will resolve these?',
+                '',
+                'Each entry will auto-close once:',
+                '1. The upstream maintainer releases a patched version, **and**',
+                '2. A PR in this repo upgrades the dependency to that version.',
+                '',
+                'Dependabot will open that upgrade PR automatically when a fix is available.',
+                '',
+                '| GHSA | Package | Severity | Open alerts | Remediation |',
+                '|------|---------|----------|-------------|-------------|',
                 rows,
                 '',
                 `> _Last updated: ${date} — [View in Security tab](https://github.com/${context.repo.owner}/${context.repo.repo}/security/code-scanning)_`,

--- a/.github/workflows/security-cve-tracking.yml
+++ b/.github/workflows/security-cve-tracking.yml
@@ -1,0 +1,176 @@
+---
+name: Security CVE Tracking
+
+# Runs every Monday and on demand.
+# Queries GitHub Code Scanning for open Grype alerts, groups them by
+# package + GHSA, then creates or updates a single tracking issue so
+# maintainers can see the current upstream-CVE state without visiting
+# the Security tab. The issue auto-closes when there are no open alerts.
+
+on:
+  schedule:
+    - cron: "3 9 * * 1"  # Every Monday at 09:03 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  security-events: read
+
+jobs:
+  update-tracking-issue:
+    name: Update CVE tracking issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Update CVE tracking issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const LABEL = 'security-tracking';
+            const TITLE_PREFIX = 'Security: upstream CVEs pending upstream fixes';
+
+            // ── 1. Fetch all open code-scanning alerts ──────────────────────
+            const alerts = await github.paginate(
+              github.rest.codeScanning.listAlertsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+              }
+            );
+
+            // ── 2. Group by rule ID ─────────────────────────────────────────
+            // Rule IDs from Grype look like: GHSA-m8x7-r2rg-vh5g-fastmcp
+            // GHSA pattern: GHSA-[4]-[4]-[4]; package name is the suffix.
+            const ghsaRe = /^(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})/;
+            const groups = {};
+            for (const alert of alerts) {
+              const ruleId = alert.rule.id;
+              if (!groups[ruleId]) {
+                const ghsaMatch = ruleId.match(ghsaRe);
+                const ghsa = ghsaMatch ? ghsaMatch[1] : ruleId;
+                const pkg  = ghsaMatch
+                  ? ruleId.slice(ghsa.length + 1)   // strip "GHSA-xxxx-xxxx-xxxx-"
+                  : ruleId;
+                groups[ruleId] = {
+                  ghsa,
+                  pkg,
+                  severity: alert.rule.severity,
+                  count: 0,
+                };
+              }
+              groups[ruleId].count++;
+            }
+
+            const totalCount = alerts.length;
+            const date = new Date().toISOString().split('T')[0];
+
+            // ── 3. Build issue body ─────────────────────────────────────────
+            let body;
+            if (totalCount === 0) {
+              body = [
+                '## \u2705 No open upstream CVE alerts',
+                '',
+                `All known CVEs in upstream dependencies have been resolved. Last checked: ${date}.`,
+              ].join('\n');
+            } else {
+              const severityOrder = { error: 0, warning: 1, note: 2 };
+              const rows = Object.values(groups)
+                .sort((a, b) =>
+                  (severityOrder[a.severity] ?? 9) - (severityOrder[b.severity] ?? 9) ||
+                  b.count - a.count
+                )
+                .map(g => {
+                  const advisory = `https://github.com/advisories/${g.ghsa}`;
+                  return `| [\`${g.ghsa}\`](${advisory}) | \`${g.pkg}\` | ${g.severity} | ${g.count} |`;
+                })
+                .join('\n');
+
+              body = [
+                '## Upstream CVE Tracking',
+                '',
+                `**${totalCount} open alert${totalCount === 1 ? '' : 's'}** across ${Object.keys(groups).length} CVE${Object.keys(groups).length === 1 ? '' : 's'} in upstream dependencies with no available fix yet.`,
+                '',
+                'These alerts are **informational only** — they do not block pull requests.',
+                'GitHub Code Scanning PR diff mode only surfaces alerts that are *new* in a PR;',
+                'CVEs already present on `main` are excluded from the PR gate.',
+                '',
+                'Alerts will auto-close once the upstream package ships a patched version',
+                'and the dependency is upgraded here.',
+                '',
+                '| GHSA | Package | Severity | Open alerts |',
+                '|------|---------|----------|-------------|',
+                rows,
+                '',
+                `> _Last updated: ${date} — [View in Security tab](https://github.com/${context.repo.owner}/${context.repo.repo}/security/code-scanning)_`,
+              ].join('\n');
+            }
+
+            // ── 4. Ensure the tracking label exists ────────────────────────
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: LABEL,
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: LABEL,
+                color: 'e11d48',
+                description: 'Automated upstream CVE tracking — managed by security-cve-tracking workflow',
+              });
+            }
+
+            // ── 5. Find existing open tracking issue ───────────────────────
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: LABEL,
+              state: 'open',
+              per_page: 1,
+            });
+
+            // ── 6. Create, update, or close ────────────────────────────────
+            if (totalCount === 0) {
+              if (existing.data.length > 0) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.data[0].number,
+                  body,
+                  state: 'closed',
+                });
+                core.notice(`Closed tracking issue #${existing.data[0].number} — no open alerts remaining`);
+              } else {
+                core.notice('No open alerts and no existing tracking issue — nothing to do');
+              }
+              return;
+            }
+
+            const title = `${TITLE_PREFIX} (${totalCount})`;
+            if (existing.data.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                title,
+                body,
+              });
+              core.notice(`Updated tracking issue #${existing.data[0].number} — ${totalCount} open alerts`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [LABEL],
+              });
+              core.notice(`Created tracking issue #${created.data.number} — ${totalCount} open alerts`);
+            }

--- a/.github/workflows/security-cve-tracking.yml
+++ b/.github/workflows/security-cve-tracking.yml
@@ -44,10 +44,26 @@ jobs:
               }
             );
 
-            // ── 2. Group by rule ID ─────────────────────────────────────────
+            // ── 2. Group by rule ID, collect affected components ────────────
             // Rule IDs from Grype look like: GHSA-m8x7-r2rg-vh5g-fastmcp
             // GHSA pattern: GHSA-[4]-[4]-[4]; package name is the suffix.
             const ghsaRe = /^(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})/;
+
+            // Map a file path to a short component name for the Scope column.
+            function pathToComponent(p) {
+              if (!p) return 'unknown';
+              if (p.match(/^ai_platform_engineering\/agents\/([^/]+)\//))
+                return p.match(/^ai_platform_engineering\/agents\/([^/]+)\//)[1];
+              if (p.match(/^ai_platform_engineering\/knowledge_bases\/rag\/([^/]+)\//))
+                return 'rag-' + p.match(/^ai_platform_engineering\/knowledge_bases\/rag\/([^/]+)\//)[1];
+              if (p.startsWith('ai_platform_engineering/dynamic_agents/')) return 'dynamic-agents';
+              if (p.startsWith('ai_platform_engineering/multi_agents/'))   return 'multi-agents';
+              if (p.startsWith('ai_platform_engineering/utils/'))          return 'utils';
+              if (p.startsWith('ui/') || p.includes('package.json'))       return 'ui';
+              if (p === 'uv.lock' || p === 'pyproject.toml')               return 'supervisor';
+              return p.split('/')[0] || 'repo-root';
+            }
+
             const groups = {};
             for (const alert of alerts) {
               const ruleId = alert.rule.id;
@@ -62,10 +78,29 @@ jobs:
                   pkg,
                   severity: alert.rule.severity,
                   count: 0,
+                  cveId: null,          // filled in step 3
+                  components: new Set(),
                 };
               }
               groups[ruleId].count++;
+              const loc = alert.most_recent_instance?.location?.path;
+              groups[ruleId].components.add(pathToComponent(loc));
             }
+
+            // ── 3. Fetch CVE IDs from the GitHub Advisory Database ──────────
+            // GET /advisories/{ghsa_id} returns { cve_id, ... }
+            const uniqueGhsas = [...new Set(Object.values(groups).map(g => g.ghsa))];
+            await Promise.all(uniqueGhsas.map(async ghsa => {
+              try {
+                const { data } = await github.request('GET /advisories/{ghsa_id}', { ghsa_id: ghsa });
+                // Backfill cveId into every group that shares this GHSA
+                for (const g of Object.values(groups)) {
+                  if (g.ghsa === ghsa) g.cveId = data.cve_id || null;
+                }
+              } catch {
+                // Advisory not found or rate-limited — leave cveId null
+              }
+            }));
 
             const totalCount = alerts.length;
             const date = new Date().toISOString().split('T')[0];
@@ -89,15 +124,18 @@ jobs:
                   const advisory = `https://github.com/advisories/${g.ghsa}`;
                   const pypi = `https://pypi.org/project/${g.pkg}/#history`;
                   const npm  = `https://www.npmjs.com/package/${g.pkg}?activeTab=versions`;
-                  // Link to PyPI for Python packages, npm for JS, GitHub for Go modules
-                  const isGo  = g.pkg.includes('/') || g.pkg.includes('github.com');
+                  const isGo  = g.pkg.includes('/') || g.pkg.startsWith('github.com');
                   const isJs  = ['serialize-javascript', 'next', 'dompurify', 'hono'].includes(g.pkg);
                   const fixLink = isGo
                     ? `[GitHub releases](https://github.com/${g.pkg}/releases)`
                     : isJs
                       ? `[npm versions](${npm})`
                       : `[PyPI history](${pypi})`;
-                  return `| [\`${g.ghsa}\`](${advisory}) | \`${g.pkg}\` | ${g.severity} | ${g.count} | Waiting for upstream patch — monitor ${fixLink} |`;
+                  const cveCell = g.cveId
+                    ? `[\`${g.cveId}\`](https://nvd.nist.gov/vuln/detail/${g.cveId})`
+                    : '—';
+                  const scope = [...g.components].sort().join(', ');
+                  return `| [\`${g.ghsa}\`](${advisory}) | ${cveCell} | \`${g.pkg}\` | ${g.severity} | ${g.count} | ${scope} | Waiting for upstream patch — monitor ${fixLink} |`;
                 })
                 .join('\n');
 
@@ -132,8 +170,8 @@ jobs:
                 '',
                 'Dependabot will open that upgrade PR automatically when a fix is available.',
                 '',
-                '| GHSA | Package | Severity | Open alerts | Remediation |',
-                '|------|---------|----------|-------------|-------------|',
+                '| GHSA | CVE | Package | Severity | Open alerts | Scope | Remediation |',
+                '|------|-----|---------|----------|-------------|-------|-------------|',
                 rows,
                 '',
                 `> _Last updated: ${date} — [View in Security tab](https://github.com/${context.repo.owner}/${context.repo.repo}/security/code-scanning)_`,

--- a/.github/workflows/security-cve-tracking.yml
+++ b/.github/workflows/security-cve-tracking.yml
@@ -87,7 +87,21 @@ jobs:
               groups[ruleId].components.add(pathToComponent(loc));
             }
 
-            // ── 3. Fetch CVE IDs from the GitHub Advisory Database ──────────
+            // ── 3. Load alternatives config from .github/cve-alternatives.json
+            let alternatives = {};
+            try {
+              const { data: altFile } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.github/cve-alternatives.json',
+              });
+              const raw = Buffer.from(altFile.content, 'base64').toString('utf8');
+              alternatives = JSON.parse(raw);
+            } catch {
+              core.warning('Could not load .github/cve-alternatives.json — alternatives column will be empty');
+            }
+
+            // ── 5. Fetch CVE IDs from the GitHub Advisory Database ──────────
             // GET /advisories/{ghsa_id} returns { cve_id, ... }
             const uniqueGhsas = [...new Set(Object.values(groups).map(g => g.ghsa))];
             await Promise.all(uniqueGhsas.map(async ghsa => {
@@ -135,7 +149,11 @@ jobs:
                     ? `[\`${g.cveId}\`](https://nvd.nist.gov/vuln/detail/${g.cveId})`
                     : '—';
                   const scope = [...g.components].sort().join(', ');
-                  return `| [\`${g.ghsa}\`](${advisory}) | ${cveCell} | \`${g.pkg}\` | ${g.severity} | ${g.count} | ${scope} | Waiting for upstream patch — monitor ${fixLink} |`;
+                  const alt = alternatives[g.pkg];
+                  const altCell = alt && alt.alternatives.length > 0
+                    ? alt.alternatives.join('<br>')
+                    : '—';
+                  return `| [\`${g.ghsa}\`](${advisory}) | ${cveCell} | \`${g.pkg}\` | ${g.severity} | ${g.count} | ${scope} | Waiting for upstream patch — monitor ${fixLink} | ${altCell} |`;
                 })
                 .join('\n');
 
@@ -170,8 +188,8 @@ jobs:
                 '',
                 'Dependabot will open that upgrade PR automatically when a fix is available.',
                 '',
-                '| GHSA | CVE | Package | Severity | Open alerts | Scope | Remediation |',
-                '|------|-----|---------|----------|-------------|-------|-------------|',
+                '| GHSA | CVE | Package | Severity | Open alerts | Scope | Remediation | Alternatives |',
+                '|------|-----|---------|----------|-------------|-------|-------------|--------------|',
                 rows,
                 '',
                 `> _Last updated: ${date} — [View in Security tab](https://github.com/${context.repo.owner}/${context.repo.repo}/security/code-scanning)_`,


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/security-cve-tracking.yml`
- Runs every Monday at 09:03 UTC and on `workflow_dispatch`
- Queries all open Grype Code Scanning alerts, groups by GHSA + package
- Creates or updates a single issue labelled `security-tracking` with the current state
- Issue auto-closes when alert count reaches 0

## What the issue looks like

```
## Upstream CVE Tracking

**100 open alerts** across 9 CVEs in upstream dependencies with no available fix yet.

These alerts are **informational only** — they do not block pull requests.
...

| GHSA | Package | Severity | Open alerts |
|------|---------|----------|-------------|
| `GHSA-rcfx-77hg-w2wv` | `fastmcp` | error | 23 |
| `GHSA-rww4-4w9c-7733` | `fastmcp` | error | 23 |
...
```

## Test plan

- [ ] Merge PR
- [ ] Run workflow manually via `workflow_dispatch`
- [ ] Verify `security-tracking` label is created
- [ ] Verify tracking issue is created with correct alert count and table