### PR TITLE
fix(supervisor): stream curl tool responses to client

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/agent.py
@@ -1616,8 +1616,8 @@ class AIPlatformEngineerA2ABinding:
                   # [{...}]" which doesn't match the UI regex.
                   if tool_name == "write_todos":
                       logging.debug("📋 Skipping write_todos ToolMessage for exec plan (handled by updates handler)")
-                  elif tool_name in rag_tool_names or tool_name == "curl":
-                    # For RAG tools and curl, suppress raw content from stream (client uses tool_call notification)
+                  elif tool_name in rag_tool_names:
+                      # For RAG tools, suppress raw content from stream (client uses tool_call notification)
                       logging.debug(f"Suppressing tool content for {tool_name} (tool_call notification already sent)")
                   # Stream other tool content as a tool notification (not chat text)
                   # During self-service workflows, suppress intermediate tool output —


### PR DESCRIPTION
## Summary

- curl was grouped with RAG tools in a suppression block that silently drops ToolMessage content before it reaches the client
- RAG tools are correctly suppressed — they return raw document chunks the LLM synthesizes internally, never the final answer
- curl is different: when the user asks to run HTTP requests, the response body IS the answer
- Fix removes curl from the suppression condition; RAG suppression unchanged

## Root cause

Added in abf02bb8 (April 17) when curl was wired into the supervisor — suppressed to prevent large HTTP bodies hitting Slack appendStream limits, but this makes curl useless for direct HTTP request tasks.

## Test plan

- [ ] Ask supervisor to run curl POST requests (e.g. to httpbin.org) and verify responses appear in chat
- [ ] Verify RAG queries still work without raw document chunks flooding the stream

Generated with Claude Code