### PR TITLE
fix(ui): sync agents tab to URL param, include agent name in editor title

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.5-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,25 +179,25 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.5
+    version: 0.4.5-dev.1
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.5-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.5
-appVersion: "0.4.5"
+version: 0.4.5-dev.1
+appVersion: "0.4.5-dev.1"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.5-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.5-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.5-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.5
-appVersion: 0.4.5
+version: 0.4.5-dev.1
+appVersion: 0.4.5-dev.1
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.5-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.5 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.5-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.5" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.5-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.5-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.5" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.5-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.5-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.5-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.5"
+version = "0.4.5-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/dynamic-agents/page.tsx
+++ b/ui/src/app/(app)/dynamic-agents/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useAdminRole } from "@/hooks/use-admin-role";
 import { AuthGuard } from "@/components/auth-guard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Bot, Server, Loader2, ShieldAlert, MessageSquare, Cpu } from "lucide-react";
 import { DynamicAgentsTab } from "@/components/dynamic-agents/DynamicAgentsTab";
@@ -15,8 +15,17 @@ import { ConversationsTab } from "@/components/dynamic-agents/ConversationsTab";
 
 function DynamicAgentsPageContent() {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { isAdmin, loading } = useAdminRole();
-  const [activeTab, setActiveTab] = React.useState("agents");
+
+  const activeTab = searchParams.get("tab") ?? "agents";
+
+  function setActiveTab(tab: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", tab);
+    router.push(`${pathname}?${params.toString()}`);
+  }
 
   // Show loading state
   if (loading) {

--- a/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
@@ -605,7 +605,13 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
           </Button>
           <div>
             <CardTitle>
-              {readOnly ? "View Agent" : isEditing ? "Edit Agent" : isCloning ? "Clone Agent" : "Create Agent"}
+              {readOnly
+                ? `View Agent — ${agent?.name}`
+                : isEditing
+                ? `Edit Agent — ${agent?.name}`
+                : isCloning
+                ? "Clone Agent"
+                : "Create Agent"}
             </CardTitle>
             <CardDescription>
               {readOnly

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.5"
+version = "0.4.5.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Two small UX improvements to the Agents admin page:

- **Tab URL sync**: clicking Agents / MCP Servers / LLM Models / Conversations now updates the URL with `?tab=<value>`, making tabs linkable and bookmarkable. Falls back to `agents` when the param is absent or unrecognised.
- **Editor title**: the View/Edit Agent card header now includes the agent name — e.g. "Edit Agent — My Agent" instead of just "Edit Agent".

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass