### PR TITLE
fix(tracing): update skill_scrubber test to use renamed _strip_known_sections

### DIFF
--- a/ai_platform_engineering/utils/tests/test_skill_scrubber.py
+++ b/ai_platform_engineering/utils/tests/test_skill_scrubber.py
@@ -24,7 +24,7 @@ from ai_platform_engineering.utils.tracing.skill_scrubber import (
     SkillContentScrubbingProcessor,
     _redact_value,
     _scrub_json,
-    _strip_skills_section,
+    _strip_known_sections,
     install_skill_content_scrubber,
 )
 
@@ -55,7 +55,7 @@ class _FakeSpan:
 # Section stripping
 # ---------------------------------------------------------------------------
 
-def test_strip_skills_section_removes_block_until_next_header() -> None:
+def test_strip_known_sections_removes_block_until_next_header() -> None:
     prompt = (
         "You are a helpful assistant.\n"
         "\n"
@@ -68,7 +68,7 @@ def test_strip_skills_section_removes_block_until_next_header() -> None:
         "## Other instructions\n"
         "Be concise.\n"
     )
-    out = _strip_skills_section(prompt)
+    out = _strip_known_sections(prompt)
     assert "Available Skills" not in out
     assert "/skills/user/foo/SKILL.md" not in out
     # Surrounding sections are preserved verbatim.
@@ -79,16 +79,16 @@ def test_strip_skills_section_removes_block_until_next_header() -> None:
     assert "[redacted from trace]" in out
 
 
-def test_strip_skills_section_handles_block_at_end_of_prompt() -> None:
+def test_strip_known_sections_handles_block_at_end_of_prompt() -> None:
     prompt = "Top.\n## Skills System\n- a\n- b\n"
-    out = _strip_skills_section(prompt)
+    out = _strip_known_sections(prompt)
     assert "- a" not in out
     assert "Top." in out
 
 
-def test_strip_skills_section_no_op_when_section_absent() -> None:
+def test_strip_known_sections_no_op_when_section_absent() -> None:
     prompt = "Plain prompt with no skills section.\n## Tools\nUse them."
-    assert _strip_skills_section(prompt) == prompt
+    assert _strip_known_sections(prompt) == prompt
 
 
 # ---------------------------------------------------------------------------
@@ -365,7 +365,7 @@ def test_strip_known_sections_removes_workflow_definition_block() -> None:
         "Prompt:\n```\nUse github_create_repo with API token ABCD ...\n```\n"
         "## Other section\nstays\n"
     )
-    out = _strip_skills_section(rendered)  # back-compat alias
+    out = _strip_known_sections(rendered)  # back-compat alias
     assert "Ask the user for" not in out
     assert "github_create_repo" not in out
     assert "API token ABCD" not in out
@@ -385,7 +385,7 @@ def test_strip_workflow_section_removes_self_service_block_in_system_prompt() ->
         "blah blah every step llm_prompt here ...\n"
         "## Tools\nuse them.\n"
     )
-    out = _strip_skills_section(prompt)
+    out = _strip_known_sections(prompt)
     assert "every step llm_prompt" not in out
     assert "## Tools\nuse them." in out
 

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.7-dev.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.7-dev.6 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,30 +179,30 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.7-dev.5
+    version: 0.4.7-dev.6
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.7-dev.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.7-dev.6 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.7-dev.5
-appVersion: "0.4.7-dev.5"
+version: 0.4.7-dev.6
+appVersion: "0.4.7-dev.6"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.7-dev.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.7-dev.6 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.7-dev.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.7-dev.6 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.7-dev.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.7-dev.6" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.7-dev.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.7-dev.6" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.7-dev.5
-appVersion: 0.4.7-dev.5
+version: 0.4.7-dev.6
+appVersion: 0.4.7-dev.6
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.7-dev.5 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.7-dev.6 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.7-dev.5 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.7-dev.6 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.7-dev.5" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.7-dev.6" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.7-dev.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.7-dev.6" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.7-dev.5" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.7-dev.6" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.7-dev.5 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.7-dev.5" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.7-dev.6 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.7-dev.6" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.7-dev.5"
+version = "0.4.7-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.7.dev5"
+version = "0.4.7.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- PR #1330 removed the `_strip_skills_section` alias from `skill_scrubber.py` to fix a CodeQL finding, but the test file still imported it
- This broke `run-tests` CI on every branch rebased on main (including PR #1324)
- Replace all `_strip_skills_section` references in `test_skill_scrubber.py` with `_strip_known_sections`; test behaviour is unchanged

## Test plan

- [ ] `run-tests` CI passes on this branch
- [ ] No import errors from `test_skill_scrubber.py`
- [ ] PR #1324 can rebase onto main after merge and pass CI