### PR TITLE
fix(supervisor,slack-bot): inject skills files into A2A state and handle Slack msg_too_long

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -879,6 +879,22 @@ def stream_a2a_response(
             additional_footer=additional_footer,
             escalation_config=escalation_config,
           )
+        if "msg_too_long" in err_str:
+          # Response exceeded Slack streaming message limit. Fall back to
+          # a regular post which uses split_text_into_blocks to chunk it.
+          logger.warning(
+            f"[{thread_ts}] Streaming message too long — posting final answer as regular message"
+          )
+          return _post_final_response(
+            slack_client,
+            channel_id,
+            thread_ts,
+            final_text,
+            response_ts,
+            triggered_by_user_id=triggered_by_user_id,
+            additional_footer=additional_footer,
+            escalation_config=escalation_config,
+          )
         raise
 
     elif can_stream:

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -45,6 +45,11 @@ except ImportError:
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+# Suppress Langfuse media scanner false positives: it recursively walks all
+# LangGraph state and tries to parse any string starting with "data:" as a
+# base64 data URI.  Skill SKILL.md content triggers this harmlessly.
+logging.getLogger("langfuse.media").setLevel(logging.CRITICAL)
+
 
 def _tool_narration(tool_name: str, tool_args: dict) -> str | None:
     """Generate a brief narration sentence to stream before a tool call.
@@ -497,6 +502,10 @@ class AIPlatformEngineerA2ABinding:
           # Store user_email in graph state for middleware to use in task prompts
           if user_email:
               state_dict['user_email'] = user_email
+          # Inject skills files into state for SkillsMiddleware / StateBackend
+          skills_files = getattr(self._mas_instance, '_skills_files', None)
+          if skills_files:
+              state_dict['files'] = dict(skills_files)
           inputs = state_dict
 
       config = self.tracing.create_config(context_id)


### PR DESCRIPTION
## Summary

- **A2A skills injection**: The A2A binding (agent.py) was not injecting _skills_files into the LangGraph state_dict, so SkillsMiddleware saw an empty StateBackend. The LLM could see skill names in the system prompt but read_file on SKILL.md paths returned not found. This adds the same files injection that the MAS serve/serve_stream paths already had.
- **Langfuse media scanner noise**: Suppresses langfuse.media logger false positives -- it recursively walks all LangGraph state and tries to parse any string starting with data: as a base64 data URI. Skill SKILL.md content triggers this harmlessly (~102 ERROR lines per request).
- **Slack msg_too_long**: stopStream now gracefully handles Slack msg_too_long error by falling back to _post_final_response() which uses split_text_into_blocks to chunk the message within Slack limits.

## Test plan

- [ ] Start a new chat in the UI and invoke a skill (e.g. coding-standards-go) -- verify the supervisor can read the SKILL.md content
- [ ] Check supervisor logs for state_keys -- should include files in the list
- [ ] Verify no langfuse.media ERROR lines in supervisor logs during a request
- [ ] Send a long response via Slack that would exceed streaming message limits -- verify it falls back to a chunked regular post