### PR TITLE
fix(checkpointer): strip ephemeral skills state from MongoDB checkpoint writes

### DIFF
--- a/ai_platform_engineering/utils/checkpointer.py
+++ b/ai_platform_engineering/utils/checkpointer.py
@@ -562,6 +562,122 @@ def _truncate_large_writes(
     return new_writes if any_truncated else writes
 
 
+# Path prefix used by skills_middleware.backend_sync.build_skills_files()
+# to store skill SKILL.md content in the LangGraph `files` state channel.
+# Any `files` entry whose key starts with this prefix is an ephemeral skill
+# file that is re-injected from the in-process _skills_files cache at the
+# start of every graph invocation (see agent.py:stream() and
+# deep_agent.py:serve()/serve_stream()).  Persisting these to MongoDB is
+# wasteful: 56 skills × ~422 files can add 1–3 MB to every checkpoint
+# document and, when combined with growing conversation state (messages,
+# todos, tasks, skills_metadata), pushes the BSON document past MongoDB's
+# hard 16 MB limit causing the supervisor to crash.
+_SKILLS_FILES_PREFIX = "/skills/"
+# assisted-by claude code claude-sonnet-4-6
+
+
+def _strip_skills_from_checkpoint(checkpoint: Checkpoint) -> Checkpoint:
+    """Return a copy of checkpoint with ephemeral skills state removed.
+
+    Strips two channels that are always re-populated at the start of each
+    graph invocation and therefore must never be persisted to MongoDB:
+
+    * ``files["/skills/*"]``  — raw SKILL.md content injected by
+      ``skills_middleware.backend_sync.build_skills_files()``.  User-created
+      files (paths that do NOT start with ``/skills/``) are preserved so that
+      sub-agent file-passing (write_file / read_file) continues to work across
+      turns.
+
+    * ``skills_metadata``  — processed skill catalogue built by
+      ``deepagents.middleware.skills.SkillsMiddleware.before_model()`` from
+      the ``files`` channel on every graph step.  It is always rebuilt from
+      the in-memory skill cache; storing it in MongoDB adds size with no
+      benefit.
+
+    Like ``_truncate_large_messages``, this function only modifies the copy
+    that is written to MongoDB.  The live in-memory LangGraph state is
+    unaffected, so ``SkillsMiddleware`` continues to see the full skill
+    catalogue for the duration of the current turn.
+
+    Why this is safe:
+    -----------------
+    ``agent.py:AIPlatformEngineerA2ABinding.stream()`` (and the equivalent
+    ``deep_agent.py:serve()`` / ``serve_stream()`` paths) inject
+    ``state_dict["files"] = dict(self._mas_instance._skills_files)`` on
+    EVERY call before ``graph.astream()``.  LangGraph reads the checkpoint
+    ONCE at the start of an invocation and then merges the ``inputs`` dict
+    into the recovered state via ``file_reducer`` (which does
+    ``{**checkpoint_files, **input_files}``).  Skills are therefore always
+    present in the in-memory state for the entire turn even though they are
+    absent from the persisted checkpoint.  Between turns (pod restarts, HITL
+    resumes) the next ``stream()`` call re-injects them again.
+    """
+    channel_values = checkpoint.get("channel_values", {})
+    modified = False
+
+    # --- Strip /skills/* entries from the `files` channel ---
+    files = channel_values.get("files")
+    if isinstance(files, dict):
+        skill_keys = [k for k in files if k.startswith(_SKILLS_FILES_PREFIX)]
+        if skill_keys:
+            new_files = {k: v for k, v in files.items() if not k.startswith(_SKILLS_FILES_PREFIX)}
+            logger.debug(
+                f"MongoDB checkpoint: stripped {len(skill_keys)} skill file entries "
+                f"from 'files' channel ({len(new_files)} user files retained)"
+            )
+            modified = True
+
+    # --- Strip the `skills_metadata` channel entirely ---
+    skills_metadata = channel_values.get("skills_metadata")
+    if skills_metadata is not None:
+        logger.debug("MongoDB checkpoint: stripped 'skills_metadata' channel")
+        modified = True
+
+    if not modified:
+        return checkpoint
+
+    new_checkpoint = dict(checkpoint)
+    new_checkpoint["channel_values"] = dict(channel_values)
+    if isinstance(files, dict) and skill_keys:
+        new_checkpoint["channel_values"]["files"] = new_files
+    if skills_metadata is not None:
+        new_checkpoint["channel_values"].pop("skills_metadata", None)
+    return new_checkpoint  # type: ignore[return-value]
+
+
+def _strip_skills_from_writes(
+    writes: "Sequence[Tuple[str, Any]]",
+) -> "Sequence[Tuple[str, Any]]":
+    """Return a copy of writes with ephemeral skills entries removed.
+
+    ``aput_writes`` persists individual node outputs.  A write of the entire
+    ``files`` channel (channel == "files", value == {"/skills/...": ...}) or
+    the ``skills_metadata`` channel triggers the same BSON size issue as a
+    full checkpoint write.  This function strips those entries for the same
+    reasons as ``_strip_skills_from_checkpoint``.
+    """
+    new_writes = []
+    modified = False
+    for channel, value in writes:
+        if channel == "skills_metadata":
+            # Drop the entire skills_metadata write
+            modified = True
+            logger.debug("MongoDB checkpoint: dropped 'skills_metadata' write entry")
+            continue
+        if channel == "files" and isinstance(value, dict):
+            skill_keys = [k for k in value if k.startswith(_SKILLS_FILES_PREFIX)]
+            if skill_keys:
+                value = {k: v for k, v in value.items() if not k.startswith(_SKILLS_FILES_PREFIX)}
+                modified = True
+                logger.debug(
+                    f"MongoDB checkpoint: stripped {len(skill_keys)} skill file entries "
+                    f"from 'files' write"
+                )
+        new_writes.append((channel, value))
+
+    return new_writes if modified else writes
+
+
 class _LazyAsyncMongoDBSaver(BaseCheckpointSaver):
     """Lazy wrapper for MongoDBSaver that initializes on first async use."""
 
@@ -615,6 +731,7 @@ class _LazyAsyncMongoDBSaver(BaseCheckpointSaver):
     ) -> dict:
         await self._ensure_initialized()
         checkpoint = _truncate_large_messages(checkpoint)
+        checkpoint = _strip_skills_from_checkpoint(checkpoint)
         return await self._saver.aput(config, checkpoint, metadata, new_versions)
 
     async def aput_writes(
@@ -622,6 +739,7 @@ class _LazyAsyncMongoDBSaver(BaseCheckpointSaver):
     ) -> None:
         await self._ensure_initialized()
         writes = _truncate_large_writes(writes)
+        writes = _strip_skills_from_writes(writes)
         return await self._saver.aput_writes(config, writes, task_id)
 
     async def alist(

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -12,6 +12,8 @@ Covers:
 - Redis checkpointer construction with TTL
 - Postgres checkpointer construction
 - MongoDB checkpointer construction
+
+assisted-by claude code claude-sonnet-4-6
 """
 
 from unittest.mock import MagicMock, patch
@@ -21,6 +23,8 @@ from ai_platform_engineering.utils.checkpointer import (
   CHECKPOINT_TYPE_MEMORY,
   _create_memory_checkpointer,
   _detect_collection_prefix,
+  _strip_skills_from_checkpoint,
+  _strip_skills_from_writes,
   create_checkpointer,
   get_checkpointer,
   get_checkpointer_config,
@@ -388,6 +392,177 @@ class TestCreateMemoryCheckpointer:
     cp1 = _create_memory_checkpointer()
     cp2 = _create_memory_checkpointer()
     assert cp1 is not cp2
+
+
+# ============================================================================
+# Skills Stripping Tests
+# ============================================================================
+
+
+class TestStripSkillsFromCheckpoint:
+  """Tests for _strip_skills_from_checkpoint()."""
+
+  def test_strips_skills_files_from_files_channel(self):
+    """Verify /skills/* entries are removed from files channel."""
+    checkpoint = {
+      "channel_values": {
+        "files": {
+          "/skills/default/aws-cost-analysis/SKILL.md": {"content": ["# AWS"]},
+          "/skills/hub-abc/github-search/SKILL.md": {"content": ["# GitHub"]},
+          "/request.txt": {"content": ["user request"]},  # User file - should be kept
+        },
+        "messages": [{"role": "user", "content": "test"}],
+      }
+    }
+    result = _strip_skills_from_checkpoint(checkpoint)
+    # Skills should be gone, user files should remain
+    assert "/skills/default/aws-cost-analysis/SKILL.md" not in result["channel_values"]["files"]
+    assert "/skills/hub-abc/github-search/SKILL.md" not in result["channel_values"]["files"]
+    assert "/request.txt" in result["channel_values"]["files"]
+    assert result["channel_values"]["files"]["/request.txt"]["content"] == ["user request"]
+
+  def test_strips_skills_metadata_channel(self):
+    """Verify skills_metadata channel is removed entirely."""
+    checkpoint = {
+      "channel_values": {
+        "skills_metadata": {"aws": {"name": "AWS", "description": "AWS Skills"}},
+        "messages": [{"role": "user", "content": "test"}],
+      }
+    }
+    result = _strip_skills_from_checkpoint(checkpoint)
+    assert "skills_metadata" not in result["channel_values"]
+    assert "messages" in result["channel_values"]  # Other channels preserved
+
+  def test_preserves_non_skills_files(self):
+    """User-created files in /request.txt, /output.json, etc. are preserved."""
+    checkpoint = {
+      "channel_values": {
+        "files": {
+          "/request.txt": {"content": ["form data"]},
+          "/output.json": {"content": ["result"]},
+          "/skills/default/tool/SKILL.md": {"content": ["skill"]},
+        }
+      }
+    }
+    result = _strip_skills_from_checkpoint(checkpoint)
+    assert "/request.txt" in result["channel_values"]["files"]
+    assert "/output.json" in result["channel_values"]["files"]
+    assert "/skills/default/tool/SKILL.md" not in result["channel_values"]["files"]
+
+  def test_returns_original_if_no_modifications_needed(self):
+    """If no skills to strip, return original checkpoint unchanged."""
+    checkpoint = {
+      "channel_values": {
+        "messages": [{"role": "user", "content": "test"}],
+        "files": {"/request.txt": {"content": ["data"]}},
+      }
+    }
+    result = _strip_skills_from_checkpoint(checkpoint)
+    assert result is checkpoint  # Should be identical (no modification)
+
+  def test_empty_files_channel(self):
+    """Handles empty files dict gracefully."""
+    checkpoint = {"channel_values": {"files": {}}}
+    result = _strip_skills_from_checkpoint(checkpoint)
+    assert result is checkpoint
+
+  def test_missing_channel_values(self):
+    """Handles checkpoint without channel_values."""
+    checkpoint = {}
+    result = _strip_skills_from_checkpoint(checkpoint)
+    assert result is checkpoint
+
+  def test_only_skills_files_no_user_files(self):
+    """All files are skills; should result in empty files dict."""
+    checkpoint = {
+      "channel_values": {
+        "files": {
+          "/skills/default/aws/SKILL.md": {"content": ["aws"]},
+          "/skills/hub-x/github/SKILL.md": {"content": ["github"]},
+        }
+      }
+    }
+    result = _strip_skills_from_checkpoint(checkpoint)
+    # All skill files removed; files dict should be empty
+    assert result["channel_values"]["files"] == {}
+
+
+class TestStripSkillsFromWrites:
+  """Tests for _strip_skills_from_writes()."""
+
+  def test_drops_skills_metadata_writes(self):
+    """Entire skills_metadata channel writes are dropped."""
+    writes = [
+      ("messages", [{"role": "user", "content": "test"}]),
+      ("skills_metadata", {"aws": {"name": "AWS"}}),
+      ("files", {"/request.txt": {"content": ["data"]}}),
+    ]
+    result = _strip_skills_from_writes(writes)
+    # skills_metadata write should be gone
+    assert len(result) == 2
+    assert not any(channel == "skills_metadata" for channel, _ in result)
+
+  def test_strips_skills_files_from_files_writes(self):
+    """Skills entries are stripped from files channel writes."""
+    writes = [
+      ("files", {
+        "/skills/default/tool/SKILL.md": {"content": ["skill"]},
+        "/skills/hub-abc/github/SKILL.md": {"content": ["github"]},
+        "/request.txt": {"content": ["user data"]},
+      })
+    ]
+    result = _strip_skills_from_writes(writes)
+    assert len(result) == 1
+    channel, value = result[0]
+    assert channel == "files"
+    assert "/skills/default/tool/SKILL.md" not in value
+    assert "/skills/hub-abc/github/SKILL.md" not in value
+    assert "/request.txt" in value
+
+  def test_preserves_non_skills_writes(self):
+    """Writes for other channels (messages, todos, etc.) are preserved."""
+    writes = [
+      ("messages", [{"role": "user", "content": "test"}]),
+      ("todos", [{"id": 1, "content": "Task 1"}]),
+      ("tasks", [{"id": 1, "task": "do something"}]),
+    ]
+    result = _strip_skills_from_writes(writes)
+    assert len(result) == 3  # All preserved
+    assert result == writes
+
+  def test_returns_original_if_no_modifications(self):
+    """If no skills to strip, return original writes unchanged."""
+    writes = [
+      ("messages", [{"role": "user", "content": "test"}]),
+      ("files", {"/request.txt": {"content": ["data"]}}),
+    ]
+    result = _strip_skills_from_writes(writes)
+    assert result is writes
+
+  def test_empty_writes_list(self):
+    """Empty writes list handled gracefully."""
+    writes = []
+    result = _strip_skills_from_writes(writes)
+    assert result == []
+
+  def test_mixed_writes_with_multiple_skills(self):
+    """Multiple skills entries mixed with other writes."""
+    writes = [
+      ("messages", [{"role": "user"}]),
+      ("skills_metadata", {}),
+      ("files", {"/skills/default/a/SKILL.md": {}, "/output.json": {}}),
+      ("todos", []),
+      ("skills_metadata", {}),  # Second occurrence
+      ("files", {"/skills/hub-x/b/SKILL.md": {}, "/request.txt": {}}),
+    ]
+    result = _strip_skills_from_writes(writes)
+    # Should have 4 remaining (2 skills_metadata dropped, 2 files with skills stripped)
+    assert len(result) == 4
+    channels = [c for c, _ in result]
+    assert channels.count("messages") == 1
+    assert channels.count("todos") == 1
+    assert channels.count("files") == 2
+    assert channels.count("skills_metadata") == 0
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem

The supervisor pod crashes repeatedly under load with:

```
[WARNING] Primary stream failed (recursion_limit=False): 'update' command document too large
[WARNING] MAX_CONTEXT_TOKENS not set; skipping context compression in error recovery
```

This causes **intermittent 503 errors** for users (~1-2 minute outage per crash while the pod restarts and passes its readiness probe).

## Root Cause

`MongoDBSaver` persists the full LangGraph graph state on every checkpoint write. In single-node mode, two channels accumulate large amounts of data that is **always re-populated from the in-process skill cache** at the start of every invocation and should never be stored in MongoDB.

## Fix

Two new helper functions added to `checkpointer.py`:

- `_strip_skills_from_checkpoint(checkpoint)` - removes /skills/* entries and skills_metadata channel
- `_strip_skills_from_writes(writes)` - drops skills_metadata and /skills/* keys from persisted writes

Both functions only modify the MongoDB-bound copy. Live in-memory state is unaffected.

## Impact

- files channel: -422 entries (~1-3 MB) stripped per write
- skills_metadata: ~1-2 MB stripped per write
- Total: ~2-5 MB per write, giving ~3x headroom before 16 MB BSON limit