### PR TITLE
fix(skills): remove install pagination and retitle to Advanced install

### DIFF
--- a/ui/src/components/skills/TrySkillsGateway.tsx
+++ b/ui/src/components/skills/TrySkillsGateway.tsx
@@ -157,7 +157,6 @@ export function TrySkillsGateway() {
   const [queryRepo, setQueryRepo] = useState("");
   const [queryTags, setQueryTags] = useState("");
   const [queryVisibility, setQueryVisibility] = useState("");
-  const [queryPageSize, setQueryPageSize] = useState("20");
   const [queryIncludeContent, setQueryIncludeContent] = useState(false);
   const [previewData, setPreviewData] = useState<any>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -181,11 +180,9 @@ export function TrySkillsGateway() {
     if (queryRepo) params.set("repo", queryRepo);
     if (queryTags.trim()) params.set("tags", queryTags.trim());
     if (queryVisibility) params.set("visibility", queryVisibility);
-    params.set("page", "1");
-    params.set("page_size", queryPageSize || "20");
     if (queryIncludeContent) params.set("include_content", "true");
     return `${baseUrl}/api/skills?${params.toString()}`;
-  }, [baseUrl, queryQ, querySource, queryRepo, queryTags, queryVisibility, queryPageSize, queryIncludeContent]);
+  }, [baseUrl, queryQ, querySource, queryRepo, queryTags, queryVisibility, queryIncludeContent]);
 
   const catalogUrl = buildCatalogUrl();
 
@@ -596,17 +593,6 @@ export function TrySkillsGateway() {
                 <option value="team">team</option>
                 <option value="personal">personal</option>
               </select>
-            </div>
-            <div>
-              <label className="text-xs font-medium text-muted-foreground">Page size</label>
-              <input
-                type="number"
-                min={1}
-                max={100}
-                value={queryPageSize}
-                onChange={(e) => setQueryPageSize(e.target.value)}
-                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
-              />
             </div>
             <div className="flex items-end pb-2">
               <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground cursor-pointer">

--- a/ui/src/components/skills/TrySkillsGateway.tsx
+++ b/ui/src/components/skills/TrySkillsGateway.tsx
@@ -432,13 +432,14 @@ export function TrySkillsGateway() {
     <div className="space-y-6 max-w-6xl">
       <div className="space-y-1">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-          How to use Skills API Gateway with coding agents
+          Advanced install
         </h1>
         <p className="text-sm text-muted-foreground">
-          Start with the live catalog (Step 1), then mint a catalog API key (Step 2) for authenticated{" "}
-          <code className="text-xs">curl</code> / installer access. Step 3 installs the single live-skills{" "}
-          <code className="text-xs">/skills</code> command. Bulk install of every previewed skill is optional and
-          listed after Step 2 as an advanced flow.
+          For first-time setup, use <strong>Quick install</strong> — it writes your config and runs the
+          installer in one shot. The steps below are for custom installs: filtering which skills to install
+          (Step 1), scripted{" "}
+          <code className="text-xs">curl</code> access via a catalog API key (Step 2), and per-agent or
+          bulk install options (Step 3).
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

- Removes `page=1&page_size=20` from the catalog URL built by `buildCatalogUrl` — the API returns all results when `page` is omitted, so bulk install no longer caps at 20 skills
- Removes the now-unused **Page size** input from the advanced catalog URL builder UI
- Renames the try-gateway page heading from _"How to use Skills API Gateway with coding agents"_ to **"Advanced install"** and rewrites the description to direct first-time users to Quick Install, reserving Steps 1–3 for custom/scripted flows

## Test plan

- [x] `TrySkillsGateway` test suite (26 tests) passes
- [ ] Verify quick-install URL no longer contains `page_size=20` in the dialog
- [ ] Verify the page heading reads "Advanced install" on `grid.outshift.io`