### PR TITLE
fix(docker): upgrade base images, binaries, and patch system CVEs

### DIFF
--- a/ai_platform_engineering/agents/aws/build/Dockerfile.a2a
+++ b/ai_platform_engineering/agents/aws/build/Dockerfile.a2a
@@ -40,7 +40,8 @@ RUN uvx awslabs.eks-mcp-server@0.1.15 --help > /dev/null 2>&1 || true && \
 FROM python:3.13-slim
 
 # Install runtime dependencies including AWS CLI v2 and kubectl
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     curl \
     unzip \
     ca-certificates \

--- a/ai_platform_engineering/agents/github/build/Dockerfile.mcp
+++ b/ai_platform_engineering/agents/github/build/Dockerfile.mcp
@@ -12,7 +12,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
 # ---------- Stage 2: Minimal runtime ----------
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates wget && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates wget && \
     adduser -D -u 1001 appuser
 
 COPY --from=builder /github-mcp-server /github-mcp-server

--- a/ai_platform_engineering/agents/netutils/build/Dockerfile.mcp
+++ b/ai_platform_engineering/agents/netutils/build/Dockerfile.mcp
@@ -34,7 +34,8 @@ RUN if [ -z "$AGENT_NAME" ]; then \
     fi
 
 # Install network diagnostic and Cisco-centric tools required by MCP tools
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     dnsutils \
     iputils-ping \
     traceroute \

--- a/ai_platform_engineering/dynamic_agents/build/Dockerfile
+++ b/ai_platform_engineering/dynamic_agents/build/Dockerfile
@@ -50,6 +50,10 @@ RUN find /app/dynamic_agents/.venv -type d -name "__pycache__" -exec rm -rf {} +
 # =============================================================================
 FROM python:3.13-slim-bookworm
 
+# Patch system packages to address CVEs
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user (UID/GID 1001 for Kubernetes compatibility)
 RUN groupadd --gid 1001 app && \
     useradd --uid 1001 --gid app --shell /bin/bash --create-home app

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-ontology
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-ontology
@@ -30,6 +30,10 @@ FROM python:3.13-slim-bookworm
 # Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
 # will fail.
 
+# Patch system packages to address CVEs
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create a non-root user
 RUN groupadd --gid 1001 app && \
     useradd --uid 1001 --gid app --shell /bin/bash --create-home app

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors
@@ -58,6 +58,7 @@ ARG VARIANT=default
 # - AWS CLI v2 for EKS authentication (k8s ingestor)
 # - Playwright/Chromium dependencies (default variant only, not slim)
 RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
     # For AWS CLI installation
     curl unzip && \

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server
@@ -55,6 +55,10 @@ FROM python:3.13-slim-bookworm
 # Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
 # will fail.
 
+# Patch system packages to address CVEs
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create a non-root user
 RUN groupadd --gid 1001 app && \
     useradd --uid 1001 --gid app --shell /bin/bash --create-home app

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,12 @@
 # ---------- Stage 0: Go toolchain (for github-mcp-server STDIO) ----------
-FROM golang:1.24-bookworm AS golang
+FROM golang:1.26-bookworm AS golang
 
 # ---------- Stage 1: Build dependencies ----------
 FROM python:3.13-slim AS builder
 
 # Install system dependencies and uv in one layer
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     gcc \
     git \
     && pip install uv \
@@ -40,7 +41,8 @@ RUN BEDROCK_PY=".venv/lib/python3.13/site-packages/langchain_aws/chat_models/bed
 FROM python:3.13-slim
 
 # Install only runtime dependencies (including uv for MCP STDIO subprocess execution)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     git \
     wget \
     curl \
@@ -76,7 +78,7 @@ RUN ARCH=$(uname -m) && \
 
 # Terraform CLI — used by terraform_fmt tool for HCL formatting in self-service tasks
 RUN ARCH=$(dpkg --print-architecture) \
-    && wget -q "https://releases.hashicorp.com/terraform/1.11.2/terraform_1.11.2_linux_${ARCH}.zip" -O /tmp/terraform.zip \
+    && wget -q "https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_linux_${ARCH}.zip" -O /tmp/terraform.zip \
     && unzip -o /tmp/terraform.zip -d /usr/local/bin/ \
     && rm /tmp/terraform.zip \
     && chmod +x /usr/local/bin/terraform
@@ -84,10 +86,10 @@ RUN ARCH=$(dpkg --print-architecture) \
 # GitHub CLI — used by gh_cli_execute tool in single-node GitHub subagent
 RUN ARCH=$(dpkg --print-architecture) \
     && curl -sfL --retry 5 --retry-delay 3 \
-       "https://github.com/cli/cli/releases/download/v2.89.0/gh_2.89.0_linux_${ARCH}.tar.gz" \
+       "https://github.com/cli/cli/releases/download/v2.90.0/gh_2.90.0_linux_${ARCH}.tar.gz" \
        -o /tmp/gh.tar.gz \
     && tar -xzf /tmp/gh.tar.gz -C /tmp \
-    && mv /tmp/gh_2.89.0_linux_${ARCH}/bin/gh /usr/local/bin/gh \
+    && mv /tmp/gh_2.90.0_linux_${ARCH}/bin/gh /usr/local/bin/gh \
     && chmod +x /usr/local/bin/gh \
     && rm -rf /tmp/gh.tar.gz /tmp/gh_*
 

--- a/build/Dockerfile.caipe-ui
+++ b/build/Dockerfile.caipe-ui
@@ -79,6 +79,9 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Patch system packages to address CVEs
+RUN apk update && apk upgrade --no-cache
+
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/build/Dockerfile.slack-bot
+++ b/build/Dockerfile.slack-bot
@@ -2,6 +2,10 @@ FROM python:3.13-slim-trixie
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# Patch system packages to address CVEs
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user
 RUN groupadd -r -g 1001 appuser && useradd -r -g appuser -u 1001 -m appuser
 

--- a/build/agents/Dockerfile.a2a
+++ b/build/agents/Dockerfile.a2a
@@ -47,7 +47,8 @@ RUN if [ -z "$AGENT_NAME" ]; then \
 
 # Install only runtime dependencies
 # Note: curl and unzip are needed for AWS CLI installation, jq for JSON processing
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     curl \
     unzip \
     jq \
@@ -96,7 +97,7 @@ RUN ARCH=$(uname -m) && \
     else \
         GH_ARCH="amd64"; \
     fi && \
-    GH_VERSION="2.89.0" && \
+    GH_VERSION="2.90.0" && \
     curl -sfL --retry 5 --retry-delay 3 "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" -o gh.tar.gz && \
     tar -xzf gh.tar.gz && \
     mv gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh && \
@@ -109,7 +110,7 @@ RUN ARCH=$(uname -m) && \
     else \
         GLAB_ARCH="amd64"; \
     fi && \
-    GLAB_VERSION="1.80.4" && \
+    GLAB_VERSION="1.92.1" && \
     curl -sfL --retry 5 --retry-delay 3 --connect-timeout 30 "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${GLAB_ARCH}.tar.gz" -o glab.tar.gz && \
     tar -xzf glab.tar.gz && \
     mv bin/glab /usr/local/bin/glab && \
@@ -122,7 +123,7 @@ RUN ARCH=$(uname -m) && \
     else \
         YQ_ARCH="amd64"; \
     fi && \
-    YQ_VERSION="v4.44.1" && \
+    YQ_VERSION="v4.53.2" && \
     curl -sfL --retry 5 --retry-delay 3 "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}" -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 

--- a/build/agents/Dockerfile.mcp
+++ b/build/agents/Dockerfile.mcp
@@ -36,7 +36,8 @@ RUN if [ -z "$AGENT_NAME" ]; then \
     fi
 
 # Install only runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/evals/Dockerfile
+++ b/evals/Dockerfile
@@ -2,10 +2,11 @@
 FROM python:3.13-slim
 
 # Install system dependencies and uv
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     curl \
     git \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/


### PR DESCRIPTION
## Summary

Addresses ~9,000 code scanning alerts from container image vulnerability scans.

### System package CVEs (libc, libsystemd, libcap, tar, etc.)
Added `apt-get upgrade -y` to all Debian-based runtime stages and `apk upgrade` to Alpine-based stages. This ensures freshly built images have all system packages at their latest patched versions.

### Binary version bumps
| Tool | Before | After |
|---|---|---|
| Go base image | `golang:1.24-bookworm` | `golang:1.26-bookworm` |
| Terraform | `1.11.2` | `1.14.8` |
| gh CLI | `2.89.0` | `2.90.0` |
| glab | `1.80.4` | `1.92.1` |
| yq | `v4.44.1` | `v4.53.2` |

### Files changed (13 Dockerfiles)
`build/Dockerfile`, `build/agents/Dockerfile.{a2a,mcp}`, `build/Dockerfile.{caipe-ui,slack-bot}`, `evals/Dockerfile`, and agent/RAG Dockerfiles.

## Test plan

- [ ] CI builds pass for all agent images
- [ ] CI builds pass for caipe-ui and slack-bot
- [ ] CI builds pass for RAG ingestors and server
