### PR TITLE
fix(rag): stop repeated structured-response cap loops

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py
@@ -241,6 +241,7 @@ class SearchCapWrapper(_CapCounterMixin, BaseTool):
 _rag_cap_hit_counts: dict[str, int] = {}
 _rag_capped_tools: dict[str, set[str]] = {}
 _rag_hard_stop_lock = threading.Lock()
+_rag_synthesis_turn_given: set[str] = set()
 
 
 def _record_rag_cap_hit(thread_id: str, tool_name: str = "") -> None:
@@ -267,6 +268,18 @@ def is_rag_hard_stopped(thread_id: str) -> bool:
         return bool(_rag_capped_tools.get(thread_id))
 
 
+def record_synthesis_turn_given(thread_id: str) -> None:
+    """Mark that the model has already received one synthesis turn after cap exhaustion."""
+    with _rag_hard_stop_lock:
+        _rag_synthesis_turn_given.add(thread_id)
+
+
+def was_synthesis_turn_given(thread_id: str) -> bool:
+    """Return True if the model already received a synthesis turn for this thread."""
+    with _rag_hard_stop_lock:
+        return thread_id in _rag_synthesis_turn_given
+
+
 def clear_rag_state(thread_id: str) -> None:
     """Reset RAG cap counters for a thread at the start of a new query.
 
@@ -276,6 +289,7 @@ def clear_rag_state(thread_id: str) -> None:
     with _rag_hard_stop_lock:
         _rag_capped_tools.pop(thread_id, None)
         _rag_cap_hit_counts.pop(thread_id, None)
+        _rag_synthesis_turn_given.discard(thread_id)
     with FetchDocumentCapWrapper._global_lock:
         FetchDocumentCapWrapper._global_counts.pop(thread_id, None)
         FetchDocumentCapWrapper._global_timestamps.pop(thread_id, None)

--- a/ai_platform_engineering/utils/deepagents_custom/middleware.py
+++ b/ai_platform_engineering/utils/deepagents_custom/middleware.py
@@ -90,6 +90,38 @@ def _generate_tool_call_id() -> str:
     return f"call_{uuid.uuid4().hex[:24]}"
 
 
+def _rag_terminal_response(tool_messages: list, thread_id: str = "") -> dict:
+    """Build the terminal state update when RAG caps are fully exhausted."""
+    try:
+        from ai_platform_engineering.multi_agents.platform_engineer.deep_agent import USE_STRUCTURED_RESPONSE  # noqa: PLC0415
+    except ImportError:
+        USE_STRUCTURED_RESPONSE = False
+
+    if USE_STRUCTURED_RESPONSE:
+        try:
+            from ai_platform_engineering.multi_agents.platform_engineer.rag_tools import (  # noqa: PLC0415
+                record_synthesis_turn_given,
+                was_synthesis_turn_given,
+            )
+            if thread_id and was_synthesis_turn_given(thread_id):
+                logger.info(
+                    "[DeterministicTaskMiddleware] RAG hard-stop: structured response mode "
+                    "synthesis turn already given, forcing jump_to=end"
+                )
+                return {"messages": tool_messages, "jump_to": "end"}
+            if thread_id:
+                record_synthesis_turn_given(thread_id)
+        except ImportError:
+            pass
+        logger.info(
+            "[DeterministicTaskMiddleware] RAG hard-stop: structured response mode "
+            "granting one synthesis turn so LLM can call ResponseFormat"
+        )
+        return {"messages": tool_messages}
+
+    return {"messages": tool_messages, "jump_to": "end"}
+
+
 class DeterministicTaskMiddleware(AgentMiddleware):
     """Middleware for deterministic task execution using before_model + wrap_tool_call.
     
@@ -311,8 +343,7 @@ class DeterministicTaskMiddleware(AgentMiddleware):
                             )
                             for tc in rag_calls
                         ]
-                        # Return tool responses WITHOUT jump_to so the LLM gets a turn to synthesize
-                        return {"messages": tool_messages}
+                        return _rag_terminal_response(tool_messages, thread_id)
             except Exception as rag_err:
                 # Log full traceback in case RAG checking is broken in a new way
                 logger.warning(f"[DeterministicTaskMiddleware] RAG hard-stop check failed: {rag_err}", exc_info=True)

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.3-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.3
+    version: 0.4.3-dev.1
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.3-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.3
-appVersion: "0.4.3"
+version: 0.4.3-dev.1
+appVersion: "0.4.3-dev.1"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.3-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.3-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.3-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.3
-appVersion: 0.4.3
+version: 0.4.3-dev.1
+appVersion: 0.4.3-dev.1
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.3-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.3 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.3-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.3" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.3-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.3-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.3" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.3-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.3-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.3-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.3"
+version = "0.4.3-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/tests/test_middleware_rag_loop_exit.py
+++ b/tests/test_middleware_rag_loop_exit.py
@@ -37,12 +37,15 @@ def _reset_rag_state():
     from ai_platform_engineering.multi_agents.platform_engineer.rag_tools import (
         _rag_capped_tools,
         _rag_cap_hit_counts,
+        _rag_synthesis_turn_given,
     )
     _rag_capped_tools.clear()
     _rag_cap_hit_counts.clear()
+    _rag_synthesis_turn_given.clear()
     yield
     _rag_capped_tools.clear()
     _rag_cap_hit_counts.clear()
+    _rag_synthesis_turn_given.clear()
 
 
 def _patch_config(thread_id: str = "test-thread"):
@@ -77,6 +80,9 @@ class TestMiddlewareRagLoopExit:
         ), patch(
             "langgraph.config.get_config",
             return_value={"configurable": {"thread_id": "t1"}},
+        ), patch(
+            "ai_platform_engineering.multi_agents.platform_engineer.deep_agent.USE_STRUCTURED_RESPONSE",
+            False,
         ):
             result = middleware.after_model(state)
 
@@ -176,6 +182,9 @@ class TestMiddlewareRagLoopExit:
         ), patch(
             "langgraph.config.get_config",
             return_value={"configurable": {"thread_id": "t5"}},
+        ), patch(
+            "ai_platform_engineering.multi_agents.platform_engineer.deep_agent.USE_STRUCTURED_RESPONSE",
+            False,
         ):
             result = middleware.after_model(state)
 
@@ -225,3 +234,23 @@ class TestMiddlewareRagLoopExit:
         state = _make_state([AIMessage(content="Just a text response")])
         middleware = DeterministicTaskMiddleware()
         assert middleware.after_model(state) is None
+
+    def test_structured_response_second_rag_cap_forces_jump_to_end(self):
+        """Structured response mode gets one synthesis turn, then force exits if RAG is called again."""
+        from ai_platform_engineering.utils.deepagents_custom.middleware import _rag_terminal_response
+        from ai_platform_engineering.multi_agents.platform_engineer.rag_tools import _rag_synthesis_turn_given
+
+        thread_id = "t-structured"
+        messages = [ToolMessage(content="RAG budget exhausted.", tool_call_id="tc-1", name="search")]
+
+        with patch(
+            "ai_platform_engineering.multi_agents.platform_engineer.deep_agent.USE_STRUCTURED_RESPONSE",
+            True,
+        ):
+            first = _rag_terminal_response(messages, thread_id)
+            second = _rag_terminal_response(messages, thread_id)
+
+        assert "jump_to" not in first
+        assert thread_id in _rag_synthesis_turn_given
+        assert second["jump_to"] == "end"
+        assert second["messages"] == messages

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.3"
+version = "0.4.3.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Backports the SDPL-1673 structured-response RAG recursion fix onto current main/0.4.x.
- Tracks when a thread has already received its post-cap synthesis turn.
- If the model ignores that nudge and calls capped RAG tools again, the middleware now forces jump_to=end instead of looping until LangGraph recursion exhaustion.

## Evidence

The existing SDPL-1673 trace analysis on PR #1303 showed 213 LLM generations, 6 real tool executions, and 203 empty search loops before recursion exhaustion. CAIPE dev tracks current platform-apps HEAD / chart 0.4.2, which does not include that second-turn force-exit behavior.

## Test plan

- [x] python3 -m py_compile ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py ai_platform_engineering/utils/deepagents_custom/middleware.py tests/test_middleware_rag_loop_exit.py
- [ ] pytest tests/test_middleware_rag_loop_exit.py -q locally blocked: this host only has Python 3.11, while repo dependencies require Python >=3.13. CI/prebuild should run in the supported environment.

Assisted-by: OpenAI Codex