### PR TITLE
feat(ui): add search filter and scroll to agent selection dropdown

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.4.8-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.8-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,30 +179,30 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.4.8-dev.1
+    version: 0.4.8-dev.2
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.8-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.8-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.4.8-dev.1
-appVersion: "0.4.8-dev.1"
+version: 0.4.8-dev.2
+appVersion: "0.4.8-dev.2"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.8-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.8-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.4.8-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.8-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.8-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.8-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.8-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.8-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.4.8-dev.1
-appVersion: 0.4.8-dev.1
+version: 0.4.8-dev.2
+appVersion: 0.4.8-dev.2
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.4.8-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.4.8-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.4.8-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.4.8-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.8-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.8-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.8-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.8-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.8-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.4.8-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.4.8-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.4.8-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.4.8-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.4.8-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.8-dev.1"
+version = "0.4.8-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import { Plus, ChevronDown, Bot, Loader2, Check } from "lucide-react";
+import { Plus, ChevronDown, Bot, Loader2, Check, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { getConfig } from "@/lib/config";
@@ -18,7 +18,9 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   const [agents, setAgents] = useState<DynamicAgentConfig[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const dynamicAgentsEnabled = getConfig("dynamicAgentsEnabled");
 
@@ -84,12 +86,29 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   const handleDropdownToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
     setDropdownOpen(!dropdownOpen);
+    if (!dropdownOpen) setSearchQuery("");
   };
 
   const handleSelectAgent = (agentId?: string) => {
     setDropdownOpen(false);
+    setSearchQuery("");
     onNewChat(agentId);
   };
+
+  // Auto-focus search input when dropdown opens
+  useEffect(() => {
+    if (dropdownOpen && searchInputRef.current) {
+      setTimeout(() => searchInputRef.current?.focus(), 50);
+    }
+  }, [dropdownOpen]);
+
+  const query = searchQuery.toLowerCase();
+  const showPlatformEngineer = "platform engineer".includes(query) || "default ai assistant".includes(query);
+  const filteredAgents = agents.filter(
+    (a) =>
+      a.name.toLowerCase().includes(query) ||
+      (a.description?.toLowerCase().includes(query) ?? false)
+  );
 
   // Collapsed mode: simple button without dropdown
   if (collapsed) {
@@ -161,25 +180,44 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
       {/* Dropdown menu */}
       {dropdownOpen && (
         <div className="absolute top-full left-0 right-0 mt-1 z-50 rounded-md bg-popover border border-border shadow-lg animate-in fade-in-0 zoom-in-95 slide-in-from-top-2">
-          <div className="py-1">
+          {/* Search input */}
+          <div className="px-2 pt-2 pb-1">
+            <div className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-muted/50 border border-border/50">
+              <Search className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              <input
+                ref={searchInputRef}
+                type="text"
+                placeholder="Search agents..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+          </div>
+
+          {/* Scrollable agent list */}
+          <div className="overflow-y-auto max-h-64 py-1">
             {/* Platform Engineer option */}
-            <button
-              onClick={() => handleSelectAgent(undefined)}
-              className="w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent transition-colors text-left"
-            >
-              <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shrink-0">
-                <Bot className="h-4 w-4 text-white" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="font-medium truncate">Platform Engineer</div>
-                <div className="text-xs text-muted-foreground truncate">
-                  Default AI assistant
+            {showPlatformEngineer && (
+              <button
+                onClick={() => handleSelectAgent(undefined)}
+                className="w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent transition-colors text-left"
+              >
+                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shrink-0">
+                  <Bot className="h-4 w-4 text-white" />
                 </div>
-              </div>
-            </button>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium truncate">Platform Engineer</div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    Default AI assistant
+                  </div>
+                </div>
+              </button>
+            )}
 
             {/* Divider if there are dynamic agents */}
-            {(loading || agents.length > 0 || error) && (
+            {showPlatformEngineer && (loading || filteredAgents.length > 0 || error) && (
               <div className="h-px bg-border my-1" />
             )}
 
@@ -199,7 +237,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
             )}
 
             {/* Dynamic agents list */}
-            {!loading && !error && agents.map((agent) => {
+            {!loading && !error && filteredAgents.map((agent) => {
               const gradientStyle = agent.ui?.gradient_theme ? getGradientStyle(agent.ui.gradient_theme) : null;
               return (
                 <button
@@ -207,7 +245,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
                   onClick={() => handleSelectAgent(agent._id)}
                   className="w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent transition-colors text-left"
                 >
-                  <div 
+                  <div
                     className={cn(
                       "w-8 h-8 rounded-full flex items-center justify-center shrink-0",
                       !gradientStyle && "bg-gradient-to-br from-purple-500 to-pink-600"
@@ -228,8 +266,15 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
               );
             })}
 
-            {/* No dynamic agents */}
-            {!loading && !error && agents.length === 0 && (
+            {/* No results */}
+            {!loading && !error && !showPlatformEngineer && filteredAgents.length === 0 && (
+              <div className="px-3 py-2 text-sm text-muted-foreground">
+                No agents match &quot;{searchQuery}&quot;
+              </div>
+            )}
+
+            {/* No dynamic agents (and no search active) */}
+            {!loading && !error && !searchQuery && agents.length === 0 && (
               <div className="px-3 py-2 text-sm text-muted-foreground">
                 No custom agents configured
               </div>

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import { Plus, ChevronDown, Bot, Loader2, Check, Search } from "lucide-react";
+import { Plus, ChevronDown, Bot, Loader2, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { getConfig } from "@/lib/config";

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -197,7 +197,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
           </div>
 
           {/* Scrollable agent list */}
-          <div className="overflow-y-auto max-h-64 py-1">
+          <div className="overflow-y-auto max-h-96 py-1">
             {/* Platform Engineer option */}
             {showPlatformEngineer && (
               <button

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.8.dev1"
+version = "0.4.8.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

The agent selection dropdown in the chat sidebar had two usability issues when many agents are configured:
1. No scroll — the list overflowed without a scrollable container
2. No way to quickly find a specific agent

This PR adds a search input at the top of the dropdown that auto-focuses on open and filters both the Platform Engineer default option and all dynamic agents by name or description. The agent list is now capped at `max-h-64` with `overflow-y-auto` so it scrolls cleanly when there are many entries. Search state is cleared on selection or close.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass