### PR TITLE
fix(ci): bump Go 1.25→1.26 and langgraph 1.0.10→1.1.6

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  actions: read
+  actions: write
 
 jobs:
   check-and-publish:
@@ -145,6 +145,24 @@ jobs:
 
           echo "✅ Release $TAG published!"
           echo "🔗 $(echo "$RELEASE_INFO" | jq -r '.url')"
+
+      - name: 🔍 Trigger post-release scans and tests
+        if: steps.check-cis.outputs.all_passed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.payload.outputs.tag }}
+        run: |
+          echo "🔍 Triggering post-release Grype container scan..."
+          gh workflow run security-scan.yml \
+            --repo="${{ github.repository }}" \
+            --field tag="$TAG" || echo "⚠️ Failed to trigger Grype scan"
+
+          echo "🧪 Triggering post-release integration test..."
+          gh workflow run tests-quick-sanity-integration-on-latest-tag.yml \
+            --repo="${{ github.repository }}" \
+            --field chart_version="$TAG" || echo "⚠️ Failed to trigger integration test"
+
+          echo "✅ Post-release workflows dispatched for $TAG"
 
       - name: 🧹 Clean up old RC tags
         if: steps.check-cis.outputs.all_passed == 'true'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,8 +28,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-    tags:
-      - "[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
     inputs:
       tag:
@@ -82,8 +80,9 @@ jobs:
   scan-containers:
     name: Container scan (${{ matrix.image }})
     runs-on: ubuntu-latest
-    # Only runs on tag pushes and manual dispatch — images don't exist yet on PRs/main
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    # Only runs on manual dispatch — tag-push triggers were removed because images
+    # are not yet published when the tag event fires (race condition).
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-quick-sanity-integration-on-latest-tag.yml
+++ b/.github/workflows/tests-quick-sanity-integration-on-latest-tag.yml
@@ -2,9 +2,6 @@ name: "[Tests][Release Tag] Quick Sanity Integration"
 description: "Deploy a release-tag Helm chart via setup-caipe.sh into Kind and run sanity tests"
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       chart_version:

--- a/ai_platform_engineering/agents/github/build/Dockerfile.mcp
+++ b/ai_platform_engineering/agents/github/build/Dockerfile.mcp
@@ -1,5 +1,5 @@
 # ---------- Stage 1: Build Go binary ----------
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache git
 

--- a/ai_platform_engineering/agents/splunk/agent_splunk/pyproject.toml
+++ b/ai_platform_engineering/agents/splunk/agent_splunk/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "langchain-google-genai==4.0.0",
     "langchain-mcp-adapters==0.1.11",
     "langchain-openai==1.1.1",
-    "langgraph==1.0.10",
+    "langgraph==1.1.6",
     "pytest==9.0.3",
     "tabulate==0.9.0",
     "uv==0.11.6",

--- a/ai_platform_engineering/agents/splunk/agent_splunk/uv.lock
+++ b/ai_platform_engineering/agents/splunk/agent_splunk/uv.lock
@@ -58,7 +58,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = "==4.0.0" },
     { name = "langchain-mcp-adapters", specifier = "==0.1.11" },
     { name = "langchain-openai", specifier = "==1.1.1" },
-    { name = "langgraph", specifier = "==1.0.10" },
+    { name = "langgraph", specifier = "==1.1.6" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "rich", specifier = "==14.1.0" },
     { name = "sseclient", specifier = "==0.0.27" },
@@ -1483,7 +1483,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.10"
+version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1493,9 +1493,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/92/14df6fefba28c10caf1cb05aa5b8c7bf005838fe32a86d903b6c7cc4018d/langgraph-1.0.10.tar.gz", hash = "sha256:73bd10ee14a8020f31ef07e9cd4c1a70c35cc07b9c2b9cd637509a10d9d51e29", size = 511644, upload-time = "2026-02-27T21:04:38.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/60/260e0c04620a37ba8916b712766c341cc5fc685dabc6948c899494bbc2ae/langgraph-1.0.10-py3-none-any.whl", hash = "sha256:7c298bef4f6ea292fcf9824d6088fe41a6727e2904ad6066f240c4095af12247", size = 160920, upload-time = "2026-02-27T21:04:35.932Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
 ]
 
 [[package]]

--- a/ai_platform_engineering/knowledge_bases/rag/agent_ontology/pyproject.toml
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_ontology/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.13, <4.0"
 dependencies = [
     # Core dependencies (includes langchain-openai via common)
     "common",
-    "langchain==1.1.3",
-    "langgraph==1.0.10",
+    "langchain==1.2.15",
+    "langgraph==1.1.6",
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
     "python-dotenv==1.2.1",

--- a/ai_platform_engineering/knowledge_bases/rag/agent_ontology/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_ontology/uv.lock
@@ -41,9 +41,9 @@ requires-dist = [
     { name = "common", directory = "../common" },
     { name = "deepagents", specifier = "==0.2.8" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.124.0" },
-    { name = "langchain", specifier = "==1.1.3" },
+    { name = "langchain", specifier = "==1.2.15" },
     { name = "langfuse", specifier = "==3.14.5" },
-    { name = "langgraph", specifier = "==1.0.10" },
+    { name = "langgraph", specifier = "==1.1.6" },
     { name = "langmem", specifier = "==0.0.30" },
     { name = "pymilvus", specifier = "==2.6.5" },
     { name = "pytest", specifier = "==9.0.3" },
@@ -1432,16 +1432,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.1.3"
+version = "1.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/5b/7c1d6fd075bdfd45ac5ff6fef2a5d2380ffb7988fc9cdd7a37b036744fe4/langchain-1.1.3.tar.gz", hash = "sha256:8c641a750a4277d948c3836529f31de496e7ed4ea9f1c77f66f1845cb586987d", size = 531368, upload-time = "2025-12-08T19:31:48.733Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/39/ed3121ea3a0c60a0cda6ea5c4c1cece013e8bbc9b18344ff3ae507728f98/langchain-1.1.3-py3-none-any.whl", hash = "sha256:e5b208ed93e553df4087117a40bd0d450f9095030a843cad35c53ff2814bf731", size = 102227, upload-time = "2025-12-08T19:31:47.246Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
 ]
 
 [[package]]
@@ -1660,7 +1660,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.10"
+version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1670,9 +1670,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/92/14df6fefba28c10caf1cb05aa5b8c7bf005838fe32a86d903b6c7cc4018d/langgraph-1.0.10.tar.gz", hash = "sha256:73bd10ee14a8020f31ef07e9cd4c1a70c35cc07b9c2b9cd637509a10d9d51e29", size = 511644, upload-time = "2026-02-27T21:04:38.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/60/260e0c04620a37ba8916b712766c341cc5fc685dabc6948c899494bbc2ae/langgraph-1.0.10-py3-none-any.whl", hash = "sha256:7c298bef4f6ea292fcf9824d6088fe41a6727e2904ad6066f240c4095af12247", size = 160920, upload-time = "2026-02-27T21:04:35.932Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
 ]
 
 [[package]]

--- a/ai_platform_engineering/multi_agents/pyproject.toml
+++ b/ai_platform_engineering/multi_agents/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "uvicorn==0.34.3",
     "config==0.5.1",
     "langchain-core==1.2.28",
-    "langgraph==1.0.10",
-    "langgraph==1.0.10",
+    "langgraph==1.1.6",
     "langfuse==3.14.5",
 
     # Transport dependencies for agent connections

--- a/ai_platform_engineering/multi_agents/uv.lock
+++ b/ai_platform_engineering/multi_agents/uv.lock
@@ -84,7 +84,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.135.3" },
     { name = "langchain-core", specifier = "==1.2.28" },
     { name = "langfuse", specifier = "==3.14.5" },
-    { name = "langgraph", specifier = "==1.0.10" },
+    { name = "langgraph", specifier = "==1.1.6" },
     { name = "langmem", specifier = "==0.0.30" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "python-dotenv", specifier = "==1.1.1" },
@@ -1358,16 +1358,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.1.3"
+version = "1.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/5b/7c1d6fd075bdfd45ac5ff6fef2a5d2380ffb7988fc9cdd7a37b036744fe4/langchain-1.1.3.tar.gz", hash = "sha256:8c641a750a4277d948c3836529f31de496e7ed4ea9f1c77f66f1845cb586987d", size = 531368, upload-time = "2025-12-08T19:31:48.733Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/39/ed3121ea3a0c60a0cda6ea5c4c1cece013e8bbc9b18344ff3ae507728f98/langchain-1.1.3-py3-none-any.whl", hash = "sha256:e5b208ed93e553df4087117a40bd0d450f9095030a843cad35c53ff2814bf731", size = 102227, upload-time = "2025-12-08T19:31:47.246Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
 ]
 
 [[package]]
@@ -1557,7 +1557,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.10"
+version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1567,9 +1567,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/92/14df6fefba28c10caf1cb05aa5b8c7bf005838fe32a86d903b6c7cc4018d/langgraph-1.0.10.tar.gz", hash = "sha256:73bd10ee14a8020f31ef07e9cd4c1a70c35cc07b9c2b9cd637509a10d9d51e29", size = 511644, upload-time = "2026-02-27T21:04:38.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/60/260e0c04620a37ba8916b712766c341cc5fc685dabc6948c899494bbc2ae/langgraph-1.0.10-py3-none-any.whl", hash = "sha256:7c298bef4f6ea292fcf9824d6088fe41a6727e2904ad6066f240c4095af12247", size = 160920, upload-time = "2026-02-27T21:04:35.932Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

### Commit 1: Fix build failures
- **Go version**: Update Dockerfile.mcp for github MCP agent from golang:1.25-alpine to golang:1.26-alpine -- the upstream github-mcp-server module now requires go >= 1.26.2
- **langgraph version**: Bump langgraph from 1.0.10 to 1.1.6 in 3 sub-packages (agent_ontology, multi_agents, splunk/agent_splunk) to match the rest of the repo -- langgraph-prebuilt==1.0.9 imports ExecutionInfo from langgraph.runtime, which only exists in langgraph >= 1.1.0
- **langchain version**: Bump langchain from 1.1.3 to 1.2.15 in agent_ontology -- langchain==1.1.3 caps langgraph < 1.1.0
- **Cleanup**: Remove duplicate langgraph==1.0.10 line in multi_agents/pyproject.toml
- Regenerated uv.lock files for all 3 affected packages

### Commit 2: Fix race condition in post-release scans/tests
- **Remove tag triggers** from security-scan.yml (Grype container scan) and tests-quick-sanity-integration-on-latest-tag.yml -- images are not published when the tag event fires, causing MANIFEST_UNKNOWN / ErrImagePull failures
- **Add watcher to release-finalize**: After all CI builds pass and the release is published, dispatch both workflows via workflow_dispatch so they run against available images
- Bump release-finalize permissions from actions:read to actions:write to allow workflow dispatch

### Commit 3: Fix bloated release notes
- Add --notes-start-tag to gh release create in release-manual.yml
- Without it, --generate-notes diffs from the previous published (non-draft) release; since releases are created as drafts, rapid releases (0.3.0, 0.3.1, 0.3.2) all inherit the same baseline producing identical bloated changelogs
- Uses the previous version already resolved in the commit-release job

### CI failures fixed

| Workflow | Job | Root cause |
|----------|-----|------------|
| [CI][MCP] Sub-Agents MCP Docker Build and Push | build-and-push (github) | go.mod requires go >= 1.26.2 (running go 1.25.9) |
| Agent ontology runtime | Import crash | ImportError: cannot import name ExecutionInfo from langgraph.runtime |
| Grype Scan (17 container scans) | All | MANIFEST_UNKNOWN -- race: images not yet built |
| [Tests][Release Tag] Quick Sanity Integration | quick-sanity-release | ErrImagePull -- race: images not yet built |
| Release notes (0.3.0-0.3.2) | Bloated/identical | --generate-notes missing --notes-start-tag |

## Test plan

- [ ] CI passes: MCP Sub-Agents builds github agent successfully
- [ ] agent_ontology container starts without ImportError
- [ ] multi_agents and splunk/agent_splunk resolve cleanly with updated lock files
- [ ] On next release, Grype container scans and integration test are dispatched by release-finalize after all CI builds pass
- [ ] On next release, release notes only include changes since the previous version