### PR TITLE
fix(dynamic-agents): enable tz_aware on MongoClient to prevent naive/aware datetime comparison

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/conversations.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/conversations.py
@@ -204,7 +204,8 @@ async def get_conversation_messages(
         additional_kwargs = getattr(msg, "additional_kwargs", {})
         if "timestamp" in additional_kwargs:
             try:
-                timestamp = datetime.fromisoformat(additional_kwargs["timestamp"])
+                ts = datetime.fromisoformat(additional_kwargs["timestamp"])
+                timestamp = ts if ts.tzinfo is not None else ts.replace(tzinfo=timezone.utc)
             except (ValueError, TypeError):
                 pass
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -141,7 +141,7 @@ class AgentRuntime:
         self._user = user
         self._client_context = client_context
         self._graph = None
-        self._mongo_client = MongoClient(self.settings.mongodb_uri)
+        self._mongo_client = MongoClient(self.settings.mongodb_uri, tz_aware=True)
         # Use MongoDBSaver from langgraph-checkpoint-mongodb for persistent chat history
         self._checkpointer = MongoDBSaver(
             self._mongo_client,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
@@ -36,6 +36,7 @@ class MongoDBService:
                 self.settings.mongodb_uri,
                 serverSelectionTimeoutMS=5000,
                 retryWrites=False,
+                tz_aware=True,
             )
             # Verify connectivity
             self._client.admin.command("ping")


### PR DESCRIPTION
# Description

Fixes `TypeError: can't compare offset-naive and offset-aware datetimes` that crashes every chat request for agents with MCP servers configured.

Both `MongoClient` instances (in `mongo.py` and `agent_runtime.py`) lacked `tz_aware=True`, so PyMongo returned naive datetimes from MongoDB. These were then compared against aware sentinels (`datetime.min.replace(tzinfo=timezone.utc)`) in `AgentRuntime.__init__` and `is_stale()`, raising `TypeError`.

**Changes:**
- Add `tz_aware=True` to both `MongoClient` calls
- Guard `datetime.fromisoformat()` in `conversations.py` against naive datetimes from message metadata

**Existing data is unaffected** — MongoDB stores datetimes as UTC milliseconds internally; `tz_aware=True` just attaches `tzinfo` on read.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] All new and existing tests pass