### PR TITLE
docs(integrations): add backstage-plugin, webex-bot, and CLI docs

### DIFF
--- a/docs/docs/integrations/backstage-plugin.md
+++ b/docs/docs/integrations/backstage-plugin.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 2
+---
+
+# Agent Forge Backstage Plugin
+
+**Agent Forge** is a Backstage community plugin that adds an AI chat interface to your Internal Developer Portal, connecting to any [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org/latest/) compatible agent — including CAIPE.
+
+Published on npm: [`@caipe/plugin-agent-forge`](https://www.npmjs.com/package/@caipe/plugin-agent-forge)
+
+Source: [cnoe-io/community-plugins — agent-forge workspace](https://github.com/cnoe-io/community-plugins/tree/main/workspaces/agent-forge)
+
+## Key Features
+
+- **A2A Protocol Support** — works with CAIPE or any A2A-compatible agent
+- **OpenID Connect Authentication** — secure token-based auth with automatic expiration handling
+- **Streaming Responses** — real-time agent response streaming
+- **Session Management** — persistent chat sessions with context preservation
+- **Multi-Agent Compatible** — configurable agent routing
+- **Customizable UI** — branding, colors, bot name, initial suggestions
+
+## Installation
+
+From your Backstage root directory:
+
+```bash
+yarn --cwd packages/app add @caipe/plugin-agent-forge
+```
+
+### Configure App.tsx (New Frontend System)
+
+```tsx
+import agentForgePlugin from '@caipe/plugin-agent-forge/alpha';
+
+const app = createApp({
+  features: [
+    // ... other features
+    agentForgePlugin,
+  ],
+});
+```
+
+### Add Navigation
+
+```tsx
+import ChatIcon from '@material-ui/icons/Chat';
+
+<SidebarItem icon={ChatIcon} to="agent-forge" text="Agent Forge" />;
+```
+
+## Configuration
+
+Add to your Backstage `app-config.yaml`:
+
+```yaml
+agentForge:
+  showOptions: true
+  botName: Agent Forge
+  botIcon: https://your-icon-url
+  initialSuggestions:
+    - 'What can you do?'
+    - 'How do I configure agents?'
+    - 'Help me with platform engineering tasks'
+    - 'Show me the latest deployments'
+```
+
+## Connecting to CAIPE
+
+Point the plugin to your running CAIPE supervisor endpoint. The plugin uses the A2A protocol for all agent communication. See [Getting Started](/getting-started/quick-start) for how to stand up a CAIPE instance.
+
+## Resources
+
+- [npm package](https://www.npmjs.com/package/@caipe/plugin-agent-forge)
+- [community-plugins workspace](https://github.com/cnoe-io/community-plugins/tree/main/workspaces/agent-forge)
+- [Example Backstage integration](https://github.com/suwhang-cisco/backstage-app/commit/9d33ad6175e2ed30a23310ccc9d44594d6b63a07)

--- a/docs/docs/integrations/cli.md
+++ b/docs/docs/integrations/cli.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 4
+---
+
+# CAIPE CLI
+
+AI-assisted coding, workflows, and platform engineering from the terminal.
+
+CAIPE CLI is a TypeScript/Bun CLI that connects to a CAIPE server via the A2A or AG-UI streaming protocol. It provides an interactive chat REPL, headless mode for CI/CD pipelines, skill management, and secure credential storage.
+
+## Installation
+
+### Quick install (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/cli/install.sh | sh
+```
+
+Installs the correct binary for your platform (macOS/Linux, arm64/x64) to `/usr/local/bin/caipe`.
+
+**Options:**
+- `CAIPE_INSTALL_DIR` — override install directory (default: `/usr/local/bin`)
+- `CAIPE_VERSION` — pin a specific version (default: latest)
+
+### npm
+
+```bash
+npm install -g caipe
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/cnoe-io/ai-platform-engineering.git
+cd ai-platform-engineering/cli
+bun install
+npm run compile   # produces dist/caipe (Bun single-file binary)
+./dist/caipe --version
+```
+
+## Quick Start
+
+```bash
+# 1. Point to your CAIPE server
+caipe config set server.url https://your-caipe-server.example.com
+
+# 2. Authenticate (opens browser for OAuth)
+caipe auth login
+
+# 3. Start chatting
+caipe
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `caipe` | Open interactive chat REPL |
+| `caipe chat` | Open chat (explicit). Options: `--agent`, `--protocol`, `--headless`, `--resume` |
+| `caipe auth login` | Authenticate via OAuth (browser or `--device` flow) |
+| `caipe auth logout` | Remove stored credentials |
+| `caipe auth status` | Print current auth state |
+| `caipe config set <key> <value>` | Set a configuration key |
+| `caipe config get <key>` | Print the current value of a key |
+| `caipe config unset <key>` | Remove a configuration key |
+| `caipe skills list` | List available skills from catalog |
+| `caipe skills install <name>` | Install a skill |
+| `caipe skills preview <name>` | Display full SKILL.md content |
+| `caipe skills update [name]` | Check and update installed skills |
+| `caipe agents list` | List available server agents |
+| `caipe agents info <name>` | Show agent capabilities |
+| `caipe memory` | Manage persistent context files |
+| `caipe commit` | DCO-compliant commit with AI attribution |
+
+### Global Options
+
+```
+--agent <name>    CAIPE server agent to use (default: "default")
+--url <url>       Override server.url from settings.json
+--no-color        Disable ANSI color output
+--json            Machine-readable JSON output
+-v, --version     Print version and exit
+```
+
+## Interactive Chat
+
+The chat REPL provides:
+
+- **Streaming responses** via A2A or AG-UI Server-Sent Events
+- **Slash commands** — type `/` for a picker: `/clear`, `/compact`, `/login`, `/skills`, `/agents`, `/help`, `/exit`
+- **Readline keybindings** — `Ctrl+A/E`, `Ctrl+B/F`, `Alt+B/F`, `Ctrl+U/K/W`, `Ctrl+D`
+- **Input history** — `Up/Down` or `Ctrl+P/N`
+- **Shell pipes** — `!command` runs a shell command and injects output
+- **Tool call visualization** — active tool calls shown in the status footer
+
+## Headless Mode
+
+For CI/CD pipelines and scripting:
+
+```bash
+# Single prompt
+caipe chat --headless --prompt "Explain the deployment architecture"
+
+# From file
+caipe chat --headless --prompt-file question.txt --output json
+
+# Multi-turn via stdin
+echo -e "Hello\nWhat is A2A?" | caipe chat --headless --interactive-stdin
+
+# With explicit token
+caipe chat --headless --token "$JWT" --prompt "status check"
+```
+
+## Configuration
+
+Settings are stored in `~/.config/caipe/settings.json`.
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `server.url` | CAIPE server base URL | `https://caipe.example.com` |
+| `auth.url` | OAuth authorization endpoint (auto-discovered if not set) | `https://auth.example.com` |
+| `auth.apiKey` | Static API key (alternative to OAuth) | `sk-...` |
+| `auth.credential-storage` | Credential backend: `encrypted-file` or `keychain` | `encrypted-file` |
+
+## Source
+
+[`cli/` directory in ai-platform-engineering](https://github.com/cnoe-io/ai-platform-engineering/tree/main/cli)

--- a/docs/docs/integrations/cli.md
+++ b/docs/docs/integrations/cli.md
@@ -4,6 +4,11 @@ sidebar_position: 4
 
 # CAIPE CLI
 
+:::caution Refactor in Progress
+The CLI is under active development. Track progress in [PR #1184](https://github.com/cnoe-io/ai-platform-engineering/pull/1184). Commands, flags, and installation paths may change before the final merge.
+:::
+
+
 AI-assisted coding, workflows, and platform engineering from the terminal.
 
 CAIPE CLI is a TypeScript/Bun CLI that connects to a CAIPE server via the A2A or AG-UI streaming protocol. It provides an interactive chat REPL, headless mode for CI/CD pipelines, skill management, and secure credential storage.

--- a/docs/docs/integrations/webex-bot.md
+++ b/docs/docs/integrations/webex-bot.md
@@ -4,6 +4,11 @@ sidebar_position: 3
 
 # Webex Bot
 
+:::caution Refactor in Progress
+This integration is being actively developed. Track progress in [PR #1038](https://github.com/cnoe-io/ai-platform-engineering/pull/1038). APIs and configuration may change before the final merge.
+:::
+
+
 The CAIPE Webex bot connects to the Webex platform via WebSocket (WDM pattern) and forwards user messages to the CAIPE supervisor via the A2A protocol. Responses are streamed back with execution plan and tool progress updates.
 
 ## Features

--- a/docs/docs/integrations/webex-bot.md
+++ b/docs/docs/integrations/webex-bot.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 3
+---
+
+# Webex Bot
+
+The CAIPE Webex bot connects to the Webex platform via WebSocket (WDM pattern) and forwards user messages to the CAIPE supervisor via the A2A protocol. Responses are streamed back with execution plan and tool progress updates.
+
+## Features
+
+- **Real-time messaging** via WebSocket (no webhooks required)
+- **A2A protocol** streaming with execution plan and tool progress
+- **Adaptive Cards** for structured responses, HITL forms, and feedback
+- **Space authorization** with MongoDB-backed registry and TTL cache
+- **1:1 and group space** support with threading
+- **Feedback collection** via Langfuse integration
+
+## Setup
+
+### Prerequisites
+
+1. Create a Webex Bot at [developer.webex.com](https://developer.webex.com/my-apps/new/bot)
+2. Copy the Bot Access Token
+3. A running CAIPE supervisor instance
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `WEBEX_BOT_TOKEN` | Yes | — | Bot access token from developer.webex.com |
+| `CAIPE_URL` | No | `http://caipe-supervisor:8000` | CAIPE supervisor URL |
+| `WEBEX_INTEGRATION_ENABLE_AUTH` | No | `false` | Enable OAuth2 for A2A requests |
+| `WEBEX_INTEGRATION_AUTH_TOKEN_URL` | If auth enabled | — | OAuth2 token URL |
+| `WEBEX_INTEGRATION_AUTH_CLIENT_ID` | If auth enabled | — | OAuth2 client ID |
+| `WEBEX_INTEGRATION_AUTH_CLIENT_SECRET` | If auth enabled | — | OAuth2 client secret |
+| `WEBEX_INTEGRATION_AUTH_SCOPE` | No | — | OAuth2 scope |
+| `WEBEX_INTEGRATION_AUTH_AUDIENCE` | No | — | OAuth2 audience |
+| `MONGODB_URI` | No | — | MongoDB connection URI for persistent sessions |
+| `MONGODB_DATABASE` | No | `caipe` | MongoDB database name |
+| `CAIPE_UI_BASE_URL` | No | `http://localhost:3000` | CAIPE UI URL for auth links |
+| `LANGFUSE_SCORING_ENABLED` | No | `false` | Enable Langfuse feedback |
+| `LANGFUSE_PUBLIC_KEY` | If Langfuse enabled | — | Langfuse public key |
+| `LANGFUSE_SECRET_KEY` | If Langfuse enabled | — | Langfuse secret key |
+| `LANGFUSE_HOST` | If Langfuse enabled | — | Langfuse host URL |
+| `WEBEX_SPACE_AUTH_CACHE_TTL` | No | `300` | Space auth cache TTL (seconds) |
+
+### Running with Docker Compose
+
+```bash
+# Add WEBEX_BOT_TOKEN to your .env file
+echo "WEBEX_BOT_TOKEN=your-bot-token-here" >> .env
+
+# Start the Webex bot
+docker compose --profile webex-bot up -d
+```
+
+### Running Locally
+
+```bash
+cd ai_platform_engineering/integrations/webex_bot
+pip install -r requirements.txt
+WEBEX_BOT_TOKEN=your-token CAIPE_URL=http://localhost:8000 python -m app
+```
+
+## Space Authorization
+
+Group spaces must be authorized before the bot responds. 1:1 direct messages are allowed by default.
+
+### Via Bot Command
+
+1. Add the bot to a Webex space
+2. Send `@BotName authorize` in the space
+3. Click the "Connect to CAIPE" button in the Adaptive Card
+4. Authenticate via OIDC in the CAIPE UI
+
+### Via Admin Dashboard
+
+1. Go to the CAIPE Admin Dashboard → Integrations tab
+2. Click "Add Space" and enter the Webex Room ID
+
+## Architecture
+
+```
+User (Webex) ──→ Webex Cloud ──→ WebSocket ──→ Webex Bot
+                                                   │
+                                            A2A Protocol (SSE)
+                                                   │
+                                                   ▼
+                                           CAIPE Supervisor
+```
+
+The bot uses the WDM (Web Device Management) pattern to establish a persistent WebSocket connection with Webex, avoiding the need for public endpoints or webhook servers.
+
+## Helm Deployment
+
+A Helm chart is included at `charts/ai-platform-engineering/charts/webex-bot`. Configure via `values.yaml`:
+
+```yaml
+webex-bot:
+  enabled: true
+  env:
+    WEBEX_BOT_TOKEN: ""
+    CAIPE_URL: "http://caipe-supervisor:8000"
+```
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| Bot not responding | Verify `WEBEX_BOT_TOKEN` is valid; check logs for WebSocket errors |
+| Space authorization denied | Verify space is authorized in admin dashboard; check MongoDB connectivity |
+| Rate limiting | Bot throttles updates to every 3 seconds; long responses split at 7000 chars |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -361,6 +361,21 @@ const sidebars: SidebarsConfig = {
           id: 'integrations/slack-bot',
           label: 'Slack Bot',
         },
+        {
+          type: 'doc',
+          id: 'integrations/backstage-plugin',
+          label: 'Agent Forge (Backstage)',
+        },
+        {
+          type: 'doc',
+          id: 'integrations/webex-bot',
+          label: 'Webex Bot',
+        },
+        {
+          type: 'doc',
+          id: 'integrations/cli',
+          label: 'CAIPE CLI',
+        },
       ],
     },
     {
@@ -509,10 +524,6 @@ const sidebars: SidebarsConfig = {
         {
           type: 'doc',
           id: 'tools-utils/agent-chat-cli',
-        },
-        {
-          type: 'doc',
-          id: 'tools-utils/agent-forge-backstage-plugin',
         },
         {
           type: 'doc',


### PR DESCRIPTION
## Summary

Adds three new entries to the Integrations sidebar section and creates their documentation pages.

### New docs

- **Agent Forge (Backstage)** — installation, Backstage config, CAIPE connection, links to npm and community-plugins
- **Webex Bot** — setup, environment variables, space authorization, Docker Compose/Helm deploy, architecture diagram; includes caution note linking to [PR #1038](https://github.com/cnoe-io/ai-platform-engineering/pull/1038)
- **CAIPE CLI** — installation (curl/npm/source), all commands, headless mode, config reference; includes caution note linking to [PR #1184](https://github.com/cnoe-io/ai-platform-engineering/pull/1184)

### Sidebar changes

- Integrations section now lists: Slack Bot, Agent Forge (Backstage), Webex Bot, CAIPE CLI
- Removed agent-forge-backstage-plugin from Tools & Utilities (now lives in Integrations)

## Test plan

- [ ] Docusaurus build passes (cd docs && npm run build)
- [ ] All four Integrations entries appear in sidebar
- [ ] Caution admonitions render on Webex and CLI pages
- [ ] Backstage plugin no longer appears under Tools & Utilities

Generated with Claude Code