### PR TITLE
fix(supervisor): add curl tool for PUT/POST support and web fetching

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -83,7 +83,6 @@ from ai_platform_engineering.multi_agents.platform_engineer.rag_prompts import g
 
 from ai_platform_engineering.multi_agents.tools import (
     curl,
-    fetch_url,
     get_current_date,
     jq,
     yq,
@@ -1377,7 +1376,6 @@ class PlatformEngineerDeepAgent:
         # Utility tools
         utility_tools = [
             curl,
-            fetch_url,
             get_current_date,
             jq,
             yq,
@@ -1518,7 +1516,7 @@ class PlatformEngineerDeepAgent:
         if USE_STRUCTURED_RESPONSE:
             system_prompt += (
                 "\n\n**Before invoking any tool, write one brief natural-language sentence describing what you are about to do.** "
-                "Describe the *intent* in plain English — NEVER mention internal tool names (search, fetch_document, fetch_url, write_todos, task, etc.). "
+                "Describe the *intent* in plain English — NEVER mention internal tool names (search, fetch_document, curl, write_todos, task, etc.). "
                 "For example: \"I'll search the knowledge base for information about X.\" or "
                 "\"Let me look up the full documentation for more details.\" or "
                 "\"I'll check with the GitHub agent for repository information.\"\n"

--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -82,6 +82,7 @@ from ai_platform_engineering.utils.prompt_config import (
 from ai_platform_engineering.multi_agents.platform_engineer.rag_prompts import get_rag_instructions
 
 from ai_platform_engineering.multi_agents.tools import (
+    curl,
     fetch_url,
     get_current_date,
     jq,
@@ -1375,6 +1376,7 @@ class PlatformEngineerDeepAgent:
 
         # Utility tools
         utility_tools = [
+            curl,
             fetch_url,
             get_current_date,
             jq,

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -57,7 +57,6 @@ logging.getLogger("langfuse.media").setLevel(logging.CRITICAL)
 # is sufficient for the client.
 _SUPPRESS_CONTENT_TOOLS: frozenset[str] = frozenset({
     "curl",
-    "fetch_url",
     "fetch_markdown",
     "wget",
 })

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -51,6 +51,17 @@ logger = logging.getLogger(__name__)
 # base64 data URI.  Skill SKILL.md content triggers this harmlessly.
 logging.getLogger("langfuse.media").setLevel(logging.CRITICAL)
 
+# Tool names whose raw content must not be streamed to clients.
+# These tools return large payloads (HTML, JSON bodies, raw HTTP responses)
+# that are for LLM internal use only — the tool_call completion notification
+# is sufficient for the client.
+_SUPPRESS_CONTENT_TOOLS: frozenset[str] = frozenset({
+    "curl",
+    "fetch_url",
+    "fetch_markdown",
+    "wget",
+})
+
 
 @dataclass
 class PlanState:
@@ -1617,9 +1628,9 @@ class AIPlatformEngineerA2ABinding:
                   # [{...}]" which doesn't match the UI regex.
                   if tool_name == "write_todos":
                       logging.debug("📋 Skipping write_todos ToolMessage for exec plan (handled by updates handler)")
-                  elif tool_name in rag_tool_names:
-                    # For RAG tools, we don't want to stream the content, as its a LOT of text
-                      logging.debug(f"Suppressing RAG tool content for {tool_name} (tool_call notification already sent)")
+                  elif tool_name in rag_tool_names or tool_name in _SUPPRESS_CONTENT_TOOLS:
+                    # For RAG/HTTP tools, suppress raw content from stream (client uses tool_call notification)
+                      logging.debug(f"Suppressing tool content for {tool_name} (tool_call notification already sent)")
                   # Stream other tool content as a tool notification (not chat text)
                   # During self-service workflows, suppress intermediate tool output —
                   # the final structured response will contain a clean summary

--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -51,17 +51,6 @@ logger = logging.getLogger(__name__)
 # base64 data URI.  Skill SKILL.md content triggers this harmlessly.
 logging.getLogger("langfuse.media").setLevel(logging.CRITICAL)
 
-# Tool names whose raw content must not be streamed to clients.
-# These tools return large payloads (HTML, JSON bodies, raw HTTP responses)
-# that are for LLM internal use only — the tool_call completion notification
-# is sufficient for the client.
-_SUPPRESS_CONTENT_TOOLS: frozenset[str] = frozenset({
-    "curl",
-    "fetch_markdown",
-    "wget",
-})
-
-
 @dataclass
 class PlanState:
     """Per-request execution plan tracking.
@@ -1627,8 +1616,8 @@ class AIPlatformEngineerA2ABinding:
                   # [{...}]" which doesn't match the UI regex.
                   if tool_name == "write_todos":
                       logging.debug("📋 Skipping write_todos ToolMessage for exec plan (handled by updates handler)")
-                  elif tool_name in rag_tool_names or tool_name in _SUPPRESS_CONTENT_TOOLS:
-                    # For RAG/HTTP tools, suppress raw content from stream (client uses tool_call notification)
+                  elif tool_name in rag_tool_names or tool_name == "curl":
+                    # For RAG tools and curl, suppress raw content from stream (client uses tool_call notification)
                       logging.debug(f"Suppressing tool content for {tool_name} (tool_call notification already sent)")
                   # Stream other tool content as a tool notification (not chat text)
                   # During self-service workflows, suppress intermediate tool output —

--- a/ai_platform_engineering/multi_agents/platform_engineer/rag_prompts.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/rag_prompts.py
@@ -46,11 +46,13 @@ _ALL_GRAPH_TOOLS_PROMPT = _rag_prompt_config.get("graph_tools_prompt", "") if _r
 _GRAPH_RAW_QUERY_NOTES = _rag_prompt_config.get("graph_raw_query_notes", "") if _rag_prompt_config else ""
 _RAG_ANSWER_FORMAT_PROMPT = _rag_prompt_config.get("answer_format_prompt", "") if _rag_prompt_config else ""
 _START_RAG_PROMPT = _rag_prompt_config.get("start_rag_prompt", "") if _rag_prompt_config else ""
+_TOOL_ARBITRATION_PROMPT = _rag_prompt_config.get("tool_arbitration_prompt", "") if _rag_prompt_config else ""
 
 _RAG_ONLY_INSTRUCTIONS = f"""
 {_START_RAG_PROMPT}
 {_SEARCH_TOOL_PROMPT}
 {_RAG_ANSWER_FORMAT_PROMPT}
+{_TOOL_ARBITRATION_PROMPT}
 """
 
 _RAG_WITH_GRAPH_INSTRUCTIONS = f"""
@@ -60,6 +62,7 @@ _RAG_WITH_GRAPH_INSTRUCTIONS = f"""
 {_ALL_GRAPH_TOOLS_PROMPT}
 {_GRAPH_RAW_QUERY_NOTES}
 {_RAG_ANSWER_FORMAT_PROMPT}
+{_TOOL_ARBITRATION_PROMPT}
 """
 
 

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -42,26 +42,43 @@ def curl(
     """
     Execute any curl command for HTTP requests (https:// only).
 
+    Use this for all HTTP operations: GET, POST, PUT, PATCH, DELETE, file downloads,
+    and fetching web page content. Replaces wget and fetch_markdown.
+
     Args:
         command: Curl command to run (e.g., "curl -s https://api.example.com/users")
         timeout: Command timeout in seconds (default: 300)
-        strip_html: If True, strip HTML tags and return plain text (useful for web pages)
+        strip_html: If True, strip HTML tags and return plain text (useful for reading web pages)
 
     Returns:
         Command output as string. On error, returns "ERROR: <message>"
 
     Examples:
+        # GET request
         curl("curl -s https://api.example.com/users")
+
+        # PUT request with JSON body
+        curl("curl -s -X PUT https://api.example.com/resource -H 'Content-Type: application/json' -d '{\"status\":\"done\"}'")
+
+        # POST with auth header
+        curl("curl -s -X POST https://api.example.com/items -H 'Authorization: Bearer TOKEN' -d '{\"name\":\"test\"}'")
+
+        # Download a file (wget equivalent)
+        curl("curl -sL -o /tmp/file.zip https://example.com/file.zip")
+
+        # Read a web page as plain text (fetch_markdown equivalent)
+        curl("curl -sL https://docs.example.com/guide", strip_html=True)
+
+        # Follow redirects
         curl("curl -sL https://example.com/redirect")
-        curl("curl -s -X POST -H 'Content-Type: application/json' -d '{\"name\":\"test\"}' https://api.example.com/users")
-        curl("curl -s https://docs.example.com/guide", strip_html=True)
 
     Common Options:
-        -s, --silent      Silent mode (no progress)
+        -s, --silent      Silent mode (no progress bar)
         -L, --location    Follow redirects
-        -X, --request     HTTP method (GET, POST, PUT, DELETE, etc.)
-        -H, --header      Add header
-        -d, --data        POST data
+        -X, --request     HTTP method (GET, POST, PUT, PATCH, DELETE)
+        -H, --header      Add request header
+        -d, --data        Request body
+        -o, --output      Save response to file (wget-style download)
     """
     try:
         args = shlex.split(command)

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -16,26 +16,9 @@ from langchain_core.tools import tool
 
 CURL_TIMEOUT = 300  # 5 minutes default
 
-# Flags that write to disk or read curl config files — disallow to prevent
-# filesystem side-effects from LLM-generated commands.
-_BLOCKED_FLAGS: frozenset[str] = frozenset({
-    "--config", "-K",
-})
-
-
 def _validate_curl_args(args: list[str]) -> str | None:
-    """Return a detailed user-facing message if args contain blocked flags or non-HTTPS URLs."""
+    """Return a detailed user-facing message if args contain non-HTTPS URLs."""
     for token in args:
-        flag = token.split("=")[0]
-        if flag in _BLOCKED_FLAGS:
-            return (
-                f"The flag '{flag}' is not supported for security reasons.\n\n"
-                "**Blocked flags:**\n"
-                "- `--config` / `-K` — loading curl config files from disk is not allowed\n\n"
-                "**Supported usage:** Pass headers (`-H`), request body (`-d`), HTTP method (`-X`), "
-                "output file (`-o`), and `https://` URLs directly in the command string."
-            )
-
         if "://" in token and not token.startswith("https://"):
             scheme = token.split("://")[0] + "://"
             return (

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -25,16 +25,30 @@ _BLOCKED_FLAGS: frozenset[str] = frozenset({
 
 
 def _validate_curl_args(args: list[str]) -> str | None:
-    """Return an error string if args contain blocked flags or non-HTTPS URLs."""
+    """Return a detailed user-facing message if args contain blocked flags or non-HTTPS URLs."""
     for token in args:
-        # Block dangerous flags (exact token match handles both "-o file" and "--output=file")
         flag = token.split("=")[0]
         if flag in _BLOCKED_FLAGS:
-            return f"ERROR: Flag '{flag}' is not allowed"
+            return (
+                f"The flag '{flag}' is not supported for security reasons.\n\n"
+                "**Blocked flags:**\n"
+                "- `-o` / `--output` — writing curl output directly to disk is not allowed; "
+                "use the response content in your next step instead\n"
+                "- `--config` / `-K` — loading curl config files from disk is not allowed\n\n"
+                "**Supported usage:** Pass headers (`-H`), request body (`-d`), HTTP method (`-X`), "
+                "and `https://` URLs directly in the command string."
+            )
 
-        # Block any non-HTTPS URL (anything containing a scheme)
         if "://" in token and not token.startswith("https://"):
-            return f"ERROR: Only https:// URLs are allowed (got '{token.split('?')[0]}')"
+            scheme = token.split("://")[0] + "://"
+            return (
+                f"The URL scheme '{scheme}' is not supported.\n\n"
+                "**Only `https://` URLs are allowed.** This tool does not support:\n"
+                "- `http://` — unencrypted HTTP\n"
+                "- `file://` — local filesystem access\n"
+                "- `ftp://`, `gopher://`, or other protocols\n\n"
+                f"Please use an `https://` endpoint instead of `{token.split('?')[0]}`."
+            )
 
     return None
 

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -43,7 +43,7 @@ def curl(
     Execute any curl command for HTTP requests (https:// only).
 
     Use this for all HTTP operations: GET, POST, PUT, PATCH, DELETE, file downloads,
-    and fetching web page content. Replaces wget and fetch_markdown.
+    and fetching web page content.
 
     Args:
         command: Curl command to run (e.g., "curl -s https://api.example.com/users")

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -21,6 +21,7 @@ CURL_TIMEOUT = 300  # 5 minutes default
 def curl(
     command: str,
     timeout: int = CURL_TIMEOUT,
+    strip_html: bool = False,
 ) -> str:
     """
     Execute any curl command for HTTP requests.
@@ -28,6 +29,7 @@ def curl(
     Args:
         command: Curl command to run (e.g., "curl -s https://api.example.com/users")
         timeout: Command timeout in seconds (default: 300)
+        strip_html: If True, strip HTML tags and return plain text (useful for web pages)
 
     Returns:
         Command output as string. On error, returns "ERROR: <message>"
@@ -36,6 +38,7 @@ def curl(
         curl("curl -s https://api.example.com/users")
         curl("curl -sL https://example.com/redirect")
         curl("curl -s -X POST -H 'Content-Type: application/json' -d '{\"name\":\"test\"}' https://api.example.com/users")
+        curl("curl -s https://docs.example.com/guide", strip_html=True)
 
     Common Options:
         -s, --silent      Silent mode (no progress)
@@ -72,7 +75,20 @@ def curl(
         if result.returncode != 0:
             return f"ERROR: {output}" if output else "ERROR: Command failed"
 
-        return output if output else "Success (no output)"
+        if not output:
+            return "Success (no output)"
+
+        if strip_html:
+            try:
+                from bs4 import BeautifulSoup  # noqa: PLC0415
+                soup = BeautifulSoup(output, 'html.parser')
+                for tag in soup(["script", "style"]):
+                    tag.decompose()
+                return soup.get_text(separator='\n', strip=True)
+            except ImportError:
+                pass  # bs4 not available, return raw output
+
+        return output
 
     except subprocess.TimeoutExpired:
         return f"ERROR: Command timed out after {timeout} seconds"

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -16,6 +16,28 @@ from langchain_core.tools import tool
 
 CURL_TIMEOUT = 300  # 5 minutes default
 
+# Flags that write to disk or read curl config files — disallow to prevent
+# filesystem side-effects from LLM-generated commands.
+_BLOCKED_FLAGS: frozenset[str] = frozenset({
+    "-o", "--output",
+    "--config", "-K",
+})
+
+
+def _validate_curl_args(args: list[str]) -> str | None:
+    """Return an error string if args contain blocked flags or non-HTTPS URLs."""
+    for token in args:
+        # Block dangerous flags (exact token match handles both "-o file" and "--output=file")
+        flag = token.split("=")[0]
+        if flag in _BLOCKED_FLAGS:
+            return f"ERROR: Flag '{flag}' is not allowed"
+
+        # Block any non-HTTPS URL (anything containing a scheme)
+        if "://" in token and not token.startswith("https://"):
+            return f"ERROR: Only https:// URLs are allowed (got '{token.split('?')[0]}')"
+
+    return None
+
 
 @tool
 def curl(
@@ -24,7 +46,7 @@ def curl(
     strip_html: bool = False,
 ) -> str:
     """
-    Execute any curl command for HTTP requests.
+    Execute any curl command for HTTP requests (https:// only).
 
     Args:
         command: Curl command to run (e.g., "curl -s https://api.example.com/users")
@@ -46,7 +68,6 @@ def curl(
         -X, --request     HTTP method (GET, POST, PUT, DELETE, etc.)
         -H, --header      Add header
         -d, --data        POST data
-        -o, --output      Write output to file
     """
     try:
         args = shlex.split(command)
@@ -56,6 +77,10 @@ def curl(
     # Ensure command starts with 'curl'
     if not args or args[0] != 'curl':
         args = ['curl'] + args
+
+    error = _validate_curl_args(args[1:])
+    if error:
+        return error
 
     try:
         result = subprocess.run(

--- a/ai_platform_engineering/utils/agent_tools/curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/curl_tool.py
@@ -19,7 +19,6 @@ CURL_TIMEOUT = 300  # 5 minutes default
 # Flags that write to disk or read curl config files — disallow to prevent
 # filesystem side-effects from LLM-generated commands.
 _BLOCKED_FLAGS: frozenset[str] = frozenset({
-    "-o", "--output",
     "--config", "-K",
 })
 
@@ -32,11 +31,9 @@ def _validate_curl_args(args: list[str]) -> str | None:
             return (
                 f"The flag '{flag}' is not supported for security reasons.\n\n"
                 "**Blocked flags:**\n"
-                "- `-o` / `--output` — writing curl output directly to disk is not allowed; "
-                "use the response content in your next step instead\n"
                 "- `--config` / `-K` — loading curl config files from disk is not allowed\n\n"
                 "**Supported usage:** Pass headers (`-H`), request body (`-d`), HTTP method (`-X`), "
-                "and `https://` URLs directly in the command string."
+                "output file (`-o`), and `https://` URLs directly in the command string."
             )
 
         if "://" in token and not token.startswith("https://"):

--- a/ai_platform_engineering/utils/agent_tools/tests/test_curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/tests/test_curl_tool.py
@@ -96,6 +96,14 @@ class TestCurlArgHandling:
         assert "PUT" in args
         assert result == '{"status":"ok"}'
 
+    def test_file_download_with_output_flag(self):
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout="")) as mock_run:
+            result = curl.invoke({"command": "curl -sL -o /tmp/file.zip https://example.com/file.zip"})
+        args = mock_run.call_args[0][0]
+        assert "-o" in args
+        assert "/tmp/file.zip" in args
+        assert result == "Success (no output)"
+
     def test_invalid_shlex_returns_error(self):
         result = curl.invoke({"command": "curl 'unterminated"})
         assert result.startswith("ERROR:")

--- a/ai_platform_engineering/utils/agent_tools/tests/test_curl_tool.py
+++ b/ai_platform_engineering/utils/agent_tools/tests/test_curl_tool.py
@@ -1,0 +1,195 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for curl_tool — guardrails, subprocess behaviour, strip_html."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from ai_platform_engineering.utils.agent_tools.curl_tool import (
+    _validate_curl_args,
+    curl,
+)
+
+
+# ---------------------------------------------------------------------------
+# _validate_curl_args — URL guardrail
+# ---------------------------------------------------------------------------
+
+class TestValidateCurlArgs:
+
+    def test_https_url_accepted(self):
+        assert _validate_curl_args(["-s", "https://api.example.com/users"]) is None
+
+    def test_https_url_with_path_and_query_accepted(self):
+        assert _validate_curl_args(["https://api.example.com/v1/items?limit=10"]) is None
+
+    def test_http_url_rejected(self):
+        msg = _validate_curl_args(["http://api.example.com"])
+        assert msg is not None
+        assert "http://" in msg
+        assert "https://" in msg
+
+    def test_file_url_rejected(self):
+        msg = _validate_curl_args(["file:///etc/passwd"])
+        assert msg is not None
+        assert "file://" in msg
+
+    def test_ftp_url_rejected(self):
+        msg = _validate_curl_args(["ftp://files.example.com/data"])
+        assert msg is not None
+        assert "ftp://" in msg
+
+    def test_no_url_in_args_accepted(self):
+        assert _validate_curl_args(["-s", "-X", "GET", "-H", "Accept: application/json"]) is None
+
+    def test_empty_args_accepted(self):
+        assert _validate_curl_args([]) is None
+
+    def test_error_message_strips_query_string(self):
+        msg = _validate_curl_args(["http://api.example.com/path?token=secret"])
+        assert "token=secret" not in msg
+        assert "http://api.example.com/path" in msg
+
+    def test_error_message_mentions_supported_protocols(self):
+        msg = _validate_curl_args(["ftp://files.example.com"])
+        assert "http://" in msg
+        assert "file://" in msg
+        assert "ftp://" in msg
+
+    def test_multiple_args_one_bad_url_rejected(self):
+        msg = _validate_curl_args(["-s", "-X", "PUT", "http://internal/api"])
+        assert msg is not None
+        assert "http://" in msg
+
+
+# ---------------------------------------------------------------------------
+# curl tool — argument handling
+# ---------------------------------------------------------------------------
+
+class TestCurlArgHandling:
+
+    def _make_completed_process(self, stdout="ok", returncode=0, stderr=""):
+        result = MagicMock(spec=subprocess.CompletedProcess)
+        result.stdout = stdout
+        result.stderr = stderr
+        result.returncode = returncode
+        return result
+
+    def test_curl_prefix_prepended_when_missing(self):
+        with patch("subprocess.run", return_value=self._make_completed_process()) as mock_run:
+            curl.invoke({"command": "-s https://api.example.com"})
+        args = mock_run.call_args[0][0]
+        assert args[0] == "curl"
+
+    def test_curl_prefix_not_doubled(self):
+        with patch("subprocess.run", return_value=self._make_completed_process()) as mock_run:
+            curl.invoke({"command": "curl -s https://api.example.com"})
+        args = mock_run.call_args[0][0]
+        assert args.count("curl") == 1
+
+    def test_put_request_args_passed_through(self):
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout='{"status":"ok"}')) as mock_run:
+            result = curl.invoke({"command": "curl -s -X PUT https://api.example.com/resource -d '{\"key\":\"val\"}'"})
+        args = mock_run.call_args[0][0]
+        assert "-X" in args
+        assert "PUT" in args
+        assert result == '{"status":"ok"}'
+
+    def test_invalid_shlex_returns_error(self):
+        result = curl.invoke({"command": "curl 'unterminated"})
+        assert result.startswith("ERROR:")
+        assert "parse" in result.lower()
+
+    def test_http_url_blocked_before_subprocess(self):
+        with patch("subprocess.run") as mock_run:
+            result = curl.invoke({"command": "curl -s http://api.example.com"})
+        mock_run.assert_not_called()
+        assert "http://" in result
+        assert "https://" in result
+
+    def test_file_url_blocked_before_subprocess(self):
+        with patch("subprocess.run") as mock_run:
+            result = curl.invoke({"command": "curl file:///etc/passwd"})
+        mock_run.assert_not_called()
+        assert "file://" in result
+
+
+# ---------------------------------------------------------------------------
+# curl tool — subprocess result handling
+# ---------------------------------------------------------------------------
+
+class TestCurlSubprocessResults:
+
+    def _make_completed_process(self, stdout="", returncode=0, stderr=""):
+        result = MagicMock(spec=subprocess.CompletedProcess)
+        result.stdout = stdout
+        result.stderr = stderr
+        result.returncode = returncode
+        return result
+
+    def test_successful_response_returned(self):
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout="hello")):
+            result = curl.invoke({"command": "curl -s https://api.example.com"})
+        assert result == "hello"
+
+    def test_empty_output_returns_success_message(self):
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout="")):
+            result = curl.invoke({"command": "curl -s https://api.example.com"})
+        assert result == "Success (no output)"
+
+    def test_nonzero_exit_code_returns_error(self):
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout="", stderr="connection refused", returncode=7)):
+            result = curl.invoke({"command": "curl -s https://api.example.com"})
+        assert result.startswith("ERROR:")
+
+    def test_stderr_appended_to_stdout(self):
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout="data", stderr="warning", returncode=0)):
+            result = curl.invoke({"command": "curl -s https://api.example.com"})
+        assert "data" in result
+        assert "warning" in result
+
+    def test_timeout_returns_error(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="curl", timeout=1)):
+            result = curl.invoke({"command": "curl -s https://api.example.com", "timeout": 1})
+        assert "timed out" in result.lower()
+
+    def test_curl_not_found_returns_error(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = curl.invoke({"command": "curl -s https://api.example.com"})
+        assert "curl command not found" in result
+
+
+# ---------------------------------------------------------------------------
+# curl tool — strip_html
+# ---------------------------------------------------------------------------
+
+class TestCurlStripHtml:
+
+    def _make_completed_process(self, stdout=""):
+        result = MagicMock(spec=subprocess.CompletedProcess)
+        result.stdout = stdout
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
+    def test_strip_html_removes_tags(self):
+        html = "<html><body><h1>Title</h1><p>Content</p><script>js()</script></body></html>"
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout=html)):
+            result = curl.invoke({"command": "curl -s https://example.com", "strip_html": True})
+        assert "<html>" not in result
+        assert "Title" in result
+        assert "Content" in result
+        assert "js()" not in result
+
+    def test_strip_html_false_returns_raw(self):
+        html = "<html><body><p>Hello</p></body></html>"
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout=html)):
+            result = curl.invoke({"command": "curl -s https://example.com", "strip_html": False})
+        assert "<html>" in result
+
+    def test_strip_html_default_is_false(self):
+        html = "<p>raw</p>"
+        with patch("subprocess.run", return_value=self._make_completed_process(stdout=html)):
+            result = curl.invoke({"command": "curl -s https://example.com"})
+        assert "<p>" in result

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.7 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.7-rc.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.7 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.7-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.6-rc.2 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.6-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.6-rc.helm.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/data/prompt_config.rag.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.rag.yaml
@@ -185,6 +185,27 @@ start_rag_prompt: |
   - Always provide a helpful, detailed answer regardless of search results
 
 # ============================================================================
+# Tool Arbitration Prompt (knowledge base vs curl)
+# ============================================================================
+tool_arbitration_prompt: |
+  ### Knowledge Base vs curl — When to Use Which:
+
+  **Always use the knowledge base first (search + fetch_document) when:**
+  - Looking up documentation, runbooks, procedures, or configuration guides
+  - Finding information about internal systems, infrastructure, or teams
+  - Answering "how to", "what is", or "explain" questions
+  - The answer is likely already captured in wikis, Confluence, Slack/Webex threads, or graph entities
+
+  **Use curl only when:**
+  - Making state-changing API calls (PUT, POST, PATCH, DELETE) that modify live systems
+  - Fetching truly live/real-time data from an external API that is not in the knowledge base
+  - The knowledge base has returned no useful results after 3+ attempts AND the information is by nature live (e.g., current pipeline status from an external API with no dedicated sub-agent)
+
+  **Never use curl as a substitute for a knowledge base search.**
+  If the question is "how do I…" or "what is…", search the knowledge base first.
+  curl is for *execution and live data*, not discovery.
+
+# ============================================================================
 # Fallback message when RAG is not available
 # ============================================================================
 rag_not_available_message: "RAG tools are not available"

--- a/charts/ai-platform-engineering/data/prompt_config.rag.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.rag.yaml
@@ -204,7 +204,7 @@ tool_arbitration_prompt: |
   **Never use curl as a substitute for a knowledge base search.**
   If the question is "how do I…" or "what is…", search the knowledge base first.
   curl is for *execution and live data*, not discovery.
-  Exception: if the user explicitly asks you to use curl, or you need real-time data from an external API, use curl — either in addition to searching the knowledge base, or without searching it first.
+  If the user says "run this curl command" or "use curl to…", or you need real-time data that the knowledge base cannot provide, execute curl directly.
 
 # ============================================================================
 # Fallback message when RAG is not available

--- a/charts/ai-platform-engineering/data/prompt_config.rag.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.rag.yaml
@@ -201,9 +201,10 @@ tool_arbitration_prompt: |
   - Fetching truly live/real-time data from an external API that is not in the knowledge base
   - The knowledge base has returned no useful results after 3+ attempts AND the information is by nature live (e.g., current pipeline status from an external API with no dedicated sub-agent)
 
-  **Never use curl as a substitute for a knowledge base search.**
+  **Never use curl as a substitute for a knowledge base search — unless the user explicitly asks you to use curl, or you need to fetch live data from an external API.**
   If the question is "how do I…" or "what is…", search the knowledge base first.
   curl is for *execution and live data*, not discovery.
+  If the user says "run this curl command" or "use curl to…", or you need real-time data that the knowledge base cannot provide, execute curl directly without searching the knowledge base first.
 
 # ============================================================================
 # Fallback message when RAG is not available

--- a/charts/ai-platform-engineering/data/prompt_config.rag.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.rag.yaml
@@ -201,10 +201,10 @@ tool_arbitration_prompt: |
   - Fetching truly live/real-time data from an external API that is not in the knowledge base
   - The knowledge base has returned no useful results after 3+ attempts AND the information is by nature live (e.g., current pipeline status from an external API with no dedicated sub-agent)
 
-  **Never use curl as a substitute for a knowledge base search — unless the user explicitly asks you to use curl, or you need to fetch live data from an external API.**
+  **Never use curl as a substitute for a knowledge base search.**
   If the question is "how do I…" or "what is…", search the knowledge base first.
   curl is for *execution and live data*, not discovery.
-  If the user says "run this curl command" or "use curl to…", or you need real-time data that the knowledge base cannot provide, execute curl directly without searching the knowledge base first.
+  Exception: if the user explicitly asks you to use curl, or you need real-time data from an external API, use curl — either in addition to searching the knowledge base, or without searching it first.
 
 # ============================================================================
 # Fallback message when RAG is not available

--- a/tests/test_supervisor_fetch_document_cap_e2e.py
+++ b/tests/test_supervisor_fetch_document_cap_e2e.py
@@ -358,20 +358,12 @@ class TestCounterPersistenceAcrossGraphRebuilds:
 
 # ---------------------------------------------------------------------------
 # ResponseFormat default-field regression tests
-# Reproduces the "bails after 1 step, 5 retries" bug from caipe-prod logs.
-# The bug: Metadata.user_input and PlatformEngineerResponse bool flags were
-# required with no defaults → Pydantic raised ValidationError → ModelRetryMiddleware
-# retried 5× → bailed with on_failure="continue" → no response emitted.
 # ---------------------------------------------------------------------------
 
 class TestResponseFormatDefaults:
 
     def test_platform_engineer_response_content_only_parses(self):
-        """PlatformEngineerResponse with only content parses without ValidationError.
-
-        This is the exact payload shape a model produces after a read-only task
-        like 'fetch doc + present documentation' — booleans omitted.
-        """
+        """PlatformEngineerResponse with only content parses without ValidationError."""
         from ai_platform_engineering.multi_agents.platform_engineer.response_format import (
             PlatformEngineerResponse,
         )
@@ -387,11 +379,7 @@ class TestResponseFormatDefaults:
         assert response.metadata is None
 
     def test_metadata_without_user_input_field_parses(self):
-        """Metadata omitting user_input still parses (defaults to False).
-
-        This is the other failure path: model includes metadata block but
-        omits user_input → previously crashed Pydantic validation.
-        """
+        """Metadata omitting user_input still parses (defaults to False)."""
         from ai_platform_engineering.multi_agents.platform_engineer.response_format import (
             PlatformEngineerResponse,
         )
@@ -416,3 +404,57 @@ class TestResponseFormatDefaults:
         assert r.is_task_complete is True
         assert r.require_user_input is False
         assert r.was_task_successful is True
+
+
+# ---------------------------------------------------------------------------
+# E2E: curl tool wired into supervisor utility_tools
+# ---------------------------------------------------------------------------
+
+class TestCurlToolInSupervisor:
+
+    def test_curl_present_in_supervisor_tools(self):
+        """curl is in the tools list passed to create_deep_agent after _build_graph()."""
+        with _make_mas_with_rag_tools([]) as (mas, mock_create_graph):
+            mas._build_graph()
+
+        tools = _get_tools_passed_to_create_deep_agent(mock_create_graph)
+        tool_names = {t.name for t in tools}
+        assert "curl" in tool_names
+
+    def test_fetch_url_not_in_supervisor_tools(self):
+        """fetch_url has been replaced by curl and must not appear in utility_tools."""
+        with _make_mas_with_rag_tools([]) as (mas, mock_create_graph):
+            mas._build_graph()
+
+        tools = _get_tools_passed_to_create_deep_agent(mock_create_graph)
+        tool_names = {t.name for t in tools}
+        assert "fetch_url" not in tool_names
+
+    def test_curl_tool_has_strip_html_param(self):
+        """curl tool exposes strip_html parameter."""
+        import inspect
+        from ai_platform_engineering.multi_agents.tools import curl
+        sig = inspect.signature(curl.func if hasattr(curl, "func") else curl)
+        assert "strip_html" in sig.parameters
+
+    def test_curl_tool_has_timeout_param(self):
+        """curl tool exposes timeout parameter."""
+        import inspect
+        from ai_platform_engineering.multi_agents.tools import curl
+        sig = inspect.signature(curl.func if hasattr(curl, "func") else curl)
+        assert "timeout" in sig.parameters
+
+    def test_curl_rejects_http_url_with_informative_message(self):
+        """curl returns a user-facing message (not an exception) for http:// URLs."""
+        from ai_platform_engineering.multi_agents.tools import curl
+        result = curl.invoke({"command": "curl -s http://internal.example.com/api"})
+        assert isinstance(result, str)
+        assert "http://" in result
+        assert "https://" in result
+
+    def test_curl_rejects_file_url_with_informative_message(self):
+        """curl returns a user-facing message for file:// URLs."""
+        from ai_platform_engineering.multi_agents.tools import curl
+        result = curl.invoke({"command": "curl file:///etc/passwd"})
+        assert isinstance(result, str)
+        assert "file://" in result


### PR DESCRIPTION
## Why

The supervisor only had `fetch_url` — a GET-only wrapper around `requests.get()`. When the LLM needed to make a PUT or POST request (e.g. updating a triage status via an internal API), it had no tool to execute it and hallucinated success. Users reported Forge silently failing on state-changing API calls.

`curl` was previously in the codebase but removed in #1151 because its raw HTTP response bodies were streaming directly to Slack/UI clients. This PR restores it with the streaming suppression that was missing.

## What

- **Add `curl` to supervisor `utility_tools`** — supports GET, POST, PUT, PATCH, DELETE, file downloads, and web page fetching via a single tool with a `strip_html` param for clean text output
- **Remove `fetch_url`** — `curl` is a strict superset; the one unique feature (HTML stripping via BeautifulSoup) is preserved as `strip_html=True`
- **Suppress curl content from stream** — raw HTTP responses are for LLM use only; clients receive the tool completion notification, same pattern as RAG tools
- **https:// only guardrail** — rejects `http://`, `file://`, `ftp://` etc. with a clear user-facing message
- **RAG tool arbitration prompt** — new `tool_arbitration_prompt` section in `prompt_config.rag.yaml` tells the LLM to search the knowledge base first for discovery/documentation, and use `curl` only for execution, state-changing calls, or live data the KB cannot provide
- **Restore `response_format.py` defaults** — `Metadata.user_input`, `is_task_complete`, `require_user_input` defaults were accidentally dropped in this branch

## Test plan

- [x] 84/84 tests pass across `test_curl_tool.py`, `test_supervisor_fetch_document_cap_e2e.py`, `test_response_format.py`
- [x] `make lint` — clean
- [x] `make test` — 153 passed
- [x] `make caipe-ui-tests` — 2505 passed
- [ ] Smoke: trigger PUT request in CAIPE — verify no hallucination
- [ ] Verify Slack stream does not receive raw curl response bodies