### PR TITLE
fix(slack): add escalation policy field and fix humble followup prompt

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -138,6 +138,11 @@ User message:
             "SLACK_INTEGRATION_PROMPT_HUMBLE_FOLLOWUP",
             """You previously saw the user's message but did not respond automatically. The user is now following up by @mentioning you.
 
+**CRITICAL: Your previous response was NOT delivered to the user.** The Slack bot silently filtered it
+before the user ever saw it. The user has NO record of any reply from you.
+Do NOT say "I replied", "I responded", "I already answered", or "I shared what I found" —
+from the user's perspective, you were completely silent.
+
 Start by briefly explaining why you did not respond earlier. There are two possible reasons based on your earlier analysis:
 1. You recognized it as a request for human action (like MR reviews, approvals, or asking someone to do something) - explain you stepped back to let humans handle it
 2. You researched but were not confident in what you found - explain you are not an expert on this topic
@@ -204,6 +209,7 @@ class VictorOpsEscalation(BaseModel):
 
     enabled: bool = False
     team: str = ""
+    escalation_policy: str = ""
 
 
 class EmojiEscalation(BaseModel):

--- a/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
@@ -32,6 +32,7 @@ def execute_escalation(
         result = _ping_victorops_oncall(
             a2a_client, slack_client, channel_id, thread_ts,
             escalation_config.victorops.team,
+            escalation_config.victorops.escalation_policy,
         )
         results.append(result)
 
@@ -48,12 +49,13 @@ def execute_escalation(
     return results
 
 
-def _ping_victorops_oncall(a2a_client, slack_client, channel_id, thread_ts, team):
+def _ping_victorops_oncall(a2a_client, slack_client, channel_id, thread_ts, team, escalation_policy=""):
     """Query the AI for VictorOps on-call, resolve to Slack user, and ping them."""
     try:
+        policy_clause = f" under escalation policy {escalation_policy}" if escalation_policy else ""
         prompt = (
-            f"RESPOND IN 1 WORD THAT IS USER EMAIL. "
-            f"WHO IS ON CALL FOR TEAM {team}?"
+            f"Respond with 1 email only. "
+            f"Who is on call RIGHT NOW for team {team}{policy_clause}?"
         )
         logger.info(f"[{thread_ts}] VictorOps: querying on-call for team {team}")
         oncall_email = None


### PR DESCRIPTION
# Description

Two Slack bot fixes:

1. **VictorOps escalation policy**: Added `escalation_policy` field to `VictorOpsEscalation` config model and updated the on-call query prompt to include it (e.g. "Who is on call RIGHT NOW for team X under escalation policy Y?"). Backward-compatible — defaults to empty string so existing configs without it continue to work.

2. **Humble followup prompt**: Forge was responding with "I replied" or "I already answered" when the user had no record of any reply. Added a CRITICAL block to the prompt making it explicit that the previous response was NOT delivered and the bot must not claim it responded.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass