### PR TITLE
fix(charts): exclude caipe-ui from ServiceMonitor scraping

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "caipe-ui.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: caipe-ui
 {{- end }}
 
 {{/*

--- a/charts/ai-platform-engineering/templates/servicemonitor.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   # Match ALL ai-platform-engineering services in this release, EXCEPT services
-  # that don't expose /metrics endpoints (mcp, rag-server, agent-ontology, skill-scanner)
+  # that don't expose /metrics endpoints (mcp, rag-server, agent-ontology, skill-scanner, caipe-ui)
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
@@ -27,6 +27,7 @@ spec:
           - rag-server
           - agent-ontology
           - skill-scanner
+          - caipe-ui
   endpoints:
     - port: http
       path: {{ .Values.metrics.path | default "/metrics" }}


### PR DESCRIPTION
## Summary

Follow-up to #1388 — `caipe-ui` was missed in that PR.

`caipe-ui` is a Next.js app and does not expose a Prometheus `/metrics` endpoint (no `prom-client` dependency, no metrics route). Add `app.kubernetes.io/component: caipe-ui` to its chart helper and extend the ServiceMonitor `NotIn` selector to exclude it, consistent with the pattern established for `rag-server`, `agent-ontology`, and `skill-scanner`.

## Test plan

- [ ] Verify `caipe-caipe-ui` no longer appears as a scrape target in Prometheus after deploying the updated chart
- [ ] Verify no `TargetDown` alerts fire for `caipe-caipe-ui`
- [ ] Verify services that do expose `/metrics` are still scraped correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)