### PR TITLE
fix(docs): migrate onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -26,7 +26,6 @@ const config: Config = {
   projectName: 'ai-platform-engineering', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -277,6 +276,9 @@ const config: Config = {
 
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
   },
   themes: ['@docusaurus/theme-mermaid'],
 };


### PR DESCRIPTION
## Summary

- Removes deprecated top-level `onBrokenMarkdownLinks: 'warn'` config
- Moves it to `markdown.hooks.onBrokenMarkdownLinks` as required by Docusaurus v4 (and warned about when `future: { v4: true }` is enabled)

## Test plan

- [ ] `npm run build` no longer emits the `siteConfig.onBrokenMarkdownLinks config option is deprecated` warning

🤖 Generated with [Claude Code](https://claude.ai/claude-code)