### PR TITLE
fix(helm): single-node MCP ServiceAccounts and configurable name prefix

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.8 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.8-rc.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.8-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -124,6 +124,22 @@ In multi-node mode reads from global.enabledSubAgents (populated by Chart.yaml i
 {{- end -}}
 {{- end -}}
 
+{{/*
+Prefix for single-node in-cluster MCP Kubernetes names: {prefix}-agent-<name>[-mcp].
+When global.singleNode.mcpResourcePrefix is non-empty, use it (e.g. "single-node" for readable kubectl).
+When empty, use .Release.Name so legacy DNS like <release>-agent-jira-mcp stays stable.
+*/}}
+{{- define "ai-platform-engineering.singleNodeMcpResourcePrefix" -}}
+{{- $g := .Values.global | default dict }}
+{{- $sn := index $g "singleNode" | default dict }}
+{{- $p := index $sn "mcpResourcePrefix" | default "" }}
+{{- if ne $p "" -}}
+{{- $p -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "ai-platform-engineering.appVersion" -}}
 {{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/templates/single-node-agent-env.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-agent-env.yaml
@@ -23,7 +23,7 @@ data:
   {{- else if $mcp.mode }}
   {{ $ENV }}_MCP_MODE: {{ $mcp.mode | quote }}
   {{- if eq $mcp.mode "http" }}
-  {{ $ENV }}_MCP_HOST: {{ printf "%s-agent-%s-mcp" $.Release.Name $name | quote }}
+  {{ $ENV }}_MCP_HOST: {{ printf "%s-agent-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $name | quote }}
   {{ $ENV }}_MCP_PORT: {{ $mcp.port | default 8000 | quote }}
   {{- end }}
   {{- end }}

--- a/charts/ai-platform-engineering/templates/single-node-mcp-deployment.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-deployment.yaml
@@ -2,7 +2,8 @@
 In single-node mode, agent subcharts are disabled so their mcp-deployment templates
 don't run.  This template creates MCP HTTP server Deployments at the parent chart
 level for every enabled subagent whose mcp.mode is "http" (and that isn't using a
-remote MCP server).
+remote MCP server). ServiceAccounts are created by single-node-mcp-serviceaccount.yaml
+using the same naming convention as the agent subchart ({prefix}-agent-<name>); see global.singleNode.mcpResourcePrefix.
 */ -}}
 {{- if eq .Values.global.deploymentMode "single-node" }}
 {{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
@@ -19,26 +20,28 @@ remote MCP server).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+  name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
     app.kubernetes.io/component: mcp
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+      app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
       app.kubernetes.io/component: mcp
       app.kubernetes.io/instance: {{ $.Release.Name }}
   template:
     metadata:
       labels:
         {{- include "ai-platform-engineering.labels" $ | nindent 8 }}
-        app.kubernetes.io/name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+        app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
         app.kubernetes.io/component: mcp
     spec:
+      serviceAccountName: {{ printf "%s-%s" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+      automountServiceAccountToken: {{ $mcp.automountServiceAccountToken | default false }}
       containers:
         - name: mcp
           image: "{{ $mcpImageRepo }}:{{ $mcpImage.tag | default (include "ai-platform-engineering.appVersion" $) }}"

--- a/charts/ai-platform-engineering/templates/single-node-mcp-service.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-service.yaml
@@ -1,7 +1,8 @@
 {{- /*
 Companion Service for single-node MCP Deployments.
 Creates a ClusterIP Service for every enabled subagent whose mcp.mode is "http"
-so the supervisor pod can reach the MCP server at <release>-agent-<name>-mcp:<port>.
+so the supervisor pod can reach the MCP server at <mcpResourcePrefix>-agent-<name>-mcp:<port>
+(default prefix is the Helm release name; override with global.singleNode.mcpResourcePrefix).
 */ -}}
 {{- if eq .Values.global.deploymentMode "single-node" }}
 {{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
@@ -18,10 +19,10 @@ so the supervisor pod can reach the MCP server at <release>-agent-<name>-mcp:<po
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+  name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
     app.kubernetes.io/component: mcp
 spec:
   type: ClusterIP
@@ -31,7 +32,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
     app.kubernetes.io/component: mcp
     app.kubernetes.io/instance: {{ $.Release.Name }}
 {{- end }}

--- a/charts/ai-platform-engineering/templates/single-node-mcp-serviceaccount.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-serviceaccount.yaml
@@ -1,0 +1,34 @@
+{{- /*
+ServiceAccounts for in-cluster HTTP MCP servers in single-node mode.
+
+The MCP Deployments are rendered by single-node-mcp-deployment.yaml while agent
+subcharts stay disabled (tags.agent-*: false). Those pods must still reference a
+ServiceAccount that matches the naming convention the supervisor and tooling use
+({prefix}-agent-<name>; prefix from global.singleNode.mcpResourcePrefix or the Helm release name), which previously only existed when the agent subchart
+created it — causing ReplicaFailure when the chart rolled forward.
+*/ -}}
+{{- if eq .Values.global.deploymentMode "single-node" }}
+{{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
+{{- if $enabled }}
+{{- $agentKey := printf "agent-%s" $name }}
+{{- $agentValues := index $.Values $agentKey | default dict }}
+{{- $mcp := $agentValues.mcp | default dict }}
+{{- $useRemote := $mcp.useRemoteMcpServer | default false }}
+{{- if and (eq ($mcp.mode | default "stdio") "http") (not $useRemote) }}
+{{- $mcpImage := $mcp.image | default dict }}
+{{- $mcpImageRepo := $mcpImage.repository | default "" }}
+{{- if $mcpImageRepo }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-%s" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+  labels:
+    {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mcp
+automountServiceAccountToken: {{ $mcp.automountServiceAccountToken | default false }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ai-platform-engineering/templates/single-node-mcp-vpa.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-vpa.yaml
@@ -19,16 +19,16 @@ VPA config is resolved per-agent (mcp.vpa) falling back to global.mcp.vpa.
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+  name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
     app.kubernetes.io/component: mcp
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ printf "%s-%s-mcp" $.Release.Name $agentKey }}
+    name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
   updatePolicy:
     updateMode: {{ $vpa.updateMode | quote }}
   resourcePolicy:

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -34,6 +34,12 @@ global:
   # Deployment mode: "single-node" (all agents in-process) or "multi-node" (each agent as a separate pod)
   deploymentMode: "multi-node"
 
+  # When deploymentMode is single-node, in-cluster MCP Services/Deployments/SAs use
+  # {mcpResourcePrefix}-agent-<name>-mcp. Leave mcpResourcePrefix unset (empty) to use the
+  # Helm release name; set to "single-node" for stable, readable resource names.
+  singleNode:
+    mcpResourcePrefix: ""
+
   createLlmSecret: false # if true, llm secret will be created by the parent chart. Otherwise, expect existing llm secret
   llmSecrets:
     create: false # do not create llm secret in subcharts (use global or existing llm secret)


### PR DESCRIPTION
## Summary
- Add `single-node-mcp-serviceaccount.yaml` so in-cluster HTTP MCP workloads in single-node mode get a dedicated ServiceAccount (`{prefix}-agent-<name>`) when agent subcharts are disabled, avoiding ReplicaFailure from missing SAs.
- Add `global.singleNode.mcpResourcePrefix`: when set, MCP Deployment/Service/SA/VPA names and `single-node-agent-env` MCP_HOST use that prefix; when empty, use `.Release.Name` (legacy behavior).
- Document `global.singleNode` in chart `values.yaml`.

## Test plan
- [ ] `helm template` single-node with `mcpResourcePrefix: single-node` and one HTTP MCP agent: SA + Service + Deployment names align; ConfigMap MCP_HOST matches Service DNS.
- [ ] With prefix unset, resource names still follow release name.

Made with [Cursor](https://cursor.com)