### PR TITLE
feat(a2a): outbound OAuth2 client_credentials auth via AuthInterceptor

### DIFF
--- a/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py
+++ b/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py
@@ -158,20 +158,18 @@ class A2ARemoteAgentConnectTool(BaseTool):
         # Tolerate odd shapes (e.g. SecurityRequirement objects)
         pass
     if 'oauth2' in required_scheme_names and 'oauth2' in schemes:
-      try:
-        from a2a.client.auth import AuthInterceptor
-        from ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service import (
-          OAuth2ClientCredentialsService,
-        )
-        interceptors = [AuthInterceptor(OAuth2ClientCredentialsService())]
-        logger.info(
-          f"Outbound A2A auth enabled for {self._agent_card.name} (scheme=oauth2)"
-        )
-      except Exception as exc:  # noqa: BLE001
-        logger.warning(
-          f"Remote {self._agent_card.name} advertises oauth2 but local "
-          f"interceptor wiring failed: {exc}. Calls will be unauthenticated."
-        )
+      # Fail fast if interceptor wiring breaks rather than silently sending
+      # unauthenticated requests that the remote agent will (correctly)
+      # 401-reject. A clear startup error is much easier to diagnose than
+      # a chain of 401s in production.
+      from a2a.client.auth import AuthInterceptor
+      from ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service import (
+        OAuth2ClientCredentialsService,
+      )
+      interceptors = [AuthInterceptor(OAuth2ClientCredentialsService())]
+      logger.info(
+        f"Outbound A2A auth enabled for {self._agent_card.name} (scheme=oauth2)"
+      )
     else:
       logger.debug(
         f"Outbound A2A auth not enabled for {self._agent_card.name} "

--- a/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py
+++ b/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py
@@ -141,9 +141,47 @@ class A2ARemoteAgentConnectTool(BaseTool):
       self._agent_card.url = self._remote_agent_card
 
     logger.info(f"Agent Card: {self._agent_card}")
+
+    # If the remote agent advertises an OAuth2 security scheme on its
+    # AgentCard, attach a2a-sdk's AuthInterceptor + OAuth2ClientCredentialsService
+    # so every outbound request carries a fresh Bearer token. Cards that don't
+    # declare oauth2 (i.e. {"public": []}) get the existing unauthenticated
+    # client unchanged — fully backward-compatible.
+    interceptors = []
+    schemes = self._agent_card.security_schemes or {}
+    required = self._agent_card.security or []
+    required_scheme_names = set()
+    for req in required:
+      try:
+        required_scheme_names.update(req.keys())
+      except AttributeError:
+        # Tolerate odd shapes (e.g. SecurityRequirement objects)
+        pass
+    if 'oauth2' in required_scheme_names and 'oauth2' in schemes:
+      try:
+        from a2a.client.auth import AuthInterceptor
+        from ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service import (
+          OAuth2ClientCredentialsService,
+        )
+        interceptors = [AuthInterceptor(OAuth2ClientCredentialsService())]
+        logger.info(
+          f"Outbound A2A auth enabled for {self._agent_card.name} (scheme=oauth2)"
+        )
+      except Exception as exc:  # noqa: BLE001
+        logger.warning(
+          f"Remote {self._agent_card.name} advertises oauth2 but local "
+          f"interceptor wiring failed: {exc}. Calls will be unauthenticated."
+        )
+    else:
+      logger.debug(
+        f"Outbound A2A auth not enabled for {self._agent_card.name} "
+        f"(remote advertises no oauth2 scheme)"
+      )
+
     self._client = A2AClient(
         httpx_client=self._httpx_client,
-        agent_card=self._agent_card
+        agent_card=self._agent_card,
+        interceptors=interceptors,
     )
     logger.info("A2AClient initialized.")
     logger.info("*" * 80)

--- a/ai_platform_engineering/utils/a2a_common/a2a_server.py
+++ b/ai_platform_engineering/utils/a2a_common/a2a_server.py
@@ -53,17 +53,36 @@ def _build_security_for_card():
 
     token_endpoint = os.environ.get('TOKEN_ENDPOINT')
     if not token_endpoint:
-        # OAuth2 enabled but no token endpoint configured — log and fall
-        # back to public so the agent doesn't refuse to start. Operators
-        # should set TOKEN_ENDPOINT to match the inbound middleware's
-        # configured ISSUER (typically `<ISSUER>/protocol/openid-connect/token`
-        # for Keycloak).
+        # OAuth2 enabled but no token endpoint configured. The AgentCard
+        # falls back to public, but the inbound OAuth2Middleware will
+        # still enforce JWT validation if A2A_AUTH_OAUTH2=true — anonymous
+        # requests will receive 401. This soft-fall-back exists only so
+        # the misconfiguration surfaces via a warning instead of a crash
+        # loop. Operators should set TOKEN_ENDPOINT to match the IdP
+        # (typically `<ISSUER>/protocol/openid-connect/token` for Keycloak).
         logger.warning(
-            "A2A_AUTH_OAUTH2=true but TOKEN_ENDPOINT not set — falling back "
-            "to security=[{public: []}]. Configure TOKEN_ENDPOINT to advertise "
-            "the OAuth2 client_credentials flow on the AgentCard."
+            "A2A_AUTH_OAUTH2=true but TOKEN_ENDPOINT not set — AgentCard "
+            "will advertise security=[{public: []}]; inbound middleware "
+            "will still reject anonymous requests with 401. Set "
+            "TOKEN_ENDPOINT so A2A clients can discover the token URL."
         )
         return [{"public": []}], None
+
+    # Warn (not reject) if the token endpoint is plaintext on a non-loopback
+    # host. Plaintext token endpoints leak client_secret on each mint and
+    # are appropriate only for local development.
+    from urllib.parse import urlparse as _urlparse
+    _parsed = _urlparse(token_endpoint)
+    if _parsed.scheme == 'http' and _parsed.hostname not in {
+        'localhost', '127.0.0.1', '::1'
+    }:
+        logger.warning(
+            "TOKEN_ENDPOINT advertised on AgentCard uses plaintext http:// "
+            "(host=%s). A2A clients minting tokens against this endpoint "
+            "will send client_secret in plaintext. Use https:// in any "
+            "non-loopback environment.",
+            _parsed.hostname,
+        )
 
     issuer = (os.environ.get('ISSUER') or '').rstrip('/')
     metadata_url = (
@@ -85,6 +104,11 @@ def _build_security_for_card():
                 flows=OAuthFlows(
                     client_credentials=ClientCredentialsOAuthFlow(
                         token_url=token_endpoint,
+                        # Empty scope map: this implementation does not
+                        # currently enforce scope-based authorization. The
+                        # inbound OAuth2Middleware authorizes via the
+                        # OAUTH2_CLIENT_ID allowlist (azp/client_id/cid
+                        # claim), not via OAuth scopes.
                         scopes={},
                     ),
                 ),

--- a/ai_platform_engineering/utils/a2a_common/a2a_server.py
+++ b/ai_platform_engineering/utils/a2a_common/a2a_server.py
@@ -1,10 +1,12 @@
 # Copyright 2025 CNOE
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+import os
 from typing import List
+
 import httpx
 import uvicorn
-import logging
 from a2a.server.apps import A2AStarletteApplication
 from a2a.server.agent_execution import AgentExecutor
 from a2a.server.request_handlers import DefaultRequestHandler
@@ -26,11 +28,80 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_CONTENT_TYPES = ['text', 'text/plain']
 
+def _build_security_for_card():
+    """Decide AgentCard `security` and `security_schemes` based on env.
+
+    When A2A_AUTH_OAUTH2=true and TOKEN_ENDPOINT is set, the AgentCard
+    advertises an OAuth2 client_credentials security scheme so A2A clients
+    (e.g. the supervisor's A2ARemoteAgentConnectTool + AuthInterceptor)
+    know to attach a Bearer token when calling this agent. Otherwise the
+    AgentCard remains unchanged: security=[{"public": []}].
+
+    Returns:
+        tuple of (security_list, security_schemes_dict | None)
+    """
+    if os.getenv('A2A_AUTH_OAUTH2', 'false').lower() != 'true':
+        return [{"public": []}], None
+
+    # Lazy imports so unauthenticated agents don't pay the cost.
+    from a2a.types import (
+        ClientCredentialsOAuthFlow,
+        OAuth2SecurityScheme,
+        OAuthFlows,
+        SecurityScheme,
+    )
+
+    token_endpoint = os.environ.get('TOKEN_ENDPOINT')
+    if not token_endpoint:
+        # OAuth2 enabled but no token endpoint configured — log and fall
+        # back to public so the agent doesn't refuse to start. Operators
+        # should set TOKEN_ENDPOINT to match the inbound middleware's
+        # configured ISSUER (typically `<ISSUER>/protocol/openid-connect/token`
+        # for Keycloak).
+        logger.warning(
+            "A2A_AUTH_OAUTH2=true but TOKEN_ENDPOINT not set — falling back "
+            "to security=[{public: []}]. Configure TOKEN_ENDPOINT to advertise "
+            "the OAuth2 client_credentials flow on the AgentCard."
+        )
+        return [{"public": []}], None
+
+    issuer = (os.environ.get('ISSUER') or '').rstrip('/')
+    metadata_url = (
+        f"{issuer}/.well-known/openid-configuration" if issuer else None
+    )
+    logger.info(
+        "[a2a_server] OAuth2 enabled. ISSUER=%s, AUDIENCE=%s, JWKS_URI=%s, "
+        "ALLOWED_ALGORITHMS=%s, TOKEN_ENDPOINT=%s",
+        issuer,
+        os.environ.get('AUDIENCE'),
+        os.environ.get('JWKS_URI'),
+        os.environ.get('ALLOWED_ALGORITHMS', 'RS256,ES256'),
+        token_endpoint,
+    )
+    schemes = {
+        'oauth2': SecurityScheme(
+            root=OAuth2SecurityScheme(
+                description='OAuth2 client_credentials for A2A',
+                flows=OAuthFlows(
+                    client_credentials=ClientCredentialsOAuthFlow(
+                        token_url=token_endpoint,
+                        scopes={},
+                    ),
+                ),
+                oauth2_metadata_url=metadata_url,
+            )
+        ),
+    }
+    return [{'oauth2': []}], schemes
+
+
 class A2AServer:
     def __init__(self, agent_name: str, agent_description: str, agent_skills: List[AgentSkill], host: str, port: int, agent_executor: AgentExecutor, metrics_enabled: bool = False, version: str = '0.1.0'):
         self.agent_name = agent_name
         self.host = host
         self.port = port
+
+        security, security_schemes = _build_security_for_card()
 
         self.agent_card = AgentCard(
             name=agent_name,
@@ -42,7 +113,8 @@ class A2AServer:
             defaultOutputModes=SUPPORTED_CONTENT_TYPES,
             capabilities=AgentCapabilities(streaming=True, pushNotifications=True),
             skills=agent_skills,
-            security=[{"public": []}],
+            security=security,
+            securitySchemes=security_schemes,
         )
         self.agent_executor = agent_executor
         self.metrics_enabled = metrics_enabled

--- a/ai_platform_engineering/utils/a2a_common/oauth2_client_credentials_service.py
+++ b/ai_platform_engineering/utils/a2a_common/oauth2_client_credentials_service.py
@@ -24,6 +24,7 @@ import asyncio
 import logging
 import os
 import time
+from urllib.parse import urlparse
 
 import httpx
 import jwt
@@ -32,6 +33,61 @@ from a2a.client.middleware import ClientCallContext
 
 logger = logging.getLogger(__name__)
 
+# Default token TTL (seconds) when the issued token is opaque (not a JWT)
+# or its `exp` claim cannot be decoded. Conservative: short enough that a
+# stale token won't outlive a typical IdP rotation, long enough to avoid
+# minting on every request.
+_DEFAULT_OPAQUE_TOKEN_TTL = 60.0
+
+# Hostnames considered acceptable for plaintext (http://) token endpoints.
+# Loopback only — anything else triggers a warning because client_secret
+# would travel in plaintext over the wire.
+_PLAINTEXT_OK_HOSTS = frozenset({'localhost', '127.0.0.1', '::1'})
+
+_TOKEN_ENDPOINT_VALIDATED = False
+
+
+def _validate_token_endpoint_scheme(token_endpoint: str) -> None:
+    """Warn (once per process) if TOKEN_ENDPOINT uses plaintext over a non-loopback host.
+
+    Refuses to escalate to an exception so misconfigured operators see
+    auth failures (clear) rather than crash loops (confusing). The warning
+    surfaces in startup logs.
+    """
+    global _TOKEN_ENDPOINT_VALIDATED
+    if _TOKEN_ENDPOINT_VALIDATED:
+        return
+    _TOKEN_ENDPOINT_VALIDATED = True
+    parsed = urlparse(token_endpoint)
+    if parsed.scheme == 'https':
+        return
+    if parsed.scheme == 'http' and parsed.hostname in _PLAINTEXT_OK_HOSTS:
+        logger.info(
+            "TOKEN_ENDPOINT uses plaintext http:// to a loopback host (%s) — "
+            "acceptable for local development only.",
+            parsed.hostname,
+        )
+        return
+    logger.warning(
+        "TOKEN_ENDPOINT scheme is %r (not https). Client secret will travel "
+        "in plaintext over the wire on each token mint. Use https:// in any "
+        "non-loopback environment.",
+        parsed.scheme or '(missing)',
+    )
+
+
+def _scrub_secret(text: str, secret: str) -> str:
+    """Redact `secret` from `text`. Cheap belt-and-suspenders for log lines.
+
+    `httpx` doesn't include request bodies in default exception reprs, but
+    some IdPs echo `client_secret` back in their error responses (e.g.
+    "invalid_client_secret: <secret>"). Scrubbing here ensures the secret
+    never leaks via the credential service's own error path.
+    """
+    if not secret or not text:
+        return text
+    return text.replace(secret, '***REDACTED***')
+
 
 class OAuth2ClientCredentialsService(CredentialService):
     """Mints + caches OAuth2 client_credentials access tokens.
@@ -39,6 +95,10 @@ class OAuth2ClientCredentialsService(CredentialService):
     Hard-coded to scheme name 'oauth2' to match what `A2AServer`'s patched
     `_build_security_for_card()` advertises. Agents using a different
     scheme name should subclass and override `SCHEME_NAME`.
+
+    One instance per `AuthInterceptor` — token cache is per-instance, not
+    per-process. Multiple instances minting against the same IdP/client is
+    inefficient but not unsafe.
     """
 
     SCHEME_NAME = 'oauth2'
@@ -57,12 +117,15 @@ class OAuth2ClientCredentialsService(CredentialService):
         """Return a valid access token for the named scheme, or None."""
         if security_scheme_name != self.SCHEME_NAME:
             return None
-        now = time.time()
         async with self._lock:
+            now = time.time()  # capture inside lock to avoid TOCTOU
             if not self._token or now >= self._refresh_after:
                 try:
                     await self._refresh()
                 except Exception as exc:  # noqa: BLE001
+                    # Stale-on-error: serve the existing token until its
+                    # actual exp if a refresh fails (transient IdP outage).
+                    now = time.time()
                     if self._token and now < self._token_exp:
                         logger.warning(
                             "OAuth2 token refresh failed; using stale token "
@@ -82,23 +145,54 @@ class OAuth2ClientCredentialsService(CredentialService):
         client_id = os.environ['OAUTH2_CLIENT_ID']
         client_secret = os.environ['OAUTH2_CLIENT_SECRET']
         token_endpoint = os.environ['TOKEN_ENDPOINT']
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.post(
-                token_endpoint,
-                data={
-                    'grant_type': 'client_credentials',
-                    'client_id': client_id,
-                    'client_secret': client_secret,
-                },
-            )
-            resp.raise_for_status()
+        _validate_token_endpoint_scheme(token_endpoint)
+
+        # `trust_env=True` honors HTTPS_PROXY / NO_PROXY / corporate CA
+        # bundles via REQUESTS_CA_BUNDLE — typical in enterprise networks.
+        async with httpx.AsyncClient(timeout=10, trust_env=True) as client:
+            try:
+                resp = await client.post(
+                    token_endpoint,
+                    data={
+                        'grant_type': 'client_credentials',
+                        'client_id': client_id,
+                        'client_secret': client_secret,
+                    },
+                )
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                # Some IdPs echo the request body in error responses — scrub
+                # client_secret from any string we might log via the caller.
+                scrubbed_msg = _scrub_secret(str(exc), client_secret)
+                raise httpx.HTTPStatusError(
+                    scrubbed_msg, request=exc.request, response=exc.response
+                ) from None
             data = resp.json()
             self._token = data['access_token']
-            decoded = jwt.decode(
-                self._token, options={'verify_signature': False}
-            )
+
+            # Decode without signature verification to extract `exp` for
+            # caching. We trust this token because we just minted it from
+            # our own configured IdP — signature verification happens at
+            # the receiving agent via OAuth2Middleware. Falls back to a
+            # short default TTL if the token is opaque (not a JWT) or the
+            # exp claim is missing.
             now = time.time()
-            self._token_exp = float(decoded.get('exp', now + 60))
+            try:
+                decoded = jwt.decode(
+                    self._token, options={'verify_signature': False}
+                )
+                self._token_exp = float(
+                    decoded.get('exp', now + _DEFAULT_OPAQUE_TOKEN_TTL)
+                )
+            except jwt.PyJWTError:
+                # Opaque token — no `exp` to extract. Use conservative default.
+                logger.debug(
+                    "Issued token is not a JWT; using conservative default "
+                    "TTL of %ds for cache eviction.",
+                    int(_DEFAULT_OPAQUE_TOKEN_TTL),
+                )
+                self._token_exp = now + _DEFAULT_OPAQUE_TOKEN_TTL
+
             ttl = self._token_exp - now
             self._refresh_after = now + max(ttl * 0.8, 30.0)
             logger.info(

--- a/ai_platform_engineering/utils/a2a_common/oauth2_client_credentials_service.py
+++ b/ai_platform_engineering/utils/a2a_common/oauth2_client_credentials_service.py
@@ -1,0 +1,110 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""OAuth2 client_credentials token service for outbound A2A m2m auth.
+
+Implements the a2a-sdk `CredentialService` protocol so A2A clients (with
+`AuthInterceptor` attached) can transparently mint and forward Bearer
+tokens when calling agents that advertise an OAuth2 security scheme on
+their AgentCard.
+
+Reads from env (matches the convention already used by the inbound
+OAuth2Middleware in `ai_platform_engineering.utils.auth.oauth2_middleware`):
+
+  - OAUTH2_CLIENT_ID      — confidential client id
+  - OAUTH2_CLIENT_SECRET  — confidential client secret
+  - TOKEN_ENDPOINT        — IdP's RFC6749 §3.2 token endpoint URL
+
+Refreshes proactively at 80% of token TTL but keeps the existing token
+until its actual `exp` if a refresh fails (transient IdP outage). Single
+asyncio.Lock per process serializes refreshes to avoid thundering herd.
+"""
+
+import asyncio
+import logging
+import os
+import time
+
+import httpx
+import jwt
+from a2a.client.auth.credentials import CredentialService
+from a2a.client.middleware import ClientCallContext
+
+logger = logging.getLogger(__name__)
+
+
+class OAuth2ClientCredentialsService(CredentialService):
+    """Mints + caches OAuth2 client_credentials access tokens.
+
+    Hard-coded to scheme name 'oauth2' to match what `A2AServer`'s patched
+    `_build_security_for_card()` advertises. Agents using a different
+    scheme name should subclass and override `SCHEME_NAME`.
+    """
+
+    SCHEME_NAME = 'oauth2'
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self._token: str | None = None
+        self._token_exp: float = 0.0       # actual token exp (seconds since epoch)
+        self._refresh_after: float = 0.0   # 80% of TTL — soft refresh deadline
+
+    async def get_credentials(
+        self,
+        security_scheme_name: str,
+        context: ClientCallContext | None,
+    ) -> str | None:
+        """Return a valid access token for the named scheme, or None."""
+        if security_scheme_name != self.SCHEME_NAME:
+            return None
+        now = time.time()
+        async with self._lock:
+            if not self._token or now >= self._refresh_after:
+                try:
+                    await self._refresh()
+                except Exception as exc:  # noqa: BLE001
+                    if self._token and now < self._token_exp:
+                        logger.warning(
+                            "OAuth2 token refresh failed; using stale token "
+                            "until exp (%ds remaining): %s",
+                            int(self._token_exp - now),
+                            exc,
+                        )
+                    else:
+                        logger.error(
+                            "OAuth2 token refresh failed and no usable token: %s",
+                            exc,
+                        )
+                        raise
+            return self._token
+
+    async def _refresh(self) -> None:
+        client_id = os.environ['OAUTH2_CLIENT_ID']
+        client_secret = os.environ['OAUTH2_CLIENT_SECRET']
+        token_endpoint = os.environ['TOKEN_ENDPOINT']
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                token_endpoint,
+                data={
+                    'grant_type': 'client_credentials',
+                    'client_id': client_id,
+                    'client_secret': client_secret,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self._token = data['access_token']
+            decoded = jwt.decode(
+                self._token, options={'verify_signature': False}
+            )
+            now = time.time()
+            self._token_exp = float(decoded.get('exp', now + 60))
+            ttl = self._token_exp - now
+            self._refresh_after = now + max(ttl * 0.8, 30.0)
+            logger.info(
+                "Minted OAuth2 client_credentials token for client_id=%s "
+                "(TTL=%ds, refresh_after=%ds)",
+                client_id,
+                int(ttl),
+                int(self._refresh_after - now),
+            )

--- a/ai_platform_engineering/utils/a2a_common/tests/test_a2a_server.py
+++ b/ai_platform_engineering/utils/a2a_common/tests/test_a2a_server.py
@@ -822,5 +822,62 @@ class TestMigratedAgentConstants(unittest.TestCase):
             self.assertIn("METRICS_ENABLED", src, f"Missing METRICS_ENABLED in {path}")
 
 
+# ---------------------------------------------------------------------------
+# Unit tests – OAuth2 security_scheme advertisement (env-conditional)
+# ---------------------------------------------------------------------------
+
+class TestA2AServerOAuth2SecurityScheme(unittest.TestCase):
+    """`A2A_AUTH_OAUTH2=true` plus TOKEN_ENDPOINT advertises OAuth2 on AgentCard."""
+
+    def test_oauth2_disabled_default(self):
+        """Default env keeps security=public, no security_schemes."""
+        s = _make_server()
+        self.assertEqual(s.agent_card.security, [{"public": []}])
+        # security_schemes can be None or absent depending on AgentCard version
+        self.assertIn(s.agent_card.security_schemes, (None, {}))
+
+    @patch.dict(os.environ, {"A2A_AUTH_OAUTH2": "true"}, clear=False)
+    def test_oauth2_enabled_without_token_endpoint_falls_back_to_public(self):
+        """A2A_AUTH_OAUTH2=true alone is insufficient — needs TOKEN_ENDPOINT."""
+        # Make sure TOKEN_ENDPOINT is NOT set
+        os.environ.pop("TOKEN_ENDPOINT", None)
+        s = _make_server()
+        self.assertEqual(s.agent_card.security, [{"public": []}])
+
+    @patch.dict(
+        os.environ,
+        {
+            "A2A_AUTH_OAUTH2": "true",
+            "TOKEN_ENDPOINT": "https://idp.example/realms/test/protocol/openid-connect/token",
+            "ISSUER": "https://idp.example/realms/test",
+            "AUDIENCE": "myagent",
+        },
+        clear=False,
+    )
+    def test_oauth2_enabled_advertises_scheme(self):
+        """Env fully configured → AgentCard.security uses 'oauth2' requirement."""
+        s = _make_server()
+        self.assertEqual(s.agent_card.security, [{"oauth2": []}])
+        self.assertIsNotNone(s.agent_card.security_schemes)
+        self.assertIn("oauth2", s.agent_card.security_schemes)
+
+    @patch.dict(
+        os.environ,
+        {
+            "A2A_AUTH_OAUTH2": "true",
+            "TOKEN_ENDPOINT": "https://idp.example/token",
+        },
+        clear=False,
+    )
+    def test_oauth2_scheme_carries_token_url(self):
+        """Advertised scheme exposes the configured token URL to clients."""
+        s = _make_server()
+        scheme = s.agent_card.security_schemes["oauth2"].root
+        self.assertEqual(
+            scheme.flows.client_credentials.token_url,
+            "https://idp.example/token",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ai_platform_engineering/utils/a2a_common/tests/test_oauth2_client_credentials_service.py
+++ b/ai_platform_engineering/utils/a2a_common/tests/test_oauth2_client_credentials_service.py
@@ -1,0 +1,230 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OAuth2ClientCredentialsService.
+
+Focuses on:
+  - SCHEME_NAME filter (returns None for non-matching scheme)
+  - Token caching + 80%-of-TTL soft refresh
+  - Stale-on-error (refresh failure but unexpired token continues serving)
+  - Hard-fail when refresh fails AND no usable token
+  - Opaque-token (non-JWT) fallback to default TTL
+  - Client secret scrubbed from exception text
+  - Plaintext TOKEN_ENDPOINT warning on non-loopback host
+"""
+
+import os
+import time
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Stub jwt before module import so we can drive `jwt.decode` deterministically.
+import sys
+if "jwt" not in sys.modules:
+    fake_jwt = types.ModuleType("jwt")
+    fake_jwt.decode = MagicMock(return_value={})
+    fake_jwt.PyJWTError = Exception
+    sys.modules["jwt"] = fake_jwt
+
+from ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service import (  # noqa: E402
+    OAuth2ClientCredentialsService,
+    _scrub_secret,
+    _validate_token_endpoint_scheme,
+)
+
+
+_MIN_ENV = {
+    "OAUTH2_CLIENT_ID": "supervisor",
+    "OAUTH2_CLIENT_SECRET": "topsecret",
+    "TOKEN_ENDPOINT": "https://idp.example/token",
+}
+
+
+def _make_response(token="abc.def.ghi", exp_in=300):
+    """Build a fake httpx.Response."""
+    resp = MagicMock()
+    resp.json.return_value = {"access_token": token}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestSchemeFilter(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_none_for_non_matching_scheme(self):
+        svc = OAuth2ClientCredentialsService()
+        result = await svc.get_credentials("api_key", context=None)
+        self.assertIsNone(result)
+
+
+class TestRefreshAndCache(unittest.IsolatedAsyncioTestCase):
+    @patch.dict(os.environ, _MIN_ENV, clear=False)
+    async def test_first_call_mints_and_caches(self):
+        svc = OAuth2ClientCredentialsService()
+        with patch(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.httpx.AsyncClient"
+        ) as fake_client_cls:
+            fake_client = AsyncMock()
+            fake_client.post.return_value = _make_response("tok-1", exp_in=600)
+            fake_client_cls.return_value.__aenter__.return_value = fake_client
+            with patch(
+                "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.jwt.decode",
+                return_value={"exp": time.time() + 600},
+            ):
+                tok = await svc.get_credentials("oauth2", context=None)
+        self.assertEqual(tok, "tok-1")
+        self.assertEqual(fake_client.post.call_count, 1)
+
+    @patch.dict(os.environ, _MIN_ENV, clear=False)
+    async def test_second_call_within_ttl_does_not_remint(self):
+        svc = OAuth2ClientCredentialsService()
+        with patch(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.httpx.AsyncClient"
+        ) as fake_client_cls:
+            fake_client = AsyncMock()
+            fake_client.post.return_value = _make_response("tok-1")
+            fake_client_cls.return_value.__aenter__.return_value = fake_client
+            with patch(
+                "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.jwt.decode",
+                return_value={"exp": time.time() + 3600},
+            ):
+                tok1 = await svc.get_credentials("oauth2", context=None)
+                tok2 = await svc.get_credentials("oauth2", context=None)
+        self.assertEqual(tok1, tok2)
+        self.assertEqual(fake_client.post.call_count, 1)
+
+
+class TestStaleOnError(unittest.IsolatedAsyncioTestCase):
+    @patch.dict(os.environ, _MIN_ENV, clear=False)
+    async def test_refresh_failure_serves_stale_token_until_exp(self):
+        svc = OAuth2ClientCredentialsService()
+
+        # 1st call: mint successfully, exp = now + 600
+        with patch(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.httpx.AsyncClient"
+        ) as fake_client_cls:
+            fake_client = AsyncMock()
+            fake_client.post.return_value = _make_response("tok-stale")
+            fake_client_cls.return_value.__aenter__.return_value = fake_client
+            with patch(
+                "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.jwt.decode",
+                return_value={"exp": time.time() + 600},
+            ):
+                first = await svc.get_credentials("oauth2", context=None)
+        self.assertEqual(first, "tok-stale")
+
+        # Force refresh window: set refresh_after to past, but token still
+        # valid for ~600s. Next call attempts refresh; we make it fail.
+        svc._refresh_after = 0.0
+        with patch(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.httpx.AsyncClient"
+        ) as fake_client_cls:
+            fake_client = AsyncMock()
+            fake_client.post.side_effect = RuntimeError("transient IdP outage")
+            fake_client_cls.return_value.__aenter__.return_value = fake_client
+            stale = await svc.get_credentials("oauth2", context=None)
+        self.assertEqual(stale, "tok-stale", "stale token should be served on refresh failure")
+
+    @patch.dict(os.environ, _MIN_ENV, clear=False)
+    async def test_refresh_failure_with_no_usable_token_raises(self):
+        svc = OAuth2ClientCredentialsService()
+        with patch(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.httpx.AsyncClient"
+        ) as fake_client_cls:
+            fake_client = AsyncMock()
+            fake_client.post.side_effect = RuntimeError("IdP down")
+            fake_client_cls.return_value.__aenter__.return_value = fake_client
+            with self.assertRaises(RuntimeError):
+                await svc.get_credentials("oauth2", context=None)
+
+
+class TestOpaqueTokenFallback(unittest.IsolatedAsyncioTestCase):
+    @patch.dict(os.environ, _MIN_ENV, clear=False)
+    async def test_opaque_token_uses_default_ttl(self):
+        """If `jwt.decode` raises (token isn't a JWT), use conservative default TTL."""
+        from ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service import (
+            _DEFAULT_OPAQUE_TOKEN_TTL,
+        )
+        svc = OAuth2ClientCredentialsService()
+
+        class _FakePyJWTError(Exception):
+            pass
+
+        with patch(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.httpx.AsyncClient"
+        ) as fake_client_cls:
+            fake_client = AsyncMock()
+            fake_client.post.return_value = _make_response("opaque-token-xyz")
+            fake_client_cls.return_value.__aenter__.return_value = fake_client
+            with patch(
+                "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.jwt.decode",
+                side_effect=_FakePyJWTError("not a jwt"),
+            ), patch(
+                "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service.jwt.PyJWTError",
+                _FakePyJWTError,
+            ):
+                start = time.time()
+                tok = await svc.get_credentials("oauth2", context=None)
+        self.assertEqual(tok, "opaque-token-xyz")
+        # exp should be approximately start + _DEFAULT_OPAQUE_TOKEN_TTL
+        self.assertAlmostEqual(
+            svc._token_exp, start + _DEFAULT_OPAQUE_TOKEN_TTL, delta=2.0
+        )
+
+
+class TestSecretScrubbing(unittest.TestCase):
+    def test_scrub_redacts_secret_in_text(self):
+        text = "Bad request: invalid_client_secret=topsecret"
+        scrubbed = _scrub_secret(text, "topsecret")
+        self.assertNotIn("topsecret", scrubbed)
+        self.assertIn("***REDACTED***", scrubbed)
+
+    def test_scrub_no_match_returns_unchanged(self):
+        self.assertEqual(_scrub_secret("hello world", "topsecret"), "hello world")
+
+    def test_scrub_empty_secret_returns_unchanged(self):
+        self.assertEqual(_scrub_secret("anything", ""), "anything")
+
+
+class TestTokenEndpointSchemeValidation(unittest.TestCase):
+    def setUp(self):
+        # Reset the module-level _TOKEN_ENDPOINT_VALIDATED guard so each
+        # test sees the warning path freshly.
+        import ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service as mod
+        mod._TOKEN_ENDPOINT_VALIDATED = False
+
+    def test_https_endpoint_no_warning(self):
+        with self.assertLogs(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service",
+            level="WARNING",
+        ) as logs:
+            _validate_token_endpoint_scheme("https://idp.example/token")
+            # Trigger a no-op log so assertLogs has something to inspect
+            import logging
+            logging.getLogger(
+                "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service"
+            ).warning("sentinel")
+        # Only the sentinel should appear; no plaintext warning
+        self.assertEqual(len(logs.records), 1)
+        self.assertEqual(logs.records[0].message, "sentinel")
+
+    def test_http_loopback_logs_info_not_warning(self):
+        with self.assertLogs(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service",
+            level="INFO",
+        ) as logs:
+            _validate_token_endpoint_scheme("http://localhost:8080/token")
+        levels = [r.levelname for r in logs.records]
+        self.assertIn("INFO", levels)
+        self.assertNotIn("WARNING", levels)
+
+    def test_http_non_loopback_warns(self):
+        with self.assertLogs(
+            "ai_platform_engineering.utils.a2a_common.oauth2_client_credentials_service",
+            level="WARNING",
+        ) as logs:
+            _validate_token_endpoint_scheme("http://idp.example/token")
+        self.assertTrue(any(r.levelname == "WARNING" for r in logs.records))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds end-to-end m2m authentication for the supervisor → remote-agent A2A leg, fully backward-compatible.

Today, [`OAuth2Middleware`](../blob/main/ai_platform_engineering/utils/auth/oauth2_middleware.py) validates inbound JWTs but the supervisor's [`A2ARemoteAgentConnectTool`](../blob/main/ai_platform_engineering/utils/a2a_common/a2a_remote_agent_connect.py#L144) constructs an `A2AClient` with **no auth wiring**. Setting `A2A_AUTH_OAUTH2=true` on a remote agent therefore 401-rejects every supervisor → agent call. The placeholder [`user_jwt = "TBD_USER_JWT"`](../blob/main/ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py#L370) confirms this was unfinished.

This change wires up `a2a-sdk`'s built-in `AuthInterceptor` only when the remote agent advertises it.

## Three pieces

### 1. `a2a_server.py` — env-conditional security scheme

When `A2A_AUTH_OAUTH2=true` AND `TOKEN_ENDPOINT` is set, the AgentCard publishes an `oauth2` security scheme with the client_credentials flow. When env isn't set, `security=[{"public": []}]` is preserved exactly.

Misconfigured agents (auth on, no token endpoint) fall back to public with a warning instead of crash-looping.

### 2. `oauth2_client_credentials_service.py` (new)

`CredentialService` implementation that mints + caches client_credentials access tokens. Refreshes at 80% of TTL, keeps stale-but-not-expired tokens through transient IdP outages, serializes refreshes via `asyncio.Lock`. Uses the existing `OAUTH2_CLIENT_ID` / `OAUTH2_CLIENT_SECRET` / `TOKEN_ENDPOINT` env vars already documented for the inbound middleware — **no new config**.

### 3. `a2a_remote_agent_connect.py` — wire the interceptor

`connect()` inspects the fetched `AgentCard` for an `oauth2` security requirement and, if present, attaches `AuthInterceptor(OAuth2ClientCredentialsService())` to the `A2AClient`. Cards advertising `{\"public\": []}` continue with no interceptor — **zero behavior change for agents that didn't opt in**.

## Backward compatibility

- Default env (`A2A_AUTH_OAUTH2` unset or false): identical to upstream behavior.
- Existing `test_agent_card_security_public` still passes.
- No new dependencies (`httpx`, `jwt`, `a2a-sdk` are all already pinned).
- No new env vars.

## Tested

New `TestA2AServerOAuth2SecurityScheme` cases cover the env matrix:
- off (default)
- on without TOKEN_ENDPOINT (falls back to public + warning)
- on with full config (advertises oauth2 scheme)
- token URL is surfaced correctly on the scheme

End-to-end: verified on a Keycloak realm. AgentCard advertises `oauth2`; supervisor mints a client_credentials token via `OAuth2ClientCredentialsService`; remote agent validates the JWT via the existing `OAuth2Middleware`; supervisor logs `Outbound A2A auth enabled for {agent}` and successful tool calls flow through.

## Naming

`OAuth2ClientCredentialsService` (not Keycloak-specific) so any RFC6749 §4.4 IdP works — Keycloak, Okta, Auth0, AWS Cognito, Azure AD, etc.

## Related

A separate PR will follow up to harden the [inbound `cid` claim check](../blob/main/ai_platform_engineering/utils/auth/oauth2_middleware.py#L121-L124) (which currently silently accepts tokens missing the client-identity claim). That hardening is gated behind an opt-in flag for backward compatibility.