### PR TITLE
fix(ui): pin @testing-library/dom to exact version 10.4.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -67,7 +67,7 @@
     "zustand": "5.0.12"
   },
   "devDependencies": {
-    "@testing-library/dom": "^10.4.1",
+    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",


### PR DESCRIPTION
## Summary

- `@testing-library/dom` in `ui/package.json` devDependencies used `^10.4.1` (semver range)
- This fails the pinned-deps CI check that requires all Node deps to be exact versions
- Fixes CI failure in https://github.com/cnoe-io/ai-platform-engineering/actions/runs/24555087250/job/71789471719

## Test plan

- [x] `python scripts/check_pinned_deps.py` passes locally with exact version

🤖 Generated with [Claude Code](https://claude.com/claude-code)