### PR TITLE
fix: replace bash 4+ case conversion for POSIX compat

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -129,7 +129,7 @@ prompt()  { echo -en "${BOLD}  ▸ $*${NC}"; }
 tty_read() { read "$@" <&3; }
 
 # Returns 0 (true) when the user wants to go back — accepts "b", "back", "0"
-_is_back() { [[ "${1,,}" == "b" || "${1,,}" == "back" || "$1" == "0" ]]; }
+_is_back() { local _v; _v="$(echo "$1" | tr '[:upper:]' '[:lower:]')"; [[ "$_v" == "b" || "$_v" == "back" || "$1" == "0" ]]; }
 
 ask_yn() {
   local question="$1" default="${2:-y}"
@@ -1757,7 +1757,7 @@ _choose_agents() {
   _input="${_input:-all}"
 
   SELECTED_AGENTS=()
-  if [[ "${_input,,}" == "all" || -z "$_input" ]]; then
+  if [[ "$(echo "$_input" | tr '[:upper:]' '[:lower:]')" == "all" || -z "$_input" ]]; then
     SELECTED_AGENTS=("${_agent_keys[@]}")
     log "All agents selected"
     return


### PR DESCRIPTION
## Description

Replace bash 4+ parameter expansion syntax (`${var,,}`) with POSIX-compatible
`tr '[:upper:]' '[:lower:]'` equivalents in `setup-caipe.sh`.

macOS ships with bash 3.2 (GPLv2), which does not support `${var,,}` (lowercase conversion) or `${var^^}` (uppercase conversion) — those operators were introduced in bash 4.0. The script broke silently on stock macOS terminals when users typed `B`, `Back`, or `ALL` in interactive prompts, because the case comparison always failed on 3.2.

Two call sites were affected:

- `_is_back()` — recognising "back"/"B"/"0" navigation input
- `_choose_agents()` — recognising "all" agent-selection input

Both are now replaced with:

```bash
local _v; _v="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
```

Related: #1304 (previous bash 3.2 compat fix)

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] All new and existing tests pass
