### PR TITLE
docs: make demo video iframe responsive on landing page

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,7 +15,23 @@ As [Platform Engineering](https://platformengineering.org/blog/what-is-platform-
 
 ![Intro](images/intro.svg)
 
-<iframe src="https://app.vidcast.io/share/embed/e0033e26-46bf-4298-8c20-0a2fd1746073" width="100%" height="100%" title="CAIPE Demo" loading="lazy" allow="fullscreen *;autoplay *;clipboard-write *;" style={{position: 'absolute', top: 0, left: 0, border: 'solid', borderRadius: '12px'}}></iframe>
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', border: '1px solid #ccc', borderRadius: '12px', marginBottom: '1.5em' }}>
+  <iframe
+    src="https://app.vidcast.io/share/embed/e0033e26-46bf-4298-8c20-0a2fd1746073"
+    title="CAIPE Demo"
+    loading="lazy"
+    allow="fullscreen; autoplay; clipboard-write"
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      border: '0',
+      borderRadius: '12px'
+    }}
+  ></iframe>
+</div>
 
 Community AI Platform Engineering (CAIPE) (pronounced as `cape`) is an open-source, *M*ulti-*A*gentic AI *S*ystem (MAS) championed by the CNOE (Cloud Native Operational Excellence) forum. CAIPE provides a secure, scalable, persona-driven reference implementation with built-in knowledge base retrieval that streamlines platform operations, accelerates workflows, and fosters innovation for modern engineering teams. It integrates seamlessly with Internal Developer Portals like Backstage and developer environments such as VS Code, enabling frictionless adoption and extensibility.
 


### PR DESCRIPTION
## Summary

- Wrap the CAIPE demo Vidcast iframe on `docs/docs/index.md` in a 16:9 aspect-ratio container so it scales correctly across viewport sizes.
- Replaces the previous absolute-positioned styling that depended on an outer sized parent and could collapse to zero height.

## Test plan

- [ ] `cd docs && npm run build` (or `yarn build`) succeeds without MDX/JSX errors
- [ ] Local Docusaurus dev server renders the landing page with the demo video visible and properly sized
- [ ] Verify responsiveness at desktop, tablet, and mobile widths
- [ ] Fullscreen / autoplay / clipboard-write iframe permissions still work


Made with [Cursor](https://cursor.com)