### PR TITLE
fix(docs): fix SSR crash, add Releases to sidebar, remove Use Cases

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,7 +15,7 @@ As [Platform Engineering](https://platformengineering.org/blog/what-is-platform-
 
 ![Intro](images/intro.svg)
 
-<iframe src="https://app.vidcast.io/share/embed/e0033e26-46bf-4298-8c20-0a2fd1746073" width="100%" height="100%" title="CAIPE Demo" loading="lazy" allow="fullscreen *;autoplay *;clipboard-write *;" style="position: absolute; top:0; left: 0; border: solid; border-radius: 12px;"></iframe>
+<iframe src="https://app.vidcast.io/share/embed/e0033e26-46bf-4298-8c20-0a2fd1746073" width="100%" height="100%" title="CAIPE Demo" loading="lazy" allow="fullscreen *;autoplay *;clipboard-write *;" style={{position: 'absolute', top: 0, left: 0, border: 'solid', borderRadius: '12px'}}></iframe>
 
 Community AI Platform Engineering (CAIPE) (pronounced as `cape`) is an open-source, *M*ulti-*A*gentic AI *S*ystem (MAS) championed by the CNOE (Cloud Native Operational Excellence) forum. CAIPE provides a secure, scalable, persona-driven reference implementation with built-in knowledge base retrieval that streamlines platform operations, accelerates workflows, and fosters innovation for modern engineering teams. It integrates seamlessly with Internal Developer Portals like Backstage and developer environments such as VS Code, enabling frictionless adoption and extensibility.
 

--- a/docs/docs/releases/_category_.json
+++ b/docs/docs/releases/_category_.json
@@ -1,8 +1,8 @@
 {
-  "label": "Use Cases",
-  "position": 5,
+  "label": "Releases",
+  "position": 99,
   "link": {
     "type": "generated-index",
-    "description": "Use Cases of the CAIPE (Community AI Platform Engineering)"
+    "description": "Release notes and migration guides for CAIPE"
   }
 }

--- a/docs/docs/releases/index.md
+++ b/docs/docs/releases/index.md
@@ -1,3 +1,7 @@
-# Use Cases
+---
+sidebar_position: 1
+---
 
-This is CAIPE Use Cases
+# Releases
+
+Release notes and migration guides for CAIPE (Community AI Platform Engineering).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -446,24 +446,6 @@ const sidebars: SidebarsConfig = {
       ],
     },
     {
-      type: 'category',
-      label: 'Use Cases',
-      items: [
-        {
-          type: 'doc',
-          id: 'usecases/platform-engineer',
-        },
-        {
-          type: 'doc',
-          id: 'usecases/incident-engineer',
-        },
-        {
-          type: 'doc',
-          id: 'usecases/product-owner',
-        },
-      ],
-    },
-    {
       type: 'doc',
       id: 'prompt-library/index',
       label: 'Prompt Library',
@@ -524,6 +506,27 @@ const sidebars: SidebarsConfig = {
       type: 'doc',
       id: 'agent-ops/index',
       label: 'AgentOps',
+    },
+    {
+      type: 'category',
+      label: 'Releases',
+      items: [
+        {
+          type: 'doc',
+          id: 'releases/index',
+          label: 'Overview',
+        },
+        {
+          type: 'doc',
+          id: 'releases/migration-0.3.x-to-0.4.0',
+          label: 'Migration: 0.3.x → 0.4.0',
+        },
+        {
+          type: 'doc',
+          id: 'releases/migration-0.2.41-to-0.3.2',
+          label: 'Migration: 0.2.41 → 0.3.2',
+        },
+      ],
     },
     {
       type: 'doc',


### PR DESCRIPTION
## Summary

- **Fix CI build failure**: Converts iframe style string to JSX object in docs/docs/index.md — React 19 SSR rejects string-style props, crashing the home page during static site generation
- **Add Releases to sidebar**: Adds a Releases category in sidebars.ts with index + two migration guide entries; fixes the mislabeled _category_.json (was 'Use Cases')
- **Remove Use Cases**: Removes the Use Cases sidebar category

## Root cause of CI failure

Commit 94c969d5 (added today before PR #1290 merged) introduced an iframe with style as an HTML string. With Docusaurus 3.9.2 + React 19 + future.v4: true, SSR strictly enforces that style must be an object, crashing the home page render.

## Test plan

- [ ] Docusaurus build passes (cd docs && npm run build)
- [ ] Home page renders at /ai-platform-engineering/
- [ ] Releases section appears in sidebar with Overview + 2 migration guides
- [ ] Use Cases no longer appears in sidebar

Generated with Claude Code