### PR TITLE
fix(slack-bot,supervisor): streaming newlines, msg_too_long resilience, A2A skills injection

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -75,10 +75,16 @@ class StreamBuffer:
     self._buffer = ""
     self._last_flush = None  # set on first append, not init — avoids stale elapsed from LLM think time
     self._flushed_any = False
+    self._trailing_newlines = 0  # count of trailing \n chars in last flushed text
+    self._dead = False  # True after msg_too_long — stop trying to append
 
   @property
   def has_flushed(self):
     return self._flushed_any
+
+  @property
+  def trailing_newlines(self):
+    return self._trailing_newlines
 
   def append(self, text):
     """Add text to the buffer; auto-flush on newline or after the interval."""
@@ -121,6 +127,8 @@ class StreamBuffer:
 
   def _send(self, text):
     """Send *text* to Slack and update bookkeeping."""
+    if self._dead:
+      return False  # stream hit msg_too_long — stop spamming Slack
     self._last_flush = time.monotonic()
     try:
       self.slack_client.chat_appendStream(
@@ -129,11 +137,16 @@ class StreamBuffer:
         chunks=[{"type": "markdown_text", "text": text}],
       )
       self._flushed_any = True
+      self._trailing_newlines = len(text) - len(text.rstrip('\n'))
       preview = text[:80].replace('\n', '\\n')
       logger.info(f"SLACK appendStream text ({len(text)} chars): {preview}{'...' if len(text) > 80 else ''}")
       return True
     except Exception as e:
-      logger.warning(f"SLACK appendStream text FAILED: {e}")
+      if "msg_too_long" in str(e):
+        self._dead = True
+        logger.warning("SLACK appendStream msg_too_long — disabling further appends")
+      else:
+        logger.warning(f"SLACK appendStream text FAILED: {e}")
       return False
 
 
@@ -205,6 +218,7 @@ def stream_a2a_response(
   step_thinking = {}  # step_id -> accumulated thinking text per step
   current_step_id = None  # which step is in_progress
   needs_separator = False  # insert \n\n before next streamed markdown (after tool_end)
+  _stream_text_started = False  # True after the first text chunk is sent to StreamBuffer
 
   # Loading messages shown in the animated typing indicator before stream starts
   _loading_messages = [
@@ -518,8 +532,20 @@ def stream_a2a_response(
             continue
           _start_stream_if_needed()
           if stream_buf:
+            # Strip leading whitespace from the very first text chunk so the
+            # Slack message doesn't start with blank lines.
+            if not _stream_text_started:
+              text = text.lstrip()
+              if not text:
+                continue
+              _stream_text_started = True
             if needs_separator and stream_buf.has_flushed:
-              text = "\n\n" + text
+              # Ensure exactly \n\n (paragraph break) between tool output and
+              # next text.  Use the buffer's trailing newline count to compute
+              # the exact deficit — no guessing about what the text starts with.
+              gap = max(0, 2 - stream_buf.trailing_newlines)
+              if gap:
+                text = "\n" * gap + text
               needs_separator = False
             stream_buf.append(text)
 
@@ -879,6 +905,22 @@ def stream_a2a_response(
             additional_footer=additional_footer,
             escalation_config=escalation_config,
           )
+        if "msg_too_long" in err_str:
+          # Response exceeded Slack streaming message limit. Fall back to
+          # a regular post which uses split_text_into_blocks to chunk it.
+          logger.warning(
+            f"[{thread_ts}] Streaming message too long — posting final answer as regular message"
+          )
+          return _post_final_response(
+            slack_client,
+            channel_id,
+            thread_ts,
+            final_text,
+            response_ts,
+            triggered_by_user_id=triggered_by_user_id,
+            additional_footer=additional_footer,
+            escalation_config=escalation_config,
+          )
         raise
 
     elif can_stream:
@@ -1057,36 +1099,52 @@ def _post_final_response(
   additional_footer=None,
   escalation_config=None,
 ):
-  """Post final response as a regular message (fallback for bot messages)."""
+  """Post final response as a regular message (fallback for bot messages).
+
+  Splits into multiple messages if the response exceeds Slack's 50-block limit.
+  """
   text_chunks = slack_formatter.split_text_into_blocks(final_text)
 
-  final_blocks = []
-  for chunk in text_chunks:
-    final_blocks.append(
-      {
-        "type": "markdown",
-        "text": chunk,
-      }
-    )
+  content_blocks = [{"type": "markdown", "text": chunk} for chunk in text_chunks]
 
-  # Append feedback + footer blocks (actions, context_actions, footer)
-  final_blocks.extend(
-    _build_stream_final_blocks(
-      channel_id, thread_ts, original_ts,
-      triggered_by_user_id=triggered_by_user_id,
-      additional_footer=additional_footer,
-      escalation_config=escalation_config,
-    )
+  footer_blocks = _build_stream_final_blocks(
+    channel_id, thread_ts, original_ts,
+    triggered_by_user_id=triggered_by_user_id,
+    additional_footer=additional_footer,
+    escalation_config=escalation_config,
   )
 
-  slack_client.chat_postMessage(
-    channel=channel_id,
-    thread_ts=thread_ts,
-    blocks=final_blocks,
-    text=final_text[:100],
-  )
+  # Slack allows max 50 blocks per message.  Reserve space for footer blocks
+  # in the last batch so they always appear at the end.
+  max_blocks = 50
+  max_content_per_msg = max_blocks - len(footer_blocks)
 
-  return final_blocks
+  all_blocks = []
+  if len(content_blocks) <= max_content_per_msg:
+    # Fits in one message
+    all_blocks = content_blocks + footer_blocks
+    slack_client.chat_postMessage(
+      channel=channel_id,
+      thread_ts=thread_ts,
+      blocks=all_blocks,
+      text=final_text[:100],
+    )
+  else:
+    # Split into multiple messages; footer on the last one
+    for i in range(0, len(content_blocks), max_content_per_msg):
+      batch = content_blocks[i:i + max_content_per_msg]
+      is_last = i + max_content_per_msg >= len(content_blocks)
+      if is_last:
+        batch.extend(footer_blocks)
+      slack_client.chat_postMessage(
+        channel=channel_id,
+        thread_ts=thread_ts,
+        blocks=batch,
+        text=final_text[:100] if i == 0 else "(continued)",
+      )
+    all_blocks = content_blocks + footer_blocks
+
+  return all_blocks
 
 
 def _build_stream_final_blocks(

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -393,10 +393,10 @@ def stream_a2a_response(
           # Deterministic chunker tags its chunks with is_final_answer=True.
           # Latch streaming_final_answer so the FINAL_RESULT handler skips
           # re-streaming the same content (prevents duplicate output).
-          # Only latch in plan flows — no-plan flows deliver FINAL_RESULT
-          # via stopStream to prevent metadata leaks from ToolStrategy output.
+          # This applies to BOTH plan and no-plan flows: is_final_answer
+          # chunks are clean post-marker text, safe to stream directly.
           artifact_meta = (parsed.artifact or {}).get("metadata", {})
-          if artifact_meta.get("is_final_answer") and not streaming_final_answer and plan_steps:
+          if artifact_meta.get("is_final_answer") and not streaming_final_answer:
             streaming_final_answer = True
 
           # Debug: log every token the Slack bot receives (LOG_LEVEL=DEBUG)
@@ -513,11 +513,13 @@ def stream_a2a_response(
               # No-plan flow after sub-agent: buffer, don't stream
               buffered_streaming_text.append(text)
               continue
-          # No-plan flows: buffer STREAMING_RESULT events silently. Only the
-          # clean FINAL_RESULT (from the ResponseFormat tool) is delivered via
-          # stopStream at finalization. This prevents ToolStrategy metadata
+          # No-plan flows: buffer non-final STREAMING_RESULT events silently.
+          # The clean FINAL_RESULT (from the ResponseFormat tool) is delivered
+          # via stopStream at finalization. This prevents ToolStrategy metadata
           # (is_task_complete=, JSON fragments) from leaking into Slack.
-          if not plan_steps and not streaming_final_answer:
+          # Exception: is_final_answer chunks are clean post-[FINAL ANSWER]
+          # marker text — stream them through for real-time output.
+          if not plan_steps and not streaming_final_answer and not artifact_meta.get("is_final_answer"):
             buffered_streaming_text.append(text)
             if not stream_ts:
               _set_typing_status("is responding...")

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -45,6 +45,11 @@ except ImportError:
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+# Suppress Langfuse media scanner false positives: it recursively walks all
+# LangGraph state and tries to parse any string starting with "data:" as a
+# base64 data URI.  Skill SKILL.md content triggers this harmlessly.
+logging.getLogger("langfuse.media").setLevel(logging.CRITICAL)
+
 
 def _tool_narration(tool_name: str, tool_args: dict) -> str | None:
     """Generate a brief narration sentence to stream before a tool call.
@@ -497,6 +502,10 @@ class AIPlatformEngineerA2ABinding:
           # Store user_email in graph state for middleware to use in task prompts
           if user_email:
               state_dict['user_email'] = user_email
+          # Inject skills files into state for SkillsMiddleware / StateBackend
+          skills_files = getattr(self._mas_instance, '_skills_files', None)
+          if skills_files:
+              state_dict['files'] = dict(skills_files)
           inputs = state_dict
 
       config = self.tracing.create_config(context_id)


### PR DESCRIPTION
## Summary

- **No-plan streaming**: Enable token-by-token streaming for no-plan flows (simple questions without tool calls). Previously these buffered all `STREAMING_RESULT` events and dumped the full answer at once via `stopStream`. Now `is_final_answer=True` chunks bypass the buffer gate and stream through in real-time.
- **Streaming newline fixes**: Strip leading whitespace from first streaming chunk; deterministic `\n\n` paragraph breaks using `StreamBuffer.trailing_newlines` counter instead of heuristic
- **msg_too_long resilience**: `StreamBuffer._dead` flag stops append spam after first failure; `stopStream` fallback to `_post_final_response()`; multi-message splitting when response exceeds Slack 50-block limit
- **Supervisor A2A binding** (from #1217): Inject `_skills_files` into LangGraph state for SkillsMiddleware; suppress Langfuse media scanner false positives

### msg_too_long multi-message splitting

```
Slack hard limit: 50 blocks per chat.postMessage

max_content_per_msg = 50 - len(footer_blocks)  # ~47-48

if content_blocks fit -> single message (content + footer)
else -> batch content_blocks in chunks of max_content_per_msg
         footer appended only to last batch
         text="(continued)" for subsequent messages
```

Supersedes #1217.

## Test plan

- [x] 32 streaming tests pass (test_a2a_streaming, test_ai_plan_streaming, test_metadata_leak_e2e)
- [x] 86 slack-bot tests pass
- [x] Ruff lint clean
- [x] CI all green (CodeQL, unit-tests, linter, DCO, conventional-commits)
- [x] Live-tested plan flows (tool calls -> token streaming -> FINAL_RESULT skipped)
- [x] Live-tested no-plan flows (simple questions -> token streaming, not buffered)
- [x] Live-tested with USE_STRUCTURED_RESPONSE=true and false
- [x] Verified msg_too_long fallback fires correctly on oversized responses
