### PR TITLE
fix(slack-bot): first-match agent wins per event, thread ownership persisted

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -176,12 +176,14 @@ def _track_interaction(
   user_name: str | None = None,
   response_time_ms: int | None = None,
   last_processed_ts: str | None = None,
+  thread_owner_agent_id: str | None = None,
 ) -> None:
   """PATCH conversation metadata with interaction tracking fields.
 
   Called after each successful AI response to record who interacted,
   how long it took, and what kind of interaction it was.  Also updates
-  ``last_processed_ts`` for delta context on follow-ups.
+  ``last_processed_ts`` for delta context on follow-ups, and persists
+  ``thread_owner_agent_id`` so thread ownership survives bot restarts.
   """
   metadata: dict[str, object] = {
     "interaction_type": interaction_type,
@@ -201,6 +203,9 @@ def _track_interaction(
 
   if last_processed_ts:
     metadata["last_processed_ts"] = last_processed_ts
+
+  if thread_owner_agent_id:
+    metadata["thread_owner_agent_id"] = thread_owner_agent_id
 
   try:
     sse_client.update_conversation_metadata(conversation_id, metadata)
@@ -300,12 +305,11 @@ def handle_mention(event, say, client):
     bot_info = client.auth_test()
     bot_user_id = bot_info.get("user_id")
 
+    # Run normal match first to seed agent_id for conversation creation.
+    # Ownership may override this below once we have conv_metadata.
     matches = _match_agents(channel_config, is_bot=False, user_id=user_id, listen="mention")
-    # First-match wins: config order is the priority order. Only one agent responds
-    # per event so that thread memory stays coherent on follow-ups.
     agent_match = matches[0] if matches else None
     agent_id = agent_match.agent_id if agent_match else (config.defaults.default_agent_id or "")
-    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
     conv_result = sse_client.create_conversation(
       title=message_text[:50].strip() or "Slack Thread",
@@ -322,6 +326,20 @@ def handle_mention(event, say, client):
     conversation_id = conv_result["conversation_id"]
     conv_created = conv_result["created"]
     conv_metadata = conv_result.get("metadata", {})
+
+    # Thread ownership: resolve from in-memory cache (hot path) or server
+    # metadata (survives restarts). Only applies to thread replies — root
+    # messages establish ownership after they respond.
+    is_thread_reply = bool(event.get("thread_ts"))
+    if is_thread_reply:
+      owner_id = session_manager.get_thread_owner(thread_ts) or conv_metadata.get("thread_owner_agent_id")
+      if owner_id:
+        session_manager.set_thread_owner(thread_ts, owner_id)  # warm cache on restart
+        logger.info(f"[{thread_ts}] Thread owned by agent={owner_id}, bypassing match")
+        agent_match = next((a for a in channel_config.agents if a.agent_id == owner_id), None)
+        agent_id = owner_id
+
+    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
 
     # Build thread context: full on first interaction, delta on follow-ups
     context_message = message_text
@@ -407,6 +425,7 @@ def handle_mention(event, say, client):
         text="Something went wrong. Click Retry to try again.",
       )
 
+    session_manager.set_thread_owner(thread_ts, agent_id)
     logger.info(f"[{thread_ts}] Completed CAIPE request for {user_name}")
 
     _track_interaction(
@@ -419,6 +438,7 @@ def handle_mention(event, say, client):
       user_name=user_name,
       response_time_ms=int((time.monotonic() - t0) * 1000),
       last_processed_ts=event.get("ts"),
+      thread_owner_agent_id=agent_id,
     )
 
   except Exception as e:
@@ -478,6 +498,22 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       },
     )
     conversation_id = conv_result["conversation_id"]
+    conv_metadata = conv_result.get("metadata", {})
+
+    # Thread ownership: bot messages start new threads so are never replies;
+    # for user messages, honour whoever responded first in this thread.
+    # Check in-memory cache first (hot path), fall back to server metadata
+    # (survives restarts). thread_root_ts is the ownership key shared with
+    # handle_mention.
+    thread_root_ts = event.get("thread_ts")
+    if not is_bot and thread_root_ts:
+      owner_id = session_manager.get_thread_owner(thread_root_ts) or conv_metadata.get("thread_owner_agent_id")
+      if owner_id:
+        session_manager.set_thread_owner(thread_root_ts, owner_id)  # warm cache on restart
+        if owner_id != agent_match.agent_id:
+          logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, skipping agent={agent_match.agent_id}")
+          return
+        logger.info(f"[{thread_root_ts}] Thread owned by agent={owner_id}, confirmed match")
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
 
@@ -528,6 +564,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       session_manager.set_skipped(thread_ts, True)
       return
 
+    session_manager.set_thread_owner(thread_root_ts or thread_ts, agent_id)
     logger.info(f"[{thread_ts}] Completed {sender_label} request for {user_name}")
 
     _track_interaction(
@@ -539,6 +576,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       user_email=user_email,
       user_name=user_name,
       response_time_ms=int((time.monotonic() - t0) * 1000),
+      thread_owner_agent_id=agent_id,
     )
 
   except Exception as e:

--- a/ai_platform_engineering/integrations/slack_bot/utils/session_manager.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/session_manager.py
@@ -63,6 +63,7 @@ class SessionManager:
     self._user_info_cache = TTLCache(ttl_seconds=600)
     self._skipped_cache = TTLCache(ttl_seconds=300)
     self._channel_info_cache = TTLCache(ttl_seconds=3600)
+    self._thread_owner_cache = TTLCache(ttl_seconds=86400)
     self._escalated_threads: set[str] = set()
 
   # ------------------------------------------------------------------
@@ -83,6 +84,20 @@ class SessionManager:
   def clear_skipped(self, thread_ts: str) -> None:
     """Clear the skipped flag."""
     self._skipped_cache.delete(thread_ts)
+
+  # ------------------------------------------------------------------
+  # Thread ownership — ensures the first agent to respond owns all
+  # follow-ups in that thread, regardless of listen mode.
+  # ------------------------------------------------------------------
+
+  def get_thread_owner(self, thread_ts: str) -> Optional[str]:
+    """Return the agent_id that first responded in this thread, or None."""
+    return self._thread_owner_cache.get(thread_ts)
+
+  def set_thread_owner(self, thread_ts: str, agent_id: str) -> None:
+    """Claim thread ownership for agent_id (first write wins)."""
+    if self._thread_owner_cache.get(thread_ts) is None:
+      self._thread_owner_cache.set(thread_ts, agent_id)
 
   # ------------------------------------------------------------------
   # Escalation dedup
@@ -133,5 +148,6 @@ class SessionManager:
       "user_cache_size": len(self._user_info_cache),
       "channel_cache_size": len(self._channel_info_cache),
       "skipped_cache_size": len(self._skipped_cache),
+      "thread_owner_cache_size": len(self._thread_owner_cache),
       "escalated_threads": len(self._escalated_threads),
     }


### PR DESCRIPTION
# Description

Two related fixes to make multi-agent channel configs behave predictably:

**First-match wins (config order = priority order)**

Previously `handle_mention` took `matches[0]` by accident, and the message handler looped over all matches firing every agent. Now both handlers explicitly take `matches[0]` with a comment explaining the intent: config order is the documented priority order, only one agent responds per event so thread memory stays coherent.

**Thread ownership persisted across restarts**

The first agent to successfully respond to a thread claims it. All follow-up messages in that thread — regardless of `listen` mode — route to that same agent. This ensures a user who starts a conversation with a Q&A agent (free post) and then @mentions the bot gets the same agent, not a different one configured for mentions.

Ownership is stored in two layers:
- **In-memory** (`session_manager._thread_owner_cache`, 24h TTL) — hot path, no extra API call
- **MongoDB** (`conversation.metadata.thread_owner_agent_id`) — written via `_track_interaction` after each successful response, read back from `conv_metadata` on cache miss (survives bot restarts)

On restart, the first message in a thread warms the cache from server metadata automatically.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass