### PR TITLE
fix(migration): handle stringified artifact dicts and passthrough event types in 0.4.0 a2a migration

### DIFF
--- a/scripts/migrations/0.4.0/migrate_messages_to_turns.py
+++ b/scripts/migrations/0.4.0/migrate_messages_to_turns.py
@@ -45,6 +45,7 @@ Usage:
 """
 
 import argparse
+import ast
 import hashlib
 import os
 import sys
@@ -61,9 +62,19 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
-# A2A artifact name → stream_events type
+# A2A event type mappings
 # ---------------------------------------------------------------------------
 
+# Top-level event types that are already normalized (pass through as-is).
+A2A_EVENT_TYPE_PASSTHROUGH: set[str] = {
+    "tool_start",
+    "tool_end",
+    "execution_plan",
+    "task",
+    "status",
+}
+
+# artifact.name → stream_events type (used when top-level type is "artifact").
 A2A_ARTIFACT_TYPE_MAP: dict[str, str] = {
     "tool_notification_start": "tool_start",
     "tool_notification_end": "tool_end",
@@ -126,21 +137,48 @@ def parse_dt(value) -> Optional[datetime]:
     return None
 
 
+def _parse_artifact(raw_artifact) -> dict:
+    """
+    Coerce the artifact field to a plain dict.
+
+    Legacy documents stored the artifact as a Python repr string
+    (e.g. "{'name': 'streaming_result', 'parts': [...]}") rather than
+    a proper sub-document.  ast.literal_eval handles that case safely.
+    """
+    if isinstance(raw_artifact, dict):
+        return raw_artifact
+    if isinstance(raw_artifact, str):
+        try:
+            parsed = ast.literal_eval(raw_artifact)
+            if isinstance(parsed, dict):
+                return parsed
+        except (ValueError, SyntaxError):
+            pass
+    return {}
+
+
 def normalize_a2a_event(raw: dict, turn_id: str, conversation_id: str, seq: int) -> dict:
     """Convert a serialised A2A event to a stream_events document."""
-    artifact = raw.get("artifact") or {}
+    raw_type = raw.get("type", "")
+    artifact = _parse_artifact(raw.get("artifact"))
     artifact_name = artifact.get("name", "")
-    event_type = A2A_ARTIFACT_TYPE_MAP.get(artifact_name, "a2a_raw")
 
-    # Namespace: prefer the artifact's own namespace, fall back to sourceAgent
+    # Top-level type is already normalised for tool_start/tool_end/etc.
+    # For "artifact" events derive the type from artifact.name instead.
+    if raw_type in A2A_EVENT_TYPE_PASSTHROUGH:
+        event_type = raw_type
+    else:
+        event_type = A2A_ARTIFACT_TYPE_MAP.get(artifact_name, "a2a_raw")
+
+    # Namespace: prefer sourceAgent field
     namespace: list[str] = []
     if raw.get("sourceAgent"):
         namespace = [raw["sourceAgent"]]
 
-    # Data payload: include artifact parts and metadata
+    # Data payload
     data: dict = {}
     if artifact:
-        data["artifact_name"] = artifact_name
+        data["artifact_name"] = artifact.get("name", "")
         parts = artifact.get("parts") or []
         if parts:
             data["parts"] = parts
@@ -153,7 +191,7 @@ def normalize_a2a_event(raw: dict, turn_id: str, conversation_id: str, seq: int)
 
     ts = parse_dt(raw.get("timestamp")) or datetime.now(timezone.utc)
 
-    event_id = stable_event_id(turn_id, f"a2a:{artifact_name}", seq)
+    event_id = stable_event_id(turn_id, f"a2a:{raw_type}:{artifact_name}", seq)
 
     return {
         "_id": event_id,


### PR DESCRIPTION
# Description

Fixes two bugs in `scripts/migrations/0.4.0/migrate_messages_to_turns.py` discovered by inspecting the actual dev DocumentDB data before running the 0.4.0 migration.

**Bug 1 — `artifact` field is a stringified Python repr, not a sub-document.**
Legacy A2A event documents stored the `artifact` field as a Python `repr()` string (e.g. `"{'name': 'streaming_result', 'parts': [...]}"`) rather than a proper nested object. The original code called `.get()` directly on the raw value, which throws `AttributeError: 'str' object has no attribute 'get'` for the 29,390+ artifact-type events in the DB and crashes the entire migration for any conversation containing them. Fixed by adding `_parse_artifact()` which safely deserializes via `ast.literal_eval()`.

**Bug 2 — Type mapping missed already-normalized top-level event types.**
The DB contains events with top-level `type` values of `"tool_start"`, `"tool_end"`, `"execution_plan"`, `"task"`, and `"status"` that are already in the correct normalized form. The original code routed everything through `A2A_ARTIFACT_TYPE_MAP` (keyed on `artifact.name`), causing all of these to fall through to `"a2a_raw"`. Fixed by adding `A2A_EVENT_TYPE_PASSTHROUGH` — these types are passed through directly; only `"artifact"`-type events go through the artifact name lookup.

Also includes the `stable_event_id` key to include `raw_type` so passthrough events and artifact events with the same sequence number get distinct deterministic IDs.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass