### PR TITLE
feat(overthink): add OVERTHINK_BOILERPLATE as server-side template variable

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -82,6 +82,15 @@ def _sanitize_agent_name(name: str) -> str:
     return re.sub(r"[\s<|\\/>]+", "_", name)
 
 
+OVERTHINK_BOILERPLATE = (
+    "If the message is only asking a human to take an action (review, approve, intervene)"
+    " — not directed at you — output ONLY: [DEFER]\n"
+    "If the message is asking you to take an action, do it directly.\n"
+    "Otherwise, search your knowledge base before responding."
+    " If you cannot find relevant sources, output ONLY: [LOW_CONFIDENCE]\n"
+    "Always end with a Sources section linking what you found."
+)
+
 # Module-level restricted Jinja2 sandbox for system prompt rendering.
 # - ChainableUndefined: missing/nested keys return "" instead of raising.
 # - Built-in globals stripped: agent prompts only need conditionals and
@@ -133,6 +142,7 @@ def _render_system_prompt(
             attempts unsafe attribute access, or otherwise fails to render.
     """
     ctx = client_context.model_dump() if client_context else {}
+    ctx.setdefault("overthink_boilerplate", OVERTHINK_BOILERPLATE)
     user_ctx = user.model_dump(exclude={"raw_claims"}) if user else {}
     try:
         template = _jinja_env.from_string(template_str)

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
@@ -175,7 +175,6 @@ class TestOverthinkConfigDefaults:
     oc = OverthinkConfig()
     assert oc.enabled is False
     assert oc.skip_markers == ["DEFER", "LOW_CONFIDENCE"]
-    assert oc.custom_prompt is None
     assert oc.followup_prompt is None
 
   def test_custom_markers(self):

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -67,18 +67,6 @@ _OVERTHINK_KEEPALIVE_MESSAGES = [
   "Really overthinking this...",
 ]
 _STATUS_OVERTHINK_WRITE_TODOS = "Checking notes..."
-
-# Default boilerplate injected when custom_prompt uses {{ overthink_boilerplate }}.
-# Tells the agent when to output [DEFER] or [LOW_CONFIDENCE] without coupling
-# the agent's own system prompt to platform marker conventions.
-OVERTHINK_BOILERPLATE = """\
-If the message is only asking a human to take an action (review, approve, intervene) \
-— not directed at you — output ONLY: [DEFER]
-If the message is asking you to take an action, do it directly.
-Otherwise, search your knowledge base before responding. \
-If you cannot find relevant sources, output ONLY: [LOW_CONFIDENCE]
-Always end with a Sources section linking what you found.\
-"""
 _STATUS_RATE_LIMIT_SECS = 1.0  # minimum seconds between setStatus calls
 
 
@@ -546,8 +534,6 @@ def stream_response(
     )
   else:
     effective_message = message_text
-    if overthink_mode:
-      effective_message = f"{OVERTHINK_BOILERPLATE}\n\nUser message: {message_text}"
     event_stream = sse_client.stream_chat(
       message=effective_message,
       conversation_id=conversation_id,

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -67,6 +67,18 @@ _OVERTHINK_KEEPALIVE_MESSAGES = [
   "Really overthinking this...",
 ]
 _STATUS_OVERTHINK_WRITE_TODOS = "Checking notes..."
+
+# Default boilerplate injected when custom_prompt uses {{ overthink_boilerplate }}.
+# Tells the agent when to output [DEFER] or [LOW_CONFIDENCE] without coupling
+# the agent's own system prompt to platform marker conventions.
+OVERTHINK_BOILERPLATE = """\
+If the message is only asking a human to take an action (review, approve, intervene) \
+— not directed at you — output ONLY: [DEFER]
+If the message is asking you to take an action, do it directly.
+Otherwise, search your knowledge base before responding. \
+If you cannot find relevant sources, output ONLY: [LOW_CONFIDENCE]
+Always end with a Sources section linking what you found.\
+"""
 _STATUS_RATE_LIMIT_SECS = 1.0  # minimum seconds between setStatus calls
 
 
@@ -534,8 +546,8 @@ def stream_response(
     )
   else:
     effective_message = message_text
-    if overthink_mode and overthink_config.custom_prompt:
-      effective_message = f"{overthink_config.custom_prompt}\n\n{message_text}"
+    if overthink_mode:
+      effective_message = f"{OVERTHINK_BOILERPLATE}\n\nUser message: {message_text}"
     event_stream = sse_client.stream_chat(
       message=effective_message,
       conversation_id=conversation_id,

--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -40,7 +40,6 @@ class EscalationConfig(BaseModel):
 class OverthinkConfig(BaseModel):
   enabled: bool = False
   skip_markers: list[str] = Field(default_factory=lambda: ["DEFER", "LOW_CONFIDENCE"])
-  custom_prompt: str | None = None
   followup_prompt: str | None = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.9"
+version = "0.4.9-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.9"
+version = "0.4.9.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Replaces the removed `custom_prompt` field on `OverthinkConfig` with a built-in `OVERTHINK_BOILERPLATE` constant injected server-side into every system prompt render context as `{{ client_context.overthink_boilerplate }}`.

Agent prompts that use `overthink: enabled: true` can now include `{{ client_context.overthink_boilerplate }}` in their system prompt to get standard `[DEFER]`/`[LOW_CONFIDENCE]` gating instructions, without coupling the agent prompt to platform marker conventions. The variable is always available but silently ignored if not referenced.

Changes:
- `agent_runtime.py`: define `OVERTHINK_BOILERPLATE` constant, inject into `ctx` before Jinja2 render
- `config_models.py`: remove `custom_prompt` from `OverthinkConfig` (no longer needed)
- `ai.py`: remove leftover message-prepending logic that was incorrectly added
- `test_config.py`: update test to match removed field

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass