### PR TITLE
feat(helm): allow custom ingress path for supervisor ingress

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.6 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.6-rc.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -184,20 +184,20 @@ dependencies:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.3.6
+    version: 0.3.6-rc.helm.1
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
     version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.6 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.6-rc.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/agent/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/agent/templates/_helpers.tpl
@@ -356,3 +356,7 @@ e.g., "agent-argocd" -> "argocd"
 {{- $name := include "agent.name" . -}}
 {{- $name | trimPrefix "agent-" -}}
 {{- end }}
+
+{{- define "agent.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/agent/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/agent/templates/_helpers.tpl
@@ -358,5 +358,5 @@ e.g., "agent-argocd" -> "argocd"
 {{- end }}
 
 {{- define "agent.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/agent/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "agent.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}
           command:

--- a/charts/ai-platform-engineering/charts/agent/templates/mcp-deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/mcp-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag | default (include "agent.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.3.6
-appVersion: "0.3.6"
+version: 0.3.6-rc.helm.1
+appVersion: "0.3.6-rc.1"

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/templates/_helpers.tpl
@@ -60,3 +60,7 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "mongodb.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/templates/_helpers.tpl
@@ -62,5 +62,5 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "mongodb.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/templates/statefulset.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "mongodb.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: mongodb

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
@@ -77,3 +77,7 @@ Determine if ingress is enabled - global takes precedence
         {{- .Values.ingress.enabled | default false -}}
     {{- end -}}
 {{- end }}
+
+{{- define "caipe-ui.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
@@ -79,5 +79,5 @@ Determine if ingress is enabled - global takes precedence
 {{- end }}
 
 {{- define "caipe-ui.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "caipe-ui.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}
           command:

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.3.6 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.6-rc.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
@@ -77,3 +77,7 @@ Determine if ingress is enabled - global takes precedence
         {{- .Values.ingress.enabled | default false -}}
     {{- end -}}
 {{- end }}
+
+{{- define "dynamic-agents.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
@@ -79,5 +79,5 @@ Determine if ingress is enabled - global takes precedence
 {{- end }}
 
 {{- define "dynamic-agents.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "dynamic-agents.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.3.6" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.3.6-rc.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/templates/_helpers.tpl
@@ -60,5 +60,5 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "langgraph-redis.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/langgraph-redis/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/templates/_helpers.tpl
@@ -58,3 +58,7 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "langgraph-redis.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/langgraph-redis/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "langgraph-redis.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.persistence.enabled }}
           lifecycle:

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.3.6
-appVersion: 0.3.6
+version: 0.3.6-rc.helm.1
+appVersion: 0.3.6-rc.1
 type: application

--- a/charts/ai-platform-engineering/charts/slack-bot/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/slack-bot/templates/_helpers.tpl
@@ -58,3 +58,7 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "slack-bot.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/slack-bot/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/slack-bot/templates/_helpers.tpl
@@ -60,5 +60,5 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "slack-bot.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/slack-bot/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: {{ include "slack-bot.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "slack-bot.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: APP_NAME

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.6 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.6-rc.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/supervisor-agent/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/templates/_helpers.tpl
@@ -223,5 +223,5 @@ Determine if metrics are enabled - global takes precedence
 {{- end -}}
 
 {{- define "supervisorAgent.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/supervisor-agent/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/templates/_helpers.tpl
@@ -221,3 +221,7 @@ Determine if metrics are enabled - global takes precedence
     {{- end -}}
     {{- $enabled -}}
 {{- end -}}
+
+{{- define "supervisorAgent.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/charts/supervisor-agent/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "supervisorAgent.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}
           command:

--- a/charts/ai-platform-engineering/charts/supervisor-agent/templates/ingress.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/templates/ingress.yaml
@@ -31,8 +31,8 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          - path: {{ $.Values.ingress.path | default "/" }}
+            pathType: {{ $.Values.ingress.pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}
@@ -42,8 +42,8 @@ spec:
     {{- else }}
     - http:
         paths:
-          - path: /
-            pathType: Prefix
+          - path: {{ $.Values.ingress.path | default "/" }}
+            pathType: {{ $.Values.ingress.pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -125,5 +125,5 @@ In multi-node mode reads from global.enabledSubAgents (populated by Chart.yaml i
 {{- end -}}
 
 {{- define "ai-platform-engineering.appVersion" -}}
-{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -123,3 +123,7 @@ In multi-node mode reads from global.enabledSubAgents (populated by Chart.yaml i
 {{- .Values.global.enabledSubAgents | default dict | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "ai-platform-engineering.appVersion" -}}
+{{- dig "global" "image" "tag" "" .Values | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/templates/single-node-mcp-deployment.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-deployment.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: mcp
-          image: "{{ $mcpImageRepo }}:{{ $mcpImage.tag | default $.Chart.AppVersion }}"
+          image: "{{ $mcpImageRepo }}:{{ $mcpImage.tag | default (include "ai-platform-engineering.appVersion" $) }}"
           imagePullPolicy: {{ $mcpImage.pullPolicy | default "Always" }}
           ports:
             - name: http

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -25,6 +25,12 @@ tags:
 
 # Global configuration shared across all subcharts
 global:
+  # -- Global image tag override. When set, overrides the default appVersion-based
+  # image tag for ALL subcharts (supervisor, agents, UI, etc.) in a single place.
+  # Individual subchart `image.tag` values still take highest precedence.
+  image:
+    tag: ""
+
   # Deployment mode: "single-node" (all agents in-process) or "multi-node" (each agent as a separate pod)
   deploymentMode: "multi-node"
 

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -6,15 +6,15 @@ version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR
 appVersion: 0.3.6 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.3.6 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.3.6-rc.1 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
     version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.6" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.3.6-rc.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
@@ -237,3 +237,7 @@ Get Neo4j password
     {{- end -}}
     {{- $password -}}
 {{- end -}}
+
+{{- define "agent.appVersion" -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/rag-stack/charts/agent-ontology/templates/deployment.yaml
+++ b/charts/rag-stack/charts/agent-ontology/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "agent.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.command }}
           command:

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.3.6" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.3.6-rc.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-ingestors/templates/_helpers.tpl
@@ -74,3 +74,7 @@ Get RAG Server URL with per-ingestor override support
 {{- end }}
 {{- end }}
 
+{{- define "rag-ingestors.appVersion" -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
+{{- end -}}
+

--- a/charts/rag-stack/charts/rag-ingestors/templates/deployment.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: {{ $.Values.serviceAccount.automount | default true }}
       containers:
         - name: ingestor
-          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default (include "rag-ingestors.appVersion" $) }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           env:
             # Core ingestor configuration

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.6" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.3.6-rc.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-redis/templates/_helpers.tpl
@@ -60,3 +60,7 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "rag-redis.appVersion" -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/rag-stack/charts/rag-redis/templates/deployment.yaml
+++ b/charts/rag-stack/charts/rag-redis/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "rag-redis.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.persistence.enabled }}
           lifecycle:

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.3.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.3.6" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.3.6-rc.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
@@ -201,3 +201,7 @@ Get Ontology Agent REST API address
     {{- end -}}
     {{- printf "http://%s:%s" $host ($port | toString) -}}
 {{- end -}}
+
+{{- define "rag-server.appVersion" -}}
+{{- .Values.global.image.tag | default .Chart.AppVersion -}}
+{{- end -}}

--- a/charts/rag-stack/charts/rag-server/templates/deployment.yaml
+++ b/charts/rag-stack/charts/rag-server/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         # Main RAG Server container
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (include "rag-server.appVersion" .) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -80,7 +80,7 @@ spec:
         {{- if .Values.webIngestor.enabled }}
         # Web Ingestor sidecar container
         - name: web-ingestor
-          image: "{{ .Values.webIngestor.image.repository }}:{{ .Values.webIngestor.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.webIngestor.image.repository }}:{{ .Values.webIngestor.image.tag | default (include "rag-server.appVersion" .) }}"
           imagePullPolicy: {{ .Values.webIngestor.image.pullPolicy }}
           {{- with .Values.webIngestor.envFrom }}
           envFrom:

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -5,6 +5,11 @@
 sunnyTesting: true
 
 global:
+  # -- Global image tag override. When set, overrides appVersion-based image tags for all rag-stack subcharts.
+  # Individual subchart image.tag values still take highest precedence.
+  image:
+    tag: ""
+
   rag:
     enableGraphRag: true
     ragServer:


### PR DESCRIPTION
# Description

We need this so we can use the same domain for demo vms and supervisor uses the prefix to differentiate


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
