### PR TITLE
fix(rag): prevent infinite loop in structured-response mode after RAG cap

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py
@@ -296,6 +296,11 @@ _rag_cap_hit_counts: dict[str, int] = {}
 _rag_capped_tools: dict[str, set[str]] = {}
 _rag_hard_stop_lock = threading.Lock()
 
+# Tracks threads that have already received one "synthesis turn" after cap
+# exhaustion in USE_STRUCTURED_RESPONSE mode.  On the second cap interception
+# the middleware must force jump_to="end" rather than looping forever.
+_rag_synthesis_turn_given: set[str] = set()
+
 
 def _record_rag_cap_hit(thread_id: str, tool_name: str = "") -> int:
     """Record a cap hit for a specific tool on this thread. Returns the new hit count."""
@@ -322,6 +327,18 @@ def is_rag_hard_stopped(thread_id: str) -> bool:
     """Return True if ANY RAG tool has been capped for this thread."""
     with _rag_hard_stop_lock:
         return bool(_rag_capped_tools.get(thread_id))
+
+
+def record_synthesis_turn_given(thread_id: str) -> None:
+    """Mark that the model has already received one synthesis turn after cap exhaustion."""
+    with _rag_hard_stop_lock:
+        _rag_synthesis_turn_given.add(thread_id)
+
+
+def was_synthesis_turn_given(thread_id: str) -> bool:
+    """Return True if the model already received a synthesis turn for this thread."""
+    with _rag_hard_stop_lock:
+        return thread_id in _rag_synthesis_turn_given
 
 
 class RagBatchCapResult:
@@ -407,6 +424,7 @@ def _cleanup_stale_hard_stop() -> None:
         _rag_capped_tools.pop(k, None)
         _rag_cap_hit_counts.pop(k, None)
         _rag_hard_stop_timestamps.pop(k, None)
+        _rag_synthesis_turn_given.discard(k)
     if stale:
         logger.debug(f"hard-stop: cleaned up {len(stale)} stale entries")
 
@@ -421,6 +439,7 @@ def clear_rag_state(thread_id: str) -> None:
         _rag_capped_tools.pop(thread_id, None)
         _rag_cap_hit_counts.pop(thread_id, None)
         _rag_hard_stop_timestamps.pop(thread_id, None)
+        _rag_synthesis_turn_given.discard(thread_id)
     with SearchCapWrapper._global_lock:
         SearchCapWrapper._global_counts.pop(thread_id, None)
         SearchCapWrapper._global_timestamps.pop(thread_id, None)

--- a/ai_platform_engineering/utils/deepagents_custom/middleware.py
+++ b/ai_platform_engineering/utils/deepagents_custom/middleware.py
@@ -90,16 +90,15 @@ def _generate_tool_call_id() -> str:
     return f"call_{uuid.uuid4().hex[:24]}"
 
 
-def _rag_terminal_response(tool_messages: list) -> dict:
+def _rag_terminal_response(tool_messages: list, thread_id: str = "") -> dict:
     """Build the terminal state update when RAG caps are fully exhausted.
 
-    In USE_STRUCTURED_RESPONSE mode the graph must not jump_to=end because
-    the LLM still needs a turn to call the ResponseFormat/PlatformEngineerResponse
-    tool — skipping it produces an empty response (same reason the write_todos
-    redundancy path avoids jump_to=end in structured mode).
+    In USE_STRUCTURED_RESPONSE mode the LLM needs one free turn to call the
+    ResponseFormat/PlatformEngineerResponse tool before the graph can exit.
+    We grant exactly one synthesis turn; if the model ignores the nudge and
+    calls a RAG tool again we force jump_to=end to prevent an infinite loop.
 
-    In plain-text mode jump_to=end is safe because the response assembler
-    reads the last prose AIMessage directly from state.
+    In plain-text mode jump_to=end is always safe.
     """
     try:
         from ai_platform_engineering.multi_agents.platform_engineer.deep_agent import USE_STRUCTURED_RESPONSE  # noqa: PLC0415
@@ -107,9 +106,26 @@ def _rag_terminal_response(tool_messages: list) -> dict:
         USE_STRUCTURED_RESPONSE = False
 
     if USE_STRUCTURED_RESPONSE:
+        try:
+            from ai_platform_engineering.multi_agents.platform_engineer.rag_tools import (  # noqa: PLC0415
+                record_synthesis_turn_given,
+                was_synthesis_turn_given,
+            )
+            if thread_id and was_synthesis_turn_given(thread_id):
+                # Already gave the model one synthesis turn and it called RAG again.
+                # Force termination to prevent an infinite loop.
+                logger.info(
+                    "[DeterministicTaskMiddleware] RAG hard-stop: structured response mode"
+                    " — synthesis turn already given, forcing jump_to=end"
+                )
+                return {"messages": tool_messages, "jump_to": "end"}
+            if thread_id:
+                record_synthesis_turn_given(thread_id)
+        except ImportError:
+            pass
         logger.info(
             "[DeterministicTaskMiddleware] RAG hard-stop: structured response mode"
-            " — omitting jump_to=end so LLM can call ResponseFormat"
+            " — granting one synthesis turn so LLM can call ResponseFormat"
         )
         return {"messages": tool_messages}
     return {"messages": tool_messages, "jump_to": "end"}
@@ -373,7 +389,7 @@ class DeterministicTaskMiddleware(AgentMiddleware):
                                 _record_rag_cap_hit(thread_id, "search")
                             if cap.fetch_excess > 0 and cap.fetch_allowed == 0:
                                 _record_rag_cap_hit(thread_id, "fetch_document")
-                            return _rag_terminal_response(tool_messages)
+                            return _rag_terminal_response(tool_messages, thread_id)
                         return {"messages": tool_messages}
 
                 # Fallback: a non-parallel call slipped through to _arun and was capped there.
@@ -395,7 +411,7 @@ class DeterministicTaskMiddleware(AgentMiddleware):
                         ]
                         for tc in rag_calls:
                             _record_rag_cap_hit(thread_id, tc["name"])
-                        return _rag_terminal_response(tool_messages)
+                        return _rag_terminal_response(tool_messages, thread_id)
             except Exception as rag_err:
                 logger.warning(f"[DeterministicTaskMiddleware] RAG cap check failed: {rag_err}", exc_info=True)
             return None

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.3.11-hotfix.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.11-hotfix.2 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.3.11-hotfix.1
+    version: 0.3.11-hotfix.2
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.11-hotfix.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.11-hotfix.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.3.11-hotfix.1
-appVersion: "0.3.11-hotfix.1"
+version: 0.3.11-hotfix.2
+appVersion: "0.3.11-hotfix.2"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.11-hotfix.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.11-hotfix.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.3.11-hotfix.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.11-hotfix.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.3.11-hotfix.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.3.11-hotfix.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.3.11-hotfix.1
-appVersion: 0.3.11-hotfix.1
+version: 0.3.11-hotfix.2
+appVersion: 0.3.11-hotfix.2
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.11-hotfix.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.3.11-hotfix.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.3.11-hotfix.1 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.3.11-hotfix.2 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.11-hotfix.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.3.11-hotfix.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.3.11-hotfix.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.3.11-hotfix.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.11-hotfix.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.3.11-hotfix.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.3.11-hotfix.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.3.11-hotfix.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.3.11-hotfix.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.3.11-hotfix.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.3.11+hotfix.1"
+version = "0.3.11+hotfix.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/tests/test_middleware_rag_loop_exit.py
+++ b/tests/test_middleware_rag_loop_exit.py
@@ -37,11 +37,13 @@ def _reset_rag_state():
     from ai_platform_engineering.multi_agents.platform_engineer.rag_tools import (
         _rag_capped_tools,
         _rag_cap_hit_counts,
+        _rag_synthesis_turn_given,
         FetchDocumentCapWrapper,
         SearchCapWrapper,
     )
     _rag_capped_tools.clear()
     _rag_cap_hit_counts.clear()
+    _rag_synthesis_turn_given.clear()
     FetchDocumentCapWrapper._global_counts.clear()
     FetchDocumentCapWrapper._global_timestamps.clear()
     SearchCapWrapper._global_counts.clear()
@@ -49,6 +51,7 @@ def _reset_rag_state():
     yield
     _rag_capped_tools.clear()
     _rag_cap_hit_counts.clear()
+    _rag_synthesis_turn_given.clear()
     FetchDocumentCapWrapper._global_counts.clear()
     FetchDocumentCapWrapper._global_timestamps.clear()
     SearchCapWrapper._global_counts.clear()
@@ -94,7 +97,7 @@ class TestMiddlewareRagLoopExit:
             return_value={"configurable": {"thread_id": "t1"}},
         ), patch(
             "ai_platform_engineering.utils.deepagents_custom.middleware._rag_terminal_response",
-            wraps=lambda msgs: {"messages": msgs},
+            wraps=lambda msgs, tid="": {"messages": msgs},
         ) as mock_terminal:
             result = middleware.after_model(state)
 
@@ -200,7 +203,7 @@ class TestMiddlewareRagLoopExit:
             return_value={"configurable": {"thread_id": "t5"}},
         ), patch(
             "ai_platform_engineering.utils.deepagents_custom.middleware._rag_terminal_response",
-            wraps=lambda msgs: {"messages": msgs},
+            wraps=lambda msgs, tid="": {"messages": msgs},
         ) as mock_terminal:
             result = middleware.after_model(state)
 
@@ -359,7 +362,7 @@ class TestMiddlewareRagLoopExit:
                 return_value={"configurable": {"thread_id": "thread-999"}},
             ), patch(
                 "ai_platform_engineering.utils.deepagents_custom.middleware._rag_terminal_response",
-                wraps=lambda msgs: {"messages": msgs},
+                wraps=lambda msgs, tid="": {"messages": msgs},
             ) as mock_terminal:
                 result = middleware.after_model(state)
         finally:
@@ -451,7 +454,7 @@ class TestMiddlewareRagLoopExit:
             return_value={"configurable": {"thread_id": thread_id}},
         ), patch(
             "ai_platform_engineering.utils.deepagents_custom.middleware._rag_terminal_response",
-            wraps=lambda msgs: {"messages": msgs},
+            wraps=lambda msgs, tid="": {"messages": msgs},
         ) as mock_terminal_t6:
             result_t6 = middleware.after_model(state_turn6)
 
@@ -476,9 +479,34 @@ class TestMiddlewareRagLoopExit:
             return_value={"configurable": {"thread_id": thread_id}},
         ), patch(
             "ai_platform_engineering.utils.deepagents_custom.middleware._rag_terminal_response",
-            wraps=lambda msgs: {"messages": msgs},
+            wraps=lambda msgs, tid="": {"messages": msgs},
         ) as mock_terminal_t7:
             result_t7 = middleware.after_model(state_turn7)
 
         assert result_t7 is not None, "Turn 7: must terminate via fallback — search still capped"
         mock_terminal_t7.assert_called_once(), "Fallback path must call _rag_terminal_response"
+
+    def test_structured_response_second_turn_forces_jump_to_end(self):
+        """In USE_STRUCTURED_RESPONSE mode, _rag_terminal_response grants one free synthesis
+        turn (no jump_to=end). If the model ignores it and hits the cap again, the second
+        call must force jump_to=end to prevent an infinite loop."""
+        from ai_platform_engineering.utils.deepagents_custom.middleware import _rag_terminal_response
+        from ai_platform_engineering.multi_agents.platform_engineer.rag_tools import (
+            _rag_synthesis_turn_given,
+        )
+
+        msgs = [ToolMessage(content="RAG cap reached.", tool_call_id="tc-1", name="search")]
+        thread_id = "t-sr-loop"
+
+        with patch(
+            "ai_platform_engineering.multi_agents.platform_engineer.deep_agent.USE_STRUCTURED_RESPONSE",
+            True,
+        ):
+            # First call: synthesis turn granted, no jump_to
+            result1 = _rag_terminal_response(msgs, thread_id)
+            assert "jump_to" not in result1, "First call must not include jump_to=end"
+            assert thread_id in _rag_synthesis_turn_given, "Must record synthesis turn given"
+
+            # Second call: model ignored synthesis nudge — force exit
+            result2 = _rag_terminal_response(msgs, thread_id)
+            assert result2.get("jump_to") == "end", "Second call must force jump_to=end"

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.3.11+hotfix.1"
+version = "0.3.11+hotfix.2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- In `USE_STRUCTURED_RESPONSE` mode, `_rag_terminal_response` previously omitted `jump_to=end` on every cap interception so the model could call `ResponseFormat` for its final answer
- But if the model ignored the synthesis nudge and called a RAG tool again, the same path fired indefinitely — causing 200+ model calls until the LangGraph recursion limit was hit
- Confirmed via trace analysis: 213 LLM generations, only 6 real tool executions, 203 empty search loops, ~$39 wasted per invocation

## Fix

Adds `_rag_synthesis_turn_given` tracking (thread-keyed set in `rag_tools.py`):
- **First cap interception**: model gets one free synthesis turn (no `jump_to=end`) — preserves existing behaviour for well-behaved models
- **Second cap interception for the same thread**: response now includes `jump_to=end`, terminating the graph

`_rag_synthesis_turn_given` is cleared in `clear_rag_state` and `_cleanup_stale_hard_stop` alongside the other per-thread RAG state.

## Test plan

- [x] 15/15 existing tests pass
- [x] New test `test_structured_response_second_turn_forces_jump_to_end` covers the second-turn force-exit path