### PR TITLE
fix(overthink): move OVERTHINK_BOILERPLATE to slack-bot, inject via client_context

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -82,15 +82,6 @@ def _sanitize_agent_name(name: str) -> str:
     return re.sub(r"[\s<|\\/>]+", "_", name)
 
 
-OVERTHINK_BOILERPLATE = (
-    "If the message is only asking a human to take an action (review, approve, intervene)"
-    " — not directed at you — output ONLY: [DEFER]\n"
-    "If the message is asking you to take an action, do it directly.\n"
-    "Otherwise, search your knowledge base before responding."
-    " If you cannot find relevant sources, output ONLY: [LOW_CONFIDENCE]\n"
-    "Always end with a Sources section linking what you found."
-)
-
 # Module-level restricted Jinja2 sandbox for system prompt rendering.
 # - ChainableUndefined: missing/nested keys return "" instead of raising.
 # - Built-in globals stripped: agent prompts only need conditionals and
@@ -142,7 +133,6 @@ def _render_system_prompt(
             attempts unsafe attribute access, or otherwise fails to render.
     """
     ctx = client_context.model_dump() if client_context else {}
-    ctx.setdefault("overthink_boilerplate", OVERTHINK_BOILERPLATE)
     user_ctx = user.model_dump(exclude={"raw_claims"}) if user else {}
     try:
         template = _jinja_env.from_string(template_str)

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -369,6 +369,8 @@ def handle_mention(event, say, client):
       "humble_followup": is_humble_followup,
       "overthink": bool(overthink and overthink.enabled),
     }
+    if overthink and overthink.enabled:
+      client_context["overthink_boilerplate"] = ai.OVERTHINK_BOILERPLATE
     if user_email:
       client_context["user_email"] = user_email
 
@@ -532,6 +534,8 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       "overthink": bool(overthink and overthink.enabled),
       "timestamp": thread_ts,
     }
+    if overthink and overthink.enabled:
+      client_context["overthink_boilerplate"] = ai.OVERTHINK_BOILERPLATE
     if user_email:
       client_context["user_email"] = user_email
     if bot_username:

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -69,6 +69,15 @@ _OVERTHINK_KEEPALIVE_MESSAGES = [
 _STATUS_OVERTHINK_WRITE_TODOS = "Checking notes..."
 _STATUS_RATE_LIMIT_SECS = 1.0  # minimum seconds between setStatus calls
 
+OVERTHINK_BOILERPLATE = (
+    "If the message is only asking a human to take an action (review, approve, intervene)"
+    " — not directed at you — output ONLY: [DEFER]\n"
+    "If the message is asking you to take an action, do it directly.\n"
+    "Otherwise, search your knowledge base before responding."
+    " If you cannot find relevant sources, output ONLY: [LOW_CONFIDENCE]\n"
+    "Always end with a Sources section linking what you found."
+)
+
 
 def _parse_write_todos_args(raw_args_json: str) -> list[dict] | None:
   """Parse the todo list from write_todos tool arguments.


### PR DESCRIPTION
# Description

Follow-up to #1364. The `OVERTHINK_BOILERPLATE` constant was incorrectly placed in `agent_runtime.py` and injected by mutating the render context. This moves it to the slack-bot where it belongs — the runtime treats `client_context` as an opaque dict and shouldn't own this logic.

- `ai.py`: define `OVERTHINK_BOILERPLATE` constant
- `app.py`: inject `overthink_boilerplate` into `client_context` when `overthink.enabled` is true
- `agent_runtime.py`: remove constant and `ctx.setdefault` added in #1364

Agent prompts use `{{ client_context.overthink_boilerplate }}`. The slack-bot can now be updated independently of the runtime.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass