### PR TITLE
fix(docs): fix broken link in 0.3.x-to-0.4.0 migration guide

### DIFF
--- a/docs/docs/releases/migration-0.3.x-to-0.4.0.md
+++ b/docs/docs/releases/migration-0.3.x-to-0.4.0.md
@@ -292,7 +292,7 @@ botConfig:
           bot_list: ["AlertBot"]
 ```
 
-See the [Slack Bot docs](/docs/integrations/slack-bot#channel-configuration) for full field reference.
+See the [Slack Bot docs](../integrations/slack-bot.md#channel-configuration) for full field reference.
 
 ---
 


### PR DESCRIPTION
## Summary

- The migration guide linked to `/docs/integrations/slack-bot#channel-configuration`
- With `routeBasePath: '/'` in `docusaurus.config.ts`, docs are served at the site root — the `/docs/` prefix does not exist
- Docusaurus reported this as a broken link, failing the GH Pages publish build
- Fixed by using a relative file reference `../integrations/slack-bot.md#channel-configuration`

## Test plan

- [ ] Docusaurus build passes (`npm run build` in `docs/`)
- [ ] CI [Publish][Docs] GH Pages workflow succeeds