### PR TITLE
fix(ci): add contents:write permission to notify-release jobs

### DIFF
--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -416,6 +416,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-changes, build-and-push, retag-unchanged]
     # Only notify for final releases (non-RC tags) - RC builds don't need release finalization
     if: |

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -381,6 +381,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-agents, build-and-push, retag-unchanged]
     # Only notify for final releases (non-RC tags) - RC builds don't need release finalization
     if: |

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -322,6 +322,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-changes, build-and-push, retag-unchanged]
     if: |
       always() &&

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -270,6 +270,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-changes, build-and-push, retag-unchanged]
     if: |
       always() &&

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -352,6 +352,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-agents, build-and-push, retag-unchanged]
     # Only notify for final releases (non-RC tags) - RC builds don't need release finalization
     if: |

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -287,6 +287,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-changes, build-and-push, retag-unchanged]
     if: |
       always() &&

--- a/.github/workflows/ci-supervisor-agent.yml
+++ b/.github/workflows/ci-supervisor-agent.yml
@@ -281,6 +281,8 @@ jobs:
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for repository_dispatch via gh api
     needs: [determine-changes, build-and-push, retag-unchanged]
     # Only notify for final releases (non-RC tags) - RC builds don't need release finalization
     if: |


### PR DESCRIPTION
## Summary

- Add `permissions: contents: write` to the `notify-release` job in all 7 CI workflows
- The job calls `gh api /repos/.../dispatches` (repository_dispatch), which requires `contents: write`
- Top-level workflow permissions only grant `contents: read`, causing HTTP 403 on every release build
- Job-level override keeps least privilege — only `notify-release` gets write access

Affected workflows:
- `ci-supervisor-agent.yml`
- `ci-slack-bot.yml`
- `ci-caipe-ui.yml`
- `ci-dynamic-agents.yml`
- `ci-mcp-sub-agent.yml`
- `ci-a2a-sub-agent.yml`
- `ci-a2a-rag.yml`

## Test plan

- [ ] Merge and verify next release tag build completes notify-release without 403
