### PR TITLE
chore: add release/0.3.11-hotfix to active-release-branches

### DIFF
--- a/.github/active-release-branches
+++ b/.github/active-release-branches
@@ -1,3 +1,4 @@
 release/0.3.0
+release/0.3.11-hotfix
 release/0.4.0
 release/0.5.0


### PR DESCRIPTION
## Summary

- Adds `release/0.3.11-hotfix` to `.github/active-release-branches`
- This enables the `[Release] Helm RC for Release Branches` and `[Release] Sync main → release branches` workflows to run for the 0.3.11 hotfix branch
- Without this entry, the `0.3.11-hotfix.1` tag was created but no Helm charts or container images were published

## Test plan

- [ ] Merge and verify `[Release] Helm RC for Release Branches` fires for `release/0.3.11-hotfix`
- [ ] Verify `0.3.11-hotfix.1` Helm chart and images appear in GHCR