### PR TITLE
fix(docker): add retry flags to glab curl download in Dockerfile.a2a

### DIFF
--- a/build/agents/Dockerfile.a2a
+++ b/build/agents/Dockerfile.a2a
@@ -110,7 +110,7 @@ RUN ARCH=$(uname -m) && \
         GLAB_ARCH="amd64"; \
     fi && \
     GLAB_VERSION="1.80.4" && \
-    curl -sL "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${GLAB_ARCH}.tar.gz" -o glab.tar.gz && \
+    curl -sfL --retry 5 --retry-delay 3 --connect-timeout 30 "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${GLAB_ARCH}.tar.gz" -o glab.tar.gz && \
     tar -xzf glab.tar.gz && \
     mv bin/glab /usr/local/bin/glab && \
     rm -rf glab.tar.gz gh_${GLAB_VERSION}_linux_${GLAB_ARCH}


### PR DESCRIPTION
## Summary

- `glab` CLI download was failing inside Docker buildkit with SSL connect error (exit code 35)
- Added `--retry 5 --retry-delay 3 --connect-timeout 30 -f` flags to the `curl` command
- Matches the pattern already used for the `gh` CLI download in the same file

## Test plan

- [ ] `docker compose build` completes successfully for `agent-petstore` target
