### PR TITLE
fix(ui): missing asyncs???

### DIFF
--- a/ui/src/components/agent-builder/AgentBuilderGallery.tsx
+++ b/ui/src/components/agent-builder/AgentBuilderGallery.tsx
@@ -243,9 +243,9 @@ export function AgentBuilderGallery({
     setActiveFormConfig(config);
   };
 
-  const handleTrySkill = () => {
+  const handleTrySkill = async () => {
     if (!activeFormConfig) return;
-    const conversationId = createConversation();
+    const conversationId = await createConversation();
     const skillId = activeFormConfig.id || activeFormConfig.name;
     setPendingMessage(`Execute skill: ${skillId}\n\nRead and follow the instructions in the SKILL.md file for the "${skillId}" skill.`);
     setActiveFormConfig(null);

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -973,9 +973,9 @@ export function SupervisorChatPanel({ endpoint, conversationId, conversationTitl
   }, [activeConversationId, createConversation, addMessage, updateConversationTitle]);
 
   // Handle /clear command
-  const handleClearCommand = useCallback(() => {
+  const handleClearCommand = useCallback(async () => {
     // Create a fresh conversation (effectively clearing the current one)
-    createConversation();
+    await createConversation();
   }, [createConversation]);
 
   // Unified slash command executor
@@ -988,7 +988,7 @@ export function SupervisorChatPanel({ endpoint, conversationId, conversationTitl
         handleHelpCommand();
         break;
       case "clear":
-        handleClearCommand();
+        await handleClearCommand();
         break;
     }
   }, [handleSkillsCommand, handleHelpCommand, handleClearCommand]);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -951,7 +951,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
         handleHelpCommand();
         break;
       case "clear":
-        handleClearCommand();
+        await handleClearCommand();
         break;
     }
   }, [handleSkillsCommand, handleHelpCommand, handleClearCommand]);

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -208,7 +208,7 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapse, onUseCa
         });
       } else {
         // Create conversation in localStorage
-        const conversationId = createConversation(agentId);
+        const conversationId = await createConversation(agentId);
 
         // Use React transition for smooth navigation
         startTransition(() => {
@@ -219,7 +219,7 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapse, onUseCa
       console.error('[Sidebar] Failed to create conversation:', error);
 
       // Fallback to localStorage
-      const conversationId = createConversation(agentId);
+      const conversationId = await createConversation(agentId);
       startTransition(() => {
         router.push(`/chat/${conversationId}`);
       });

--- a/ui/src/components/skills/SkillsGallery.tsx
+++ b/ui/src/components/skills/SkillsGallery.tsx
@@ -453,7 +453,7 @@ export function SkillsGallery({
     setParamValues(defaults);
   };
 
-  const handleTrySkill = () => {
+  const handleTrySkill = async () => {
     if (!activeFormConfig) return;
     const vars = extractTemplateVars(activeFormConfig);
     // Check required fields
@@ -471,7 +471,7 @@ export function SkillsGallery({
       }
     }
 
-    const conversationId = createConversation();
+    const conversationId = await createConversation();
     setPendingMessage(message);
     setActiveFormConfig(null);
     router.push(`/chat/${conversationId}`);

--- a/ui/src/store/__tests__/chat-store.test.ts
+++ b/ui/src/store/__tests__/chat-store.test.ts
@@ -701,6 +701,57 @@ describe('chat-store', () => {
   });
 
   // --------------------------------------------------------------------------
+  // loadTurnsFromServer
+  // --------------------------------------------------------------------------
+
+  describe('loadTurnsFromServer', () => {
+    it('hydrates supervisor conversations from the messages collection', async () => {
+      const conv = makeConversation({ id: 'supervisor-history' });
+      useChatStore.setState({ conversations: [conv] });
+
+      mockApiClient.getMessages.mockResolvedValue({
+        items: [
+          {
+            _id: 'mongo-user',
+            message_id: 'msg-user',
+            conversation_id: 'supervisor-history',
+            role: 'user',
+            content: 'What changed in prod?',
+            created_at: '2025-01-01T00:00:00Z',
+            metadata: { turn_id: 'turn-supervisor' },
+          },
+          {
+            _id: 'mongo-assistant',
+            message_id: 'msg-assistant',
+            conversation_id: 'supervisor-history',
+            role: 'assistant',
+            content: 'Here is the summary.',
+            created_at: '2025-01-01T00:00:01Z',
+            metadata: { turn_id: 'turn-supervisor', is_final: true },
+          },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 100,
+        has_more: false,
+      });
+
+      await useChatStore.getState().loadTurnsFromServer('supervisor-history');
+
+      expect(mockApiClient.getMessages).toHaveBeenCalledWith(
+        'supervisor-history',
+        { page_size: 100 },
+      );
+
+      const updatedConv = useChatStore.getState().conversations.find(
+        c => c.id === 'supervisor-history',
+      );
+      expect(updatedConv!.messages).toHaveLength(2);
+      expect(updatedConv!.messages[1].content).toBe('Here is the summary.');
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // loadConversationsFromServer — deletion sync
   // --------------------------------------------------------------------------
 

--- a/ui/src/store/chat-store.ts
+++ b/ui/src/store/chat-store.ts
@@ -70,7 +70,7 @@ interface ChatState {
   saveMessagesToServer: (conversationId: string) => Promise<void>; // Save messages to MongoDB after streaming
   recoverInterruptedTask: (conversationId: string, messageId: string, endpoint: string, accessToken?: string) => Promise<boolean>; // Level 2: Poll tasks/get for interrupted messages
   loadMessagesFromServer: (conversationId: string, options?: { force?: boolean }) => Promise<void>; // Load messages from MongoDB when opening conversation
-  loadTurnsFromServer: (conversationId: string) => Promise<void>; // No-op stub — Supervisor path will be restored in Phase 4
+  loadTurnsFromServer: (conversationId: string) => Promise<void>; // Supervisor history loader
   evictOldMessageContent: (conversationId: string, messageIdsToEvict: string[]) => void; // Evict content from old messages to free memory
 
   // Unviewed conversation actions
@@ -1482,13 +1482,16 @@ const storeImplementation = (set: any, get: any) => ({
       },
 
       // ═══════════════════════════════════════════════════════════════
-      // loadTurnsFromServer — NO-OP STUB.
+      // loadTurnsFromServer
       //
-      // Supervisor conversation loading will be restored when needed.
-      // The stub is kept so existing callers compile without changes.
+      // Platform Engineer/Supervisor conversations are still persisted in the
+      // legacy messages collection in current deployments. Keep the public
+      // action name used by ChatContainer, but hydrate from messages so default
+      // CAIPE chat history survives refreshes just like Dynamic Agent history.
       // ═══════════════════════════════════════════════════════════════
-      loadTurnsFromServer: async (_conversationId: string) => {
-        // No-op — supervisor path uses A2A directly
+      loadTurnsFromServer: async (conversationId: string) => {
+        console.log(`[ChatStore] Loading supervisor history for: ${conversationId}`);
+        await get().loadMessagesFromServer(conversationId, { force: true });
       },
 
       // Evict content from old messages to free memory.


### PR DESCRIPTION
# Description

Fixed by Codex. This fixes both no history chat issue and skills trigger from Skills tab issue.

Analysis by Claude:

Supervisor Chat Persistence Bug — Analysis Complete
Root cause: Both supervisor and dynamic agent chats write to the messages collection (via saveMessagesToServer → POST /api/chat/conversations/[id]/messages). But on reload:
- Dynamic agents → loadMessagesFromServer → GET /api/chat/conversations/[id]/messages — works
- Supervisor → loadTurnsFromServer → no-op stub — messages never load back
The Invalid conversation ID format error was a red herring or transient — all conversation IDs are UUIDs (server uses uuidv4(), client uses crypto.randomUUID()). The validateUUID regex accepts these.
Fix: Replace all loadTurnsFromServer calls with loadMessagesFromServer in:
1. ChatContainer.tsx — 3 call sites (lines 160, 171, 219)
2. Sidebar.tsx — 1 call site (line 162)
3. Remove the no-op stub from chat-store.ts and its type definition
4. Update tests
loadMessagesFromServer already handles both DA and supervisor conversations — it branches on isDynamicAgentConversation() only for logging, not for core logic. 


## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
