### PR TITLE
fix(ui): don't persist session-expired errors in chat history

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -63,6 +63,7 @@
         "zustand": "5.0.12"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
@@ -4443,7 +4444,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4555,8 +4555,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4805,6 +4804,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4812,7 +4812,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6495,6 +6495,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -6876,8 +6877,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -10413,7 +10413,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12564,7 +12563,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12580,7 +12578,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12680,8 +12677,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "@codemirror/lang-markdown": "6.5.0",
     "@codemirror/language-data": "6.5.2",
     "@codemirror/theme-one-dark": "6.1.3",
+    "@mongodb-js/saslprep": "1.4.6",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-label": "2.1.8",
@@ -45,7 +46,6 @@
     "langfuse": "3.38.20",
     "lodash": "4.18.1",
     "lucide-react": "1.7.0",
-    "@mongodb-js/saslprep": "1.4.6",
     "mongodb": "7.1.1",
     "next": "16.2.3",
     "next-auth": "4.24.13",
@@ -67,6 +67,7 @@
     "zustand": "5.0.12"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -863,7 +863,10 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
 
     } catch (error) {
       console.error("[A2A SDK] Stream error:", error);
-      appendToMessage(convId, assistantMsgId, `\n\n**Error:** ${(error as Error).message || "Failed to connect to A2A endpoint"}`);
+      // Session expiry is handled by TokenExpiryGuard — don't persist the error in chat history
+      if (!(error as Error).message?.startsWith("Session expired:")) {
+        appendToMessage(convId, assistantMsgId, `\n\n**Error:** ${(error as Error).message || "Failed to connect to A2A endpoint"}`);
+      }
       setConversationStreaming(convId, null);
     }
   }, [isThisConversationStreaming, activeConversationId, endpoint, accessToken, selectedAgentId, createConversation, clearA2AEvents, clearSSEEvents, addMessage, appendToMessage, updateMessage, addEventToMessage, addA2AEvent, addSSEEvent, setConversationStreaming]);
@@ -1301,8 +1304,10 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
       setConversationStreaming(activeConversationId, null);
     } catch (error) {
       console.error("[ChatPanel] HITL resume error:", error);
-      appendToMessage(activeConversationId, assistantMsgId,
-        `\n\n**Error:** ${(error as Error).message || "Failed to resume"}`);
+      if (!(error as Error).message?.startsWith("Session expired:")) {
+        appendToMessage(activeConversationId, assistantMsgId,
+          `\n\n**Error:** ${(error as Error).message || "Failed to resume"}`);
+      }
       setConversationStreaming(activeConversationId, null);
     }
   }, [pendingUserInput, activeConversationId, endpoint, accessToken, addMessage, updateMessage,
@@ -1455,8 +1460,10 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
       setConversationStreaming(activeConversationId, null);
     } catch (error) {
       console.error("[ChatPanel] SSE HITL resume error:", error);
-      appendToMessage(activeConversationId, assistantMsgId,
-        `\n\n**Error:** ${(error as Error).message || "Failed to resume"}`);
+      if (!(error as Error).message?.startsWith("Session expired:")) {
+        appendToMessage(activeConversationId, assistantMsgId,
+          `\n\n**Error:** ${(error as Error).message || "Failed to resume"}`);
+      }
       setConversationStreaming(activeConversationId, null);
     }
   }, [pendingUserInput, activeConversationId, accessToken, addMessage, updateMessage,

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -811,7 +811,9 @@ export function DynamicAgentChatPanel({ endpoint, conversationId, conversationTi
 
     } catch (error) {
       console.error("[DynamicAgent] Stream error:", error);
-      appendToMessage(convId, assistantMsgId, `\n\n**Error:** ${(error as Error).message || "Failed to connect to agent endpoint"}`);
+      if (!(error as Error).message?.startsWith("Session expired:")) {
+        appendToMessage(convId, assistantMsgId, `\n\n**Error:** ${(error as Error).message || "Failed to connect to agent endpoint"}`);
+      }
       // Set interrupted status on error
       updateMessage(convId!, assistantMsgId, {
         turnStatus: "interrupted" as TurnStatus,

--- a/ui/src/components/chat/__tests__/ChatPanel.session-expired.test.tsx
+++ b/ui/src/components/chat/__tests__/ChatPanel.session-expired.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Unit tests: session-expired errors must not be persisted in chat history.
+ *
+ * When the A2A client receives a 401, it throws "Session expired: …".
+ * The TokenExpiryGuard already handles the UX (modal + redirect), so
+ * appendToMessage must NOT be called for that error class.  All other
+ * errors (network failure, backend 500, etc.) must still appear inline.
+ *
+ * Tests:
+ * - Stream error: session-expired is NOT appended to chat
+ * - Stream error: non-session-expired error IS appended to chat
+ */
+
+import React from 'react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+
+// ============================================================================
+// Polyfills (jsdom gaps)
+// ============================================================================
+
+Element.prototype.scrollIntoView = jest.fn()
+
+// ============================================================================
+// Tracked mocks — stable references so we can assert on them
+// ============================================================================
+
+const mockAppendToMessage = jest.fn()
+const mockAddMessage = jest.fn(() => 'assistant-msg-1')
+const mockGetActiveConversation = jest.fn()
+const mockIsConversationStreaming = jest.fn(() => false)
+const mockSetConversationStreaming = jest.fn()
+
+// ============================================================================
+// Module mocks — must be declared before imports
+// ============================================================================
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(() => ({
+    data: { user: { name: 'Test', email: 'test@test.com' }, accessToken: 'tok' },
+    status: 'authenticated',
+    update: jest.fn(),
+  })),
+}))
+
+jest.mock('@/store/chat-store', () => {
+  const mockUseChatStore: any = jest.fn(() => ({
+    activeConversationId: 'conv-1',
+    getActiveConversation: mockGetActiveConversation,
+    createConversation: jest.fn(() => 'conv-1'),
+    addMessage: mockAddMessage,
+    updateMessage: jest.fn(),
+    appendToMessage: mockAppendToMessage,
+    addEventToMessage: jest.fn(),
+    addA2AEvent: jest.fn(),
+    clearA2AEvents: jest.fn(),
+    addSSEEvent: jest.fn(),
+    clearSSEEvents: jest.fn(),
+    setConversationStreaming: mockSetConversationStreaming,
+    isConversationStreaming: mockIsConversationStreaming,
+    cancelConversationRequest: jest.fn(),
+    updateMessageFeedback: jest.fn(),
+    consumePendingMessage: jest.fn(() => null),
+    recoverInterruptedTask: jest.fn(),
+    evictOldMessageContent: jest.fn(),
+    loadMessagesFromServer: jest.fn(),
+    updateConversationTitle: jest.fn(),
+  }))
+  mockUseChatStore.getState = jest.fn(() => ({ conversations: [] }))
+  return { useChatStore: mockUseChatStore }
+})
+
+jest.mock('@/lib/a2a-sdk-client', () => ({
+  A2ASDKClient: jest.fn(),
+  toStoreEvent: jest.fn((e: any, id: string) => ({ ...e, id })),
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn((key: string) => {
+    const cfg: Record<string, any> = {
+      appName: 'Test App',
+      tagline: 'Tagline',
+      description: 'Desc',
+      ssoEnabled: false,
+    }
+    return cfg[key] ?? null
+  }),
+}))
+
+jest.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+  deduplicateByKey: (arr: any[], keyFn: (i: any) => string) => {
+    const seen = new Set<string>()
+    return arr.filter((item: any) => {
+      const key = keyFn(item)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  },
+}))
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef(({ children, ...p }: any, ref: any) => <div ref={ref} {...p}>{children}</div>),
+    button: React.forwardRef(({ children, ...p }: any, ref: any) => <button ref={ref} {...p}>{children}</button>),
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}))
+
+jest.mock('react-markdown', () => ({ children }: any) => <div>{children}</div>)
+jest.mock('remark-gfm', () => () => {})
+jest.mock('react-syntax-highlighter', () => ({
+  Prism: ({ children }: any) => <pre>{children}</pre>,
+}))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+jest.mock('react-textarea-autosize', () =>
+  React.forwardRef((props: any, ref: any) => <textarea ref={ref} {...props} />)
+)
+
+jest.mock('../FeedbackButton', () => ({ FeedbackButton: () => null }))
+jest.mock('../CustomCallButtons', () => ({ DEFAULT_AGENTS: [], CustomCall: () => null }))
+jest.mock('@/components/shared/AgentLogos', () => ({ AGENT_LOGOS: {} }))
+jest.mock('../MetadataInputForm', () => ({ MetadataInputForm: () => null }))
+jest.mock('../AgentStreamBox', () => ({
+  AgentStreamBox: () => <div data-testid="agent-stream-box" />,
+}))
+
+jest.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: React.forwardRef(({ children, viewportRef, ...props }: any, ref: any) => {
+    const setRef = React.useCallback((node: HTMLDivElement | null) => {
+      if (viewportRef) viewportRef.current = node
+    }, [viewportRef])
+    return (
+      <div ref={ref} data-testid="scroll-area" {...props}>
+        <div ref={setRef} data-testid="scroll-viewport">{children}</div>
+      </div>
+    )
+  }),
+}))
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+  TooltipProvider: ({ children }: any) => <>{children}</>,
+  TooltipTrigger: React.forwardRef(({ children, asChild, ...props }: any, ref: any) => {
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement<any>, { ref, ...props })
+    }
+    return <div ref={ref} {...props}>{children}</div>
+  }),
+}))
+
+jest.mock('@/components/ui/button', () => ({
+  Button: React.forwardRef(({ children, ...p }: any, ref: any) => <button ref={ref} {...p}>{children}</button>),
+}))
+
+// ============================================================================
+// Imports — after mocks
+// ============================================================================
+
+import { ChatPanel } from '../ChatPanel'
+import { A2ASDKClient } from '@/lib/a2a-sdk-client'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function setupA2AClientToThrow(errorMessage: string) {
+  ;(A2ASDKClient as jest.Mock).mockImplementation(() => ({
+    abort: jest.fn(),
+    sendMessageStream: jest.fn().mockImplementation(async function* () {
+      throw new Error(errorMessage)
+    }),
+  }))
+}
+
+async function renderAndSendMessage(message = 'hello world') {
+  mockGetActiveConversation.mockReturnValue({
+    id: 'conv-1',
+    title: 'Test',
+    messages: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  })
+
+  render(<ChatPanel endpoint="/api/test" />)
+
+  const textarea = screen.getByRole('textbox')
+  fireEvent.change(textarea, { target: { value: message } })
+
+  await act(async () => {
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 })
+    // Flush microtask queue so the async submitMessage catch block runs
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ChatPanel — session-expired error suppression', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsConversationStreaming.mockReturnValue(false)
+    mockAddMessage.mockReturnValue('assistant-msg-1')
+  })
+
+  it('does NOT append "Session expired" error to chat history', async () => {
+    setupA2AClientToThrow(
+      'Session expired: Your authentication token has expired. Please save your work and log in again.'
+    )
+
+    await renderAndSendMessage()
+
+    await waitFor(() => {
+      const calls = mockAppendToMessage.mock.calls
+      const hasSessionExpiredMsg = calls.some(
+        (args) => typeof args[2] === 'string' && args[2].includes('Session expired')
+      )
+      expect(hasSessionExpiredMsg).toBe(false)
+    })
+  })
+
+  it('DOES append non-session-expired errors to chat history', async () => {
+    setupA2AClientToThrow('Network error: connection refused')
+
+    await renderAndSendMessage()
+
+    await waitFor(() => {
+      expect(mockAppendToMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.stringContaining('Network error: connection refused')
+      )
+    })
+  })
+
+  it('does not suppress errors that merely contain "session" elsewhere in the message', async () => {
+    setupA2AClientToThrow('Invalid session configuration detected')
+
+    await renderAndSendMessage()
+
+    await waitFor(() => {
+      expect(mockAppendToMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.stringContaining('Invalid session configuration detected')
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- When A2A client gets a 401, it throws `Session expired: ...`
- Previously this was appended into the assistant message and persisted in MongoDB — recovering a chat showed the error inline
- The `TokenExpiryGuard` already handles the UX (modal + redirect), so skip `appendToMessage` for session expiry errors
- Fixed in all 4 catch blocks: `ChatPanel.tsx` (3 blocks) and `DynamicAgentChatPanel.tsx` (1 block)

## Test plan

- [ ] Trigger a session expiry mid-chat (let token expire or manually invalidate)
- [ ] Verify `TokenExpiryGuard` modal appears as expected
- [ ] Verify the chat thread does NOT contain an inline `**Error:** Session expired:` message after recovery
- [ ] Verify other (non-auth) errors still appear inline in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)