### PR TITLE
fix(Dockerfile): Standardise non-root user configuration for Dockerfiles in repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,16 @@ PYTHONPATH=. uv run pytest tests/<test_file>.py -v
 PYTHONPATH=. uv run pytest tests/<test_file>.py::<TestClass> -v
 ```
 
+## Container & Helm Security Standards
+
+These standards apply to every new agent Dockerfile and every new Helm chart subchart.
+
+### Dockerfiles
+
+All agent and MCP server images should run as a non-root user at **UID 1001 / GID 1001**.
+
+If a Dockerfile does not have a `USER` directive, `runAsNonRoot: true` in the Helm chart will cause the pod to fail at startup. Check `docker inspect <image> --format '{{.Config.User}}'` to confirm before setting that value in a chart.
+
 ## Reusable Skills
 
 The `skills/` directory contains reusable tools organized by category:

--- a/ai_platform_engineering/agents/github/build/Dockerfile.mcp
+++ b/ai_platform_engineering/agents/github/build/Dockerfile.mcp
@@ -13,11 +13,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
 FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates wget && \
-    adduser -D -u 10001 nonroot
+    adduser -D -u 1001 appuser
 
 COPY --from=builder /github-mcp-server /github-mcp-server
 
-USER nonroot
+USER appuser
 
 EXPOSE 8000
 

--- a/build/Dockerfile.slack-bot
+++ b/build/Dockerfile.slack-bot
@@ -2,6 +2,9 @@ FROM python:3.13-slim-trixie
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# Create non-root user
+RUN groupadd -r -g 1001 appuser && useradd -r -g appuser -u 1001 -m appuser
+
 WORKDIR /app
 
 COPY ai_platform_engineering/integrations/slack_bot/ /app/
@@ -11,5 +14,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ENV PATH="/app/.venv/bin:${PATH}" \
     UV_PROJECT_ENVIRONMENT="/app/.venv"
+
+RUN chown -R appuser:appuser /app
+
+USER appuser
 
 CMD ["python", "-m", "app"]


### PR DESCRIPTION
# Description

- Standardise non-root user configuration across agent/MCP container images to appuser at UID 1001 / GID 1001
- `Dockerfile.mcp` (GitHub MCP): change existing nonroot user (UID 10001) to appuser (UID 1001)
- `Dockerfile.slack-bot`: add missing non-root user (this previously ran as root)
- Document the UID/GID 1001 standard in `CLAUDE.md` so future Dockerfiles follow the same convention

These changes are being proposed after auditing the Dockerfile user configuration ahead of implementing work for issue https://github.com/cnoe-io/ai-platform-engineering/issues/950. This PR services to unblock some of the config we want to apply.

## Motivation

Kubernetes `securityContext` fields `runAsUser`, `runAsGroup`, and `fsGroup` ideally need a consistent UID/GID to template these using Helm . The previous configs for these two Dockerfiles were "non-standard".

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
