### PR TITLE
fix(supervisor): add defaults to ResponseFormat required bool fields

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/response_format.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/response_format.py
@@ -18,14 +18,14 @@ class InputField(BaseModel):
 
 class Metadata(BaseModel):
     """Model for response metadata"""
-    user_input: bool = Field(description="Whether user input is required. Set to true when tools ask for specific information from user.")
+    user_input: bool = Field(default=False, description="Whether user input is required. Set to true when tools ask for specific information from user.")
     input_fields: Optional[List[InputField]] = Field(default=None, description="List of input fields extracted from the tool's specific request, if any")
 
 
 class PlatformEngineerResponse(BaseModel):
     """Structured response format for AI Platform Engineer"""
-    is_task_complete: bool = Field(description="Whether the task is complete. Set to false if tools ask for more information.")
-    require_user_input: bool = Field(description="Whether user input is required. Set to true if tools request specific information from user.")
+    is_task_complete: bool = Field(default=True, description="Whether the task is complete. Set to false if tools ask for more information.")
+    require_user_input: bool = Field(default=False, description="Whether user input is required. Set to true if tools request specific information from user.")
     was_task_successful: bool = Field(default=True, description="Whether the task was completed successfully. Set to false when the task failed (e.g., a sub-agent was unavailable, an operation errored out) but there is nothing more you can do.")
     content: str = Field(description="The main response content in markdown format. When tools ask for information, preserve their exact message without rewriting.")
     metadata: Optional[Metadata] = Field(default=None, description="Additional metadata about the response")

--- a/ai_platform_engineering/multi_agents/platform_engineer/tests/test_response_format.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/tests/test_response_format.py
@@ -113,12 +113,16 @@ class TestMetadata:
         meta = Metadata(user_input=True, input_fields=[])
         assert meta.input_fields == []
 
-    def test_missing_user_input_raises_validation_error(self):
-        """Missing user_input raises ValidationError."""
-        with pytest.raises(ValidationError) as exc_info:
-            Metadata(input_fields=[])
-        errors = exc_info.value.errors()
-        assert any(e["loc"] == ("user_input",) for e in errors)
+    def test_user_input_defaults_to_false(self):
+        """user_input defaults to False when omitted (prevents ResponseFormat retry loop)."""
+        meta = Metadata(input_fields=[])
+        assert meta.user_input is False
+
+    def test_metadata_no_args_defaults_user_input_false(self):
+        """Metadata() with no args defaults user_input=False."""
+        meta = Metadata()
+        assert meta.user_input is False
+        assert meta.input_fields is None
 
     def test_user_input_as_true(self):
         """user_input as True."""
@@ -236,8 +240,20 @@ class TestPlatformEngineerResponse:
         assert response.was_task_successful is False
         assert "unavailable" in response.content
 
-    def test_missing_required_fields_raises_validation_error(self):
-        """Missing required fields raise ValidationError."""
+    def test_bool_defaults_allow_content_only_response(self):
+        """is_task_complete and require_user_input default — only content is required.
+
+        This documents the fix for the ResponseFormat retry loop: a partial LLM
+        response that omits the bool flags no longer fails Pydantic validation.
+        """
+        response = PlatformEngineerResponse(content="Documentation retrieved.")
+        assert response.is_task_complete is True
+        assert response.require_user_input is False
+        assert response.was_task_successful is True
+        assert response.metadata is None
+
+    def test_missing_content_still_raises_validation_error(self):
+        """content is still required — PlatformEngineerResponse() without it fails."""
         with pytest.raises(ValidationError):
             PlatformEngineerResponse()
 

--- a/tests/test_supervisor_fetch_document_cap_e2e.py
+++ b/tests/test_supervisor_fetch_document_cap_e2e.py
@@ -354,3 +354,65 @@ class TestCounterPersistenceAcrossGraphRebuilds:
                 assert caps == 1, f"User {uid}: expected 1 cap, got {caps}"
 
         asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# ResponseFormat default-field regression tests
+# Reproduces the "bails after 1 step, 5 retries" bug from caipe-prod logs.
+# The bug: Metadata.user_input and PlatformEngineerResponse bool flags were
+# required with no defaults → Pydantic raised ValidationError → ModelRetryMiddleware
+# retried 5× → bailed with on_failure="continue" → no response emitted.
+# ---------------------------------------------------------------------------
+
+class TestResponseFormatDefaults:
+
+    def test_platform_engineer_response_content_only_parses(self):
+        """PlatformEngineerResponse with only content parses without ValidationError.
+
+        This is the exact payload shape a model produces after a read-only task
+        like 'fetch doc + present documentation' — booleans omitted.
+        """
+        from ai_platform_engineering.multi_agents.platform_engineer.response_format import (
+            PlatformEngineerResponse,
+        )
+        import json
+
+        payload = json.dumps({"content": "Here is the Claude Code setup documentation."})
+        response = PlatformEngineerResponse.model_validate_json(payload)
+
+        assert response.content == "Here is the Claude Code setup documentation."
+        assert response.is_task_complete is True
+        assert response.require_user_input is False
+        assert response.was_task_successful is True
+        assert response.metadata is None
+
+    def test_metadata_without_user_input_field_parses(self):
+        """Metadata omitting user_input still parses (defaults to False).
+
+        This is the other failure path: model includes metadata block but
+        omits user_input → previously crashed Pydantic validation.
+        """
+        from ai_platform_engineering.multi_agents.platform_engineer.response_format import (
+            PlatformEngineerResponse,
+        )
+        import json
+
+        payload = json.dumps({
+            "content": "Task complete.",
+            "metadata": {"input_fields": None},
+        })
+        response = PlatformEngineerResponse.model_validate_json(payload)
+
+        assert response.metadata is not None
+        assert response.metadata.user_input is False
+
+    def test_fully_omitted_booleans_all_default_correctly(self):
+        """All three bool fields default to their sensible values when omitted."""
+        from ai_platform_engineering.multi_agents.platform_engineer.response_format import (
+            PlatformEngineerResponse,
+        )
+
+        r = PlatformEngineerResponse(content="Done.")
+        assert r.is_task_complete is True
+        assert r.require_user_input is False
+        assert r.was_task_successful is True


### PR DESCRIPTION
## Summary

- `PlatformEngineerResponse.is_task_complete` and `require_user_input` were required booleans with no defaults — a partial LLM response omitting them failed Pydantic validation
- `Metadata.user_input` had the same issue
- This triggered `ModelRetryMiddleware` to retry 5× before bailing with `on_failure="continue"`, producing no response (observed in caipe-prod as supervisor calling `ResponseFormat` 5 times then bailing after 1 step)
- Added defaults: `is_task_complete=True`, `require_user_input=False`, `user_input=False`

## Test plan

- [x] Updated `test_response_format.py`: replaced `test_missing_user_input_raises_validation_error` (now wrong) with tests documenting the new defaults; added `test_bool_defaults_allow_content_only_response`
- [x] Added `TestResponseFormatDefaults` in `test_supervisor_fetch_document_cap_e2e.py` covering the exact partial-payload shapes that were previously failing
- [x] All 37 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)