### PR TITLE
fix(rag-server): install chromium_headless_shell and add init container chart support

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors
@@ -131,7 +131,11 @@ RUN if [ "$VARIANT" != "slim" ]; then \
             rm /tmp/chrome.zip && \
             ln -sf /opt/chrome/chrome-${PLATFORM}/chrome /opt/chrome/chrome && \
             chmod -R 755 /opt/chrome && \
-            playwright install-deps chromium; \
+            playwright install-deps chromium && \
+            # Also install Playwright's chromium_headless_shell (used by headless launches)
+            # PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH only overrides full-chromium; headless shell
+            # resolves via PLAYWRIGHT_BROWSERS_PATH and must be present there.
+            playwright install chromium; \
         fi; \
     fi
 

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.4
+    version: 0.4.4-dev.1
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.3 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.4-dev.2
+    version: 0.4.4-dev.3
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.3 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.4-dev.2
-appVersion: "0.4.4-dev.2"
+version: 0.4.4-dev.3
+appVersion: "0.4.4-dev.3"

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.4
-appVersion: "0.4.4"
+version: 0.4.4-dev.1
+appVersion: "0.4.4-dev.1"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.3 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.3 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.3" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.4-dev.2
-appVersion: 0.4.4-dev.2
+version: 0.4.4-dev.3
+appVersion: 0.4.4-dev.3
 type: application

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.4
-appVersion: 0.4.4
+version: 0.4.4-dev.1
+appVersion: 0.4.4-dev.1
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.3 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.4-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.4-dev.3 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.3" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.3" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.3" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.4-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4-dev.2" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.3" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/templates/deployment.yaml
+++ b/charts/rag-stack/charts/rag-server/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "rag-server.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount | default false }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         # Main RAG Server container
         - name: {{ .Chart.Name }}
@@ -103,7 +107,15 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.webIngestor.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/rag-stack/charts/rag-server/values.yaml
+++ b/charts/rag-stack/charts/rag-server/values.yaml
@@ -77,6 +77,11 @@ webIngestor:
   # Additional envFrom references (secrets, configmaps)
   envFrom: []
 
+  # Extra volume mounts for the web-ingestor container (e.g. for Playwright browser cache)
+  extraVolumeMounts: []
+  # - name: playwright-browsers
+  #   mountPath: /opt/playwright
+
   # Resource limits for the web ingestor sidecar
   resources:
     requests:
@@ -105,6 +110,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Init containers to run before the main containers (e.g. install Playwright browsers)
+initContainers: []
+# - name: playwright-install
+#   image: "ghcr.io/cnoe-io/caipe-rag-ingestors:0.4.4"
+#   command: ["sh", "-c", "playwright install chromium"]
+#   volumeMounts:
+#     - name: playwright-browsers
+#       mountPath: /opt/playwright
+
+# Extra volumes for the pod (referenced by initContainers or webIngestor.extraVolumeMounts)
+extraVolumes: []
+# - name: playwright-browsers
+#   emptyDir: {}
 
 podAnnotations: {}
 podLabels: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.4-dev.2"
+version = "0.4.4-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.4"
+version = "0.4.4-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.4.dev2"
+version = "0.4.4.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.4"
+version = "0.4.4.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- **`Dockerfile.ingestors` (x86_64)**: Run `playwright install chromium` after Chrome for Testing download so that `chromium_headless_shell` is available in `/opt/playwright`. Playwright >= 1.44 uses `chromium_headless_shell` (not the full chromium binary) for headless launches. `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/opt/chrome/chrome` only overrides the full `chromium` browser type, not headless shell — so the `0.4.4` image on amd64 always fails JS rendering with: `BrowserType.launch: Executable doesn't exist at /opt/playwright/chromium_headless_shell-*`
- **`charts/rag-stack/charts/rag-server`**: Add `initContainers`, `extraVolumes`, and `webIngestor.extraVolumeMounts` chart values so operators can mount an emptyDir and install Playwright browsers at pod startup as a workaround on clusters running older images.

## Root cause

The `linux/amd64` build path:
1. Downloads Chrome for Testing → `/opt/chrome/chrome` ✅
2. Runs `playwright install-deps chromium` (system deps only) ✅
3. **Never runs `playwright install chromium`** → `chromium_headless_shell` absent ❌

The `linux/arm64` build path already runs `playwright install chromium` correctly.

## Test plan

- [ ] Build `linux/amd64` image and verify `/opt/playwright/chromium_headless_shell-*/...` exists
- [ ] Web ingestor JS rendering succeeds with `SCRAPY_JAVASCRIPT_ENABLED=true`
- [ ] `linux/arm64` build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)