### PR TITLE
fix(ui): remove $facet aggregation for CosmosDB/DocumentDB compatibility

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.4
+    version: 0.4.4-dev.1
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.4
-appVersion: "0.4.4"
+version: 0.4.4-dev.1
+appVersion: "0.4.4-dev.1"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.4
-appVersion: 0.4.4
+version: 0.4.4-dev.1
+appVersion: 0.4.4-dev.1
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.4 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.4-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.4" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.4-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.4-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.4"
+version = "0.4.4-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/__tests__/admin-audit-logs.test.ts
+++ b/ui/src/app/api/__tests__/admin-audit-logs.test.ts
@@ -125,13 +125,9 @@ function setupAdminWithConversations(convData: any[] = []) {
   mockGetServerSession.mockResolvedValue(adminSession());
 
   const convCol = createMockCollection();
+  convCol.countDocuments.mockResolvedValue(convData.length);
   convCol.aggregate.mockReturnValue({
-    toArray: jest.fn().mockResolvedValue([
-      {
-        items: convData,
-        totalCount: [{ count: convData.length }],
-      },
-    ]),
+    toArray: jest.fn().mockResolvedValue(convData),
   });
   mockCollections['conversations'] = convCol;
 
@@ -309,31 +305,36 @@ describe('GET /api/admin/audit-logs — Listing', () => {
     expect(matchStage.$match.deleted_at).toEqual({ $ne: null, $exists: true });
   });
 
-  it('uses $lookup to get last message timestamp', async () => {
-    const { convCol } = setupAdminWithConversations([]);
+  it('fetches last message timestamps separately (no $lookup)', async () => {
+    const { convCol } = setupAdminWithConversations([
+      { _id: 'conv-1', owner_id: 'alice@example.com', title: 'Test', created_at: new Date(), updated_at: new Date() },
+    ]);
 
     const req = makeRequest('/api/admin/audit-logs');
     await listGET(req);
 
+    // Pipeline should NOT contain $lookup
     const pipeline = convCol.aggregate.mock.calls[0][0];
     const lookupStage = pipeline.find((s: any) => s.$lookup);
-    expect(lookupStage).toBeDefined();
-    expect(lookupStage.$lookup.from).toBe('messages');
-    expect(lookupStage.$lookup.localField).toBe('_id');
-    expect(lookupStage.$lookup.foreignField).toBe('conversation_id');
+    expect(lookupStage).toBeUndefined();
   });
 
-  it('uses $facet for pagination', async () => {
+  it('uses countDocuments + pipeline for pagination (no $facet)', async () => {
     const { convCol } = setupAdminWithConversations([]);
 
     const req = makeRequest('/api/admin/audit-logs?page=2&page_size=10');
     await listGET(req);
 
+    // countDocuments called for total
+    expect(convCol.countDocuments).toHaveBeenCalled();
+    // Pipeline should have $skip and $limit but no $facet
     const pipeline = convCol.aggregate.mock.calls[0][0];
     const facetStage = pipeline.find((s: any) => s.$facet);
-    expect(facetStage).toBeDefined();
-    expect(facetStage.$facet.items).toBeDefined();
-    expect(facetStage.$facet.totalCount).toBeDefined();
+    expect(facetStage).toBeUndefined();
+    const skipStage = pipeline.find((s: any) => s.$skip !== undefined);
+    const limitStage = pipeline.find((s: any) => s.$limit !== undefined);
+    expect(skipStage.$skip).toBe(10);
+    expect(limitStage.$limit).toBe(10);
   });
 });
 
@@ -915,10 +916,8 @@ describe('GET /api/admin/audit-logs — Filter Edge Cases', () => {
     await listGET(req);
 
     const pipeline = convCol.aggregate.mock.calls[0][0];
-    const facetStage = pipeline.find((s: any) => s.$facet);
-    const itemsPipeline = facetStage.$facet.items;
-    const skipStage = itemsPipeline.find((s: any) => s.$skip !== undefined);
-    const limitStage = itemsPipeline.find((s: any) => s.$limit !== undefined);
+    const skipStage = pipeline.find((s: any) => s.$skip !== undefined);
+    const limitStage = pipeline.find((s: any) => s.$limit !== undefined);
     expect(skipStage.$skip).toBe(0);
     expect(limitStage.$limit).toBe(20);
   });
@@ -930,8 +929,7 @@ describe('GET /api/admin/audit-logs — Filter Edge Cases', () => {
     await listGET(req);
 
     const pipeline = convCol.aggregate.mock.calls[0][0];
-    const facetStage = pipeline.find((s: any) => s.$facet);
-    const sortStage = facetStage.$facet.items.find((s: any) => s.$sort);
+    const sortStage = pipeline.find((s: any) => s.$sort);
     expect(sortStage.$sort.updated_at).toBe(-1);
   });
 });

--- a/ui/src/app/api/admin/audit-logs/route.ts
+++ b/ui/src/app/api/admin/audit-logs/route.ts
@@ -74,7 +74,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // Count total matching documents (separate query for CosmosDB/DocumentDB compatibility)
     const total = await conversations.countDocuments(matchStage);
 
-    // Pipeline without $lookup/$facet for CosmosDB/DocumentDB compat
+    // IMPORTANT: All queries must be compatible with CosmosDB and DocumentDB.
+    // Do NOT use $facet or sub-pipeline $lookup (let/pipeline) — they are unsupported.
     const pipeline: any[] = [
       { $match: matchStage },
       {

--- a/ui/src/app/api/admin/audit-logs/route.ts
+++ b/ui/src/app/api/admin/audit-logs/route.ts
@@ -71,25 +71,15 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const conversations = await getCollection<Conversation>('conversations');
 
+    // Count total matching documents (separate query for CosmosDB/DocumentDB compatibility)
+    const total = await conversations.countDocuments(matchStage);
+
+    // Pipeline without $lookup/$facet for CosmosDB/DocumentDB compat
     const pipeline: any[] = [
       { $match: matchStage },
       {
-        $lookup: {
-          from: 'messages',
-          localField: '_id',
-          foreignField: 'conversation_id',
-          pipeline: [
-            { $sort: { created_at: -1 as const } },
-            { $limit: 1 },
-            { $project: { created_at: 1 } },
-          ],
-          as: '_last_msg',
-        },
-      },
-      {
         $addFields: {
           message_count: { $ifNull: ['$metadata.total_messages', 0] },
-          last_message_at: { $arrayElemAt: ['$_last_msg.created_at', 0] },
           status: {
             $cond: {
               if: {
@@ -110,22 +100,29 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           },
         },
       },
-      { $project: { _last_msg: 0 } },
-      {
-        $facet: {
-          items: [
-            { $sort: { updated_at: -1 as const } },
-            { $skip: skip },
-            { $limit: pageSize },
-          ],
-          totalCount: [{ $count: 'count' }],
-        },
-      },
+      { $sort: { updated_at: -1 as const } },
+      { $skip: skip },
+      { $limit: pageSize },
     ];
 
-    const [result] = await conversations.aggregate(pipeline).toArray();
-    const items = result?.items || [];
-    const total = result?.totalCount?.[0]?.count || 0;
+    const items: any[] = await conversations.aggregate(pipeline).toArray();
+
+    // Batch-fetch last message timestamps (avoids sub-pipeline $lookup)
+    if (items.length > 0) {
+      const convIds = items.map((item) => item._id);
+      const messages = await getCollection('messages');
+      const lastMessages: any[] = await messages
+        .aggregate([
+          { $match: { conversation_id: { $in: convIds } } },
+          { $sort: { created_at: -1 as const } },
+          { $group: { _id: '$conversation_id', last_at: { $first: '$created_at' } } },
+        ])
+        .toArray();
+      const lastMsgMap = new Map(lastMessages.map((m) => [m._id, m.last_at]));
+      for (const item of items) {
+        item.last_message_at = lastMsgMap.get(item._id) || null;
+      }
+    }
 
     return paginatedResponse(items, total, page, pageSize);
   });

--- a/ui/src/app/api/dynamic-agents/conversations/route.ts
+++ b/ui/src/app/api/dynamic-agents/conversations/route.ts
@@ -63,76 +63,68 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const conversations = await getCollection<Conversation>("conversations");
 
-    // Pipeline restructured to avoid MongoDB 100MB $lookup limit (Location4568).
-    // 1. Pagination ($skip/$limit) runs BEFORE $lookup so we only join for the current page
-    // 2. $lookup uses a sub-pipeline with $count to avoid materializing full checkpoint documents
+    // Count total matching documents (separate query for CosmosDB/DocumentDB compatibility)
+    const total = await conversations.countDocuments(matchStage);
+
+    // Fetch paginated items — no $lookup/$facet for CosmosDB/DocumentDB compat
     const pipeline: object[] = [
       { $match: matchStage },
       { $sort: { updated_at: -1 as const } },
+      { $skip: skip },
+      { $limit: pageSize },
       {
-        $facet: {
-          items: [
-            { $skip: skip },
-            { $limit: pageSize },
-            // Lookup checkpoint count using sub-pipeline (avoids 100MB limit)
-            {
-              $lookup: {
-                from: "checkpoints_conversation",
-                let: { threadId: "$_id" },
-                pipeline: [
-                  { $match: { $expr: { $eq: ["$thread_id", "$$threadId"] } } },
-                  { $count: "count" },
-                ],
-                as: "_checkpoints",
-              },
-            },
-            {
-              $addFields: {
-                checkpoint_count: {
-                  $ifNull: [{ $arrayElemAt: ["$_checkpoints.count", 0] }, 0],
-                },
-                // Project a derived agent_id for backward compat with the admin UI
-                agent_id: {
-                  $let: {
-                    vars: {
-                      agentParticipant: {
-                        $arrayElemAt: [
-                          { $filter: { input: "$participants", as: "p", cond: { $eq: ["$$p.type", "agent"] } } },
-                          0,
-                        ],
-                      },
-                    },
-                    in: "$$agentParticipant.id",
-                  },
+        $addFields: {
+          // Derive agent_id for backward compat with the admin UI
+          agent_id: {
+            $let: {
+              vars: {
+                agentParticipant: {
+                  $arrayElemAt: [
+                    { $filter: { input: "$participants", as: "p", cond: { $eq: ["$$p.type", "agent"] } } },
+                    0,
+                  ],
                 },
               },
+              in: "$$agentParticipant.id",
             },
-            {
-              $project: {
-                _id: 0,
-                id: "$_id",
-                title: 1,
-                owner_id: 1,
-                agent_id: 1,
-                created_at: 1,
-                updated_at: 1,
-                checkpoint_count: 1,
-                client_type: 1,
-                idempotency_key: 1,
-                metadata: 1,
-                is_archived: 1,
-                deleted_at: 1,
-              },
-            },
-          ],
-          totalCount: [{ $count: "count" }],
+          },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          id: "$_id",
+          title: 1,
+          owner_id: 1,
+          agent_id: 1,
+          created_at: 1,
+          updated_at: 1,
+          client_type: 1,
+          idempotency_key: 1,
+          metadata: 1,
+          is_archived: 1,
+          deleted_at: 1,
         },
       },
     ];
 
-    const [result] = await conversations.aggregate(pipeline).toArray();
-    const items = result?.items || [];
-    const total = result?.totalCount?.[0]?.count || 0;
+    const items: any[] = await conversations.aggregate(pipeline).toArray();
+
+    // Batch-fetch checkpoint counts for this page (avoids sub-pipeline $lookup)
+    if (items.length > 0) {
+      const threadIds = items.map((item) => item.id);
+      const checkpoints = await getCollection("checkpoints_conversation");
+      const counts: any[] = await checkpoints
+        .aggregate([
+          { $match: { thread_id: { $in: threadIds } } },
+          { $group: { _id: "$thread_id", count: { $sum: 1 } } },
+        ])
+        .toArray();
+      const countMap = new Map(counts.map((c) => [c._id, c.count]));
+      for (const item of items) {
+        item.checkpoint_count = countMap.get(item.id) || 0;
+      }
+    }
 
     return paginatedResponse(items, total, page, pageSize);
   });

--- a/ui/src/app/api/dynamic-agents/conversations/route.ts
+++ b/ui/src/app/api/dynamic-agents/conversations/route.ts
@@ -66,7 +66,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // Count total matching documents (separate query for CosmosDB/DocumentDB compatibility)
     const total = await conversations.countDocuments(matchStage);
 
-    // Fetch paginated items — no $lookup/$facet for CosmosDB/DocumentDB compat
+    // IMPORTANT: All queries must be compatible with CosmosDB and DocumentDB.
+    // Do NOT use $facet or sub-pipeline $lookup (let/pipeline) — they are unsupported.
     const pipeline: object[] = [
       { $match: matchStage },
       { $sort: { updated_at: -1 as const } },

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -134,12 +134,15 @@ class APIClient {
     page_size?: number;
     archived?: boolean;
     pinned?: boolean;
+    client_type?: string;
   }): Promise<PaginatedResponse<Conversation>> {
     const searchParams = new URLSearchParams();
     if (params?.page) searchParams.set('page', params.page.toString());
     if (params?.page_size) searchParams.set('page_size', params.page_size.toString());
     if (params?.archived !== undefined) searchParams.set('archived', params.archived.toString());
     if (params?.pinned !== undefined) searchParams.set('pinned', params.pinned.toString());
+    // Default to webui conversations only — excludes Slack/other client conversations
+    searchParams.set('client_type', params?.client_type || 'webui');
 
     return this.request(`/api/chat/conversations?${searchParams}`);
   }

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.4"
+version = "0.4.4.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Removes `$facet` aggregation stage from two API routes that broke on CosmosDB and Amazon DocumentDB (which don't support `$facet`). Replaces with separate `countDocuments()` + flat aggregation pipeline — functionally identical, universally compatible.

Also adds `client_type=webui` default filter to the conversation list API client so Slack conversations no longer appear in the web UI sidebar.

**Affected routes:**
- `GET /api/dynamic-agents/conversations` — admin conversation list
- `GET /api/admin/audit-logs` — admin audit logs

**Error resolved:** `MongoServerError: Aggregation stage not supported: '$facet'`

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass