### PR TITLE
docs(community): update Meeting Recordings link to CNOE YouTube channel

### DIFF
--- a/docs/docs/community/index.md
+++ b/docs/docs/community/index.md
@@ -1,6 +1,6 @@
 # CNOE Agentic AI SIG Community
 
-🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://github.com/cnoe-io/agentic-ai/wiki/Meeting-Recordings) | 🏛️ [Governance](https://github.com/cnoe-io/governance/tree/main/sigs/agentic-ai) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
+🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://www.youtube.com/@cnoe-community) | 🏛️ [Governance](https://github.com/cnoe-io/governance/tree/main/sigs/agentic-ai) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
 
 ### 🗓️ Weekly Meetings
 

--- a/docs/versioned_docs/version-0.4.8/community/index.md
+++ b/docs/versioned_docs/version-0.4.8/community/index.md
@@ -1,6 +1,6 @@
 # CNOE Agentic AI SIG Community
 
-🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://github.com/cnoe-io/agentic-ai/wiki/Meeting-Recordings) | 🏛️ [Governance](https://github.com/cnoe-io/governance/tree/main/sigs/agentic-ai) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
+🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://www.youtube.com/@cnoe-community) | 🏛️ [Governance](https://github.com/cnoe-io/governance/tree/main/sigs/agentic-ai) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
 
 ### 🗓️ Weekly Meetings
 

--- a/docs/versioned_docs/version-0.4.9/community/index.md
+++ b/docs/versioned_docs/version-0.4.9/community/index.md
@@ -1,6 +1,6 @@
 # CNOE Agentic AI SIG Community
 
-🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://github.com/cnoe-io/agentic-ai/wiki/Meeting-Recordings) | 🏛️ [Governance](https://github.com/cnoe-io/governance/tree/main/sigs/agentic-ai) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
+🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://www.youtube.com/@cnoe-community) | 🏛️ [Governance](https://github.com/cnoe-io/governance/tree/main/sigs/agentic-ai) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
 
 ### 🗓️ Weekly Meetings
 


### PR DESCRIPTION
## Summary

- Replace GitHub wiki Meeting Recordings link with the official CNOE YouTube channel (`https://www.youtube.com/@cnoe-community`)
- Updated across all doc versions: current, 0.4.9, and 0.4.8

## Test plan

- [ ] Verify the Meeting Recordings link on the community page points to `https://www.youtube.com/@cnoe-community`