### PR TITLE
fix(docs): escape bare < in plan.md to fix MDX build error

### DIFF
--- a/docs/docs/specs/shared-conversation-api/plan.md
+++ b/docs/docs/specs/shared-conversation-api/plan.md
@@ -131,7 +131,7 @@ interface Conversation {
 
 #### 2.3 Update DynamicAgentChatPanel (`ui/src/components/chat/DynamicAgentChatPanel.tsx`)
 - `submitMessage` must await conversation creation before starting the stream
-- Currently fire-and-forget; needs to block on the API response (~<50ms latency for MongoDB insert)
+- Currently fire-and-forget; needs to block on the API response (~&lt;50ms latency for MongoDB insert)
 
 #### 2.4 Update conversation list UI
 - Add `client_type` filter to conversation sidebar


### PR DESCRIPTION
## Summary

- `~<50ms` on line 134 of `docs/docs/specs/shared-conversation-api/plan.md` caused a Docusaurus MDX compile error
- MDX (micromark-extension-mdx-jsx) treats `<` as a JSX tag open; digit `5` following is an invalid tag name character
- Fixed by replacing `<` with `&lt;`
- Cherry-picked onto latest `main` (v0.4.1)

## Test plan

- [x] Verify Docusaurus build passes (fixes [run 24876908569](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/24876908569/job/72835597518))

🤖 Generated with [Claude Code](https://claude.ai/claude-code)