### PR TITLE
fix(docker): force HTTP/1.1 for kubectl downloads to avoid HTTP/2 errors

### DIFF
--- a/build/agents/Dockerfile.a2a
+++ b/build/agents/Dockerfile.a2a
@@ -83,9 +83,9 @@ RUN ARCH=$(uname -m) && \
     else \
         KUBECTL_ARCH="amd64"; \
     fi && \
-    KUBECTL_VERSION=$(curl -sfL --retry 5 --retry-delay 3 https://dl.k8s.io/release/stable.txt) && \
+    KUBECTL_VERSION=$(curl -sfL --http1.1 --retry 5 --retry-delay 3 --connect-timeout 30 https://dl.k8s.io/release/stable.txt) && \
     if [ -z "$KUBECTL_VERSION" ]; then echo "Failed to fetch kubectl version"; exit 1; fi && \
-    curl -sfLO --retry 5 --retry-delay 3 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl" && \
+    curl -sfLO --http1.1 --retry 5 --retry-delay 3 --connect-timeout 30 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
## Summary

- `dl.k8s.io` intermittently fails during Docker builds with HTTP/2 protocol errors (curl exit codes 56 and 92)
- Force HTTP/1.1 via `--http1.1` for both the `stable.txt` version fetch and the kubectl binary download
- Add `--connect-timeout 30` for consistency with other download steps in the Dockerfile

## Test plan

- [ ] Docker build of any `Dockerfile.a2a`-based agent completes without kubectl download errors