### PR TITLE
fix(forge): SDPL-1736 sanitize tool_use names to prevent Bedrock ValidationException

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -52,6 +52,9 @@ from ai_platform_engineering.utils.deepagents_custom.policy_middleware import (
 from ai_platform_engineering.utils.deepagents_custom.self_service_middleware import (
     SelfServiceWorkflowMiddleware,
 )
+from ai_platform_engineering.utils.deepagents_custom.sanitize_tool_names_middleware import (
+    SanitizeToolNamesMiddleware,
+)
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from ai_platform_engineering.utils.deepagents_custom.tools import (
     tool_result_to_file,
@@ -1608,6 +1611,7 @@ This format is required so the UI can display agent stickers next to each task.
         # ModelRetryMiddleware is always included (essential for error recovery).
         middleware_list = [
             ModelRetryMiddleware(max_retries=5, on_failure="continue", backoff_factor=2.0),
+            SanitizeToolNamesMiddleware(),
         ]
 
         _mw_flags = {

--- a/ai_platform_engineering/utils/deepagents_custom/__init__.py
+++ b/ai_platform_engineering/utils/deepagents_custom/__init__.py
@@ -45,6 +45,10 @@ from ai_platform_engineering.utils.deepagents_custom.self_service_middleware imp
     SelfServiceWorkflowMiddleware,
 )
 
+from ai_platform_engineering.utils.deepagents_custom.sanitize_tool_names_middleware import (
+    SanitizeToolNamesMiddleware,
+)
+
 # Export custom tools
 from ai_platform_engineering.utils.deepagents_custom.tools import (
     tool_result_to_file,
@@ -83,6 +87,7 @@ __all__ = [
     "PolicyMiddleware",
     "CLORM_AVAILABLE",
     "SelfServiceWorkflowMiddleware",
+    "SanitizeToolNamesMiddleware",
     # Legacy aliases
     "QuickActionTasksAnnouncementMiddleware",
     "SubAgentExecutionMiddleware",

--- a/ai_platform_engineering/utils/deepagents_custom/sanitize_tool_names_middleware.py
+++ b/ai_platform_engineering/utils/deepagents_custom/sanitize_tool_names_middleware.py
@@ -1,0 +1,107 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Middleware to sanitize tool_use names before they reach the model.
+
+When the model hallucinates XML-style tool calls (e.g. ``<invoke name="get_current_date" />``),
+the Bedrock streaming parser can store the raw XML fragment as the ``tool_use.name`` field —
+e.g. ``get_current_date" />\n</invoke>``.  Bedrock's ConverseStream rejects any name that
+doesn't match ``[a-zA-Z0-9_-]+``, causing a ValidationException that exhausts all retries.
+
+This middleware runs in ``before_agent`` to strip any trailing garbage from tool call names
+in the message history so that every message sent to Bedrock has a clean, valid name.
+"""
+
+import logging
+import re
+from typing import Any
+
+from langchain_core.messages import AIMessage
+from langgraph.types import Overwrite
+
+try:
+    from langchain.agents.middleware.types import AgentMiddleware, AgentState
+except ImportError:
+    try:
+        from langchain.agents.middleware import AgentMiddleware, AgentState
+    except ImportError:
+        from deepagents.middleware import AgentMiddleware, AgentState
+
+logger = logging.getLogger(__name__)
+
+_VALID_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+_LEADING_VALID = re.compile(r"^([a-zA-Z0-9_-]+)")
+
+
+def _sanitize_name(name: str) -> str:
+    """Return the leading valid portion of a tool name, or the name unchanged if already valid."""
+    if _VALID_TOOL_NAME.match(name):
+        return name
+    m = _LEADING_VALID.match(name)
+    if m:
+        clean = m.group(1)
+        logger.warning(
+            "[SanitizeToolNamesMiddleware] Corrected invalid tool_use name %r → %r "
+            "(likely XML-artifact from model hallucination)",
+            name,
+            clean,
+        )
+        return clean
+    # No valid prefix at all — return as-is and let Bedrock surface the error normally
+    logger.error("[SanitizeToolNamesMiddleware] Cannot sanitize tool_use name %r — no valid prefix", name)
+    return name
+
+
+class SanitizeToolNamesMiddleware(AgentMiddleware):
+    """Strips XML artifacts from tool_use names before the agent/model is invoked.
+
+    Bedrock ConverseStream requires tool names to match ``[a-zA-Z0-9_-]+``.  When the
+    model produces XML-style tool calls (e.g. ``<invoke name="foo" />``) the parser can
+    embed the XML fragment in the ``name`` field, which Bedrock then rejects.
+
+    This middleware scans every ``AIMessage`` in the history and truncates any tool call
+    name to its leading valid characters.
+    """
+
+    def before_agent(self, state: AgentState, runtime: Any = None) -> dict[str, Any] | None:  # noqa: ARG002
+        """Sanitize tool_use names in all AIMessages before the agent runs."""
+        messages = state.get("messages") or []
+        if not messages:
+            return None
+
+        patched: list = []
+        any_patched = False
+
+        for msg in messages:
+            if isinstance(msg, AIMessage) and msg.tool_calls:
+                clean_calls = []
+                msg_patched = False
+                for tc in msg.tool_calls:
+                    raw_name = tc.get("name", "")
+                    clean_name = _sanitize_name(raw_name)
+                    if clean_name != raw_name:
+                        tc = {**tc, "name": clean_name}
+                        msg_patched = True
+                    clean_calls.append(tc)
+
+                if msg_patched:
+                    any_patched = True
+                    # Rebuild the AIMessage with corrected tool_calls.
+                    # Copy all extra fields so nothing else is lost.
+                    patched.append(
+                        AIMessage(
+                            content=msg.content,
+                            tool_calls=clean_calls,
+                            additional_kwargs=msg.additional_kwargs,
+                            response_metadata=msg.response_metadata,
+                            id=msg.id,
+                        )
+                    )
+                    continue
+
+            patched.append(msg)
+
+        if not any_patched:
+            return None
+
+        return {"messages": Overwrite(patched)}

--- a/tests/test_sanitize_tool_names_middleware.py
+++ b/tests/test_sanitize_tool_names_middleware.py
@@ -1,0 +1,128 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SanitizeToolNamesMiddleware.
+
+Verifies that tool_use names containing XML artifacts (produced when the model
+hallucinates ``<invoke name="..." />`` style calls) are stripped to their valid
+leading ``[a-zA-Z0-9_-]+`` portion before being sent to Bedrock ConverseStream.
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from ai_platform_engineering.utils.deepagents_custom.sanitize_tool_names_middleware import (
+    SanitizeToolNamesMiddleware,
+    _sanitize_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_name unit tests
+# ---------------------------------------------------------------------------
+
+def test_sanitize_name_already_valid():
+    assert _sanitize_name("get_current_date") == "get_current_date"
+
+
+def test_sanitize_name_with_xml_suffix():
+    # Exact artifact observed in production trace 46a74faf
+    assert _sanitize_name('get_current_date" />\n</invoke>') == "get_current_date"
+
+
+def test_sanitize_name_with_space_suffix():
+    assert _sanitize_name("my_tool some garbage") == "my_tool"
+
+
+def test_sanitize_name_hyphen_and_underscore():
+    assert _sanitize_name("my-tool_name") == "my-tool_name"
+
+
+def test_sanitize_name_no_valid_prefix_returns_original():
+    # No leading valid chars — return as-is so Bedrock surfaces the error
+    bad = " no-leading-valid"
+    assert _sanitize_name(bad) == bad
+
+
+# ---------------------------------------------------------------------------
+# SanitizeToolNamesMiddleware.before_agent tests
+# ---------------------------------------------------------------------------
+
+def _make_state(*messages):
+    return {"messages": list(messages)}
+
+
+def test_no_messages_returns_none():
+    mw = SanitizeToolNamesMiddleware()
+    assert mw.before_agent({"messages": []}) is None
+
+
+def test_no_ai_messages_returns_none():
+    mw = SanitizeToolNamesMiddleware()
+    state = _make_state(HumanMessage(content="hello"))
+    assert mw.before_agent(state) is None
+
+
+def test_valid_tool_names_returns_none():
+    """If all names are already valid, the middleware should be a no-op."""
+    mw = SanitizeToolNamesMiddleware()
+    ai_msg = AIMessage(
+        content="",
+        tool_calls=[{"name": "get_current_date", "args": {}, "id": "tc1"}],
+    )
+    state = _make_state(HumanMessage(content="hi"), ai_msg)
+    assert mw.before_agent(state) is None
+
+
+def test_invalid_tool_name_is_sanitized():
+    """AIMessage with XML-artifact name gets corrected in the returned messages."""
+    mw = SanitizeToolNamesMiddleware()
+    bad_name = 'get_current_date" />\n</invoke>'
+    ai_msg = AIMessage(
+        content="",
+        tool_calls=[{"name": bad_name, "args": {}, "id": "tc1"}],
+    )
+    state = _make_state(HumanMessage(content="hi"), ai_msg)
+    result = mw.before_agent(state)
+
+    assert result is not None
+    patched_messages = result["messages"].value  # Overwrite wraps the list
+    ai_patched = next(m for m in patched_messages if isinstance(m, AIMessage))
+    assert ai_patched.tool_calls[0]["name"] == "get_current_date"
+
+
+def test_non_ai_messages_preserved():
+    """HumanMessage and ToolMessage pass through unchanged."""
+    mw = SanitizeToolNamesMiddleware()
+    human = HumanMessage(content="hello")
+    tool_msg = ToolMessage(content="result", tool_call_id="tc0", name="some_tool")
+    bad_ai = AIMessage(
+        content="",
+        tool_calls=[{"name": 'foo" />\n</invoke>', "args": {}, "id": "tc1"}],
+    )
+    state = _make_state(human, tool_msg, bad_ai)
+    result = mw.before_agent(state)
+
+    assert result is not None
+    patched = result["messages"].value
+    assert patched[0] is human
+    assert patched[1] is tool_msg
+
+
+def test_multiple_tool_calls_partial_fix():
+    """Only the invalid tool call names are corrected; valid ones are unchanged."""
+    mw = SanitizeToolNamesMiddleware()
+    ai_msg = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "valid_tool", "args": {}, "id": "tc1"},
+            {"name": 'bad_tool" />\n</invoke>', "args": {}, "id": "tc2"},
+        ],
+    )
+    state = _make_state(ai_msg)
+    result = mw.before_agent(state)
+
+    assert result is not None
+    patched = result["messages"].value
+    ai_patched = next(m for m in patched if isinstance(m, AIMessage))
+    names = [tc["name"] for tc in ai_patched.tool_calls]
+    assert names == ["valid_tool", "bad_tool"]


### PR DESCRIPTION
_[GAI]_

> **⚠️ Hotfix off `0.3.9`** — this branch was cut from the `0.3.9` tag, not `main` (which is at `0.4.1`). Intended for backport/cherry-pick to the production deployment running `0.3.9`.

## Context

When the model (claude-sonnet-4-5) hallucinates XML-style tool calls like:

```
<invoke name="get_current_date" />
</invoke>
```

...instead of the expected JSON format, the Bedrock streaming parser stores the raw XML fragment as the `tool_use.name` field — e.g. `get_current_date" />\n</invoke>`. Bedrock's `ConverseStream` rejects any name not matching `[a-zA-Z0-9_-]+`, causing a `ValidationException` that exhausts all 6 retry attempts and surfaces as a hard failure to the user.

**Observed in production trace:** `46a74faf0258e6710bade8a39724e85a` (2026-04-24, Forge alert triage)

### Fix

Adds `SanitizeToolNamesMiddleware` (`ai_platform_engineering/utils/deepagents_custom/sanitize_tool_names_middleware.py`) which:

- Runs in `before_agent` — scans every `AIMessage` in the history
- Strips any trailing garbage from `tool_call` names, keeping only the leading `[a-zA-Z0-9_-]+` characters
- Logs a `WARNING` when a name is corrected (observable in traces)
- Is always-on — wired into the main platform engineer deep agent's `middleware_list` alongside `ModelRetryMiddleware`

## Validation

- 11 unit tests added in `tests/test_sanitize_tool_names_middleware.py`, all passing
- `make lint` clean