### PR TITLE
fix(slack-bot): remove nonexistent keyword_search param from RAG search prompts

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -81,7 +81,7 @@ You MUST execute search queries against the knowledge base before responding.
 - Do NOT assume you know the answer - always search first
 - Try different keyword combinations and related concepts
 - Aim for at least 5 search queries to ensure comprehensive coverage
-- Use both keyword_search=true (for exact terms, parameter names, config values) AND semantic search (for concepts, how-to questions) — do not use only one mode
+- Use varied query phrasing: exact terms for config values/parameter names, broader concepts for how-to questions — do not rely on a single query
 - If any result looks relevant, use fetch_document to get the full content — prioritize configuration/setup documents over error or troubleshooting documents
 If you respond without searching, your answer will likely be wrong.
 

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.6-rc.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.6-rc.2 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.6-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.6-rc.helm.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/data/prompt_config.rag.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.rag.yaml
@@ -8,13 +8,12 @@
 search_tool_prompt: |
   ### Search Tool Usage:
 
-  **Search Modes:**
-  - **Semantic (default, `keyword_search=False`)**: Use FULL SENTENCES for natural language
+  **Query Phrasing:**
+  - **Semantic queries** — use FULL SENTENCES for natural language concepts
     - ✅ Good: "What is the nexus deployment process?"
     - ❌ Bad: "nexus deployment"
-  - **Keyword (`keyword_search=True`)**: Use SPECIFIC KEYWORDS or exact terms
+  - **Keyword queries** — use SPECIFIC KEYWORDS or exact terms for error codes, exact names, IPs
     - ✅ Good: "ERROR-404", "S3BucketEncryptionDisabled"
-    - Use for error codes, exact names, IP addresses, technical identifiers
 
   **Search Returns:**
   The search automatically returns BOTH types in a dictionary:
@@ -47,7 +46,7 @@ search_tool_prompt: |
 
   **BE PERSISTENT - Minimum 3 approaches:**
   - Vary search terms: synonyms ("kubernetes"↔"k8s", "deploy"↔"deployment"), abbreviations ("CI/CD"↔"continuous integration"), broader/narrower ("errors"→"HTTP errors"→"404 errors")
-  - Toggle semantic/keyword modes - if sentences don't work, try keyword search for: error codes ("ERROR-404"), IPs ("10.0.1.5"), exact names ("prod-deployment-abc"), stack traces
+  - Vary query phrasing - if sentences don't work, try short keywords for: error codes ("ERROR-404"), IPs ("10.0.1.5"), exact names ("prod-deployment-abc"), stack traces
   - Try different datasource filters
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Remove `keyword_search=True/False` from RAG search tool system prompts — this parameter never existed in the `search` tool schema
- Fix applied in two places: `config_models.py` (Slack bot inline prompt) and `prompt_config.rag.yaml` (Helm chart prompt config)
- Replace with equivalent phrasing guidance that doesn't reference nonexistent parameters

## Root Cause

The system prompt instructed the LLM to call `search(keyword_search=True)` for exact-term searches and `search(keyword_search=False)` for semantic searches. The `search` tool schema only accepts `query`, `structured_entity_type`, `datasource_id`, `limit`, `similarity_threshold`, and `thought`. Pydantic rejected `keyword_search` on every invocation.

This caused **7 traced production failures today** — users received "I ran into an issue" error messages instead of answers.

## Test plan

- [ ] Verify search tool calls no longer include `keyword_search` in LLM outputs
- [ ] Confirm no Pydantic validation errors in traces after deploy

SDPL-1601