### PR TITLE
docs: rewrite constitution as principles and guardrails

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,218 +1,89 @@
-# AI Platform Engineering (CAIPE) Constitution
+# CAIPE Constitution
 
-## Core Principles
+## Design Principles
 
-### I. Specifications as the Source of Truth
+### I. Worse is Better
 
-All development begins with a specification. Code serves the specification — not the other way around. The `.specify/` directory is the canonical source of intent, architecture, and design. Agents may generate and evolve code freely; they must not contradict a ratified specification without an amendment.
+Simplicity of implementation wins over simplicity of interface — [Richard Gabriel, 1989](https://en.wikipedia.org/wiki/Worse_is_better).
 
-- Every feature starts as a specification in `docs/docs/specs/<###-feature-name>/spec.md`
-- PRD-level decisions are captured in `.specify/` and reviewed by engineers
-- Code is regenerated from specifications; outdated code is replaced, not patched
+- Ship working software over perfecting it. Iterate in small increments.
+- Avoid premature abstraction. Build the concrete thing first; extract patterns when they prove themselves.
+- A system that is simple to build, deploy, and debug beats one that is theoretically elegant.
+- Do not overcomplicate the implementation to achieve an elegant interface. A rough interface with a simple implementation is preferable.
 
-### II. Agent-First Architecture
+### II. YAGNI
 
-AI agents are first-class contributors. CAIPE is itself a multi-agent system, and its development workflows are designed to minimize unnecessary human intervention in mechanical code production while preserving human judgment for architecture, ethics, and business logic.
+[You Aren't Gonna Need It](https://martinfowler.com/bliki/Yagni.html). Implement exactly what is needed now. Do not add functionality on the speculation that it might be useful later. Speculative features add maintenance burden and complexity with no guaranteed payoff.
 
-- Each domain (ArgoCD, AWS, Jira, Splunk, PagerDuty, etc.) has a dedicated agent with specialized knowledge
-- The Supervisor agent orchestrates multi-agent collaboration via the A2A protocol
-- New repos are initialized with AI tool configurations (`.claude/`, `.cursor/`, `.codex/`)
-- Skills, rules, and prompts encode institutional knowledge so agents operate autonomously
-- Plans are stored in `.specify/` and tracked for active agent execution
-- Background agents are expected to complete work units without per-step guidance
+### III. Rule of Three
 
-### III. MCP Server Pattern
+Tolerate duplication until the third occurrence, then refactor. Delete dead code — version control is the safety net.
 
-Each agent exposes its tools through a Model Context Protocol (MCP) server. MCP servers are the primary integration layer between agents and external systems.
+### IV. Composition over Inheritance
 
-- Each agent has an MCP server for tool access
-- MCP servers provide paginated, memory-safe access to external systems
-- Strict limits on response sizes to prevent OOM issues
-- MCP interactions follow the [CoSAI MCP Security guidelines](https://www.coalitionforsafeai.org/): input validation, sandboxing, transport security, and human-in-the-loop for risky operations
+Favor composition and dependency injection over class hierarchies. Keep modules loosely coupled and independently testable.
 
-### IV. LangGraph-Based Agents
+### V. Specs as Source of Truth
 
-All agents are built on LangGraph for stateful, graph-based execution. This ensures consistent patterns across the codebase and enables advanced workflows.
+All features start as a specification in `docs/docs/specs/<###-feature-name>/`. Code serves the spec. The spec-driven workflow (specify → plan → tasks → implement) is the standard development process. Details in `.specify/SPECS.md`.
 
-- Support for interrupts, checkpoints, and human-in-the-loop workflows
-- TypedDict state management with clear node definitions
-- Redis-backed checkpoint persistence for production deployments
-- Agent graphs are testable in isolation with mocked dependencies
+### VI. CI Gates Are Non-Negotiable
 
-### V. A2A Protocol Compliance
+No code ships without passing lint and test gates. `.specify/TESTING.md` defines the quality gates for this repository.
 
-All inter-agent communication follows Google's Agent-to-Agent (A2A) protocol. This ensures interoperability across agents and enables streaming, task lifecycle management, and artifact exchange.
+### VII. Security by Default
 
-- Support for streaming via SSE with artifact updates
-- Task lifecycle: created → working → completed/failed/canceled
-- Agent Cards describe capabilities and are discoverable by the Supervisor
-- Multi-turn conversations with context preservation across agent boundaries
+- No secrets in source — environment injection only
+- Validate all external inputs at system boundaries
+- Defense in depth — do not trust any single layer to be the only safeguard
+- Be wary of injecting external inputs into prompts and logic — treat them as untrusted
+- External dependencies are reviewed for supply chain risk
 
-### VI. Skills over Ad-Hoc Prompts
+## Coding Practices
 
-Reusable, versioned skills replace one-off prompts. Skills encapsulate organizational best practices, tool integrations, and workflow patterns. They are the mechanism by which institutional knowledge is shared across projects.
+- **Type hints** — all Python functions must have type hints for parameters and return values
+- **Imports at top** — organized by stdlib / third-party / local
+- **Error handling** — use specific exceptions, log with context, never swallow silently
+- **Docstrings** — required on public functions and classes
+- **Logging** — no `print()` in production code; use structured logging (`loguru`)
+- **Constants** — named constants over magic numbers and strings
 
-- Skills MUST implement the [agentskills.io specification](https://agentskills.io/specification)
-- Public skills from registries are security-scanned before adoption
-- Project-specific skills live in `.cursor/commands/` (and equivalent per tool)
-- Skills may bundle scripts and data; scripts must be auditable
+## Documentation
 
-### VII. Test-First Quality Gates (NON-NEGOTIABLE)
+- **Component READMEs** — every component directory has a README explaining what it does, how to configure it, and how to run it
+- **API and config docs** — public APIs, config schemas, and environment variables are documented where they are defined
+- **Architecture decisions** — significant design choices are recorded in `.specify/ARCHITECTURE.md` or as ADRs in `docs/`
+- **Code comments** — explain *why*, not *what*. No narration of obvious logic. Non-obvious tradeoffs, workarounds, and constraints get a comment.
 
-No production code ships without passing its defined quality gates. Tests are derived from specifications, not written after implementation.
+## Tech Stack
 
-- Acceptance criteria in specs become automated test scenarios
-- `.specify/TESTING.md` defines the minimum quality gates for this repository
-- Red-Green-Refactor cycle is enforced: tests fail first, then implementation follows
-- CI must gate on all quality criteria defined in TESTING.md
-- `make lint`, `make test`, and `make caipe-ui-tests` must all pass before any PR merges
-- Integration smoke tests (`make quick-sanity`) must pass for changes affecting agent communication, supervisor routing, or UI-to-supervisor interactions
-- **Minimal integration test environment**: `caipe-supervisor`, `agent-github`, `agent-netutils` (profiles: `github`, `netutils-agent`) — no RAG or other agents required for basic validation
-- Start with: `docker compose -f docker-compose.dev.yaml --profile github --profile netutils-agent up -d --build`
-
-### VIII. Structured Documentation
-
-Every repository maintains a living `docs/` directory that agents and engineers both read and write. Documentation is not optional; it is the memory of the system.
-
-- `.specify/ARCHITECTURE.md` — high-level architecture, always current
-- `.specify/TESTING.md` — quality gates and test strategy
-- `.specify/SKILLS.md` — skills inventory and usage guidelines
-- `.specify/SPECS.md` — specs and plans conventions
-- `docs/docs/specs/<###-feature>/` — per-feature specs, plans, tasks, ADRs (auto-published)
-
-### IX. Security and Compliance by Default
-
-Security is not a phase; it is a constraint woven into every specification and skill.
-
-- Skills sourced externally are reviewed for supply chain risks before use
-- No secrets in source; environment injection via approved mechanisms only
-- Every skill that carries scripts is audited and version-pinned
-- OWASP Top 10 mitigations are standard requirements in all web-facing specs
-- MCP servers validate all inputs and enforce least privilege
-
-### X. Simplicity and Avoiding Over-Engineering
-
-Implement exactly what the specification requires — no more.
-
-- [YAGNI](https://martinfowler.com/bliki/Yagni.html) — "You Aren't Gonna Need It" (Ron Jeffries, Extreme Programming) applies to both engineers and agents
-- [Rule of Three](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)) — tolerate duplication until the third occurrence, then refactor (Don Roberts, via Martin Fowler's *[Refactoring](https://martinfowler.com/books/refactoring.html)*, 1999)
-- [Dead Code](https://martinfowler.com/bliki/DeadCode.html) is deleted, not commented out (Martin Fowler's *[Refactoring](https://martinfowler.com/books/refactoring.html)*) — version control is the safety net
-
-## Development Workflow
-
-### Branching and Commits
-
-- Branch naming: **`prebuild/<type>/<description>`** where `<type>` matches the Conventional Commits verb
-- [Conventional Commits](https://www.conventionalcommits.org/) required on all commits
-- Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `build`, `ci`
-- Format: `<type>(<optional scope>): <description>`
-- DCO sign-off required: `Signed-off-by: <Name> <email>`
-
-**Examples**:
-
-```
-prebuild/feat/add-auth
-prebuild/fix/null-pointer
-prebuild/docs/update-architecture
-prebuild/chore/spec-kit-constitution
-```
-
-### Prebuild CI Pipeline
-
-The `prebuild/` branch prefix is **required** — it triggers the pre-release CI pipeline that builds Docker images and Helm charts for testing before merge.
-
-**What happens when you push a `prebuild/` branch**:
-
-1. **Pre-release Docker images** are built and pushed to `ghcr.io/<org>/prebuild/<image>` tagged with the PR number
-2. **Pre-release Helm chart** versions are auto-bumped with an `-rc` suffix and published to the OCI registry
-3. **CI workflows** (linting, unit tests) run on the PR but skip the production `[CI]` image builds (those only run on `main`)
-
-| Trigger | What Builds | Image Registry | Tag Format |
-|---------|------------|----------------|------------|
-| PR from `prebuild/*` branch | Pre-release images | `ghcr.io/<org>/prebuild/<image>` | `pr-<number>-<sha>` |
-| Push to `main` | Production images | `ghcr.io/<org>/<image>` | `latest`, `<sha>` |
-| Git tag (`v*.*.*`) | Release images | `ghcr.io/<org>/<image>` | `<version>`, `stable` |
-
-**Pre-release images built per PR** (only when relevant paths change):
-
-| Image | Paths Triggering Build |
-|-------|----------------------|
-| `ai-platform-engineering` (supervisor) | `build/Dockerfile`, `ai_platform_engineering/multi_agents/**`, `pyproject.toml` |
-| `ai-platform-engineering-a2a-sub-agent` | `build/Dockerfile.a2a-sub-agent`, `ai_platform_engineering/agents/**` |
-| `ai-platform-engineering-mcp-agent` | `build/Dockerfile.mcp-agent`, `ai_platform_engineering/agents/**` |
-| `ai-platform-engineering-dynamic-agents` | `build/Dockerfile.dynamic-agents`, `ai_platform_engineering/agents/**` |
-| `caipe-ui` | `build/Dockerfile.caipe-ui`, `ui/**` |
-| `ai-platform-engineering-slack-bot` | `build/Dockerfile.slack-bot`, `ai_platform_engineering/integrations/slack_bot/**` |
-| `ai-platform-engineering-a2a-rag` | `ai_platform_engineering/knowledge_bases/rag/**` |
-
-**Helm chart pre-release**: When chart files under `charts/` change on a `prebuild/` PR, the `helm-rc-version-bump` workflow auto-bumps chart versions with an `-rc.<pr>` suffix and the `helm-pre-release` workflow publishes the chart to the OCI registry.
-
-**Always create `prebuild/` branches** — branches without this prefix will not produce testable images or charts.
-
-### Spec-Driven Workflow
-
-1. **Specify**: Run `/speckit.specify <description>` to create `docs/docs/specs/<###>/spec.md`
-2. **Plan**: Run `/speckit.plan <tech choices>` to produce `docs/docs/specs/<###>/plan.md`
-3. **Tasks**: Run `/speckit.tasks` to produce `docs/docs/specs/<###>/tasks.md`
-4. **Implement**: Run `/speckit.implement` to execute tasks against the plan
-5. **Review**: Engineer reviews generated code against spec acceptance criteria
-
-### Bug Handling in Spec-Driven Development
-
-Bugs are classified into three tiers based on their relationship to specifications. Agents and engineers must identify the correct tier before starting work.
-
-| Tier | Name | Trigger | Spec Action | Branch | Workflow |
-|------|------|---------|-------------|--------|----------|
-| 1 | Spec violation | Code doesn't match its spec | None — spec is correct | `prebuild/fix/<description>` | Fix code, reference existing spec |
-| 2 | Spec gap | Bug reveals uncovered edge case | Update existing spec | `prebuild/fix/<description>` | Amend spec, then fix code |
-| 3 | Design flaw | Bug reveals architectural issue | New spec required | `prebuild/feat/<###-description>` | Full `/speckit.specify` pipeline |
-
-**Tier 1 — Spec violation**: The spec already defines the correct behavior; the implementation is wrong. Create a `prebuild/fix/` branch, fix the code, and reference the existing spec's acceptance criteria. One commit: `fix(<scope>): <description>`.
-
-**Tier 2 — Spec gap**: The bug exposes something the spec never considered (missing edge case, unhandled error). Update the existing `specs/<###>/spec.md` with new acceptance criteria, then fix the code. Two commits: `docs: add missing edge case to spec`, then `fix: handle edge case`.
-
-**Tier 3 — Design flaw**: The bug reveals a systemic or architectural problem that requires rethinking. This goes through the full pipeline — run `/speckit.specify` to create a new spec, then plan, tasks, and implement.
-
-### Agent Autonomy Levels
-
-Based on [The 8 Levels of Agentic Engineering](https://www.bassimeledath.com/blog/levels-of-agentic-engineering) by Bassim Eledath and [Harness Engineering](https://openai.com/index/harness-engineering/) by OpenAI.
-
-| Level | Name | Description | Human Role |
-|-------|------|-------------|------------|
-| 1 | Tab Complete | AI suggests next character inputs | Reviews every change |
-| 2 | Agent IDE | User chats with AI assistant for changes | Reviews most changes |
-| 3 | Context Engineering | Optimize prompts to AI coding tools | Reviews architecture |
-| 4 | Compounding Engineering | Add update prompt feedback loop | Reviews outputs |
-| 5 | MCP and Skills | Give coding tool access to live systems | Reviews incidents |
-| 6 | Harness Engineering | Add live data to update feedback loop | Works on the system |
-| 7 | Background Agents | Enable agents to get and complete work autonomously | Approves work units |
-
-**Target**: CAIPE operates at Level 6. This constitution and its supporting docs enable that baseline.
-
-## Technology Stack
-
-| Component | Technology |
-|-----------|------------|
-| Agents | Python 3.11+, LangGraph, LangChain |
-| MCP Servers | FastMCP, httpx |
-| Multi-Agent | A2A Protocol, SSE streaming |
-| UI | Next.js 16, React 19, Tailwind CSS |
+| Layer | Technologies |
+|-------|-------------|
+| Backend | Python 3.11+, LangGraph, LangChain |
+| Frontend | Next.js, React, Tailwind CSS |
 | Deployment | Docker, Kubernetes, Helm |
-| Documentation | Docusaurus |
-| Package Manager | uv (Python), npm (UI) |
 | Linting | Ruff (Python), ESLint (TypeScript) |
-| Testing | pytest (Python), Jest (UI) |
+| Testing | pytest (Python), Jest (TypeScript) |
+| Package managers | uv (Python), npm (TypeScript) |
+
+Architecture decisions and protocol choices live in `.specify/ARCHITECTURE.md`.
+
+## Git Conventions
+
+- [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
+- Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `build`, `ci`
+- DCO sign-off required: `Signed-off-by: <Name> <email>`
+- Branch prefix: `prebuild/<type>/<description>` — required for CI to build images
+
+## References
+
+- `.specify/ARCHITECTURE.md` — architecture and protocol decisions
+- `.specify/TESTING.md` — quality gates and test strategy
+- `.specify/SPECS.md` — spec conventions and workflow
+- `AGENTS.md` — AI agent behavior and autonomy expectations
 
 ## Governance
 
-This Constitution supersedes all other per-repo conventions unless explicitly overridden with documented rationale.
+This constitution sets guardrails, not architecture. Amendments require a PR with rationale.
 
-Amendments require:
-
-1. A specification describing the change and its rationale
-2. Review and approval via PR
-3. Migration plan for existing agents and configurations
-
-All PRs must verify constitutional compliance. Complexity violations must be justified in the PR description.
-
-**Version**: 0.0.1 | **Ratified**: 2026-03-16 | **Last Amended**: 2026-03-16
+**Version**: 1.0.0 | **Last Amended**: 2026-04-14


### PR DESCRIPTION
# Description

Rewrites the CAIPE constitution from a prescriptive architecture document (218 lines) into a lean set of principles and guardrails (87 lines).

**What was removed:**
- Architecture mandates: A2A Protocol Compliance, LangGraph-Based Agents, MCP Server Pattern, Agent-First Architecture
- Process bloat: bug tier taxonomy, autonomy levels table, CI pipeline internals (prebuild image tables, Helm chart mechanics)
- Prescriptive details: `make` commands, docker compose examples, Skills over Ad-Hoc Prompts

**What was added:**
- Design principles: Worse is Better (Richard Gabriel), YAGNI, Rule of Three, Composition over Inheritance
- Coding practices: type hints, imports, error handling, docstrings, structured logging, named constants
- Documentation requirements: component READMEs, API/config docs, architecture decisions, "comments explain why not what"

**What was kept (trimmed):**
- Specs as Source of Truth (principle only, workflow details in SPECS.md)
- CI Gates Non-Negotiable (principle only, details in TESTING.md)
- Security by Default (3 bullets, no OWASP/MCP specifics)
- Git conventions (conventional commits, DCO, prebuild/ branching)
- Tech stack (languages + frameworks, no version pinning)

Architecture-specific content (protocol choices, agent patterns, CI pipeline details) belongs in `.specify/ARCHITECTURE.md`, not the constitution.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass