### PR TITLE
feat: shared conversation API with delta thread context and Slack permalink

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -32,8 +32,10 @@ from utils.config_models import get_escalation_config
 app = App(token=os.environ.get("SLACK_INTEGRATION_BOT_TOKEN", os.environ.get("SLACK_BOT_TOKEN", "")))
 APP_NAME = os.environ.get("SLACK_INTEGRATION_APP_NAME", os.environ.get("APP_NAME", "CAIPE"))
 
-# Initialize OAuth2 auth client if enabled
 AUTH_ENABLED = os.environ.get("SLACK_INTEGRATION_ENABLE_AUTH", "false").lower() == "true"
+
+SLACK_WORKSPACE_URL = os.environ.get("SLACK_WORKSPACE_URL", "")
+logger.info("SLACK_WORKSPACE_URL={}", SLACK_WORKSPACE_URL or "(not set)")
 
 auth_client = None
 if AUTH_ENABLED:
@@ -122,6 +124,7 @@ def _resolve_conversation_id(thread_ts: str, channel_id: str, agent_id: str = ""
       "thread_ts": thread_ts,
       "channel_id": channel_id,
       **({"channel_name": channel_name} if channel_name else {}),
+      **({"workspace_url": SLACK_WORKSPACE_URL} if SLACK_WORKSPACE_URL else {}),
     },
   )
   return conv_result["conversation_id"]
@@ -221,13 +224,11 @@ def handle_mention(event, say, client):
     bot_info = client.auth_test()
     bot_user_id = bot_info.get("user_id")
 
-    context_message = message_text
-    if event.get("thread_ts"):
-      context_message = slack_context.build_thread_context(app, channel_id, thread_ts, message_text, bot_user_id)
-
     agent_id = _get_agent_id(channel_config)
 
-    # Create or retrieve conversation via shared API (server owns ID generation)
+    # Create or retrieve conversation via shared API (server owns ID generation).
+    # Must happen BEFORE context building so we can use `created` to decide
+    # full vs delta thread context.
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack Thread",
       agent_id=agent_id,
@@ -237,9 +238,21 @@ def handle_mention(event, say, client):
         "thread_ts": thread_ts,
         "channel_id": channel_id,
         "channel_name": channel_config.name,
+        **({"workspace_url": SLACK_WORKSPACE_URL} if SLACK_WORKSPACE_URL else {}),
       },
     )
     conversation_id = conv_result["conversation_id"]
+    conv_created = conv_result["created"]
+    conv_metadata = conv_result.get("metadata", {})
+
+    # Build thread context: full on first interaction, delta on follow-ups
+    context_message = message_text
+    if event.get("thread_ts"):
+      if conv_created:
+        context_message = slack_context.build_thread_context(app, channel_id, thread_ts, message_text, bot_user_id)
+      else:
+        since_ts = conv_metadata.get("last_processed_ts", thread_ts)
+        context_message = slack_context.build_delta_context(app, channel_id, thread_ts, message_text, bot_user_id, since_ts=since_ts)
 
     is_humble_followup = session_manager.is_skipped(thread_ts)
     if is_humble_followup:
@@ -308,6 +321,13 @@ def handle_mention(event, say, client):
 
     logger.info(f"[{thread_ts}] Completed CAIPE request for {user_name}")
 
+    # Record the timestamp of the last processed message so subsequent
+    # interactions can fetch only the delta.
+    try:
+      sse_client.update_conversation_metadata(conversation_id, {"last_processed_ts": event.get("ts")})
+    except Exception:
+      logger.warning(f"[{thread_ts}] Failed to update last_processed_ts — delta context may fall back to full on next turn")
+
   except Exception as e:
     logger.exception(f"Error handling CAIPE mention: {e}")
     try:
@@ -361,6 +381,7 @@ def handle_qanda_message(event, say, client):
         "thread_ts": thread_ts,
         "channel_id": channel_id,
         "channel_name": channel_config.name,
+        **({"workspace_url": SLACK_WORKSPACE_URL} if SLACK_WORKSPACE_URL else {}),
       },
     )
     conversation_id = conv_result["conversation_id"]
@@ -441,17 +462,15 @@ def handle_dm_message(event, say, client):
     bot_info = client.auth_test()
     bot_user_id = bot_info.get("user_id")
 
-    context_message = message_text
-    if event.get("thread_ts"):
-      context_message = slack_context.build_thread_context(app, event.get("channel"), thread_ts, message_text, bot_user_id)
-
     agent_id = _get_agent_id_for_dm()
     if not agent_id:
       logger.error(f"[{thread_ts}] No agent_id configured for DMs — set SLACK_INTEGRATION_DM_AGENT_ID or SLACK_INTEGRATION_DEFAULT_AGENT_ID")
       say(text="Sorry, DMs aren't configured yet — no agent ID is set. Please contact an admin.", thread_ts=thread_ts)
       return
 
-    # Create or retrieve conversation via shared API (server owns ID generation)
+    # Create or retrieve conversation via shared API (server owns ID generation).
+    # Must happen BEFORE context building so we can use `created` to decide
+    # full vs delta thread context.
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack DM",
       agent_id=agent_id,
@@ -461,9 +480,21 @@ def handle_dm_message(event, say, client):
         "thread_ts": thread_ts,
         "channel_id": channel_id,
         "channel_type": "dm",
+        **({"workspace_url": SLACK_WORKSPACE_URL} if SLACK_WORKSPACE_URL else {}),
       },
     )
     conversation_id = conv_result["conversation_id"]
+    conv_created = conv_result["created"]
+    conv_metadata = conv_result.get("metadata", {})
+
+    # Build thread context: full on first interaction, delta on follow-ups
+    context_message = message_text
+    if event.get("thread_ts"):
+      if conv_created:
+        context_message = slack_context.build_thread_context(app, channel_id, thread_ts, message_text, bot_user_id)
+      else:
+        since_ts = conv_metadata.get("last_processed_ts", thread_ts)
+        context_message = slack_context.build_delta_context(app, channel_id, thread_ts, message_text, bot_user_id, since_ts=since_ts)
 
     client_context = {
       "source": "slack",
@@ -518,6 +549,13 @@ def handle_dm_message(event, say, client):
       )
 
     logger.info(f"[{thread_ts}] Completed DM request for {user_name}")
+
+    # Record the timestamp of the last processed message so subsequent
+    # interactions can fetch only the delta.
+    try:
+      sse_client.update_conversation_metadata(conversation_id, {"last_processed_ts": event.get("ts")})
+    except Exception:
+      logger.warning(f"[{thread_ts}] Failed to update last_processed_ts — delta context may fall back to full on next turn")
 
   except Exception as e:
     logger.exception(f"Error handling DM message: {e}")

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -24,7 +24,7 @@ from utils import slack_context
 from utils import slack_formatter
 from utils.hitl_handler import HITLCallbackHandler
 
-from sse_client import SSEClient, thread_ts_to_conversation_id
+from sse_client import SSEClient
 from utils.session_manager import SessionManager
 from utils.scoring import submit_feedback_score
 from utils.config_models import get_escalation_config
@@ -101,6 +101,30 @@ def _get_agent_id_for_dm() -> str:
     return config.defaults.default_agent_id
   logger.warning("No agent_id configured for DMs — using empty string")
   return ""
+
+
+def _resolve_conversation_id(thread_ts: str, channel_id: str, agent_id: str = "", owner_id: str = "") -> str:
+  """Resolve a Slack thread to its server-side conversation_id via idempotency_key lookup.
+
+  Calls create_conversation with the thread_ts as idempotency_key. If the
+  conversation already exists the server returns it (created=false); otherwise
+  a new one is created. This ensures all handlers in a thread share the same
+  conversation_id used by UI and LangGraph checkpoints.
+  """
+  channel_config = config.channels.get(channel_id)
+  channel_name = channel_config.name if channel_config else None
+  conv_result = sse_client.create_conversation(
+    title="Slack Thread",
+    agent_id=agent_id,
+    owner_id=owner_id or None,
+    idempotency_key=thread_ts,
+    metadata={
+      "thread_ts": thread_ts,
+      "channel_id": channel_id,
+      **({"channel_name": channel_name} if channel_name else {}),
+    },
+  )
+  return conv_result["conversation_id"]
 
 
 def _call_ai(
@@ -202,7 +226,20 @@ def handle_mention(event, say, client):
       context_message = slack_context.build_thread_context(app, channel_id, thread_ts, message_text, bot_user_id)
 
     agent_id = _get_agent_id(channel_config)
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
+
+    # Create or retrieve conversation via shared API (server owns ID generation)
+    conv_result = sse_client.create_conversation(
+      title=message_text[:50].strip() or "Slack Thread",
+      agent_id=agent_id,
+      owner_id=user_email or user_id,
+      idempotency_key=thread_ts,
+      metadata={
+        "thread_ts": thread_ts,
+        "channel_id": channel_id,
+        "channel_name": channel_config.name,
+      },
+    )
+    conversation_id = conv_result["conversation_id"]
 
     is_humble_followup = session_manager.is_skipped(thread_ts)
     if is_humble_followup:
@@ -313,7 +350,20 @@ def handle_qanda_message(event, say, client):
 
     channel_config = config.channels[channel_id]
     agent_id = _get_agent_id(channel_config)
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
+
+    # Create or retrieve conversation via shared API (server owns ID generation)
+    conv_result = sse_client.create_conversation(
+      title=message_text[:50].strip() or "Slack Q&A",
+      agent_id=agent_id,
+      owner_id=user_email or user_id,
+      idempotency_key=thread_ts,
+      metadata={
+        "thread_ts": thread_ts,
+        "channel_id": channel_id,
+        "channel_name": channel_config.name,
+      },
+    )
+    conversation_id = conv_result["conversation_id"]
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
 
@@ -400,7 +450,20 @@ def handle_dm_message(event, say, client):
       logger.error(f"[{thread_ts}] No agent_id configured for DMs — set SLACK_INTEGRATION_DM_AGENT_ID or SLACK_INTEGRATION_DEFAULT_AGENT_ID")
       say(text="Sorry, DMs aren't configured yet — no agent ID is set. Please contact an admin.", thread_ts=thread_ts)
       return
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
+
+    # Create or retrieve conversation via shared API (server owns ID generation)
+    conv_result = sse_client.create_conversation(
+      title=message_text[:50].strip() or "Slack DM",
+      agent_id=agent_id,
+      owner_id=user_email or user_id,
+      idempotency_key=thread_ts,
+      metadata={
+        "thread_ts": thread_ts,
+        "channel_id": channel_id,
+        "channel_type": "dm",
+      },
+    )
+    conversation_id = conv_result["conversation_id"]
 
     client_context = {
       "source": "slack",
@@ -620,6 +683,7 @@ def handle_caipe_feedback(ack, body, client):
     is_positive = feedback_type == "positive"
 
     feedback_value = "thumbs_up" if is_positive else "thumbs_down"
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id)
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -628,6 +692,7 @@ def handle_caipe_feedback(ack, body, client):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
       message_ts=message_ts,
     )
 
@@ -681,6 +746,9 @@ def handle_feedback_more_detail(ack, body, client):
     if not channel_id or not thread_ts:
       return
 
+    agent_id = _get_agent_id(config.channels.get(channel_id))
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id, agent_id)
+
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -689,13 +757,12 @@ def handle_feedback_more_detail(ack, body, client):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
       message_ts=message_ts,
     )
 
     client.chat_postEphemeral(channel=channel_id, user=user_id, thread_ts=thread_ts, text=f"Got it! Asking {APP_NAME} for more detail...")
 
-    agent_id = _get_agent_id(config.channels.get(channel_id))
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
     team_id = body.get("team", {}).get("id")
 
     channel_config = config.channels.get(channel_id)
@@ -730,6 +797,9 @@ def handle_feedback_less_verbose(ack, body, client):
     if not channel_id or not thread_ts:
       return
 
+    agent_id = _get_agent_id(config.channels.get(channel_id))
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id, agent_id)
+
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -738,13 +808,12 @@ def handle_feedback_less_verbose(ack, body, client):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
       message_ts=message_ts,
     )
 
     client.chat_postEphemeral(channel=channel_id, user=user_id, thread_ts=thread_ts, text=f"Got it! Asking {APP_NAME} for a more concise response...")
 
-    agent_id = _get_agent_id(config.channels.get(channel_id))
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
     team_id = body.get("team", {}).get("id")
 
     channel_config = config.channels.get(channel_id)
@@ -779,6 +848,14 @@ def handle_caipe_retry(ack, body, client):
     if not channel_id or not thread_ts:
       return
 
+    if not utils.check_has_jira_info(channel_id):
+      return
+
+    channel_config = config.channels[channel_id]
+    agent_id = _get_agent_id(channel_config)
+    # Resolve server-side conversation_id for this thread
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id, agent_id)
+
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -787,6 +864,7 @@ def handle_caipe_retry(ack, body, client):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
       message_ts=message_ts,
     )
 
@@ -796,14 +874,6 @@ def handle_caipe_retry(ack, body, client):
     bot_user_id = bot_info.get("user_id")
 
     thread_context = slack_context.build_thread_context(app, channel_id, thread_ts, "", bot_user_id)
-
-    if not utils.check_has_jira_info(channel_id):
-      return
-
-    channel_config = config.channels[channel_id]
-    agent_id = _get_agent_id(channel_config)
-    # Use a new conversation_id for retries to avoid LangGraph state conflicts
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
 
     retry_message = ai.RETRY_PROMPT_PREFIX + thread_context
 
@@ -865,6 +935,7 @@ def handle_escalation_get_help(ack, body, client):
     session_manager.set_escalated(thread_ts)
 
     # Track escalation in feedback
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id)
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -873,6 +944,7 @@ def handle_escalation_get_help(ack, body, client):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
     )
 
     client.chat_postEphemeral(
@@ -936,6 +1008,7 @@ def handle_delete_message(ack, body, client):
       logger.warning(f"[{thread_ts}] Unauthorized delete attempt by <@{user_id}>")
       return
 
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id)
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -944,6 +1017,7 @@ def handle_delete_message(ack, body, client):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
     )
 
     client.chat_delete(channel=channel_id, ts=message_ts)
@@ -1020,6 +1094,9 @@ def handle_wrong_answer_submission(ack, body, client, view):
     if not correction_text:
       return
 
+    agent_id = _get_agent_id(config.channels.get(channel_id))
+    conversation_id = _resolve_conversation_id(thread_ts, channel_id, agent_id)
+
     submit_feedback_score(
       thread_ts=thread_ts,
       user_id=user_id,
@@ -1028,6 +1105,7 @@ def handle_wrong_answer_submission(ack, body, client, view):
       slack_client=client,
       session_manager=session_manager,
       config=config,
+      conversation_id=conversation_id,
       comment=correction_text,
       message_ts=message_ts,
     )
@@ -1039,8 +1117,6 @@ def handle_wrong_answer_submission(ack, body, client, view):
       text=f"Got it! Asking {APP_NAME} to correct the response based on your feedback...",
     )
 
-    agent_id = _get_agent_id(config.channels.get(channel_id))
-    conversation_id = thread_ts_to_conversation_id(thread_ts)
     correction_prompt = f'The user indicated your previous response was incorrect and provided the following IMPORTANT context: "{correction_text}"\n\nPlease carefully review this feedback and provide a corrected response.'
 
     # Get escalation config for this channel

--- a/ai_platform_engineering/integrations/slack_bot/sse_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/sse_client.py
@@ -248,7 +248,46 @@ class SSEClient:
       created,
     )
 
-    return {"conversation_id": conversation_id, "created": created}
+    return {
+      "conversation_id": conversation_id,
+      "created": created,
+      "metadata": conversation.get("metadata", {}),
+    }
+
+  def update_conversation_metadata(
+    self,
+    conversation_id: str,
+    metadata: Dict[str, Any],
+  ) -> None:
+    """Merge keys into an existing conversation's metadata.
+
+    Calls ``PATCH /api/chat/conversations/{id}/metadata``.  Only the
+    ``metadata`` field is updated — no other conversation fields are
+    touched.
+
+    Args:
+        conversation_id: UUID of the conversation to update.
+        metadata: Dict of keys to shallow-merge into existing metadata.
+
+    Raises:
+        Exception: On HTTP errors.
+    """
+    url = f"{self.base_url}/api/chat/conversations/{conversation_id}/metadata"
+    headers = self._get_headers()
+    headers["Accept"] = "application/json"
+
+    with httpx.Client(timeout=30) as client:
+      response = client.patch(url, json={"metadata": metadata}, headers=headers)
+
+    if response.status_code not in (200, 204):
+      logger.error(
+        "Failed to update conversation metadata: status={} body={}",
+        response.status_code,
+        response.text[:500],
+      )
+      raise Exception(f"Failed to update conversation metadata: HTTP {response.status_code}")
+
+    logger.debug("Updated metadata for conversation {}: {}", conversation_id, metadata)
 
   def stream_chat(
     self,

--- a/ai_platform_engineering/integrations/slack_bot/sse_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/sse_client.py
@@ -24,7 +24,11 @@ SLACK_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "slack.caipe.io")
 def thread_ts_to_conversation_id(thread_ts: str) -> str:
   """Convert a Slack thread_ts to a deterministic conversation UUID.
 
-  Same thread_ts always produces the same UUID v5.
+  .. deprecated::
+      Use ``SSEClient.create_conversation()`` instead.  This function is
+      kept only as a fallback for secondary handlers (button actions) that
+      operate on threads whose conversation was already created by a primary
+      handler.  It will be removed once all handlers are migrated.
 
   Args:
       thread_ts: Slack thread timestamp string.
@@ -165,6 +169,86 @@ class SSEClient:
       token = self.auth_client.get_access_token()
       headers["Authorization"] = f"Bearer {token}"
     return headers
+
+  def create_conversation(
+    self,
+    title: str,
+    agent_id: str,
+    owner_id: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+  ) -> Dict[str, Any]:
+    """Create or retrieve an existing conversation via the shared API.
+
+    Uses the Next.js ``POST /api/chat/conversations`` endpoint. When an
+    ``idempotency_key`` is provided, the server returns the existing
+    conversation instead of creating a duplicate. This maintains a 1-1
+    mapping between integration-specific identities (e.g. Slack thread_ts)
+    and the conversation_id used by UI and LangGraph checkpoints.
+
+    Args:
+        title: Conversation title (first message truncated).
+        agent_id: Dynamic agent config ID.
+        owner_id: User email. If omitted, server uses the service account identity.
+        idempotency_key: Dedup key mapping integration identity to conversation_id
+            (e.g. Slack thread_ts).
+        metadata: Arbitrary metadata (channel_id, channel_name, etc.).
+
+    Returns:
+        Dict with ``conversation_id`` (str) and ``created`` (bool).
+
+    Raises:
+        Exception: On HTTP errors or invalid response.
+    """
+    url = f"{self.base_url}/api/chat/conversations"
+    headers = self._get_headers()
+    # Conversation API expects JSON, not SSE
+    headers["Accept"] = "application/json"
+
+    payload: Dict[str, Any] = {
+      "title": title,
+      "client_type": "slack",
+      "agent_id": agent_id,
+    }
+    if owner_id:
+      payload["owner_id"] = owner_id
+    if idempotency_key:
+      payload["idempotency_key"] = idempotency_key
+    if metadata:
+      payload["metadata"] = metadata
+
+    logger.debug(
+      "Creating conversation: url={} owner_id={} idempotency_key={}",
+      url,
+      owner_id,
+      idempotency_key,
+    )
+
+    with httpx.Client(timeout=30) as client:
+      response = client.post(url, json=payload, headers=headers)
+
+    if response.status_code not in (200, 201):
+      logger.error(
+        "Failed to create conversation: status={} body={}",
+        response.status_code,
+        response.text[:500],
+      )
+      raise Exception(f"Failed to create conversation: HTTP {response.status_code}")
+
+    data = response.json()
+    result = data.get("data", data)
+    conversation = result.get("conversation", {})
+    created = result.get("created", True)
+
+    conversation_id = conversation.get("_id", "")
+    logger.info(
+      "Conversation {}: id={} created={}",
+      "created" if created else "found existing",
+      conversation_id,
+      created,
+    )
+
+    return {"conversation_id": conversation_id, "created": created}
 
   def stream_chat(
     self,

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_langfuse_feedback.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_langfuse_feedback.py
@@ -44,6 +44,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=self._make_config(),
+      conversation_id="test-conv-id",
     )
 
     assert result is True
@@ -57,8 +58,8 @@ class TestScoringUtility:
     assert payload["value"] == "thumbs_up"
     # traceId is now always None (trace tracking removed in AG-UI migration)
     assert payload["traceId"] is None
-    # conversationId is now deterministic UUID v5 from thread_ts
-    assert payload["conversationId"] is not None
+    # conversationId is the server-side ID passed by the caller
+    assert payload["conversationId"] == "test-conv-id"
     assert payload["channelId"] == "C123"
     assert payload["channelName"] == "#test-channel"
     assert payload["threadTs"] == "thread_123"
@@ -83,6 +84,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=self._make_config(channel_id="C02AVQ61E3H"),
+      conversation_id="test-conv-id",
       message_ts="1775145010.565959",
     )
 
@@ -109,6 +111,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=self._make_config(channel_id="C02AVQ61E3H"),
+      conversation_id="test-conv-id",
       message_ts="wrong_answer",  # invalid — from old button format
     )
 
@@ -136,6 +139,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=self._make_config(),
+      conversation_id="test-conv-id",
     )
 
     assert result is False
@@ -155,6 +159,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=self._make_config(),
+      conversation_id="test-conv-id",
     )
 
     assert result is False
@@ -178,6 +183,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=self._make_config(),
+      conversation_id="test-conv-id",
       comment="The endpoint doesn't exist",
     )
 
@@ -208,6 +214,7 @@ class TestScoringUtility:
       slack_client=self._make_slack_client(),
       session_manager=self._make_session_manager(),
       config=mock_config,
+      conversation_id="test-conv-id",
     )
 
     payload = mock_post.call_args[1]["json"]

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -20,9 +20,9 @@ import time
 from loguru import logger
 
 try:
-  from sse_client import SSEClient, SSEEventType, thread_ts_to_conversation_id  # type: ignore[import]
+  from sse_client import SSEClient, SSEEventType  # type: ignore[import]
 except ImportError:
-  from ..sse_client import SSEClient, SSEEventType, thread_ts_to_conversation_id
+  from ..sse_client import SSEClient, SSEEventType
 from . import slack_formatter
 from . import utils as _utils
 from .config import config
@@ -1266,7 +1266,18 @@ def handle_ai_alert_processing(
     logger.info(f"[{thread_ts}] Silencing AI alert processing")
     return "Silenced"
 
-  conversation_id = thread_ts_to_conversation_id(thread_ts)
+  # Resolve conversation_id via idempotency_key (thread_ts) — creates if first call
+  conv_result = sse_client.create_conversation(
+    title=f"Alert: {bot_username}"[:50],
+    agent_id=agent_id,
+    idempotency_key=thread_ts,
+    metadata={
+      "thread_ts": thread_ts,
+      "channel_id": channel_id,
+      "alert_bot": bot_username,
+    },
+  )
+  conversation_id = conv_result["conversation_id"]
 
   result = stream_response(
     sse_client=sse_client,

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -1275,6 +1275,7 @@ def handle_ai_alert_processing(
       "thread_ts": thread_ts,
       "channel_id": channel_id,
       "alert_bot": bot_username,
+      **({"workspace_url": os.environ.get("SLACK_WORKSPACE_URL", "")} if os.environ.get("SLACK_WORKSPACE_URL") else {}),
     },
   )
   conversation_id = conv_result["conversation_id"]

--- a/ai_platform_engineering/integrations/slack_bot/utils/scoring.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/scoring.py
@@ -12,10 +12,6 @@ import requests
 from typing import Optional
 from loguru import logger
 
-try:
-  from sse_client import thread_ts_to_conversation_id  # type: ignore[import]
-except ImportError:
-  from ..sse_client import thread_ts_to_conversation_id
 from .session_manager import SessionManager
 from .config_models import Config
 
@@ -48,6 +44,7 @@ def submit_feedback_score(
   slack_client,
   session_manager: SessionManager,
   config: Config,
+  conversation_id: str,
   comment: Optional[str] = None,
   message_ts: Optional[str] = None,
 ) -> bool:
@@ -55,9 +52,20 @@ def submit_feedback_score(
   Submit feedback by calling POST /api/feedback on the CAIPE UI.
 
   The API handles both Langfuse scoring and MongoDB writes.
+
+  Args:
+      thread_ts: Slack thread timestamp.
+      user_id: Slack user ID.
+      channel_id: Slack channel ID.
+      feedback_value: Feedback type (e.g. thumbs_up, thumbs_down, retry).
+      slack_client: Slack WebClient.
+      session_manager: Session manager for user info caching.
+      config: Bot configuration.
+      conversation_id: Server-side conversation ID (resolved via idempotency_key).
+      comment: Optional feedback comment text.
+      message_ts: Optional specific message timestamp.
   """
   trace_id = None  # Trace ID tracking removed in AG-UI migration
-  context_id = thread_ts_to_conversation_id(thread_ts)
 
   # Resolve user email from Slack
   user_email = None
@@ -98,7 +106,7 @@ def submit_feedback_score(
     "messageId": message_ts if message_ts and "." in message_ts and message_ts.replace(".", "").isdigit() else None,
     "feedbackType": feedback_type,
     "value": feedback_value,
-    "conversationId": context_id or f"slack-{thread_ts}",
+    "conversationId": conversation_id,
     "source": "slack",
     "channelId": channel_id,
     "channelName": display_channel_name,

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
@@ -6,119 +6,222 @@ Slack Thread Context Utilities
 Handles fetching and building conversation context from Slack threads:
 - Fetch thread history
 - Get user display names
-- Build formatted conversation context for AI
+- Build formatted conversation context for AI (full + delta)
 - Extract message text from events
 """
 
 import os
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from loguru import logger
 
 APP_NAME = os.environ.get("SLACK_INTEGRATION_APP_NAME", os.environ.get("APP_NAME", "CAIPE"))
 
+THREAD_HISTORY_LIMIT = int(os.environ.get("SLACK_INTEGRATION_THREAD_HISTORY_LIMIT", "50"))
 
-def fetch_thread_history(app, channel_id: str, thread_ts: str) -> List[Dict[str, Any]]:
-    """Fetch all messages from a Slack thread."""
-    try:
-        result = app.client.conversations_replies(
-            channel=channel_id, ts=thread_ts, limit=100
-        )
-        return result.get("messages", [])
-    except Exception as e:
-        logger.warning(f"Error fetching thread history: {e}")
-        return []
+
+def fetch_thread_history(
+  app,
+  channel_id: str,
+  thread_ts: str,
+  oldest: Optional[str] = None,
+  limit: int = THREAD_HISTORY_LIMIT,
+) -> List[Dict[str, Any]]:
+  """Fetch messages from a Slack thread.
+
+  Args:
+      app: Slack Bolt app instance.
+      channel_id: Slack channel ID.
+      thread_ts: Thread root timestamp.
+      oldest: If set, only return messages newer than this timestamp.
+      limit: Maximum number of messages to fetch.
+
+  Returns:
+      List of message dicts from the Slack API.
+  """
+  try:
+    kwargs: Dict[str, Any] = {
+      "channel": channel_id,
+      "ts": thread_ts,
+      "limit": limit,
+    }
+    if oldest:
+      kwargs["oldest"] = oldest
+    result = app.client.conversations_replies(**kwargs)
+    return result.get("messages", [])
+  except Exception as e:
+    logger.warning(f"Error fetching thread history: {e}")
+    return []
 
 
 def get_user_display_name(app, user_id: str) -> str:
-    """Get display name for a user."""
-    try:
-        result = app.client.users_info(user=user_id)
-        user = result.get("user", {})
-        return (
-            user.get("profile", {}).get("display_name")
-            or user.get("real_name")
-            or user.get("name")
-            or f"User {user_id}"
-        )
-    except Exception as e:
-        logger.warning(f"Error fetching user info: {e}")
-        return f"User {user_id}"
+  """Get display name for a user."""
+  try:
+    result = app.client.users_info(user=user_id)
+    user = result.get("user", {})
+    return user.get("profile", {}).get("display_name") or user.get("real_name") or user.get("name") or f"User {user_id}"
+  except Exception as e:
+    logger.warning(f"Error fetching user info: {e}")
+    return f"User {user_id}"
 
 
-def build_thread_context(
-    app, channel_id: str, thread_ts: str, current_message: str, bot_user_id: str
+def _is_our_bot(msg: Dict[str, Any], bot_user_id: str) -> bool:
+  """Check whether a Slack message was sent by our bot."""
+  if msg.get("bot_id"):
+    user_id = msg.get("user")
+    return user_id is not None and user_id == bot_user_id
+  return False
+
+
+def _label_speaker(app, msg: Dict[str, Any], bot_user_id: str) -> str:
+  """Return a human-readable speaker label for a Slack message."""
+  user_id = msg.get("user")
+  bot_id = msg.get("bot_id")
+
+  if bot_id or (user_id and user_id == bot_user_id):
+    return APP_NAME
+  elif user_id:
+    return get_user_display_name(app, user_id)
+  return "Unknown"
+
+
+def build_thread_context(app, channel_id: str, thread_ts: str, current_message: str, bot_user_id: str) -> str:
+  """Build formatted conversation context from a full thread.
+
+  Used on the **first** bot interaction in a thread (``created=True``) to
+  give the agent awareness of all prior messages, including those between
+  humans that happened before the bot was invoked.
+
+  Messages are capped to :data:`THREAD_HISTORY_LIMIT`.
+  """
+  messages = fetch_thread_history(app, channel_id, thread_ts)
+
+  if not messages:
+    return current_message
+
+  # Cap to the most recent N messages (keep tail)
+  if len(messages) > THREAD_HISTORY_LIMIT:
+    messages = messages[-THREAD_HISTORY_LIMIT:]
+
+  conversation_lines = ["Previous conversation:"]
+  conversation_lines.append("---")
+
+  for msg in messages:
+    full_text = extract_message_text(msg)
+
+    if not full_text.strip():
+      continue
+
+    speaker = _label_speaker(app, msg, bot_user_id)
+    conversation_lines.append(f"{speaker}: {full_text}")
+
+  conversation_lines.append("---")
+  conversation_lines.append(f"Current question: {current_message}")
+
+  return "\n".join(conversation_lines)
+
+
+def build_delta_context(
+  app,
+  channel_id: str,
+  thread_ts: str,
+  current_message: str,
+  bot_user_id: str,
+  since_ts: str,
+  cap: int = THREAD_HISTORY_LIMIT,
 ) -> str:
-    """Build formatted conversation context from a thread."""
-    messages = fetch_thread_history(app, channel_id, thread_ts)
+  """Build context containing only messages new since the bot's last turn.
 
-    if not messages:
-        return current_message
+  Used on **follow-up** interactions in a thread (``created=False``) to
+  avoid re-sending the full history that the agent already has in its
+  LangGraph checkpoint chain.
 
-    conversation_lines = ["Previous conversation:"]
-    conversation_lines.append("---")
+  Only non-bot messages are included — the agent already has its own prior
+  messages in checkpoints.  Other bots' messages (e.g. alert bots) are kept.
 
-    for msg in messages:
-        full_text = extract_message_text(msg)
+  Args:
+      app: Slack Bolt app instance.
+      channel_id: Slack channel ID.
+      thread_ts: Thread root timestamp.
+      current_message: The user's current message text.
+      bot_user_id: Our bot's Slack user ID (to filter out our messages).
+      since_ts: Only include messages newer than this timestamp.
+      cap: Maximum number of context messages to include.
 
-        if not full_text.strip():
-            continue
+  Returns:
+      The user's message, optionally prefixed with a delta context preamble.
+  """
+  messages = fetch_thread_history(app, channel_id, thread_ts, oldest=since_ts)
 
-        user_id = msg.get("user")
-        bot_id = msg.get("bot_id")
+  # Filter out our bot's own messages (agent has those in checkpoints)
+  new_messages = [m for m in messages if not _is_our_bot(m, bot_user_id)]
 
-        if bot_id or (user_id and user_id == bot_user_id):
-            speaker = APP_NAME
-        elif user_id:
-            speaker = get_user_display_name(app, user_id)
-        else:
-            speaker = "Unknown"
+  # Also filter out the current message itself (it will be appended at the end)
+  # The current message has the same ts as event["ts"]
+  new_messages = [m for m in new_messages if m.get("ts") != since_ts]
 
-        conversation_lines.append(f"{speaker}: {full_text}")
+  if not new_messages:
+    return current_message
 
-    conversation_lines.append("---")
-    conversation_lines.append(f"Current question: {current_message}")
+  # Cap to the most recent N (keep tail)
+  if len(new_messages) > cap:
+    new_messages = new_messages[-cap:]
 
-    return "\n".join(conversation_lines)
+  lines = [
+    f"Since your last message, the following conversation took place (last {len(new_messages)} messages):",
+    "---",
+  ]
+
+  for msg in new_messages:
+    full_text = extract_message_text(msg)
+    if not full_text.strip():
+      continue
+    speaker = _label_speaker(app, msg, bot_user_id)
+    lines.append(f"{speaker}: {full_text}")
+
+  lines.append("---")
+  lines.append(f"Current question: {current_message}")
+
+  return "\n".join(lines)
 
 
 def extract_message_text(event: Dict[str, Any]) -> str:
-    """Extract comprehensive message text from a Slack event."""
-    content_parts = []
+  """Extract comprehensive message text from a Slack event."""
+  content_parts = []
 
-    text = event.get("text", "")
-    if text.strip():
-        content_parts.append(text)
+  text = event.get("text", "")
+  if text.strip():
+    content_parts.append(text)
 
-    if event.get("blocks"):
-        for block in event.get("blocks", []):
-            if block.get("type") == "section" and block.get("text"):
-                block_text = block["text"].get("text", "")
-                if block_text and block_text not in content_parts:
-                    content_parts.append(block_text)
-            elif block.get("type") == "context":
-                for element in block.get("elements", []):
-                    if element.get("type") == "mrkdwn":
-                        elem_text = element.get("text", "")
-                        if elem_text and elem_text not in content_parts:
-                            content_parts.append(elem_text)
-            elif block.get("type") == "header" and block.get("text"):
-                header_text = block["text"].get("text", "")
-                if header_text and header_text not in content_parts:
-                    content_parts.append(f"**{header_text}**")
+  if event.get("blocks"):
+    for block in event.get("blocks", []):
+      if block.get("type") == "section" and block.get("text"):
+        block_text = block["text"].get("text", "")
+        if block_text and block_text not in content_parts:
+          content_parts.append(block_text)
+      elif block.get("type") == "context":
+        for element in block.get("elements", []):
+          if element.get("type") == "mrkdwn":
+            elem_text = element.get("text", "")
+            if elem_text and elem_text not in content_parts:
+              content_parts.append(elem_text)
+      elif block.get("type") == "header" and block.get("text"):
+        header_text = block["text"].get("text", "")
+        if header_text and header_text not in content_parts:
+          content_parts.append(f"**{header_text}**")
 
-    if event.get("attachments"):
-        for attachment in event.get("attachments", []):
-            if attachment.get("title"):
-                content_parts.append(f"Title: {attachment['title']}")
-            if attachment.get("text"):
-                content_parts.append(attachment["text"])
-            if attachment.get("pretext"):
-                content_parts.append(attachment["pretext"])
-            if attachment.get("fields"):
-                for field in attachment["fields"]:
-                    field_title = field.get("title", "")
-                    field_value = field.get("value", "")
-                    if field_title or field_value:
-                        content_parts.append(f"{field_title}: {field_value}")
+  if event.get("attachments"):
+    for attachment in event.get("attachments", []):
+      if attachment.get("title"):
+        content_parts.append(f"Title: {attachment['title']}")
+      if attachment.get("text"):
+        content_parts.append(attachment["text"])
+      if attachment.get("pretext"):
+        content_parts.append(attachment["pretext"])
+      if attachment.get("fields"):
+        for field in attachment["fields"]:
+          field_title = field.get("title", "")
+          field_value = field.get("value", "")
+          if field_title or field_value:
+            content_parts.append(f"{field_title}: {field_value}")
 
-    return "\n".join(content_parts).strip()
+  return "\n".join(content_parts).strip()

--- a/docs/docs/specs/shared-conversation-api/delta-thread-context.md
+++ b/docs/docs/specs/shared-conversation-api/delta-thread-context.md
@@ -1,0 +1,191 @@
+# Delta Thread Context for Slack Bot
+
+## Status: Planned
+
+## Problem
+
+When a user posts a follow-up message in a Slack thread, the bot calls
+`build_thread_context` which fetches **all** messages from the Slack API and
+embeds them as a text blob in the user message. This blob then gets stored in
+LangGraph checkpoints. On every subsequent turn the entire prior history is
+re-embedded, causing **quadratic growth** in checkpoint storage.
+
+Additionally, the Slack API is called on every follow-up just to reconstruct
+history that the agent already has in its checkpoint chain.
+
+### What checkpoints already store
+
+LangGraph checkpoints contain all messages exchanged **with the agent** — but
+they do *not* contain messages posted by other humans or bots in the Slack
+thread that the agent wasn't part of. `build_thread_context` fills that gap by
+providing the full thread context.
+
+## Solution: Option C — Delta Context as Message Preamble
+
+Instead of always sending the full thread history, only send **new messages
+since the bot's last interaction** on follow-up turns.
+
+### How it works
+
+**First turn** (`created=true` from idempotency API):
+- Full `build_thread_context` output — same as today.
+- Needed because the agent has no checkpoint history yet and there may be
+  pre-bot messages in the thread.
+
+**Follow-up turns** (`created=false`):
+- Fetch only messages **newer than `last_processed_ts`** from Slack.
+- Filter out the bot's own messages (agent has those in checkpoints).
+- Cap to last N messages (configurable via env var, default 50).
+- If no new non-bot messages exist, send just the raw user message.
+- Otherwise prepend a preamble:
+
+```
+Since your last message, the following conversation took place (last N messages):
+---
+Alice: I think we should try the new approach
+Bob: Agreed, let me check the docs
+---
+Current question: @CAIPE can you help with this?
+```
+
+**After each turn**: Store `last_processed_ts` in conversation metadata via a
+new PATCH endpoint so we know where to resume from next time.
+
+### Root messages vs thread replies
+
+| Scenario | Thread context? | Delta applies? |
+|---|---|---|
+| @mention in channel (no thread) | No — message is the thread root | No — first turn, no prior context |
+| @mention inside a thread (first bot interaction) | Yes — full `build_thread_context` | No — `created=true`, full context |
+| @mention inside a thread (follow-up) | Yes — delta only | **Yes** — `created=false` |
+| Q&A (auto-respond, root only) | No — only fires for `not is_thread` | No |
+| DM (no thread) | No | No |
+| DM inside thread (follow-up) | Yes — delta only | **Yes** — `created=false` |
+
+## Implementation Plan
+
+### 1. `slack_context.py` — New function + env var
+
+- Extract constant:
+  ```python
+  SLACK_THREAD_HISTORY_LIMIT = int(os.environ.get(
+      "SLACK_INTEGRATION_THREAD_HISTORY_LIMIT", "50"
+  ))
+  ```
+- Update `fetch_thread_history`: use the constant instead of hardcoded `100`.
+  Add optional `oldest` param to support delta fetches via Slack's
+  `conversations_replies(oldest=...)`.
+- New function:
+  ```python
+  def build_delta_context(
+      app,
+      channel_id: str,
+      thread_ts: str,
+      current_message: str,
+      bot_user_id: str,
+      since_ts: str,
+      cap: int = SLACK_THREAD_HISTORY_LIMIT,
+  ) -> str:
+  ```
+  - Calls `fetch_thread_history` with `oldest=since_ts`
+  - Filters out our bot's messages (agent has those in checkpoints)
+  - If no new non-bot messages → returns just `current_message`
+  - Otherwise returns preamble + messages + current question
+  - Caps to last `cap` messages
+
+### 2. `sse_client.py` — Return metadata + new PATCH method
+
+- **`create_conversation` return**: include `metadata` from the conversation
+  doc so callers can read `last_processed_ts`:
+  ```python
+  return {
+      "conversation_id": conversation_id,
+      "created": created,
+      "metadata": conversation.get("metadata", {}),
+  }
+  ```
+- **New method**:
+  ```python
+  def update_conversation_metadata(
+      self, conversation_id: str, metadata: Dict[str, Any]
+  ) -> None:
+  ```
+  Calls `PATCH /api/chat/conversations/{id}/metadata` with Bearer auth.
+  Merges provided keys into existing metadata.
+
+### 3. `app.py` — Reorder handler flow
+
+Current flow in `handle_mention` and `handle_dm_message`:
+```
+1. build_thread_context (always full)
+2. create_conversation
+3. _call_ai(message_text=context_message)
+```
+
+New flow:
+```
+1. create_conversation → {created, metadata}
+2. Build context:
+   - if created=true AND event has thread_ts:
+       context_message = build_thread_context(full, capped)
+   - elif created=false AND event has thread_ts:
+       since_ts = metadata.get("last_processed_ts", thread_ts)
+       context_message = build_delta_context(since_ts)
+   - else:
+       context_message = message_text  (root message, no thread)
+3. _call_ai(message_text=context_message)
+4. update_conversation_metadata(conversation_id, {
+       "last_processed_ts": event["ts"]
+   })
+```
+
+Q&A handler — no change (only fires for root messages, never has thread
+context).
+
+### 4. New API endpoint: `PATCH /api/chat/conversations/[id]/metadata`
+
+**Route**: `ui/src/app/api/chat/conversations/[id]/metadata/route.ts`
+
+```
+PATCH /api/chat/conversations/{id}/metadata
+Authorization: Bearer <jwt>
+Body: { "metadata": { "last_processed_ts": "1776686296.562309" } }
+```
+
+- Uses `getAuthFromBearerOrSession` (supports Bearer JWT from Slack bot)
+- Shallow-merges `body.metadata` into existing `conversation.metadata`
+- **Only allows updating `metadata`** — nothing else
+- Returns updated conversation
+
+### 5. Types: `ui/src/types/mongodb.ts`
+
+Add:
+```typescript
+export interface PatchConversationMetadataRequest {
+  metadata: Record<string, unknown>;
+}
+```
+
+## What doesn't change
+
+- `build_thread_context` — stays as-is, used for first-turn full context
+- Q&A handler — only processes root messages, no thread context
+- Button handlers (`_resolve_conversation_id`) — don't touch message context
+- `ai.py` alert handler — alert threads are bot-initiated, different pattern
+- `client_context` dict — unchanged, still carries channel info
+
+## Edge cases
+
+- **`last_processed_ts` missing on existing conversations** — falls back to
+  `thread_ts` (thread root), giving full history. Same behavior as today.
+  Graceful degradation.
+- **Bot restart / metadata lost** — metadata is in MongoDB, survives restarts.
+- **Multiple users posting between bot turns** — all captured in the delta.
+  Only the bot's own messages are filtered out.
+- **Other bots posting in thread** — kept in delta (only our bot filtered).
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `SLACK_INTEGRATION_THREAD_HISTORY_LIMIT` | `50` | Max messages to include in thread context (both full and delta modes) |

--- a/docs/docs/specs/shared-conversation-api/plan.md
+++ b/docs/docs/specs/shared-conversation-api/plan.md
@@ -1,0 +1,177 @@
+# Shared Conversation API
+
+> **Branch:** `prebuild/feat/shared-conversation-api`
+> **Base:** `release/0.4.0`
+> **Status:** In Progress
+
+## Problem
+
+The Web UI and Slack bot create conversations differently:
+
+- **Web UI**: Generates a random UUID v4 client-side, creates a MongoDB document via `POST /api/chat/conversations` (cookie auth only, hardcoded `client_type: 'ui'`).
+- **Slack bot**: Generates a deterministic UUID v5 from `thread_ts`, sends it directly to the DA backend. No MongoDB conversation document is ever created. Slack conversations are invisible to the web UI.
+
+Both paths use the same DA backend, and the conversation ID becomes the LangGraph `thread_id`. But without a shared conversation record, there's no unified view of conversations across clients.
+
+## Goal
+
+A single `POST /api/chat/conversations` endpoint that **both** the web UI and Slack bot call to create conversations. The server owns ID generation, stores a consistent document, and supports create-or-return (upsert) semantics.
+
+## Design
+
+### Endpoint: `POST /api/chat/conversations`
+
+**Auth:** `getAuthFromBearerOrSession` (supports Bearer JWT for service-to-service + session cookie for browser)
+
+**Request body:**
+
+```ts
+interface CreateConversationRequest {
+  title: string;                          // required
+  client_type: "webui" | "slack";         // required, enum-validated
+  agent_id?: string;                      // optional, builds participants
+  owner_id?: string;                      // optional, see trust note below
+  metadata?: Record<string, unknown>;     // optional, arbitrary key/values
+  tags?: string[];                        // optional
+}
+```
+
+Key rules:
+- **No `id` from caller** — the server generates a UUID v4 and owns ID generation.
+- **`client_type`** is validated against enum `["webui", "slack"]`. Any other value is rejected with a `400` and a helpful message listing valid values.
+- **`metadata`** is an arbitrary `Record<string, unknown>`. The client decides what to put here. Slack will send `{ thread_ts, channel_id, channel_name }`. The web UI can send whatever it wants. No hardcoded keys.
+- **`owner_id`**: If provided, used as-is. If omitted, falls back to `user.email` from auth. See risk note.
+
+**Upsert (create-or-return):**
+
+If a conversation already exists with matching `metadata.thread_ts` + `owner_id`, return the existing document instead of creating a new one. This covers the Slack case where the same thread sends multiple messages.
+
+**Response:**
+
+```ts
+// 201 Created (new conversation)
+{ conversation: { _id, title, client_type, owner_id, ... }, created: true }
+
+// 200 OK (existing conversation returned)
+{ conversation: { _id, title, client_type, owner_id, ... }, created: false }
+```
+
+### Conversation Document (MongoDB)
+
+```ts
+interface Conversation {
+  _id: string;                            // server-generated UUID v4
+  title: string;
+  client_type: "webui" | "slack";         // TOP-LEVEL (promoted from metadata)
+  owner_id: string;                       // user email or service identity
+  participants: Participant[];
+  created_at: Date;
+  updated_at: Date;
+  metadata: Record<string, unknown>;      // arbitrary client metadata
+  sharing: { ... };                       // sharing settings
+  tags: string[];
+  is_archived: boolean;
+  is_pinned: boolean;
+}
+```
+
+**Backward compatibility:** Older documents have `metadata.client_type: 'ui'` but no top-level `client_type`. Queries treat missing `client_type` as `"webui"`.
+
+### Endpoint: `GET /api/chat/conversations`
+
+- Remove the phantom `source: { $ne: 'slack' }` filter (dead code — `source` was never written).
+- Add `client_type` as a query parameter: `?client_type=webui`, `?client_type=slack`, or omit for all.
+- Backward compat: documents without top-level `client_type` are treated as `"webui"`.
+
+### `owner_id` Trust Model
+
+> **⚠️ RISK:** Any Bearer-authenticated caller can set `owner_id` to any email.
+> This is accepted for now to unblock the Slack integration. The Slack bot
+> knows the user's email (via Slack `users.info` API) and sends it as `owner_id`.
+>
+> **Future mitigation:** Implement a service account allowlist — only specific
+> OAuth2 client IDs (identified from JWT `sub` claim) are permitted to set
+> `owner_id` on behalf of users. Regular browser sessions should never be
+> allowed to override `owner_id`.
+
+## Implementation Plan
+
+### Phase 1: API Changes
+
+#### 1.1 Update types (`ui/src/types/mongodb.ts`)
+- Add `ClientType = "webui" | "slack"` type
+- Add `client_type: ClientType` to `Conversation` interface (top-level)
+- Update `CreateConversationRequest`: remove `id`, add `client_type`, `owner_id?`, `metadata?`
+- Keep `metadata.client_type` on the interface for backward compat reads
+
+#### 1.2 Update `POST /api/chat/conversations` (`ui/src/app/api/chat/conversations/route.ts`)
+- Switch `withAuth` → `getAuthFromBearerOrSession`
+- Validate `client_type` against enum, reject with helpful 400 if invalid
+- Generate UUID v4 server-side (remove `body.id || uuidv4()` → always `uuidv4()`)
+- Accept `owner_id` from body (with risk comment), fallback to `user.email`
+- Accept `metadata` as `Record<string, unknown>`
+- Set `client_type` as top-level field
+- Implement upsert: check for existing conversation matching `metadata.thread_ts` + `owner_id` before insert
+- Return `{ conversation, created: boolean }` with appropriate status code (201 or 200)
+
+#### 1.3 Update `GET /api/chat/conversations` (`ui/src/app/api/chat/conversations/route.ts`)
+- Remove `source: { $ne: 'slack' }` filter
+- Add `client_type` query param filter
+- Handle backward compat for docs without top-level `client_type`
+
+### Phase 2: Web UI Changes
+
+#### 2.1 Update API client (`ui/src/lib/api-client.ts`)
+- Update `createConversation()` to match new request/response shape
+
+#### 2.2 Update Zustand store (`ui/src/store/chat-store.ts`)
+- `createConversation()` becomes async — awaits server response to get the server-generated ID
+- Remove `generateId()` call for conversation creation
+- Pass `client_type: "webui"` in the request
+
+#### 2.3 Update DynamicAgentChatPanel (`ui/src/components/chat/DynamicAgentChatPanel.tsx`)
+- `submitMessage` must await conversation creation before starting the stream
+- Currently fire-and-forget; needs to block on the API response (~<50ms latency for MongoDB insert)
+
+#### 2.4 Update conversation list UI
+- Add `client_type` filter to conversation sidebar
+- Show a Slack icon/badge on Slack-originated conversations
+- Wire up `client_type` query param to the API call
+
+### Phase 3: Slack Bot Changes
+
+#### 3.1 Add `create_conversation()` to SSE client (`ai_platform_engineering/integrations/slack_bot/sse_client.py`)
+- New method: `POST {CAIPE_API_URL}/api/chat/conversations`
+- Pass `client_type: "slack"`, `owner_id`, `agent_id`, `title`, `metadata: { thread_ts, channel_id, channel_name, ... }`
+- Handle `created: true` (new) vs `created: false` (existing) responses
+- Return the conversation `_id`
+
+#### 3.2 Update Slack handlers (`ai_platform_engineering/integrations/slack_bot/app.py`)
+- Call `create_conversation()` before `stream_chat()` in all three modes (@mention, Q&A, DM)
+- Use the server-returned `_id` as `conversation_id` for `stream_chat()`
+- Remove/deprecate `thread_ts_to_conversation_id()` (or keep as fallback)
+
+### Phase 4: Cleanup
+
+- Remove `metadata.client_type` writes (replaced by top-level `client_type`)
+- Add MongoDB index on `{ "metadata.thread_ts": 1, owner_id: 1 }` for upsert performance
+- Migration note: existing documents retain `metadata.client_type` — no backfill needed, queries handle both
+
+## Files to Modify
+
+| File | Phase | Changes |
+|------|-------|---------|
+| `ui/src/types/mongodb.ts` | 1.1 | `ClientType`, updated `Conversation`, updated `CreateConversationRequest` |
+| `ui/src/app/api/chat/conversations/route.ts` | 1.2, 1.3 | Auth switch, upsert, `client_type` top-level, GET filter |
+| `ui/src/lib/api-client.ts` | 2.1 | Updated request/response types |
+| `ui/src/store/chat-store.ts` | 2.2 | Async `createConversation`, no client-side ID |
+| `ui/src/components/chat/DynamicAgentChatPanel.tsx` | 2.3 | Await conversation creation |
+| Conversation sidebar component(s) | 2.4 | `client_type` filter, Slack badge |
+| `ai_platform_engineering/integrations/slack_bot/sse_client.py` | 3.1 | `create_conversation()` method |
+| `ai_platform_engineering/integrations/slack_bot/app.py` | 3.2 | Call before streaming, use returned ID |
+
+## Decisions
+
+1. **Default filter for conversation list**: Return ALL conversations (no `client_type` filter by default). Users see both webui and Slack conversations in the sidebar.
+2. **Conversation title for Slack**: First message truncated.
+3. **Thread context deduplication**: Separate follow-up task. For now, focus only on conversation_id unification.

--- a/ui/src/app/api/chat/conversations/[id]/metadata/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/metadata/route.ts
@@ -1,0 +1,69 @@
+/**
+ * PATCH /api/chat/conversations/[id]/metadata
+ *
+ * Shallow-merge caller-provided keys into the conversation's metadata.
+ * Only metadata is mutable via this endpoint — no other fields are touched.
+ *
+ * Supports Bearer JWT (Slack bot service account) and session cookies.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import {
+  getAuthFromBearerOrSession,
+  withErrorHandler,
+  successResponse,
+  ApiError,
+  validateUUID,
+} from '@/lib/api-middleware';
+import type { Conversation, PatchConversationMetadataRequest } from '@/types/mongodb';
+
+export const PATCH = withErrorHandler(async (
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) => {
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 },
+    );
+  }
+
+  await getAuthFromBearerOrSession(request);
+
+  const params = await context.params;
+  const conversationId = params.id;
+
+  if (!validateUUID(conversationId)) {
+    throw new ApiError('Invalid conversation ID format', 400);
+  }
+
+  const body: PatchConversationMetadataRequest = await request.json();
+
+  if (!body.metadata || typeof body.metadata !== 'object' || Array.isArray(body.metadata)) {
+    throw new ApiError('Request body must contain a "metadata" object', 400);
+  }
+
+  const conversations = await getCollection<Conversation>('conversations');
+  const conversation = await conversations.findOne({ _id: conversationId });
+
+  if (!conversation) {
+    throw new ApiError('Conversation not found', 404);
+  }
+
+  // Shallow-merge provided keys into existing metadata using dot notation
+  // so MongoDB only updates the specified fields without replacing the entire
+  // metadata object (avoids TypeScript intersection type issues).
+  const setFields: Record<string, unknown> = { updated_at: new Date() };
+  for (const [key, value] of Object.entries(body.metadata)) {
+    setFields[`metadata.${key}`] = value;
+  }
+
+  await conversations.updateOne(
+    { _id: conversationId },
+    { $set: setFields },
+  );
+
+  const updated = await conversations.findOne({ _id: conversationId });
+  return successResponse(updated);
+});

--- a/ui/src/app/api/chat/conversations/route.ts
+++ b/ui/src/app/api/chat/conversations/route.ts
@@ -1,11 +1,11 @@
 // GET /api/chat/conversations - List user's conversations
-// POST /api/chat/conversations - Create new conversation
+// POST /api/chat/conversations - Create new conversation (or return existing via upsert)
 
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
 import {
-  withAuth,
+  getAuthFromBearerOrSession,
   withErrorHandler,
   successResponse,
   paginatedResponse,
@@ -13,12 +13,13 @@ import {
   getPaginationParams,
   getUserTeamIds,
 } from '@/lib/api-middleware';
-import type { Conversation, CreateConversationRequest } from '@/types/mongodb';
+import type { Conversation, CreateConversationRequest, ClientType } from '@/types/mongodb';
+import { VALID_CLIENT_TYPES } from '@/types/mongodb';
+import { buildParticipants } from '@/types/a2a';
 import packageJson from '../../../../../package.json';
 
 // GET /api/chat/conversations
 export const GET = withErrorHandler(async (request: NextRequest) => {
-  // Check if MongoDB is configured
   if (!isMongoDBConfigured) {
     return NextResponse.json(
       {
@@ -26,69 +27,94 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         error: 'MongoDB not configured - use localStorage mode',
         code: 'MONGODB_NOT_CONFIGURED',
       },
-      { status: 503 } // Service Unavailable
+      { status: 503 }
     );
   }
 
-  return withAuth(request, async (req, user) => {
-    const { page, pageSize, skip } = getPaginationParams(request);
-    const url = new URL(request.url);
-    const archived = url.searchParams.get('archived') === 'true';
-    const pinned = url.searchParams.get('pinned') === 'true';
+  const { user } = await getAuthFromBearerOrSession(request);
+  const { page, pageSize, skip } = getPaginationParams(request);
+  const url = new URL(request.url);
+  const archived = url.searchParams.get('archived') === 'true';
+  const pinned = url.searchParams.get('pinned') === 'true';
+  const clientTypeParam = url.searchParams.get('client_type') as ClientType | null;
 
-    const conversations = await getCollection<Conversation>('conversations');
+  // Validate client_type param if provided
+  if (clientTypeParam && !VALID_CLIENT_TYPES.includes(clientTypeParam)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Invalid client_type: "${clientTypeParam}". Valid values: ${VALID_CLIENT_TYPES.join(', ')}`,
+      },
+      { status: 400 }
+    );
+  }
 
-    // Resolve user's team memberships for team-shared conversations
-    const userTeamIds = await getUserTeamIds(user.email);
+  const conversations = await getCollection<Conversation>('conversations');
 
-    // Build query — include conversations owned, shared directly, via teams, or public
-    const ownershipConditions: any[] = [
-      { owner_id: user.email },
-      { 'sharing.shared_with': user.email },
-      { 'sharing.is_public': true },
-    ];
+  // Resolve user's team memberships for team-shared conversations
+  const userTeamIds = await getUserTeamIds(user.email);
 
-    if (userTeamIds.length > 0) {
-      ownershipConditions.push({
-        'sharing.shared_with_teams': { $in: userTeamIds },
+  // Build query — include conversations owned, shared directly, via teams, or public
+  const ownershipConditions: any[] = [
+    { owner_id: user.email },
+    { 'sharing.shared_with': user.email },
+    { 'sharing.is_public': true },
+  ];
+
+  if (userTeamIds.length > 0) {
+    ownershipConditions.push({
+      'sharing.shared_with_teams': { $in: userTeamIds },
+    });
+  }
+
+  // Exclude soft-deleted conversations
+  const query: any = {
+    $or: ownershipConditions,
+    $and: [
+      { $or: [{ deleted_at: null }, { deleted_at: { $exists: false } }] },
+    ],
+  };
+
+  // Filter by client_type if specified.
+  // Backward compat: older documents without top-level client_type are treated as 'webui'.
+  if (clientTypeParam) {
+    if (clientTypeParam === 'webui') {
+      // Match docs with client_type: 'webui' OR missing client_type (legacy)
+      query.$and.push({
+        $or: [
+          { client_type: 'webui' },
+          { client_type: { $exists: false } },
+        ],
       });
+    } else {
+      query.$and.push({ client_type: clientTypeParam });
     }
+  }
 
-    // Exclude soft-deleted and Slack conversations from normal listing
-    const query: any = {
-      source: { $ne: 'slack' },
-      $or: ownershipConditions,
-      $and: [
-        { $or: [{ deleted_at: null }, { deleted_at: { $exists: false } }] },
-      ],
-    };
+  if (archived !== null) {
+    query.is_archived = archived;
+  }
 
-    if (archived !== null) {
-      query.is_archived = archived;
-    }
+  if (pinned) {
+    query.is_pinned = true;
+  }
 
-    if (pinned) {
-      query.is_pinned = true;
-    }
+  // Get total count
+  const total = await conversations.countDocuments(query);
 
-    // Get total count
-    const total = await conversations.countDocuments(query);
+  // Get paginated results
+  const items = await conversations
+    .find(query)
+    .sort({ is_pinned: -1, updated_at: -1 })
+    .skip(skip)
+    .limit(pageSize)
+    .toArray();
 
-    // Get paginated results
-    const items = await conversations
-      .find(query)
-      .sort({ is_pinned: -1, updated_at: -1 })
-      .skip(skip)
-      .limit(pageSize)
-      .toArray();
-
-    return paginatedResponse(items, total, page, pageSize);
-  });
+  return paginatedResponse(items, total, page, pageSize);
 });
 
 // POST /api/chat/conversations
 export const POST = withErrorHandler(async (request: NextRequest) => {
-  // Check if MongoDB is configured
   if (!isMongoDBConfigured) {
     return NextResponse.json(
       {
@@ -96,43 +122,80 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
         error: 'MongoDB not configured - use localStorage mode',
         code: 'MONGODB_NOT_CONFIGURED',
       },
-      { status: 503 } // Service Unavailable
+      { status: 503 }
     );
   }
 
-  return withAuth(request, async (req, user) => {
-    const body: CreateConversationRequest = await request.json();
+  const { user } = await getAuthFromBearerOrSession(request);
+  const body: CreateConversationRequest = await request.json();
 
-    validateRequired(body, ['title']);
+  validateRequired(body, ['title', 'client_type']);
 
-    const conversations = await getCollection<Conversation>('conversations');
-
-    const now = new Date();
-    const newConversation: Conversation = {
-      _id: body.id || uuidv4(), // Use client-provided ID if given, otherwise generate
-      title: body.title,
-      owner_id: user.email,
-      participants: body.participants || [],
-      created_at: now,
-      updated_at: now,
-      metadata: {
-        client_type: 'ui',
-        ui_version: packageJson.version,
-        total_messages: 0,
+  // Validate client_type enum
+  if (!VALID_CLIENT_TYPES.includes(body.client_type)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Invalid client_type: "${body.client_type}". Valid values: ${VALID_CLIENT_TYPES.join(', ')}`,
       },
-      sharing: {
-        is_public: false,
-        shared_with: [],
-        shared_with_teams: [],
-        share_link_enabled: false,
-      },
-      tags: body.tags || [],
-      is_archived: false,
-      is_pinned: false,
-    };
+      { status: 400 }
+    );
+  }
 
-    await conversations.insertOne(newConversation);
+  const conversations = await getCollection<Conversation>('conversations');
 
-    return successResponse(newConversation, 201);
-  });
+  // ⚠️ RISK: owner_id can be set by any authenticated caller. This trusts the caller
+  // (e.g. Slack bot setting owner_id to the Slack user's email). Future mitigation:
+  // implement a service account allowlist — only specific OAuth2 client IDs should be
+  // permitted to set owner_id on behalf of users.
+  const ownerId = body.owner_id || user.email;
+
+  // Idempotency: if an idempotency_key is provided, return the existing conversation
+  // instead of creating a duplicate. This maintains a 1-1 mapping between integration-
+  // specific identities (e.g. Slack thread_ts) and the conversation_id used by
+  // UI and LangGraph checkpoints.
+  if (body.idempotency_key) {
+    const existing = await conversations.findOne({
+      idempotency_key: body.idempotency_key,
+    });
+    if (existing) {
+      return successResponse({ conversation: existing, created: false }, 200);
+    }
+  }
+
+  const now = new Date();
+  const clientMetadata: Record<string, unknown> = {
+    ...body.metadata,
+    total_messages: 0,
+  };
+
+  // Add UI-specific metadata
+  if (body.client_type === 'webui') {
+    clientMetadata.ui_version = packageJson.version;
+  }
+
+  const newConversation: Conversation = {
+    _id: uuidv4(), // Server owns ID generation
+    title: body.title,
+    client_type: body.client_type,
+    owner_id: ownerId,
+    ...(body.idempotency_key && { idempotency_key: body.idempotency_key }),
+    participants: buildParticipants(body.agent_id, ownerId),
+    created_at: now,
+    updated_at: now,
+    metadata: clientMetadata as Conversation['metadata'],
+    sharing: {
+      is_public: false,
+      shared_with: [],
+      shared_with_teams: [],
+      share_link_enabled: false,
+    },
+    tags: body.tags || [],
+    is_archived: false,
+    is_pinned: false,
+  };
+
+  await conversations.insertOne(newConversation);
+
+  return successResponse({ conversation: newConversation, created: true }, 201);
 });

--- a/ui/src/app/api/dynamic-agents/conversations/route.ts
+++ b/ui/src/app/api/dynamic-agents/conversations/route.ts
@@ -119,6 +119,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
                 checkpoint_count: 1,
                 client_type: 1,
                 idempotency_key: 1,
+                metadata: 1,
                 is_archived: 1,
                 deleted_at: 1,
               },

--- a/ui/src/app/api/dynamic-agents/conversations/route.ts
+++ b/ui/src/app/api/dynamic-agents/conversations/route.ts
@@ -117,6 +117,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
                 created_at: 1,
                 updated_at: 1,
                 checkpoint_count: 1,
+                client_type: 1,
+                idempotency_key: 1,
                 is_archived: 1,
                 deleted_at: 1,
               },

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -363,7 +363,7 @@ export function SupervisorChatPanel({ endpoint, conversationId, conversationTitl
     // Create conversation if needed
     let convId = activeConversationId;
     if (!convId) {
-      convId = createConversation();
+      convId = await createConversation();
     }
 
     // Clear previous turn's events (tasks, tool completions, stream events)
@@ -891,7 +891,7 @@ export function SupervisorChatPanel({ endpoint, conversationId, conversationTitl
   const handleSkillsCommand = useCallback(async () => {
     let convId = activeConversationId;
     if (!convId) {
-      convId = createConversation();
+      convId = await createConversation();
     }
 
     // Add user message showing the command
@@ -942,10 +942,10 @@ export function SupervisorChatPanel({ endpoint, conversationId, conversationTitl
   }, [activeConversationId, createConversation, addMessage, updateMessage, updateConversationTitle]);
 
   // Handle /help command: show available commands in chat
-  const handleHelpCommand = useCallback(() => {
+  const handleHelpCommand = useCallback(async () => {
     let convId = activeConversationId;
     if (!convId) {
-      convId = createConversation();
+      convId = await createConversation();
     }
     const turnId = `turn-${Date.now()}`;
     addMessage(convId, { role: "user", content: "/help" }, turnId);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -748,7 +748,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
     // Create conversation if needed
     let convId = activeConversationId;
     if (!convId) {
-      convId = createConversation(agentId);
+      convId = await createConversation(agentId);
     }
 
     // Build client context for system prompt rendering and user_info tool
@@ -839,7 +839,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
   const handleSkillsCommand = useCallback(async () => {
     let convId = activeConversationId;
     if (!convId) {
-      convId = createConversation(agentId);
+      convId = await createConversation(agentId);
     }
 
     const turnId = `turn-${Date.now()}`;
@@ -888,10 +888,10 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
   }, [activeConversationId, createConversation, addMessage, updateMessage, updateConversationTitle]);
 
   // Handle /help command: show available commands in chat
-  const handleHelpCommand = useCallback(() => {
+  const handleHelpCommand = useCallback(async () => {
     let convId = activeConversationId;
     if (!convId) {
-      convId = createConversation(agentId);
+      convId = await createConversation(agentId);
     }
     const turnId = `turn-${Date.now()}`;
     addMessage(convId, { role: "user", content: "/help" }, turnId);
@@ -916,8 +916,8 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
   }, [activeConversationId, createConversation, addMessage, updateConversationTitle]);
 
   // Handle /clear command
-  const handleClearCommand = useCallback(() => {
-    createConversation(agentId);
+  const handleClearCommand = useCallback(async () => {
+    await createConversation(agentId);
   }, [createConversation, agentId]);
 
   // Unified slash command executor

--- a/ui/src/components/dynamic-agents/ConversationsTab.tsx
+++ b/ui/src/components/dynamic-agents/ConversationsTab.tsx
@@ -28,6 +28,7 @@ import {
   Hash,
   Globe,
   Copy,
+  ExternalLink,
 } from "lucide-react";
 import { getGradientStyle } from "@/lib/gradient-themes";
 import type { AgentUIConfig } from "@/types/dynamic-agent";
@@ -42,6 +43,13 @@ interface ConversationItem {
   checkpoint_count: number;
   client_type?: string;
   idempotency_key?: string;
+  metadata?: {
+    thread_ts?: string;
+    channel_id?: string;
+    channel_name?: string;
+    workspace_url?: string;
+    [key: string]: unknown;
+  };
   is_archived: boolean;
   deleted_at: string | null;
 }
@@ -201,6 +209,13 @@ export function ConversationsTab() {
       hour: "2-digit",
       minute: "2-digit",
     });
+  };
+
+  const buildSlackPermalink = (conv: ConversationItem): string | null => {
+    const meta = conv.metadata;
+    if (!meta?.workspace_url || !meta?.channel_id || !meta?.thread_ts) return null;
+    const tsClean = meta.thread_ts.replace(".", "");
+    return `${meta.workspace_url}/archives/${meta.channel_id}/p${tsClean}`;
   };
 
   return (
@@ -512,6 +527,25 @@ export function ConversationsTab() {
                     {selectedConversation.client_type === "slack" ? "Slack" : "Web"}
                   </Badge>
                 </div>
+
+                {/* Slack permalink (for Slack conversations) */}
+                {(() => {
+                  const permalink = buildSlackPermalink(selectedConversation);
+                  return permalink ? (
+                    <div className="flex items-center gap-2">
+                      <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                      <a
+                        href={permalink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+                      >
+                        View Slack thread
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  ) : null;
+                })()}
 
                 {/* ID */}
                 <div className="flex items-start gap-2">

--- a/ui/src/components/dynamic-agents/ConversationsTab.tsx
+++ b/ui/src/components/dynamic-agents/ConversationsTab.tsx
@@ -7,6 +7,12 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   MessageSquare,
   Trash2,
   Loader2,
@@ -18,6 +24,10 @@ import {
   Archive,
   ChevronLeft,
   ChevronRight,
+  Clock,
+  Hash,
+  Globe,
+  Copy,
 } from "lucide-react";
 import { getGradientStyle } from "@/lib/gradient-themes";
 import type { AgentUIConfig } from "@/types/dynamic-agent";
@@ -30,6 +40,8 @@ interface ConversationItem {
   created_at: string;
   updated_at: string;
   checkpoint_count: number;
+  client_type?: string;
+  idempotency_key?: string;
   is_archived: boolean;
   deleted_at: string | null;
 }
@@ -62,6 +74,7 @@ export function ConversationsTab() {
   const [totalPages, setTotalPages] = React.useState(1);
   const [total, setTotal] = React.useState(0);
   const [clearingId, setClearingId] = React.useState<string | null>(null);
+  const [selectedConversation, setSelectedConversation] = React.useState<ConversationItem | null>(null);
   const { toast } = useToast();
 
   // Fetch agents once on mount to build lookup map
@@ -284,9 +297,10 @@ export function ConversationsTab() {
               {conversations.map((conv) => (
                 <div
                   key={conv.id}
-                  className={`grid grid-cols-12 gap-4 py-3 px-2 rounded-lg hover:bg-muted/50 items-center ${
+                  className={`grid grid-cols-12 gap-4 py-3 px-2 rounded-lg hover:bg-muted/50 items-center cursor-pointer ${
                     conv.deleted_at ? "opacity-60" : ""
                   }`}
+                  onClick={() => setSelectedConversation(conv)}
                 >
                   <div className="col-span-4">
                     <div className="flex items-center gap-3">
@@ -295,8 +309,20 @@ export function ConversationsTab() {
                       </div>
                       <div className="min-w-0 flex-1">
                         <div className="font-medium text-sm truncate">{conv.title}</div>
-                        <div className="text-xs text-muted-foreground font-mono break-all">
-                          {conv.id}
+                        <div className="flex items-center gap-2 mt-0.5">
+                          <Badge
+                            variant="outline"
+                            className={`text-[10px] px-1.5 py-0 leading-4 ${
+                              conv.client_type === "slack"
+                                ? "text-purple-600 border-purple-300"
+                                : "text-blue-600 border-blue-300"
+                            }`}
+                          >
+                            {conv.client_type === "slack" ? "Slack" : "Web"}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground font-mono truncate">
+                            {conv.id}
+                          </span>
                         </div>
                       </div>
                     </div>
@@ -362,7 +388,7 @@ export function ConversationsTab() {
                       variant="ghost"
                       size="icon"
                       className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                      onClick={() => handleClear(conv.id)}
+                      onClick={(e) => { e.stopPropagation(); handleClear(conv.id); }}
                       disabled={clearingId === conv.id}
                       title="Clear checkpoint data"
                     >
@@ -457,6 +483,161 @@ export function ConversationsTab() {
           </>
         )}
       </CardContent>
+
+      {/* Conversation Detail Modal */}
+      <Dialog open={!!selectedConversation} onOpenChange={(open) => { if (!open) setSelectedConversation(null); }}>
+        <DialogContent className="sm:max-w-lg">
+          {selectedConversation && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <MessageSquare className="h-5 w-5 text-blue-500 shrink-0" />
+                  <span className="break-words">{selectedConversation.title}</span>
+                </DialogTitle>
+              </DialogHeader>
+
+              <div className="space-y-4 pt-2">
+                {/* Source badge */}
+                <div className="flex items-center gap-2">
+                  <Globe className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">Source</span>
+                  <Badge
+                    variant="outline"
+                    className={
+                      selectedConversation.client_type === "slack"
+                        ? "text-purple-600 border-purple-300"
+                        : "text-blue-600 border-blue-300"
+                    }
+                  >
+                    {selectedConversation.client_type === "slack" ? "Slack" : "Web"}
+                  </Badge>
+                </div>
+
+                {/* ID */}
+                <div className="flex items-start gap-2">
+                  <Hash className="h-4 w-4 text-muted-foreground mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-muted-foreground">Conversation ID</div>
+                    <div className="flex items-center gap-1.5">
+                      <code className="text-sm font-mono break-all">{selectedConversation.id}</code>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 shrink-0"
+                        onClick={() => { navigator.clipboard.writeText(selectedConversation.id); toast("Copied to clipboard", "success"); }}
+                      >
+                        <Copy className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Owner */}
+                {selectedConversation.idempotency_key && (
+                  <div className="flex items-start gap-2">
+                    <Hash className="h-4 w-4 text-muted-foreground mt-0.5" />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm text-muted-foreground">
+                        Idempotency Key (internal chat ID for {selectedConversation.client_type === "slack" ? "Slack" : selectedConversation.client_type || "unknown client"})
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <code className="text-sm font-mono break-all">{selectedConversation.idempotency_key}</code>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0"
+                          onClick={() => { navigator.clipboard.writeText(selectedConversation.idempotency_key!); toast("Copied to clipboard", "success"); }}
+                        >
+                          <Copy className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Owner */}
+                <div className="flex items-start gap-2">
+                  <User className="h-4 w-4 text-muted-foreground mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-muted-foreground">Owner</div>
+                    <div className="text-sm break-all">{selectedConversation.owner_id}</div>
+                  </div>
+                </div>
+
+                {/* Agent */}
+                <div className="flex items-start gap-2">
+                  <Bot className="h-4 w-4 text-muted-foreground mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-muted-foreground">Agent</div>
+                    <div className="text-sm">{getAgentName(selectedConversation.agent_id)}</div>
+                    {selectedConversation.agent_id && (
+                      <code className="text-xs text-muted-foreground font-mono break-all">{selectedConversation.agent_id}</code>
+                    )}
+                  </div>
+                </div>
+
+                {/* Status */}
+                <div className="flex items-center gap-2">
+                  <Archive className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">Status</span>
+                  {selectedConversation.deleted_at ? (
+                    <Badge variant="outline" className="gap-1 text-orange-600 border-orange-300">Trash</Badge>
+                  ) : selectedConversation.is_archived ? (
+                    <Badge variant="outline" className="gap-1 text-muted-foreground">Archived</Badge>
+                  ) : (
+                    <Badge variant="outline" className="gap-1 text-green-600 border-green-300">Active</Badge>
+                  )}
+                </div>
+
+                {/* Checkpoints */}
+                <div className="flex items-center gap-2">
+                  <MessageSquare className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">Checkpoints</span>
+                  <span className="text-sm">{selectedConversation.checkpoint_count}</span>
+                </div>
+
+                {/* Dates */}
+                <div className="flex items-start gap-2">
+                  <Clock className="h-4 w-4 text-muted-foreground mt-0.5" />
+                  <div>
+                    <div className="text-sm">
+                      <span className="text-muted-foreground">Created:</span>{" "}
+                      {formatDate(selectedConversation.created_at)}
+                    </div>
+                    <div className="text-sm">
+                      <span className="text-muted-foreground">Updated:</span>{" "}
+                      {formatDate(selectedConversation.updated_at)}
+                    </div>
+                    {selectedConversation.deleted_at && (
+                      <div className="text-sm">
+                        <span className="text-muted-foreground">Deleted:</span>{" "}
+                        {formatDate(selectedConversation.deleted_at)}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex justify-end pt-2 border-t">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => { handleClear(selectedConversation.id); setSelectedConversation(null); }}
+                    disabled={clearingId === selectedConversation.id}
+                  >
+                    {clearingId === selectedConversation.id ? (
+                      <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    ) : (
+                      <Trash2 className="h-4 w-4 mr-2" />
+                    )}
+                    Clear Checkpoint Data
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -174,10 +174,12 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapse, onUseCa
       if (storageMode === 'mongodb') {
         // MongoDB mode: Create conversation on server
         const { apiClient } = await import('@/lib/api-client');
-        const conversation = await apiClient.createConversation({
+        const result = await apiClient.createConversation({
           title: "New Conversation",
-          participants: buildParticipants(agentId),
+          client_type: 'webui',
+          agent_id: agentId,
         });
+        const conversation = result.conversation;
 
         // Add to local store immediately
         const newConversation: Conversation = {
@@ -528,7 +530,7 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapse, onUseCa
                               // so the user always has somewhere to land
                               let navigateToId: string | null = null;
                               if (isLastConversation) {
-                                navigateToId = createConversation();
+                                navigateToId = await createConversation();
                                 console.log('[Sidebar] Created replacement conversation:', navigateToId);
                               }
 

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
         className
       )}
       {...props}

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -7,6 +7,7 @@ import type {
   User,
   UserSettings,
   CreateConversationRequest,
+  CreateConversationResponse,
   UpdateConversationRequest,
   ShareConversationRequest,
   AddMessageRequest,
@@ -145,7 +146,7 @@ class APIClient {
 
   async createConversation(
     data: CreateConversationRequest
-  ): Promise<Conversation> {
+  ): Promise<CreateConversationResponse> {
     return this.request('/api/chat/conversations', {
       method: 'POST',
       body: JSON.stringify(data),

--- a/ui/src/store/__tests__/chat-store.test.ts
+++ b/ui/src/store/__tests__/chat-store.test.ts
@@ -24,7 +24,7 @@ jest.mock('@/lib/api-client', () => ({
     addMessage: jest.fn().mockResolvedValue({}),
     getMessages: jest.fn().mockResolvedValue({ items: [], total: 0 }),
     getConversations: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, page_size: 100, has_more: false }),
-    createConversation: jest.fn().mockResolvedValue({}),
+    createConversation: jest.fn().mockResolvedValue({ conversation: { _id: 'server-generated-id' }, created: true }),
     deleteConversation: jest.fn().mockResolvedValue({ deleted: true }),
     updateConversation: jest.fn().mockResolvedValue({}),
   },
@@ -1046,29 +1046,26 @@ describe('chat-store', () => {
 
   describe('createConversation', () => {
     it('creates conversation on server in MongoDB mode', async () => {
-      const id = useChatStore.getState().createConversation();
+      const id = await useChatStore.getState().createConversation();
 
-      expect(id).toBeDefined();
+      expect(id).toBe('server-generated-id');
       expect(useChatStore.getState().conversations).toHaveLength(1);
       expect(useChatStore.getState().activeConversationId).toBe(id);
 
-      // Wait for async server call
-      await jest.runAllTimersAsync();
-
       expect(mockApiClient.createConversation).toHaveBeenCalledWith(
         expect.objectContaining({
-          id,
           title: 'New Conversation',
+          client_type: 'webui',
         })
       );
     });
 
-    it('does not call server in localStorage mode', () => {
+    it('does not call server in localStorage mode', async () => {
       (global as any).__mockStorageMode = 'localStorage';
 
       // The store is already created, but createConversation checks
       // getStorageMode() internally on each call
-      const id = useChatStore.getState().createConversation();
+      const id = await useChatStore.getState().createConversation();
 
       expect(id).toBeDefined();
       expect(useChatStore.getState().conversations).toHaveLength(1);

--- a/ui/src/store/chat-store.ts
+++ b/ui/src/store/chat-store.ts
@@ -35,7 +35,7 @@ interface ChatState {
   inputRequiredConversations: Set<string>;
 
   // Actions
-  createConversation: (agentId?: string) => string;
+  createConversation: (agentId?: string) => Promise<string>;
   setActiveConversation: (id: string) => void;
   addMessage: (conversationId: string, message: Omit<ChatMessage, "id" | "timestamp" | "events">, turnId?: string, messageId?: string) => string;
   updateMessage: (conversationId: string, messageId: string, updates: Partial<ChatMessage>) => void;
@@ -253,41 +253,40 @@ const storeImplementation = (set: any, get: any) => ({
       unviewedConversations: new Set<string>(),
       inputRequiredConversations: new Set<string>(),
 
-      createConversation: (agentId?: string) => {
-        const id = generateId();
+      createConversation: async (agentId?: string) => {
+        const storageMode = getStorageMode();
+
+        let id: string;
+
+        if (storageMode === 'mongodb') {
+          // MongoDB mode: server owns ID generation
+          const result = await apiClient.createConversation({
+            title: 'New Conversation',
+            client_type: 'webui',
+            agent_id: agentId,
+          });
+          id = result.conversation._id;
+        } else {
+          // localStorage mode: generate locally
+          id = generateId();
+        }
+
         const newConversation: Conversation = {
           id,
           title: "New Conversation",
           createdAt: new Date(),
           updatedAt: new Date(),
           messages: [],
-          a2aEvents: [], // Initialize with empty events
-          streamEvents: [], // Initialize with empty stream events for Dynamic Agents
+          a2aEvents: [],
+          streamEvents: [],
           participants: buildParticipants(agentId),
         };
 
-        const storageMode = getStorageMode();
-
-        // In MongoDB mode: create on server first
-        // In localStorage mode: create locally
-        if (storageMode === 'mongodb') {
-          // MongoDB mode: Create on server with the same ID used locally
-          apiClient.createConversation({
-            id,
-            title: newConversation.title,
-            participants: buildParticipants(agentId),
-          }).then(() => {
-            console.log('[ChatStore] Created conversation in MongoDB:', id);
-          }).catch((error) => {
-            console.error('[ChatStore] Failed to create conversation in MongoDB:', error);
-          });
-        }
-
-        // Update local state (in localStorage mode, this persists via Zustand)
+        // Update local state
         set((state: ChatState) => ({
           conversations: [newConversation, ...state.conversations],
           activeConversationId: id,
-          a2aEvents: [], // Clear global events for new conversation
+          a2aEvents: [],
         }));
 
         return id;

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -283,6 +283,10 @@ export interface UpdateConversationRequest {
   is_pinned?: boolean;
 }
 
+export interface PatchConversationMetadataRequest {
+  metadata: Record<string, unknown>;
+}
+
 export interface ShareConversationRequest {
   user_emails?: string[];
   team_ids?: string[];

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -32,6 +32,12 @@ export interface UserPublicInfo {
 // Conversation Collection
 // ============================================================================
 
+/** Valid client types for conversation creation. */
+export type ClientType = 'webui' | 'slack';
+
+/** All valid client_type values — used for runtime validation. */
+export const VALID_CLIENT_TYPES: readonly ClientType[] = ['webui', 'slack'] as const;
+
 /**
  * A conversation participant — either an agent or a user.
  *
@@ -44,16 +50,18 @@ export interface Participant {
 }
 
 export interface Conversation {
-  _id: string; // UUID for shareable links
+  _id: string; // UUID for shareable links (server-generated)
   title: string;
+  client_type: ClientType; // Top-level: 'webui' | 'slack' (promoted from metadata)
   owner_id: string; // User email
+  idempotency_key?: string; // Maps integration-specific identity (e.g. Slack thread_ts) to conversation_id used by UI/checkpoints
   participants: Participant[]; // Agents and users involved in this conversation
   created_at: Date;
   updated_at: Date;
-  metadata: {
-    /** Which client created this conversation: 'ui', 'slack', 'api', etc. */
-    client_type: string;
-    /** UI version (from package.json) when client_type is 'ui' */
+  metadata: Record<string, unknown> & {
+    /** @deprecated Use top-level client_type instead. Kept for backward compat reads. */
+    client_type?: string;
+    /** UI version (from package.json) when client_type is 'webui' */
     ui_version?: string;
     total_messages: number;
     total_tokens?: number;
@@ -253,10 +261,19 @@ export interface SharingAccess {
 
 // Conversation API
 export interface CreateConversationRequest {
-  id?: string; // Client-generated UUID — ensures client and server share the same ID
   title: string;
+  client_type: ClientType; // Required: 'webui' | 'slack'
+  agent_id?: string; // Optional: builds participants with this agent
+  owner_id?: string; // Optional: trusted callers (e.g. Slack bot) can set on behalf of user
+  idempotency_key?: string; // Maps integration-specific identity (e.g. Slack thread_ts) to conversation_id used by UI/checkpoints
+  metadata?: Record<string, unknown>; // Optional: arbitrary key/values from client
   tags?: string[];
-  participants?: Participant[]; // Agents and users; empty/undefined = Platform Engineer (default)
+}
+
+/** Response from POST /api/chat/conversations */
+export interface CreateConversationResponse {
+  conversation: Conversation;
+  created: boolean; // true = new, false = existing (upsert matched)
 }
 
 export interface UpdateConversationRequest {


### PR DESCRIPTION
# Description

Unifies how the Web UI and Slack bot create and manage conversations through a single shared API, eliminating duplicated logic and enabling cross-client admin visibility.

**Key changes across 4 commits:**

1. **Shared Conversation API** (`feat(ui)`) — Server-owned ID generation, `idempotency_key` for dedup, `client_type` enum (`webui` | `slack`), Bearer token auth for service accounts, async store integration. All UI callers updated.

2. **Slack bot migration** (`feat(slack)`) — All 10 handlers migrated to call the shared conversation API instead of managing IDs locally.

3. **Admin UI enhancements** (`feat(ui)`) — `client_type` badges (Web/Slack) in ConversationsTab, detail modal with idempotency key display, fade-only dialog animation.

4. **Delta thread context** (`feat(slack)`) — Eliminates quadratic checkpoint growth by only embedding new Slack messages since `last_processed_ts` on follow-ups (full context on first turn). New `PATCH /api/chat/conversations/[id]/metadata` endpoint with MongoDB dot-notation `$set` for safe metadata merges. Slack permalink rendered in ConversationsTab detail modal. `SLACK_WORKSPACE_URL` logged at startup.

**Design decisions:**
- Server owns all conversation ID generation — callers never create their own
- `idempotency_key` maps integration-specific identities (e.g. Slack `channel:thread_ts`) to conversation IDs
- Delta context uses `SLACK_INTEGRATION_THREAD_HISTORY_LIMIT` env var (default 50)
- PATCH metadata uses dot-notation `$set` so other metadata keys are not clobbered
- `workspace_url` stored in conversation metadata at creation for Slack permalink construction

**Specs:**
- `docs/docs/specs/shared-conversation-api/plan.md`
- `docs/docs/specs/shared-conversation-api/delta-thread-context.md`

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass