### PR TITLE
fix(docs): escape MDX angle bracket in spec plan + add PR docs build check

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Docusaurus site

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -1,0 +1,40 @@
+# Validate Docusaurus build on every PR that touches docs/
+name: "[Check] Docs Build"
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+
+jobs:
+  build:
+    name: Build Docusaurus site
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔒 harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "lts/*"
+      - name: Install helm-docs
+        env:
+          HELM_DOCS_VERSION: "1.14.2"
+        run: |
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xz helm-docs
+          sudo mv helm-docs /usr/local/bin/helm-docs
+      - name: Generate Helm chart docs
+        run: make helm-docs
+      - name: Install dependencies
+        run: |
+          cd docs
+          npm install
+      - name: Build Docusaurus site
+        run: |
+          cd docs
+          npm run build

--- a/docs/docs/releases/migration-0.3.x-to-0.4.0.md
+++ b/docs/docs/releases/migration-0.3.x-to-0.4.0.md
@@ -414,7 +414,7 @@ python scripts/migrations/0.4.0/migrate_slack_meta_to_metadata.py --dry-run
 python scripts/migrations/0.4.0/migrate_slack_meta_to_metadata.py --verbose
 ```
 
-All scripts are **idempotent** and **non-destructive** — the original `messages`, `slack_sessions`, and `slack_meta` data are never deleted. See [`scripts/migrations/0.4.0/RUN.md`](../../../../scripts/migrations/0.4.0/RUN.md) for full verification commands and expected output.
+All scripts are **idempotent** and **non-destructive** — the original `messages`, `slack_sessions`, and `slack_meta` data are never deleted. See [`scripts/migrations/0.4.0/RUN.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/scripts/migrations/0.4.0/RUN.md) for full verification commands and expected output.
 
 **New collections created:** `turns`, `stream_events`
 **Collections deprecated (not deleted):** `messages`, `slack_sessions`

--- a/docs/docs/specs/2026-04-29-agent-editor-unsaved-warning/plan.md
+++ b/docs/docs/specs/2026-04-29-agent-editor-unsaved-warning/plan.md
@@ -19,7 +19,7 @@ Dirty-state detection is value-based: snapshot the editor's initial form values 
 **Testing**: Jest + React Testing Library (UI tests). Manual verification via the quickstart for the three navigation paths.
 **Target Platform**: Browser (modern evergreen — same as the rest of the CAIPE UI)
 **Project Type**: Web application — frontend changes only (`ui/` workspace)
-**Performance Goals**: Dirty-state comparison runs on every render of the editor; must remain O(fields) and complete in <1ms for the realistic agent-config payload (≤50 fields, ≤a few KB total). No noticeable input lag on form changes.
+**Performance Goals**: Dirty-state comparison runs on every render of the editor; must remain O(fields) and complete in under 1ms for the realistic agent-config payload (50 fields or fewer, a few KB total). No noticeable input lag on form changes.
 **Constraints**:
 - No native browser dialogs (no `window.confirm`, no `beforeunload` hooks).
 - Must reuse the existing `UnsavedChangesDialog` to keep visual parity with the Task Builder warning.


### PR DESCRIPTION
## Summary

- **Root cause**: `docs/docs/specs/2026-04-29-agent-editor-unsaved-warning/plan.md` line 22 contained `<1ms` which the MDX compiler parses as an invalid JSX tag (tags cannot start with a digit), breaking `npm run build` on every push to main — see failing run https://github.com/cnoe-io/ai-platform-engineering/actions/runs/25472576380
- **Fix**: Replace `<1ms` with `under 1ms`
- **New CI check**: `.github/workflows/docs-build-check.yml` runs `npm run build` on every PR touching `docs/**` so this class of error is caught at review time rather than post-merge

## Test plan

- [ ] Confirm `[Publish][Docs] GH Pages` passes on main after merge
- [ ] Open a test PR touching `docs/` and verify `[Check] Docs Build` appears as a PR check

Generated with [Claude Code](https://claude.com/claude-code)