### PR TITLE
feat(auth): add dual auth middleware for shared key + OAuth2 coexistence

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py
@@ -200,7 +200,15 @@ app.mount("/", _skills_api)
 A2A_AUTH_OAUTH2 = os.getenv('A2A_AUTH_OAUTH2', 'false').lower() == 'true'
 A2A_AUTH_SHARED_KEY = os.getenv('A2A_AUTH_SHARED_KEY')
 
-if A2A_AUTH_SHARED_KEY:
+if A2A_AUTH_SHARED_KEY and A2A_AUTH_OAUTH2:
+    logger.info("Using dual authentication (shared key + OAuth2 JWT)")
+    from ai_platform_engineering.utils.auth.dual_auth_middleware import DualAuthMiddleware
+    app.add_middleware(
+        DualAuthMiddleware,
+        agent_card=get_agent_card(host, port, external_url),
+        public_paths=['/.well-known/agent.json', '/.well-known/agent-card.json'],
+    )
+elif A2A_AUTH_SHARED_KEY:
     logger.info("Using shared key authentication")
     from ai_platform_engineering.utils.auth.shared_key_middleware import SharedKeyMiddleware
     app.add_middleware(

--- a/ai_platform_engineering/utils/auth/dual_auth_middleware.py
+++ b/ai_platform_engineering/utils/auth/dual_auth_middleware.py
@@ -1,0 +1,122 @@
+"""Dual authentication middleware for A2A access.
+
+Accepts EITHER a shared key OR a valid OAuth2 JWT bearer token.
+This allows machine-to-machine A2A clients to use a shared key while
+the UI continues to use OIDC/OAuth2 JWT tokens.
+
+Priority:
+  1. If the bearer token matches A2A_AUTH_SHARED_KEY → allow immediately.
+  2. Otherwise, validate as an OAuth2 JWT token.
+  3. If both fail → 401 Unauthorized.
+"""
+
+import logging
+import os
+
+from a2a.types import AgentCard
+from dotenv import load_dotenv
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+
+# NOTE: verify_token is imported lazily in dispatch() to avoid pulling in
+# OAuth2 module-level env validation (JWKS_URI, AUDIENCE, etc.) at import
+# time.  The oauth2_middleware module only initialises those globals when
+# A2A_AUTH_OAUTH2=true, which may not be set when this module is first
+# imported during middleware registration.
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+A2A_AUTH_SHARED_KEY = os.getenv("A2A_AUTH_SHARED_KEY")
+
+if not A2A_AUTH_SHARED_KEY:
+    raise ValueError(
+        "DualAuthMiddleware requires A2A_AUTH_SHARED_KEY to be set. "
+        "Use OAuth2Middleware or SharedKeyMiddleware directly if you only "
+        "need one auth method."
+    )
+
+
+class DualAuthMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware that accepts shared-key OR OAuth2 JWT bearer tokens."""
+
+    def __init__(
+        self,
+        app: Starlette,
+        agent_card: AgentCard = None,
+        public_paths: list[str] = None,
+    ):
+        super().__init__(app)
+        self.agent_card = agent_card
+        self.public_paths = set(public_paths or [])
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+
+        # Allow OPTIONS requests (CORS preflight) without authentication
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
+        # Allow public paths
+        if path in self.public_paths:
+            return await call_next(request)
+
+        # Extract Authorization header
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            logger.warning("Missing or malformed Authorization header")
+            return self._unauthorized(
+                "Missing or malformed Authorization header.", request
+            )
+
+        access_token = auth_header.split("Bearer ")[1]
+
+        # 1. Try shared key first (fast path for A2A machine-to-machine)
+        if access_token == A2A_AUTH_SHARED_KEY:
+            logger.debug("Authenticated via shared key")
+            return await call_next(request)
+
+        # 2. Fall back to OAuth2 JWT validation (UI OIDC flow)
+        #    Lazy import to avoid module-level env validation side effects.
+        from ai_platform_engineering.utils.auth.oauth2_middleware import verify_token
+
+        try:
+            is_valid = verify_token(access_token)
+            if is_valid:
+                logger.debug("Authenticated via OAuth2 JWT")
+                return await call_next(request)
+            else:
+                logger.warning("Token failed both shared key and OAuth2 validation")
+                return self._unauthorized(
+                    "Invalid or expired access token.", request
+                )
+        except Exception as e:
+            logger.error("Authentication error: %s", e, exc_info=True)
+            return self._forbidden(f"Authentication failed: {e}", request)
+
+    def _forbidden(self, reason: str, request: Request):
+        accept_header = request.headers.get("accept", "")
+        if "text/event-stream" in accept_header:
+            return PlainTextResponse(
+                f"error forbidden: {reason}",
+                status_code=403,
+                media_type="text/event-stream",
+            )
+        return JSONResponse(
+            {"error": "forbidden", "reason": reason}, status_code=403
+        )
+
+    def _unauthorized(self, reason: str, request: Request):
+        accept_header = request.headers.get("accept", "")
+        if "text/event-stream" in accept_header:
+            return PlainTextResponse(
+                f"error unauthorized: {reason}",
+                status_code=401,
+                media_type="text/event-stream",
+            )
+        return JSONResponse(
+            {"error": "unauthorized", "reason": reason}, status_code=401
+        )

--- a/ai_platform_engineering/utils/auth/dual_auth_middleware.py
+++ b/ai_platform_engineering/utils/auth/dual_auth_middleware.py
@@ -82,10 +82,12 @@ class DualAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         # 2. Fall back to OAuth2 JWT validation (UI OIDC flow)
-        #    Lazy import to avoid module-level env validation side effects.
-        from ai_platform_engineering.utils.auth.oauth2_middleware import verify_token
-
         try:
+            # Lazy import to avoid module-level env validation side effects.
+            from ai_platform_engineering.utils.auth.oauth2_middleware import (
+                verify_token,
+            )
+
             is_valid = verify_token(access_token)
             if is_valid:
                 logger.debug("Authenticated via OAuth2 JWT")

--- a/ai_platform_engineering/utils/auth/dual_auth_middleware.py
+++ b/ai_platform_engineering/utils/auth/dual_auth_middleware.py
@@ -10,6 +10,7 @@ Priority:
   3. If both fail → 401 Unauthorized.
 """
 
+import hmac
 import logging
 import os
 
@@ -75,7 +76,8 @@ class DualAuthMiddleware(BaseHTTPMiddleware):
         access_token = auth_header.split("Bearer ")[1]
 
         # 1. Try shared key first (fast path for A2A machine-to-machine)
-        if access_token == A2A_AUTH_SHARED_KEY:
+        # Use constant-time comparison to prevent timing attacks.
+        if hmac.compare_digest(access_token, A2A_AUTH_SHARED_KEY):
             logger.debug("Authenticated via shared key")
             return await call_next(request)
 

--- a/tests/test_dual_auth_middleware.py
+++ b/tests/test_dual_auth_middleware.py
@@ -32,16 +32,14 @@ async def agent_card_endpoint(request: Request):
     return JSONResponse({"name": "test-agent"})
 
 
-def _make_app(verify_return=False):
+def _make_app():
     """Create a Starlette app with DualAuthMiddleware.
 
-    Uses unittest.mock to patch verify_token at the call site inside
-    dual_auth_middleware.dispatch(), avoiding the oauth2_middleware
-    module-level env validation entirely.
+    Patches the env so the middleware module-level check for
+    A2A_AUTH_SHARED_KEY passes, then builds a fresh app with
+    the middleware attached.
     """
-    # Patch the env so the middleware module accepts the shared key
     with patch.dict(os.environ, {"A2A_AUTH_SHARED_KEY": SHARED_KEY}):
-        # Reimport to pick up patched env
         import importlib
         import ai_platform_engineering.utils.auth.dual_auth_middleware as dam
         importlib.reload(dam)
@@ -52,26 +50,10 @@ def _make_app(verify_return=False):
             Route("/.well-known/agent.json", agent_card_endpoint),
         ],
     )
-
-    # Patch verify_token lazily imported inside dispatch
-    _original_dispatch = dam.DualAuthMiddleware.dispatch
-
-    async def _patched_dispatch(self, request, call_next):
-        with patch(
-            "ai_platform_engineering.utils.auth.oauth2_middleware.verify_token",
-            side_effect=lambda t: verify_return if not callable(verify_return) else verify_return(t),
-        ):
-            return await _original_dispatch(self, request, call_next)
-
-    with patch.object(dam.DualAuthMiddleware, "dispatch", _patched_dispatch):
-        app.add_middleware(
-            dam.DualAuthMiddleware,
-            public_paths=PUBLIC_PATHS,
-        )
-
-    # Restore dispatch for actual use
-    dam.DualAuthMiddleware.dispatch = _original_dispatch
-
+    app.add_middleware(
+        dam.DualAuthMiddleware,
+        public_paths=PUBLIC_PATHS,
+    )
     return app
 
 
@@ -80,7 +62,7 @@ class TestDualAuthMiddleware:
 
     def test_shared_key_grants_access(self):
         """Shared key in Bearer header should be accepted immediately."""
-        app = _make_app(verify_return=False)
+        app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.get("/", headers={"Authorization": f"Bearer {SHARED_KEY}"})
         assert resp.status_code == 200
@@ -88,17 +70,29 @@ class TestDualAuthMiddleware:
 
     def test_valid_jwt_grants_access(self):
         """Valid OAuth2 JWT should be accepted when shared key doesn't match."""
-        app = _make_app(verify_return=lambda t: t == "valid-jwt-token")
+        app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/", headers={"Authorization": "Bearer valid-jwt-token"})
+        with patch(
+            "ai_platform_engineering.utils.auth.oauth2_middleware.verify_token",
+            side_effect=lambda t: t == "valid-jwt-token",
+        ):
+            resp = client.get(
+                "/", headers={"Authorization": "Bearer valid-jwt-token"}
+            )
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
     def test_invalid_token_rejected(self):
         """Token that is neither shared key nor valid JWT should be rejected."""
-        app = _make_app(verify_return=False)
+        app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/", headers={"Authorization": "Bearer bad-token"})
+        with patch(
+            "ai_platform_engineering.utils.auth.oauth2_middleware.verify_token",
+            return_value=False,
+        ):
+            resp = client.get(
+                "/", headers={"Authorization": "Bearer bad-token"}
+            )
         assert resp.status_code == 401
 
     def test_missing_auth_header_rejected(self):
@@ -133,12 +127,15 @@ class TestDualAuthMiddleware:
 
     def test_jwt_validation_error_returns_403(self):
         """If JWT validation raises an exception, return 403."""
-        def exploding_verify(token):
-            raise RuntimeError("JWKS fetch failed")
-
-        app = _make_app(verify_return=exploding_verify)
+        app = _make_app()
         client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/", headers={"Authorization": "Bearer some-token"})
+        with patch(
+            "ai_platform_engineering.utils.auth.oauth2_middleware.verify_token",
+            side_effect=RuntimeError("JWKS fetch failed"),
+        ):
+            resp = client.get(
+                "/", headers={"Authorization": "Bearer some-token"}
+            )
         assert resp.status_code == 403
 
     def test_sse_unauthorized_format(self):

--- a/tests/test_dual_auth_middleware.py
+++ b/tests/test_dual_auth_middleware.py
@@ -10,9 +10,8 @@ Verifies that:
 """
 
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse

--- a/tests/test_dual_auth_middleware.py
+++ b/tests/test_dual_auth_middleware.py
@@ -1,0 +1,150 @@
+"""Unit tests for DualAuthMiddleware.
+
+Verifies that:
+- Shared key grants access immediately.
+- Valid OAuth2 JWT grants access when shared key doesn't match.
+- Invalid tokens (neither shared key nor valid JWT) are rejected.
+- Public paths bypass auth.
+- OPTIONS (CORS preflight) bypass auth.
+- Missing/malformed Authorization header returns 401.
+"""
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+SHARED_KEY = "test-shared-key-12345"
+PUBLIC_PATHS = ["/.well-known/agent.json", "/.well-known/agent-card.json"]
+
+
+async def dummy_endpoint(request: Request):
+    return JSONResponse({"status": "ok"})
+
+
+async def agent_card_endpoint(request: Request):
+    return JSONResponse({"name": "test-agent"})
+
+
+def _make_app(verify_return=False):
+    """Create a Starlette app with DualAuthMiddleware.
+
+    Uses unittest.mock to patch verify_token at the call site inside
+    dual_auth_middleware.dispatch(), avoiding the oauth2_middleware
+    module-level env validation entirely.
+    """
+    # Patch the env so the middleware module accepts the shared key
+    with patch.dict(os.environ, {"A2A_AUTH_SHARED_KEY": SHARED_KEY}):
+        # Reimport to pick up patched env
+        import importlib
+        import ai_platform_engineering.utils.auth.dual_auth_middleware as dam
+        importlib.reload(dam)
+
+    app = Starlette(
+        routes=[
+            Route("/", dummy_endpoint, methods=["GET", "POST", "OPTIONS"]),
+            Route("/.well-known/agent.json", agent_card_endpoint),
+        ],
+    )
+
+    # Patch verify_token lazily imported inside dispatch
+    _original_dispatch = dam.DualAuthMiddleware.dispatch
+
+    async def _patched_dispatch(self, request, call_next):
+        with patch(
+            "ai_platform_engineering.utils.auth.oauth2_middleware.verify_token",
+            side_effect=lambda t: verify_return if not callable(verify_return) else verify_return(t),
+        ):
+            return await _original_dispatch(self, request, call_next)
+
+    with patch.object(dam.DualAuthMiddleware, "dispatch", _patched_dispatch):
+        app.add_middleware(
+            dam.DualAuthMiddleware,
+            public_paths=PUBLIC_PATHS,
+        )
+
+    # Restore dispatch for actual use
+    dam.DualAuthMiddleware.dispatch = _original_dispatch
+
+    return app
+
+
+class TestDualAuthMiddleware:
+    """Tests for dual shared-key + OAuth2 authentication."""
+
+    def test_shared_key_grants_access(self):
+        """Shared key in Bearer header should be accepted immediately."""
+        app = _make_app(verify_return=False)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/", headers={"Authorization": f"Bearer {SHARED_KEY}"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_valid_jwt_grants_access(self):
+        """Valid OAuth2 JWT should be accepted when shared key doesn't match."""
+        app = _make_app(verify_return=lambda t: t == "valid-jwt-token")
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/", headers={"Authorization": "Bearer valid-jwt-token"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_invalid_token_rejected(self):
+        """Token that is neither shared key nor valid JWT should be rejected."""
+        app = _make_app(verify_return=False)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/", headers={"Authorization": "Bearer bad-token"})
+        assert resp.status_code == 401
+
+    def test_missing_auth_header_rejected(self):
+        """Missing Authorization header should return 401."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/")
+        assert resp.status_code == 401
+
+    def test_malformed_auth_header_rejected(self):
+        """Non-Bearer Authorization header should return 401."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+        assert resp.status_code == 401
+
+    def test_public_path_bypasses_auth(self):
+        """Public paths should be accessible without auth."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/.well-known/agent.json")
+        assert resp.status_code == 200
+
+    def test_options_bypasses_auth(self):
+        """OPTIONS requests (CORS preflight) should bypass auth."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.options("/")
+        # Starlette may return 400/405 for OPTIONS without CORS middleware,
+        # but the auth middleware itself should not block it.
+        assert resp.status_code != 401
+
+    def test_jwt_validation_error_returns_403(self):
+        """If JWT validation raises an exception, return 403."""
+        def exploding_verify(token):
+            raise RuntimeError("JWKS fetch failed")
+
+        app = _make_app(verify_return=exploding_verify)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/", headers={"Authorization": "Bearer some-token"})
+        assert resp.status_code == 403
+
+    def test_sse_unauthorized_format(self):
+        """SSE-accepting clients should get text/event-stream error responses."""
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/", headers={"Accept": "text/event-stream"})
+        assert resp.status_code == 401
+        assert "text/event-stream" in resp.headers.get("content-type", "")


### PR DESCRIPTION
## Problem

When `A2A_AUTH_SHARED_KEY` is set in `main.py`, the auth middleware selection uses an if/elif chain that **overrides** OAuth2, breaking the UI's OIDC-based backend calls.

## Solution

Adds a `DualAuthMiddleware` that supports both auth methods simultaneously:

1. **New file:** `ai_platform_engineering/utils/auth/dual_auth_middleware.py`
   - Checks if bearer token matches `A2A_AUTH_SHARED_KEY` → allows immediately (using `hmac.compare_digest` to prevent timing attacks)
   - Otherwise falls back to `verify_token()` from `oauth2_middleware.py` for JWT/JWKS validation
   - Same public_paths and CORS preflight handling as existing middlewares
   - Lazy import of OAuth2 verifier to avoid premature env validation at module load

2. **Modified:** `main.py` auth selection now has a new top-level branch:
   - `if A2A_AUTH_SHARED_KEY and A2A_AUTH_OAUTH2` → DualAuthMiddleware (new)
   - `elif A2A_AUTH_SHARED_KEY` → SharedKeyMiddleware (unchanged)
   - `elif A2A_AUTH_OAUTH2` → OAuth2Middleware (unchanged)
   - `else` → no auth (unchanged)

3. **Tests:** `tests/test_dual_auth_middleware.py` covering both auth paths, rejection cases, public paths, and CORS preflight

## Testing

```bash
uv run pytest tests/test_dual_auth_middleware.py -v
```