### PR TITLE
fix(charts): exclude non-metrics services from ServiceMonitor scraping

### DIFF
--- a/charts/ai-platform-engineering/templates/servicemonitor.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor.yaml
@@ -14,8 +14,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # Match ALL ai-platform-engineering services in this release, EXCEPT MCP services
-  # MCP containers don't expose /metrics endpoints
+  # Match ALL ai-platform-engineering services in this release, EXCEPT services
+  # that don't expose /metrics endpoints (mcp, rag-server, agent-ontology, skill-scanner)
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
@@ -24,6 +24,9 @@ spec:
         operator: NotIn
         values:
           - mcp
+          - rag-server
+          - agent-ontology
+          - skill-scanner
   endpoints:
     - port: http
       path: {{ .Values.metrics.path | default "/metrics" }}

--- a/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "agent.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: agent-ontology
 {{- end }}
 
 {{/*

--- a/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
@@ -38,6 +38,7 @@ helm.sh/chart: {{ include "rag-server.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: rag-server
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Summary

- `rag-server`, `agent-ontology`, and `skill-scanner` do not expose a `/metrics` endpoint, but the ServiceMonitor selector was scraping them anyway, causing Prometheus to record `up=0` and fire `TargetDown` alerts for healthy pods
- Add `app.kubernetes.io/component` labels to `rag-server` and `agent-ontology` chart helpers (`skill-scanner` already had one)
- Extend the ServiceMonitor `NotIn` selector to exclude `rag-server`, `agent-ontology`, and `skill-scanner` alongside the existing `mcp` exclusion

## Root cause

The ServiceMonitor comment noted that MCP services were excluded because they don't expose `/metrics`. The same is true for `rag-server` (FastAPI app with no Prometheus middleware), `agent-ontology` (same), and `skill-scanner` (a third-party REST API). Without the component label + exclusion, Prometheus scrapes their `http` port, gets a 404/connection error, and marks the target as down.

## Test plan

- [ ] Verify `rag-server`, `agent-ontology`, and `skill-scanner` services no longer appear as scrape targets in Prometheus after deploying the updated chart
- [ ] Verify no `TargetDown` alerts fire for these services
- [ ] Verify that services which do expose `/metrics` (e.g. `dynamic-agents`, `supervisor-agent`) are still scraped correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)