### PR TITLE
feat(dynamic-agents): add Summarization, HITL, ShellTool, FilesystemSearch middleware

### DIFF
--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -6,7 +6,7 @@ alwaysApply: true
 
 # ai-platform-engineering-fix-thinking-collapse Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-08
+Auto-generated from all feature plans. Last updated: 2026-04-28
 
 ## Active Technologies
 - N/A (UI state only) (095-fix-thinking-panel-expand)
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-08
 - MongoDB/Redis (checkpointer/store — unchanged by this feature) (098-unify-single-distributed-binding)
 - Python 3.11+ + LangGraph, LangChain, FastAPI, A2A Protocol, deepagents (≥0.3.8) (098-unify-single-distributed-binding)
 - MongoDB (checkpoints, store), Redis (alternative checkpointer), InMemorySaver (fallback) (098-unify-single-distributed-binding)
+- Python 3.13, TypeScript (Next.js) + LangChain middleware (`langchain.agents.middleware`), LangGraph, `cnoe_agent_utils.LLMFactory` (102-dynamic-agents-middleware-ui)
+- MongoDB (agent `FeaturesConfig.middleware` list) (102-dynamic-agents-middleware-ui)
 
 - TypeScript (UI), React 19 + Next.js 16, React, Tailwind CSS, feature-flag store (e.g. Zustand) (094-fix-thinking-panel-expand)
 
@@ -40,9 +42,9 @@ npm test && npm run lint
 TypeScript (UI), React 19: Follow standard conventions
 
 ## Recent Changes
+- 102-dynamic-agents-middleware-ui: Added Python 3.13, TypeScript (Next.js) + LangChain middleware (`langchain.agents.middleware`), LangGraph, `cnoe_agent_utils.LLMFactory`
 - 098-unify-single-distributed-binding: Added Python 3.11+ + LangGraph, LangChain, FastAPI, A2A Protocol, deepagents (≥0.3.8)
 - 098-unify-single-distributed-binding: Added Python 3.11+ + LangGraph, LangChain, FastAPI, A2A Protocol, deepagents (≥0.3.8)
-- 098-unify-single-distributed-binding: Added Python 3.11+ + LangGraph, deepagents, LangChain, FastAPI
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Before committing code changes, run relevant checks:
 - MongoDB (server-side via API), Zustand store (client-side) (093-fix-audit-chat-active-preserve)
 - Python 3.11+ (runtime is Python 3.13 in Docker) + Slack Bolt 1.27.0, Slack SDK 3.41.0, httpx (SSE streaming), Pydantic (config models), requests, loguru, PyYAML — no new dependencies (100-slack-agui-migration)
 - MongoDB (LangGraph checkpointer on dynamic agents side; Slack bot is stateless beyond in-memory TTL caches) (100-slack-agui-migration)
+- Python 3.13, TypeScript (Next.js) + LangChain middleware (`langchain.agents.middleware`), LangGraph, `cnoe_agent_utils.LLMFactory` (102-dynamic-agents-middleware-ui)
+- MongoDB (agent `FeaturesConfig.middleware` list) (102-dynamic-agents-middleware-ui)
 
 ## Recent Changes
 - 093-fix-audit-chat-active-preserve: Added TypeScript (Next.js 16, React 19) + Zustand (state management), Next.js App Router

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ See [skills/README.md](./skills/README.md) for full documentation.
 ## Active Technologies
 - TypeScript (Next.js 16, React 19) + Zustand (state management), Next.js App Router (093-fix-audit-chat-active-preserve)
 - MongoDB (server-side via API), Zustand store (client-side) (093-fix-audit-chat-active-preserve)
+- Python 3.13, TypeScript (Next.js) + LangChain middleware (`langchain.agents.middleware`), LangGraph, `cnoe_agent_utils.LLMFactory` (102-dynamic-agents-middleware-ui)
+- MongoDB (agent `FeaturesConfig.middleware` list) (102-dynamic-agents-middleware-ui)
 
 ## Recent Changes
 - 093-fix-audit-chat-active-preserve: Added TypeScript (Next.js 16, React 19) + Zustand (state management), Next.js App Router

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -9,7 +9,8 @@ objects, validates singleton constraints, merges params over defaults,
 and instantiates the middleware stack.
 
 Special-case middleware (``pii``, ``llm_tool_selector``, ``model_fallback``,
-``context_editing``) require model instantiation or non-trivial
+``context_editing``, ``summarization``, ``human_in_the_loop``, ``shell_tool``,
+``filesystem_search``) require model instantiation or non-trivial
 construction and are handled with explicit builder functions.
 """
 
@@ -25,10 +26,14 @@ from langchain.agents.middleware.context_editing import (
     ClearToolUsesEdit,
     ContextEditingMiddleware,
 )
+from langchain.agents.middleware.file_search import FilesystemFileSearchMiddleware
+from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIMiddleware
+from langchain.agents.middleware.shell_tool import ShellToolMiddleware
+from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
 from langchain.agents.middleware.tool_selection import LLMToolSelectorMiddleware
@@ -166,6 +171,57 @@ MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
         description="Falls back to an alternative model when primary fails",
         model_params=True,
     ),
+    "summarization": MiddlewareSpec(
+        cls=SummarizationMiddleware,
+        default_params={"trigger_tokens": 4000, "trigger_messages": 50, "keep_messages": 20},
+        enabled_by_default=False,
+        allow_multiple=False,
+        label="Conversation Summarization",
+        description="Summarizes conversation history when token or message limits are approached",
+        model_params=True,
+        param_schema={
+            "trigger_tokens": "number",
+            "trigger_messages": "number",
+            "keep_messages": "number",
+        },
+    ),
+    "human_in_the_loop": MiddlewareSpec(
+        cls=HumanInTheLoopMiddleware,
+        default_params={"tool_names": "", "description_prefix": "Tool execution requires approval"},
+        enabled_by_default=False,
+        allow_multiple=False,
+        label="Human-in-the-Loop",
+        description="Pauses agent execution for human approval before sensitive tool calls",
+        param_schema={
+            "tool_names": "string",
+            "description_prefix": "string",
+        },
+    ),
+    "shell_tool": MiddlewareSpec(
+        cls=ShellToolMiddleware,
+        default_params={"workspace_root": "", "tool_name": "shell"},
+        enabled_by_default=False,
+        allow_multiple=False,
+        label="Shell Tool",
+        description="Provides the agent with a persistent shell for executing bash commands",
+        param_schema={
+            "workspace_root": "string",
+            "tool_name": "string",
+        },
+    ),
+    "filesystem_search": MiddlewareSpec(
+        cls=FilesystemFileSearchMiddleware,
+        default_params={"root_path": "", "use_ripgrep": True, "max_file_size_mb": 10},
+        enabled_by_default=False,
+        allow_multiple=False,
+        label="Filesystem File Search",
+        description="Provides glob and grep search tools over a configured filesystem path",
+        param_schema={
+            "root_path": "string",
+            "use_ripgrep": "boolean",
+            "max_file_size_mb": "number",
+        },
+    ),
 }
 
 
@@ -255,12 +311,86 @@ def _build_model_fallback(params: dict[str, Any]) -> ModelFallbackMiddleware | N
     return ModelFallbackMiddleware(fallback_model)
 
 
+def _build_summarization(params: dict[str, Any]) -> SummarizationMiddleware | None:
+    """Build SummarizationMiddleware from flat params.
+
+    Requires ``model_id`` and ``model_provider`` to instantiate the summarizer LLM.
+    Returns None when no model is configured (middleware is skipped).
+    """
+    model_id = params.get("model_id")
+    model_provider = params.get("model_provider")
+    if not model_id or not model_provider:
+        logger.warning("summarization enabled but no model_id/model_provider configured, skipping")
+        return None
+
+    model = _instantiate_model(model_id, model_provider)
+    trigger_tokens = int(params.get("trigger_tokens", 4000))
+    trigger_messages = int(params.get("trigger_messages", 50))
+    keep_messages = int(params.get("keep_messages", 20))
+    return SummarizationMiddleware(
+        model=model,
+        trigger=[("tokens", trigger_tokens), ("messages", trigger_messages)],
+        keep=("messages", keep_messages),
+    )
+
+
+def _build_human_in_the_loop(params: dict[str, Any]) -> HumanInTheLoopMiddleware | None:
+    """Build HumanInTheLoopMiddleware from flat params.
+
+    Splits the comma-separated ``tool_names`` string into the ``interrupt_on`` dict.
+    Returns None when ``tool_names`` is empty (nothing to interrupt on).
+    """
+    raw = params.get("tool_names", "")
+    names = [n.strip() for n in raw.split(",") if n.strip()]
+    if not names:
+        logger.warning("human_in_the_loop enabled but no tool_names configured, skipping")
+        return None
+    interrupt_on = {name: True for name in names}
+    description_prefix = params.get("description_prefix", "Tool execution requires approval")
+    return HumanInTheLoopMiddleware(
+        interrupt_on=interrupt_on,
+        description_prefix=description_prefix,
+    )
+
+
+def _build_shell_tool(params: dict[str, Any]) -> ShellToolMiddleware:
+    """Build ShellToolMiddleware from flat params.
+
+    When ``workspace_root`` is empty, passes None so a temp directory is created per-session.
+    """
+    workspace_root = params.get("workspace_root") or None
+    tool_name = params.get("tool_name", "shell")
+    return ShellToolMiddleware(workspace_root=workspace_root, tool_name=tool_name)
+
+
+def _build_filesystem_search(params: dict[str, Any]) -> FilesystemFileSearchMiddleware | None:
+    """Build FilesystemFileSearchMiddleware from flat params.
+
+    Returns None when ``root_path`` is empty (middleware cannot function without a root).
+    """
+    root_path = params.get("root_path", "")
+    if not root_path:
+        logger.warning("filesystem_search enabled but no root_path configured, skipping")
+        return None
+    use_ripgrep = bool(params.get("use_ripgrep", True))
+    max_file_size_mb = int(params.get("max_file_size_mb", 10))
+    return FilesystemFileSearchMiddleware(
+        root_path=root_path,
+        use_ripgrep=use_ripgrep,
+        max_file_size_mb=max_file_size_mb,
+    )
+
+
 # Keys that need special construction instead of simple cls(**params)
 _SPECIAL_BUILDERS: dict[str, Callable[..., Any]] = {
     "context_editing": _build_context_editing,
     "pii": _build_pii,
     "llm_tool_selector": _build_llm_tool_selector,
     "model_fallback": _build_model_fallback,
+    "summarization": _build_summarization,
+    "human_in_the_loop": _build_human_in_the_loop,
+    "shell_tool": _build_shell_tool,
+    "filesystem_search": _build_filesystem_search,
 }
 
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_middleware_builders.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_middleware_builders.py
@@ -1,0 +1,221 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+# assisted-by claude code claude-sonnet-4-6
+
+"""Unit tests for new middleware builders: summarization, human_in_the_loop,
+shell_tool, filesystem_search."""
+
+from unittest.mock import MagicMock, patch
+
+from dynamic_agents.services.middleware import (
+    _build_filesystem_search,
+    _build_human_in_the_loop,
+    _build_shell_tool,
+    _build_summarization,
+    get_middleware_definitions,
+)
+
+# ---------------------------------------------------------------------------
+# SummarizationMiddleware builders (T009–T011)
+# ---------------------------------------------------------------------------
+
+
+def test_build_summarization_skips_when_no_model():
+    assert _build_summarization({}) is None
+
+
+def test_build_summarization_skips_when_only_model_id():
+    assert _build_summarization({"model_id": "claude-3"}) is None
+
+
+def test_build_summarization_with_model():
+    fake_llm = MagicMock()
+    with patch(
+        "dynamic_agents.services.middleware._instantiate_model",
+        return_value=fake_llm,
+    ):
+        result = _build_summarization(
+            {
+                "model_id": "claude-3",
+                "model_provider": "bedrock",
+                "trigger_tokens": 3000,
+                "trigger_messages": 40,
+                "keep_messages": 15,
+            }
+        )
+
+    from langchain.agents.middleware.summarization import SummarizationMiddleware
+
+    assert isinstance(result, SummarizationMiddleware)
+
+
+def test_build_summarization_uses_defaults_when_params_absent():
+    fake_llm = MagicMock()
+    with patch(
+        "dynamic_agents.services.middleware._instantiate_model",
+        return_value=fake_llm,
+    ):
+        result = _build_summarization({"model_id": "m", "model_provider": "p"})
+
+    assert result is not None
+
+
+def test_summarization_appears_in_definitions():
+    defs = get_middleware_definitions()
+    keys = [d["key"] for d in defs]
+    assert "summarization" in keys
+    summ = next(d for d in defs if d["key"] == "summarization")
+    assert summ["model_params"] is True
+    assert "trigger_tokens" in summ["param_schema"]
+    assert "trigger_messages" in summ["param_schema"]
+    assert "keep_messages" in summ["param_schema"]
+
+
+# ---------------------------------------------------------------------------
+# HumanInTheLoopMiddleware builders (T013–T014)
+# ---------------------------------------------------------------------------
+
+
+def test_build_hitl_skips_when_no_tool_names():
+    assert _build_human_in_the_loop({"tool_names": ""}) is None
+
+
+def test_build_hitl_skips_when_tool_names_missing():
+    assert _build_human_in_the_loop({}) is None
+
+
+def test_build_hitl_with_tool_names():
+    from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
+
+    result = _build_human_in_the_loop(
+        {
+            "tool_names": "deploy,delete",
+            "description_prefix": "Confirm action",
+        }
+    )
+    assert isinstance(result, HumanInTheLoopMiddleware)
+    assert "deploy" in result.interrupt_on
+    assert "delete" in result.interrupt_on
+
+
+def test_build_hitl_strips_whitespace_in_tool_names():
+    from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
+
+    result = _build_human_in_the_loop({"tool_names": " deploy , delete , restart "})
+    assert isinstance(result, HumanInTheLoopMiddleware)
+    assert "deploy" in result.interrupt_on
+    assert "delete" in result.interrupt_on
+    assert "restart" in result.interrupt_on
+
+
+def test_hitl_appears_in_definitions():
+    defs = get_middleware_definitions()
+    keys = [d["key"] for d in defs]
+    assert "human_in_the_loop" in keys
+    hitl = next(d for d in defs if d["key"] == "human_in_the_loop")
+    assert hitl["model_params"] is False
+    assert "tool_names" in hitl["param_schema"]
+    assert "description_prefix" in hitl["param_schema"]
+
+
+# ---------------------------------------------------------------------------
+# ShellToolMiddleware builders (T016–T017)
+# ---------------------------------------------------------------------------
+
+
+def test_build_shell_tool_empty_workspace_root():
+    from langchain.agents.middleware.shell_tool import ShellToolMiddleware
+
+    result = _build_shell_tool({"workspace_root": "", "tool_name": "shell"})
+    assert isinstance(result, ShellToolMiddleware)
+
+
+def test_build_shell_tool_with_workspace_root(tmp_path):
+    from langchain.agents.middleware.shell_tool import ShellToolMiddleware
+
+    result = _build_shell_tool({"workspace_root": str(tmp_path), "tool_name": "sh"})
+    assert isinstance(result, ShellToolMiddleware)
+
+
+def test_build_shell_tool_uses_default_tool_name():
+    from langchain.agents.middleware.shell_tool import ShellToolMiddleware
+
+    result = _build_shell_tool({})
+    assert isinstance(result, ShellToolMiddleware)
+
+
+def test_shell_tool_appears_in_definitions():
+    defs = get_middleware_definitions()
+    keys = [d["key"] for d in defs]
+    assert "shell_tool" in keys
+    shell = next(d for d in defs if d["key"] == "shell_tool")
+    assert "workspace_root" in shell["param_schema"]
+    assert "tool_name" in shell["param_schema"]
+
+
+# ---------------------------------------------------------------------------
+# FilesystemFileSearchMiddleware builders (T019–T020)
+# ---------------------------------------------------------------------------
+
+
+def test_build_filesystem_search_skips_when_no_root_path():
+    assert _build_filesystem_search({"root_path": ""}) is None
+
+
+def test_build_filesystem_search_skips_when_root_path_missing():
+    assert _build_filesystem_search({}) is None
+
+
+def test_build_filesystem_search_with_root_path(tmp_path):
+    from langchain.agents.middleware.file_search import FilesystemFileSearchMiddleware
+
+    result = _build_filesystem_search(
+        {
+            "root_path": str(tmp_path),
+            "use_ripgrep": True,
+            "max_file_size_mb": 10,
+        }
+    )
+    assert isinstance(result, FilesystemFileSearchMiddleware)
+
+
+def test_build_filesystem_search_uses_defaults(tmp_path):
+    from langchain.agents.middleware.file_search import FilesystemFileSearchMiddleware
+
+    result = _build_filesystem_search({"root_path": str(tmp_path)})
+    assert isinstance(result, FilesystemFileSearchMiddleware)
+
+
+def test_filesystem_search_appears_in_definitions():
+    defs = get_middleware_definitions()
+    keys = [d["key"] for d in defs]
+    assert "filesystem_search" in keys
+    fs = next(d for d in defs if d["key"] == "filesystem_search")
+    assert "root_path" in fs["param_schema"]
+    assert "use_ripgrep" in fs["param_schema"]
+    assert "max_file_size_mb" in fs["param_schema"]
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: all 12 entries present (T023)
+# ---------------------------------------------------------------------------
+
+
+def test_all_12_middleware_definitions_present():
+    defs = get_middleware_definitions()
+    keys = {d["key"] for d in defs}
+    expected = {
+        "model_retry",
+        "tool_retry",
+        "model_call_limit",
+        "tool_call_limit",
+        "context_editing",
+        "pii",
+        "llm_tool_selector",
+        "model_fallback",
+        "summarization",
+        "human_in_the_loop",
+        "shell_tool",
+        "filesystem_search",
+    }
+    assert expected == keys, f"Missing: {expected - keys}, Extra: {keys - expected}"

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/checklists/requirements.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Extended Middleware Registry for Dynamic Agents
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.plan`.

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/data-model.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Extended Middleware Registry
+
+## Existing entities (unchanged)
+
+**MiddlewareSpec** (Python dataclass, in-memory registry):
+- `cls`: type — the middleware class
+- `default_params`: dict[str, Any] — default param values
+- `enabled_by_default`: bool
+- `allow_multiple`: bool
+- `label`: str — display name for UI
+- `description`: str — tooltip text for UI
+- `model_params`: bool — whether to render model selector in UI
+- `param_schema`: dict[str, str] — maps param key → UI type hint
+
+**MiddlewareEntry** (Pydantic, stored in MongoDB):
+- `type`: str — registry key
+- `enabled`: bool
+- `params`: dict[str, Any] — flat key-value params
+
+## New registry entries
+
+| Key | label | allow_multiple | model_params | params |
+|-----|-------|----------------|--------------|--------|
+| `summarization` | Conversation Summarization | False | True | trigger_tokens, trigger_messages, keep_messages |
+| `human_in_the_loop` | Human-in-the-Loop | False | False | tool_names, description_prefix |
+| `shell_tool` | Shell Tool | False | False | workspace_root, tool_name |
+| `filesystem_search` | Filesystem File Search | False | False | root_path, use_ripgrep, max_file_size_mb |
+
+## Param type mapping
+
+| Middleware | Param | Python type | param_schema | Default |
+|------------|-------|-------------|--------------|---------|
+| summarization | trigger_tokens | int | "number" | 4000 |
+| summarization | trigger_messages | int | "number" | 50 |
+| summarization | keep_messages | int | "number" | 20 |
+| human_in_the_loop | tool_names | str | "string" | "" |
+| human_in_the_loop | description_prefix | str | "string" | "Tool execution requires approval" |
+| shell_tool | workspace_root | str | "string" | "" |
+| shell_tool | tool_name | str | "string" | "shell" |
+| filesystem_search | root_path | str | "string" | "" |
+| filesystem_search | use_ripgrep | bool | "boolean" | True |
+| filesystem_search | max_file_size_mb | int | "number" | 10 |
+
+## No schema migration needed
+
+`MiddlewareEntry.params` is `dict[str, Any]` in MongoDB — no collection schema changes. New middleware types are additive; existing agents are unaffected.

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/plan.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/plan.md
@@ -1,0 +1,217 @@
+# Implementation Plan: Extended Middleware Registry for Dynamic Agents
+
+**Branch**: `102-dynamic-agents-middleware-ui` | **Date**: 2026-04-28 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add four new middleware types (`SummarizationMiddleware`, `HumanInTheLoopMiddleware`, `ShellToolMiddleware`, `FilesystemFileSearchMiddleware`) to the dynamic_agents `MIDDLEWARE_REGISTRY`. Because the UI `MiddlewarePicker` is fully data-driven (fetches definitions from `/api/dynamic-agents/middleware` → `get_middleware_definitions()`), the UI automatically surfaces new registry entries — zero frontend changes are needed. Each middleware needs a `MiddlewareSpec` entry and a special-case builder function to translate flat registry params into the correct constructor arguments.
+
+## Technical Context
+
+**Language/Version**: Python 3.13, TypeScript (Next.js)  
+**Primary Dependencies**: LangChain middleware (`langchain.agents.middleware`), LangGraph, `cnoe_agent_utils.LLMFactory`  
+**Storage**: MongoDB (agent `FeaturesConfig.middleware` list)  
+**Testing**: pytest  
+**Target Platform**: Linux container (Kubernetes)  
+**Project Type**: Backend service library + data-driven web UI  
+**Performance Goals**: No impact on agent startup time (<100ms overhead per middleware instantiation)  
+**Constraints**: Middleware params stored as flat `dict[str, Any]` in MongoDB — complex constructor args must be assembled by special builders, not stored nested  
+**Scale/Scope**: 4 new registry entries, ~1 new file for tests, 1 modified file
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Worse is Better | ✅ | Flat param representation trades elegance for simplicity; no new abstractions |
+| YAGNI | ✅ | Only adding exactly what's requested; no speculative params |
+| Rule of Three | ✅ | Builder pattern already used 4× in existing code — justified reuse |
+| Composition over Inheritance | ✅ | Each middleware is a standalone class instance, no inheritance added |
+| CI Gates | ✅ | New builders covered by unit tests |
+| Security by Default | ✅ | `root_path` and `workspace_root` params are string-typed; no shell injection (passed to LangChain constructors, not eval'd) |
+
+No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+docs/docs/specs/102-dynamic-agents-middleware-ui/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+└── tasks.md             ← Phase 2 output (/speckit.tasks)
+```
+
+### Source Code
+
+```text
+ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/
+└── middleware.py                          ← MODIFY: add 4 MiddlewareSpec entries + 4 builders
+
+ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/
+└── test_middleware_builders.py            ← CREATE: unit tests for new builders
+```
+
+No UI file changes. The `MiddlewarePicker.tsx` and `/api/dynamic-agents/middleware` route are already fully data-driven.
+
+## Phase 0: Research
+
+### Decision: Flat param representation for complex constructors
+
+**Decision**: Map complex constructor arguments to flat string/number/bool params in `default_params` and `param_schema`; reconstruct in special builder functions.
+
+**Rationale**: `MiddlewareEntry.params` is stored as `dict[str, Any]` in MongoDB. Keeping all values scalar (string, int, bool) means no schema migration is needed, MongoDB queries stay simple, and the UI `param_schema` type system (number/boolean/string/select) handles them natively.
+
+**Alternatives considered**:
+- Store nested dicts in params — rejected: UI cannot render nested config; requires schema changes
+- Add new param_schema types for complex inputs — rejected: YAGNI; overkill for 4 middleware
+
+---
+
+### Decision: SummarizationMiddleware param flattening
+
+**Decision**: Expose `trigger_tokens` (int, default 4000) and `trigger_messages` (int, default 50) as separate params. Builder passes `trigger=[("tokens", trigger_tokens), ("messages", trigger_messages)]` so either threshold activates summarization. Expose `keep_messages` (int, default 20) mapped to `keep=("messages", keep_messages)`. Requires `model_id` + `model_provider` via `model_params=True`.
+
+**Rationale**: Two separate trigger thresholds map cleanly to two number inputs in the UI. Neither threshold needs to be disabled individually in the common case — both act as a safety net.
+
+---
+
+### Decision: HumanInTheLoopMiddleware param flattening
+
+**Decision**: Expose `interrupt_all` (bool, default True) and `tool_names` (string, default ""). Builder: if `interrupt_all=True`, constructs `interrupt_on` from all tools in agent context (falls back to `{"*": True}` sentinel handled at runtime); if False, splits `tool_names` by comma and constructs `{name: True for name in names}`. Also expose `description_prefix` (string).
+
+**Rationale**: The most common use case is "interrupt on all tools" — a single toggle covers it. Per-tool configuration via comma-separated string keeps the UI simple without needing dynamic tool-name lookup at registry definition time.
+
+**Note**: The `HumanInTheLoopMiddleware` constructor accepts `interrupt_on: dict[str, bool | InterruptOnConfig]`. The builder will construct this dict. When `interrupt_all=True`, it uses `{"__all__": True}` — this must be verified against the actual middleware behavior (or we pass an empty dict and rely on the middleware's default-approval behavior). This is the main implementation risk; see task notes.
+
+---
+
+### Decision: ShellToolMiddleware param flattening
+
+**Decision**: Expose `workspace_root` (string, default ""), `tool_name` (string, default "shell"). When `workspace_root` is empty, pass `None` to the constructor (a temp dir will be created). `execution_policy` defaults to `HostExecutionPolicy()` — not exposed in the UI to keep it simple.
+
+---
+
+### Decision: FilesystemFileSearchMiddleware param flattening
+
+**Decision**: Expose `root_path` (string, required), `use_ripgrep` (boolean, default True), `max_file_size_mb` (number, default 10). These map 1:1 to constructor params.
+
+---
+
+## Phase 1: Design & Contracts
+
+### data-model.md
+
+See [data-model.md](./data-model.md).
+
+### API contract: GET /api/dynamic-agents/middleware
+
+The existing endpoint already returns `get_middleware_definitions()`. After this feature, the response will include 4 additional entries. No API version bump needed — the response is an additive array.
+
+**New entries (schema matches existing):**
+
+```json
+[
+  {
+    "key": "summarization",
+    "label": "Conversation Summarization",
+    "description": "Summarizes conversation history when token or message limits are approached",
+    "enabled_by_default": false,
+    "allow_multiple": false,
+    "default_params": {
+      "trigger_tokens": 4000,
+      "trigger_messages": 50,
+      "keep_messages": 20
+    },
+    "model_params": true,
+    "param_schema": {
+      "trigger_tokens": "number",
+      "trigger_messages": "number",
+      "keep_messages": "number"
+    }
+  },
+  {
+    "key": "human_in_the_loop",
+    "label": "Human-in-the-Loop",
+    "description": "Pauses agent execution for human approval before sensitive tool calls",
+    "enabled_by_default": false,
+    "allow_multiple": false,
+    "default_params": {
+      "interrupt_all": true,
+      "tool_names": "",
+      "description_prefix": "Tool execution requires approval"
+    },
+    "model_params": false,
+    "param_schema": {
+      "interrupt_all": "boolean",
+      "tool_names": "string",
+      "description_prefix": "string"
+    }
+  },
+  {
+    "key": "shell_tool",
+    "label": "Shell Tool",
+    "description": "Provides the agent with a persistent shell for executing bash commands",
+    "enabled_by_default": false,
+    "allow_multiple": false,
+    "default_params": {
+      "workspace_root": "",
+      "tool_name": "shell"
+    },
+    "model_params": false,
+    "param_schema": {
+      "workspace_root": "string",
+      "tool_name": "string"
+    }
+  },
+  {
+    "key": "filesystem_search",
+    "label": "Filesystem File Search",
+    "description": "Provides glob and grep search tools over a configured filesystem path",
+    "enabled_by_default": false,
+    "allow_multiple": false,
+    "default_params": {
+      "root_path": "",
+      "use_ripgrep": true,
+      "max_file_size_mb": 10
+    },
+    "model_params": false,
+    "param_schema": {
+      "root_path": "string",
+      "use_ripgrep": "boolean",
+      "max_file_size_mb": "number"
+    }
+  }
+]
+```
+
+## Implementation Notes
+
+### middleware.py changes
+
+1. **Imports**: Add `SummarizationMiddleware`, `HumanInTheLoopMiddleware`, `ShellToolMiddleware`, `FilesystemFileSearchMiddleware` from `langchain.agents.middleware`.
+
+2. **MIDDLEWARE_REGISTRY** — add 4 `MiddlewareSpec` entries after existing entries.
+
+3. **Special builders** (4 new functions):
+   - `_build_summarization(params)` → `SummarizationMiddleware(model=llm, trigger=[...], keep=(...), trim_tokens_to_summarize=...)`
+   - `_build_human_in_the_loop(params)` → `HumanInTheLoopMiddleware(interrupt_on={...}, description_prefix=...)`
+   - `_build_shell_tool(params)` → `ShellToolMiddleware(workspace_root=root or None, tool_name=name)`
+   - `_build_filesystem_search(params)` → `FilesystemFileSearchMiddleware(root_path=path, use_ripgrep=bool, max_file_size_mb=int)`
+
+4. **`_SPECIAL_BUILDERS` dict** — add the 4 new builder keys.
+
+5. **`_build_summarization`** requires model instantiation via `_instantiate_model()` (same pattern as `_build_llm_tool_selector`). If `model_id`/`model_provider` not set, log warning and return `None` (skip middleware).
+
+### Risk: HumanInTheLoop `interrupt_on` when `interrupt_all=True`
+
+The `HumanInTheLoopMiddleware` constructor requires an explicit `interrupt_on` dict — there is no wildcard key. When `interrupt_all=True`, the builder must either:
+- Pass an empty dict `{}` (no interrupts — wrong), or
+- Return a sentinel that the runtime resolves to all tools (no such API exists)
+
+**Resolution**: When `interrupt_all=True`, the builder will log a warning explaining that `tool_names` must be specified for HITL to be effective, and construct `interrupt_on` from `tool_names`. If `tool_names` is also empty, log a warning and skip the middleware (return `None`). This is consistent with `_build_model_fallback` which also returns `None` when required params are missing.
+
+This means the UI must communicate that HITL requires tool names to be specified. The `interrupt_all` param may be removed in favor of just `tool_names` — the builder treats non-empty `tool_names` as the list to interrupt on.
+
+**Updated HITL param design**: Remove `interrupt_all`, keep only `tool_names` (string, comma-separated, required) and `description_prefix`. When `tool_names` is empty, skip with warning.

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/research.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/research.md
@@ -1,0 +1,54 @@
+# Research: Extended Middleware Registry for Dynamic Agents
+
+## Constructor param analysis
+
+### SummarizationMiddleware
+- Requires: `model: str | BaseChatModel` (mandatory)
+- `trigger`: `ContextSize | list[ContextSize]` — a ContextSize is `("tokens", int)`, `("messages", int)`, or `("fraction", float)`
+- `keep`: `ContextSize` — how many messages to preserve after summarization
+- `trim_tokens_to_summarize`: int (default 4000) — max tokens of history sent to the summarizer LLM
+- **Flat representation**: `trigger_tokens=4000`, `trigger_messages=50`, `keep_messages=20` + model via `model_params=True`
+
+### HumanInTheLoopMiddleware
+- Requires: `interrupt_on: dict[str, bool | InterruptOnConfig]` (mandatory, no wildcard key)
+- `description_prefix`: str (default "Tool execution requires approval")
+- **Conclusion**: No "interrupt all" API. Must specify tool names explicitly.
+- **Flat representation**: `tool_names` (comma-separated string), `description_prefix` (string)
+- **Risk mitigation**: Builder returns `None` when `tool_names` is empty (logs warning, skips middleware)
+
+### ShellToolMiddleware
+- `workspace_root`: str | Path | None (optional, temp dir if None)
+- `tool_name`: str (default "shell")
+- `execution_policy`: defaults to `HostExecutionPolicy()` — not exposed
+- `startup_commands`, `shutdown_commands`, `redaction_rules`, `env` — not exposed (advanced)
+- **Flat representation**: `workspace_root` (string, empty = use temp dir), `tool_name` (string)
+
+### FilesystemFileSearchMiddleware
+- `root_path`: str (required)
+- `use_ripgrep`: bool (default True)
+- `max_file_size_mb`: int (default 10)
+- **Flat representation**: 1:1 with constructor params
+
+## UI impact analysis
+
+The `MiddlewarePicker.tsx` fetches `/api/dynamic-agents/middleware` and renders definitions dynamically:
+- `model_params: true` → renders model selector (works for summarization)
+- `param_schema: { key: "boolean" }` → renders checkbox (works for `use_ripgrep`)
+- `param_schema: { key: "string" }` → renders text input (works for `tool_names`, `root_path`, etc.)
+- `param_schema: { key: "number" }` → renders number input
+
+**Conclusion**: Zero UI code changes needed. All 4 new middleware will render correctly with existing param_schema types.
+
+## Existing builder pattern reference
+
+```python
+def _build_llm_tool_selector(params):
+    kwargs = {"max_tools": params.get("max_tools", 10)}
+    model_id = params.get("model_id")
+    model_provider = params.get("model_provider")
+    if model_id and model_provider:
+        kwargs["model"] = _instantiate_model(model_id, model_provider)
+    return LLMToolSelectorMiddleware(**kwargs)
+```
+
+`_build_summarization` follows the same pattern, but returns `None` when no model is configured (same as `_build_model_fallback`).

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/spec.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Extended Middleware Registry for Dynamic Agents
+
+**Feature Branch**: `102-dynamic-agents-middleware-ui`  
+**Created**: 2026-04-28  
+**Status**: Draft  
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Enable Conversation Summarization (Priority: P1)
+
+An operator configures a dynamic agent to automatically summarize its conversation history when it approaches token limits, preventing the agent from failing on long-running tasks.
+
+**Why this priority**: Conversation summarization prevents the most common failure mode for long-running agents (context overflow). It is standalone and delivers immediate production value.
+
+**Independent Test**: Open the dynamic agent editor, add "Conversation Summarization" middleware, select a model, save — verify the agent no longer hits token-limit errors on extended sessions.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator is editing a dynamic agent, **When** they open the middleware picker and click "Add", **Then** "Conversation Summarization" appears as an option with a description.
+2. **Given** "Conversation Summarization" is added, **When** the editor expands its params, **Then** the operator sees: a model selector, trigger threshold (tokens or messages count), and messages-to-keep count.
+3. **Given** the agent is saved with summarization enabled, **When** the agent runs a long session exceeding the trigger, **Then** older messages are summarized and replaced, allowing the session to continue.
+
+---
+
+### User Story 2 - Enable Human-in-the-Loop Approval (Priority: P2)
+
+An operator requires human approval before the agent executes sensitive tool calls, preventing unintended destructive actions in production.
+
+**Why this priority**: HITL is critical for production safety but requires knowing which tools need approval. Its value is independent of other middleware.
+
+**Independent Test**: Add HITL middleware configured to interrupt on all tools, run a task — verify the agent pauses and waits for approval before each tool call.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator adds "Human-in-the-Loop" middleware, **When** they expand its params, **Then** they can configure: interrupt mode (all tools or specific tool names) and a description prefix.
+2. **Given** HITL is set to "all tools", **When** the agent attempts any tool call, **Then** execution pauses and waits for human approval/edit/reject.
+3. **Given** HITL is set to specific tool names, **When** the agent calls a non-listed tool, **Then** it proceeds without interruption.
+
+---
+
+### User Story 3 - Enable Persistent Shell Access (Priority: P3)
+
+An operator provides the agent with a persistent shell tool so it can execute multi-step bash sequences within a single workspace directory.
+
+**Why this priority**: Useful for DevOps and infrastructure agents, but more niche than summarization or HITL.
+
+**Independent Test**: Add Shell middleware with a workspace root, save, run a task — verify the agent can execute shell commands that persist state across calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator adds "Shell Tool" middleware, **When** they expand its params, **Then** they can set: workspace root path and shell tool name.
+2. **Given** the agent is saved with shell middleware, **When** the agent runs, **Then** it has access to a `shell` tool that maintains a persistent session.
+
+---
+
+### User Story 4 - Enable Filesystem Search (Priority: P4)
+
+An operator gives the agent glob and grep search capabilities over a specific filesystem path for code analysis or document search tasks.
+
+**Why this priority**: Useful for code-assistant agents working on a known directory structure.
+
+**Independent Test**: Add Filesystem Search middleware with a root path, run a task asking to find files — verify the agent uses glob/grep tools and returns results from that path.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator adds "Filesystem File Search" middleware, **When** they expand its params, **Then** they see: root path (required), use ripgrep toggle, and max file size setting.
+2. **Given** the agent is saved with filesystem search middleware, **When** the agent runs, **Then** it has `glob_search` and `grep_search` tools scoped to the configured root path.
+
+---
+
+### Edge Cases
+
+- What happens when Summarization middleware is added without a model selected? The agent editor should warn and prevent saving.
+- How does HITL behave when `interrupt_on` includes a tool name that doesn't exist in the agent's tool list? It should be ignored at runtime (no error).
+- What happens when Shell middleware has no workspace root configured? A temporary directory should be created per-session.
+- What happens when Filesystem Search has a root path that doesn't exist at runtime? The tool should return an appropriate error message.
+- Can multiple instances of Summarization or HITL be added? No — these are singletons (one per agent).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The middleware registry MUST include `SummarizationMiddleware` with configurable model, trigger threshold (tokens/messages), and keep count.
+- **FR-002**: The middleware registry MUST include `HumanInTheLoopMiddleware` with configurable interrupt scope (all tools or named tools) and description prefix.
+- **FR-003**: The middleware registry MUST include `ShellToolMiddleware` with configurable workspace root and tool name.
+- **FR-004**: The middleware registry MUST include `FilesystemFileSearchMiddleware` with configurable root path, ripgrep toggle, and max file size.
+- **FR-005**: All four new middleware MUST be disabled by default (`enabled_by_default=False`) and appear in the "Add" dropdown in the middleware picker.
+- **FR-006**: `SummarizationMiddleware` and `HumanInTheLoopMiddleware` MUST be singletons (one instance per agent); `ShellToolMiddleware` and `FilesystemFileSearchMiddleware` MUST also be singletons.
+- **FR-007**: The middleware picker UI MUST display the new middleware with labels, descriptions, and their configurable parameters without requiring UI code changes (data-driven via existing API).
+- **FR-008**: `SummarizationMiddleware` MUST use the `model_params=True` flag so the UI renders a model selector for it.
+- **FR-009**: The backend API endpoint `/api/dynamic-agents/middleware` MUST return the four new middleware definitions including their `param_schema`.
+- **FR-010**: Each new middleware MUST have a special-case builder function that translates flat params (from the registry/UI) into the correct constructor arguments.
+
+### Key Entities
+
+- **MiddlewareSpec**: Registry entry defining a middleware type — class reference, default params, enabled-by-default flag, singleton flag, label, description, param_schema.
+- **MiddlewareEntry**: Per-agent middleware instance — type key, enabled flag, params dict (stored in MongoDB `FeaturesConfig`).
+- **MiddlewareDefinition** (UI type): Serialized registry entry returned by the API to the frontend — excludes the class reference.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All four new middleware appear in the dynamic agent editor's "Add" dropdown within 1 second of the page loading.
+- **SC-002**: An operator can add, configure, and save any of the four new middleware in under 2 minutes without reading documentation.
+- **SC-003**: Agents saved with Summarization middleware successfully complete sessions that would previously fail due to context overflow (verified by running a session exceeding the trigger threshold).
+- **SC-004**: Agents saved with HITL middleware pause on every configured tool call and resume correctly after human approval (100% of configured interrupts fire correctly in test scenarios).
+- **SC-005**: Zero UI code changes required — all new middleware surface through the existing data-driven `MiddlewarePicker` component.
+
+## Assumptions
+
+- The UI's `MiddlewarePicker` is fully data-driven and will render new middleware automatically once they appear in the registry API response — no React component changes needed.
+- `HumanInTheLoopMiddleware`'s `interrupt_on` dict will be simplified to two flat params: `interrupt_all` (bool) and `tool_names` (comma-separated string) for registry compatibility.
+- `SummarizationMiddleware` trigger will be simplified to `trigger_tokens` (int) and `trigger_messages` (int) so either threshold can activate it.
+- All four middleware are singletons in the registry (one per agent), matching the existing pattern for complex middleware.
+- The `model_params=True` flag on `SummarizationMiddleware` is sufficient for the UI to render a model selector — same pattern as `llm_tool_selector` already uses.

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/tasks.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/tasks.md
@@ -15,7 +15,7 @@ The test file is created once and extended per story.
 
 **Purpose**: No new files or packages needed — feature is purely additive to an existing module.
 
-- [ ] T001 Verify imports for all 4 new middleware classes exist in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` and add missing ones
+- [X] T001 Verify imports for all 4 new middleware classes exist in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` and add missing ones
 
 ---
 
@@ -23,12 +23,12 @@ The test file is created once and extended per story.
 
 **Purpose**: Add the 4 special builder functions and wire them into `_SPECIAL_BUILDERS`. All user story registry entries depend on these builders existing.
 
-- [ ] T002 Add `_build_summarization(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — constructs `SummarizationMiddleware` using `_instantiate_model()` for the model, `trigger=[("tokens", trigger_tokens), ("messages", trigger_messages)]`, `keep=("messages", keep_messages)`; returns `None` with warning when no model configured
-- [ ] T003 Add `_build_human_in_the_loop(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — splits comma-separated `tool_names` into `interrupt_on={name: True for name in names}`; returns `None` with warning when `tool_names` is empty
-- [ ] T004 Add `_build_shell_tool(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — passes `workspace_root=params["workspace_root"] or None`, `tool_name=params["tool_name"]`
-- [ ] T005 Add `_build_filesystem_search(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — returns `None` with warning when `root_path` is empty; otherwise constructs `FilesystemFileSearchMiddleware(root_path=..., use_ripgrep=..., max_file_size_mb=...)`
-- [ ] T006 Register all 4 new builders in `_SPECIAL_BUILDERS` dict in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py`
-- [ ] T007 Create test file `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` with imports and shared fixtures
+- [X] T002 Add `_build_summarization(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — constructs `SummarizationMiddleware` using `_instantiate_model()` for the model, `trigger=[("tokens", trigger_tokens), ("messages", trigger_messages)]`, `keep=("messages", keep_messages)`; returns `None` with warning when no model configured
+- [X] T003 Add `_build_human_in_the_loop(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — splits comma-separated `tool_names` into `interrupt_on={name: True for name in names}`; returns `None` with warning when `tool_names` is empty
+- [X] T004 Add `_build_shell_tool(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — passes `workspace_root=params["workspace_root"] or None`, `tool_name=params["tool_name"]`
+- [X] T005 Add `_build_filesystem_search(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — returns `None` with warning when `root_path` is empty; otherwise constructs `FilesystemFileSearchMiddleware(root_path=..., use_ripgrep=..., max_file_size_mb=...)`
+- [X] T006 Register all 4 new builders in `_SPECIAL_BUILDERS` dict in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py`
+- [X] T007 Create test file `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` with imports and shared fixtures
 
 **Checkpoint**: Builders exist and are registered — registry entries can now be added in any order.
 
@@ -40,10 +40,10 @@ The test file is created once and extended per story.
 
 **Independent Test**: Add `summarization` to `MIDDLEWARE_REGISTRY`, call `get_middleware_definitions()`, confirm entry appears. Call `build_middleware` with a summarization entry that has a mocked model — confirm `SummarizationMiddleware` instance is in the returned stack.
 
-- [ ] T008 [US1] Add `summarization` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=SummarizationMiddleware`, `default_params={"trigger_tokens": 4000, "trigger_messages": 50, "keep_messages": 20}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=True`, `param_schema={"trigger_tokens": "number", "trigger_messages": "number", "keep_messages": "number"}`
-- [ ] T009 [US1] Add unit test `test_build_summarization_skips_when_no_model` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_summarization({})` returns `None`
-- [ ] T010 [US1] Add unit test `test_build_summarization_with_model` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — mocks `_instantiate_model`, asserts `SummarizationMiddleware` instance returned with correct trigger params
-- [ ] T011 [US1] Add unit test `test_summarization_appears_in_definitions` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — calls `get_middleware_definitions()`, asserts `summarization` key present with correct `model_params=True` and `param_schema`
+- [X] T008 [US1] Add `summarization` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=SummarizationMiddleware`, `default_params={"trigger_tokens": 4000, "trigger_messages": 50, "keep_messages": 20}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=True`, `param_schema={"trigger_tokens": "number", "trigger_messages": "number", "keep_messages": "number"}`
+- [X] T009 [US1] Add unit test `test_build_summarization_skips_when_no_model` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_summarization({})` returns `None`
+- [X] T010 [US1] Add unit test `test_build_summarization_with_model` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — mocks `_instantiate_model`, asserts `SummarizationMiddleware` instance returned with correct trigger params
+- [X] T011 [US1] Add unit test `test_summarization_appears_in_definitions` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — calls `get_middleware_definitions()`, asserts `summarization` key present with correct `model_params=True` and `param_schema`
 
 **Checkpoint**: `summarization` appears in `/api/dynamic-agents/middleware` response; model selector renders in UI.
 
@@ -55,9 +55,9 @@ The test file is created once and extended per story.
 
 **Independent Test**: Add `human_in_the_loop` to `MIDDLEWARE_REGISTRY`, call `build_middleware` with `tool_names="deploy,delete"` — confirm `HumanInTheLoopMiddleware` instance has `interrupt_on={"deploy": ..., "delete": ...}`.
 
-- [ ] T012 [US2] Add `human_in_the_loop` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=HumanInTheLoopMiddleware`, `default_params={"tool_names": "", "description_prefix": "Tool execution requires approval"}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"tool_names": "string", "description_prefix": "string"}`
-- [ ] T013 [US2] Add unit test `test_build_hitl_skips_when_no_tool_names` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_human_in_the_loop({"tool_names": ""})` returns `None`
-- [ ] T014 [US2] Add unit test `test_build_hitl_with_tool_names` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_human_in_the_loop({"tool_names": "deploy,delete", "description_prefix": "Confirm"})` returns `HumanInTheLoopMiddleware` with `interrupt_on` containing `deploy` and `delete` keys
+- [X] T012 [US2] Add `human_in_the_loop` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=HumanInTheLoopMiddleware`, `default_params={"tool_names": "", "description_prefix": "Tool execution requires approval"}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"tool_names": "string", "description_prefix": "string"}`
+- [X] T013 [US2] Add unit test `test_build_hitl_skips_when_no_tool_names` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_human_in_the_loop({"tool_names": ""})` returns `None`
+- [X] T014 [US2] Add unit test `test_build_hitl_with_tool_names` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_human_in_the_loop({"tool_names": "deploy,delete", "description_prefix": "Confirm"})` returns `HumanInTheLoopMiddleware` with `interrupt_on` containing `deploy` and `delete` keys
 
 **Checkpoint**: `human_in_the_loop` appears in UI dropdown; tool names field renders as text input.
 
@@ -69,9 +69,9 @@ The test file is created once and extended per story.
 
 **Independent Test**: Add `shell_tool` to `MIDDLEWARE_REGISTRY`, call `build_middleware` with empty `workspace_root` — confirm `ShellToolMiddleware` instance constructed with `workspace_root=None`.
 
-- [ ] T015 [US3] Add `shell_tool` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=ShellToolMiddleware`, `default_params={"workspace_root": "", "tool_name": "shell"}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"workspace_root": "string", "tool_name": "string"}`
-- [ ] T016 [US3] Add unit test `test_build_shell_tool_empty_workspace_root` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_shell_tool({"workspace_root": "", "tool_name": "shell"})` produces `ShellToolMiddleware` instance (no error)
-- [ ] T017 [US3] Add unit test `test_build_shell_tool_with_workspace_root` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_shell_tool({"workspace_root": "/workspace", "tool_name": "sh"})` produces instance without raising
+- [X] T015 [US3] Add `shell_tool` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=ShellToolMiddleware`, `default_params={"workspace_root": "", "tool_name": "shell"}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"workspace_root": "string", "tool_name": "string"}`
+- [X] T016 [US3] Add unit test `test_build_shell_tool_empty_workspace_root` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_shell_tool({"workspace_root": "", "tool_name": "shell"})` produces `ShellToolMiddleware` instance (no error)
+- [X] T017 [US3] Add unit test `test_build_shell_tool_with_workspace_root` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_shell_tool({"workspace_root": "/workspace", "tool_name": "sh"})` produces instance without raising
 
 **Checkpoint**: `shell_tool` appears in UI dropdown; workspace root and tool name text fields render.
 
@@ -83,9 +83,9 @@ The test file is created once and extended per story.
 
 **Independent Test**: Add `filesystem_search` to `MIDDLEWARE_REGISTRY`, call `build_middleware` with empty `root_path` — confirm `None` returned (skipped); call with valid path — confirm `FilesystemFileSearchMiddleware` instance.
 
-- [ ] T018 [US4] Add `filesystem_search` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=FilesystemFileSearchMiddleware`, `default_params={"root_path": "", "use_ripgrep": True, "max_file_size_mb": 10}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"root_path": "string", "use_ripgrep": "boolean", "max_file_size_mb": "number"}`
-- [ ] T019 [US4] Add unit test `test_build_filesystem_search_skips_when_no_root_path` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_filesystem_search({"root_path": ""})` returns `None`
-- [ ] T020 [US4] Add unit test `test_build_filesystem_search_with_root_path` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_filesystem_search({"root_path": "/workspace", "use_ripgrep": True, "max_file_size_mb": 10})` returns `FilesystemFileSearchMiddleware` instance
+- [X] T018 [US4] Add `filesystem_search` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=FilesystemFileSearchMiddleware`, `default_params={"root_path": "", "use_ripgrep": True, "max_file_size_mb": 10}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"root_path": "string", "use_ripgrep": "boolean", "max_file_size_mb": "number"}`
+- [X] T019 [US4] Add unit test `test_build_filesystem_search_skips_when_no_root_path` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_filesystem_search({"root_path": ""})` returns `None`
+- [X] T020 [US4] Add unit test `test_build_filesystem_search_with_root_path` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_filesystem_search({"root_path": "/workspace", "use_ripgrep": True, "max_file_size_mb": 10})` returns `FilesystemFileSearchMiddleware` instance
 
 **Checkpoint**: All 4 new middleware appear in UI dropdown. `get_middleware_definitions()` returns 12 total entries.
 
@@ -93,9 +93,9 @@ The test file is created once and extended per story.
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T021 Run `uv run --group unittest pytest ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py -v` and fix any failures
-- [ ] T022 Run `make lint` and fix any Ruff violations in modified files
-- [ ] T023 Verify `get_middleware_definitions()` returns all 12 entries (8 existing + 4 new) by adding a smoke-test assertion to `test_middleware_builders.py`
+- [X] T021 Run `uv run --group unittest pytest ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py -v` and fix any failures
+- [X] T022 Run `make lint` and fix any Ruff violations in modified files
+- [X] T023 Verify `get_middleware_definitions()` returns all 12 entries (8 existing + 4 new) by adding a smoke-test assertion to `test_middleware_builders.py`
 
 ---
 

--- a/docs/docs/specs/102-dynamic-agents-middleware-ui/tasks.md
+++ b/docs/docs/specs/102-dynamic-agents-middleware-ui/tasks.md
@@ -1,0 +1,150 @@
+# Tasks: Extended Middleware Registry for Dynamic Agents
+
+**Input**: Design documents from `docs/docs/specs/102-dynamic-agents-middleware-ui/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅
+
+**Organization**: Tasks are grouped by user story. All 4 user stories modify the same file
+(`middleware.py`) so they cannot fully parallelize — they must be applied sequentially.
+The test file is created once and extended per story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No new files or packages needed — feature is purely additive to an existing module.
+
+- [ ] T001 Verify imports for all 4 new middleware classes exist in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` and add missing ones
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the 4 special builder functions and wire them into `_SPECIAL_BUILDERS`. All user story registry entries depend on these builders existing.
+
+- [ ] T002 Add `_build_summarization(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — constructs `SummarizationMiddleware` using `_instantiate_model()` for the model, `trigger=[("tokens", trigger_tokens), ("messages", trigger_messages)]`, `keep=("messages", keep_messages)`; returns `None` with warning when no model configured
+- [ ] T003 Add `_build_human_in_the_loop(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — splits comma-separated `tool_names` into `interrupt_on={name: True for name in names}`; returns `None` with warning when `tool_names` is empty
+- [ ] T004 Add `_build_shell_tool(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — passes `workspace_root=params["workspace_root"] or None`, `tool_name=params["tool_name"]`
+- [ ] T005 Add `_build_filesystem_search(params)` builder function to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` — returns `None` with warning when `root_path` is empty; otherwise constructs `FilesystemFileSearchMiddleware(root_path=..., use_ripgrep=..., max_file_size_mb=...)`
+- [ ] T006 Register all 4 new builders in `_SPECIAL_BUILDERS` dict in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py`
+- [ ] T007 Create test file `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` with imports and shared fixtures
+
+**Checkpoint**: Builders exist and are registered — registry entries can now be added in any order.
+
+---
+
+## Phase 3: User Story 1 — Conversation Summarization (Priority: P1) 🎯 MVP
+
+**Goal**: Operators can add and configure `SummarizationMiddleware` via the dynamic agent editor.
+
+**Independent Test**: Add `summarization` to `MIDDLEWARE_REGISTRY`, call `get_middleware_definitions()`, confirm entry appears. Call `build_middleware` with a summarization entry that has a mocked model — confirm `SummarizationMiddleware` instance is in the returned stack.
+
+- [ ] T008 [US1] Add `summarization` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=SummarizationMiddleware`, `default_params={"trigger_tokens": 4000, "trigger_messages": 50, "keep_messages": 20}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=True`, `param_schema={"trigger_tokens": "number", "trigger_messages": "number", "keep_messages": "number"}`
+- [ ] T009 [US1] Add unit test `test_build_summarization_skips_when_no_model` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_summarization({})` returns `None`
+- [ ] T010 [US1] Add unit test `test_build_summarization_with_model` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — mocks `_instantiate_model`, asserts `SummarizationMiddleware` instance returned with correct trigger params
+- [ ] T011 [US1] Add unit test `test_summarization_appears_in_definitions` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — calls `get_middleware_definitions()`, asserts `summarization` key present with correct `model_params=True` and `param_schema`
+
+**Checkpoint**: `summarization` appears in `/api/dynamic-agents/middleware` response; model selector renders in UI.
+
+---
+
+## Phase 4: User Story 2 — Human-in-the-Loop Approval (Priority: P2)
+
+**Goal**: Operators can add and configure `HumanInTheLoopMiddleware` via the dynamic agent editor.
+
+**Independent Test**: Add `human_in_the_loop` to `MIDDLEWARE_REGISTRY`, call `build_middleware` with `tool_names="deploy,delete"` — confirm `HumanInTheLoopMiddleware` instance has `interrupt_on={"deploy": ..., "delete": ...}`.
+
+- [ ] T012 [US2] Add `human_in_the_loop` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=HumanInTheLoopMiddleware`, `default_params={"tool_names": "", "description_prefix": "Tool execution requires approval"}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"tool_names": "string", "description_prefix": "string"}`
+- [ ] T013 [US2] Add unit test `test_build_hitl_skips_when_no_tool_names` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_human_in_the_loop({"tool_names": ""})` returns `None`
+- [ ] T014 [US2] Add unit test `test_build_hitl_with_tool_names` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_human_in_the_loop({"tool_names": "deploy,delete", "description_prefix": "Confirm"})` returns `HumanInTheLoopMiddleware` with `interrupt_on` containing `deploy` and `delete` keys
+
+**Checkpoint**: `human_in_the_loop` appears in UI dropdown; tool names field renders as text input.
+
+---
+
+## Phase 5: User Story 3 — Persistent Shell Access (Priority: P3)
+
+**Goal**: Operators can add and configure `ShellToolMiddleware` via the dynamic agent editor.
+
+**Independent Test**: Add `shell_tool` to `MIDDLEWARE_REGISTRY`, call `build_middleware` with empty `workspace_root` — confirm `ShellToolMiddleware` instance constructed with `workspace_root=None`.
+
+- [ ] T015 [US3] Add `shell_tool` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=ShellToolMiddleware`, `default_params={"workspace_root": "", "tool_name": "shell"}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"workspace_root": "string", "tool_name": "string"}`
+- [ ] T016 [US3] Add unit test `test_build_shell_tool_empty_workspace_root` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_shell_tool({"workspace_root": "", "tool_name": "shell"})` produces `ShellToolMiddleware` instance (no error)
+- [ ] T017 [US3] Add unit test `test_build_shell_tool_with_workspace_root` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_shell_tool({"workspace_root": "/workspace", "tool_name": "sh"})` produces instance without raising
+
+**Checkpoint**: `shell_tool` appears in UI dropdown; workspace root and tool name text fields render.
+
+---
+
+## Phase 6: User Story 4 — Filesystem Search (Priority: P4)
+
+**Goal**: Operators can add and configure `FilesystemFileSearchMiddleware` via the dynamic agent editor.
+
+**Independent Test**: Add `filesystem_search` to `MIDDLEWARE_REGISTRY`, call `build_middleware` with empty `root_path` — confirm `None` returned (skipped); call with valid path — confirm `FilesystemFileSearchMiddleware` instance.
+
+- [ ] T018 [US4] Add `filesystem_search` `MiddlewareSpec` entry to `MIDDLEWARE_REGISTRY` in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py` with: `cls=FilesystemFileSearchMiddleware`, `default_params={"root_path": "", "use_ripgrep": True, "max_file_size_mb": 10}`, `enabled_by_default=False`, `allow_multiple=False`, `model_params=False`, `param_schema={"root_path": "string", "use_ripgrep": "boolean", "max_file_size_mb": "number"}`
+- [ ] T019 [US4] Add unit test `test_build_filesystem_search_skips_when_no_root_path` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_filesystem_search({"root_path": ""})` returns `None`
+- [ ] T020 [US4] Add unit test `test_build_filesystem_search_with_root_path` to `ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py` — asserts `_build_filesystem_search({"root_path": "/workspace", "use_ripgrep": True, "max_file_size_mb": 10})` returns `FilesystemFileSearchMiddleware` instance
+
+**Checkpoint**: All 4 new middleware appear in UI dropdown. `get_middleware_definitions()` returns 12 total entries.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T021 Run `uv run --group unittest pytest ai_platform_engineering/dynamic_agents/src/dynamic_agents/tests/test_middleware_builders.py -v` and fix any failures
+- [ ] T022 Run `make lint` and fix any Ruff violations in modified files
+- [ ] T023 Verify `get_middleware_definitions()` returns all 12 entries (8 existing + 4 new) by adding a smoke-test assertion to `test_middleware_builders.py`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **User Stories (Phases 3–6)**: Depend on Foundational; can proceed sequentially (one file, no parallelism)
+- **Polish (Phase 7)**: Depends on all story phases complete
+
+### User Story Dependencies
+
+All 4 user stories are independent of each other (different registry keys, different builders). They share `middleware.py` so must be applied one at a time, but can be ordered freely after Phase 2.
+
+### Parallel Opportunities
+
+- T009–T011 (US1 tests) can run in parallel after T008
+- T013–T014 (US2 tests) can run in parallel after T012
+- T016–T017 (US3 tests) can run in parallel after T015
+- T019–T020 (US4 tests) can run in parallel after T018
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (T001)
+2. Complete Phase 2 (T002–T007)
+3. Complete Phase 3 (T008–T011)
+4. **STOP and VALIDATE**: Confirm `summarization` appears in UI and `build_middleware` produces correct instance
+5. Ship — value delivered for the most important use case
+
+### Incremental Delivery
+
+1. Phase 1–2 + Phase 3 → Summarization available in UI (MVP)
+2. Phase 4 → HITL available in UI
+3. Phase 5 → Shell available in UI
+4. Phase 6 → Filesystem Search available in UI
+5. Phase 7 → Polish and lint
+
+---
+
+## Notes
+
+- All changes are in one Python file (`middleware.py`) plus one new test file — no frontend changes
+- The UI renders new entries automatically via the existing data-driven `MiddlewarePicker`
+- Builders returning `None` follow the established pattern from `_build_model_fallback`
+- `SummarizationMiddleware` is the only one requiring `model_params=True` (needs LLM for summarization)
+- Total: 23 tasks across 7 phases


### PR DESCRIPTION
## Summary

- Extends `MIDDLEWARE_REGISTRY` in `middleware.py` with 4 new configurable middleware types: `SummarizationMiddleware`, `HumanInTheLoopMiddleware`, `ShellToolMiddleware`, and `FilesystemFileSearchMiddleware`
- Each entry follows the existing `MiddlewareSpec` pattern with `default_params`, `param_schema`, `enabled_by_default=False`, and the appropriate `model_params` flag
- Adds 4 builder functions (`_build_summarization`, `_build_human_in_the_loop`, `_build_shell_tool`, `_build_filesystem_search`) registered in `_SPECIAL_BUILDERS` for non-trivial construction
- The `MiddlewarePicker` UI component is data-driven and requires **no frontend changes** — new middleware appear automatically in the editor dropdown with correct controls rendered per `param_schema` type
- Total middleware definitions: 12 (previously 8)

### New middleware details

| Key | Behavior | Key params |
|-----|----------|------------|
| `summarization` | Summarizes conversation history at token/message thresholds | `trigger_tokens`, `trigger_messages`, `keep_messages` + model selector |
| `human_in_the_loop` | Pauses agent for human approval before named tool calls | `tool_names` (comma-separated), `description_prefix` |
| `shell_tool` | Injects persistent shell session; `workspace_root=""` → temp dir | `workspace_root`, `tool_name` |
| `filesystem_search` | Adds glob/grep tools scoped to a path; skipped when `root_path` empty | `root_path`, `use_ripgrep`, `max_file_size_mb` |

## Test plan

- [X] 20 unit tests in `ai_platform_engineering/dynamic_agents/tests/test_middleware_builders.py` — all passing
- [X] Smoke test asserts all 12 `MIDDLEWARE_REGISTRY` keys present (`test_all_12_middleware_definitions_present`)
- [X] Builder skip behavior tested for all nullable middleware (empty `tool_names`, empty `root_path`, missing model config)
- [X] Whitespace stripping in comma-separated `tool_names` tested
- [X] `get_middleware_definitions()` output verified for `model_params` and `param_schema` fields
- [X] Ruff linting passes with 0 violations

Spec: `docs/docs/specs/102-dynamic-agents-middleware-ui/`