### PR TITLE
ci: gate Chart.yaml version bumps behind helm-chart-bump label

### DIFF
--- a/.github/actions/update-version-files/action.yml
+++ b/.github/actions/update-version-files/action.yml
@@ -25,6 +25,16 @@ inputs:
       Examples: 0.3.0-rc.2, 0.3.0-rc.2-chart.1, a commit SHA.
     required: false
     default: ''
+  bump_charts:
+    description: >
+      Whether to bump Chart.yaml versions in full-update mode.
+      Set to 'false' for PRs that only touch Python/UI code and do not
+      need a pre-built Helm chart — avoids the version-conflict noise
+      caused by every concurrent PR bumping chart versions independently.
+      Chart-only mode (version ending in -chart.M) always bumps charts
+      regardless of this flag.
+    required: false
+    default: 'true'
 
 outputs:
   final_version:
@@ -52,6 +62,7 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
         DIFF_TARGET: ${{ inputs.diff_target }}
+        BUMP_CHARTS: ${{ inputs.bump_charts }}
       run: |
         set -euo pipefail
 
@@ -276,25 +287,29 @@ runs:
           uv lock
           echo "  ✅ uv.lock regenerated"
 
-          # Update ALL Chart.yaml: version + appVersion
-          for CHART_FILE in $CHART_FILES; do
-            yq -i ".version = \"$VERSION\"" "$CHART_FILE"
-            yq -i ".appVersion = \"$VERSION\"" "$CHART_FILE"
-            echo "  ✅ Updated $CHART_FILE (version + appVersion)"
-          done
+          if [[ "$BUMP_CHARTS" == "true" ]]; then
+            # Update ALL Chart.yaml: version + appVersion
+            for CHART_FILE in $CHART_FILES; do
+              yq -i ".version = \"$VERSION\"" "$CHART_FILE"
+              yq -i ".appVersion = \"$VERSION\"" "$CHART_FILE"
+              echo "  ✅ Updated $CHART_FILE (version + appVersion)"
+            done
 
-          # Update ALL local dependency version references
-          echo ""
-          echo "🔄 Updating local dependency version references to '$VERSION'..."
+            # Update ALL local dependency version references
+            echo ""
+            echo "🔄 Updating local dependency version references to '$VERSION'..."
 
-          for CHART_FILE in $CHART_FILES; do
-            if yq -e '.dependencies' "$CHART_FILE" > /dev/null 2>&1; then
-              for LOCAL_CHART in $LOCAL_CHART_NAMES; do
-                yq -i "(.dependencies[] | select(.name == \"$LOCAL_CHART\" and .repository == null)).version = \"$VERSION\"" "$CHART_FILE" 2>/dev/null || true
-                yq -i "(.dependencies[] | select(.name == \"$LOCAL_CHART\" and .repository != null and (.repository | test(\"^file://\")))).version = \"$VERSION\"" "$CHART_FILE" 2>/dev/null || true
-              done
-            fi
-          done
+            for CHART_FILE in $CHART_FILES; do
+              if yq -e '.dependencies' "$CHART_FILE" > /dev/null 2>&1; then
+                for LOCAL_CHART in $LOCAL_CHART_NAMES; do
+                  yq -i "(.dependencies[] | select(.name == \"$LOCAL_CHART\" and .repository == null)).version = \"$VERSION\"" "$CHART_FILE" 2>/dev/null || true
+                  yq -i "(.dependencies[] | select(.name == \"$LOCAL_CHART\" and .repository != null and (.repository | test(\"^file://\")))).version = \"$VERSION\"" "$CHART_FILE" 2>/dev/null || true
+                done
+              fi
+            done
+          else
+            echo "  ⏭️ Skipping Chart.yaml updates (helm-chart-bump label not present)"
+          fi
 
           echo "✅ Full update complete"
         fi

--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]'
     outputs:
       new_commit: ${{ steps.update.outputs.skip_commit == 'false' || (steps.release-check.outputs.is_release_merge == 'true' && steps.release-check.outputs.needs_prepare == 'true' && steps.branch-status.outputs.needs_update != 'true' && steps.mergeability.outputs.has_conflicts != 'true') }}
-      should_prebuild: ${{ steps.prebuild-check.outputs.should_run }}
+      should_prebuild: ${{ steps.helm-labels.outputs.should_run }}
     steps:
       - name: 🔒 Harden runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -305,6 +305,40 @@ jobs:
         with:
           version: ${{ steps.release-check.outputs.version }}
 
+      # ── Check labels before version bumping ───────────────────────────
+      - name: 🏷️ Check helm labels
+        id: helm-labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEAD_REF="${{ github.head_ref }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          BUMP_CHARTS=false
+          SHOULD_PREBUILD=false
+
+          # prebuild/* branches always bump charts and publish
+          if [[ "$HEAD_REF" == prebuild/* ]]; then
+            BUMP_CHARTS=true
+            SHOULD_PREBUILD=true
+            echo "✅ prebuild/ branch — chart bump + prebuild publishing enabled"
+          fi
+
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null | tr '\n' ',' || echo "")
+
+          if [[ "$LABELS" == *"helm-chart-bump"* ]]; then
+            BUMP_CHARTS=true
+            echo "✅ helm-chart-bump label — chart versions will be bumped"
+          fi
+
+          if [[ "$LABELS" == *"helm-prerelease"* ]]; then
+            SHOULD_PREBUILD=true
+            echo "✅ helm-prerelease label — prebuild chart publishing enabled"
+          fi
+
+          echo "bump_charts=$BUMP_CHARTS" >> $GITHUB_OUTPUT
+          echo "should_run=$SHOULD_PREBUILD" >> $GITHUB_OUTPUT
+
       # ── Normal path: determine-version + update-version-files ──────────
       - name: 🏷️ Determine version
         if: ${{ steps.release-check.outputs.is_release_merge != 'true' && steps.branch-status.outputs.needs_update != 'true' && steps.mergeability.outputs.has_conflicts != 'true' }}
@@ -320,6 +354,7 @@ jobs:
         with:
           version: ${{ steps.version.outputs.tag }}
           diff_target: ${{ steps.version.outputs.diff_target }}
+          bump_charts: ${{ steps.helm-labels.outputs.bump_charts }}
 
       # ── Commit changes to PR branch ────────────────────────────────────
       - name: 📤 Commit version bump
@@ -329,40 +364,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Stage version-related files (+ changelog for release merge PRs)
           git add pyproject.toml uv.lock CHANGELOG.md || true
-          find charts -name "Chart.yaml" -type f -exec git add {} +
+
+          if [[ "${{ steps.helm-labels.outputs.bump_charts }}" == "true" ]]; then
+            find charts -name "Chart.yaml" -type f -exec git add {} +
+          fi
 
           TAG="${{ steps.update.outputs.final_version || steps.release-check.outputs.version }}"
           git commit -m "chore: bump version to $TAG"
           git push
 
           echo "✅ Committed version bump to $TAG"
-
-      - name: 🔍 Check if prebuild should run
-        id: prebuild-check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          HEAD_REF="${{ github.head_ref }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-
-          SHOULD_RUN=false
-
-          # Check for prebuild/ branch
-          if [[ "$HEAD_REF" == prebuild/* ]]; then
-            echo "✅ Matched: prebuild/ branch"
-            SHOULD_RUN=true
-          fi
-
-          # Check for helm-prerelease label
-          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null | tr '\n' ',' || echo "")
-          if [[ "$LABELS" == *"helm-prerelease"* ]]; then
-            echo "✅ Matched: helm-prerelease label"
-            SHOULD_RUN=true
-          fi
-
-          echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
 
       - name: ❌ Require branch update before merge
         if: steps.branch-status.outputs.needs_update == 'true' || steps.mergeability.outputs.has_conflicts == 'true'


### PR DESCRIPTION
## Summary

- Every PR touching Python/UI/chart files was getting an automatic `Chart.yaml` version bump committed to its branch
- When two PRs were open simultaneously, both got different chart versions — whichever merged second would conflict on rebase
- This is the root cause of the recurring helm chart conflict every PR experiences

## What changed

**Before**: `Chart.yaml` files were bumped on every PR that touched `charts/**`, `ai_platform_engineering/**`, or `ui/**`

**After**: `Chart.yaml` files are only bumped when:
- The branch is `prebuild/*` (unchanged behaviour), OR
- The PR has the `helm-chart-bump` label applied

`pyproject.toml` and `uv.lock` are still bumped on every PR as before.

## What is NOT changed

- Docker image prebuilds are unaffected — they are controlled by the `prebuild/*` branch prefix and `helm-prerelease` label, neither of which changed
- Release and hotfix paths are unaffected
- Chart-only mode (`-chart.M` version suffix) is unaffected

## Test plan

- [ ] Open a normal PR without `helm-chart-bump` — verify only `pyproject.toml`/`uv.lock` are bumped, no `Chart.yaml` changes
- [ ] Apply `helm-chart-bump` label — verify `Chart.yaml` files are now bumped
- [ ] Open a `prebuild/*` branch PR — verify chart bumps still happen automatically