### PR TITLE
fix(setup): guard empty-array expansions for bash 3.2 compat

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -408,14 +408,18 @@ choose_cluster() {
       [[ -n "$c" ]] && kind_clusters+=("$c")
     done < <(kind get clusters 2>/dev/null)
 
-    for c in "${kind_clusters[@]}"; do
-      options+=("kind:${c}")
-      if [[ "kind-${c}" == "$current_ctx" ]]; then
-        labels+=("Kind cluster: ${c}  ${DIM}(current context)${NC}")
-      else
-        labels+=("Kind cluster: ${c}")
-      fi
-    done
+    # assisted-by claude code claude-sonnet-4-6
+    # bash 3.2 (macOS default) treats ${empty_array[@]} as unbound with set -u
+    if [[ ${#kind_clusters[@]} -gt 0 ]]; then
+      for c in "${kind_clusters[@]}"; do
+        options+=("kind:${c}")
+        if [[ "kind-${c}" == "$current_ctx" ]]; then
+          labels+=("Kind cluster: ${c}  ${DIM}(current context)${NC}")
+        else
+          labels+=("Kind cluster: ${c}")
+        fi
+      done
+    fi
   fi
 
   # Option: switch to another kubectl context
@@ -485,14 +489,16 @@ choose_cluster() {
       done < <(kubectl config get-contexts -o name 2>/dev/null)
 
       local j=1
-      for ctx in "${ctx_arr[@]}"; do
-        if [[ "$ctx" == "$current_ctx" ]]; then
-          echo -e "    ${BOLD}${j})${NC} ${ctx}  ${DIM}(current)${NC}"
-        else
-          echo -e "    ${BOLD}${j})${NC} ${ctx}"
-        fi
-        j=$((j + 1))
-      done
+      if [[ ${#ctx_arr[@]} -gt 0 ]]; then
+        for ctx in "${ctx_arr[@]}"; do
+          if [[ "$ctx" == "$current_ctx" ]]; then
+            echo -e "    ${BOLD}${j})${NC} ${ctx}  ${DIM}(current)${NC}"
+          else
+            echo -e "    ${BOLD}${j})${NC} ${ctx}"
+          fi
+          j=$((j + 1))
+        done
+      fi
       echo ""
       prompt "Select a context ${CYAN}[1]${NC}${BOLD}: "
       tty_read -r ctx_choice


### PR DESCRIPTION
macOS ships bash 3.2 as /bin/bash. When the script is piped via curl | bash, it runs under bash 3.2 where set -u treats an empty array expansion ${arr[@]} as an unbound variable, causing:

  bash: line 360: kind_clusters[@]: unbound variable

Fixed two locations in choose_cluster():
- kind_clusters[@]: triggered when kind is installed but has no clusters
- ctx_arr[@]: triggered when listing kubectl contexts returns nothing

Guard each loop with ${#arr[@]} -gt 0, which is safe in bash 3.2 even for empty arrays under nounset.

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
