### PR TITLE
fix(admin): correct feedback dedup, user linkage, and top user display

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/interaction_tracker.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/interaction_tracker.py
@@ -107,10 +107,12 @@ class InteractionTracker:
                             "name": user_name or user_email.split("@")[0],
                             "role": "user",
                             "source": "slack",
-                            "slack_user_id": user_id,
                             "created_at": now,
                         },
-                        "$set": {"last_login": now},
+                        "$set": {
+                            "last_login": now,
+                            "slack_user_id": user_id,
+                        },
                     },
                     upsert=True,
                 )

--- a/scripts/migrations/0.3.0/backfill_feedback_from_langfuse.py
+++ b/scripts/migrations/0.3.0/backfill_feedback_from_langfuse.py
@@ -159,17 +159,20 @@ def map_rating(value: str) -> str:
 
 
 def dedup_scores_by_permalink(scores: list[dict]) -> list[dict]:
-    """Group scores by slack_permalink, keep the best per group.
+    """Group scores by (slack_permalink, user_email), keep the best per group.
 
-    Priority: specific reason > thumbs_up > thumbs_down, then latest createdAt.
+    Multiple users can vote on the same bot response — each user's final vote
+    counts independently.  Within a single user's votes on the same permalink,
+    priority: specific reason > thumbs_up > thumbs_down, then latest createdAt.
     """
-    by_permalink: dict[str, list[dict]] = defaultdict(list)
+    by_key: dict[tuple[str, str], list[dict]] = defaultdict(list)
     no_permalink = []
 
     for s in scores:
         pl = (s.get("metadata") or {}).get("slack_permalink", "")
+        user = (s.get("metadata") or {}).get("user_email", "") or (s.get("metadata") or {}).get("user_id", "")
         if pl:
-            by_permalink[pl].append(s)
+            by_key[(pl, user)].append(s)
         else:
             no_permalink.append(s)
 
@@ -183,11 +186,11 @@ def dedup_scores_by_permalink(scores: list[dict]) -> list[dict]:
         return (priority, ts)
 
     deduped = []
-    for pl, group in by_permalink.items():
+    for key, group in by_key.items():
         deduped.append(max(group, key=sort_key))
 
     total_removed = len(scores) - len(deduped) - len(no_permalink)
-    print(f"Dedup by permalink: {len(scores)} scores -> {len(deduped)} unique + {len(no_permalink)} without permalink ({total_removed} duplicates removed)")
+    print(f"Dedup by (permalink, user): {len(scores)} scores -> {len(deduped)} unique + {len(no_permalink)} without permalink ({total_removed} duplicates removed)")
 
     return deduped + no_permalink
 
@@ -387,11 +390,12 @@ def main():
     skipped_existing = 0
 
     for doc in docs:
-        # Upsert on (slack_permalink, source) to prevent duplicates on re-runs
+        # Upsert on (slack_permalink, user_email, source) — each user's vote
+        # on a bot response is independent; re-runs update rather than duplicate.
         permalink = doc.get("slack_permalink")
         if permalink:
             result = feedback_coll.update_one(
-                {"slack_permalink": permalink, "source": "slack"},
+                {"slack_permalink": permalink, "user_email": doc["user_email"], "source": "slack"},
                 {
                     "$set": {
                         "trace_id": doc["trace_id"],

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -61,8 +61,8 @@ interface AdminStats {
     messages: number;
   }>;
   top_users: {
-    by_conversations: Array<{ _id: string; count: number }>;
-    by_messages: Array<{ _id: string; count: number }>;
+    by_conversations: Array<{ _id: string; count: number; name?: string }>;
+    by_messages: Array<{ _id: string; count: number; name?: string }>;
   };
   top_agents: Array<{ _id: string; count: number }>;
   feedback_summary: {
@@ -2122,11 +2122,11 @@ function AdminPage() {
                               <p className="text-sm text-muted-foreground text-center py-4">No data yet</p>
                             ) : stats.top_users.by_conversations.map((u, i) => (
                               <div key={u._id} className="flex items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                  <div className="w-6 text-sm text-muted-foreground">#{i + 1}</div>
-                                  <div className="text-sm truncate max-w-[200px] text-primary hover:underline cursor-pointer" onClick={() => setSelectedUserEmail(u._id)}>{u._id}</div>
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <div className="w-6 text-sm text-muted-foreground shrink-0">#{i + 1}</div>
+                                  <div className="text-sm truncate max-w-[200px] text-primary hover:underline cursor-pointer" onClick={() => setSelectedUserEmail(u._id)} title={u._id}>{u.name || u._id}</div>
                                 </div>
-                                <div className="text-sm font-medium">{u.count} chats</div>
+                                <div className="text-sm font-medium shrink-0">{u.count} chats</div>
                               </div>
                             ))}
                           </div>
@@ -2143,11 +2143,11 @@ function AdminPage() {
                               <p className="text-sm text-muted-foreground text-center py-4">No data yet</p>
                             ) : stats.top_users.by_messages.map((u, i) => (
                               <div key={u._id} className="flex items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                  <div className="w-6 text-sm text-muted-foreground">#{i + 1}</div>
-                                  <div className="text-sm truncate max-w-[200px] text-primary hover:underline cursor-pointer" onClick={() => setSelectedUserEmail(u._id)}>{u._id}</div>
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <div className="w-6 text-sm text-muted-foreground shrink-0">#{i + 1}</div>
+                                  <div className="text-sm truncate max-w-[200px] text-primary hover:underline cursor-pointer" onClick={() => setSelectedUserEmail(u._id)} title={u._id}>{u.name || u._id}</div>
                                 </div>
-                                <div className="text-sm font-medium">{u.count} messages</div>
+                                <div className="text-sm font-medium shrink-0">{u.count} messages</div>
                               </div>
                             ))}
                           </div>

--- a/ui/src/app/api/__tests__/feedback-submission.test.ts
+++ b/ui/src/app/api/__tests__/feedback-submission.test.ts
@@ -237,9 +237,9 @@ describe('POST /api/feedback — Slack with channel: 3 Langfuse scores + upsert'
     expect(mockInsertOne).not.toHaveBeenCalled();
 
     const [filter, update, options] = mockUpdateOne.mock.calls[0];
-    // Upsert filter: keyed on thread_ts, user_id, source
+    // Upsert filter: keyed on message_id, user_id, source
     expect(filter).toEqual({
-      thread_ts: 'thread-123',
+      message_id: 'thread-123',
       user_id: 'U99',
       source: 'slack',
     });

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -245,7 +245,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // ═══════════════════════════════════════════════════════════════
 
     // Top users by conversation count (direct — conversations have owner_id)
-    const topUsersByConversations = await conversations.aggregate([
+    const rawTopByConvs = await conversations.aggregate([
       { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
       { $group: { _id: '$owner_id', count: { $sum: 1 } } },
       { $sort: { count: -1 } },
@@ -254,7 +254,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     // Top users by message count — $lookup through conversations for old
     // messages that lack owner_id, $coalesce with direct owner_id for new ones.
-    const topUsersByMessages = await messages.aggregate([
+    const rawTopByMsgs = await messages.aggregate([
       { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
       {
         $lookup: {
@@ -276,6 +276,36 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       { $sort: { count: -1 } },
       { $limit: 10 },
     ]).toArray();
+
+    // Resolve display names for top user IDs — owner_id may be an email
+    // or a raw Slack/bot ID when email resolution failed at interaction time.
+    const topOwnerIds = [...new Set([
+      ...rawTopByConvs.map((u) => u._id),
+      ...rawTopByMsgs.map((u) => u._id),
+    ])].filter(Boolean);
+
+    const userDocs = topOwnerIds.length > 0
+      ? await users.find(
+          { $or: [{ email: { $in: topOwnerIds } }, { slack_user_id: { $in: topOwnerIds } }] },
+          { projection: { email: 1, name: 1, slack_user_id: 1 } },
+        ).toArray()
+      : [];
+
+    const nameByOwner = new Map<string, string>();
+    for (const u of userDocs) {
+      if (u.email) nameByOwner.set(u.email, u.name || u.email);
+      if (u.slack_user_id) nameByOwner.set(u.slack_user_id, u.name || u.email);
+    }
+
+    const enrichTopUsers = (raw: typeof rawTopByConvs) =>
+      raw.map((u) => ({
+        _id: u._id,
+        count: u.count,
+        name: nameByOwner.get(u._id) || u._id,
+      }));
+
+    const topUsersByConversations = enrichTopUsers(rawTopByConvs);
+    const topUsersByMessages = enrichTopUsers(rawTopByMsgs);
 
     // ═══════════════════════════════════════════════════════════════
     // ENHANCED ANALYTICS

--- a/ui/src/app/api/feedback/route.ts
+++ b/ui/src/app/api/feedback/route.ts
@@ -141,12 +141,17 @@ export async function POST(request: NextRequest): Promise<NextResponse<FeedbackR
         const feedbackColl = await getCollection("feedback");
         const now = new Date();
 
-        // For Slack: upsert on (threadTs, userId, source) so refinement
-        // actions update the initial thumbs_down rather than duplicating.
-        // For web: insert per message_id submission.
+        // For Slack: upsert on (messageId, userId, source) so refinement
+        // actions update the initial thumbs_down rather than duplicating,
+        // while still allowing different users (or the same user on different
+        // bot replies in the same thread) to each have their own feedback doc.
         if (source === "slack" && body.threadTs && body.userId) {
           await feedbackColl.updateOne(
-            { thread_ts: body.threadTs, user_id: body.userId, source: "slack" },
+            {
+              message_id: body.messageId || body.threadTs,
+              user_id: body.userId,
+              source: "slack",
+            },
             {
               $set: {
                 trace_id: body.traceId || null,
@@ -157,11 +162,11 @@ export async function POST(request: NextRequest): Promise<NextResponse<FeedbackR
                 conversation_id: body.conversationId || `slack-${body.threadTs}`,
                 channel_id: body.channelId || null,
                 channel_name: body.channelName || null,
+                thread_ts: body.threadTs,
                 slack_permalink: body.slackPermalink || null,
                 updated_at: now,
               },
               $setOnInsert: {
-                message_id: body.messageId || null,
                 created_at: now,
               },
             },


### PR DESCRIPTION
# Description

Fixes three related data accuracy issues on the admin dashboard:

1. **Feedback dedup logic**: The Langfuse backfill and live feedback path deduped by permalink only, dropping votes when multiple users reacted to the same bot response. Now dedupes by `(permalink, user_email)` so each user's vote counts independently.

2. **Slack feedback upsert key**: Changed from `(thread_ts, user_id)` to `(message_id, user_id)` so a user rating two different bot replies in the same thread keeps both votes, while still allowing mind-changes on a single message.

3. **User linkage**: Moved `slack_user_id` from `$setOnInsert` to `$set` in `interaction_tracker.py` so existing web users get their Slack ID linked on every interaction (self-healing).

4. **Top user display**: Admin stats API now resolves display names from the users collection, querying by both `email` and `slack_user_id`. Frontend shows resolved names with email tooltip.

**Data repair**: 38 missing feedback docs (lost during original per-permalink dedup) were inserted into prod via a one-time k8s job. New totals: 189 positive / 414 total = 45.7%.

### Files changed
- `interaction_tracker.py` — slack_user_id linkage fix
- `ui/src/app/api/admin/stats/route.ts` — top user name enrichment
- `ui/src/app/(app)/admin/page.tsx` — display name + layout fixes
- `ui/src/app/api/feedback/route.ts` — Slack upsert key fix
- `scripts/migrations/0.3.0/backfill_feedback_from_langfuse.py` — dedup + upsert key fix

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass