### PR TITLE
fix(supervisor): replace RemoveMessage with synthetic ToolMessage for orphaned tool calls

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -118,9 +118,19 @@ class AIPlatformEngineerA2ABinding:
       """
       CRITICAL: Repair orphaned tool calls in message history.
 
-      Bedrock/Anthropic requires ToolMessages to appear IMMEDIATELY after
-      the AIMessage with tool_use. If we can't properly repair the ordering,
-      we remove the problematic AIMessages entirely.
+      Bedrock/Anthropic requires a ToolMessage (tool_result) to appear immediately
+      after the AIMessage that contains the matching tool_use block. When a session
+      is interrupted mid-tool-call, the checkpoint holds an AIMessage with unresolved
+      tool_call_ids and no corresponding ToolMessages.
+
+      Strategy: inject a synthetic ToolMessage for each orphaned tool_call_id.
+      This keeps the AIMessage intact (Bedrock adjacency requirement satisfied) and
+      routes the graph to the `tools` node next (tools→model), so the new user query
+      is processed correctly.
+
+      Do NOT remove the AIMessage and replace with a placeholder (old approach):
+      that caused the graph to route to END instead of model, leaking the placeholder
+      text directly to users.
 
       This is essential for recovery when:
       - A sub-agent call fails mid-stream (e.g., context overflow)
@@ -131,8 +141,6 @@ class AIPlatformEngineerA2ABinding:
           config: Runnable configuration with thread_id
       """
       try:
-          from langchain_core.messages import RemoveMessage
-
           state = await self.graph.aget_state(config)
           if not state or not state.values:
               return
@@ -196,38 +204,46 @@ class AIPlatformEngineerA2ABinding:
               f"IDs: {list(orphaned.keys())}, Names: {orphaned_names}"
           )
 
-          # STRATEGY: Remove ONLY the AIMessages that have orphaned tool calls.
-          # This preserves earlier conversation history while eliminating the problematic
-          # messages that would cause Bedrock validation errors.
+          # STRATEGY: Inject synthetic ToolMessages for each orphaned tool call.
           #
-          # We cannot simply append ToolMessages at the end because Bedrock requires
-          # tool_result immediately after tool_use. And we cannot remove ALL messages
-          # because that triggers IndexError when LangGraph's should_continue runs.
+          # We keep the AIMessage intact and append a synthetic ToolMessage for
+          # each unresolved tool_call_id. This satisfies Bedrock's requirement
+          # that every tool_use block is followed by a matching tool_result,
+          # and routes the graph to the `tools` node next (tools→model) so the
+          # model processes the new user query correctly.
+          #
+          # Previous approach (remove AIMessage with RemoveMessage) was broken:
+          # removing the AIMessage caused LangGraph to set checkpoint next=END,
+          # so the new query was never processed and placeholder text leaked to users.
 
-          # Get the IDs of AIMessages that have orphaned tool calls
-          ai_msg_ids_to_remove = set()
+          synthetic_tool_msgs = []
           for tool_call_id, (msg_idx, tool_name, ai_msg_id) in orphaned.items():
-              if ai_msg_id:
-                  ai_msg_ids_to_remove.add(ai_msg_id)
-                  logging.info(
-                      f"🔧 Will remove AIMessage with orphaned tool_call: "
-                      f"msg_id={ai_msg_id[:20] if ai_msg_id else 'None'}..., "
-                      f"tool={tool_name}, tool_call_id={tool_call_id[:20]}..."
+              synthetic_tool_msgs.append(
+                  ToolMessage(
+                      content=f"Tool '{tool_name}' did not complete (session was interrupted).",
+                      tool_call_id=tool_call_id,
+                      name=tool_name,
                   )
-
-          if ai_msg_ids_to_remove:
-              # Remove only the problematic AIMessages
-              remove_messages = [RemoveMessage(id=msg_id) for msg_id in ai_msg_ids_to_remove]
-              await self.graph.aupdate_state(config, {"messages": remove_messages})
+              )
               logging.info(
-                  f"✅ Supervisor: Removed {len(ai_msg_ids_to_remove)} AIMessage(s) with orphaned tool calls. "
-                  f"Earlier conversation history preserved."
+                  f"🔧 Adding synthetic ToolMessage for orphaned tool: "
+                  f"{tool_name} (tool_call_id={tool_call_id[:20]}...)"
+              )
+
+          if synthetic_tool_msgs:
+              await self.graph.aupdate_state(
+                  config,
+                  {"messages": synthetic_tool_msgs},
+                  as_node="tools",
+              )
+              logging.info(
+                  f"✅ Supervisor: Repaired {len(synthetic_tool_msgs)} orphaned tool call(s) "
+                  f"with synthetic ToolMessages. Graph will route to model node next."
               )
           else:
-              # No message IDs found - fall back to just logging
               logging.warning(
-                  f"⚠️ Supervisor: Found orphaned tool calls but no message IDs to remove. "
-                  f"Orphaned tools: {orphaned_names}"
+                  f"⚠️ Supervisor: Found orphaned tool calls but could not build synthetic "
+                  f"ToolMessages. Orphaned tools: {orphaned_names}"
               )
 
       except Exception as e:

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_binding_e2e.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/tests/test_agent_binding_e2e.py
@@ -12,10 +12,10 @@ Coverage
    - no AIMessages in history
 
 2. _repair_orphaned_tool_calls — repair paths
-   - single orphan → RemoveMessage for that AIMessage ID
-   - multiple orphans on same AIMessage → exactly one RemoveMessage
-   - multiple orphans on different AIMessages → one RemoveMessage each
-   - orphan with no msg ID → no aupdate_state (logs warning only)
+   - single orphan → synthetic ToolMessage injected via as_node='tools'
+   - multiple orphans on same AIMessage → one synthetic ToolMessage per orphan
+   - multiple orphans on different AIMessages → one synthetic ToolMessage per orphan
+   - orphan with no AI msg ID → ToolMessage still injected (keyed on tool_call_id)
    - Bedrock additional_kwargs storage location detected
    - Bedrock content-block storage location detected
 
@@ -36,7 +36,7 @@ Coverage
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -167,14 +167,14 @@ class TestRepairOrphanedToolCallsNoOp:
 
 
 # ===========================================================================
-# 2. Repair paths — RemoveMessage strategy
+# 2. Repair paths — synthetic ToolMessage strategy
 # ===========================================================================
 
 class TestRepairOrphanedToolCallsRepair:
 
     @pytest.mark.asyncio
-    async def test_single_orphan_removes_ai_message(self):
-        """One orphaned tool call → RemoveMessage for its AIMessage ID."""
+    async def test_single_orphan_injects_synthetic_tool_message(self):
+        """One orphaned tool call → one synthetic ToolMessage injected via as_node='tools'."""
 
         binding = _make_binding()
         ai_msg = _make_ai_message(["tc-1"], ["jira_search"], msg_id="ai-msg-orphan")
@@ -184,15 +184,17 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         binding.graph.aupdate_state.assert_awaited_once()
-        call_args = binding.graph.aupdate_state.call_args
-        messages = call_args[0][1]["messages"]
+        _, call_kwargs = binding.graph.aupdate_state.call_args
+        assert call_kwargs.get("as_node") == "tools"
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
         assert len(messages) == 1
-        assert isinstance(messages[0], RemoveMessage)
-        assert messages[0].id == "ai-msg-orphan"
+        assert isinstance(messages[0], ToolMessage)
+        assert messages[0].tool_call_id == "tc-1"
+        assert messages[0].name == "jira_search"
 
     @pytest.mark.asyncio
-    async def test_multiple_orphans_same_ai_message_one_remove(self):
-        """Two orphaned tool calls on same AIMessage → exactly one RemoveMessage."""
+    async def test_multiple_orphans_same_ai_message_one_per_orphan(self):
+        """Two orphaned tool calls on same AIMessage → two synthetic ToolMessages."""
 
         binding = _make_binding()
         ai_msg = _make_ai_message(["tc-1", "tc-2"], ["tool_a", "tool_b"], msg_id="ai-multi")
@@ -202,13 +204,14 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert len(messages) == 1
-        assert isinstance(messages[0], RemoveMessage)
-        assert messages[0].id == "ai-multi"
+        assert len(messages) == 2
+        assert all(isinstance(m, ToolMessage) for m in messages)
+        injected_ids = {m.tool_call_id for m in messages}
+        assert injected_ids == {"tc-1", "tc-2"}
 
     @pytest.mark.asyncio
-    async def test_multiple_orphans_different_ai_messages_one_remove_each(self):
-        """Orphans on two separate AIMessages → two RemoveMessages."""
+    async def test_multiple_orphans_different_ai_messages_one_per_orphan(self):
+        """Orphans on two separate AIMessages → one synthetic ToolMessage per orphan."""
 
         binding = _make_binding()
         ai1 = _make_ai_message(["tc-1"], ["tool_a"], msg_id="ai-first")
@@ -219,13 +222,14 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        ids_removed = {m.id for m in messages}
-        assert ids_removed == {"ai-first", "ai-second"}
-        assert all(isinstance(m, RemoveMessage) for m in messages)
+        assert len(messages) == 2
+        assert all(isinstance(m, ToolMessage) for m in messages)
+        injected_ids = {m.tool_call_id for m in messages}
+        assert injected_ids == {"tc-1", "tc-2"}
 
     @pytest.mark.asyncio
-    async def test_partial_orphans_only_orphaned_ai_message_removed(self):
-        """One AI message resolved, one orphaned → only orphaned one removed."""
+    async def test_partial_orphans_only_unresolved_are_repaired(self):
+        """One AI message resolved, one orphaned → only orphaned tool call gets synthetic ToolMessage."""
 
         binding = _make_binding()
         ai_resolved = _make_ai_message(["tc-resolved"], ["tool_ok"], msg_id="ai-ok")
@@ -239,17 +243,16 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        ids_removed = {m.id for m in messages}
-        assert "ai-bad" in ids_removed
-        assert "ai-ok" not in ids_removed
+        assert len(messages) == 1
+        assert isinstance(messages[0], ToolMessage)
+        assert messages[0].tool_call_id == "tc-orphan"
 
     @pytest.mark.asyncio
-    async def test_orphan_without_msg_id_no_update_state(self):
-        """AIMessage with no id → can't build RemoveMessage, no aupdate_state call."""
+    async def test_orphan_injects_tool_message_regardless_of_ai_msg_id(self):
+        """AIMessage with no id still gets a synthetic ToolMessage (keyed on tool_call_id, not AI msg id)."""
         ai_msg = AIMessage(content="", tool_calls=[
             {"id": "tc-noid", "name": "tool_x", "args": {}, "type": "tool_call"}
         ])
-        # Don't set id (AIMessage id defaults to auto-generated, but we clear it)
         ai_msg.id = None
 
         binding = _make_binding()
@@ -258,14 +261,17 @@ class TestRepairOrphanedToolCallsRepair:
 
         await binding._repair_orphaned_tool_calls(CONFIG)
 
-        binding.graph.aupdate_state.assert_not_awaited()
+        binding.graph.aupdate_state.assert_awaited_once()
+        messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(messages) == 1
+        assert isinstance(messages[0], ToolMessage)
+        assert messages[0].tool_call_id == "tc-noid"
 
     @pytest.mark.asyncio
     async def test_bedrock_additional_kwargs_tooluse_detected(self):
-        """Bedrock stores tool_call IDs in additional_kwargs['tool_use']."""
+        """Bedrock stores tool_call IDs in additional_kwargs['tool_use'] — synthetic ToolMessage injected."""
 
         binding = _make_binding()
-        # No standard tool_calls — only additional_kwargs Bedrock storage
         ai_msg = AIMessage(
             content="",
             additional_kwargs={"tool_use": [{"id": "bedrock-tc-1", "name": "bedrock_tool"}]},
@@ -278,11 +284,11 @@ class TestRepairOrphanedToolCallsRepair:
 
         binding.graph.aupdate_state.assert_awaited_once()
         messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert any(isinstance(m, RemoveMessage) and m.id == "ai-bedrock" for m in messages)
+        assert any(isinstance(m, ToolMessage) and m.tool_call_id == "bedrock-tc-1" for m in messages)
 
     @pytest.mark.asyncio
     async def test_bedrock_content_block_tool_use_detected(self):
-        """Bedrock stores tool_call IDs in content blocks with type='tool_use'."""
+        """Bedrock stores tool_call IDs in content blocks with type='tool_use' — synthetic ToolMessage injected."""
 
         binding = _make_binding()
         ai_msg = AIMessage(
@@ -296,13 +302,13 @@ class TestRepairOrphanedToolCallsRepair:
 
         binding.graph.aupdate_state.assert_awaited_once()
         messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        assert any(isinstance(m, RemoveMessage) and m.id == "ai-block" for m in messages)
+        assert any(isinstance(m, ToolMessage) and m.tool_call_id == "block-tc-1" for m in messages)
 
     @pytest.mark.asyncio
-    async def test_history_preserved_only_orphaned_removed(self):
+    async def test_history_preserved_only_orphaned_repaired(self):
         """
         Earlier clean conversation (HumanMessage + AI + ToolMessage) must be
-        preserved; only the orphaned AIMessage is removed.
+        preserved; only the orphaned tool call gets a synthetic ToolMessage.
         """
 
         binding = _make_binding()
@@ -319,9 +325,9 @@ class TestRepairOrphanedToolCallsRepair:
         await binding._repair_orphaned_tool_calls(CONFIG)
 
         messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
-        removed_ids = {m.id for m in messages if isinstance(m, RemoveMessage)}
-        assert removed_ids == {"ai-orphan"}
-        assert "ai-old" not in removed_ids
+        assert len(messages) == 1
+        assert isinstance(messages[0], ToolMessage)
+        assert messages[0].tool_call_id == "tc-orphan"
 
 
 # ===========================================================================

--- a/ai_platform_engineering/multi_agents/platform_engineer/tests/test_repair_orphaned_tool_calls.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/tests/test_repair_orphaned_tool_calls.py
@@ -1,0 +1,374 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for _repair_orphaned_tool_calls in AIPlatformEngineerA2ABinding.
+
+Background
+----------
+When a session is interrupted mid-tool-call the LangGraph checkpoint holds an
+AIMessage with unresolved tool_call_ids and no corresponding ToolMessages.
+The old repair strategy removed the AIMessage using RemoveMessage. Because
+removing the AIMessage left no tool_calls, LangGraph set checkpoint next=END,
+causing the next user query to be skipped entirely and placeholder text to leak
+directly to users.
+
+The new strategy keeps the AIMessage intact and injects a synthetic ToolMessage
+per orphaned tool_call_id via as_node="tools". This satisfies Bedrock's adjacency
+requirement (tool_result immediately follows tool_use) and routes the graph
+tools→model so the new user query is processed correctly.
+
+These tests verify:
+  1. No-op paths (empty state, no orphans, already resolved)
+  2. Single and multiple orphan repair (correct ToolMessages, correct as_node)
+  3. Deterministic-task pending-tool-call is never repaired
+  4. The old RemoveMessage approach is never used
+  5. Exception paths do not propagate to callers
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage, HumanMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ai_message(tool_call_ids: list[str], tool_names: list[str] | None = None, msg_id: str = "ai-msg-1"):
+    """Build an AIMessage with one or more tool_calls."""
+    tool_names = tool_names or ["search_tool"] * len(tool_call_ids)
+    tool_calls = [
+        {"id": tc_id, "name": name, "args": {}}
+        for tc_id, name in zip(tool_call_ids, tool_names)
+    ]
+    return AIMessage(content="", tool_calls=tool_calls, id=msg_id)
+
+
+def _make_tool_message(tool_call_id: str, tool_name: str = "search_tool"):
+    """Build a resolved ToolMessage."""
+    return ToolMessage(content="result", tool_call_id=tool_call_id, name=tool_name)
+
+
+def _make_state(messages: list, pending_task_id: str | None = None):
+    """Build a mock graph state object."""
+    state = MagicMock()
+    values = {"messages": messages}
+    if pending_task_id:
+        values["pending_task_tool_call_id"] = pending_task_id
+    state.values = values
+    return state
+
+
+def _make_binding():
+    """
+    Instantiate AIPlatformEngineerA2ABinding with all external deps mocked.
+    Sets _initialized=True so ensure_initialized() is skipped.
+    """
+    with patch(
+        "ai_platform_engineering.multi_agents.platform_engineer"
+        ".protocol_bindings.a2a.agent.AIPlatformEngineerMAS"
+    ), patch(
+        "ai_platform_engineering.multi_agents.platform_engineer"
+        ".protocol_bindings.a2a.agent.TracingManager"
+    ):
+        from ai_platform_engineering.multi_agents.platform_engineer.protocol_bindings.a2a.agent import (
+            AIPlatformEngineerA2ABinding,
+        )
+        binding = AIPlatformEngineerA2ABinding.__new__(AIPlatformEngineerA2ABinding)
+        binding._initialized = True
+        binding._previous_todos = {}
+        binding._task_plan_entries = {}
+        binding._in_self_service_workflow = False
+        binding._execution_plan_sent = False
+        binding.tracing = MagicMock()
+        binding.graph = AsyncMock()
+        return binding
+
+
+# ---------------------------------------------------------------------------
+# _repair_orphaned_tool_calls — no-op paths
+# ---------------------------------------------------------------------------
+
+class TestRepairOrphanedToolCallsNoOp:
+
+    @pytest.mark.asyncio
+    async def test_empty_state_is_noop(self):
+        """aget_state returns None → aupdate_state is never called."""
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(return_value=None)
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_state_with_empty_values_is_noop(self):
+        """State exists but values is empty dict → aupdate_state is never called."""
+        binding = _make_binding()
+        state = MagicMock()
+        state.values = {}
+        binding.graph.aget_state = AsyncMock(return_value=state)
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_state_with_no_messages_is_noop(self):
+        """Messages list is empty → aupdate_state is never called."""
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([]))
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_tool_calls_resolved_is_noop(self):
+        """Every tool_call_id has a matching ToolMessage → aupdate_state is never called."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["jira_search"])
+        tool_msg = _make_tool_message("tc-1", "jira_search")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg, tool_msg]))
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_messages_without_ai_messages_is_noop(self):
+        """Only HumanMessages in history → no tool_calls to repair."""
+        binding = _make_binding()
+        msgs = [HumanMessage(content="hello"), HumanMessage(content="world")]
+        binding.graph.aget_state = AsyncMock(return_value=_make_state(msgs))
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _repair_orphaned_tool_calls — repair paths
+# ---------------------------------------------------------------------------
+
+class TestRepairOrphanedToolCallsRepair:
+
+    @pytest.mark.asyncio
+    async def test_single_orphan_injects_one_synthetic_tool_message(self):
+        """One orphaned tool call → one synthetic ToolMessage injected."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-orphan-1"], ["argocd_search"])
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_awaited_once()
+        injected_messages = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(injected_messages) == 1
+        msg = injected_messages[0]
+        assert isinstance(msg, ToolMessage)
+        assert msg.tool_call_id == "tc-orphan-1"
+        assert msg.name == "argocd_search"
+        assert "argocd_search" in msg.content
+        assert "interrupted" in msg.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_single_orphan_uses_as_node_tools(self):
+        """aupdate_state MUST be called with as_node='tools' to route graph correctly."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["jira_search"])
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        _, call_kwargs = binding.graph.aupdate_state.call_args
+        assert call_kwargs.get("as_node") == "tools", (
+            "Must use as_node='tools' so LangGraph routes tools→model, not END"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_orphans_inject_one_message_per_orphan(self):
+        """Three orphaned tool calls → three synthetic ToolMessages, one per orphan."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(
+            ["tc-1", "tc-2", "tc-3"],
+            ["jira_search", "argocd_list", "github_pr"],
+            msg_id="ai-multi",
+        )
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        injected = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(injected) == 3
+        injected_ids = {m.tool_call_id for m in injected}
+        assert injected_ids == {"tc-1", "tc-2", "tc-3"}
+        injected_names = {m.name for m in injected}
+        assert injected_names == {"jira_search", "argocd_list", "github_pr"}
+
+    @pytest.mark.asyncio
+    async def test_partial_orphans_only_missing_ones_are_repaired(self):
+        """Two tool calls, one resolved, one orphaned → only orphan repaired."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-resolved", "tc-orphan"], ["tool_a", "tool_b"])
+        resolved = _make_tool_message("tc-resolved", "tool_a")
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg, resolved]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        injected = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(injected) == 1
+        assert injected[0].tool_call_id == "tc-orphan"
+        assert injected[0].name == "tool_b"
+
+    @pytest.mark.asyncio
+    async def test_old_remove_message_approach_never_used(self):
+        """Verify RemoveMessage is never passed to aupdate_state (old broken approach)."""
+        from langchain_core.messages import RemoveMessage
+
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["search"])
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        injected = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        for msg in injected:
+            assert not isinstance(msg, RemoveMessage), (
+                "RemoveMessage must never be used — it routes graph to END, leaking "
+                "placeholder text to users"
+            )
+
+    @pytest.mark.asyncio
+    async def test_synthetic_message_content_names_the_tool(self):
+        """Synthetic ToolMessage content mentions the tool name for debuggability."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["confluence_search"])
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        injected = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert "confluence_search" in injected[0].content
+
+    @pytest.mark.asyncio
+    async def test_multiple_ai_messages_repairs_only_unresolved(self):
+        """
+        Conversation: ai_msg_1 (resolved), ai_msg_2 (orphaned).
+        Only ai_msg_2's tool call should be repaired.
+        """
+        binding = _make_binding()
+        ai_msg_1 = _make_ai_message(["tc-done"], ["tool_done"], msg_id="ai-1")
+        resolved = _make_tool_message("tc-done", "tool_done")
+        ai_msg_2 = _make_ai_message(["tc-broken"], ["tool_broken"], msg_id="ai-2")
+        binding.graph.aget_state = AsyncMock(
+            return_value=_make_state([ai_msg_1, resolved, ai_msg_2])
+        )
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        injected = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(injected) == 1
+        assert injected[0].tool_call_id == "tc-broken"
+
+
+# ---------------------------------------------------------------------------
+# _repair_orphaned_tool_calls — deterministic task pending-tool-call guard
+# ---------------------------------------------------------------------------
+
+class TestRepairPendingDeterministicTask:
+
+    @pytest.mark.asyncio
+    async def test_pending_task_id_is_skipped(self):
+        """
+        If pending_task_tool_call_id is set, that specific tool call must NOT be
+        repaired — DeterministicTaskMiddleware will handle it.
+        """
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-pending"], ["deterministic_task"])
+        binding.graph.aget_state = AsyncMock(
+            return_value=_make_state([ai_msg], pending_task_id="tc-pending")
+        )
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        binding.graph.aupdate_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pending_task_skipped_but_other_orphans_repaired(self):
+        """
+        pending_task_tool_call_id is skipped; other orphaned tool calls still repaired.
+        """
+        binding = _make_binding()
+        ai_msg = _make_ai_message(
+            ["tc-pending", "tc-broken"],
+            ["deterministic_task", "jira_search"],
+        )
+        binding.graph.aget_state = AsyncMock(
+            return_value=_make_state([ai_msg], pending_task_id="tc-pending")
+        )
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+        injected = binding.graph.aupdate_state.call_args[0][1]["messages"]
+        assert len(injected) == 1
+        assert injected[0].tool_call_id == "tc-broken"
+        assert all(m.tool_call_id != "tc-pending" for m in injected)
+
+
+# ---------------------------------------------------------------------------
+# _repair_orphaned_tool_calls — exception handling
+# ---------------------------------------------------------------------------
+
+class TestRepairExceptionHandling:
+
+    @pytest.mark.asyncio
+    async def test_exception_in_aget_state_does_not_propagate(self):
+        """aget_state raises → repair logs error and returns without re-raising."""
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(side_effect=RuntimeError("checkpoint failure"))
+        binding.graph.aupdate_state = AsyncMock()
+
+        # Must not raise
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+    @pytest.mark.asyncio
+    async def test_exception_in_aupdate_state_does_not_propagate(self):
+        """aupdate_state raises → repair logs error and returns without re-raising."""
+        binding = _make_binding()
+        ai_msg = _make_ai_message(["tc-1"], ["search"])
+        binding.graph.aget_state = AsyncMock(return_value=_make_state([ai_msg]))
+        binding.graph.aupdate_state = AsyncMock(side_effect=RuntimeError("state write failed"))
+
+        # Must not raise
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t1"}})
+
+    @pytest.mark.asyncio
+    async def test_fallback_reset_attempted_on_exception(self):
+        """
+        When aget_state raises and the graph has a checkpointer, the fallback
+        recovery attempts to inject a HumanMessage reset marker.
+        """
+        binding = _make_binding()
+        binding.graph.aget_state = AsyncMock(side_effect=RuntimeError("db timeout"))
+        binding.graph.checkpointer = MagicMock()  # checkpointer present
+        binding.graph.aupdate_state = AsyncMock()
+
+        await binding._repair_orphaned_tool_calls({"configurable": {"thread_id": "t-fail"}})
+
+        # Fallback should have tried aupdate_state with a HumanMessage (if it attempts recovery)
+        if binding.graph.aupdate_state.call_count > 0:
+            msgs = binding.graph.aupdate_state.call_args[0][1]["messages"]
+            assert len(msgs) == 1
+            assert isinstance(msgs[0], HumanMessage)

--- a/ai_platform_engineering/multi_agents/platform_engineer/tests/test_repair_orphaned_tool_calls.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/tests/test_repair_orphaned_tool_calls.py
@@ -29,7 +29,7 @@ These tests verify:
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage, HumanMessage
+from langchain_core.messages import AIMessage, ToolMessage, HumanMessage
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ports and retargets the fix from PR #1073, which modified \`agent_single.py\` — a file removed in #1151 when single/distributed bindings were unified. The same bug was still present in \`agent.py\`.

**Root cause**: When a session is interrupted mid-tool-call, the LangGraph checkpoint holds an \`AIMessage\` with unresolved \`tool_call_ids\`. The old repair (\`RemoveMessage\`) deleted the \`AIMessage\`, leaving no \`tool_calls\` in the checkpoint. LangGraph then set \`next=END\`, causing the next user query to be skipped entirely and placeholder text to leak to the user.

**Fix**: Keep the \`AIMessage\` intact. Inject a synthetic \`ToolMessage\` per orphaned \`tool_call_id\` via \`aupdate_state(..., as_node="tools")\`. This:
- Satisfies Bedrock/Anthropic adjacency requirement (\`tool_result\` immediately after \`tool_use\`)
- Routes the graph \`tools→model\` so the new user query is processed correctly
- Never leaks internal repair state to users

## Changes

- \`agent.py\`: Replace \`RemoveMessage\` strategy with synthetic \`ToolMessage\` injection using \`as_node="tools"\`
- \`tests/test_repair_orphaned_tool_calls.py\`: 17 new unit tests targeting \`agent.py\` (no-op paths, repair paths, pending-task guard, exception handling)
- \`tests/test_agent_binding_e2e.py\`: Updated 8 existing tests that expected the old \`RemoveMessage\` behavior to assert the new synthetic \`ToolMessage\` strategy

## Quality

- \`make lint\` ✅
- \`make test\` ✅ (656 passed, 1 skipped)
- \`make caipe-ui-tests\` ✅ (2471 passed, 1 skipped)

## Test plan

- [x] All existing tests updated and passing locally
- [x] 17 new unit tests pass locally
- [ ] Verify interrupted sessions recover correctly and next query is processed (not skipped)

Closes #1073