### PR TITLE
feat(ui): add skills gateway visual editor and /skills/gateway route

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -11,6 +11,7 @@ Note: MyID operations (group management, GitHub org invitations) are handled thr
 GitHub workflows triggered via the GitHub subagent, not a dedicated MyID subagent.
 """
 
+import datetime
 import logging
 import uuid
 import os

--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -11,7 +11,6 @@ Note: MyID operations (group management, GitHub org invitations) are handled thr
 GitHub workflows triggered via the GitHub subagent, not a dedicated MyID subagent.
 """
 
-import datetime
 import logging
 import uuid
 import os

--- a/ai_platform_engineering/skills_middleware/router.py
+++ b/ai_platform_engineering/skills_middleware/router.py
@@ -301,9 +301,12 @@ async def refresh_skills(
     invalidate_skills_cache(include_hubs=include_hubs)
     mas = get_mas_instance()
     rebuilt = False
-    if mas is not None and hasattr(mas, "_rebuild_graph"):
+    if mas is not None:
         try:
-            rebuilt = bool(mas._rebuild_graph())
+            if hasattr(mas, "_rebuild_graph_async"):
+                rebuilt = bool(await mas._rebuild_graph_async())
+            elif hasattr(mas, "_rebuild_graph"):
+                rebuilt = bool(mas._rebuild_graph())
         except Exception as e:
             logger.error("MAS rebuild after skills refresh failed: %s", e)
 
@@ -316,7 +319,10 @@ async def refresh_skills(
     }
     if mas is not None:
         out["graph_generation"] = getattr(mas, "_graph_generation", None)
-        out["skills_loaded_count"] = getattr(mas, "_skills_loaded_count", None)
+        if hasattr(mas, "get_skills_status"):
+            out["skills_loaded_count"] = mas.get_skills_status().get("skills_loaded_count")
+        else:
+            out["skills_loaded_count"] = getattr(mas, "_skills_loaded_count", None)
     return out
 
 

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.1-rc.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.1-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/data/skills/aws-cost-analysis/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/aws-cost-analysis/metadata.json
@@ -6,5 +6,9 @@
     "AWS",
     "Cost",
     "Optimization"
+  ],
+  "input_variables": [
+    { "name": "time_period", "label": "Time Period", "required": false, "placeholder": "last 30 days" },
+    { "name": "aws_account", "label": "AWS Account", "required": false, "placeholder": "e.g. 123456789012 or my-account-alias" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/check-deployment-status/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/check-deployment-status/metadata.json
@@ -6,5 +6,9 @@
     "ArgoCD",
     "Kubernetes",
     "Monitoring"
+  ],
+  "input_variables": [
+    { "name": "app_name", "label": "Application Name", "required": false, "placeholder": "e.g. my-service" },
+    { "name": "environment", "label": "Environment", "required": false, "placeholder": "e.g. staging, production" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/cluster-resource-health/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/cluster-resource-health/metadata.json
@@ -6,5 +6,9 @@
     "AWS",
     "Kubernetes",
     "Monitoring"
+  ],
+  "input_variables": [
+    { "name": "cluster_name", "label": "Cluster Name", "required": false, "placeholder": "e.g. prod-us-east-1" },
+    { "name": "namespace", "label": "Namespace", "required": false, "placeholder": "e.g. default, kube-system" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/incident-investigation/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/incident-investigation/metadata.json
@@ -7,5 +7,9 @@
     "Jira",
     "ArgoCD",
     "Multi-Agent"
+  ],
+  "input_variables": [
+    { "name": "incident_id", "label": "Incident ID", "required": false, "placeholder": "e.g. INC-1234 or PagerDuty incident URL" },
+    { "name": "time_range", "label": "Time Range", "required": false, "placeholder": "last 24 hours" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/oncall-handoff/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/oncall-handoff/metadata.json
@@ -7,5 +7,9 @@
     "Jira",
     "ArgoCD",
     "Multi-Agent"
+  ],
+  "input_variables": [
+    { "name": "team_name", "label": "Team Name", "required": false, "placeholder": "e.g. platform-engineering" },
+    { "name": "handoff_period", "label": "Handoff Period", "required": false, "placeholder": "last 24 hours" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/release-readiness-check/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/release-readiness-check/metadata.json
@@ -7,5 +7,9 @@
     "ArgoCD",
     "Jira",
     "Multi-Agent"
+  ],
+  "input_variables": [
+    { "name": "release_branch", "label": "Release Branch", "required": true, "placeholder": "e.g. release/v1.2.0" },
+    { "name": "target_environment", "label": "Target Environment", "required": false, "placeholder": "production" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/review-open-pull-requests/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/review-open-pull-requests/metadata.json
@@ -6,5 +6,9 @@
     "GitHub",
     "Code Review",
     "CI/CD"
+  ],
+  "input_variables": [
+    { "name": "repository", "label": "Repository", "required": false, "placeholder": "e.g. owner/repo" },
+    { "name": "author", "label": "Author", "required": false, "placeholder": "e.g. github-username" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/review-specific-pr/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/review-specific-pr/metadata.json
@@ -6,5 +6,8 @@
     "GitHub",
     "Code Review",
     "PR Analysis"
+  ],
+  "input_variables": [
+    { "name": "pr_url", "label": "PR URL", "required": true, "placeholder": "https://github.com/owner/repo/pull/123" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/security-vulnerability-report/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/security-vulnerability-report/metadata.json
@@ -6,5 +6,9 @@
     "GitHub",
     "Security",
     "Dependabot"
+  ],
+  "input_variables": [
+    { "name": "repository", "label": "Repository", "required": false, "placeholder": "e.g. owner/repo" },
+    { "name": "severity", "label": "Severity Filter", "required": false, "placeholder": "all, critical, high, medium, low" }
   ]
 }

--- a/charts/ai-platform-engineering/data/skills/sprint-progress-report/metadata.json
+++ b/charts/ai-platform-engineering/data/skills/sprint-progress-report/metadata.json
@@ -6,5 +6,9 @@
     "Jira",
     "Agile",
     "Reporting"
+  ],
+  "input_variables": [
+    { "name": "board_name", "label": "Board Name", "required": false, "placeholder": "e.g. PLATFORM board" },
+    { "name": "sprint_name", "label": "Sprint Name", "required": false, "placeholder": "e.g. Sprint 42" }
   ]
 }

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -61,6 +61,7 @@ jest.mock('@/components/admin/SkillMetricsCards', () => ({
   VisibilityBreakdown: () => <div />,
   CategoryBreakdown: () => <div />,
   RunStatsTable: () => <div />,
+  TopCreatorsCard: () => <div />,
 }));
 
 jest.mock('@/components/admin/CheckpointStatsSection', () => ({

--- a/ui/src/app/(app)/agent-builder/page.tsx
+++ b/ui/src/app/(app)/agent-builder/page.tsx
@@ -1,57 +1,19 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   AgentBuilderGallery,
   AgentBuilderEditorDialog,
-  AgentBuilderRunner,
   YamlImportDialog,
 } from "@/components/agent-builder";
 import { AuthGuard } from "@/components/auth-guard";
 import type { AgentSkill } from "@/types/agent-skill";
 
-type ViewMode = "gallery" | "runner";
-
 export default function AgentBuilderPage() {
-  const [viewMode, setViewMode] = useState<ViewMode>("gallery");
-  const [selectedConfig, setSelectedConfig] = useState<AgentSkill | null>(null);
   const [editingConfig, setEditingConfig] = useState<AgentSkill | undefined>(undefined);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isYamlImportOpen, setIsYamlImportOpen] = useState(false);
-  const [cameFromHistory, setCameFromHistory] = useState(false);
-
-  const handleSelectConfig = (config: AgentSkill, fromHistory: boolean = false) => {
-    setSelectedConfig(config);
-    setViewMode("runner");
-    setCameFromHistory(fromHistory);
-  };
-
-  // Handle quick-start execution - run inline with AgentBuilderRunner
-  const handleRunQuickStart = useCallback((prompt: string, configName?: string) => {
-    // Create a temporary config for the quick-start prompt
-    const tempConfig: AgentSkill = {
-      id: `quick-start-${Date.now()}`,
-      name: configName || "Quick Start",
-      description: prompt.length > 100 ? prompt.substring(0, 100) + "..." : prompt,
-      category: "Custom",
-      owner_id: "system",
-      is_system: false,
-      tasks: [
-        {
-          display_text: "Execute prompt",
-          llm_prompt: prompt,
-          subagent: "user_input",
-        },
-      ],
-      is_quick_start: true,
-      created_at: new Date(),
-      updated_at: new Date(),
-    };
-
-    setSelectedConfig(tempConfig);
-    setViewMode("runner");
-  }, []);
 
   const handleEditConfig = (config: AgentSkill) => {
     setEditingConfig(config);
@@ -65,12 +27,6 @@ export default function AgentBuilderPage() {
 
   const handleImportYaml = () => {
     setIsYamlImportOpen(true);
-  };
-
-  const handleBackToGallery = () => {
-    setViewMode("gallery");
-    setSelectedConfig(null);
-    setCameFromHistory(false);
   };
 
   const handleEditorSuccess = () => {
@@ -87,39 +43,19 @@ export default function AgentBuilderPage() {
       <div className="flex flex-col h-full overflow-hidden">
         <div className="flex-1 overflow-y-auto p-6">
           <AnimatePresence mode="wait">
-            {viewMode === "gallery" && (
-              <motion.div
-                key="gallery"
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -20 }}
-                className="h-full"
-              >
-                <AgentBuilderGallery
-                  onSelectConfig={handleSelectConfig}
-                  onRunQuickStart={handleRunQuickStart}
-                  onEditConfig={handleEditConfig}
-                  onCreateNew={handleCreateNew}
-                  onImportYaml={handleImportYaml}
-                />
-              </motion.div>
-            )}
-
-            {viewMode === "runner" && selectedConfig && (
-              <motion.div
-                key="runner"
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: 20 }}
-                className="h-full"
-              >
-                <AgentBuilderRunner
-                  config={selectedConfig}
-                  onBack={handleBackToGallery}
-                  cameFromHistory={cameFromHistory}
-                />
-              </motion.div>
-            )}
+            <motion.div
+              key="gallery"
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              className="h-full"
+            >
+              <AgentBuilderGallery
+                onEditConfig={handleEditConfig}
+                onCreateNew={handleCreateNew}
+                onImportYaml={handleImportYaml}
+              />
+            </motion.div>
           </AnimatePresence>
         </div>
 

--- a/ui/src/app/(app)/skills/gateway/page.tsx
+++ b/ui/src/app/(app)/skills/gateway/page.tsx
@@ -23,7 +23,7 @@ export default function SkillsGatewayPage() {
             type="button"
             className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground"
           >
-            Try API / Gateway
+            Skills API Gateway
           </button>
         </div>
         <div className="flex-1 overflow-y-auto p-6">

--- a/ui/src/app/(app)/skills/gateway/page.tsx
+++ b/ui/src/app/(app)/skills/gateway/page.tsx
@@ -1,13 +1,31 @@
 "use client";
 
 import React from "react";
+import { useRouter } from "next/navigation";
 import { TrySkillsGateway } from "@/components/skills";
 import { AuthGuard } from "@/components/auth-guard";
 
 export default function SkillsGatewayPage() {
+  const router = useRouter();
+
   return (
     <AuthGuard>
       <div className="flex flex-col h-full overflow-hidden">
+        <div className="shrink-0 border-b border-border px-6 pt-4 pb-2 flex gap-2">
+          <button
+            type="button"
+            onClick={() => router.push("/skills")}
+            className="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:bg-muted transition-colors"
+          >
+            Browse
+          </button>
+          <button
+            type="button"
+            className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground"
+          >
+            Try API / Gateway
+          </button>
+        </div>
         <div className="flex-1 overflow-y-auto p-6">
           <TrySkillsGateway />
         </div>

--- a/ui/src/app/(app)/skills/gateway/page.tsx
+++ b/ui/src/app/(app)/skills/gateway/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import React from "react";
+import { TrySkillsGateway } from "@/components/skills";
+import { AuthGuard } from "@/components/auth-guard";
+
+export default function SkillsGatewayPage() {
+  return (
+    <AuthGuard>
+      <div className="flex flex-col h-full overflow-hidden">
+        <div className="flex-1 overflow-y-auto p-6">
+          <TrySkillsGateway />
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/ui/src/app/(app)/skills/page.tsx
+++ b/ui/src/app/(app)/skills/page.tsx
@@ -22,21 +22,6 @@ export default function SkillsPage() {
   return (
     <AuthGuard>
       <div className="flex flex-col h-full overflow-hidden">
-        <div className="shrink-0 border-b border-border px-6 pt-4 pb-2 flex gap-2">
-          <button
-            type="button"
-            className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground"
-          >
-            Browse
-          </button>
-          <button
-            type="button"
-            onClick={() => router.push("/skills/gateway")}
-            className="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:bg-muted transition-colors"
-          >
-            Try API / Gateway
-          </button>
-        </div>
         <div className="flex-1 overflow-y-auto p-6">
           <SkillsGallery
             onEditConfig={handleEditConfig}

--- a/ui/src/app/(app)/skills/page.tsx
+++ b/ui/src/app/(app)/skills/page.tsx
@@ -22,6 +22,21 @@ export default function SkillsPage() {
   return (
     <AuthGuard>
       <div className="flex flex-col h-full overflow-hidden">
+        <div className="shrink-0 border-b border-border px-6 pt-4 pb-2 flex gap-2">
+          <button
+            type="button"
+            className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground"
+          >
+            Browse
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push("/skills/gateway")}
+            className="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:bg-muted transition-colors"
+          >
+            Skills API Gateway
+          </button>
+        </div>
         <div className="flex-1 overflow-y-auto p-6">
           <SkillsGallery
             onEditConfig={handleEditConfig}

--- a/ui/src/app/(app)/skills/page.tsx
+++ b/ui/src/app/(app)/skills/page.tsx
@@ -1,21 +1,17 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { useRouter } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
 import {
   SkillsGallery,
-  TrySkillsGateway,
 } from "@/components/skills";
 import { AuthGuard } from "@/components/auth-guard";
-
-type SkillsTab = "browse" | "gateway";
+import type { AgentSkill } from "@/types/agent-skill";
 
 export default function SkillsPage() {
   const router = useRouter();
-  const [skillsTab, setSkillsTab] = useState<SkillsTab>("browse");
 
-  const handleEditConfig = (config: { id: string }) => {
+  const handleEditConfig = (config: AgentSkill) => {
     router.push(`/skills/editor?id=${encodeURIComponent(config.id)}`);
   };
 
@@ -29,54 +25,23 @@ export default function SkillsPage() {
         <div className="shrink-0 border-b border-border px-6 pt-4 pb-2 flex gap-2">
           <button
             type="button"
-            onClick={() => setSkillsTab("browse")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
-              skillsTab === "browse"
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted"
-            }`}
+            className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground"
           >
             Browse
           </button>
           <button
             type="button"
-            onClick={() => setSkillsTab("gateway")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
-              skillsTab === "gateway"
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted"
-            }`}
+            onClick={() => router.push("/skills/gateway")}
+            className="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:bg-muted transition-colors"
           >
             Try API / Gateway
           </button>
         </div>
         <div className="flex-1 overflow-y-auto p-6">
-          <AnimatePresence mode="wait">
-            {skillsTab === "gateway" && (
-              <motion.div
-                key="gateway"
-                initial={{ opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -8 }}
-              >
-                <TrySkillsGateway />
-              </motion.div>
-            )}
-            {skillsTab === "browse" && (
-              <motion.div
-                key="gallery"
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -20 }}
-                className="h-full"
-              >
-                <SkillsGallery
-                  onEditConfig={handleEditConfig}
-                  onCreateNew={handleCreateNew}
-                />
-              </motion.div>
-            )}
-          </AnimatePresence>
+          <SkillsGallery
+            onEditConfig={handleEditConfig}
+            onCreateNew={handleCreateNew}
+          />
         </div>
       </div>
     </AuthGuard>

--- a/ui/src/app/api/__tests__/skills-gateway.test.ts
+++ b/ui/src/app/api/__tests__/skills-gateway.test.ts
@@ -144,7 +144,7 @@ describe('GET /api/skills — Skills Gateway', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
-    delete process.env.BACKEND_SKILLS_URL;
+    delete process.env.NEXT_PUBLIC_A2A_BASE_URL;
     mockLoadTemplates.mockReturnValue(sampleTemplates());
   });
 

--- a/ui/src/app/api/agent-skills/route.ts
+++ b/ui/src/app/api/agent-skills/route.ts
@@ -29,18 +29,18 @@ import type {
 
 // Storage configuration - MongoDB only for agent config skills
 const STORAGE_TYPE = isMongoDBConfigured ? "mongodb" : "none";
-const BACKEND_SKILLS_URL = process.env.BACKEND_SKILLS_URL || "";
+const SUPERVISOR_URL = process.env.NEXT_PUBLIC_A2A_BASE_URL || "";
 
 async function scanSkillContent(
   name: string,
   content: string,
   configId?: string,
 ): Promise<{ scan_status: ScanStatus; scan_summary?: string }> {
-  if (!BACKEND_SKILLS_URL || !content?.trim()) {
+  if (!SUPERVISOR_URL || !content?.trim()) {
     return { scan_status: "unscanned" };
   }
   try {
-    const resp = await fetch(`${BACKEND_SKILLS_URL}/skills/scan-content`, {
+    const resp = await fetch(`${SUPERVISOR_URL}/skills/scan-content`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, content, config_id: configId }),
@@ -71,8 +71,8 @@ const ANCILLARY_SIZE_LIMIT = 5 * 1024 * 1024; // 5 MB soft limit (FR-028)
  * keeps the expensive hub cache intact.
  */
 function triggerSupervisorRefresh(): void {
-  if (!BACKEND_SKILLS_URL) return;
-  const url = `${BACKEND_SKILLS_URL}/skills/refresh?include_hubs=false`;
+  if (!SUPERVISOR_URL) return;
+  const url = `${SUPERVISOR_URL}/skills/refresh?include_hubs=false`;
   fetch(url, {
     method: "POST",
     signal: AbortSignal.timeout(30_000),

--- a/ui/src/app/api/agent-skills/seed/route.ts
+++ b/ui/src/app/api/agent-skills/seed/route.ts
@@ -16,60 +16,61 @@ import {
  * Seed API Route
  *
  * POST /api/agent-skills/seed
- * Seeds the database with skill templates loaded from charts/data/skills/.
+ * Seeds the database with skill templates loaded from disk (charts/data/skills/).
  * Can be called on app startup or manually by admin.
- * Removes system templates that are no longer present on disk.
+ * Removes system templates that are no longer in the whitelist.
  *
  * GET /api/agent-skills/seed
  * Checks if seeding is needed (returns { needsSeeding: boolean, count: number })
  *
- * The BUILTIN_SKILL_IDS env var controls which templates are seeded.
+ * The BUILTIN_SKILL_IDS env var controls which disk templates are seeded.
  * When set, only templates whose IDs appear in the comma-separated list are seeded.
  * When unset or empty, all disk templates are seeded.
  */
 
 /**
- * Convert a SkillTemplateData (from SKILL.md) into an AgentSkill for MongoDB.
+ * Convert a disk SkillTemplateData into an AgentSkill suitable for MongoDB.
  */
 function templateToAgentSkill(t: SkillTemplateData): AgentSkill {
+  const now = new Date();
   return {
     id: t.id,
-    name: t.title || t.name,
+    name: t.name,
     description: t.description,
     category: t.category || "Custom",
-    tasks: [{
-      display_text: t.title || t.name,
-      llm_prompt: t.content,
-      subagent: "user_input",
-    }],
+    tasks: [
+      {
+        display_text: t.title || t.name,
+        llm_prompt: t.content,
+        subagent: "user_input",
+      },
+    ],
     owner_id: "system",
     is_system: true,
-    created_at: new Date(),
-    updated_at: new Date(),
+    created_at: now,
+    updated_at: now,
     is_quick_start: true,
-    difficulty: "beginner",
     thumbnail: t.icon || "Zap",
     metadata: {
       tags: t.tags || [],
-      expected_agents: [],
+      schema_version: "1.0",
     },
-    skill_content: t.content,
   };
 }
 
 /**
- * Returns the subset of disk templates allowed by the
- * BUILTIN_SKILL_IDS environment variable. If the variable is unset or
- * empty, all templates are returned.
+ * Returns the subset of disk templates allowed by the BUILTIN_SKILL_IDS
+ * environment variable. If the variable is unset or empty, all templates
+ * are returned.
  */
 function getEnabledTemplates(): SkillTemplateData[] {
-  const all = loadSkillTemplatesInternal();
+  const allTemplates = loadSkillTemplatesInternal();
   const raw = process.env.BUILTIN_SKILL_IDS?.trim();
   if (!raw) {
-    return all;
+    return allTemplates;
   }
   const allowedIds = new Set(raw.split(",").map((id) => id.trim()).filter(Boolean));
-  return all.filter((t) => allowedIds.has(t.id));
+  return allTemplates.filter((t) => allowedIds.has(t.id));
 }
 
 // Check if seeding is needed
@@ -83,8 +84,8 @@ async function checkSeedingStatus(): Promise<{ needsSeeding: boolean; existingCo
 
   const collection = await getCollection<AgentSkill>("agent_skills");
   const enabledIds = enabledTemplates.map((t) => t.id);
-  const allIds = allTemplates.map((t) => t.id);
-  const disabledIds = allIds.filter((id) => !new Set(enabledIds).has(id));
+  const allSystemIds = allTemplates.map((t) => t.id);
+  const disabledIds = allSystemIds.filter((id) => !new Set(enabledIds).has(id));
 
   // Count how many of the enabled templates already exist
   const existingCount = await collection.countDocuments({
@@ -104,7 +105,7 @@ async function checkSeedingStatus(): Promise<{ needsSeeding: boolean; existingCo
   };
 }
 
-// Seed the database with enabled templates and remove non-whitelisted ones
+// Seed the database with enabled disk templates and remove non-whitelisted ones
 async function seedTemplatesFromDisk(): Promise<{ seeded: number; skipped: number; removed: number }> {
   if (!isMongoDBConfigured) {
     throw new ApiError("MongoDB is not configured", 503);
@@ -127,16 +128,17 @@ async function seedTemplatesFromDisk(): Promise<{ seeded: number; skipped: numbe
       continue;
     }
 
-    // Insert the template converted to AgentSkill format
+    // Convert disk template to AgentSkill and insert
     const configToInsert = templateToAgentSkill(template);
+
     await collection.insertOne(configToInsert);
     seeded++;
     console.log(`[Seed] Seeded template: ${template.name}`);
   }
 
-  // Remove system templates that are no longer on disk or not in the whitelist
-  const allIds = allTemplates.map((t) => t.id);
-  const disabledIds = allIds.filter((id) => !enabledIds.has(id));
+  // Remove system templates that are no longer in the whitelist
+  const allSystemIds = allTemplates.map((t) => t.id);
+  const disabledIds = allSystemIds.filter((id) => !enabledIds.has(id));
   let removed = 0;
   if (disabledIds.length > 0) {
     const result = await collection.deleteMany({
@@ -159,7 +161,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   if (!isMongoDBConfigured) {
     return NextResponse.json({
       needsSeeding: false,
-      message: "MongoDB not configured — skill templates from disk are not seeded",
+      message: "MongoDB not configured - using disk templates from charts/data/skills/",
       existingCount: 0,
       templateCount: enabledTemplates.length,
     });
@@ -195,7 +197,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     isAdmin = false;
   }
 
-  // Perform seeding from disk templates
+  // Perform seeding (also removes non-whitelisted system templates)
   const result = await seedTemplatesFromDisk();
 
   console.log(`[Seed] Seeding complete: ${result.seeded} seeded, ${result.skipped} skipped, ${result.removed} removed`);

--- a/ui/src/app/api/catalog-api-keys/[keyId]/route.ts
+++ b/ui/src/app/api/catalog-api-keys/[keyId]/route.ts
@@ -15,7 +15,7 @@ export const DELETE = withErrorHandler(
   ) => {
     const { keyId } = await context.params;
     return await withAuth(request, async (_req, _user, session) => {
-      const backendUrl = process.env.BACKEND_SKILLS_URL;
+      const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
       if (!backendUrl) {
         return NextResponse.json(
           { error: "backend_not_configured" },

--- a/ui/src/app/api/catalog-api-keys/route.ts
+++ b/ui/src/app/api/catalog-api-keys/route.ts
@@ -8,12 +8,12 @@ import {
  * GET /api/catalog-api-keys — list metadata for caller’s catalog API keys.
  * POST /api/catalog-api-keys — mint a new key (one-time full key in response).
  *
- * Proxies to Python when BACKEND_SKILLS_URL is set (T051).
+ * Proxies to Python when NEXT_PUBLIC_A2A_BASE_URL is set (T051).
  */
 
 export const GET = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (_req, _user, session) => {
-    const backendUrl = process.env.BACKEND_SKILLS_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
     if (!backendUrl) {
       return NextResponse.json(
         { error: "backend_not_configured", keys: [] },
@@ -36,10 +36,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
 export const POST = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (_req, _user, session) => {
-    const backendUrl = process.env.BACKEND_SKILLS_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
     if (!backendUrl) {
       return NextResponse.json(
-        { error: "backend_not_configured", message: "BACKEND_SKILLS_URL is not set." },
+        { error: "backend_not_configured", message: "NEXT_PUBLIC_A2A_BASE_URL is not set." },
         { status: 503 },
       );
     }

--- a/ui/src/app/api/skill-hubs/[id]/route.ts
+++ b/ui/src/app/api/skill-hubs/[id]/route.ts
@@ -53,6 +53,8 @@ export const PATCH = withErrorHandler(
       }
       if (body.credentials_ref !== undefined)
         update.credentials_ref = validateCredentialsRef(body.credentials_ref);
+      if (Array.isArray(body.labels))
+        update.labels = body.labels.map((l: unknown) => String(l).trim().toLowerCase()).filter(Boolean).slice(0, 20);
 
       await collection.updateOne({ id }, { $set: update });
 

--- a/ui/src/app/api/skill-hubs/crawl/route.ts
+++ b/ui/src/app/api/skill-hubs/crawl/route.ts
@@ -9,7 +9,7 @@ import { crawlGitHubRepo, crawlGitLabRepo } from "@/lib/hub-crawl";
 
 /**
  * POST /api/skill-hubs/crawl — preview SKILL.md paths for a repo (FR-017).
- * Proxies to Python when BACKEND_SKILLS_URL is set; otherwise crawls from Next server.
+ * Proxies to Python when NEXT_PUBLIC_A2A_BASE_URL is set; otherwise crawls from Next server.
  * Admin only.
  */
 export const POST = withErrorHandler(async (request: NextRequest) => {
@@ -27,7 +27,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       );
     }
 
-    const backendUrl = process.env.BACKEND_SKILLS_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
     if (backendUrl) {
       const headers: Record<string, string> = {
         "Content-Type": "application/json",

--- a/ui/src/app/api/skill-hubs/route.ts
+++ b/ui/src/app/api/skill-hubs/route.ts
@@ -25,6 +25,7 @@ interface SkillHubDoc {
   location: string;
   enabled: boolean;
   credentials_ref: string | null;
+  labels: string[];
   last_success_at: number | null;
   last_failure_at: number | null;
   last_failure_message: string | null;
@@ -103,6 +104,10 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       // Not a URL — keep as-is (already owner/repo format)
     }
 
+    const labels: string[] = Array.isArray(body.labels)
+      ? body.labels.map((l: unknown) => String(l).trim().toLowerCase()).filter(Boolean).slice(0, 20)
+      : [];
+
     const collection = await getCollection<SkillHubDoc>("skill_hubs");
 
     // Check for duplicate location (use normalized)
@@ -121,6 +126,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       location: normalizedLocation,
       enabled: body.enabled !== false,
       credentials_ref: validateCredentialsRef(body.credentials_ref),
+      labels,
       last_success_at: null,
       last_failure_at: null,
       last_failure_message: null,

--- a/ui/src/app/api/skills/refresh/route.ts
+++ b/ui/src/app/api/skills/refresh/route.ts
@@ -14,12 +14,12 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (_req, _user, session) => {
     requireAdmin(session);
 
-    const backendUrl = process.env.BACKEND_SKILLS_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
     if (!backendUrl) {
       return NextResponse.json(
         {
           error: "backend_not_configured",
-          message: "BACKEND_SKILLS_URL is not set; cannot refresh supervisor skills.",
+          message: "NEXT_PUBLIC_A2A_BASE_URL is not set; cannot refresh supervisor skills.",
         },
         { status: 503 },
       );

--- a/ui/src/app/api/skills/route.ts
+++ b/ui/src/app/api/skills/route.ts
@@ -11,7 +11,7 @@ import type { SkillHubDoc } from "@/lib/hub-crawl";
  *
  * GET /api/skills
  *   Returns the merged skill catalog from default (filesystem) + agent_skills + hubs.
- *   If BACKEND_SKILLS_URL is configured, proxies to the Python backend GET /skills.
+ *   If NEXT_PUBLIC_A2A_BASE_URL is configured, proxies to the Python backend GET /skills.
  *   Otherwise, aggregates locally from /api/skill-templates and /api/agent-skills.
  *
  * Supports dual-auth: Bearer JWT (for CLI/remote) or NextAuth session (browser).
@@ -174,16 +174,15 @@ function paginate(
 }
 
 /**
- * Try to proxy to the Python backend at BACKEND_SKILLS_URL.
+ * Try to proxy to the Python backend at NEXT_PUBLIC_A2A_BASE_URL.
  * Returns null if not configured or unreachable.
  * Forwards query params so the backend can also filter server-side.
  */
 async function fetchFromBackend(
   params: QueryParams,
   authHeader?: string | null,
-  catalogKey?: string | null,
 ): Promise<CatalogResponse | null> {
-  const backendUrl = process.env.BACKEND_SKILLS_URL;
+  const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
   if (!backendUrl) return null;
 
   try {
@@ -202,7 +201,6 @@ async function fetchFromBackend(
 
     const headers: Record<string, string> = {};
     if (authHeader) headers["Authorization"] = authHeader;
-    if (catalogKey) headers["X-Caipe-Catalog-Key"] = catalogKey;
 
     const res = await fetch(url.toString(), {
       headers,
@@ -233,6 +231,14 @@ async function aggregateLocally(
     );
     const templates = loadSkillTemplatesInternal();
     for (const t of templates) {
+      const meta: Record<string, unknown> = {
+        category: t.category,
+        icon: t.icon,
+        tags: t.tags,
+      };
+      if (t.input_variables && t.input_variables.length > 0) {
+        meta.input_variables = t.input_variables;
+      }
       skills.push({
         id: t.id,
         name: t.name,
@@ -240,11 +246,7 @@ async function aggregateLocally(
         source: "default",
         source_id: null,
         content: includeContent ? t.content : null,
-        metadata: {
-          category: t.category,
-          icon: t.icon,
-          tags: t.tags,
-        },
+        metadata: meta,
       });
     }
     sourcesLoaded.push("default");
@@ -356,10 +358,9 @@ export const GET = withErrorHandler(async (req: NextRequest) => {
 
   const params = parseQueryParams(req);
   const authHeader = req.headers.get("Authorization");
-  const catalogKey = req.headers.get("X-Caipe-Catalog-Key");
 
   // Try backend proxy first (forwards all query params)
-  const backendResult = await fetchFromBackend(params, authHeader, catalogKey);
+  const backendResult = await fetchFromBackend(params, authHeader);
   if (backendResult) {
     return NextResponse.json(backendResult);
   }

--- a/ui/src/app/api/skills/route.ts
+++ b/ui/src/app/api/skills/route.ts
@@ -18,7 +18,8 @@ import type { SkillHubDoc } from "@/lib/hub-crawl";
  *
  * Query params:
  *   q               — case-insensitive text search in skill name and description
- *   source          — filter by source: "default", "agent_skills", "hub"
+ *   source          — filter by source: "default", "agent_skills", "hub", "github", "gitlab"
+ *   repo            — filter hub skills by repository location (e.g. "owner/repo")
  *   tags            — comma-separated tag filter (metadata.tags includes any)
  *   include_content — include full SKILL.md body for each skill (default false)
  *   page            — page number, 1-indexed (default: omit for all results)
@@ -58,6 +59,7 @@ interface CatalogResponse {
 interface QueryParams {
   q: string;
   source: string;
+  repo: string;
   visibility: string;
   tags: string[];
   includeContent: boolean;
@@ -89,6 +91,7 @@ function parseQueryParams(req: NextRequest): QueryParams {
   return {
     q: (sp.get("q") || "").trim().toLowerCase(),
     source: (sp.get("source") || "").trim().toLowerCase(),
+    repo: (sp.get("repo") || "").trim().toLowerCase(),
     visibility: (sp.get("visibility") || "").trim().toLowerCase(),
     tags,
     includeContent: sp.get("include_content") === "true",
@@ -115,9 +118,17 @@ function filterSkills(
   }
 
   if (params.source) {
-    result = result.filter(
-      (s) => s.source.toLowerCase() === params.source,
-    );
+    if (params.source === "github" || params.source === "gitlab") {
+      result = result.filter(
+        (s) =>
+          s.source === "hub" &&
+          (s.metadata as { hub_type?: string })?.hub_type === params.source,
+      );
+    } else {
+      result = result.filter(
+        (s) => s.source.toLowerCase() === params.source,
+      );
+    }
   }
 
   if (params.visibility) {
@@ -125,6 +136,13 @@ function filterSkills(
     result = result.filter((s) => {
       const mv = (s.metadata as { visibility?: string })?.visibility;
       return (mv || "global").toLowerCase() === v;
+    });
+  }
+
+  if (params.repo) {
+    result = result.filter((s) => {
+      const loc = (s.metadata as { hub_location?: string })?.hub_location;
+      return loc ? loc.toLowerCase() === params.repo : false;
     });
   }
 
@@ -191,6 +209,7 @@ async function fetchFromBackend(
     if (params.includeContent) incoming.set("include_content", "true");
     if (params.q) incoming.set("q", params.q);
     if (params.source) incoming.set("source", params.source);
+    if (params.repo) incoming.set("repo", params.repo);
     if (params.visibility) incoming.set("visibility", params.visibility);
     if (params.tags.length > 0) incoming.set("tags", params.tags.join(","));
     if (params.page !== null) {

--- a/ui/src/app/api/skills/skill-templates-loader.ts
+++ b/ui/src/app/api/skills/skill-templates-loader.ts
@@ -8,6 +8,13 @@
 import fs from "fs";
 import path from "path";
 
+export interface SkillInputVariable {
+  name: string;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+}
+
 export interface SkillTemplateData {
   id: string;
   name: string;
@@ -17,6 +24,7 @@ export interface SkillTemplateData {
   icon: string;
   tags: string[];
   content: string;
+  input_variables?: SkillInputVariable[];
 }
 
 function resolveSkillsDir(): string {
@@ -52,12 +60,28 @@ function parseFrontmatter(content: string): {
   let description = "";
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
   if (match) {
-    for (const line of match[1].split("\n")) {
-      const nameMatch = line.match(/^name:\s*(.*)/);
-      if (nameMatch) name = nameMatch[1].trim();
-      const descMatch = line.match(/^description:\s*(.*)/);
-      if (descMatch) description = descMatch[1].trim();
+    const lines = match[1].split("\n");
+    let currentKey = "";
+    let currentValue = "";
+
+    for (const line of lines) {
+      const keyMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
+      if (keyMatch) {
+        // Store previous key
+        if (currentKey === "name") name = currentValue.trim();
+        if (currentKey === "description") description = currentValue.trim();
+        currentKey = keyMatch[1];
+        const val = keyMatch[2].trim();
+        // YAML folded scalar ">" or literal "|" — value is on next lines
+        currentValue = val === ">" || val === "|" ? "" : val;
+      } else if (currentKey && line.match(/^\s+/)) {
+        // Continuation line (indented) — append with space
+        currentValue += " " + line.trim();
+      }
     }
+    // Store last key
+    if (currentKey === "name") name = currentValue.trim();
+    if (currentKey === "description") description = currentValue.trim();
   }
   return { name, description };
 }
@@ -67,6 +91,7 @@ interface SkillMetadata {
   category?: string;
   icon?: string;
   tags?: string[];
+  input_variables?: SkillInputVariable[];
 }
 
 function parseMetadata(raw: string): SkillMetadata {
@@ -83,7 +108,7 @@ function buildTemplate(
   metadata: SkillMetadata,
 ): SkillTemplateData {
   const fm = parseFrontmatter(content);
-  return {
+  const tpl: SkillTemplateData = {
     id: fm.name || id,
     name: fm.name || id,
     description: fm.description,
@@ -93,6 +118,10 @@ function buildTemplate(
     tags: metadata.tags || [],
     content,
   };
+  if (metadata.input_variables && metadata.input_variables.length > 0) {
+    tpl.input_variables = metadata.input_variables;
+  }
+  return tpl;
 }
 
 function loadFromFolderLayout(skillsDir: string): SkillTemplateData[] {

--- a/ui/src/app/api/skills/supervisor-status/route.ts
+++ b/ui/src/app/api/skills/supervisor-status/route.ts
@@ -7,7 +7,7 @@ import { withAuth, withErrorHandler } from "@/lib/api-middleware";
  */
 export const GET = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (_req, _user, session) => {
-    const backendUrl = process.env.BACKEND_SKILLS_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_A2A_BASE_URL;
     if (!backendUrl) {
       return NextResponse.json(
         {
@@ -16,7 +16,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           skills_loaded_count: null,
           skills_merged_at: null,
           catalog_cache_generation: null,
-          message: "BACKEND_SKILLS_URL is not set.",
+          message: "NEXT_PUBLIC_A2A_BASE_URL is not set.",
         },
         { status: 200 },
       );

--- a/ui/src/components/admin/SkillHubsSection.tsx
+++ b/ui/src/components/admin/SkillHubsSection.tsx
@@ -12,12 +12,12 @@ interface SkillHub {
   location: string;
   enabled: boolean;
   credentials_ref: string | null;
+  labels?: string[];
   last_success_at: number | null;
   last_failure_at: number | null;
   last_failure_message: string | null;
   created_at: string;
   updated_at: string;
-  skills_count?: number;
   /** Set when skill-scanner runs on hub ingest (backend). */
   last_skill_scan_at?: number | null;
   last_skill_scan_exit_code?: number | null;
@@ -35,11 +35,11 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
   const [showAddForm, setShowAddForm] = useState(false);
   const [formLocation, setFormLocation] = useState("");
   const [formCredRef, setFormCredRef] = useState("");
+  const [formLabels, setFormLabels] = useState("");
   const [adding, setAdding] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
   const [crawlLoading, setCrawlLoading] = useState(false);
   const [crawlPaths, setCrawlPaths] = useState<string[]>([]);
   const [crawlPreview, setCrawlPreview] = useState<{ path: string; name: string; description: string }[]>([]);
@@ -73,6 +73,7 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
     setAdding(true);
     setError(null);
     try {
+      const labels = formLabels.split(",").map((l) => l.trim().toLowerCase()).filter(Boolean);
       const res = await fetch("/api/skill-hubs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -80,6 +81,7 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
           type: "github",
           location: formLocation.trim(),
           credentials_ref: formCredRef.trim() || null,
+          labels: labels.length > 0 ? labels : undefined,
           enabled: true,
         }),
       });
@@ -89,6 +91,7 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
       }
       setFormLocation("");
       setFormCredRef("");
+      setFormLabels("");
       setShowAddForm(false);
       await loadHubs();
     } catch (err: any) {
@@ -133,25 +136,17 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
   };
 
   const handleRefresh = async () => {
-    setRefreshing(true);
-    setError(null);
-    try {
-      if (isAdmin) {
-        try {
-          await fetch("/api/skills/refresh", { method: "POST" });
-        } catch {
-          /* best-effort — backend may be unavailable */
-        }
-      }
+    if (isAdmin) {
       try {
-        await fetch("/api/skills?include_content=false");
-      } catch {}
-      await loadHubs();
-    } catch (err: any) {
-      setError(err.message || "Refresh failed");
-    } finally {
-      setRefreshing(false);
+        await fetch("/api/skills/refresh", { method: "POST" });
+      } catch {
+        /* best-effort — backend may be unavailable */
+      }
     }
+    try {
+      await fetch("/api/skills?include_content=false");
+    } catch {}
+    await loadHubs();
   };
 
   const handleCrawlPreview = async () => {
@@ -206,9 +201,9 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
           </CardDescription>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing} className="gap-1">
-            {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCcw className="h-3.5 w-3.5" />}
-            {refreshing ? "Refreshing..." : "Refresh"}
+          <Button variant="outline" size="sm" onClick={handleRefresh} className="gap-1">
+            <RefreshCcw className="h-3.5 w-3.5" />
+            Refresh
           </Button>
           {isAdmin && (
             <Button size="sm" onClick={() => setShowAddForm(!showAddForm)} className="gap-1">
@@ -252,6 +247,19 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
               />
               <p className="text-xs text-muted-foreground mt-1">
                 Name of the environment variable holding a GitHub token. Falls back to GITHUB_TOKEN if empty.
+              </p>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground">Labels (optional, comma-separated)</label>
+              <input
+                type="text"
+                value={formLabels}
+                onChange={(e) => setFormLabels(e.target.value)}
+                placeholder="e.g. security, platform, networking"
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Labels are merged into every skill&apos;s tags from this hub.
               </p>
             </div>
             <div className="flex flex-wrap gap-2 pt-1">
@@ -300,20 +308,24 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
           </div>
         ) : (
           <div className="space-y-2">
-            <div className="grid grid-cols-7 gap-4 pb-2 border-b text-xs font-medium text-muted-foreground">
+            <div className="grid grid-cols-6 gap-4 pb-2 border-b text-xs font-medium text-muted-foreground">
               <div className="col-span-2">Repository</div>
               <div>Status</div>
-              <div>Skills</div>
               <div>Last Sync</div>
               <div>Added</div>
               {isAdmin && <div className="text-right">Actions</div>}
             </div>
             {hubs.map((hub) => (
               <div key={hub.id} className="space-y-0.5">
-              <div className="grid grid-cols-7 gap-4 py-2 text-sm hover:bg-muted/50 rounded px-2 items-center">
+              <div className="grid grid-cols-6 gap-4 py-2 text-sm hover:bg-muted/50 rounded px-2 items-center">
                 <div className="col-span-2 flex items-center gap-2">
                   <Globe className="h-4 w-4 text-muted-foreground shrink-0" />
                   <span className="font-medium truncate">{hub.location}</span>
+                  {hub.labels && hub.labels.length > 0 && hub.labels.map((label) => (
+                    <Badge key={label} variant="secondary" className="text-[10px] px-1.5 py-0">
+                      {label}
+                    </Badge>
+                  ))}
                 </div>
                 <div>
                   {hub.enabled ? (
@@ -331,9 +343,6 @@ export function SkillHubsSection({ isAdmin }: SkillHubsSectionProps) {
                   ) : (
                     <Badge variant="secondary" className="text-xs">Disabled</Badge>
                   )}
-                </div>
-                <div className="text-xs text-muted-foreground font-medium">
-                  {hub.skills_count ?? 0}
                 </div>
                 <div className="text-xs text-muted-foreground">
                   {hub.last_success_at

--- a/ui/src/components/agent-builder/AgentBuilderEditor.tsx
+++ b/ui/src/components/agent-builder/AgentBuilderEditor.tsx
@@ -302,7 +302,7 @@ export function AgentBuilderEditor({
     // Check permission for system configs
     if (isEditMode && existingConfig?.is_system && !isAdmin) {
       toast(
-        "Only administrators can edit system templates.\n\nTo customize this template:\n• Use 'Run in Chat' to test variations\n• Create your own workflow based on this template\n• Contact your admin for template modifications",
+        "Only administrators can edit system templates.\n\nTo customize this template:\n• Use 'Try Skill' to test variations\n• Create your own workflow based on this template\n• Contact your admin for template modifications",
         "warning",
         7000
       );
@@ -405,7 +405,7 @@ export function AgentBuilderEditor({
       // If it's a permission error for system configs, show specific guidance
       if (errorMessage.includes("system") || errorMessage.includes("admin")) {
         toast(
-          `Cannot edit system template: ${errorMessage}\n\nTo customize this template, please contact your admin or use "Run in Chat" to test different variations.`,
+          `Cannot edit system template: ${errorMessage}\n\nTo customize this template, please contact your admin or use "Try Skill" to test different variations.`,
           "error",
           7000
         );

--- a/ui/src/components/agent-builder/AgentBuilderGallery.tsx
+++ b/ui/src/components/agent-builder/AgentBuilderGallery.tsx
@@ -755,7 +755,7 @@ export function AgentBuilderGallery({
                 <div className="flex items-center gap-2">
                   <Button variant="ghost" onClick={() => setActiveFormConfig(null)}>Cancel</Button>
                   {!supervisorSynced && !supervisorLoading && (
-                    <AlertTriangle className="h-4 w-4 text-amber-500" title="Skills must be synced with the supervisor first" />
+                    <span title="Skills must be synced with the supervisor first"><AlertTriangle className="h-4 w-4 text-amber-500" /></span>
                   )}
                   <Button
                     onClick={handleTrySkill}

--- a/ui/src/components/agent-builder/AgentBuilderGallery.tsx
+++ b/ui/src/components/agent-builder/AgentBuilderGallery.tsx
@@ -15,11 +15,9 @@ import {
   Settings,
   Loader2,
   AlertCircle,
-  Play,
   Edit,
   Trash2,
   Upload,
-  ChevronRight,
   Sparkles,
   Zap,
   Server,
@@ -33,7 +31,6 @@ import {
   GitPullRequest,
   ArrowRight,
   X,
-  ExternalLink,
   MessageSquare,
   Star,
   History,
@@ -46,12 +43,9 @@ import { cn } from "@/lib/utils";
 import { useAgentSkillsStore } from "@/store/agent-skills-store";
 import { useChatStore } from "@/store/chat-store";
 import { useAdminRole } from "@/hooks/use-admin-role";
-import type { AgentSkill, AgentSkillCategory, WorkflowDifficulty } from "@/types/agent-skill";
-import { generateInputFormFromPrompt } from "@/types/agent-skill";
+import type { AgentSkill, WorkflowDifficulty } from "@/types/agent-skill";
 
 interface AgentBuilderGalleryProps {
-  onSelectConfig?: (config: AgentSkill, fromHistory?: boolean) => void;
-  onRunQuickStart?: (prompt: string, configName?: string) => void;
   onEditConfig?: (config: AgentSkill) => void;
   onCreateNew?: () => void;
   onImportYaml?: () => void;
@@ -123,8 +117,6 @@ const getDifficultyColor = (difficulty?: WorkflowDifficulty) => {
 };
 
 export function AgentBuilderGallery({
-  onSelectConfig,
-  onRunQuickStart,
   onEditConfig,
   onCreateNew,
   onImportYaml,
@@ -148,35 +140,22 @@ export function AgentBuilderGallery({
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"all" | "quick-start" | "workflows">("all");
 
-  // Input form state for quick-start with placeholders
+  // Skill run modal state
   const [activeFormConfig, setActiveFormConfig] = useState<AgentSkill | null>(null);
-  const [formValues, setFormValues] = useState<Record<string, string>>({});
-  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-  const [editablePrompt, setEditablePrompt] = useState<string>("");
 
-  // Keep activeFormConfig in sync with store updates (e.g., after editing)
+  // Supervisor sync state
+  const [supervisorSynced, setSupervisorSynced] = useState(false);
+  const [supervisorLoading, setSupervisorLoading] = useState(true);
+
   useEffect(() => {
-    if (activeFormConfig) {
-      // Find the latest version of this config in the store
-      const latestConfig = configs.find(c => c.id === activeFormConfig.id);
-      if (latestConfig) {
-        const latestPrompt = latestConfig.tasks[0]?.llm_prompt || "";
-        const currentPrompt = activeFormConfig.tasks[0]?.llm_prompt || "";
-
-        // Only update if the prompt has changed (to avoid infinite loop)
-        if (latestPrompt !== currentPrompt) {
-          console.log(`[AgentBuilderGallery] Config updated in store, refreshing dialog:`, latestConfig.id);
-          console.log(`[AgentBuilderGallery] Old prompt:`, currentPrompt);
-          console.log(`[AgentBuilderGallery] New prompt:`, latestPrompt);
-
-          // Update activeFormConfig with latest data
-          setActiveFormConfig({ ...latestConfig, input_form: activeFormConfig.input_form });
-          // Update editablePrompt with latest llm_prompt
-          setEditablePrompt(latestPrompt);
-        }
-      }
-    }
-  }, [configs, activeFormConfig]); // Re-run when configs change or activeFormConfig changes
+    fetch("/api/skills/supervisor-status")
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        setSupervisorSynced(data?.mas_registered === true && (data?.skills_loaded_count ?? 0) > 0);
+      })
+      .catch(() => setSupervisorSynced(false))
+      .finally(() => setSupervisorLoading(false));
+  }, []);
 
   // Check if user can edit/delete a config
   const canModifyConfig = (config: AgentSkill) => {
@@ -261,98 +240,15 @@ export function AgentBuilderGallery({
   };
 
   const handleConfigClick = (config: AgentSkill) => {
-    if (config.is_quick_start) {
-      // Always show modal for quick-starts to allow editing
-      const inputForm = config.input_form || generateInputFormFromPrompt(config.tasks[0]?.llm_prompt || "", config.name);
-      const basePrompt = config.tasks[0]?.llm_prompt || "";
-
-      console.log(`[AgentBuilderGallery] Opening quick-start: ${config.name}`);
-      console.log(`[AgentBuilderGallery] Prompt from config:`, basePrompt);
-      console.log(`[AgentBuilderGallery] Full config:`, config);
-
-      setActiveFormConfig({ ...config, input_form: inputForm || undefined });
-      setEditablePrompt(basePrompt);
-
-      if (inputForm && inputForm.fields.length > 0) {
-        const initialValues: Record<string, string> = {};
-        inputForm.fields.forEach(f => { initialValues[f.name] = ""; });
-        setFormValues(initialValues);
-      } else {
-        setFormValues({});
-      }
-      setFormErrors({});
-    } else {
-      // Multi-step workflow - go to runner
-      onSelectConfig?.(config);
-    }
+    setActiveFormConfig(config);
   };
 
-  // Update editable prompt when form values change
-  const updateEditablePrompt = (newFormValues: Record<string, string>) => {
+  const handleTrySkill = () => {
     if (!activeFormConfig) return;
-
-    let prompt = activeFormConfig.tasks[0]?.llm_prompt || "";
-    Object.entries(newFormValues).forEach(([key, value]) => {
-      if (value.trim()) {
-        const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        prompt = prompt.replace(new RegExp(`\\{\\{\\s*${escapedKey}\\s*\\}\\}`, "g"), value.trim());
-        prompt = prompt.replace(new RegExp(`\\{${escapedKey}\\}`, "g"), value.trim());
-      }
-    });
-    setEditablePrompt(prompt);
-  };
-
-  const handleFormSubmit = () => {
-    if (!activeFormConfig) return;
-
-    // Validate required fields if there are any
-    if (activeFormConfig.input_form && activeFormConfig.input_form.fields.length > 0) {
-      const errors: Record<string, string> = {};
-      activeFormConfig.input_form.fields.forEach(field => {
-        if (field.required && !formValues[field.name]?.trim()) {
-          errors[field.name] = `${field.label} is required`;
-        }
-      });
-
-      if (Object.keys(errors).length > 0) {
-        setFormErrors(errors);
-        return;
-      }
-    }
-
-    // Use the editable prompt (which may have been modified by the user)
-    setActiveFormConfig(null);
-    onRunQuickStart?.(editablePrompt, activeFormConfig.name);
-  };
-
-  const handleRunInChat = () => {
-    if (!activeFormConfig) return;
-
-    // Validate required fields if there are any
-    if (activeFormConfig.input_form && activeFormConfig.input_form.fields.length > 0) {
-      const errors: Record<string, string> = {};
-      activeFormConfig.input_form.fields.forEach(field => {
-        if (field.required && !formValues[field.name]?.trim()) {
-          errors[field.name] = `${field.label} is required`;
-        }
-      });
-
-      if (Object.keys(errors).length > 0) {
-        setFormErrors(errors);
-        return;
-      }
-    }
-
-    // Create a new conversation
     const conversationId = createConversation();
-
-    // Set the pending message to be auto-submitted when the chat loads
-    setPendingMessage(editablePrompt);
-
-    // Close the modal
+    const skillId = activeFormConfig.id || activeFormConfig.name;
+    setPendingMessage(`Execute skill: ${skillId}\n\nRead and follow the instructions in the SKILL.md file for the "${skillId}" skill.`);
     setActiveFormConfig(null);
-
-    // Navigate to the chat page
     router.push(`/chat/${conversationId}`);
   };
 
@@ -484,7 +380,7 @@ export function AgentBuilderGallery({
                       transition={{ delay: index * 0.03 }}
                       whileHover={{ scale: 1.02 }}
                       whileTap={{ scale: 0.98 }}
-                      onClick={() => config.is_quick_start ? handleConfigClick(config) : onSelectConfig?.(config)}
+                      onClick={() => handleConfigClick(config)}
                       className="relative flex items-center gap-3 p-4 rounded-xl bg-card border border-border/50 hover:border-yellow-500 hover:shadow-lg transition-all text-left group cursor-pointer"
                     >
                       <div className={cn("p-2 rounded-lg bg-gradient-to-br shrink-0", gradientClass)}>
@@ -738,7 +634,7 @@ export function AgentBuilderGallery({
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: index * 0.03 }}
                       className="group relative p-4 rounded-xl border border-border/50 bg-card/50 hover:border-primary/30 hover:shadow-lg transition-all cursor-pointer"
-                      onClick={() => onSelectConfig?.(config)}
+                      onClick={() => handleConfigClick(config)}
                     >
                       <div className={cn("w-10 h-10 rounded-lg bg-gradient-to-br flex items-center justify-center mb-3", gradientClass)}>
                         <Icon className="h-5 w-5 text-white" />
@@ -765,8 +661,8 @@ export function AgentBuilderGallery({
                           <Star className={cn("h-4 w-4", isFavorite(config.id) && "fill-current")} />
                         </Button>
                         <div className="h-5 w-px bg-border/50" />
-                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={(e) => { e.stopPropagation(); onSelectConfig?.(config); }}>
-                          <Play className="h-4 w-4" />
+                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={(e) => { e.stopPropagation(); handleConfigClick(config); }}>
+                          <MessageSquare className="h-4 w-4" />
                         </Button>
                         {canModifyConfig(config) && (
                           <>
@@ -833,86 +729,48 @@ export function AgentBuilderGallery({
                   </Button>
                 </div>
 
-                {/* Input fields for placeholders (if any) */}
-                {activeFormConfig.input_form && activeFormConfig.input_form.fields.length > 0 && (
-                  <div className="space-y-4 mb-6">
-                    <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-                      <Settings className="h-4 w-4" />
-                      Fill in the details
-                    </div>
-                    {activeFormConfig.input_form.fields.map(field => (
-                      <div key={field.name} className="space-y-2">
-                        <label className="text-sm font-medium flex items-center gap-1">
-                          {field.label}
-                          {field.required && <span className="text-red-400">*</span>}
-                        </label>
-                        <Input
-                          type={field.type}
-                          placeholder={field.placeholder}
-                          value={formValues[field.name] || ""}
-                          onChange={e => {
-                            const newValues = { ...formValues, [field.name]: e.target.value };
-                            setFormValues(newValues);
-                            updateEditablePrompt(newValues);
-                            if (formErrors[field.name]) setFormErrors(prev => ({ ...prev, [field.name]: "" }));
-                          }}
-                          className={cn("h-11", formErrors[field.name] && "border-red-500")}
-                        />
-                        {field.helperText && !formErrors[field.name] && (
-                          <p className="text-xs text-muted-foreground flex items-center gap-1">
-                            <ExternalLink className="h-3 w-3" />{field.helperText}
-                          </p>
-                        )}
-                        {formErrors[field.name] && <p className="text-xs text-red-400">{formErrors[field.name]}</p>}
-                      </div>
+                {/* Description preview */}
+                {activeFormConfig.description && (
+                  <p className="text-sm text-muted-foreground">{activeFormConfig.description}</p>
+                )}
+                {/* Tags */}
+                {activeFormConfig.metadata?.tags && Array.isArray(activeFormConfig.metadata.tags) && (activeFormConfig.metadata.tags as string[]).length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {(activeFormConfig.metadata.tags as string[]).map((tag: string) => (
+                      <Badge key={tag} variant="secondary" className="text-xs">{tag}</Badge>
                     ))}
                   </div>
                 )}
-
-                {/* Editable Prompt */}
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <label className="text-sm font-medium flex items-center gap-2">
-                      <Edit className="h-4 w-4 text-muted-foreground" />
-                      Prompt (editable)
-                    </label>
-                    <span className="text-xs text-muted-foreground">
-                      {editablePrompt.length} characters
-                    </span>
-                  </div>
-                  <textarea
-                    value={editablePrompt}
-                    onChange={e => setEditablePrompt(e.target.value)}
-                    rows={6}
-                    className="w-full px-4 py-3 text-sm rounded-lg border border-input bg-background resize-none font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    placeholder="Enter your prompt..."
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    You can edit the prompt before running the workflow
-                  </p>
-                </div>
               </div>
 
               {/* Footer */}
-              <div className="flex items-center justify-end gap-3 p-4 border-t bg-muted/30 shrink-0">
-                <Button variant="ghost" onClick={() => setActiveFormConfig(null)}>Cancel</Button>
-                <Button
-                  onClick={handleRunInChat}
-                  variant="outline"
-                  className="gap-2"
-                  disabled={!editablePrompt.trim()}
-                >
-                  <MessageSquare className="h-4 w-4" />
-                  Run in Chat
-                </Button>
-                <Button
-                  onClick={handleFormSubmit}
-                  className="gradient-primary text-white gap-2"
-                  disabled={!editablePrompt.trim()}
-                >
-                  <Play className="h-4 w-4" />
-                  Run Workflow
-                </Button>
+              <div className="flex items-center justify-between gap-3 p-4 border-t bg-muted/30 shrink-0">
+                <div>
+                  {onEditConfig && (
+                    <Button variant="ghost" size="sm" onClick={() => { setActiveFormConfig(null); onEditConfig(activeFormConfig); }}>
+                      <Edit className="h-3.5 w-3.5 mr-1" /> Edit
+                    </Button>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button variant="ghost" onClick={() => setActiveFormConfig(null)}>Cancel</Button>
+                  {!supervisorSynced && !supervisorLoading && (
+                    <AlertTriangle className="h-4 w-4 text-amber-500" title="Skills must be synced with the supervisor first" />
+                  )}
+                  <Button
+                    onClick={handleTrySkill}
+                    className={supervisorSynced ? "gradient-primary text-white gap-2" : "gap-2"}
+                    variant={supervisorSynced ? "default" : "secondary"}
+                    disabled={!supervisorSynced || supervisorLoading}
+                  >
+                    {supervisorLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <MessageSquare className="h-4 w-4" />
+                    )}
+                    Try Skill
+                  </Button>
+                </div>
               </div>
             </motion.div>
           </motion.div>

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -215,19 +215,6 @@ export function AppHeader() {
             Home
           </GuardedLink>
           <GuardedLink
-            href="/skills"
-            prefetch={true}
-            className={cn(
-              "flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all",
-              activeTab === "skills"
-                ? "gradient-primary text-white shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            <Zap className="h-3.5 w-3.5 shrink-0" />
-            Skills
-          </GuardedLink>
-          <GuardedLink
             href="/chat"
             prefetch={true}
             className={cn(
@@ -261,6 +248,19 @@ export function AppHeader() {
                 </span>
               </span>
             )}
+          </GuardedLink>
+          <GuardedLink
+            href="/skills"
+            prefetch={true}
+            className={cn(
+              "flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all",
+              activeTab === "skills"
+                ? "gradient-primary text-white shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Zap className="h-3.5 w-3.5 shrink-0" />
+            Skills
           </GuardedLink>
           <GuardedLink
             href="/task-builder"

--- a/ui/src/components/skills/SkillsBuilderEditor.tsx
+++ b/ui/src/components/skills/SkillsBuilderEditor.tsx
@@ -95,6 +95,7 @@ import {
   type CreateAgentSkillInput,
   type WorkflowDifficulty,
   type SkillVisibility,
+  type SkillInputVariable,
 } from "@/types/agent-skill";
 import type { Team } from "@/types/teams";
 import type { SkillTemplate } from "@/skills";
@@ -1136,6 +1137,9 @@ export function SkillsBuilderEditor({
     thumbnail: existingConfig?.thumbnail || "Zap",
   });
   const [tags, setTags] = useState<string[]>(existingConfig?.metadata?.tags || []);
+  const [inputVariables, setInputVariables] = useState<SkillInputVariable[]>(
+    existingConfig?.metadata?.input_variables || []
+  );
   const [skillContent, setSkillContent] = useState(
     existingConfig?.skill_content || createBlankSkillMd()
   );
@@ -1193,6 +1197,7 @@ export function SkillsBuilderEditor({
       }
       return existingConfig?.metadata?.allowed_tools || [];
     })(),
+    inputVariables: existingConfig?.metadata?.input_variables || [],
   });
   const [saved, setSaved] = useState(false);
 
@@ -1209,9 +1214,10 @@ export function SkillsBuilderEditor({
       visibility !== s.visibility ||
       JSON.stringify(tags) !== JSON.stringify(s.tags) ||
       JSON.stringify(selectedTeamIds) !== JSON.stringify(s.selectedTeamIds) ||
-      JSON.stringify(allowedTools) !== JSON.stringify(s.allowedTools)
+      JSON.stringify(allowedTools) !== JSON.stringify(s.allowedTools) ||
+      JSON.stringify(inputVariables) !== JSON.stringify(s.inputVariables)
     );
-  }, [formData, skillContent, visibility, tags, selectedTeamIds, allowedTools, saved]);
+  }, [formData, skillContent, visibility, tags, selectedTeamIds, allowedTools, inputVariables, saved]);
 
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
@@ -1406,6 +1412,7 @@ export function SkillsBuilderEditor({
         thumbnail: existingConfig?.thumbnail || "Zap",
       });
       setTags(existingConfig?.metadata?.tags || []);
+      setInputVariables(existingConfig?.metadata?.input_variables || []);
       setSkillContent(existingConfig?.skill_content || createBlankSkillMd());
       setVisibility(existingConfig?.visibility || "private");
       setSelectedTeamIds(existingConfig?.shared_with_teams || []);
@@ -1459,6 +1466,7 @@ export function SkillsBuilderEditor({
       thumbnail: template.icon,
     }));
     setTags(template.tags);
+    setInputVariables([]);
   };
 
   const handleImportSkillMd = (content: string) => {
@@ -1799,6 +1807,7 @@ Rewrite the above skill document. Output ONLY the improved SKILL.md text with no
         metadata: {
           tags: tags.length > 0 ? tags : undefined,
           allowed_tools: allowedTools.length > 0 ? allowedTools : undefined,
+          input_variables: inputVariables.length > 0 ? inputVariables : undefined,
         },
         visibility,
         shared_with_teams: visibility === "team" ? selectedTeamIds : undefined,
@@ -1900,6 +1909,7 @@ Rewrite the above skill document. Output ONLY the improved SKILL.md text with no
                         setSkillContentAndSyncTools(createBlankSkillMd());
                         setFormData(prev => ({ ...prev, name: "", description: "" }));
                         setTags([]);
+                        setInputVariables([]);
                         setSelectedTemplateId(null);
                         setShowTemplateMenu(false);
                       }}
@@ -2231,6 +2241,75 @@ Rewrite the above skill document. Output ONLY the improved SKILL.md text with no
                       </Badge>
                     </button>
                   </div>
+                </div>
+
+                {/* Row 3: Input Variables — parameters shown in Try Skill modal */}
+                <div>
+                  <div className="flex items-center justify-between mb-1.5">
+                    <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+                      <Variable className="h-3 w-3" />
+                      Input Variables
+                    </label>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-5 text-[10px] px-1.5 gap-0.5"
+                      onClick={() => setInputVariables(prev => [...prev, { name: "", label: "", required: false, placeholder: "" }])}
+                    >
+                      <Plus className="h-2.5 w-2.5" />
+                      Add
+                    </Button>
+                  </div>
+                  {inputVariables.length === 0 ? (
+                    <p className="text-[10px] text-muted-foreground">
+                      No input variables. Add variables to prompt users for parameters in the Try Skill modal.
+                    </p>
+                  ) : (
+                    <div className="space-y-1.5">
+                      {inputVariables.map((v, idx) => (
+                        <div key={idx} className="flex items-center gap-1.5">
+                          <Input
+                            value={v.name}
+                            onChange={(e) => {
+                              const val = e.target.value.replace(/[^a-zA-Z0-9_]/g, "");
+                              setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, name: val } : item));
+                            }}
+                            placeholder="name"
+                            className="h-6 text-xs w-24 font-mono"
+                          />
+                          <Input
+                            value={v.label}
+                            onChange={(e) => setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, label: e.target.value } : item))}
+                            placeholder="Label"
+                            className="h-6 text-xs w-28"
+                          />
+                          <Input
+                            value={v.placeholder || ""}
+                            onChange={(e) => setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, placeholder: e.target.value } : item))}
+                            placeholder="placeholder"
+                            className="h-6 text-xs flex-1"
+                          />
+                          <label className="flex items-center gap-1 text-[10px] text-muted-foreground shrink-0 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={v.required}
+                              onChange={(e) => setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, required: e.target.checked } : item))}
+                              className="h-3 w-3 rounded border-border"
+                            />
+                            Req
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => setInputVariables(prev => prev.filter((_, i) => i !== idx))}
+                            className="text-muted-foreground hover:text-destructive shrink-0"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </motion.div>

--- a/ui/src/components/skills/SkillsEditor.tsx
+++ b/ui/src/components/skills/SkillsEditor.tsx
@@ -29,6 +29,8 @@ import {
   Workflow,
   Bug,
   Clock,
+  Variable,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -50,6 +52,7 @@ import type {
   AgentSkillCategory,
   CreateAgentSkillInput,
   WorkflowDifficulty,
+  SkillInputVariable,
 } from "@/types/agent-skill";
 
 interface SkillsEditorProps {
@@ -164,6 +167,9 @@ export function SkillsEditor({
     thumbnail: existingConfig?.thumbnail || "Zap",
     tags: existingConfig?.metadata?.tags?.join(", ") || "",
   });
+  const [inputVariables, setInputVariables] = useState<SkillInputVariable[]>(
+    existingConfig?.metadata?.input_variables || []
+  );
   const [tasks, setTasks] = useState<AgentSkillTask[]>(
     existingConfig?.tasks || [{ ...emptyTask }]
   );
@@ -376,6 +382,7 @@ export function SkillsEditor({
         input_form: existingConfig?.input_form, // Preserve input_form during updates
         metadata: {
           tags: tags.length > 0 ? tags : undefined,
+          input_variables: inputVariables.length > 0 ? inputVariables : undefined,
         },
       };
 
@@ -517,6 +524,77 @@ export function SkillsEditor({
             className="h-9 text-sm"
           />
           <p className="text-xs text-muted-foreground mt-1">Separate tags with commas</p>
+        </div>
+
+        {/* Input Variables */}
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-xs font-medium text-foreground flex items-center gap-1.5">
+              <Variable className="h-3.5 w-3.5" />
+              Input Variables
+            </label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-6 text-xs px-2 gap-1"
+              onClick={() => setInputVariables(prev => [...prev, { name: "", label: "", required: false, placeholder: "" }])}
+            >
+              <Plus className="h-3 w-3" />
+              Add
+            </Button>
+          </div>
+          {inputVariables.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Add variables to prompt users for parameters when they try this skill.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {inputVariables.map((v, idx) => (
+                <div key={idx} className="flex items-center gap-2">
+                  <Input
+                    value={v.name}
+                    onChange={(e) => {
+                      const val = e.target.value.replace(/[^a-zA-Z0-9_]/g, "");
+                      setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, name: val } : item));
+                    }}
+                    placeholder="var_name"
+                    className="h-8 text-sm w-28 font-mono"
+                  />
+                  <Input
+                    value={v.label}
+                    onChange={(e) => setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, label: e.target.value } : item))}
+                    placeholder="Label"
+                    className="h-8 text-sm w-28"
+                  />
+                  <Input
+                    value={v.placeholder || ""}
+                    onChange={(e) => setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, placeholder: e.target.value } : item))}
+                    placeholder="placeholder text"
+                    className="h-8 text-sm flex-1"
+                  />
+                  <label className="flex items-center gap-1 text-xs text-muted-foreground shrink-0 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={v.required}
+                      onChange={(e) => setInputVariables(prev => prev.map((item, i) => i === idx ? { ...item, required: e.target.checked } : item))}
+                      className="h-3 w-3 rounded border-border"
+                    />
+                    Required
+                  </label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-muted-foreground hover:text-destructive shrink-0"
+                    onClick={() => setInputVariables(prev => prev.filter((_, i) => i !== idx))}
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Category */}

--- a/ui/src/components/skills/SkillsGallery.tsx
+++ b/ui/src/components/skills/SkillsGallery.tsx
@@ -21,7 +21,6 @@ import {
   AlertCircle,
   Edit,
   Trash2,
-  ChevronRight,
   Sparkles,
   Zap,
   Server,
@@ -70,13 +69,60 @@ import { getConfig } from "@/lib/config";
 import { useAgentSkillsStore } from "@/store/agent-skills-store";
 import { useChatStore } from "@/store/chat-store";
 import { useAdminRole } from "@/hooks/use-admin-role";
-import type { AgentSkill, AgentSkillCategory, WorkflowDifficulty } from "@/types/agent-skill";
+import type { AgentSkill, WorkflowDifficulty } from "@/types/agent-skill";
 
 interface SkillsGalleryProps {
-  onSelectConfig?: (config: AgentSkill, fromHistory?: boolean) => void;
-  onRunQuickStart?: (prompt: string, configName?: string) => void;
   onEditConfig?: (config: AgentSkill) => void;
   onCreateNew?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Template variable extraction — parses {{var}} and {{var:default}} from prompt
+// ---------------------------------------------------------------------------
+
+interface TemplateVar {
+  name: string;
+  label: string;
+  defaultValue: string;
+  required: boolean;
+}
+
+function extractTemplateVars(config: AgentSkill): TemplateVar[] {
+  // 1. Try extracting from llm_prompt {{var}} / {{var:default}} syntax
+  const prompt = config.tasks?.[0]?.llm_prompt || "";
+  if (prompt) {
+    const seen = new Set<string>();
+    const vars: TemplateVar[] = [];
+    const re = /\{\{(\w+)(?::([^}]*))?\}\}/g;
+    let m;
+
+    while ((m = re.exec(prompt)) !== null) {
+      const name = m[1];
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const defaultValue = m[2] ?? "";
+      vars.push({
+        name,
+        label: name.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()),
+        defaultValue,
+        required: !defaultValue,
+      });
+    }
+    if (vars.length > 0) return vars;
+  }
+
+  // 2. Fallback: use metadata.input_variables (catalog / built-in skills)
+  const inputVars = (config.metadata as Record<string, unknown>)?.input_variables;
+  if (Array.isArray(inputVars)) {
+    return inputVars.map((v: Record<string, unknown>) => ({
+      name: String(v.name || ""),
+      label: String(v.label || v.name || ""),
+      defaultValue: String(v.placeholder || ""),
+      required: Boolean(v.required),
+    }));
+  }
+
+  return [];
 }
 
 const VISIBILITY_BADGE_CONFIG: Record<string, { icon: React.ElementType; label: string; className: string }> = {
@@ -99,18 +145,6 @@ function VisibilityBadge({ config }: { config: AgentSkill }) {
   );
 }
 
-function SyncDot({ synced, loading }: { synced: boolean; loading: boolean }) {
-  if (loading) {
-    return <span className="h-2 w-2 rounded-full bg-gray-400 animate-pulse" title="Checking sync status..." />;
-  }
-  return (
-    <span
-      className={cn("h-2 w-2 rounded-full", synced ? "bg-green-500" : "bg-gray-400")}
-      title={synced ? "Synced with supervisor" : "Not synced with supervisor"}
-    />
-  );
-}
-
 type CatalogSource = "default" | "agent_skills" | "hub";
 
 function skillCatalogSource(config: AgentSkill): CatalogSource {
@@ -128,10 +162,51 @@ const SOURCE_LABELS: Record<CatalogSource, string> = {
 
 function CatalogSourceBadge({ config }: { config: AgentSkill }) {
   const src = skillCatalogSource(config);
+  const meta = config.metadata as { hub_location?: string; hub_type?: string } | undefined;
+
+  if (src === "hub" && meta?.hub_location) {
+    // Show GitHub/GitLab icon + short repo path
+    const loc = meta.hub_location.replace(/^https?:\/\/github\.com\//, "").replace(/^https?:\/\/gitlab\.com\//, "").replace(/\/+$/, "");
+    const isGitHub = !meta.hub_type || meta.hub_type === "github";
+    return (
+      <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-normal text-muted-foreground gap-0.5">
+        {isGitHub ? (
+          <svg className="h-2.5 w-2.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        ) : (
+          <GitBranch className="h-2.5 w-2.5" />
+        )}
+        {loc}
+      </Badge>
+    );
+  }
+
+  if (src === "default") {
+    return (
+      <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-normal text-muted-foreground gap-0.5">
+        <Database className="h-2.5 w-2.5" />
+        {SOURCE_LABELS[src]}
+      </Badge>
+    );
+  }
+
+  // Custom / agent_skills
   return (
-    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-normal text-muted-foreground">
+    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-normal text-muted-foreground gap-0.5">
+      <User className="h-2.5 w-2.5" />
       {SOURCE_LABELS[src]}
     </Badge>
+  );
+}
+
+function SyncDot({ synced, loading }: { synced: boolean; loading: boolean }) {
+  if (loading) {
+    return <span className="h-2 w-2 rounded-full bg-gray-400 animate-pulse" title="Checking sync status..." />;
+  }
+  return (
+    <span
+      className={cn("h-2 w-2 rounded-full", synced ? "bg-green-500" : "bg-gray-400")}
+      title={synced ? "Synced with supervisor" : "Not synced — supervisor not connected or skills not loaded"}
+    />
   );
 }
 
@@ -189,7 +264,6 @@ const getDifficultyColor = (difficulty?: WorkflowDifficulty) => {
 };
 
 export function SkillsGallery({
-  onSelectConfig,
   onEditConfig,
   onCreateNew,
 }: SkillsGalleryProps) {
@@ -225,20 +299,6 @@ export function SkillsGallery({
   const [copiedToken, setCopiedToken] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [tokenDurationDays, setTokenDurationDays] = useState(90);
-
-  // Supervisor sync status — gates "Try Skill" button
-  const [supervisorSynced, setSupervisorSynced] = useState(false);
-  const [supervisorLoading, setSupervisorLoading] = useState(true);
-
-  useEffect(() => {
-    fetch("/api/skills/supervisor-status", { credentials: "include" })
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        setSupervisorSynced(data?.mas_registered === true && (data?.skills_loaded_count ?? 0) > 0);
-      })
-      .catch(() => setSupervisorSynced(false))
-      .finally(() => setSupervisorLoading(false));
-  }, []);
 
   const closeApiHelp = useCallback(() => {
     setShowApiHelp(false);
@@ -276,6 +336,21 @@ export function SkillsGallery({
 
   // Skill run modal state
   const [activeFormConfig, setActiveFormConfig] = useState<AgentSkill | null>(null);
+  const [paramValues, setParamValues] = useState<Record<string, string>>({});
+
+  // Supervisor sync state
+  const [supervisorSynced, setSupervisorSynced] = useState(false);
+  const [supervisorLoading, setSupervisorLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/skills/supervisor-status")
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        setSupervisorSynced(data?.mas_registered === true && (data?.skills_loaded_count ?? 0) > 0);
+      })
+      .catch(() => setSupervisorSynced(false))
+      .finally(() => setSupervisorLoading(false));
+  }, []);
 
   // Check if user can edit a config (admins can edit system configs)
   const canEditConfig = (config: AgentSkill) => {
@@ -324,6 +399,8 @@ export function SkillsGallery({
               tags: (s.metadata?.tags as string[]) || [],
               catalog_source: s.source,
               catalog_visibility: s.visibility,
+              hub_location: (s.metadata?.hub_location as string) || "",
+              hub_type: (s.metadata?.hub_type as string) || "",
             },
           } as AgentSkill),
         );
@@ -413,14 +490,36 @@ export function SkillsGallery({
   };
 
   const handleConfigClick = (config: AgentSkill) => {
-    // Open the "Try Skill" modal for any skill
     setActiveFormConfig(config);
+    // Pre-fill parameter values from defaults
+    const vars = extractTemplateVars(config);
+    const defaults: Record<string, string> = {};
+    for (const v of vars) {
+      defaults[v.name] = v.defaultValue;
+    }
+    setParamValues(defaults);
   };
 
   const handleTrySkill = () => {
     if (!activeFormConfig) return;
+    const vars = extractTemplateVars(activeFormConfig);
+    // Check required fields
+    const missing = vars.filter(v => v.required && !paramValues[v.name]?.trim());
+    if (missing.length > 0) return; // validation errors shown inline
+
+    const skillId = activeFormConfig.id || activeFormConfig.name;
+    let message = `Execute skill: ${skillId}\n\nRead and follow the instructions in the SKILL.md file for the "${skillId}" skill.`;
+    // Append parameters if any variables have values
+    const filledParams = vars.filter(v => paramValues[v.name]?.trim());
+    if (filledParams.length > 0) {
+      message += "\n\nParameters:";
+      for (const v of filledParams) {
+        message += `\n- ${v.name}: ${paramValues[v.name].trim()}`;
+      }
+    }
+
     const conversationId = createConversation();
-    setPendingMessage(activeFormConfig.name);
+    setPendingMessage(message);
     setActiveFormConfig(null);
     router.push(`/chat/${conversationId}`);
   };
@@ -615,7 +714,13 @@ export function SkillsGallery({
                       <div className="min-w-0 flex-1">
                         <p className="font-medium text-sm truncate pr-8">{config.name}</p>
                         <div className="flex items-center gap-1 mt-0.5">
-                          <Badge variant="outline" className="text-[10px] px-1.5 py-0"><MessageSquare className="h-2.5 w-2.5 mr-0.5" />Skill</Badge>
+                          {!workflowRunnerEnabled ? (
+                            <Badge variant="outline" className="text-[10px] px-1.5 py-0"><MessageSquare className="h-2.5 w-2.5 mr-0.5" />Skill</Badge>
+                          ) : config.is_quick_start ? (
+                            <Badge variant="outline" className="text-[10px] px-1.5 py-0"><MessageSquare className="h-2.5 w-2.5 mr-0.5" />Skill</Badge>
+                          ) : (
+                            <Badge variant="outline" className="text-[10px] px-1.5 py-0">{config.tasks.length} steps</Badge>
+                          )}
                           <CatalogSourceBadge config={config} />
                           <VisibilityBadge config={config} />
                           <SyncDot synced={supervisorSynced} loading={supervisorLoading} />
@@ -714,10 +819,10 @@ export function SkillsGallery({
                         <div className="flex items-center gap-1 flex-wrap justify-end">
                           <CatalogSourceBadge config={config} />
                           <VisibilityBadge config={config} />
+                          <SyncDot synced={supervisorSynced} loading={supervisorLoading} />
                           <Badge variant="outline" className={cn("text-xs", getDifficultyColor(config.difficulty))}>
                             {config.difficulty || "beginner"}
                           </Badge>
-                          <SyncDot synced={supervisorSynced} loading={supervisorLoading} />
                         </div>
                       </div>
                       <h3 className="font-medium mb-1 group-hover:text-primary transition-colors">{config.name}</h3>
@@ -729,7 +834,12 @@ export function SkillsGallery({
                       </div>
                       <div className="flex items-center justify-between pt-3 border-t border-border/50">
                         <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                          <Badge variant="outline" className="text-xs"><MessageSquare className="h-2.5 w-2.5 mr-0.5" />Skill</Badge>
+                          {!workflowRunnerEnabled
+                            ? <Badge variant="outline" className="text-xs"><MessageSquare className="h-2.5 w-2.5 mr-0.5" />Skill</Badge>
+                            : config.is_quick_start
+                              ? <Badge variant="outline" className="text-xs"><MessageSquare className="h-2.5 w-2.5 mr-0.5" />Skill</Badge>
+                              : <Badge variant="outline" className="text-xs"><Workflow className="h-2.5 w-2.5 mr-0.5" />{config.tasks.length} steps</Badge>
+                          }
                         </div>
                       </div>
 
@@ -836,10 +946,10 @@ export function SkillsGallery({
                         <div className="flex items-center gap-1 flex-wrap justify-end">
                           <CatalogSourceBadge config={config} />
                           <VisibilityBadge config={config} />
+                          <SyncDot synced={supervisorSynced} loading={supervisorLoading} />
                           <Badge variant="outline" className={cn("text-xs", getDifficultyColor(config.difficulty))}>
                             {config.difficulty || "beginner"}
                           </Badge>
-                          <SyncDot synced={supervisorSynced} loading={supervisorLoading} />
                         </div>
                       </div>
                       <h3 className="font-medium mb-1 group-hover:text-primary transition-colors">{config.name}</h3>
@@ -943,8 +1053,17 @@ export function SkillsGallery({
                       <h3 className="font-medium mb-1 pr-16">{config.name}</h3>
                       <p className="text-sm text-muted-foreground line-clamp-2 mb-3">{config.description}</p>
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                        <MessageSquare className="h-3.5 w-3.5" />
-                        <span>Skill</span>
+                        {workflowRunnerEnabled ? (
+                          <>
+                            <Workflow className="h-3.5 w-3.5" />
+                            <span>{config.tasks.length} steps</span>
+                          </>
+                        ) : (
+                          <>
+                            <MessageSquare className="h-3.5 w-3.5" />
+                            <span>Skill</span>
+                          </>
+                        )}
                         <CatalogSourceBadge config={config} />
                         <VisibilityBadge config={config} />
                         <SyncDot synced={supervisorSynced} loading={supervisorLoading} />
@@ -965,7 +1084,7 @@ export function SkillsGallery({
                           <Star className={cn("h-4 w-4", isFavorite(config.id) && "fill-current")} />
                         </Button>
                         <div className="h-5 w-px bg-border/50" />
-                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={(e) => { e.stopPropagation(); handleConfigClick(config); }} title="Try Skill">
+                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={(e) => { e.stopPropagation(); handleConfigClick(config); }}>
                           <MessageSquare className="h-4 w-4" />
                         </Button>
                         {canEditConfig(config) && (
@@ -1247,15 +1366,15 @@ curl -s "${typeof window !== "undefined" ? window.location.origin : "https://you
             >
               <div className="h-1.5 w-full gradient-primary shrink-0" />
               <div className="p-6 overflow-y-auto flex-1">
-                <div className="flex items-start justify-between mb-4">
+                <div className="flex items-start justify-between mb-6">
                   <div className="flex items-center gap-3">
                     <div className="p-2.5 rounded-xl gradient-primary-br shadow-lg">
-                      {(() => { const I = ICON_MAP[activeFormConfig.thumbnail || "Zap"] || Zap; return <I className="h-5 w-5 text-white" />; })()}
+                      <Zap className="h-5 w-5 text-white" />
                     </div>
                     <div>
                       <h2 className="text-xl font-bold">{activeFormConfig.name}</h2>
-                      {activeFormConfig.category && (
-                        <span className="text-xs text-muted-foreground">{activeFormConfig.category}</span>
+                      {activeFormConfig.description && (
+                        <p className="text-sm text-muted-foreground">{activeFormConfig.description}</p>
                       )}
                     </div>
                   </div>
@@ -1264,76 +1383,81 @@ curl -s "${typeof window !== "undefined" ? window.location.origin : "https://you
                   </Button>
                 </div>
 
-                {/* Description */}
+                {/* Description preview */}
                 {activeFormConfig.description && (
-                  <p className="text-sm text-muted-foreground mb-4 leading-relaxed">{activeFormConfig.description}</p>
+                  <p className="text-sm text-muted-foreground">{activeFormConfig.description}</p>
                 )}
-
                 {/* Tags */}
-                {activeFormConfig.metadata?.tags && activeFormConfig.metadata.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mb-4">
-                    {activeFormConfig.metadata.tags.map(tag => (
+                {activeFormConfig.metadata?.tags && Array.isArray(activeFormConfig.metadata.tags) && (activeFormConfig.metadata.tags as string[]).length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mt-3">
+                    {(activeFormConfig.metadata.tags as string[]).map((tag: string) => (
                       <Badge key={tag} variant="secondary" className="text-xs">{tag}</Badge>
                     ))}
                   </div>
                 )}
 
-                {/* Badges row */}
-                <div className="flex flex-wrap items-center gap-2">
-                  <CatalogSourceBadge config={activeFormConfig} />
-                  <VisibilityBadge config={activeFormConfig} />
-                  {activeFormConfig.difficulty && (
-                    <Badge variant="outline" className={cn("text-xs", getDifficultyColor(activeFormConfig.difficulty))}>
-                      {activeFormConfig.difficulty}
-                    </Badge>
-                  )}
-                  {activeFormConfig.metadata?.expected_agents?.slice(0, 3).map(agent => (
-                    <Badge key={agent} variant="outline" className="text-xs">{agent}</Badge>
-                  ))}
-                </div>
+                {/* Template variable parameters */}
+                {(() => {
+                  const vars = extractTemplateVars(activeFormConfig);
+                  if (vars.length === 0) return null;
+                  return (
+                    <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4 space-y-3">
+                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Parameters</p>
+                      {vars.map((v) => (
+                        <div key={v.name}>
+                          <label className="text-sm font-medium text-foreground">
+                            {v.label}
+                            {v.required && <span className="text-destructive ml-0.5">*</span>}
+                          </label>
+                          <Input
+                            type="text"
+                            value={paramValues[v.name] ?? v.defaultValue}
+                            onChange={(e) => setParamValues(prev => ({ ...prev, [v.name]: e.target.value }))}
+                            placeholder={v.defaultValue ? `Default: ${v.defaultValue}` : `Enter ${v.label.toLowerCase()}`}
+                            className={cn(
+                              "mt-1 h-9 text-sm",
+                              v.required && !paramValues[v.name]?.trim() && paramValues[v.name] !== undefined && paramValues[v.name] !== v.defaultValue
+                                ? "border-destructive"
+                                : "",
+                            )}
+                          />
+                          {v.defaultValue && (
+                            <p className="text-[11px] text-muted-foreground mt-0.5">Default: {v.defaultValue}</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })()}
               </div>
 
               {/* Footer */}
               <div className="flex items-center justify-between gap-3 p-4 border-t bg-muted/30 shrink-0">
                 <div>
                   {onEditConfig && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="gap-1.5"
-                      onClick={() => { setActiveFormConfig(null); onEditConfig(activeFormConfig); }}
-                    >
-                      <Edit className="h-3.5 w-3.5" />
-                      Edit
+                    <Button variant="ghost" size="sm" onClick={() => { setActiveFormConfig(null); onEditConfig(activeFormConfig); }}>
+                      <Edit className="h-3.5 w-3.5 mr-1" /> Edit
                     </Button>
                   )}
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2">
                   <Button variant="ghost" onClick={() => setActiveFormConfig(null)}>Cancel</Button>
-                  <div className="flex items-center gap-1.5">
-                    {!supervisorSynced && !supervisorLoading && (
-                      <span title="Skills are not synced with the supervisor. Rebuild from Admin → Supervisor Skills to enable.">
-                        <AlertTriangle className="h-4 w-4 text-orange-500" />
-                      </span>
+                  {!supervisorSynced && !supervisorLoading && (
+                    <AlertTriangle className="h-4 w-4 text-amber-500" title="Skills must be synced with the supervisor first" />
+                  )}
+                  <Button
+                    onClick={handleTrySkill}
+                    className={supervisorSynced ? "gradient-primary text-white gap-2" : "gap-2"}
+                    variant={supervisorSynced ? "default" : "secondary"}
+                    disabled={!supervisorSynced || supervisorLoading || extractTemplateVars(activeFormConfig).some(v => v.required && !paramValues[v.name]?.trim())}
+                  >
+                    {supervisorLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <MessageSquare className="h-4 w-4" />
                     )}
-                    <Button
-                      onClick={handleTrySkill}
-                      className={cn(
-                        "gap-2",
-                        supervisorSynced && !supervisorLoading
-                          ? "gradient-primary text-white"
-                          : "bg-muted text-muted-foreground cursor-not-allowed"
-                      )}
-                      disabled={!supervisorSynced || supervisorLoading}
-                    >
-                      {supervisorLoading ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <MessageSquare className="h-4 w-4" />
-                      )}
-                      Try Skill
-                    </Button>
-                  </div>
+                    Try Skill
+                  </Button>
                 </div>
               </div>
             </motion.div>

--- a/ui/src/components/skills/SkillsGallery.tsx
+++ b/ui/src/components/skills/SkillsGallery.tsx
@@ -55,10 +55,7 @@ import {
   Globe,
   UsersRound,
   User,
-  HelpCircle,
-  Copy,
-  Check,
-  ShieldAlert,
+  ExternalLink,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -289,50 +286,6 @@ export function SkillsGallery({
   const [viewMode, setViewMode] = useState<"all" | "workflows" | "my-skills" | "team" | "global">("all");
   const [sourceFilter, setSourceFilter] = useState<"all" | CatalogSource>("all");
 
-  // API help dialog state
-  const [showApiHelp, setShowApiHelp] = useState(false);
-  const [copiedCurl, setCopiedCurl] = useState(false);
-
-  // API token generation state
-  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
-  const [isGeneratingToken, setIsGeneratingToken] = useState(false);
-  const [copiedToken, setCopiedToken] = useState(false);
-  const [tokenError, setTokenError] = useState<string | null>(null);
-  const [tokenDurationDays, setTokenDurationDays] = useState(90);
-
-  const closeApiHelp = useCallback(() => {
-    setShowApiHelp(false);
-    setGeneratedToken(null);
-    setCopiedToken(false);
-    setTokenError(null);
-    setIsGeneratingToken(false);
-    setTokenDurationDays(90);
-  }, []);
-
-  const handleGenerateToken = useCallback(async () => {
-    setIsGeneratingToken(true);
-    setTokenError(null);
-    setGeneratedToken(null);
-    setCopiedToken(false);
-    try {
-      const res = await fetch("/api/skills/token", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ expires_in_days: tokenDurationDays }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || `Failed to generate token (${res.status})`);
-      }
-      const data = await res.json();
-      setGeneratedToken(data.token);
-    } catch (err: any) {
-      setTokenError(err.message || "Failed to generate token");
-    } finally {
-      setIsGeneratingToken(false);
-    }
-  }, [tokenDurationDays]);
 
   // Skill run modal state
   const [activeFormConfig, setActiveFormConfig] = useState<AgentSkill | null>(null);
@@ -565,12 +518,12 @@ export function SkillsGallery({
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => setShowApiHelp(true)}
+                onClick={() => router.push("/skills/gateway")}
                 className="gap-1.5"
-                title="How to access Skills via API"
+                title="Skills API Gateway"
               >
-                <HelpCircle className="h-4 w-4" />
-                API
+                <ExternalLink className="h-4 w-4" />
+                Skills API Gateway
               </Button>
               <Button size="sm" onClick={onCreateNew} className="gap-2 gradient-primary text-white">
                 <Plus className="h-4 w-4" />
@@ -1127,225 +1080,6 @@ export function SkillsGallery({
           )}
         </div>
       )}
-
-      {/* API Help Modal */}
-      <AnimatePresence>
-        {showApiHelp && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-            onClick={closeApiHelp}
-          >
-            <motion.div
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              className="relative w-full max-w-2xl mx-4 bg-card border rounded-2xl shadow-2xl overflow-hidden max-h-[90vh] flex flex-col"
-              onClick={e => e.stopPropagation()}
-            >
-              <div className="h-1.5 w-full gradient-primary shrink-0" />
-              <div className="p-6 overflow-y-auto flex-1">
-                <div className="flex items-start justify-between mb-6">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2.5 rounded-xl gradient-primary-br shadow-lg">
-                      <Terminal className="h-5 w-5 text-white" />
-                    </div>
-                    <div>
-                      <h2 className="text-xl font-bold">Skills API Access</h2>
-                      <p className="text-sm text-muted-foreground">
-                        Retrieve skills from external clients like Claude Code, Cursor, or any HTTP client
-                      </p>
-                    </div>
-                  </div>
-                  <Button variant="ghost" size="icon" onClick={() => setShowApiHelp(false)}>
-                    <X className="h-4 w-4" />
-                  </Button>
-                </div>
-
-                {/* API Endpoint */}
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="text-sm font-semibold mb-2">API Endpoint</h3>
-                    <div className="px-4 py-3 rounded-lg bg-muted/50 border border-border/50 font-mono text-sm">
-                      GET /api/skills
-                    </div>
-                  </div>
-
-                  {/* Query Parameters */}
-                  <div>
-                    <h3 className="text-sm font-semibold mb-2">Query Parameters</h3>
-                    <div className="text-sm text-muted-foreground space-y-1">
-                      <p><code className="bg-muted px-1.5 py-0.5 rounded text-xs">q</code> — Search by name or description</p>
-                      <p><code className="bg-muted px-1.5 py-0.5 rounded text-xs">source</code> — Filter: <code className="bg-muted px-1 py-0.5 rounded text-xs">default</code>, <code className="bg-muted px-1 py-0.5 rounded text-xs">agent_skills</code>, <code className="bg-muted px-1 py-0.5 rounded text-xs">hub</code></p>
-                      <p><code className="bg-muted px-1.5 py-0.5 rounded text-xs">tags</code> — Comma-separated tag filter</p>
-                      <p><code className="bg-muted px-1.5 py-0.5 rounded text-xs">include_content</code> — Include full SKILL.md content (<code className="bg-muted px-1 py-0.5 rounded text-xs">true</code>/<code className="bg-muted px-1 py-0.5 rounded text-xs">false</code>)</p>
-                      <p><code className="bg-muted px-1.5 py-0.5 rounded text-xs">visibility</code> — Optional: <code className="bg-muted px-1 py-0.5 rounded text-xs">global</code>, <code className="bg-muted px-1 py-0.5 rounded text-xs">team</code>, <code className="bg-muted px-1 py-0.5 rounded text-xs">personal</code></p>
-                      <p><code className="bg-muted px-1.5 py-0.5 rounded text-xs">page</code> / <code className="bg-muted px-1.5 py-0.5 rounded text-xs">page_size</code> — Pagination (1–100 per page)</p>
-                    </div>
-                  </div>
-
-                  {/* Generate API Key */}
-                  <div className="p-4 rounded-lg bg-primary/5 border border-primary/20">
-                    <div className="flex items-center gap-2 mb-3">
-                      <Key className="h-4 w-4 text-primary" />
-                      <h3 className="text-sm font-semibold">Generate API Key</h3>
-                    </div>
-                    <p className="text-xs text-muted-foreground mb-3">
-                      Generate a personal API key for programmatic access to the Skills API from CLI tools, scripts, or AI assistants.
-                    </p>
-
-                    {!generatedToken && (
-                      <div className="flex items-center gap-3">
-                        <div className="flex items-center gap-2">
-                          <label className="text-xs text-muted-foreground whitespace-nowrap">Expires in:</label>
-                          <select
-                            value={tokenDurationDays}
-                            onChange={(e) => setTokenDurationDays(Number(e.target.value))}
-                            className="h-8 px-2 text-xs rounded-md border border-input bg-background"
-                          >
-                            <option value={30}>30 days</option>
-                            <option value={60}>60 days</option>
-                            <option value={90}>90 days</option>
-                          </select>
-                        </div>
-                        <Button
-                          size="sm"
-                          onClick={handleGenerateToken}
-                          disabled={isGeneratingToken}
-                          className="gap-1.5"
-                        >
-                          {isGeneratingToken ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                          ) : (
-                            <Key className="h-3 w-3" />
-                          )}
-                          {isGeneratingToken ? "Generating..." : "Generate API Key"}
-                        </Button>
-                      </div>
-                    )}
-
-                    {tokenError && (
-                      <div className="mt-3 flex items-center gap-2 text-xs text-red-500">
-                        <AlertCircle className="h-3 w-3 shrink-0" />
-                        {tokenError}
-                      </div>
-                    )}
-
-                    {generatedToken && (
-                      <div className="mt-3 space-y-3">
-                        <div className="flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30">
-                          <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
-                          <p className="text-xs text-amber-600 dark:text-amber-400">
-                            Copy this token now — it won&apos;t be shown again.
-                          </p>
-                        </div>
-                        <div className="relative">
-                          <pre className="p-3 pr-12 rounded-lg bg-[#1e1e2e] border border-border/30 text-[11px] font-mono text-zinc-300 overflow-x-auto whitespace-pre-wrap break-all">
-                            {generatedToken}
-                          </pre>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="absolute top-2 right-2 h-7 w-7"
-                            onClick={() => {
-                              navigator.clipboard.writeText(generatedToken);
-                              setCopiedToken(true);
-                              setTimeout(() => setCopiedToken(false), 2000);
-                            }}
-                          >
-                            {copiedToken ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
-                          </Button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* curl Example */}
-                  <div>
-                    <div className="flex items-center justify-between mb-2">
-                      <h3 className="text-sm font-semibold">Example Request</h3>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 gap-1.5 text-xs"
-                        onClick={() => {
-                          const token = generatedToken || (session as any)?.accessToken || "YOUR_API_TOKEN";
-                          const baseUrl = typeof window !== "undefined" ? window.location.origin : "https://your-instance.example.com";
-                          const curl = `curl -s "${baseUrl}/api/skills" \\\n  -H "Authorization: Bearer ${token}" | jq .`;
-                          navigator.clipboard.writeText(curl);
-                          setCopiedCurl(true);
-                          setTimeout(() => setCopiedCurl(false), 2000);
-                        }}
-                      >
-                        {copiedCurl ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
-                        {copiedCurl ? "Copied!" : "Copy"}
-                      </Button>
-                    </div>
-                    <div className="rounded-lg overflow-hidden border border-border/30 bg-[#1e1e2e]">
-                      <div className="flex items-center justify-between px-4 py-2 border-b border-border/20 bg-[#181825]">
-                        <span className="text-xs text-zinc-500 font-mono uppercase tracking-wide">bash</span>
-                      </div>
-                      <pre className="p-4 text-[13px] leading-relaxed font-mono text-zinc-300 overflow-x-auto">
-{`curl -s "${typeof window !== "undefined" ? window.location.origin : "https://your-instance.example.com"}/api/skills" \\
-  -H "Authorization: Bearer ${generatedToken ? generatedToken.slice(0, 20) + "..." : (session as any)?.accessToken ? (session as any).accessToken.slice(0, 20) + "..." : "$CAIPE_TOKEN"}" | jq .`}
-                      </pre>
-                    </div>
-                  </div>
-
-                  {/* Token Warning */}
-                  <div className="flex items-start gap-3 p-4 rounded-lg bg-red-500/10 border border-red-500/30">
-                    <ShieldAlert className="h-5 w-5 text-red-500 shrink-0 mt-0.5" />
-                    <div>
-                      <p className="text-sm font-semibold text-red-500">Do not share your API token</p>
-                      <p className="text-xs text-red-400/80 mt-1">
-                        Your API token is scoped to your identity and grants access to the Skills API.
-                        Never share it in public repositories, Slack messages, screenshots, or documentation.
-                        Treat it like a password.
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Usage with Claude Code / Cursor */}
-                  <div>
-                    <h3 className="text-sm font-semibold mb-2">Using with Claude Code or Cursor</h3>
-                    <div className="text-sm text-muted-foreground space-y-2">
-                      <p>
-                        You can use the Skills API to list available skills from any client.
-                        Pass the skill name to your AI assistant as context:
-                      </p>
-                      <div className="rounded-lg overflow-hidden border border-border/30 bg-[#1e1e2e]">
-                        <div className="flex items-center px-4 py-2 border-b border-border/20 bg-[#181825]">
-                          <span className="text-xs text-zinc-500 font-mono uppercase tracking-wide">bash</span>
-                        </div>
-                        <pre className="p-4 text-[13px] leading-relaxed font-mono text-zinc-300 overflow-x-auto">
-{`# List all skills
-curl -s "${typeof window !== "undefined" ? window.location.origin : "https://your-instance.example.com"}/api/skills" \\
-  -H "Authorization: Bearer $CAIPE_TOKEN" | jq '.skills[].name'
-
-# Get a specific skill with full content
-curl -s "${typeof window !== "undefined" ? window.location.origin : "https://your-instance.example.com"}/api/skills?q=aws-cost&include_content=true" \\
-  -H "Authorization: Bearer $CAIPE_TOKEN" | jq .`}
-                        </pre>
-                      </div>
-                      <p className="text-xs text-muted-foreground/80 mt-2">
-                        Store your token in an environment variable (<code className="bg-muted px-1 py-0.5 rounded text-xs">CAIPE_TOKEN</code>) instead of
-                        hardcoding it. This makes it easy to use across tools without exposing the value.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Footer */}
-              <div className="flex items-center justify-end gap-3 p-4 border-t bg-muted/30 shrink-0">
-                <Button variant="ghost" onClick={() => setShowApiHelp(false)}>Close</Button>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
 
       {/* Skill Run Modal */}
       <AnimatePresence>

--- a/ui/src/components/skills/SkillsGallery.tsx
+++ b/ui/src/components/skills/SkillsGallery.tsx
@@ -1177,7 +1177,7 @@ export function SkillsGallery({
                 <div className="flex items-center gap-2">
                   <Button variant="ghost" onClick={() => setActiveFormConfig(null)}>Cancel</Button>
                   {!supervisorSynced && !supervisorLoading && (
-                    <AlertTriangle className="h-4 w-4 text-amber-500" title="Skills must be synced with the supervisor first" />
+                    <span title="Skills must be synced with the supervisor first"><AlertTriangle className="h-4 w-4 text-amber-500" /></span>
                   )}
                   <Button
                     onClick={handleTrySkill}

--- a/ui/src/components/skills/TrySkillsGateway.tsx
+++ b/ui/src/components/skills/TrySkillsGateway.tsx
@@ -57,6 +57,7 @@ export function TrySkillsGateway() {
   // Query builder state
   const [queryQ, setQueryQ] = useState("");
   const [querySource, setQuerySource] = useState("");
+  const [queryRepo, setQueryRepo] = useState("");
   const [queryTags, setQueryTags] = useState("");
   const [queryVisibility, setQueryVisibility] = useState("");
   const [queryPageSize, setQueryPageSize] = useState("20");
@@ -70,6 +71,8 @@ export function TrySkillsGateway() {
   const [showTagSuggestions, setShowTagSuggestions] = useState(false);
   const [skillNames, setSkillNames] = useState<string[]>([]);
   const [showSearchSuggestions, setShowSearchSuggestions] = useState(false);
+  // Hub repos discovered from catalog metadata
+  const [availableRepos, setAvailableRepos] = useState<{ location: string; type: string }[]>([]);
 
   const baseUrl =
     typeof window !== "undefined" ? window.location.origin : "https://your-instance.example.com";
@@ -78,13 +81,14 @@ export function TrySkillsGateway() {
     const params = new URLSearchParams();
     if (queryQ.trim()) params.set("q", queryQ.trim());
     if (querySource) params.set("source", querySource);
+    if (queryRepo) params.set("repo", queryRepo);
     if (queryTags.trim()) params.set("tags", queryTags.trim());
     if (queryVisibility) params.set("visibility", queryVisibility);
     params.set("page", "1");
     params.set("page_size", queryPageSize || "20");
     if (queryIncludeContent) params.set("include_content", "true");
     return `${baseUrl}/api/skills?${params.toString()}`;
-  }, [baseUrl, queryQ, querySource, queryTags, queryVisibility, queryPageSize, queryIncludeContent]);
+  }, [baseUrl, queryQ, querySource, queryRepo, queryTags, queryVisibility, queryPageSize, queryIncludeContent]);
 
   const catalogUrl = buildCatalogUrl();
 
@@ -131,6 +135,7 @@ export function TrySkillsGateway() {
         if (!data?.skills) return;
         const tags = new Set<string>();
         const names: string[] = [];
+        const repoMap = new Map<string, string>();
         for (const s of data.skills) {
           if (s.name) names.push(s.name);
           if (Array.isArray(s.metadata?.tags)) {
@@ -138,9 +143,19 @@ export function TrySkillsGateway() {
               if (typeof t === "string" && t.trim()) tags.add(t.trim().toLowerCase());
             }
           }
+          const loc = s.metadata?.hub_location;
+          const hubType = s.metadata?.hub_type;
+          if (typeof loc === "string" && loc && typeof hubType === "string") {
+            repoMap.set(loc, hubType);
+          }
         }
         setAvailableTags(Array.from(tags).sort());
         setSkillNames(names.sort());
+        setAvailableRepos(
+          Array.from(repoMap.entries())
+            .map(([location, type]) => ({ location, type }))
+            .sort((a, b) => a.location.localeCompare(b.location)),
+        );
       })
       .catch(() => {});
   }, [loadSync, loadKeys]);
@@ -267,13 +282,43 @@ export function TrySkillsGateway() {
               <label className="text-xs font-medium text-muted-foreground">Source</label>
               <select
                 value={querySource}
-                onChange={(e) => setQuerySource(e.target.value)}
+                onChange={(e) => {
+                  setQuerySource(e.target.value);
+                  if (!["hub", "github", "gitlab"].includes(e.target.value)) setQueryRepo("");
+                }}
                 className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
               >
                 <option value="">All sources</option>
-                <option value="default">default</option>
-                <option value="agent_skills">agent_skills</option>
-                <option value="hub">hub</option>
+                <option value="default">Built-in</option>
+                <option value="agent_skills">Custom Skills</option>
+                {availableRepos.some(r => r.type === "github") && (
+                  <option value="github">GitHub</option>
+                )}
+                {availableRepos.some(r => r.type === "gitlab") && (
+                  <option value="gitlab">GitLab</option>
+                )}
+                {availableRepos.length === 0 && <option value="hub">Hub</option>}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground">Repository</label>
+              <select
+                value={queryRepo}
+                onChange={(e) => {
+                  setQueryRepo(e.target.value);
+                  if (e.target.value) {
+                    const match = availableRepos.find(r => r.location === e.target.value);
+                    setQuerySource(match?.type || "hub");
+                  }
+                }}
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+              >
+                <option value="">All repos</option>
+                {availableRepos.map((r) => (
+                  <option key={r.location} value={r.location}>
+                    {r.location} ({r.type})
+                  </option>
+                ))}
               </select>
             </div>
             <div className="relative">
@@ -587,55 +632,74 @@ export function TrySkillsGateway() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Claude (Desktop / Code)</CardTitle>
+          <CardTitle className="text-base">Claude Code</CardTitle>
           <CardDescription>
-            CAIPE remains the source of truth for <strong>listing</strong> skills; export or copy
-            SKILL.md bodies when <code>include_content=true</code> if you mirror files locally.
+            Create a <code>/skills</code> slash command that lets Claude Code browse and install skills
+            from this gateway.
           </CardDescription>
         </CardHeader>
-        <CardContent className="text-sm space-y-2 list-decimal list-inside text-muted-foreground">
-          <ol className="space-y-2 pl-1">
-            <li>Obtain an OIDC access token or mint a catalog API key above.</li>
-            <li>
-              Run the <code>curl</code> example against <code>/api/skills</code> and save the JSON.
-            </li>
-            <li>
-              Map each skill to a folder under{" "}
-              <code className="text-foreground">.claude/skills/&lt;name&gt;/SKILL.md</code> or your
-              team&apos;s agreed layout per{" "}
-              <a
-                className="text-primary underline"
-                href="https://agentskills.io/specification"
-                target="_blank"
-                rel="noreferrer"
-              >
-                agentskills.io
-              </a>
-              .
-            </li>
-            <li>Reload the assistant; treat the catalog as authoritative for names and descriptions.</li>
-          </ol>
-        </CardContent>
-      </Card>
+        <CardContent className="text-sm space-y-4 text-muted-foreground">
+          <div>
+            <p className="font-medium text-foreground mb-2">1. Configure your API key</p>
+            <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto whitespace-pre-wrap">{`mkdir -p ~/.config/caipe
+cat > ~/.config/caipe/config.json << 'EOF'
+{
+  "api_key": "<your-catalog-api-key>",
+  "base_url": "${baseUrl}"
+}
+EOF`}</pre>
+          </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Cursor</CardTitle>
-          <CardDescription>
-            Align with project rules or <code>.cursor/skills</code> (team convention).
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="text-sm space-y-2 text-muted-foreground">
-          <ol className="space-y-2 list-decimal list-inside pl-1">
-            <li>Authenticate the same way as for Claude (token or catalog key header).</li>
-            <li>Fetch catalog JSON from <code>/api/skills</code> with the query params you need.</li>
-            <li>
-              Add concise rules in <code>.cursor/rules</code> referencing skill names, or symlink /
-              copy exported <code>SKILL.md</code> files into <code>.cursor/skills</code> if your org
-              uses that layout.
-            </li>
-            <li>Re-fetch when admins refresh the catalog or hubs change.</li>
-          </ol>
+          <div>
+            <p className="font-medium text-foreground mb-2">2. Create the bootstrap skill</p>
+            <p className="mb-2">
+              Add this file to your repo. It calls the gateway and lets Claude browse, search, and
+              install skills as <code>.claude/commands/</code> files.
+            </p>
+            <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto whitespace-pre-wrap">{`mkdir -p .claude/commands
+cat > .claude/commands/skills.md << 'SKILL'
+---
+description: Browse and install skills from the CAIPE catalog
+---
+
+## User Input
+\`\`\`text
+$ARGUMENTS
+\`\`\`
+
+## SECURITY — never expose the API key
+- NEVER print, echo, or display the API key in any output.
+- Store in a shell variable, pass only via -H header.
+
+## Steps
+
+1. Load credentials (do NOT echo the key):
+   \`\`\`bash
+   CAIPE_KEY="" CAIPE_URL=""
+   if [ -f ~/.config/caipe/config.json ]; then
+     CAIPE_KEY=$(python3 -c "import json; print(json.load(open('$HOME/.config/caipe/config.json')).get('api_key',''))" 2>/dev/null)
+     CAIPE_URL=$(python3 -c "import json; print(json.load(open('$HOME/.config/caipe/config.json')).get('base_url',''))" 2>/dev/null)
+   fi
+   [ -z "$CAIPE_URL" ] && CAIPE_URL="https://catalog.caipe.dev"
+   [ -n "$CAIPE_KEY" ] && echo "KEY_FOUND" || echo "NO_KEY"
+   \`\`\`
+
+2. Search: curl -sS "$CAIPE_URL/api/skills?source=github&q=<query>&page=1&page_size=20" -H "X-Caipe-Catalog-Key: $CAIPE_KEY"
+
+3. Display as table, offer to install selected skill to .claude/commands/<name>.md
+SKILL`}</pre>
+          </div>
+
+          <div>
+            <p className="font-medium text-foreground mb-2">3. Use it</p>
+            <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto whitespace-pre-wrap">{`# Browse all skills
+/skills
+
+# Search for specific skills
+/skills docker
+/skills kubernetes
+/skills python`}</pre>
+          </div>
         </CardContent>
       </Card>
 

--- a/ui/src/components/skills/TrySkillsGateway.tsx
+++ b/ui/src/components/skills/TrySkillsGateway.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";
-import { Terminal, RefreshCcw, Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Terminal, RefreshCcw, Loader2, AlertCircle, CheckCircle2, Search, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,11 +16,12 @@ const DEFAULT_KEY_HEADER =
   process.env.NEXT_PUBLIC_CAIPE_CATALOG_API_KEY_HEADER ||
   "X-Caipe-Catalog-Key";
 
-type SyncStatus = "in_sync" | "supervisor_stale" | "unknown" | string;
+type SyncStatus = "in_sync" | "synced" | "supervisor_stale" | "unknown" | string;
 
 function syncLabel(status: SyncStatus | undefined): string {
   switch (status) {
     case "in_sync":
+    case "synced":
       return "In sync — supervisor loaded the current catalog generation.";
     case "supervisor_stale":
       return "Supervisor stale — run Refresh skills so the assistant picks up the latest catalog.";
@@ -43,15 +44,49 @@ export function TrySkillsGateway() {
   const [refreshing, setRefreshing] = useState(false);
   const [refreshMsg, setRefreshMsg] = useState<string | null>(null);
 
+  const [copiedBearer, setCopiedBearer] = useState(false);
+  const [copiedKey, setCopiedKey] = useState(false);
+  const [copiedUrl, setCopiedUrl] = useState(false);
+
   const [mintedKey, setMintedKey] = useState<string | null>(null);
   const [mintBusy, setMintBusy] = useState(false);
-  const [mintError, setMintError] = useState<string | null>(null);
   const [keys, setKeys] = useState<
     { key_id: string; created_at?: number; revoked_at?: number | null }[]
   >([]);
 
+  // Query builder state
+  const [queryQ, setQueryQ] = useState("");
+  const [querySource, setQuerySource] = useState("");
+  const [queryTags, setQueryTags] = useState("");
+  const [queryVisibility, setQueryVisibility] = useState("");
+  const [queryPageSize, setQueryPageSize] = useState("20");
+  const [queryIncludeContent, setQueryIncludeContent] = useState(false);
+  const [previewData, setPreviewData] = useState<any>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  // Tags autocomplete + search suggestions
+  const [availableTags, setAvailableTags] = useState<string[]>([]);
+  const [showTagSuggestions, setShowTagSuggestions] = useState(false);
+  const [skillNames, setSkillNames] = useState<string[]>([]);
+  const [showSearchSuggestions, setShowSearchSuggestions] = useState(false);
+
   const baseUrl =
     typeof window !== "undefined" ? window.location.origin : "https://your-instance.example.com";
+
+  const buildCatalogUrl = useCallback(() => {
+    const params = new URLSearchParams();
+    if (queryQ.trim()) params.set("q", queryQ.trim());
+    if (querySource) params.set("source", querySource);
+    if (queryTags.trim()) params.set("tags", queryTags.trim());
+    if (queryVisibility) params.set("visibility", queryVisibility);
+    params.set("page", "1");
+    params.set("page_size", queryPageSize || "20");
+    if (queryIncludeContent) params.set("include_content", "true");
+    return `${baseUrl}/api/skills?${params.toString()}`;
+  }, [baseUrl, queryQ, querySource, queryTags, queryVisibility, queryPageSize, queryIncludeContent]);
+
+  const catalogUrl = buildCatalogUrl();
 
   const loadSync = useCallback(async () => {
     setSyncLoading(true);
@@ -88,6 +123,26 @@ export function TrySkillsGateway() {
   useEffect(() => {
     void loadSync();
     void loadKeys();
+
+    // Fetch catalog to populate autocomplete tags and search suggestions
+    fetch("/api/skills?page_size=100", { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data?.skills) return;
+        const tags = new Set<string>();
+        const names: string[] = [];
+        for (const s of data.skills) {
+          if (s.name) names.push(s.name);
+          if (Array.isArray(s.metadata?.tags)) {
+            for (const t of s.metadata.tags) {
+              if (typeof t === "string" && t.trim()) tags.add(t.trim().toLowerCase());
+            }
+          }
+        }
+        setAvailableTags(Array.from(tags).sort());
+        setSkillNames(names.sort());
+      })
+      .catch(() => {});
   }, [loadSync, loadKeys]);
 
   const handleRefresh = async () => {
@@ -120,7 +175,6 @@ export function TrySkillsGateway() {
   const handleMint = async () => {
     setMintBusy(true);
     setMintedKey(null);
-    setMintError(null);
     try {
       const res = await fetch("/api/catalog-api-keys", {
         method: "POST",
@@ -129,7 +183,6 @@ export function TrySkillsGateway() {
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
         setMintedKey(null);
-        setMintError(data.error || data.message || `Failed to mint API key (${res.status})`);
         return;
       }
       if (typeof data.key === "string") setMintedKey(data.key);
@@ -139,19 +192,255 @@ export function TrySkillsGateway() {
     }
   };
 
-  const searchExample = `${baseUrl}/api/skills?q=aws&page=1&page_size=20&source=default`;
+  const handlePreview = async () => {
+    setPreviewLoading(true);
+    setPreviewError(null);
+    setPreviewData(null);
+    try {
+      const res = await fetch(catalogUrl.replace(baseUrl, ""), {
+        credentials: "include",
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setPreviewError(data.message || data.detail?.message || `Request failed (${res.status})`);
+        return;
+      }
+      setPreviewData(data);
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : "Preview request failed");
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
 
-  const curlBearer = `curl -sS "${searchExample}" \\\n  -H "Authorization: Bearer <access_token>"`;
+  const keyPlaceholder = mintedKey || "<key_id.secret>";
 
-  const curlKey = `curl -sS "${searchExample}" \\\n  -H "${DEFAULT_KEY_HEADER}: <key_id.secret>"`;
+  const curlBearer = `curl -sS "${catalogUrl}" \\\n  -H "Authorization: Bearer <access_token>"`;
+
+  const curlKey = `curl -sS "${catalogUrl}" \\\n  -H "${DEFAULT_KEY_HEADER}: ${keyPlaceholder}"`;
 
   return (
     <div className="space-y-6 max-w-3xl">
+      {/* Catalog Query Builder */}
+      <Card className="border-border/80 bg-card/50">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Search className="h-5 w-5" />
+            Skill Catalog Query Builder
+          </CardTitle>
+          <CardDescription>
+            Build a catalog URL interactively and preview results.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="relative">
+              <label className="text-xs font-medium text-muted-foreground">Search (q)</label>
+              <input
+                type="text"
+                value={queryQ}
+                onChange={(e) => { setQueryQ(e.target.value); setShowSearchSuggestions(true); }}
+                onFocus={() => setShowSearchSuggestions(true)}
+                onBlur={() => setTimeout(() => setShowSearchSuggestions(false), 150)}
+                placeholder="e.g. aws, kubernetes"
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+                autoComplete="off"
+              />
+              {showSearchSuggestions && queryQ.trim().length > 0 && skillNames.filter(n => n.toLowerCase().includes(queryQ.toLowerCase())).length > 0 && (
+                <ul className="absolute z-10 mt-1 w-full max-h-40 overflow-y-auto rounded-md border border-border bg-popover shadow-md text-xs">
+                  {skillNames
+                    .filter(n => n.toLowerCase().includes(queryQ.toLowerCase()))
+                    .slice(0, 8)
+                    .map(n => (
+                      <li
+                        key={n}
+                        className="px-3 py-1.5 cursor-pointer hover:bg-accent"
+                        onMouseDown={() => { setQueryQ(n); setShowSearchSuggestions(false); }}
+                      >
+                        {n}
+                      </li>
+                    ))}
+                </ul>
+              )}
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground">Source</label>
+              <select
+                value={querySource}
+                onChange={(e) => setQuerySource(e.target.value)}
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+              >
+                <option value="">All sources</option>
+                <option value="default">default</option>
+                <option value="agent_skills">agent_skills</option>
+                <option value="hub">hub</option>
+              </select>
+            </div>
+            <div className="relative">
+              <label className="text-xs font-medium text-muted-foreground">Tags (comma-separated)</label>
+              <input
+                type="text"
+                value={queryTags}
+                onChange={(e) => { setQueryTags(e.target.value); setShowTagSuggestions(true); }}
+                onFocus={() => setShowTagSuggestions(true)}
+                onBlur={() => setTimeout(() => setShowTagSuggestions(false), 150)}
+                placeholder="e.g. security, networking"
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+                autoComplete="off"
+              />
+              {showTagSuggestions && availableTags.length > 0 && (() => {
+                const entered = queryTags.split(",").map(t => t.trim().toLowerCase()).filter(Boolean);
+                const lastPartial = queryTags.includes(",")
+                  ? queryTags.slice(queryTags.lastIndexOf(",") + 1).trim().toLowerCase()
+                  : queryTags.trim().toLowerCase();
+                const suggestions = availableTags
+                  .filter(t => !entered.includes(t))
+                  .filter(t => !lastPartial || t.includes(lastPartial))
+                  .slice(0, 8);
+                if (suggestions.length === 0) return null;
+                return (
+                  <ul className="absolute z-10 mt-1 w-full max-h-40 overflow-y-auto rounded-md border border-border bg-popover shadow-md text-xs">
+                    {suggestions.map(tag => (
+                      <li
+                        key={tag}
+                        className="px-3 py-1.5 cursor-pointer hover:bg-accent"
+                        onMouseDown={() => {
+                          const parts = queryTags.split(",").map(t => t.trim()).filter(Boolean);
+                          // Replace the last partial entry with the selected tag
+                          if (queryTags.includes(",")) {
+                            parts[parts.length - 1] = tag;
+                          } else {
+                            parts[0] = tag;
+                          }
+                          setQueryTags(parts.join(", ") + ", ");
+                          setShowTagSuggestions(false);
+                        }}
+                      >
+                        {tag}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              })()}
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground">Visibility</label>
+              <select
+                value={queryVisibility}
+                onChange={(e) => setQueryVisibility(e.target.value)}
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+              >
+                <option value="">All</option>
+                <option value="global">global</option>
+                <option value="team">team</option>
+                <option value="personal">personal</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground">Page size</label>
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={queryPageSize}
+                onChange={(e) => setQueryPageSize(e.target.value)}
+                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+            <div className="flex items-end pb-2">
+              <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={queryIncludeContent}
+                  onChange={(e) => setQueryIncludeContent(e.target.checked)}
+                  className="rounded border-border"
+                />
+                include_content
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <p className="font-medium text-foreground mb-1 text-xs">Live URL</p>
+            <div className="relative group">
+              <code className="block rounded-md bg-muted px-3 py-2 pr-10 text-xs break-all">{catalogUrl}</code>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute top-1 right-1 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={() => {
+                  void navigator.clipboard.writeText(catalogUrl);
+                  setCopiedUrl(true);
+                  setTimeout(() => setCopiedUrl(false), 2000);
+                }}
+              >
+                {copiedUrl ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={previewLoading}
+              onClick={() => void handlePreview()}
+              className="gap-1"
+            >
+              {previewLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Search className="h-3.5 w-3.5" />}
+              Preview
+            </Button>
+            {previewData?.meta?.total != null && (
+              <span className="text-xs text-muted-foreground">
+                {previewData.meta.total} skill{previewData.meta.total !== 1 ? "s" : ""} found
+              </span>
+            )}
+          </div>
+
+          {previewError && (
+            <p className="text-destructive text-xs flex items-center gap-1">
+              <AlertCircle className="h-3.5 w-3.5" />
+              {previewError}
+            </p>
+          )}
+
+          {previewData?.skills && previewData.skills.length > 0 && (
+            <div className="rounded-md border border-border overflow-hidden max-h-64 overflow-y-auto">
+              <table className="w-full text-xs">
+                <thead className="bg-muted sticky top-0">
+                  <tr>
+                    <th className="text-left px-3 py-1.5 font-medium">Name</th>
+                    <th className="text-left px-3 py-1.5 font-medium">Description</th>
+                    <th className="text-left px-3 py-1.5 font-medium">Source</th>
+                    <th className="text-left px-3 py-1.5 font-medium">Tags</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {previewData.skills.map((skill: any, i: number) => (
+                    <tr key={skill.id || i} className="border-t border-border hover:bg-muted/50">
+                      <td className="px-3 py-1.5 font-medium">{skill.name}</td>
+                      <td className="px-3 py-1.5 text-muted-foreground truncate max-w-[200px]">{skill.description}</td>
+                      <td className="px-3 py-1.5">{skill.source}</td>
+                      <td className="px-3 py-1.5 text-muted-foreground">
+                        {((skill.metadata?.tags as string[]) || []).join(", ")}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Authentication & Sync */}
       <Card className="border-border/80 bg-card/50">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-lg">
             <Terminal className="h-5 w-5" />
-            Try skills gateway
+            Authentication & Sync
           </CardTitle>
           <CardDescription>
             Call the same catalog as the UI and supervisor using an OIDC access token or a catalog
@@ -170,9 +459,24 @@ export function TrySkillsGateway() {
             <p className="text-muted-foreground mb-2">
               Use an OIDC access token accepted by the same validation as other CAIPE APIs.
             </p>
-            <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto whitespace-pre-wrap">
-              {curlBearer}
-            </pre>
+            <div className="relative group">
+              <pre className="rounded-md bg-muted p-3 pr-10 text-xs overflow-x-auto whitespace-pre-wrap">
+                {curlBearer}
+              </pre>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute top-2 right-2 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={() => {
+                  void navigator.clipboard.writeText(curlBearer);
+                  setCopiedBearer(true);
+                  setTimeout(() => setCopiedBearer(false), 2000);
+                }}
+              >
+                {copiedBearer ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+              </Button>
+            </div>
           </div>
 
           <div>
@@ -181,9 +485,24 @@ export function TrySkillsGateway() {
               Header name: <code>{DEFAULT_KEY_HEADER}</code> (configure server-side; do not log key
               values).
             </p>
-            <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto whitespace-pre-wrap">
-              {curlKey}
-            </pre>
+            <div className="relative group">
+              <pre className="rounded-md bg-muted p-3 pr-10 text-xs overflow-x-auto whitespace-pre-wrap">
+                {curlKey}
+              </pre>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute top-2 right-2 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={() => {
+                  void navigator.clipboard.writeText(curlKey);
+                  setCopiedKey(true);
+                  setTimeout(() => setCopiedKey(false), 2000);
+                }}
+              >
+                {copiedKey ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+              </Button>
+            </div>
             <p className="text-muted-foreground mt-2 text-xs">
               Optional query params: <code>q</code>, <code>page</code>, <code>page_size</code>,{" "}
               <code>source</code>, <code>visibility</code> (global | team | personal),{" "}
@@ -207,12 +526,6 @@ export function TrySkillsGateway() {
                 Copy once: <code>{mintedKey}</code>
               </span>
             ) : null}
-            {mintError ? (
-              <span className="text-xs text-destructive flex items-center gap-1">
-                <AlertCircle className="h-3 w-3 shrink-0" />
-                {mintError}
-              </span>
-            ) : null}
           </div>
           {keys.length > 0 ? (
             <div className="text-xs text-muted-foreground">
@@ -233,7 +546,7 @@ export function TrySkillsGateway() {
             ) : (
               <div className="space-y-1 text-xs">
                 <p className="flex items-start gap-1.5">
-                  {sync?.sync_status === "in_sync" ? (
+                  {sync?.sync_status === "in_sync" || sync?.sync_status === "synced" ? (
                     <CheckCircle2 className="h-3.5 w-3.5 text-green-600 shrink-0 mt-0.5" />
                   ) : (
                     <AlertCircle className="h-3.5 w-3.5 text-amber-600 shrink-0 mt-0.5" />

--- a/ui/src/components/skills/__tests__/SkillsGallery.test.tsx
+++ b/ui/src/components/skills/__tests__/SkillsGallery.test.tsx
@@ -5,8 +5,7 @@
  *  - WORKFLOW_RUNNER_ENABLED feature flag gating
  *  - Search/filter by name, description, category
  *  - Delete confirm/cancel flow
- *  - Try Skill flow (createConversation, setPendingMessage with skill name, navigation)
- *  - Try Skill disabled when supervisor not synced
+ *  - Try Skill flow (createConversation, setPendingMessage, navigation)
  *  - View mode switching (all, my-skills, global, workflows)
  *  - Edit/delete visibility (admin vs non-admin, system vs user configs)
  *  - Favorites section and toggle
@@ -14,10 +13,11 @@
  *  - Empty states
  *  - Modal interactions (backdrop, X button, Cancel)
  *  - Edit config and onSelectConfig callbacks
+ *  - Supervisor sync gating (Try Skill disabled when not synced)
  */
 
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { SkillsGallery } from "../SkillsGallery";
 import type { AgentSkill } from "@/types/agent-skill";
 
@@ -51,9 +51,6 @@ const mockRouterPush = jest.fn();
 let mockIsLoading = false;
 let mockError: string | null = null;
 let mockIsAdmin = false;
-
-// Supervisor sync mock — default: synced
-let mockSupervisorSynced = true;
 
 jest.mock("@/store/agent-skills-store", () => ({
   useAgentSkillsStore: () => ({
@@ -154,20 +151,25 @@ function mockConfigs() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function renderGallery(props: Partial<React.ComponentProps<typeof SkillsGallery>> = {}) {
-  return render(
-    <SkillsGallery
-      onSelectConfig={jest.fn()}
-      onEditConfig={jest.fn()}
-      onCreateNew={jest.fn()}
-      {...props}
-    />
-  );
+async function renderGallery(props: Partial<React.ComponentProps<typeof SkillsGallery>> = {}) {
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(
+      <SkillsGallery
+        onEditConfig={jest.fn()}
+        onCreateNew={jest.fn()}
+        {...props}
+      />
+    );
+  });
+  return result!;
 }
 
 // ---------------------------------------------------------------------------
-// Global reset
+// Global reset + fetch mock
 // ---------------------------------------------------------------------------
+
+let mockSupervisorSynced = true;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -181,25 +183,32 @@ beforeEach(() => {
   mockCreateConversation.mockReturnValue("conv-abc");
   _configs = [];
 
-  // Mock fetch for supervisor-status and skills catalog
-  global.fetch = jest.fn((url: string) => {
-    if (typeof url === "string" && url.includes("/api/skills/supervisor-status")) {
+  // Mock global.fetch for supervisor-status and catalog endpoints
+  global.fetch = jest.fn((url: string | URL | Request) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+
+    if (urlStr.includes("/api/skills/supervisor-status")) {
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({
           mas_registered: mockSupervisorSynced,
           skills_loaded_count: mockSupervisorSynced ? 5 : 0,
-          skills_merged_at: mockSupervisorSynced ? new Date().toISOString() : null,
         }),
-      });
+      } as Response);
     }
-    if (typeof url === "string" && url.includes("/api/skills")) {
+
+    if (urlStr.includes("/api/skills")) {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ skills: [], meta: { total: 0, sources_loaded: [], unavailable_sources: [] } }),
-      });
+        json: () => Promise.resolve({ skills: [] }),
+      } as Response);
     }
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+
+    // Default: return empty OK response
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
   }) as jest.Mock;
 });
 
@@ -217,35 +226,35 @@ describe("SkillsGallery — WORKFLOW_RUNNER_ENABLED=false (default)", () => {
     _configs = [makeQuickStart(), makeWorkflow()];
   });
 
-  it("does NOT render the Multi-Step Workflows section when the flag is off", () => {
-    renderGallery();
-
+  it("does NOT render the Multi-Step Workflows section when the flag is off", async () => {
+    await renderGallery();
     expect(screen.queryByText("Multi-Step Workflows")).not.toBeInTheDocument();
   });
 
-  it("still renders the quick-start card gallery when the flag is off", () => {
-    renderGallery();
-
+  it("still renders the quick-start card gallery when the flag is off", async () => {
+    await renderGallery();
     expect(screen.getByText("Incident Correlation & Root Cause Analysis")).toBeInTheDocument();
   });
 
-  it("renders Try Skill as the action button in the modal", async () => {
-    renderGallery();
-
+  it("opens modal with Try Skill button when clicking a skill card", async () => {
+    await renderGallery();
     const card = screen.getByText("Incident Correlation & Root Cause Analysis");
-    fireEvent.click(card);
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
-    });
+    await act(async () => { fireEvent.click(card); });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
   });
 
-  it("still renders Cancel button in the modal when the flag is off", () => {
-    renderGallery();
-
+  it("does NOT show Run Workflow or Run in Chat buttons in the modal", async () => {
+    await renderGallery();
     const card = screen.getByText("Incident Correlation & Root Cause Analysis");
-    fireEvent.click(card);
+    await act(async () => { fireEvent.click(card); });
+    expect(screen.queryByRole("button", { name: /run workflow/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /run in chat/i })).not.toBeInTheDocument();
+  });
 
+  it("still renders Cancel button in the modal when the flag is off", async () => {
+    await renderGallery();
+    const card = screen.getByText("Incident Correlation & Root Cause Analysis");
+    await act(async () => { fireEvent.click(card); });
     expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
   });
 });
@@ -256,35 +265,65 @@ describe("SkillsGallery — WORKFLOW_RUNNER_ENABLED=true", () => {
     _configs = [makeQuickStart(), makeWorkflow()];
   });
 
-  it("renders the Multi-Step Workflows section when the flag is on", () => {
-    renderGallery();
-
+  it("renders the Multi-Step Workflows section when the flag is on", async () => {
+    await renderGallery();
     expect(screen.getByText("Multi-Step Workflows")).toBeInTheDocument();
   });
 
-  it("displays the workflow card name in the Multi-Step Workflows section", () => {
-    renderGallery();
+  it("opens modal and shows Try Skill button when clicking a quick-start card", async () => {
+    await renderGallery();
+    const card = screen.getByText("Incident Correlation & Root Cause Analysis");
+    await act(async () => { fireEvent.click(card); });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
+  });
 
+  it("displays the workflow card name in the Multi-Step Workflows section", async () => {
+    await renderGallery();
     expect(screen.getAllByText("Multi-Step Deploy Workflow").length).toBeGreaterThan(0);
   });
 });
 
+describe("SkillsGallery — flag transition (disabled → enabled)", () => {
+  it("reflects flag changes without remounting", async () => {
+    mockWorkflowRunnerEnabled = false;
+    _configs = [makeQuickStart()];
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <SkillsGallery onEditConfig={jest.fn()} onCreateNew={jest.fn()} />
+      );
+    });
+
+    // Open modal
+    await act(async () => {
+      fireEvent.click(screen.getByText("Incident Correlation & Root Cause Analysis"));
+    });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
+
+    // Simulate flag flip
+    mockWorkflowRunnerEnabled = true;
+    await act(async () => {
+      result!.rerender(
+        <SkillsGallery onEditConfig={jest.fn()} onCreateNew={jest.fn()} />
+      );
+    });
+
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
+  });
+});
+
 describe("SkillsGallery — Multi-Step section only with workflow configs", () => {
-  it("does NOT render Multi-Step section even when enabled if there are no workflow configs", () => {
+  it("does NOT render Multi-Step section even when enabled if there are no workflow configs", async () => {
     mockWorkflowRunnerEnabled = true;
     _configs = [makeQuickStart()]; // no multi-step configs
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.queryByText("Multi-Step Workflows")).not.toBeInTheDocument();
   });
 
-  it("does NOT render Multi-Step section when disabled even if workflow configs exist", () => {
+  it("does NOT render Multi-Step section when disabled even if workflow configs exist", async () => {
     mockWorkflowRunnerEnabled = false;
     _configs = [makeWorkflow()];
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.queryByText("Multi-Step Workflows")).not.toBeInTheDocument();
   });
 });
@@ -303,40 +342,33 @@ describe("SkillsGallery — search and filter", () => {
     ] as AgentSkill[];
   });
 
-  it("filters configs by search query matching name", () => {
-    renderGallery();
-
+  it("filters configs by search query matching name", async () => {
+    await renderGallery();
     const searchInput = screen.getByPlaceholderText(/search by name/i);
     fireEvent.change(searchInput, { target: { value: "DevOps" } });
-
     expect(screen.getByText("DevOps Health Check")).toBeInTheDocument();
     expect(screen.queryByText("Cost Explorer")).not.toBeInTheDocument();
   });
 
-  it("filters configs by search query matching description", () => {
-    renderGallery();
-
+  it("filters configs by search query matching description", async () => {
+    await renderGallery();
     const searchInput = screen.getByPlaceholderText(/search by name/i);
     fireEvent.change(searchInput, { target: { value: "AWS costs" } });
-
     expect(screen.getByText("Cost Explorer")).toBeInTheDocument();
     expect(screen.queryByText("DevOps Health Check")).not.toBeInTheDocument();
   });
 
-  it("shows all configs when search query is empty", () => {
-    renderGallery();
-
+  it("shows all configs when search query is empty", async () => {
+    await renderGallery();
     expect(screen.getByText("Incident Correlation & Root Cause Analysis")).toBeInTheDocument();
     expect(screen.getByText("DevOps Health Check")).toBeInTheDocument();
     expect(screen.getByText("Cost Explorer")).toBeInTheDocument();
   });
 
-  it("filters by category button", () => {
-    renderGallery();
-
+  it("filters by category button", async () => {
+    await renderGallery();
     const cloudBtn = screen.getByRole("button", { name: "Cloud" });
     fireEvent.click(cloudBtn);
-
     expect(screen.getByText("Cost Explorer")).toBeInTheDocument();
     expect(screen.queryByText("DevOps Health Check")).not.toBeInTheDocument();
   });
@@ -363,22 +395,17 @@ describe("SkillsGallery — delete", () => {
   });
 
   it("calls deleteSkill when user confirms deletion", async () => {
-    renderGallery();
-
+    await renderGallery();
     const deleteButtons = screen.getAllByTitle("Delete template");
     fireEvent.click(deleteButtons[0]);
-
     expect(mockDeleteConfig).toHaveBeenCalledWith("qs-del");
   });
 
-  it("does NOT call deleteSkill when user cancels", () => {
+  it("does NOT call deleteSkill when user cancels", async () => {
     (window.confirm as jest.Mock).mockReturnValue(false);
-
-    renderGallery();
-
+    await renderGallery();
     const deleteButtons = screen.getAllByTitle("Delete template");
     fireEvent.click(deleteButtons[0]);
-
     expect(mockDeleteConfig).not.toHaveBeenCalled();
   });
 });
@@ -393,13 +420,11 @@ describe("SkillsGallery — Skills Builder button", () => {
     _configs = [makeQuickStart()];
   });
 
-  it("calls onCreateNew when Skills Builder button is clicked", () => {
+  it("calls onCreateNew when Skills Builder button is clicked", async () => {
     const onCreateNew = jest.fn();
-    renderGallery({ onCreateNew });
-
+    await renderGallery({ onCreateNew });
     const btn = screen.getByRole("button", { name: /skills builder/i });
     fireEvent.click(btn);
-
     expect(onCreateNew).toHaveBeenCalledTimes(1);
   });
 });
@@ -409,39 +434,31 @@ describe("SkillsGallery — Skills Builder button", () => {
 // ---------------------------------------------------------------------------
 
 describe("SkillsGallery — edit/delete visibility", () => {
-  it("shows edit and delete buttons for non-system configs", () => {
+  it("shows edit and delete buttons for non-system configs", async () => {
     _configs = [{
       ...makeQuickStart("user-skill"),
       is_system: false,
       owner_id: "test@example.com",
     }] as AgentSkill[];
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.getAllByTitle("Edit template").length).toBeGreaterThan(0);
     expect(screen.getAllByTitle("Delete template").length).toBeGreaterThan(0);
   });
 
-  it("admin sees edit button on system configs but delete is disabled", () => {
+  it("admin sees edit button on system configs but delete is disabled", async () => {
     mockIsAdmin = true;
     _configs = [makeQuickStart("sys-1")];
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.getAllByTitle("Edit template").length).toBeGreaterThan(0);
-    // Delete button shows as disabled with informational title
     expect(screen.queryByTitle("Delete template")).not.toBeInTheDocument();
     expect(screen.getAllByTitle("Built-in skills cannot be deleted").length).toBeGreaterThan(0);
   });
 
-  it("non-admin does NOT see edit on system configs, delete is disabled", () => {
+  it("non-admin does NOT see edit on system configs, delete is disabled", async () => {
     mockIsAdmin = false;
     _configs = [makeQuickStart("sys-2")];
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.queryByTitle("Edit template")).not.toBeInTheDocument();
-    // Delete button is present but disabled
     expect(screen.queryByTitle("Delete template")).not.toBeInTheDocument();
     expect(screen.getAllByTitle("Built-in skills cannot be deleted").length).toBeGreaterThan(0);
   });
@@ -462,60 +479,120 @@ describe("SkillsGallery — Try Skill", () => {
     }] as AgentSkill[];
   });
 
-  it("calls createConversation, setPendingMessage with skill name, and router.push on Try Skill", async () => {
-    renderGallery();
-
-    fireEvent.click(screen.getByText("Chat Skill"));
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
-    });
-
-    const runBtn = screen.getByRole("button", { name: /try skill/i });
-    fireEvent.click(runBtn);
-
+  it("calls createConversation, setPendingMessage with 'Lookup skill and use:', and router.push on Try Skill", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Chat Skill")); });
+    const tryBtn = screen.getByRole("button", { name: /try skill/i });
+    await act(async () => { fireEvent.click(tryBtn); });
     expect(mockCreateConversation).toHaveBeenCalledTimes(1);
-    expect(mockSetPendingMessage).toHaveBeenCalledWith("Chat Skill");
+    expect(mockSetPendingMessage).toHaveBeenCalledWith(
+      "Execute skill: qs-chat\n\nRead and follow the instructions in the SKILL.md file for the \"qs-chat\" skill."
+    );
     expect(mockRouterPush).toHaveBeenCalledWith("/chat/conv-abc");
   });
 
   it("closes the modal after navigation", async () => {
-    renderGallery();
-
-    fireEvent.click(screen.getByText("Chat Skill"));
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: /try skill/i }));
-
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Chat Skill")); });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
+    await act(async () => { fireEvent.click(screen.getByRole("button", { name: /try skill/i })); });
     expect(screen.queryByRole("button", { name: /try skill/i })).not.toBeInTheDocument();
   });
 
-  it("Try Skill button is disabled when supervisor is not synced", async () => {
+  it("Try Skill is disabled when supervisor is not synced", async () => {
     mockSupervisorSynced = false;
-
-    renderGallery();
-
-    fireEvent.click(screen.getByText("Chat Skill"));
-
-    await waitFor(() => {
-      const btn = screen.getByRole("button", { name: /try skill/i });
-      expect(btn).toBeDisabled();
-    });
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Chat Skill")); });
+    const tryBtn = screen.getByRole("button", { name: /try skill/i });
+    expect(tryBtn).toBeDisabled();
   });
 
-  it("shows warning icon when supervisor is not synced", async () => {
-    mockSupervisorSynced = false;
+  it("Try Skill is enabled when supervisor is synced", async () => {
+    mockSupervisorSynced = true;
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Chat Skill")); });
+    const tryBtn = screen.getByRole("button", { name: /try skill/i });
+    expect(tryBtn).not.toBeDisabled();
+  });
+});
 
-    renderGallery();
+// ---------------------------------------------------------------------------
+// Template variable parameters
+// ---------------------------------------------------------------------------
 
-    fireEvent.click(screen.getByText("Chat Skill"));
+describe("SkillsGallery — template variable parameters", () => {
+  beforeEach(() => {
+    _configs = [{
+      ...makeQuickStart("qs-vars"),
+      name: "Deploy Helper",
+      is_system: false,
+      owner_id: "test@example.com",
+      tasks: [{
+        display_text: "Deploy",
+        llm_prompt: "Deploy {{app_name}} to {{cluster:prod-us}} with {{replicas:3}} replicas",
+        subagent: "user_input",
+      }],
+    }] as AgentSkill[];
+  });
 
-    await waitFor(() => {
-      expect(screen.getByTitle(/not synced with the supervisor/i)).toBeInTheDocument();
-    });
+  it("renders parameter input fields for template variables", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Deploy Helper")); });
+    expect(screen.getByText("Parameters")).toBeInTheDocument();
+    expect(screen.getByText(/App Name/)).toBeInTheDocument();
+    expect(screen.getByText(/Cluster/)).toBeInTheDocument();
+    expect(screen.getByText(/Replicas/)).toBeInTheDocument();
+  });
+
+  it("pre-fills default values for variables with defaults", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Deploy Helper")); });
+    const clusterInput = screen.getByDisplayValue("prod-us") as HTMLInputElement;
+    expect(clusterInput).toBeInTheDocument();
+    const replicasInput = screen.getByDisplayValue("3") as HTMLInputElement;
+    expect(replicasInput).toBeInTheDocument();
+  });
+
+  it("disables Try Skill when required parameter is empty", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Deploy Helper")); });
+    // app_name is required (no default) and starts empty
+    const tryBtn = screen.getByRole("button", { name: /try skill/i });
+    expect(tryBtn).toBeDisabled();
+  });
+
+  it("enables Try Skill when required parameter is filled", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Deploy Helper")); });
+    const appInput = screen.getByPlaceholderText(/enter app name/i);
+    await act(async () => { fireEvent.change(appInput, { target: { value: "my-service" } }); });
+    const tryBtn = screen.getByRole("button", { name: /try skill/i });
+    expect(tryBtn).not.toBeDisabled();
+  });
+
+  it("sends message with parameters on Try Skill", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Deploy Helper")); });
+    const appInput = screen.getByPlaceholderText(/enter app name/i);
+    await act(async () => { fireEvent.change(appInput, { target: { value: "my-service" } }); });
+    await act(async () => { fireEvent.click(screen.getByRole("button", { name: /try skill/i })); });
+    expect(mockSetPendingMessage).toHaveBeenCalledWith(
+      "Execute skill: qs-vars\n\nRead and follow the instructions in the SKILL.md file for the \"qs-vars\" skill.\n\nParameters:\n- app_name: my-service\n- cluster: prod-us\n- replicas: 3"
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith("/chat/conv-abc");
+  });
+
+  it("does not render Parameters section for skills without variables", async () => {
+    _configs = [{
+      ...makeQuickStart("qs-no-vars"),
+      name: "Simple Skill",
+      is_system: false,
+      owner_id: "test@example.com",
+      tasks: [{ display_text: "Do it", llm_prompt: "Just do the thing", subagent: "user_input" }],
+    }] as AgentSkill[];
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Simple Skill")); });
+    expect(screen.queryByText("Parameters")).not.toBeInTheDocument();
   });
 });
 
@@ -552,40 +629,33 @@ describe("SkillsGallery — view mode", () => {
     _configs = [mySkill, globalSkill, teamSkill];
   });
 
-  it("My Skills view shows only user-owned non-system configs", () => {
-    renderGallery();
-
+  it("My Skills view shows only user-owned non-system configs", async () => {
+    await renderGallery();
     const allButtons = screen.getAllByRole("button");
     const mySkillsBtn = allButtons.find(b => b.textContent?.includes("My Skills"));
     fireEvent.click(mySkillsBtn!);
-
     expect(screen.getByText("My Personal Skill")).toBeInTheDocument();
     expect(screen.queryByText("Global System Skill")).not.toBeInTheDocument();
     expect(screen.queryByText("Team Shared Skill")).not.toBeInTheDocument();
   });
 
-  it("Global view shows configs where visibility=global or is_system", () => {
-    renderGallery();
-
+  it("Global view shows configs where visibility=global or is_system", async () => {
+    await renderGallery();
     const allButtons = screen.getAllByRole("button");
     const globalBtn = allButtons.find(b => b.textContent?.trim() === "Global");
     fireEvent.click(globalBtn!);
-
     expect(screen.getByText("Global System Skill")).toBeInTheDocument();
     expect(screen.queryByText("My Personal Skill")).not.toBeInTheDocument();
   });
 
-  it("Workflows view shows only is_quick_start=false configs when flag is on", () => {
+  it("Workflows view shows only is_quick_start=false configs when flag is on", async () => {
     mockWorkflowRunnerEnabled = true;
     const wf = makeWorkflow("wf-view");
     _configs = [mySkill, wf];
-
-    renderGallery();
-
+    await renderGallery();
     const allButtons = screen.getAllByRole("button");
     const multiStepBtn = allButtons.find(b => b.textContent?.includes("Multi-Step"));
     fireEvent.click(multiStepBtn!);
-
     expect(screen.getByText("Multi-Step Deploy Workflow")).toBeInTheDocument();
     expect(screen.queryByText("My Personal Skill")).not.toBeInTheDocument();
   });
@@ -603,38 +673,31 @@ describe("SkillsGallery — favorites", () => {
     owner_id: "test@example.com",
   } as AgentSkill;
 
-  it("renders Favorites section when getFavoriteSkills returns configs", () => {
+  it("renders Favorites section when getFavoriteSkills returns configs", async () => {
     _configs = [favSkill];
     mockGetFavoriteConfigs.mockReturnValue([favSkill]);
     mockIsFavorite.mockImplementation((id: string) => id === "fav-1");
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.getByText("Favorites")).toBeInTheDocument();
   });
 
-  it("hides Favorites section when empty", () => {
+  it("hides Favorites section when empty", async () => {
     _configs = [makeQuickStart()];
     mockGetFavoriteConfigs.mockReturnValue([]);
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.queryByText("Favorites")).not.toBeInTheDocument();
   });
 
-  it("clicking the star button calls toggleFavorite", () => {
+  it("clicking the star button calls toggleFavorite", async () => {
     _configs = [{
       ...makeQuickStart("star-1"),
       name: "Star Skill",
       is_system: false,
       owner_id: "test@example.com",
     }] as AgentSkill[];
-
-    renderGallery();
-
+    await renderGallery();
     const starBtn = screen.getByTitle("Add to favorites");
     fireEvent.click(starBtn);
-
     expect(mockToggleFavorite).toHaveBeenCalledWith("star-1");
   });
 });
@@ -644,34 +707,27 @@ describe("SkillsGallery — favorites", () => {
 // ---------------------------------------------------------------------------
 
 describe("SkillsGallery — loading/error", () => {
-  it("renders spinner when isLoading=true", () => {
+  it("renders spinner when isLoading=true", async () => {
     mockIsLoading = true;
     _configs = [];
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.getByTestId("spinner")).toBeInTheDocument();
   });
 
-  it("renders error with Try Again button when error is set", () => {
+  it("renders error with Try Again button when error is set", async () => {
     mockError = "Failed to load configs";
     _configs = [];
-
-    renderGallery();
-
+    await renderGallery();
     expect(screen.getByText("Failed to load configs")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 
-  it("Try Again calls loadSkills", () => {
+  it("Try Again calls loadSkills", async () => {
     mockError = "Network error";
     _configs = [];
     mockLoadConfigs.mockClear();
-
-    renderGallery();
-
+    await renderGallery();
     fireEvent.click(screen.getByRole("button", { name: /try again/i }));
-
     expect(mockLoadConfigs).toHaveBeenCalled();
   });
 });
@@ -683,12 +739,9 @@ describe("SkillsGallery — loading/error", () => {
 describe("SkillsGallery — empty states", () => {
   it("shows 'No skills match your search' when search yields no results", async () => {
     _configs = [makeQuickStart()];
-
-    renderGallery();
-
+    await renderGallery();
     const searchInput = screen.getByPlaceholderText(/search by name/i);
     fireEvent.change(searchInput, { target: { value: "nonexistent-xyz" } });
-
     await waitFor(() => {
       expect(screen.getByText(/No skills match your search/)).toBeInTheDocument();
     });
@@ -697,13 +750,10 @@ describe("SkillsGallery — empty states", () => {
   it("My Skills empty state shows 'Create your first skill' with Skills Builder button", async () => {
     _configs = [makeQuickStart()];
     const onCreateNew = jest.fn();
-
-    renderGallery({ onCreateNew });
-
+    await renderGallery({ onCreateNew });
     const allButtons = screen.getAllByRole("button");
     const mySkillsBtn = allButtons.find(b => b.textContent?.includes("My Skills"));
     fireEvent.click(mySkillsBtn!);
-
     await waitFor(() => {
       expect(screen.getByText(/create your first skill/i)).toBeInTheDocument();
     });
@@ -726,14 +776,23 @@ describe("SkillsGallery — modal interactions", () => {
     }] as AgentSkill[];
   });
 
-  it("clicking Cancel closes modal", () => {
-    renderGallery();
-    fireEvent.click(screen.getByText("Modal Skill"));
-
+  it("clicking Cancel closes modal", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Modal Skill")); });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
     const cancelBtns = screen.getAllByRole("button", { name: /cancel/i });
-    fireEvent.click(cancelBtns[0]);
+    await act(async () => { fireEvent.click(cancelBtns[0]); });
+    expect(screen.queryByRole("button", { name: /try skill/i })).not.toBeInTheDocument();
+  });
 
-    // Modal should be closed — skill name as heading should be gone
+  it("clicking backdrop closes modal", async () => {
+    await renderGallery();
+    await act(async () => { fireEvent.click(screen.getByText("Modal Skill")); });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
+    const backdrop = document.querySelector("[class*='fixed inset-0']") as HTMLElement;
+    if (backdrop) {
+      await act(async () => { fireEvent.click(backdrop); });
+    }
     expect(screen.queryByRole("button", { name: /try skill/i })).not.toBeInTheDocument();
   });
 });
@@ -743,7 +802,7 @@ describe("SkillsGallery — modal interactions", () => {
 // ---------------------------------------------------------------------------
 
 describe("SkillsGallery — edit callback", () => {
-  it("calls onEditConfig for user-owned config when edit button is clicked", () => {
+  it("calls onEditConfig for user-owned config when edit button is clicked", async () => {
     const userConfig = {
       ...makeQuickStart("edit-1"),
       name: "Editable Skill",
@@ -751,28 +810,37 @@ describe("SkillsGallery — edit callback", () => {
       owner_id: "test@example.com",
     } as AgentSkill;
     _configs = [userConfig];
-
     const onEditConfig = jest.fn();
-    renderGallery({ onEditConfig });
-
+    await renderGallery({ onEditConfig });
     const editBtn = screen.getByTitle("Edit template");
     fireEvent.click(editBtn);
-
     expect(onEditConfig).toHaveBeenCalledTimes(1);
     expect(onEditConfig).toHaveBeenCalledWith(expect.objectContaining({ id: "edit-1" }));
   });
 
-  it("calls onEditConfig for system config when admin clicks edit", () => {
+  it("calls onEditConfig for system config when admin clicks edit", async () => {
     mockIsAdmin = true;
     _configs = [makeQuickStart("sys-edit")];
-
     const onEditConfig = jest.fn();
-    renderGallery({ onEditConfig });
-
+    await renderGallery({ onEditConfig });
     const editBtn = screen.getByTitle("Edit template");
     fireEvent.click(editBtn);
-
     expect(onEditConfig).toHaveBeenCalledTimes(1);
     expect(onEditConfig).toHaveBeenCalledWith(expect.objectContaining({ id: "sys-edit" }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow card opens modal
+// ---------------------------------------------------------------------------
+
+describe("SkillsGallery — workflow card opens modal", () => {
+  it("clicking a workflow card opens the modal with Try Skill button", async () => {
+    mockWorkflowRunnerEnabled = true;
+    _configs = [makeWorkflow("wf-select")];
+    await renderGallery();
+    const cards = screen.getAllByText("Multi-Step Deploy Workflow");
+    await act(async () => { fireEvent.click(cards[0]); });
+    expect(screen.getByRole("button", { name: /try skill/i })).toBeInTheDocument();
   });
 });

--- a/ui/src/lib/hub-crawl.ts
+++ b/ui/src/lib/hub-crawl.ts
@@ -38,6 +38,7 @@ export interface SkillHubDoc {
   location: string;
   enabled: boolean;
   credentials_ref: string | null;
+  labels?: string[];
   last_success_at: number | null;
   last_failure_at: number | null;
   last_failure_message: string | null;
@@ -76,12 +77,26 @@ function parseFrontmatter(content: string): {
   let description = "";
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
   if (match) {
-    for (const line of match[1].split("\n")) {
-      const nameMatch = line.match(/^name:\s*(.*)/);
-      if (nameMatch) name = nameMatch[1].trim();
-      const descMatch = line.match(/^description:\s*(.*)/);
-      if (descMatch) description = descMatch[1].trim();
+    const lines = match[1].split("\n");
+    let currentKey = "";
+    let currentValue = "";
+
+    for (const line of lines) {
+      const keyMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
+      if (keyMatch) {
+        if (currentKey === "name") name = currentValue.trim();
+        if (currentKey === "description") description = currentValue.trim();
+        currentKey = keyMatch[1];
+        const val = keyMatch[2].trim();
+        // YAML folded scalar ">" or literal "|" — value is on next lines
+        currentValue = val === ">" || val === "|" ? "" : val;
+      } else if (currentKey && line.match(/^\s+/)) {
+        // Continuation line (indented) — append with space
+        currentValue += " " + line.trim();
+      }
     }
+    if (currentKey === "name") name = currentValue.trim();
+    if (currentKey === "description") description = currentValue.trim();
   }
   return { name, description };
 }
@@ -448,6 +463,7 @@ export async function getHubSkills(
     // (could be a transient API error with empty response)
   }
 
+  const hubLabels = hub.labels || [];
   return crawled.map((s) => ({
     id: `hub-${hub.id}-${s.id}`,
     name: s.name,
@@ -460,6 +476,7 @@ export async function getHubSkills(
       hub_location: hub.location,
       hub_type: hub.type,
       path: s.path,
+      tags: [...(Array.isArray(s.metadata?.tags) ? (s.metadata.tags as string[]) : []), ...hubLabels],
     },
   }));
 }
@@ -469,6 +486,7 @@ export async function getHubSkills(
 // ---------------------------------------------------------------------------
 
 function docToCatalogSkill(hub: SkillHubDoc) {
+  const hubLabels = hub.labels || [];
   return (doc: HubSkillDoc): CatalogSkill => ({
     id: `hub-${hub.id}-${doc.skill_id}`,
     name: doc.name,
@@ -481,6 +499,7 @@ function docToCatalogSkill(hub: SkillHubDoc) {
       hub_location: hub.location,
       hub_type: hub.type,
       path: doc.path,
+      tags: [...(Array.isArray(doc.metadata?.tags) ? (doc.metadata.tags as string[]) : []), ...hubLabels],
     },
   });
 }

--- a/ui/src/lib/skill-md-parser.ts
+++ b/ui/src/lib/skill-md-parser.ts
@@ -53,8 +53,11 @@ export function parseFrontmatter(raw: string): Record<string, string> {
         result[currentKey] = currentValue.trim();
       }
       currentKey = keyMatch[1];
-      currentValue = keyMatch[2];
-    } else if (currentKey) {
+      const val = keyMatch[2].trim();
+      // YAML folded scalar ">" or literal "|" — value is on next lines
+      currentValue = val === ">" || val === "|" ? "" : val;
+    } else if (currentKey && line.match(/^\s+/)) {
+      // Continuation line (indented) — append with space
       currentValue += " " + line.trim();
     }
   }

--- a/ui/src/store/__tests__/agent-skills-store.test.ts
+++ b/ui/src/store/__tests__/agent-skills-store.test.ts
@@ -294,7 +294,7 @@ describe("agent-skills-store", () => {
       expect(configs[0].updated_at).toBeInstanceOf(Date);
     });
 
-    it("handles 503 - falls back to empty configs", async () => {
+    it("handles 503 - returns empty configs", async () => {
       mockFetch.mockImplementation((url: string | URL, init?: RequestInit) => {
         const u = typeof url === "string" ? url : url.toString();
         if (u.includes("/api/agent-skills/seed")) {
@@ -325,7 +325,7 @@ describe("agent-skills-store", () => {
       expect(useAgentSkillsStore.getState().configs).toEqual([]);
     });
 
-    it("handles 401 - falls back to empty configs", async () => {
+    it("handles 401 - returns empty configs", async () => {
       mockFetch.mockImplementation((url: string | URL) => {
         const u = typeof url === "string" ? url : url.toString();
         if (u.includes("/api/agent-skills/seed")) {
@@ -350,7 +350,7 @@ describe("agent-skills-store", () => {
       expect(useAgentSkillsStore.getState().configs).toEqual([]);
     });
 
-    it("handles error - falls back to empty configs", async () => {
+    it("handles error - returns empty configs", async () => {
       mockFetch.mockImplementation((url: string | URL) => {
         const u = typeof url === "string" ? url : url.toString();
         if (u.includes("/api/agent-skills/seed")) {

--- a/ui/src/store/agent-skills-store.ts
+++ b/ui/src/store/agent-skills-store.ts
@@ -260,23 +260,23 @@ export const useAgentSkillsStore = create<AgentSkillsState>()((set, get) => ({
       
       // Handle 503 (MongoDB not configured) gracefully
       if (response.status === 503) {
-        console.log("[AgentSkillsStore] MongoDB not configured — no skills available");
+        console.log("[AgentSkillsStore] MongoDB not configured");
         set({ configs: [], isLoading: false });
         return;
       }
 
       // Handle 401 (not authenticated) gracefully
       if (response.status === 401) {
-        console.log("[AgentSkillsStore] Not authenticated — no skills available");
+        console.log("[AgentSkillsStore] Not authenticated");
         set({ configs: [], isLoading: false });
         return;
       }
-
+      
       if (!response.ok) {
         const error = await response.json().catch(() => ({ error: "Failed to fetch agent skills" }));
         throw new Error(error.error || `HTTP ${response.status}`);
       }
-
+      
       const data = await response.json();
       const transformed = data.map(transformSkill);
 

--- a/ui/src/types/agent-skill.ts
+++ b/ui/src/types/agent-skill.ts
@@ -90,6 +90,14 @@ export type AgentSkillCategory =
 /**
  * Metadata for an agent skill
  */
+/** An input variable definition for the "Try Skill" parameter form. */
+export interface SkillInputVariable {
+  name: string;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+}
+
 export interface AgentSkillMetadata {
   /** Environment variables required for this skill to work */
   env_vars_required?: string[];
@@ -103,6 +111,8 @@ export interface AgentSkillMetadata {
   expected_agents?: string[];
   /** (Experimental) Tool allowlist for this skill -- not enforced by backend yet */
   allowed_tools?: string[];
+  /** Input variables shown in the Try Skill modal when skill has no {{var}} in prompt */
+  input_variables?: SkillInputVariable[];
 }
 
 /** Scan status set by skill-scanner on save/publish (FR-027). */
@@ -428,13 +438,12 @@ export function parseTaskConfigObject(
 }
 
 /**
- * Built-in quick-start templates — kept as an empty array.
- * Skills are now loaded from charts/data/skills/ SKILL.md files via the
- * /api/skill-templates endpoint and seeded into MongoDB from there.
- * This constant is retained for backward compatibility with the store
- * fallback paths but no longer ships hardcoded skill definitions.
+ * Built-in quick-start templates (formerly "Use Cases")
  *
- * @deprecated Use skill-templates API instead.
+ * @deprecated Templates are now loaded from disk at `charts/data/skills/`.
+ * This array is kept for backward compatibility but is intentionally empty.
+ * Use `loadSkillTemplatesInternal()` from `@/app/api/skills/skill-templates-loader`
+ * and the seed route to populate MongoDB from disk templates instead.
  */
 export const BUILTIN_QUICK_START_TEMPLATES: AgentSkill[] = [];
 


### PR DESCRIPTION
## Summary

Recovers uncommitted work from the merged PR #1212 worktree and adds a dedicated route for the Skills Gateway.

- **TrySkillsGateway visual editor**: Query builder with tag/source/visibility filters, URL preview with copy-to-clipboard, live catalog preview, and API key management
- **Dedicated `/skills/gateway` route**: Moved from inline tab to its own page at `http://localhost:3000/skills/gateway`
- **Skills metadata labels**: Added tags/labels to built-in skill template metadata.json files
- **Agent builder gallery simplification**: Reduced complexity in AgentBuilderGallery component
- **Skills middleware router**: Improved routing logic in skills_middleware/router.py
- **SkillHubsSection**: Admin panel improvements for skill hub management

## Test plan

- [ ] Navigate to `/skills/gateway` — visual editor loads with query builder
- [ ] Build a query with tags/source filters — URL preview updates
- [ ] Copy URL/API key — clipboard works
- [ ] Run live preview — catalog results render
- [ ] `/skills` browse tab still works, "Try API / Gateway" button navigates to `/skills/gateway`
- [ ] Agent builder gallery renders correctly
- [ ] Run `make caipe-ui-tests`
