### PR TITLE
fix(slack-bot): get first matched agent, wire overthink

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -301,19 +301,13 @@ def handle_mention(event, say, client):
     bot_user_id = bot_info.get("user_id")
 
     matches = _match_agents(channel_config, is_bot=False, user_id=user_id, listen="mention")
-    if not matches:
-      # Fall back to global default agent with no special config
-      matches = [None]
+    first_agent_id = matches[0].agent_id if matches else (config.defaults.default_agent_id or "")
 
-    # Conversation and context are per-thread — create once, shared across all matched agents.
-    primary_agent_id = matches[0].agent_id if matches[0] else (config.defaults.default_agent_id or "")
-
-    # Create or retrieve conversation via shared API (server owns ID generation).
-    # Must happen BEFORE context building so we can use `created` to decide
-    # full vs delta thread context.
+    # create_conversation is idempotent on thread_ts but we need conv_created/metadata
+    # to decide full vs delta context, so call it once before the loop.
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack Thread",
-      agent_id=primary_agent_id,
+      agent_id=first_agent_id,
       owner_id=user_email or user_id,
       idempotency_key=thread_ts,
       metadata={
@@ -344,8 +338,8 @@ def handle_mention(event, say, client):
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
     team_id = event.get("team")
 
-    for agent_match in matches:
-      agent_id = agent_match.agent_id if agent_match else (config.defaults.default_agent_id or "")
+    for agent_match in matches if matches else [None]:
+      agent_id = agent_match.agent_id if agent_match else first_agent_id
       overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
       agent_context_message = context_message

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -301,15 +301,19 @@ def handle_mention(event, say, client):
     bot_user_id = bot_info.get("user_id")
 
     matches = _match_agents(channel_config, is_bot=False, user_id=user_id, listen="mention")
-    agent_match = matches[0] if matches else None
-    agent_id = agent_match.agent_id if agent_match else (config.defaults.default_agent_id or "")
+    if not matches:
+      # Fall back to global default agent with no special config
+      matches = [None]
+
+    # Conversation and context are per-thread — create once, shared across all matched agents.
+    primary_agent_id = matches[0].agent_id if matches[0] else (config.defaults.default_agent_id or "")
 
     # Create or retrieve conversation via shared API (server owns ID generation).
     # Must happen BEFORE context building so we can use `created` to decide
     # full vs delta thread context.
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack Thread",
-      agent_id=agent_id,
+      agent_id=primary_agent_id,
       owner_id=user_email or user_id,
       idempotency_key=thread_ts,
       metadata={
@@ -336,69 +340,82 @@ def handle_mention(event, say, client):
     if is_humble_followup:
       logger.info(f"[{thread_ts}] Detected humble followup - thread was previously skipped")
       session_manager.clear_skipped(thread_ts)
-      overthink = agent_match.users.overthink if agent_match and agent_match.users else None
-      if overthink and overthink.followup_prompt:
-        context_message = f"{overthink.followup_prompt}\n\n{context_message}"
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
-
-    client_context = {
-      "source": "slack",
-      "channel_type": "channel",
-      "channel_name": channel_config.name,
-      "channel_topic": channel_info.get("topic", ""),
-      "channel_purpose": channel_info.get("purpose", ""),
-      "humble_followup": is_humble_followup,
-    }
-    if user_email:
-      client_context["user_email"] = user_email
-
     team_id = event.get("team")
-    esc_config = get_escalation_config(agent_match) if agent_match else None
 
-    result = _call_ai(
-      client=client,
-      channel_id=channel_id,
-      thread_ts=thread_ts,
-      message_text=context_message,
-      user_id=user_id,
-      team_id=team_id,
-      agent_id=agent_id,
-      conversation_id=conversation_id,
-      escalation_config=esc_config,
-      client_context=client_context,
-    )
+    for agent_match in matches:
+      agent_id = agent_match.agent_id if agent_match else (config.defaults.default_agent_id or "")
+      overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
-    if isinstance(result, dict) and result.get("retry_needed"):
-      original_error = result.get("error", "Unknown error")
-      logger.warning(f"[{thread_ts}] Request failed, showing retry button: {original_error[:100]}")
+      agent_context_message = context_message
+      if is_humble_followup and overthink and overthink.followup_prompt:
+        agent_context_message = f"{overthink.followup_prompt}\n\n{context_message}"
 
-      client.chat_postMessage(
-        channel=channel_id,
+      client_context = {
+        "source": "slack",
+        "channel_type": "channel",
+        "channel_name": channel_config.name,
+        "channel_topic": channel_info.get("topic", ""),
+        "channel_purpose": channel_info.get("purpose", ""),
+        "humble_followup": is_humble_followup,
+        "overthink": bool(overthink and overthink.enabled),
+      }
+      if user_email:
+        client_context["user_email"] = user_email
+
+      esc_config = get_escalation_config(agent_match) if agent_match else None
+
+      result = _call_ai(
+        client=client,
+        channel_id=channel_id,
         thread_ts=thread_ts,
-        blocks=[
-          {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": "Something went wrong - some tools or subagents may have timed out. Would you like to try again?",
-            },
-          },
-          {
-            "type": "actions",
-            "elements": [
-              {
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Retry"},
-                "style": "primary",
-                "action_id": "caipe_retry",
-                "value": f"{channel_id}|{thread_ts}||{agent_id}",
-              },
-            ],
-          },
-        ],
-        text="Something went wrong. Click Retry to try again.",
+        message_text=agent_context_message,
+        user_id=user_id,
+        team_id=team_id,
+        agent_id=agent_id,
+        conversation_id=conversation_id,
+        overthink_config=overthink,
+        escalation_config=esc_config,
+        client_context=client_context,
       )
+
+      if isinstance(result, dict) and result.get("skipped"):
+        reason = result.get("reason", "unknown")
+        logger.info(f"[{thread_ts}] Overthink: skipped mention response ({reason}) for {user_name}")
+        session_manager.set_skipped(thread_ts, True)
+        continue
+
+      if isinstance(result, dict) and result.get("retry_needed"):
+        original_error = result.get("error", "Unknown error")
+        logger.warning(f"[{thread_ts}] Request failed, showing retry button: {original_error[:100]}")
+
+        client.chat_postMessage(
+          channel=channel_id,
+          thread_ts=thread_ts,
+          blocks=[
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "Something went wrong - some tools or subagents may have timed out. Would you like to try again?",
+              },
+            },
+            {
+              "type": "actions",
+              "elements": [
+                {
+                  "type": "button",
+                  "text": {"type": "plain_text", "text": "Retry"},
+                  "style": "primary",
+                  "action_id": "caipe_retry",
+                  "value": f"{channel_id}|{thread_ts}||{agent_id}",
+                },
+              ],
+            },
+          ],
+          text="Something went wrong. Click Retry to try again.",
+        )
 
     logger.info(f"[{thread_ts}] Completed CAIPE request for {user_name}")
 

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -335,7 +335,7 @@ def handle_mention(event, say, client):
       owner_id = session_manager.get_thread_owner(thread_ts) or conv_metadata.get("thread_owner_agent_id")
       if owner_id:
         session_manager.set_thread_owner(thread_ts, owner_id)  # warm cache on restart
-        logger.info(f"[{thread_ts}] Thread owned by agent={owner_id}, bypassing match")
+        logger.info(f"[{thread_ts}] Thread owned by agent={owner_id}, bypassing match{_msg_link(channel_id, thread_ts)}")
         agent_match = next((a for a in channel_config.agents if a.agent_id == owner_id), None)
         agent_id = owner_id
 
@@ -390,7 +390,7 @@ def handle_mention(event, say, client):
 
     if isinstance(result, dict) and result.get("skipped"):
       reason = result.get("reason", "unknown")
-      logger.info(f"[{thread_ts}] Overthink: skipped mention response ({reason}) for {user_name}")
+      logger.info(f"[{thread_ts}] Overthink: skipped mention response ({reason}) for {user_name}{_msg_link(channel_id, thread_ts)}")
       session_manager.set_skipped(thread_ts, True)
       return
 
@@ -511,9 +511,9 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       if owner_id:
         session_manager.set_thread_owner(thread_root_ts, owner_id)  # warm cache on restart
         if owner_id != agent_match.agent_id:
-          logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, skipping agent={agent_match.agent_id}")
+          logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, skipping agent={agent_match.agent_id}{_msg_link(channel_id, thread_root_ts)}")
           return
-        logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, confirmed match")
+        logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, confirmed match{_msg_link(channel_id, thread_root_ts)}")
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
 

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -301,13 +301,15 @@ def handle_mention(event, say, client):
     bot_user_id = bot_info.get("user_id")
 
     matches = _match_agents(channel_config, is_bot=False, user_id=user_id, listen="mention")
-    first_agent_id = matches[0].agent_id if matches else (config.defaults.default_agent_id or "")
+    # First-match wins: config order is the priority order. Only one agent responds
+    # per event so that thread memory stays coherent on follow-ups.
+    agent_match = matches[0] if matches else None
+    agent_id = agent_match.agent_id if agent_match else (config.defaults.default_agent_id or "")
+    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
-    # create_conversation is idempotent on thread_ts but we need conv_created/metadata
-    # to decide full vs delta context, so call it once before the loop.
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack Thread",
-      agent_id=first_agent_id,
+      agent_id=agent_id,
       owner_id=user_email or user_id,
       idempotency_key=thread_ts,
       metadata={
@@ -334,82 +336,76 @@ def handle_mention(event, say, client):
     if is_humble_followup:
       logger.info(f"[{thread_ts}] Detected humble followup - thread was previously skipped")
       session_manager.clear_skipped(thread_ts)
+      if overthink and overthink.followup_prompt:
+        context_message = f"{overthink.followup_prompt}\n\n{context_message}"
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
     team_id = event.get("team")
 
-    for agent_match in matches if matches else [None]:
-      agent_id = agent_match.agent_id if agent_match else first_agent_id
-      overthink = agent_match.users.overthink if agent_match and agent_match.users else None
+    client_context = {
+      "source": "slack",
+      "channel_type": "channel",
+      "channel_name": channel_config.name,
+      "channel_topic": channel_info.get("topic", ""),
+      "channel_purpose": channel_info.get("purpose", ""),
+      "humble_followup": is_humble_followup,
+      "overthink": bool(overthink and overthink.enabled),
+    }
+    if user_email:
+      client_context["user_email"] = user_email
 
-      agent_context_message = context_message
-      if is_humble_followup and overthink and overthink.followup_prompt:
-        agent_context_message = f"{overthink.followup_prompt}\n\n{context_message}"
+    esc_config = get_escalation_config(agent_match) if agent_match else None
 
-      client_context = {
-        "source": "slack",
-        "channel_type": "channel",
-        "channel_name": channel_config.name,
-        "channel_topic": channel_info.get("topic", ""),
-        "channel_purpose": channel_info.get("purpose", ""),
-        "humble_followup": is_humble_followup,
-        "overthink": bool(overthink and overthink.enabled),
-      }
-      if user_email:
-        client_context["user_email"] = user_email
+    result = _call_ai(
+      client=client,
+      channel_id=channel_id,
+      thread_ts=thread_ts,
+      message_text=context_message,
+      user_id=user_id,
+      team_id=team_id,
+      agent_id=agent_id,
+      conversation_id=conversation_id,
+      overthink_config=overthink,
+      escalation_config=esc_config,
+      client_context=client_context,
+    )
 
-      esc_config = get_escalation_config(agent_match) if agent_match else None
+    if isinstance(result, dict) and result.get("skipped"):
+      reason = result.get("reason", "unknown")
+      logger.info(f"[{thread_ts}] Overthink: skipped mention response ({reason}) for {user_name}")
+      session_manager.set_skipped(thread_ts, True)
+      return
 
-      result = _call_ai(
-        client=client,
-        channel_id=channel_id,
+    if isinstance(result, dict) and result.get("retry_needed"):
+      original_error = result.get("error", "Unknown error")
+      logger.warning(f"[{thread_ts}] Request failed, showing retry button: {original_error[:100]}")
+
+      client.chat_postMessage(
+        channel=channel_id,
         thread_ts=thread_ts,
-        message_text=agent_context_message,
-        user_id=user_id,
-        team_id=team_id,
-        agent_id=agent_id,
-        conversation_id=conversation_id,
-        overthink_config=overthink,
-        escalation_config=esc_config,
-        client_context=client_context,
-      )
-
-      if isinstance(result, dict) and result.get("skipped"):
-        reason = result.get("reason", "unknown")
-        logger.info(f"[{thread_ts}] Overthink: skipped mention response ({reason}) for {user_name}")
-        session_manager.set_skipped(thread_ts, True)
-        continue
-
-      if isinstance(result, dict) and result.get("retry_needed"):
-        original_error = result.get("error", "Unknown error")
-        logger.warning(f"[{thread_ts}] Request failed, showing retry button: {original_error[:100]}")
-
-        client.chat_postMessage(
-          channel=channel_id,
-          thread_ts=thread_ts,
-          blocks=[
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "Something went wrong - some tools or subagents may have timed out. Would you like to try again?",
+        blocks=[
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Something went wrong - some tools or subagents may have timed out. Would you like to try again?",
+            },
+          },
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Retry"},
+                "style": "primary",
+                "action_id": "caipe_retry",
+                "value": f"{channel_id}|{thread_ts}||{agent_id}",
               },
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": {"type": "plain_text", "text": "Retry"},
-                  "style": "primary",
-                  "action_id": "caipe_retry",
-                  "value": f"{channel_id}|{thread_ts}||{agent_id}",
-                },
-              ],
-            },
-          ],
-          text="Something went wrong. Click Retry to try again.",
-        )
+            ],
+          },
+        ],
+        text="Something went wrong. Click Retry to try again.",
+      )
 
     logger.info(f"[{thread_ts}] Completed CAIPE request for {user_name}")
 
@@ -742,8 +738,9 @@ def handle_message_events(body, say, client):
   if not matches:
     return
 
-  for agent_match in matches:
-    _route_to_agent(event, say, client, channel_config, agent_match, is_bot=is_bot, bot_username=bot_username)
+  # First-match wins: config order is the priority order. Only one agent responds
+  # per event so that thread memory stays coherent on follow-ups.
+  _route_to_agent(event, say, client, channel_config, matches[0], is_bot=is_bot, bot_username=bot_username)
 
 
 # =============================================================================

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -176,12 +176,14 @@ def _track_interaction(
   user_name: str | None = None,
   response_time_ms: int | None = None,
   last_processed_ts: str | None = None,
+  thread_owner_agent_id: str | None = None,
 ) -> None:
   """PATCH conversation metadata with interaction tracking fields.
 
   Called after each successful AI response to record who interacted,
   how long it took, and what kind of interaction it was.  Also updates
-  ``last_processed_ts`` for delta context on follow-ups.
+  ``last_processed_ts`` for delta context on follow-ups, and persists
+  ``thread_owner_agent_id`` so thread ownership survives bot restarts.
   """
   metadata: dict[str, object] = {
     "interaction_type": interaction_type,
@@ -201,6 +203,9 @@ def _track_interaction(
 
   if last_processed_ts:
     metadata["last_processed_ts"] = last_processed_ts
+
+  if thread_owner_agent_id:
+    metadata["thread_owner_agent_id"] = thread_owner_agent_id
 
   try:
     sse_client.update_conversation_metadata(conversation_id, metadata)
@@ -300,12 +305,11 @@ def handle_mention(event, say, client):
     bot_info = client.auth_test()
     bot_user_id = bot_info.get("user_id")
 
+    # Run normal match first to seed agent_id for conversation creation.
+    # Ownership may override this below once we have conv_metadata.
     matches = _match_agents(channel_config, is_bot=False, user_id=user_id, listen="mention")
-    # First-match wins: config order is the priority order. Only one agent responds
-    # per event so that thread memory stays coherent on follow-ups.
     agent_match = matches[0] if matches else None
     agent_id = agent_match.agent_id if agent_match else (config.defaults.default_agent_id or "")
-    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack Thread",
@@ -322,6 +326,20 @@ def handle_mention(event, say, client):
     conversation_id = conv_result["conversation_id"]
     conv_created = conv_result["created"]
     conv_metadata = conv_result.get("metadata", {})
+
+    # Thread ownership: resolve from in-memory cache (hot path) or server
+    # metadata (survives restarts). Only applies to thread replies — root
+    # messages establish ownership after they respond.
+    is_thread_reply = bool(event.get("thread_ts"))
+    if is_thread_reply:
+      owner_id = session_manager.get_thread_owner(thread_ts) or conv_metadata.get("thread_owner_agent_id")
+      if owner_id:
+        session_manager.set_thread_owner(thread_ts, owner_id)  # warm cache on restart
+        logger.info(f"[{thread_ts}] Thread owned by agent={owner_id}, bypassing match")
+        agent_match = next((a for a in channel_config.agents if a.agent_id == owner_id), None)
+        agent_id = owner_id
+
+    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
     # Build thread context: full on first interaction, delta on follow-ups
     context_message = message_text
@@ -407,6 +425,7 @@ def handle_mention(event, say, client):
         text="Something went wrong. Click Retry to try again.",
       )
 
+    session_manager.set_thread_owner(thread_ts, agent_id)
     logger.info(f"[{thread_ts}] Completed CAIPE request for {user_name}")
 
     _track_interaction(
@@ -419,6 +438,7 @@ def handle_mention(event, say, client):
       user_name=user_name,
       response_time_ms=int((time.monotonic() - t0) * 1000),
       last_processed_ts=event.get("ts"),
+      thread_owner_agent_id=agent_id,
     )
 
   except Exception as e:
@@ -478,6 +498,22 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       },
     )
     conversation_id = conv_result["conversation_id"]
+    conv_metadata = conv_result.get("metadata", {})
+
+    # Thread ownership: bot messages start new threads so are never replies;
+    # for user messages, honour whoever responded first in this thread.
+    # Check in-memory cache first (hot path), fall back to server metadata
+    # (survives restarts). thread_root_ts is the ownership key shared with
+    # handle_mention.
+    thread_root_ts = event.get("thread_ts")
+    if not is_bot and thread_root_ts:
+      owner_id = session_manager.get_thread_owner(thread_root_ts) or conv_metadata.get("thread_owner_agent_id")
+      if owner_id:
+        session_manager.set_thread_owner(thread_root_ts, owner_id)  # warm cache on restart
+        if owner_id != agent_match.agent_id:
+          logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, skipping agent={agent_match.agent_id}")
+          return
+        logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, confirmed match")
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
 
@@ -528,6 +564,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       session_manager.set_skipped(thread_ts, True)
       return
 
+    session_manager.set_thread_owner(thread_root_ts or thread_ts, agent_id)
     logger.info(f"[{thread_ts}] Completed {sender_label} request for {user_name}")
 
     _track_interaction(
@@ -539,6 +576,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       user_email=user_email,
       user_name=user_name,
       response_time_ms=int((time.monotonic() - t0) * 1000),
+      thread_owner_agent_id=agent_id,
     )
 
   except Exception as e:

--- a/ai_platform_engineering/integrations/slack_bot/utils/session_manager.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/session_manager.py
@@ -63,6 +63,7 @@ class SessionManager:
     self._user_info_cache = TTLCache(ttl_seconds=600)
     self._skipped_cache = TTLCache(ttl_seconds=300)
     self._channel_info_cache = TTLCache(ttl_seconds=3600)
+    self._thread_owner_cache = TTLCache(ttl_seconds=86400)
     self._escalated_threads: set[str] = set()
 
   # ------------------------------------------------------------------
@@ -83,6 +84,20 @@ class SessionManager:
   def clear_skipped(self, thread_ts: str) -> None:
     """Clear the skipped flag."""
     self._skipped_cache.delete(thread_ts)
+
+  # ------------------------------------------------------------------
+  # Thread ownership — ensures the first agent to respond owns all
+  # follow-ups in that thread, regardless of listen mode.
+  # ------------------------------------------------------------------
+
+  def get_thread_owner(self, thread_ts: str) -> Optional[str]:
+    """Return the agent_id that first responded in this thread, or None."""
+    return self._thread_owner_cache.get(thread_ts)
+
+  def set_thread_owner(self, thread_ts: str, agent_id: str) -> None:
+    """Claim thread ownership for agent_id (first write wins)."""
+    if self._thread_owner_cache.get(thread_ts) is None:
+      self._thread_owner_cache.set(thread_ts, agent_id)
 
   # ------------------------------------------------------------------
   # Escalation dedup
@@ -133,5 +148,6 @@ class SessionManager:
       "user_cache_size": len(self._user_info_cache),
       "channel_cache_size": len(self._channel_info_cache),
       "skipped_cache_size": len(self._skipped_cache),
+      "thread_owner_cache_size": len(self._thread_owner_cache),
       "escalated_threads": len(self._escalated_threads),
     }

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.4-dev.1
+    version: 0.4.4-dev.2
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.4-dev.1
-appVersion: "0.4.4-dev.1"
+version: 0.4.4-dev.2
+appVersion: "0.4.4-dev.2"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.4-dev.1
-appVersion: 0.4.4-dev.1
+version: 0.4.4-dev.2
+appVersion: 0.4.4-dev.2
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.4-dev.1"
+version = "0.4.4-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -545,7 +545,7 @@ export const authOptions: NextAuthOptions = {
             return token;
           }
 
-          console.log(`[Auth] Token expires in ${timeUntilExpiry}s, attempting refresh...`);
+          console.debug(`[Auth] Token expires in ${timeUntilExpiry}s, attempting refresh...`);
 
           // Only attempt refresh if we have a refresh token
           if (token.refreshToken) {
@@ -589,7 +589,7 @@ export const authOptions: NextAuthOptions = {
 
             return refreshedToken;
           } else {
-            console.warn("[Auth] No refresh token available, falling back to expiry warnings");
+            console.debug("[Auth] No refresh token available, falling back to expiry warnings");
             // Don't set error - just fall back to warning system
             // This allows graceful degradation if provider doesn't support refresh tokens
           }

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.4.dev1"
+version = "0.4.4.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

`handle_mention` had two platform bugs observed in `#forge-playground`:

1. **Overthink not gating on mentions**: `_call_ai` was called without `overthink_config`, so agents configured with `overthink: enabled: true` and `listen: all` (or `listen: mention`) would respond unconditionally to `@mentions` — the overthink suppression logic was never reached.

2. **Only the first matched agent fired**: `handle_mention` used `matches[0]` instead of looping, so when multiple agents match a mention (e.g. a `listen: mention` default agent + a `listen: all` overthink agent), only the first was called and the rest were silently dropped.

**Fix**: mirror the message handler's pattern — loop over all matched agents, extract `overthink` per agent, pass it to `_call_ai`, and handle `skipped` results. Each agent also gets its own `agent_context_message` so `followup_prompt` is correctly prepended per-agent on humble followups. Added `"overthink"` key to `client_context` to match what `_route_to_agent` sets.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass