### PR TITLE
docs(rbac): add identity group ReBAC specification

### DIFF
--- a/docs/docs/specs/2026-05-11-identity-group-rebac/checklists/requirements.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Enterprise Identity Group Sync and Universal ReBAC
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-11  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on first review.
+- The specification intentionally names domain systems and concepts already present in the product discussion, including Keycloak, Okta, Active Directory, ReBAC, Slack channels, teams, agents, tools, knowledge bases, skills, tasks, policies, and admin surfaces.
+- No clarification questions are required before planning.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/identity-group-sync-api.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/identity-group-sync-api.md
@@ -1,0 +1,248 @@
+# Contract: Identity Group Sync Admin API
+
+## Scope
+
+These BFF endpoints support provider health, regex mapping clusters, dry-run previews, applied sync runs, external group links, membership source review, and skipped-user remediation. All endpoints require authenticated admin access and must additionally pass ReBAC checks for the relevant admin surface and provider/team scope.
+
+## Authorization
+
+- Global RBAC administrators can view and manage all sync providers and rules.
+- Scoped team administrators can view sync-derived membership for teams they administer but cannot create provider-wide mapping rules unless delegated.
+- Dry-run execution requires `use` on the identity sync admin surface.
+- Applying changes requires `manage` on the identity sync admin surface and `manage` on affected team resources.
+
+## Endpoints
+
+### `GET /api/admin/identity-group-sync/providers`
+
+Returns configured identity sources and health status.
+
+**Response**
+
+```json
+{
+  "providers": [
+    {
+      "id": "okta-primary",
+      "type": "okta",
+      "display_name": "Okta",
+      "status": "healthy",
+      "capabilities": ["list_groups", "list_group_members", "immutable_group_ids"],
+      "last_checked_at": "2026-05-11T00:00:00Z"
+    }
+  ]
+}
+```
+
+### `GET /api/admin/identity-group-sync/rules`
+
+Lists mapping clusters.
+
+**Query**
+
+- `provider_id`: optional provider filter.
+- `status`: optional rule status filter.
+
+**Response**
+
+```json
+{
+  "rules": [
+    {
+      "id": "rule-platform-teams",
+      "provider_id": "okta-primary",
+      "name": "Platform teams",
+      "priority": 10,
+      "enabled": true,
+      "review_status": "enabled",
+      "include_patterns": ["^CAIPE-(?<team>[A-Za-z0-9-]+)-(?<role>Members|Admins)$"],
+      "exclude_patterns": ["^CAIPE-Experimental-"],
+      "team_slug_template": "${team}",
+      "role_map": {
+        "Members": "member",
+        "Admins": "admin"
+      },
+      "auto_create_team": true
+    }
+  ]
+}
+```
+
+### `POST /api/admin/identity-group-sync/rules`
+
+Creates a draft mapping cluster. Saving a rule does not enable writes until a dry-run has been reviewed.
+
+**Request**
+
+```json
+{
+  "provider_id": "okta-primary",
+  "name": "Platform teams",
+  "priority": 10,
+  "include_patterns": ["^CAIPE-(?<team>[A-Za-z0-9-]+)-(?<role>Members|Admins)$"],
+  "exclude_patterns": ["^CAIPE-Experimental-"],
+  "team_name_template": "${team}",
+  "team_slug_template": "${team}",
+  "role_map": {
+    "Members": "member",
+    "Admins": "admin"
+  },
+  "auto_create_team": true
+}
+```
+
+**Response**
+
+```json
+{
+  "rule": {
+    "id": "rule-platform-teams",
+    "review_status": "dry_run_required"
+  }
+}
+```
+
+### `PATCH /api/admin/identity-group-sync/rules/{rule_id}`
+
+Updates a mapping cluster. Material edits move enabled rules back to `dry_run_required`.
+
+**Request**
+
+```json
+{
+  "enabled": false,
+  "priority": 20,
+  "exclude_patterns": ["^CAIPE-Experimental-", "^CAIPE-Legacy-"]
+}
+```
+
+### `POST /api/admin/identity-group-sync/dry-run`
+
+Runs a preview without mutating MongoDB, Keycloak, or OpenFGA.
+
+**Request**
+
+```json
+{
+  "provider_id": "okta-primary",
+  "rule_ids": ["rule-platform-teams"],
+  "sample_limit": 500,
+  "include_members": true
+}
+```
+
+**Response**
+
+```json
+{
+  "run_id": "sync-run-preview-001",
+  "mode": "dry_run",
+  "status": "completed",
+  "summary": {
+    "matched_groups": 28,
+    "ignored_groups": 141,
+    "teams_to_create": 4,
+    "memberships_to_add": 213,
+    "memberships_to_remove": 12,
+    "skipped_users": 6,
+    "conflicts": 1,
+    "relationship_grants": 426,
+    "relationship_revocations": 24
+  },
+  "conflicts": [
+    {
+      "type": "team_slug_collision",
+      "team_slug": "platform",
+      "external_group_id": "00g123",
+      "message": "Generated team slug already exists with a different external group link"
+    }
+  ]
+}
+```
+
+### `POST /api/admin/identity-group-sync/apply`
+
+Applies a reviewed dry-run or starts an applied reconciliation.
+
+**Request**
+
+```json
+{
+  "provider_id": "okta-primary",
+  "rule_ids": ["rule-platform-teams"],
+  "based_on_run_id": "sync-run-preview-001",
+  "apply_membership_removals": true,
+  "apply_team_creates": true
+}
+```
+
+**Response**
+
+```json
+{
+  "run_id": "sync-run-apply-001",
+  "mode": "manual_apply",
+  "status": "running"
+}
+```
+
+### `GET /api/admin/identity-group-sync/runs/{run_id}`
+
+Returns run status, summary, warnings, errors, generated team links, membership diffs, and generated ReBAC tuple diffs.
+
+### `GET /api/admin/identity-group-sync/teams/{team_id}/membership-sources`
+
+Returns all source records explaining team membership.
+
+**Response**
+
+```json
+{
+  "team": {
+    "id": "team-platform",
+    "slug": "platform"
+  },
+  "memberships": [
+    {
+      "user_subject": "user-123",
+      "user_email": "user@example.com",
+      "relationship": "member",
+      "sources": [
+        {
+          "source_type": "manual",
+          "status": "active",
+          "managed": false
+        },
+        {
+          "source_type": "okta",
+          "provider_id": "okta-primary",
+          "external_group_id": "00g123",
+          "status": "active",
+          "managed": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+### `POST /api/admin/identity-group-sync/skipped-users/{source_id}/resolve`
+
+Links a skipped upstream member to a Keycloak subject or marks the record intentionally ignored.
+
+**Request**
+
+```json
+{
+  "resolution": "link_user",
+  "user_subject": "user-123"
+}
+```
+
+## Errors
+
+- `400`: invalid regex, unsupported role map, invalid provider capability, or malformed request.
+- `403`: missing ReBAC permission for provider, team, or admin surface.
+- `409`: stale dry-run, team slug collision, conflicting rule priority, or unsafe removal blocked.
+- `422`: valid request shape but unresolved identity links or conflicts prevent apply.
+- `500`: unexpected provider, database, Keycloak, or OpenFGA failure.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/openfga-model-contract.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/openfga-model-contract.md
@@ -1,0 +1,126 @@
+# Contract: OpenFGA Model Shape
+
+## Scope
+
+This contract documents the target relationship model that the implementation must encode in OpenFGA. Exact syntax may vary as the deploy model is evolved, but every runtime check must map to a resource, relation, subject, and action from this contract.
+
+## Subject Types
+
+- `user:<keycloak-subject>`
+- `team:<team-slug>#member`
+- `team:<team-slug>#admin`
+- `external_group:<provider-id>/<group-id>#member`
+- `slack_channel:<workspace-id>/<channel-id>#member`
+- `service_account:<id>`
+- `anonymous:*` only when explicitly intended and documented.
+
+## Resource Types
+
+- `organization`
+- `team`
+- `external_group`
+- `slack_workspace`
+- `slack_channel`
+- `agent`
+- `mcp_server`
+- `tool`
+- `knowledge_base`
+- `document`
+- `skill`
+- `task`
+- `conversation`
+- `admin_surface`
+- `policy`
+- `audit_view`
+- `secret_reference`
+- `system_config`
+
+## Standard Actions
+
+| Action | Purpose |
+|--------|---------|
+| `discover` | Resource appears in selectors/search. |
+| `read` | View resource metadata or contents. |
+| `use` | Use a resource without changing it. |
+| `invoke` | Invoke an agent or task-capable resource. |
+| `call` | Call an MCP server/tool. |
+| `write` | Update mutable resource data. |
+| `create` | Create child resources in a scope. |
+| `delete` | Delete or archive a resource. |
+| `manage` | Manage assignments and settings. |
+| `administer` | Delegate/administer policy for a resource. |
+| `audit` | View audit and decision history. |
+| `approve` | Approve staged policy changes. |
+| `share` | Share a resource with another subject/scope. |
+| `ingest` | Add documents or data to a knowledge base. |
+
+## Relationship Families
+
+### Team Membership
+
+```text
+team:<slug>#member <- user:<subject>
+team:<slug>#admin <- user:<subject>
+team:<slug>#member <- external_group:<provider>/<group>#member
+team:<slug>#admin <- external_group:<provider>/<group>#member
+```
+
+### Team Resource Access
+
+```text
+agent:<id>#can_use <- team:<slug>#member
+agent:<id>#can_manage <- team:<slug>#admin
+tool:<id>#can_call <- team:<slug>#member
+knowledge_base:<id>#can_read <- team:<slug>#member
+knowledge_base:<id>#can_ingest <- team:<slug>#admin
+skill:<id>#can_use <- team:<slug>#member
+task:<id>#can_invoke <- team:<slug>#member
+```
+
+### Slack Channel Access
+
+```text
+slack_channel:<workspace>/<channel>#member <- user:<subject>
+slack_channel:<workspace>/<channel>#admin <- team:<slug>#admin
+slack_channel:<workspace>/<channel>#allowed_agent <- agent:<id>
+slack_channel:<workspace>/<channel>#allowed_tool <- tool:<id>
+slack_channel:<workspace>/<channel>#allowed_knowledge_base <- knowledge_base:<id>
+```
+
+Runtime checks must combine:
+
+```text
+user is channel member
+channel is allowed selected resource
+user/team can use selected resource
+```
+
+### Admin Surface Access
+
+```text
+admin_surface:<key>#can_read <- team:<slug>#admin
+admin_surface:<key>#can_manage <- team:<slug>#admin
+admin_surface:<key>#can_audit <- audit_view:<id>#viewer
+```
+
+### Policy Ownership
+
+```text
+policy:<id>#owner <- user:<subject>
+policy:<id>#approver <- team:<slug>#admin
+policy:<id>#can_apply <- admin_surface:rebac#can_manage
+```
+
+## Validation Rules
+
+- Every tuple must use a known resource type and relation.
+- Every action exposed in the UI must resolve to one or more model relations.
+- Relationship write APIs must reject unknown types, unknown relations, and subjects outside the caller's delegated scope.
+- Public/anonymous access must use an explicit resource relationship and must be visible in the graph.
+- ReBAC-denied checks are final unless the runtime surface is still explicitly marked `rebac_shadowed`.
+
+## Migration Notes
+
+- Keycloak resource roles can temporarily generate corresponding ReBAC tuples during migration.
+- CEL admin tab policies and AgentGateway MCP policies can run in shadow mode until the matching ReBAC check is verified.
+- OpenFGA model changes must be deployed before tuple writers emit new relation names.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md
@@ -1,0 +1,249 @@
+# Contract: Universal ReBAC Policy API
+
+## Scope
+
+These BFF endpoints expose guided relationship authoring, graph visualization, tuple inspection, and access checking across all CAIPE resource types. Raw OpenFGA access remains server-side only; clients interact through validated CAIPE resource and relationship contracts.
+
+## Authorization
+
+- All endpoints require an authenticated session.
+- Read endpoints require `read` on the OpenFGA/ReBAC admin surface or a scoped relationship to the requested resource.
+- Write endpoints require `manage` on the target resource or delegated policy scope.
+- Access checker requests can be limited to the caller's subject unless the caller has audit/admin permission.
+
+## Resource Reference
+
+```json
+{
+  "type": "agent",
+  "id": "platform-engineer",
+  "display_name": "Platform Engineer"
+}
+```
+
+Supported resource types include:
+
+- `organization`
+- `user`
+- `external_group`
+- `team`
+- `slack_workspace`
+- `slack_channel`
+- `agent`
+- `mcp_server`
+- `tool`
+- `knowledge_base`
+- `document`
+- `skill`
+- `task`
+- `conversation`
+- `admin_surface`
+- `policy`
+- `audit_view`
+- `secret_reference`
+- `system_config`
+
+## Relationship Request
+
+```json
+{
+  "subject": {
+    "type": "team",
+    "id": "platform",
+    "relation": "member"
+  },
+  "action": "use",
+  "resource": {
+    "type": "agent",
+    "id": "platform-engineer"
+  },
+  "source": {
+    "type": "manual",
+    "id": "change-set-123"
+  }
+}
+```
+
+## Endpoints
+
+### `GET /api/admin/rebac/catalog`
+
+Returns all resources visible to the caller for policy authoring.
+
+**Query**
+
+- `type`: optional resource type filter.
+- `team`: optional team scope.
+- `status`: optional status filter.
+- `search`: optional display-name search.
+
+**Response**
+
+```json
+{
+  "resources": [
+    {
+      "type": "agent",
+      "id": "platform-engineer",
+      "display_name": "Platform Engineer",
+      "status": "active",
+      "enforcement_status": "rebac_enforced"
+    }
+  ],
+  "actions": {
+    "agent": ["discover", "read", "use", "manage", "invoke"],
+    "tool": ["discover", "read", "use", "manage", "call"]
+  }
+}
+```
+
+### `POST /api/admin/rebac/change-sets`
+
+Creates a staged set of relationship grants and revocations.
+
+**Request**
+
+```json
+{
+  "description": "Grant platform team access to Slack channel resources",
+  "grants": [
+    {
+      "subject": { "type": "team", "id": "platform", "relation": "member" },
+      "action": "use",
+      "resource": { "type": "agent", "id": "platform-engineer" }
+    }
+  ],
+  "revocations": []
+}
+```
+
+**Response**
+
+```json
+{
+  "change_set_id": "change-set-123",
+  "status": "validating",
+  "validation": {
+    "allowed": true,
+    "warnings": [],
+    "blocked_changes": []
+  }
+}
+```
+
+### `POST /api/admin/rebac/change-sets/{change_set_id}/validate`
+
+Validates the staged change set for relationship shape, delegated admin scope, circular grants, and unsafe revocations.
+
+### `POST /api/admin/rebac/change-sets/{change_set_id}/apply`
+
+Writes validated relationships to OpenFGA and records provenance in MongoDB.
+
+**Response**
+
+```json
+{
+  "change_set_id": "change-set-123",
+  "status": "applied",
+  "applied": {
+    "grants": 1,
+    "revocations": 0
+  }
+}
+```
+
+### `GET /api/admin/rebac/graph`
+
+Returns graph nodes and edges for a scope.
+
+**Query**
+
+- `scope`: `all`, `team`, `resource`, `subject`, or `slack_channel`.
+- `scope_id`: required unless scope is `all`.
+- `limit`: maximum edge count.
+- `cursor`: pagination cursor.
+
+**Response**
+
+```json
+{
+  "nodes": [
+    {
+      "id": "team:platform#member",
+      "type": "team",
+      "label": "Platform members"
+    },
+    {
+      "id": "agent:platform-engineer",
+      "type": "agent",
+      "label": "Platform Engineer"
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-1",
+      "from": "team:platform#member",
+      "to": "agent:platform-engineer",
+      "relation": "can_use",
+      "source_type": "manual"
+    }
+  ],
+  "truncated": false,
+  "next_cursor": null
+}
+```
+
+### `POST /api/admin/rebac/check`
+
+Checks and explains an access decision.
+
+**Request**
+
+```json
+{
+  "subject": {
+    "type": "user",
+    "id": "user-123"
+  },
+  "action": "use",
+  "resource": {
+    "type": "agent",
+    "id": "platform-engineer"
+  },
+  "context": {
+    "slack_channel": "C123"
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "allowed": true,
+  "decision": "allow",
+  "checked_at": "2026-05-11T00:00:00Z",
+  "explanation": {
+    "path": [
+      "user:user-123 member of team:platform",
+      "team:platform#member can_use agent:platform-engineer"
+    ],
+    "policy_sources": ["manual:change-set-123"]
+  }
+}
+```
+
+### `GET /api/admin/rebac/resources/{type}/{id}/relationships`
+
+Returns active and staged relationships for a resource.
+
+### `GET /api/admin/rebac/enforcement-status`
+
+Reports which resource types and runtime surfaces are not gated, role-gated, shadowed, or ReBAC-enforced.
+
+## Errors
+
+- `400`: unsupported resource type/action, malformed subject, or invalid graph scope.
+- `403`: caller cannot inspect or mutate the requested scope.
+- `409`: change set stale, unsafe last-admin revocation, or conflicting relationship ownership.
+- `422`: relationship shape valid but unsupported by the OpenFGA model.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/slack-rebac-api.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/contracts/slack-rebac-api.md
@@ -1,0 +1,175 @@
+# Contract: Slack Channel ReBAC Administration and Runtime
+
+## Scope
+
+Slack channel access becomes many-to-many. A Slack channel can be granted access to multiple agents, tools, and knowledge bases, while users must still satisfy team/channel/resource ReBAC checks before invoking anything from Slack.
+
+## Admin Endpoints
+
+### `GET /api/admin/slack/channels`
+
+Lists Slack channels visible to the caller.
+
+**Query**
+
+- `team`: optional CAIPE team scope.
+- `search`: optional channel name search.
+
+**Response**
+
+```json
+{
+  "channels": [
+    {
+      "workspace_id": "T123",
+      "channel_id": "C123",
+      "name": "platform-support",
+      "team_slugs": ["platform"],
+      "status": "active"
+    }
+  ]
+}
+```
+
+### `GET /api/admin/slack/channels/{workspace_id}/{channel_id}/resources`
+
+Returns resources currently exposed through a Slack channel.
+
+**Response**
+
+```json
+{
+  "channel": {
+    "workspace_id": "T123",
+    "channel_id": "C123",
+    "name": "platform-support"
+  },
+  "resources": [
+    {
+      "resource_type": "agent",
+      "resource_id": "platform-engineer",
+      "relationship": "allowed_agent",
+      "status": "active",
+      "source_type": "manual"
+    },
+    {
+      "resource_type": "knowledge_base",
+      "resource_id": "platform-runbooks",
+      "relationship": "allowed_knowledge_base",
+      "status": "active",
+      "source_type": "policy_rule"
+    }
+  ]
+}
+```
+
+### `POST /api/admin/slack/channels/{workspace_id}/{channel_id}/resources`
+
+Stages or applies resource grants for a Slack channel.
+
+**Request**
+
+```json
+{
+  "mode": "stage",
+  "grants": [
+    {
+      "resource_type": "agent",
+      "resource_id": "platform-engineer",
+      "relationship": "allowed_agent"
+    },
+    {
+      "resource_type": "tool",
+      "resource_id": "argocd.list_applications",
+      "relationship": "allowed_tool"
+    }
+  ],
+  "revocations": []
+}
+```
+
+**Response**
+
+```json
+{
+  "change_set_id": "change-set-slack-001",
+  "status": "validating",
+  "validation": {
+    "allowed": true,
+    "warnings": []
+  }
+}
+```
+
+### `POST /api/admin/slack/channels/{workspace_id}/{channel_id}/access-check`
+
+Previews whether a Slack user can invoke a selected resource from a channel.
+
+**Request**
+
+```json
+{
+  "user_subject": "user-123",
+  "resource_type": "agent",
+  "resource_id": "platform-engineer",
+  "action": "invoke"
+}
+```
+
+**Response**
+
+```json
+{
+  "allowed": true,
+  "checks": [
+    {
+      "name": "channel_membership",
+      "allowed": true
+    },
+    {
+      "name": "channel_resource_grant",
+      "allowed": true
+    },
+    {
+      "name": "user_resource_access",
+      "allowed": true
+    }
+  ]
+}
+```
+
+## Runtime Contract
+
+Slack bot runtime must perform these checks for a message or slash command:
+
+1. Resolve Slack user to a Keycloak user subject.
+2. Resolve Slack channel to `slack_channel:<workspace_id>/<channel_id>`.
+3. Resolve selected agent/tool/knowledge base resource.
+4. Check user access to the Slack channel.
+5. Check channel access to the selected resource.
+6. Check user/team access to the selected resource.
+7. Deny by default with a user-safe explanation if any check fails.
+
+### Runtime Decision Shape
+
+```json
+{
+  "allowed": false,
+  "decision": "deny",
+  "reason_code": "channel_resource_not_granted",
+  "safe_message": "This Slack channel is not authorized to use the selected agent.",
+  "audit": {
+    "workspace_id": "T123",
+    "channel_id": "C123",
+    "resource_type": "agent",
+    "resource_id": "platform-engineer"
+  }
+}
+```
+
+## Errors
+
+- `403`: caller cannot administer the channel or selected resource.
+- `404`: channel/resource not found or hidden from caller scope.
+- `409`: selected channel is archived or resource enforcement state blocks the operation.
+- `422`: relationship is unsupported for the selected resource type.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/data-model.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/data-model.md
@@ -1,0 +1,399 @@
+# Data Model: Enterprise Identity Group Sync and Universal ReBAC
+
+## Overview
+
+This feature separates four kinds of state:
+
+- **Identity input**: upstream provider groups, user identities, and group claims.
+- **Administrative intent**: sync rules, manual team membership, policy ownership, and staged policy changes.
+- **Authorization facts**: active ReBAC relationships used for allow/deny checks.
+- **Audit and explainability**: sync runs, relationship source records, drift findings, access-check explanations, and enforcement status.
+
+MongoDB stores identity sync intent, provenance, status, and UI-friendly records. OpenFGA stores active relationship facts. Keycloak stores user identity, token issuance state, and limited bootstrap/transitional roles.
+
+## Entities
+
+### IdentityProvider
+
+Represents an upstream group source.
+
+**Fields**
+
+- `id`: stable provider identifier, such as `okta-primary`, `ad-corporate`, or `oidc-claims`.
+- `type`: `okta`, `active_directory`, or `oidc_claims`.
+- `display_name`: administrator-facing label.
+- `status`: `not_configured`, `configured`, `healthy`, `degraded`, or `disabled`.
+- `last_checked_at`: latest provider health check time.
+- `capabilities`: supported operations such as group listing, group member listing, delta sync, and immutable group IDs.
+
+**Relationships**
+
+- Has many `ExternalGroup`.
+- Has many `IdentityGroupSyncRule`.
+- Has many `IdentityGroupSyncRun`.
+
+**Validation**
+
+- Provider identifiers are unique.
+- Disabled providers cannot run scheduled sync.
+- Secrets and credentials are never stored in this entity as source-controlled values.
+
+### IdentityGroupSyncRule
+
+Defines how upstream groups become CAIPE teams and membership relationships.
+
+**Fields**
+
+- `id`: stable rule identifier.
+- `provider_id`: target provider.
+- `name`: administrator-facing rule name.
+- `priority`: integer ordering, lower values evaluated first.
+- `enabled`: whether the rule can affect applied sync.
+- `review_status`: `draft`, `dry_run_required`, `reviewed`, `enabled`, or `disabled`.
+- `include_patterns`: ordered group matching patterns.
+- `exclude_patterns`: patterns that prevent a group from matching.
+- `team_name_template`: template for generated team display name.
+- `team_slug_template`: template for generated team slug.
+- `role_map`: mapping from captured upstream role labels to CAIPE relationships such as `member` and `admin`.
+- `auto_create_team`: whether approved matches can create teams.
+- `default_relationship_policy_ids`: optional approved policies that can create baseline relationships for newly created teams.
+- `created_by`, `created_at`, `updated_by`, `updated_at`.
+
+**Relationships**
+
+- Belongs to `IdentityProvider`.
+- Produces `ExternalGroupTeamLink`.
+- Produces `TeamMembershipSource`.
+- Referenced by `IdentityGroupSyncRun`.
+
+**Validation**
+
+- Rule IDs are unique.
+- Priorities are deterministic within a provider.
+- Include patterns must contain enough captured data to derive team slug and role.
+- Rules that create teams or memberships require dry-run review before enablement.
+- A rule cannot directly grant application resources unless it references an approved default relationship policy.
+
+### ExternalGroup
+
+Represents a group discovered from an upstream provider.
+
+**Fields**
+
+- `provider_id`: source provider.
+- `external_group_id`: immutable upstream group identifier when available.
+- `display_name`: current upstream display name.
+- `normalized_name`: normalized value used for matching and search.
+- `status`: `active`, `inactive`, `deleted`, `renamed`, `unreadable`, or `unknown`.
+- `member_count`: latest known member count.
+- `last_seen_at`: latest discovery time.
+- `metadata`: non-secret provider attributes useful for audit and display.
+
+**Relationships**
+
+- Belongs to `IdentityProvider`.
+- May link to one or more `Team` records through `ExternalGroupTeamLink`.
+- May produce many `TeamMembershipSource` records.
+
+**Validation**
+
+- Prefer immutable group ID for identity. Display name is mutable and cannot be the only key if an immutable ID exists.
+- Deleted or unreadable groups cannot create new memberships.
+
+### ExternalGroupTeamLink
+
+Records how an external group maps to a CAIPE team.
+
+**Fields**
+
+- `provider_id`.
+- `external_group_id`.
+- `sync_rule_id`.
+- `team_id`.
+- `team_slug`.
+- `relationship_role`: `member` or `admin`.
+- `status`: `active`, `stale`, `conflicted`, `disabled`, or `pending_review`.
+- `first_seen_at`, `last_seen_at`, `last_applied_at`.
+- `conflict_reason`: optional explanation.
+
+**Relationships**
+
+- Belongs to `ExternalGroup`.
+- Belongs to `Team`.
+- Belongs to `IdentityGroupSyncRule`.
+
+**Validation**
+
+- One active link for a provider/group/rule/role target.
+- Conflicting generated team slugs must not auto-merge without review.
+
+### Team
+
+Local collaboration and authorization grouping.
+
+**Fields**
+
+- `id`.
+- `slug`: stable resource identifier.
+- `name`: display name.
+- `description`.
+- `source`: `manual`, `identity_sync`, `bootstrap`, or `migration`.
+- `status`: `active`, `archived`, `pending_review`, or `disabled`.
+- `owner_id`.
+- `created_by`, `created_at`, `updated_by`, `updated_at`.
+
+**Relationships**
+
+- Has many `TeamMembershipSource`.
+- Has many ReBAC relationships to resources.
+- May have many `ExternalGroupTeamLink`.
+- May administer scoped resources.
+
+**Validation**
+
+- Slugs are unique and deterministic.
+- Team archive disables new grants but does not silently delete audit history.
+- Team creation from group sync requires approved mapping and no unresolved slug collision.
+
+### TeamMembershipSource
+
+Explains why a user has a team relationship.
+
+**Fields**
+
+- `team_id`, `team_slug`.
+- `user_subject`: Keycloak subject when known.
+- `user_email`: email or username used for resolution.
+- `relationship`: `member` or `admin`.
+- `source_type`: `manual`, `okta`, `active_directory`, `oidc_claim`, `bootstrap`, `migration`, or `policy_rule`.
+- `provider_id`: optional upstream provider.
+- `external_group_id`: optional upstream group identifier.
+- `sync_rule_id`: optional mapping rule.
+- `managed`: whether automated sync can remove this source.
+- `status`: `active`, `stale`, `pending_identity_link`, `disabled_user`, `removed`, or `error`.
+- `first_seen_at`, `last_seen_at`, `last_applied_at`.
+- `created_by`, `created_at`, `removed_by`, `removed_at`.
+
+**Relationships**
+
+- Belongs to `Team`.
+- May belong to `ExternalGroupTeamLink`.
+- Materializes a ReBAC relationship from `user:<subject>` to `team:<slug>`.
+
+**Validation**
+
+- Multiple active sources can grant the same relationship.
+- Removing one managed source does not revoke access while another active source remains.
+- Sources without a resolved subject cannot create active ReBAC tuples.
+
+### ReBACResource
+
+Canonical representation of a protected resource.
+
+**Fields**
+
+- `resource_type`: organization, user, external group, team, Slack workspace, Slack channel, agent, MCP server, tool, knowledge base, document, skill, task, conversation, admin surface, policy, audit view, secret reference, or system configuration.
+- `resource_id`.
+- `display_name`.
+- `status`: `active`, `disabled`, `archived`, `deleted`, or `unknown`.
+- `owner_subjects`: subjects that own or administer the resource.
+- `enforcement_status`: `not_gated`, `role_gated`, `rebac_shadowed`, `rebac_enforced`, or `deprecated`.
+- `metadata`: non-secret display/search attributes.
+
+**Relationships**
+
+- Target of `ReBACRelationship`.
+- Appears in graph and access checker results.
+
+**Validation**
+
+- Resource identifiers are unique by type and ID.
+- Deleted resources cannot receive new grants.
+- Public or anonymous access must be explicitly represented.
+
+### ReBACRelationship
+
+An active or staged authorization fact.
+
+**Fields**
+
+- `subject`: user, team members, team admins, external group, service account, or anonymous subject.
+- `action`: discover, read, use, write, create, delete, manage, administer, audit, approve, share, ingest, invoke, or call.
+- `resource`: typed resource reference.
+- `source_type`: manual, identity_sync, policy_rule, migration, bootstrap, or system.
+- `source_id`: optional sync rule, policy, or run reference.
+- `status`: `staged`, `active`, `revoked`, `blocked`, or `error`.
+- `created_by`, `created_at`, `revoked_by`, `revoked_at`.
+
+**Relationships**
+
+- Materialized in OpenFGA when active.
+- Linked to `PolicyChangeSet`, `IdentityGroupSyncRun`, or manual admin action for provenance.
+
+**Validation**
+
+- Action must be supported by the resource type.
+- Subject type must be valid for the relationship.
+- Privilege escalation checks must pass before save.
+
+### PolicyRule
+
+Reusable administrative rule that generates or validates relationships.
+
+**Fields**
+
+- `id`, `name`, `description`.
+- `scope`: global, team-scoped, provider-scoped, channel-scoped, or resource-scoped.
+- `rule_type`: default team baseline, Slack channel grant, admin delegation, resource template, migration, or validation-only.
+- `status`: draft, dry-run, active, disabled, or archived.
+- `generated_relationships`: expected relationship templates.
+- `approval_required`: whether changes need approval.
+- `created_by`, `created_at`, `updated_by`, `updated_at`.
+
+**Relationships**
+
+- May be referenced by `IdentityGroupSyncRule`.
+- Generates `PolicyChangeSet`.
+- Produces `ReBACRelationship` records.
+
+**Validation**
+
+- Rules that grant resources require explicit review.
+- Rules cannot grant permissions outside the author's own delegation scope.
+
+### PolicyChangeSet
+
+Staged relationship changes awaiting save or approval.
+
+**Fields**
+
+- `id`.
+- `status`: draft, validating, blocked, pending_approval, approved, applied, failed, or cancelled.
+- `grants`: relationships to add.
+- `revocations`: relationships to remove.
+- `blocked_changes`: invalid or unauthorized changes.
+- `impact_summary`.
+- `created_by`, `created_at`, `approved_by`, `applied_by`, `applied_at`.
+
+**Relationships**
+
+- Contains many `ReBACRelationship` candidates.
+- Produces audit events and OpenFGA tuple writes/deletes when applied.
+
+**Validation**
+
+- Must pass relationship validation before apply.
+- Must not remove the last administrator for critical resources unless override is approved.
+
+### SlackChannelGrant
+
+Channel-scoped access to agents, tools, and knowledge bases.
+
+**Fields**
+
+- `slack_workspace_id`.
+- `slack_channel_id`.
+- `resource_type`: agent, tool, or knowledge base.
+- `resource_id`.
+- `relationship`: allowed agent, allowed tool, allowed knowledge base, read, use, ingest, or manage.
+- `source_type`: manual, policy_rule, migration, or identity_sync.
+- `status`: active, disabled, revoked, or error.
+
+**Relationships**
+
+- Belongs to `SlackChannel`.
+- Links to resource-specific ReBAC relationships.
+
+**Validation**
+
+- A channel can have multiple grants.
+- A user must still satisfy channel access and selected resource access at invocation time.
+
+### IdentityGroupSyncRun
+
+Dry-run or applied reconciliation execution.
+
+**Fields**
+
+- `id`.
+- `mode`: dry_run, scheduled, manual_apply, or login_time_refresh.
+- `provider_id`.
+- `rule_ids`.
+- `status`: running, completed, completed_with_warnings, failed, cancelled.
+- `started_by`, `started_at`, `completed_at`.
+- `matched_groups`, `ignored_groups`, `created_teams`, `linked_teams`, `membership_adds`, `membership_removes`, `skipped_users`, `conflicts`, `warnings`, `errors`.
+- `relationship_grants`, `relationship_revocations`.
+
+**Relationships**
+
+- References rules, external groups, team links, membership sources, and relationship changes.
+
+**Validation**
+
+- Dry runs do not mutate state.
+- Applied runs record enough detail to reconstruct changes.
+
+### DriftFinding
+
+Mismatch between expected and actual authorization state.
+
+**Fields**
+
+- `id`.
+- `finding_type`: missing_team, missing_membership, stale_membership, role_mismatch, tuple_mismatch, disabled_user_active_access, deleted_resource_active_grant, or policy_conflict.
+- `severity`: info, warning, high, critical.
+- `status`: open, acknowledged, remediated, ignored.
+- `subject`, `resource`, `source`.
+- `detected_at`, `resolved_at`.
+- `recommended_action`.
+
+**Relationships**
+
+- May reference sync rules, teams, external groups, Keycloak roles, and ReBAC relationships.
+
+## State Transitions
+
+### IdentityGroupSyncRule
+
+```text
+draft -> dry_run_required -> reviewed -> enabled -> disabled
+draft -> disabled
+enabled -> disabled
+enabled -> dry_run_required   # after material rule edits
+```
+
+### TeamMembershipSource
+
+```text
+pending_identity_link -> active -> stale -> removed
+active -> disabled_user -> active
+active -> error -> active
+```
+
+### PolicyChangeSet
+
+```text
+draft -> validating -> pending_approval -> approved -> applied
+draft -> validating -> blocked
+pending_approval -> cancelled
+approved -> failed
+failed -> validating
+```
+
+### ReBACResource Enforcement
+
+```text
+not_gated -> role_gated -> rebac_shadowed -> rebac_enforced
+rebac_enforced -> deprecated
+```
+
+## Index and Query Considerations
+
+- Sync rule lookup by provider, status, and priority.
+- External group lookup by provider and immutable external group ID.
+- Team slug uniqueness.
+- Membership source lookup by team, user subject, source type, and status.
+- Sync run history by provider, mode, status, and started time.
+- Relationship provenance lookup by subject, resource, source type, and status.
+- Slack channel grant lookup by workspace, channel, resource type, and status.
+- Drift finding lookup by status, severity, finding type, and detected time.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/mongodb-migration.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/mongodb-migration.md
@@ -1,0 +1,208 @@
+# MongoDB Migration: Enterprise Identity Group Sync and Universal ReBAC
+
+## Required or No-Op
+
+Database changes are required. This feature introduces new MongoDB collections and indexes for identity group sync, relationship provenance, policy change sets, Slack channel multi-resource grants, enforcement status, and drift findings.
+
+No destructive migration is planned. Collections can be created lazily by the application, but production rollout should create indexes before enabling scheduled sync.
+
+## New Collections
+
+### `identity_providers`
+
+Stores non-secret provider metadata and health state.
+
+**Indexes**
+
+- Unique: `{ id: 1 }`
+- Query: `{ type: 1, status: 1 }`
+
+### `identity_group_sync_rules`
+
+Stores ordered regex mapping clusters.
+
+**Indexes**
+
+- Unique: `{ id: 1 }`
+- Query: `{ provider_id: 1, enabled: 1, priority: 1 }`
+- Query: `{ provider_id: 1, review_status: 1 }`
+
+### `external_groups`
+
+Stores discovered upstream group metadata.
+
+**Indexes**
+
+- Unique: `{ provider_id: 1, external_group_id: 1 }`
+- Query: `{ provider_id: 1, normalized_name: 1 }`
+- Query: `{ provider_id: 1, status: 1, last_seen_at: -1 }`
+
+### `external_group_team_links`
+
+Links external groups to CAIPE teams.
+
+**Indexes**
+
+- Unique: `{ provider_id: 1, external_group_id: 1, sync_rule_id: 1, relationship_role: 1 }`
+- Query: `{ team_id: 1, status: 1 }`
+- Query: `{ sync_rule_id: 1, status: 1 }`
+
+### `team_membership_sources`
+
+Tracks why a user has a team relationship.
+
+**Indexes**
+
+- Query: `{ team_id: 1, user_subject: 1, relationship: 1, status: 1 }`
+- Query: `{ source_type: 1, provider_id: 1, external_group_id: 1, status: 1 }`
+- Query: `{ sync_rule_id: 1, status: 1, last_seen_at: -1 }`
+- Query: `{ user_subject: 1, status: 1 }`
+
+### `rebac_resources`
+
+Stores canonical resource metadata for graph and authoring views.
+
+**Indexes**
+
+- Unique: `{ resource_type: 1, resource_id: 1 }`
+- Query: `{ resource_type: 1, status: 1 }`
+- Query: `{ enforcement_status: 1, resource_type: 1 }`
+
+### `rebac_relationship_sources`
+
+Stores relationship provenance and status for tuples written to OpenFGA.
+
+**Indexes**
+
+- Query: `{ "resource.type": 1, "resource.id": 1, status: 1 }`
+- Query: `{ "subject.type": 1, "subject.id": 1, status: 1 }`
+- Query: `{ source_type: 1, source_id: 1, status: 1 }`
+- Query: `{ status: 1, created_at: -1 }`
+
+### `policy_rules`
+
+Stores reusable relationship-generation rules.
+
+**Indexes**
+
+- Unique: `{ id: 1 }`
+- Query: `{ scope: 1, status: 1 }`
+- Query: `{ rule_type: 1, status: 1 }`
+
+### `policy_change_sets`
+
+Stores staged relationship grants/revocations and validation state.
+
+**Indexes**
+
+- Unique: `{ id: 1 }`
+- Query: `{ status: 1, created_at: -1 }`
+- Query: `{ created_by: 1, status: 1 }`
+
+### `slack_channel_grants`
+
+Stores Slack channel to resource grants for authoring and provenance.
+
+**Indexes**
+
+- Unique: `{ slack_workspace_id: 1, slack_channel_id: 1, resource_type: 1, resource_id: 1, relationship: 1 }`
+- Query: `{ slack_workspace_id: 1, slack_channel_id: 1, status: 1 }`
+- Query: `{ resource_type: 1, resource_id: 1, status: 1 }`
+
+### `identity_group_sync_runs`
+
+Stores dry-run and applied sync run summaries.
+
+**Indexes**
+
+- Unique: `{ id: 1 }`
+- Query: `{ provider_id: 1, mode: 1, status: 1, started_at: -1 }`
+- Query: `{ status: 1, started_at: -1 }`
+
+### `rbac_drift_findings`
+
+Stores reconciliation and enforcement drift findings.
+
+**Indexes**
+
+- Query: `{ status: 1, severity: 1, detected_at: -1 }`
+- Query: `{ finding_type: 1, status: 1 }`
+- Query: `{ "resource.type": 1, "resource.id": 1, status: 1 }`
+
+## Existing Collection Updates
+
+### `teams`
+
+Add optional fields:
+
+- `source`
+- `status`
+- `owner_id`
+- `external_group_links`
+- `created_by`
+- `updated_by`
+
+**Indexes**
+
+- Ensure unique team slug index exists.
+- Add query index `{ status: 1, source: 1 }`.
+
+### Existing Slack channel mapping data
+
+If the current stack stores one agent per channel, backfill equivalent `slack_channel_grants` records:
+
+- Channel to existing agent as `allowed_agent`.
+- Preserve original mapping source as `migration`.
+- Do not infer tool or knowledge base access.
+
+## Data Movement
+
+### Backfill Team Membership Sources
+
+For existing team membership records:
+
+1. Create `team_membership_sources` records with `source_type: "migration"`.
+2. Mark `managed: false`.
+3. Write active ReBAC team membership tuples if missing.
+4. Record skipped users whose Keycloak subject cannot be resolved.
+
+### Backfill Team Resource Relationships
+
+For existing team resource assignments:
+
+1. Create `rebac_relationship_sources` records with `source_type: "migration"`.
+2. Write matching OpenFGA tuples for agents, tools, and knowledge bases.
+3. Keep existing Keycloak resource roles until the relevant runtime surface is `rebac_enforced`.
+
+### Backfill Slack Channel Grants
+
+For existing channel-agent mappings:
+
+1. Create `rebac_resources` for Slack workspaces/channels.
+2. Create `slack_channel_grants` for the mapped agent.
+3. Write OpenFGA channel-resource relationships.
+4. Mark enforcement as `rebac_shadowed` until Slack runtime checks are enabled.
+
+## Rollback
+
+Rollback should be non-destructive:
+
+1. Disable scheduled identity group sync.
+2. Disable ReBAC-enforced runtime flags and return affected surfaces to `rebac_shadowed` or role-gated mode.
+3. Stop writing new tuples from sync runs.
+4. Preserve new MongoDB collections for audit unless a backup/restore plan is explicitly approved.
+5. If required, delete only tuples whose source is the rolled-back change set or sync run.
+
+## Environments
+
+- **Development**: Collections and indexes can be created on application startup or by a local migration script.
+- **Staging**: Create indexes, run migration backfills, verify graph/access checker, then enable scheduled sync in dry-run mode.
+- **Production**: Take a MongoDB backup, create indexes, run idempotent backfills in batches, run drift detection, enable dry-run scheduled sync, then promote runtime surfaces to ReBAC enforcement incrementally.
+
+## OpenFGA Migration Dependency
+
+The OpenFGA authorization model must support the target resource types and relations before backfills write new tuple types. Model rollout should precede tuple writers in each environment.
+
+## Keycloak Transition Dependency
+
+Keycloak resource roles remain during migration. New implementation should avoid creating permanent per-resource roles for every resource and should move resource authorization to OpenFGA as surfaces become `rebac_enforced`.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/plan.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Enterprise Identity Group Sync and Universal ReBAC
+
+**Branch**: `2026-05-11-identity-group-rebac` | **Date**: 2026-05-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `docs/docs/specs/2026-05-11-identity-group-rebac/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Expand CAIPE authorization from mixed Keycloak/CEL/resource-role checks into a ReBAC-first model where every protected resource is represented as an authorization object, every action is checked through relationships, Slack channels can access many agents/tools/knowledge bases, and Okta/AD/OIDC groups can create and maintain CAIPE team membership through reviewed regex mapping clusters. The implementation will introduce an Identity Group Sync domain, extend OpenFGA modeling and tuple authoring, add scoped admin surfaces and policy explanation, and migrate runtime policy enforcement incrementally while keeping Keycloak as identity and bootstrap-role infrastructure.
+
+## Technical Context
+
+**Language/Version**: TypeScript / Next.js 16 + React 19 for CAIPE Admin UI and BFF APIs; Python 3.11+ for Slack bot and AgentGateway OpenFGA bridge.  
+**Primary Dependencies**: NextAuth.js, MongoDB driver, Keycloak Admin REST, OpenFGA HTTP API, AgentGateway ext_authz, Slack Web API/Bolt, React Flow for graph visualization.  
+**Storage**: MongoDB for sync rules, sync runs, external group links, membership sources, team/channel/resource intent, audit metadata, and policy ownership metadata; OpenFGA for authorization tuples; Keycloak for identity, token issuance, limited realm roles, users, and upstream attributes.  
+**Testing**: Jest for UI/BFF unit and contract tests, Playwright for RBAC/admin E2E, pytest for Python Slack bot and bridge tests, existing RBAC matrix tests for authorization outcomes.  
+**Target Platform**: Docker Compose development stack and Kubernetes/Helm deployment path for CAIPE services.  
+**Project Type**: Web application with BFF APIs, Python integration services, identity provider integration, policy enforcement integrations, and documentation artifacts.  
+**Performance Goals**: Dry-run preview for 500 groups in under 5 minutes; filtered graph views under 5 seconds for typical admin datasets; authorization checks fast enough for Slack/AgentGateway interactive use without perceptible user delay.  
+**Constraints**: Deny by default; no secrets in source; dry-run before enabling new group mapping clusters; manual memberships preserved unless explicitly removed; immutable upstream group IDs preferred; no application-resource grants from group existence alone.  
+**Scale/Scope**: Enterprise group sync for hundreds of groups and thousands of users; universal ReBAC coverage for teams, users, groups, Slack channels, agents, tools, knowledge bases, skills, tasks, conversations, admin surfaces, policies, audit views, and system configuration scopes.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Worse is Better / YAGNI**: PASS. Plan favors staged delivery: first sync metadata and dry-run, then tuple materialization, then runtime enforcement migration. Avoids a one-shot rewrite of all authorization paths.
+- **Rule of Three / Composition**: PASS. New sync, policy authoring, graph, and enforcement responsibilities remain separate domains with explicit contracts; common relationship validation should be shared only after patterns repeat.
+- **Specs as Source of Truth**: PASS. This feature is driven from `spec.md` and generates plan, research, data model, contracts, quickstart, and migration notes before tasks.
+- **CI Gates Are Non-Negotiable**: PASS. Plan includes Jest, Playwright, pytest, and RBAC matrix coverage.
+- **Security by Default**: PASS. Deny-by-default ReBAC, dry-run review, scoped admin, audit records, immutable group IDs, no implicit anonymous access, no secrets in source.
+- **Documentation**: PASS. RBAC reference docs, API/config docs, and migration guidance must be updated during implementation.
+
+**Post-Design Re-Check**: PASS. `research.md`, `data-model.md`, contracts, quickstart, and `mongodb-migration.md` preserve the same gates. The design adds necessary storage and API surfaces for the requested enterprise sync and universal ReBAC scope without introducing unmanaged secrets, implicit grants, or unreviewed destructive sync behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/<YYYY-MM-DD-feature>/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+├── db-migration.md      # Phase 1 when storage is involved (see Database migrations below); optional name: mongodb-migration.md, sql-migrations.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+ui/
+├── src/app/api/admin/identity-group-sync/    # Sync rules, dry-run, apply, runs, links, remediation
+├── src/app/api/admin/openfga/                # Tuple, graph, relationship, check APIs expanded for universal resources
+├── src/app/api/admin/teams/                  # Team and manual membership management
+├── src/app/api/admin/slack/                  # Slack channel multi-resource grants
+├── src/app/api/rbac/                         # Access checker and enforcement status APIs
+├── src/components/admin/                     # Identity Group Sync, ReBAC graph, policy builder, scoped admin UI
+├── src/lib/rbac/                             # ReBAC model helpers, tuple builders, policy validation, Keycloak transition helpers
+└── src/types/                                # Shared UI/BFF types for sync, resources, policies, graph
+
+ai_platform_engineering/
+└── integrations/slack_bot/                   # Slack channel/team/resource enforcement and OBO context updates
+
+deploy/
+├── agentgateway/                             # PEP config templates and policy bridge metadata
+└── openfga-experiment/                       # OpenFGA model, seed, bridge behavior during migration
+
+tests/
+├── rbac/                                     # RBAC matrix, fixtures, and cross-surface authorization checks
+└── integration/                              # Service-level integration tests where applicable
+
+docs/docs/security/rbac/                     # Canonical RBAC architecture, workflows, usage, file map
+docs/docs/specs/2026-05-11-identity-group-rebac/
+```
+
+**Structure Decision**: Use the existing CAIPE web application and integration-service layout. Keep identity sync and policy authoring in the Next.js BFF/Admin UI boundary, keep Slack runtime enforcement in the Slack bot integration, keep AgentGateway/OpenFGA bridge changes under deploy assets, and keep matrix/E2E tests in existing RBAC test locations.
+
+## Database migrations
+
+*Include this section when **Technical Context → Storage** is not N/A (MongoDB, PostgreSQL, Redis persistence, etc.). Omit entirely for UI-only or stateless features.*
+
+**Deliverable**: `mongodb-migration.md` in this feature spec directory.
+
+MongoDB changes are required for sync rules, sync runs, external group links, membership source tracking, Slack channel multi-resource grants, relationship ownership metadata, and drift findings. OpenFGA model migration and Keycloak role transition are covered as operational migration steps linked from the MongoDB migration notes.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/quickstart.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/quickstart.md
@@ -1,0 +1,117 @@
+# Quickstart: Enterprise Identity Group Sync and Universal ReBAC
+
+## Goal
+
+Validate the planned feature in a local or development CAIPE stack before creating implementation tasks. The quickstart focuses on the end-to-end behavior administrators and runtime services must support.
+
+## Prerequisites
+
+- CAIPE development stack with UI, MongoDB, Keycloak, OpenFGA, AgentGateway, and Slack bot components available.
+- At least one admin user with bootstrap Keycloak admin role and matching ReBAC admin-surface access.
+- Test users in Keycloak.
+- Test teams, agents, tools, knowledge bases, skills, and tasks.
+- A test identity group source or fixture data that represents Okta/AD/OIDC groups.
+- Optional Slack workspace/channel fixture data for Slack channel checks.
+
+## Scenario 1: Create an Identity Group Mapping Cluster
+
+1. Open CAIPE Admin.
+2. Navigate to Identity Group Sync.
+3. Select an identity provider.
+4. Create a mapping cluster with:
+   - Include pattern matching approved team groups.
+   - Exclude pattern for experimental or legacy groups.
+   - Captures for team name and role.
+   - Role map from upstream group role to CAIPE `member` or `admin`.
+   - Auto-create team enabled.
+5. Save the rule.
+
+**Expected result**: The rule is saved as a draft or dry-run-required rule. It does not create teams, memberships, Keycloak roles, or OpenFGA tuples yet.
+
+## Scenario 2: Preview Sync Safely
+
+1. Run a dry-run for the new mapping cluster.
+2. Review matched groups, ignored groups, generated teams, skipped users, membership adds/removes, and ReBAC tuple diffs.
+3. Confirm any conflicts are visible and block apply.
+
+**Expected result**: Dry-run produces no mutations and explains exactly what would change.
+
+## Scenario 3: Apply Approved Sync
+
+1. Resolve conflicts and skipped users.
+2. Re-run dry-run until it is clean.
+3. Apply the reviewed run.
+4. Open the generated team.
+5. Inspect membership source records.
+
+**Expected result**: Teams are created when approved, memberships are active, source records show provider/group/rule provenance, and OpenFGA relationships exist for team membership.
+
+## Scenario 4: Preserve Manual Membership
+
+1. Manually add a user to a team.
+2. Add the same user through a synced group.
+3. Remove the user from the upstream group fixture.
+4. Run sync.
+
+**Expected result**: The synced source becomes stale or removed, but the user's effective team membership remains active because the manual source still grants it.
+
+## Scenario 5: Grant Team Access to Resources
+
+1. Open ReBAC Policy Builder.
+2. Select a team userset such as `team:platform#member`.
+3. Grant access to an agent, a tool, a knowledge base, a skill, and a task.
+4. Validate the staged change set.
+5. Apply it.
+6. Open the graph and access checker.
+
+**Expected result**: The graph shows the new relationships and the access checker explains allowed access paths for team members.
+
+## Scenario 6: Configure Slack Channel Many-to-Many Access
+
+1. Open a Slack channel in Admin.
+2. Grant the channel access to multiple agents, tools, and knowledge bases.
+3. Check a test user, channel, and resource invocation.
+
+**Expected result**: The access checker requires all of these to pass:
+
+- User can use the Slack channel.
+- Slack channel is allowed to expose the selected resource.
+- User or user's team can use the selected resource.
+
+## Scenario 7: Verify Deny-by-Default Runtime
+
+1. Remove the channel-to-agent grant.
+2. Try the same Slack invocation.
+3. Remove the team-to-agent grant.
+4. Try the invocation again.
+
+**Expected result**: Each missing relationship causes a deny with a safe reason code and an audit record. No Keycloak realm role or legacy CEL rule should silently allow access once the surface is ReBAC-enforced.
+
+## Scenario 8: Review Enforcement Status
+
+1. Open the ReBAC enforcement status view.
+2. Inspect all resource types and runtime surfaces.
+
+**Expected result**: Each resource type is marked as `not_gated`, `role_gated`, `rebac_shadowed`, `rebac_enforced`, or `deprecated`. Implementation tasks must move critical paths to `rebac_enforced` with tests.
+
+## Verification Commands
+
+Run the relevant checks after implementation:
+
+```bash
+make lint
+make test
+make caipe-ui-tests
+make test-rbac
+```
+
+Targeted checks expected for this feature:
+
+```bash
+npm run test -- --runInBand identity-group-sync
+npm run test -- --runInBand rebac
+PYTHONPATH=. uv run pytest tests/rbac -v
+PYTHONPATH=. uv run pytest integration/ -k "slack and rbac" -v
+```
+
+Exact commands may be adjusted during `/speckit.tasks` based on the files selected for implementation.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/research.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/research.md
@@ -1,0 +1,112 @@
+# Research: Enterprise Identity Group Sync and Universal ReBAC
+
+## Decision: Treat enterprise groups as identity inputs, not direct application grants
+
+**Decision**: Okta, Active Directory, and OIDC group claims will feed CAIPE team membership and team administration relationships. Enterprise group existence alone will not grant agents, tools, knowledge bases, skills, tasks, Slack channels, or admin pages.
+
+**Rationale**: Enterprise groups are useful organizational inputs but often contain naming conventions, nesting, exceptions, and stale memberships that do not directly match product authorization intent. Resolving groups into CAIPE teams keeps enterprise identity as the source for membership while preserving product-level ReBAC as the source for resource access.
+
+**Alternatives considered**:
+
+- Grant resources directly from external groups. Rejected because it couples product policy to upstream naming and makes access explanations brittle when groups are renamed or repurposed.
+- Ignore external groups and keep manual teams only. Rejected because it cannot scale and would drift from enterprise identity.
+
+## Decision: Use ordered regex mapping clusters with dry-run approval
+
+**Decision**: Group-to-team sync will use multiple ordered mapping clusters. Each cluster can include and exclude group patterns, capture team and role components, map captured role values to CAIPE member/admin relationships, and preview results before enablement.
+
+**Rationale**: Enterprises rarely have one naming convention. Ordered clusters let CAIPE support multiple patterns without hardcoding provider-specific logic. Dry-run approval is required because mapping mistakes can create teams or revoke memberships at scale.
+
+**Alternatives considered**:
+
+- One global regex. Rejected because it cannot model multiple naming families or migrations.
+- Manual mapping table only. Rejected because it is too costly for hundreds of groups.
+- Automatic enablement after saving a rule. Rejected because unsafe mappings can create or remove access before review.
+
+## Decision: Preserve manual membership as a separate source
+
+**Decision**: Team membership will track source records. A user can have the same team relationship from manual assignment, Okta group, AD group, OIDC claim, bootstrap, or policy rule. Removing one source removes only that source, not the relationship if another source remains active.
+
+**Rationale**: Manual assignments are needed for bootstrap, exceptions, temporary access, and teams that do not yet have upstream groups. Source tracking prevents sync from deleting intentionally manual access and provides explainability.
+
+**Alternatives considered**:
+
+- Store only a flattened team member list. Rejected because it cannot explain or safely revoke multi-source membership.
+- Let sync own all team membership. Rejected because it breaks manual emergency and migration workflows.
+
+## Decision: Represent every protected item as a ReBAC resource
+
+**Decision**: Users, teams, external groups, Slack workspaces, Slack channels, agents, MCP servers, tools, knowledge bases, documents, skills, tasks, conversations, admin surfaces, policies, audit views, secret references, and system configuration scopes will be modeled as ReBAC resources with a shared action vocabulary.
+
+**Rationale**: The user's stated goal is that every atomic resource is gated. A universal resource vocabulary makes access checks, graph visualization, admin scoping, and audit explanation consistent across product surfaces.
+
+**Alternatives considered**:
+
+- Model only agents/tools/knowledge bases in ReBAC. Rejected because admin pages, Slack channels, tasks, and skills would remain bypass-prone side paths.
+- Keep resource-specific ad hoc permission systems. Rejected because it prevents a single graph and access checker from explaining decisions.
+
+## Decision: Keep Keycloak for identity and migration compatibility, not final resource authorization
+
+**Decision**: Keycloak remains the identity provider, token issuer, and bootstrap/global-role source. Resource-specific realm roles remain only as transitional compatibility until matching ReBAC enforcement is active.
+
+**Rationale**: Existing services depend on Keycloak tokens and roles. Removing roles immediately would be disruptive, but continuing to treat them as final resource grants would conflict with ReBAC as the target PDP.
+
+**Alternatives considered**:
+
+- Replace Keycloak roles immediately. Rejected due to migration risk and current runtime dependencies.
+- Keep all current resource roles permanently. Rejected because role explosion and encoded string semantics do not scale to scoped administration or graph explainability.
+
+## Decision: Slack channels are first-class many-to-many authorization resources
+
+**Decision**: Slack channels will be modeled as resources that can be associated with multiple agents, tools, and knowledge bases. Slack invocation must satisfy channel access and selected resource access.
+
+**Rationale**: A Slack channel is a collaboration space, not a single-agent binding. The current one-channel-to-one-agent mapping cannot represent real team workflows. ReBAC relationships can express channel-to-many-resource access and channel-scoped administrators.
+
+**Alternatives considered**:
+
+- Keep one bound agent per channel. Rejected by requirement and insufficient for multi-agent workflows.
+- Treat Slack channel membership as enough to use all team resources. Rejected because teams may need different channels with different agent/tool/KB exposure.
+
+## Decision: Policy authoring must be guided, staged, and validated
+
+**Decision**: Administrators create and update ReBAC relationships through guided forms and graph interactions that stage grants/revocations, validate them, preview impact, and audit every saved change.
+
+**Rationale**: Raw tuple editing is powerful but error-prone. The UI must support safe delegation to scoped admins who may not understand low-level relationship syntax.
+
+**Alternatives considered**:
+
+- Raw tuple editor only. Rejected because it is not safe enough for scoped administrators.
+- Hardcoded resource assignment screens only. Rejected because the resource set is broad and needs graph visibility.
+
+## Decision: Use graph visualization and access checker as operational controls
+
+**Decision**: CAIPE will provide all-relationships graph visualization and an access checker that explains allowed and denied decisions.
+
+**Rationale**: ReBAC systems are difficult to operate without explainability. Administrators need to answer who has access, why they have it, which upstream group or policy created it, and what is missing when access is denied.
+
+**Alternatives considered**:
+
+- Provide only tabular tuple lists. Rejected because tuple lists do not show paths or inheritance clearly.
+- Provide only runtime denials. Rejected because support and audit workflows need proactive investigation.
+
+## Decision: MongoDB stores intent and provenance; OpenFGA stores relationship facts
+
+**Decision**: MongoDB will store sync rules, sync runs, external group links, membership sources, policy change metadata, relationship ownership, and UI intent. OpenFGA will store the active relationship facts used for ReBAC checks.
+
+**Rationale**: OpenFGA is optimized for relationship checks, not full administrative provenance. MongoDB is already the source for CAIPE team/resource intent and can store audit-friendly metadata, status, and previews.
+
+**Alternatives considered**:
+
+- Store all metadata only in OpenFGA. Rejected because provenance, dry-run state, and sync history require richer records.
+- Store all authorization only in MongoDB. Rejected because the target architecture requires a dedicated ReBAC PDP.
+
+## Decision: Scheduled sync plus login-time refresh
+
+**Decision**: The system supports dry-run, scheduled reconciliation, and login-time refresh. Scheduled sync remains authoritative for cleanup and drift detection; login-time refresh accelerates membership updates for the current user when trusted group claims are present.
+
+**Rationale**: Scheduled sync is reliable for full reconciliation. Login-time refresh improves user experience after group changes but cannot safely prune absent users or detect deleted groups by itself.
+
+**Alternatives considered**:
+
+- Scheduled sync only. Rejected because users may wait too long after group membership changes.
+- Login-time sync only. Rejected because it cannot reconcile users who do not log in and cannot detect global drift.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/spec.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/spec.md
@@ -1,0 +1,334 @@
+# Feature Specification: Enterprise Identity Group Sync and Universal ReBAC
+
+**Feature Branch**: `2026-05-11-identity-group-rebac`  
+**Created**: 2026-05-11  
+**Status**: Draft  
+**Input**: User description: "Create a very detailed specification for comprehensive ReBAC authorization expansion, including Okta/AD group synchronization to create teams and memberships, manual team management, automatic ReBAC based on rules, Keycloak realm roles, representation of every atomic resource in ReBAC, UI-based policy creation and updating, graph visualization, policy access checking, and Slack channel access to multiple agents, tools, and knowledge bases."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sync Enterprise Groups Into CAIPE Teams (Priority: P1)
+
+An identity administrator wants CAIPE to mirror enterprise group membership from Okta or Active Directory into CAIPE teams. When a group name matches an approved mapping rule, CAIPE should create the corresponding team if it does not already exist, assign users to the appropriate team relationship, and keep the relationship current as upstream group membership changes.
+
+**Why this priority**: Enterprise groups are the primary source of organizational truth. Without group synchronization, team membership must be maintained manually and ReBAC policy will drift from enterprise identity.
+
+**Independent Test**: Can be fully tested by configuring group mapping rules, running a dry run against representative groups, approving the sync, and confirming that expected CAIPE teams and user-team relationships are created, updated, and removed without granting unrelated resource access.
+
+**Acceptance Scenarios**:
+
+1. **Given** an enterprise group named `CAIPE-Platform-Engineering-Members` and no CAIPE team named `platform-engineering`, **When** an administrator runs group sync with a rule that captures the team name and member role, **Then** CAIPE creates the team and records each group member as a team member.
+2. **Given** an enterprise group named `CAIPE-Platform-Engineering-Admins`, **When** group sync evaluates the rule set, **Then** CAIPE records matching users as scoped administrators for the `platform-engineering` team.
+3. **Given** a user is removed from an upstream managed group, **When** the next sync runs, **Then** the managed membership is removed from CAIPE unless the user also has a manual or separately managed membership source that still grants access.
+4. **Given** a group mapping rule is configured in dry-run mode, **When** an administrator previews the sync, **Then** CAIPE shows teams to create, memberships to add, memberships to remove, conflicts, skipped users, and ReBAC relationship changes before any state is changed.
+
+---
+
+### User Story 2 - Manage Teams and Members Manually (Priority: P1)
+
+A platform administrator or scoped team administrator wants to create teams manually, add or remove members, assign team administrators, and preserve those manual assignments even when automated enterprise group sync also exists.
+
+**Why this priority**: Not all access comes from upstream identity groups. CAIPE must support bootstrap teams, temporary access, exceptions, and early adoption before enterprise group naming is fully standardized.
+
+**Independent Test**: Can be fully tested by creating a team in the admin UI, adding users manually, running group sync, and confirming manual members remain intact unless explicitly removed by an authorized administrator.
+
+**Acceptance Scenarios**:
+
+1. **Given** a platform administrator manually creates a CAIPE team, **When** the team is saved, **Then** the team is available as a ReBAC subject and can receive resource grants.
+2. **Given** a manually added member is not present in any matching enterprise group, **When** automated group sync runs, **Then** CAIPE preserves the manual membership and clearly labels it as manually managed.
+3. **Given** a scoped team administrator has management rights for one team, **When** they edit membership, **Then** they can manage only that team and cannot view or modify unrelated teams.
+
+---
+
+### User Story 3 - Represent Every Protected Resource in ReBAC (Priority: P1)
+
+A security administrator wants every meaningful CAIPE resource to be represented in ReBAC so access decisions are consistent across the UI, Slack, AgentGateway, agent execution, tools, knowledge bases, skills, tasks, conversations, policies, and admin pages.
+
+**Why this priority**: The end goal is that every resource is gated. Incomplete resource modeling creates bypasses, inconsistent admin behavior, and policies that cannot be visualized or audited end-to-end.
+
+**Independent Test**: Can be fully tested by selecting representative resources of each type, creating allow relationships, running policy checks for each action, and confirming unauthorized users are denied by default.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent, tool, knowledge base, skill, task, Slack channel, conversation, admin page, policy, and audit view exist, **When** the ReBAC graph is loaded, **Then** each appears as a distinct resource node with its supported relationships.
+2. **Given** no relationship grants a user access to a resource, **When** the user attempts to use, read, update, manage, or audit that resource, **Then** the action is denied.
+3. **Given** a team has a grant to use an agent but no grant to manage it, **When** a team member invokes the agent and then attempts to edit its configuration, **Then** invocation is allowed and configuration is denied.
+
+---
+
+### User Story 4 - Create and Update ReBAC Policies in the UI (Priority: P2)
+
+A platform administrator wants a rich policy-authoring UI that can create, review, update, and revoke relationships without hand-writing tuple data. The UI should support guided forms, graph editing, staged diffs, validation, and safe review before saving.
+
+**Why this priority**: ReBAC is powerful but easy to misuse if administrators must type raw relationships. A guided UI improves correctness and makes policy changes auditable.
+
+**Independent Test**: Can be fully tested by creating policies through the UI, previewing the change set, saving the policy, verifying the graph changes, and checking effective access before and after the update.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator selects a team and a resource, **When** they choose a supported action such as read, use, write, manage, or audit, **Then** CAIPE stages a valid ReBAC relationship for review.
+2. **Given** an administrator drags a resource node onto the graph and connects it to a team or user node, **When** the relationship is valid for the resource type, **Then** CAIPE stages the corresponding policy update.
+3. **Given** an administrator attempts to create an unsupported relationship, **When** they preview or save the policy, **Then** CAIPE blocks the change and explains which part is invalid.
+4. **Given** a staged policy diff contains grants and revocations, **When** the administrator saves it, **Then** CAIPE applies the diff atomically from the user's perspective and records an audit event for each relationship change.
+
+---
+
+### User Story 5 - Visualize All Relationships and Explain Access (Priority: P2)
+
+A platform administrator, auditor, or scoped administrator wants to see the complete authorization graph, filter it by team, user, resource, Slack channel, or provider group, and understand why a user can or cannot access a resource.
+
+**Why this priority**: A universal ReBAC model is only operable if administrators can inspect it. Visualization and explainability are required for troubleshooting, audits, and security reviews.
+
+**Independent Test**: Can be fully tested by creating a known set of teams, groups, resources, and relationships, loading the graph, filtering it, and comparing the graph and policy checker results to expected access paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple teams, Slack channels, agents, tools, knowledge bases, skills, and tasks have relationships, **When** an administrator opens the all-relationships graph, **Then** CAIPE displays the system-wide graph and allows filtering to a smaller scope.
+2. **Given** a user is a member of a synced enterprise group that maps to a CAIPE team, **When** the administrator asks why the user can access an agent, **Then** CAIPE shows the access path from enterprise group to team to resource.
+3. **Given** access is denied, **When** the administrator uses the policy checker, **Then** CAIPE identifies the missing relationship or conflicting prerequisite rather than returning only a generic denial.
+
+---
+
+### User Story 6 - Gate Slack Channels to Multiple Agents, Tools, and Knowledge Bases (Priority: P2)
+
+A team administrator wants one Slack channel to provide access to several agents, tools, and knowledge bases. The channel should no longer be limited to a single bound agent. Channel access should be governed by ReBAC relationships and should require both channel permission and resource permission.
+
+**Why this priority**: Slack channels are collaboration spaces, not one-agent endpoints. The current one-to-one channel-agent mapping cannot represent real team workflows.
+
+**Independent Test**: Can be fully tested by granting one Slack channel access to several agents and knowledge bases, invoking each from Slack as an authorized and unauthorized user, and confirming that access follows the configured relationships.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Slack channel is associated with a CAIPE team, **When** a team administrator grants the channel access to three agents, **Then** users in that team can choose from those agents in that channel subject to their resource permissions.
+2. **Given** an agent is not allowed in a Slack channel, **When** a user attempts to invoke that agent from the channel, **Then** CAIPE denies the request even if the user can use the agent elsewhere.
+3. **Given** a Slack channel has access to a knowledge base but not an ingestion permission, **When** a user asks a question from the channel and later attempts ingestion, **Then** reading is allowed and ingestion is denied.
+
+---
+
+### User Story 7 - Maintain Keycloak Realm Roles During the Transition (Priority: P3)
+
+A platform administrator needs the system to continue working while authorization transitions from role-heavy checks to ReBAC-first checks. Keycloak realm roles must remain understandable, bounded, and compatible with existing JWT-based paths until ReBAC is authoritative for each resource.
+
+**Why this priority**: Existing clients and services depend on Keycloak realm roles. A safe migration requires clear role semantics and a way to compare current role-based decisions with the target ReBAC decisions.
+
+**Independent Test**: Can be fully tested by reviewing a user's roles and ReBAC relationships side by side, then confirming the system applies the expected decision during the migration period.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has legacy realm roles and new ReBAC relationships, **When** an administrator opens an access explanation, **Then** CAIPE shows which decision source allowed or denied the action.
+2. **Given** a resource type has been migrated to ReBAC enforcement, **When** a stale resource-specific realm role exists, **Then** it no longer grants access by itself.
+3. **Given** the system still relies on realm roles for a not-yet-migrated resource type, **When** an administrator checks access, **Then** CAIPE clearly marks the resource as using transitional role-based enforcement.
+
+### Edge Cases
+
+- Upstream enterprise group names match multiple regex clusters; CAIPE must select a deterministic winner by priority and report the ambiguity.
+- Two different upstream groups normalize to the same CAIPE team slug; CAIPE must prevent accidental merges unless an administrator explicitly maps them to the same team.
+- A synced group contains users who do not have linked CAIPE identities; CAIPE must skip them, report them, and avoid creating orphan access relationships.
+- A user is granted membership by multiple sources, such as Okta group, AD group, and manual assignment; CAIPE must remove access only when all granting sources are gone.
+- A manually managed team has the same name as a newly discovered enterprise group; CAIPE must link or reject based on administrator-approved mapping rules, not silently overwrite ownership.
+- An enterprise group is deleted or renamed upstream; CAIPE must show the missing source, avoid deleting manually managed teams automatically, and apply configured pruning rules only to managed memberships.
+- A scoped administrator attempts to manage policies outside their scope; CAIPE must deny the action and record the denial.
+- A Slack channel has multiple agents and tools but a user has access to only some of them; CAIPE must show only allowed choices and deny direct attempts to invoke disallowed resources.
+- Anonymous users request public resources; CAIPE must allow only resources explicitly marked as public or anonymous-readable and deny all other actions.
+- A policy change would remove the last administrator for a team, channel, or critical resource; CAIPE must warn and require an authorized override or prevent the change.
+- The all-relationships graph is very large; CAIPE must provide filtering, pagination, or scope controls so administrators can still investigate access paths.
+- Sync runs partially fail; CAIPE must report which groups, users, teams, and relationships succeeded or failed and avoid presenting an incomplete run as successful.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: CAIPE MUST support configurable identity group synchronization from enterprise identity sources including Okta groups, Active Directory groups, and OIDC group claims where available.
+- **FR-002**: CAIPE MUST support multiple ordered regex mapping clusters for enterprise groups, including include patterns, exclude patterns, priority, captured team names, captured roles, and deterministic team slug normalization.
+- **FR-003**: CAIPE MUST provide a dry-run mode for identity group sync that shows matched groups, ignored groups, teams to create, existing teams to link, memberships to add, memberships to remove, conflicts, skipped users, and ReBAC relationship changes before any changes are applied.
+- **FR-004**: CAIPE MUST create a CAIPE team automatically when an approved identity group mapping resolves to a team that does not exist and no conflict is detected.
+- **FR-005**: CAIPE MUST allow administrators to manually create teams, add members, remove members, assign team administrators, and manage membership independently of enterprise group sync.
+- **FR-006**: CAIPE MUST track membership source information for each team membership, including whether the membership is manual, synced, managed, inherited, active, stale, or pending user linkage.
+- **FR-007**: CAIPE MUST preserve manually managed memberships during automated sync unless an authorized administrator explicitly removes them.
+- **FR-008**: CAIPE MUST reconcile enterprise group membership into ReBAC user-team relationships for member and team-admin roles.
+- **FR-009**: CAIPE MUST treat absence of an allow relationship as deny for every protected action.
+- **FR-010**: CAIPE MUST support explicit anonymous or public access only through intentionally configured relationships; anonymous access MUST NOT be inferred from missing authentication.
+- **FR-011**: CAIPE MUST define a standard action vocabulary for resources: discover, read, use, write, create, delete, manage, administer, audit, approve, and share.
+- **FR-012**: CAIPE MUST represent every atomic protected resource as a ReBAC resource, including users, teams, enterprise groups, Slack workspaces, Slack channels, agents, MCP servers, tools, knowledge bases, documents, skills, tasks, conversations, admin surfaces, policies, audit views, secrets references, and system-level configuration scopes.
+- **FR-013**: CAIPE MUST support scoped administrators for each eligible resource type, including teams, Slack channels, agents, tools, knowledge bases, skills, tasks, policies, audit views, and admin pages.
+- **FR-014**: CAIPE MUST support admin page access as ReBAC-managed resources so that page visibility, read access, write access, and management actions can be scoped by team or resource ownership.
+- **FR-015**: CAIPE MUST provide a UI for creating, updating, previewing, saving, and revoking ReBAC policies without requiring administrators to type raw relationship data.
+- **FR-016**: CAIPE MUST validate policy changes before saving and reject unsupported relationships, malformed resource identifiers, unsupported actions, and privilege escalation attempts.
+- **FR-017**: CAIPE MUST provide a staged policy diff experience that clearly separates grants, revocations, unchanged relationships, and relationships blocked by validation.
+- **FR-018**: CAIPE MUST provide a policy access checker that answers whether a subject can perform an action on a resource and explains the access path or missing prerequisite.
+- **FR-019**: CAIPE MUST provide a graph visualization for all ReBAC relationships and allow administrators to filter by subject, team, enterprise group, Slack channel, resource type, resource identifier, action, source, and enforcement status.
+- **FR-020**: CAIPE MUST support Slack channels as first-class ReBAC resources.
+- **FR-021**: CAIPE MUST support one Slack channel having access to multiple agents, tools, and knowledge bases.
+- **FR-022**: CAIPE MUST require Slack invocations to satisfy channel access, selected-agent access, selected-tool access, and selected-knowledge-base access as applicable.
+- **FR-023**: CAIPE MUST support channel-scoped administrators who can manage only allowed channel relationships and cannot grant resources they do not control.
+- **FR-024**: CAIPE MUST support resource templates or policy rules that automatically create baseline ReBAC relationships for newly synced teams, while requiring administrators to preview and approve any rule that grants access beyond team membership.
+- **FR-025**: CAIPE MUST keep Keycloak realm roles documented and bounded during migration, distinguishing bootstrap roles, transitional compatibility roles, and resource-specific roles planned for replacement by ReBAC checks.
+- **FR-026**: CAIPE MUST ensure Keycloak realm roles do not become the long-term source of resource authorization once the equivalent ReBAC enforcement is active.
+- **FR-027**: CAIPE MUST record audit events for identity sync runs, team creation, membership changes, policy changes, access checks, denials, and administrative overrides.
+- **FR-028**: CAIPE MUST provide drift detection between enterprise identity groups, CAIPE teams, Keycloak realm roles, and ReBAC relationships.
+- **FR-029**: CAIPE MUST clearly label each resource type's enforcement status as not gated, role-gated, ReBAC-shadowed, ReBAC-enforced, or deprecated.
+- **FR-030**: CAIPE MUST provide safe migration visibility so administrators can compare legacy role decisions against ReBAC decisions before switching a resource type to ReBAC enforcement.
+- **FR-031**: CAIPE MUST prevent policy updates that would leave critical resources without any administrator unless an explicit break-glass workflow is used.
+- **FR-032**: CAIPE MUST support importing or discovering enterprise groups without automatically granting access until mapping rules are enabled.
+- **FR-033**: CAIPE MUST provide clear remediation for skipped or unresolved users, including missing identity links, duplicate identities, disabled accounts, and inactive upstream users.
+- **FR-034**: CAIPE MUST support revocation propagation so removed group membership, removed team membership, disabled users, and deleted resources no longer authorize access after reconciliation.
+- **FR-035**: CAIPE MUST expose relationship ownership metadata so administrators can distinguish relationships created manually, by identity sync, by default rules, by migration, or by system bootstrap.
+- **FR-036**: CAIPE MUST support three identity sync operating modes: dry run preview, scheduled reconciliation, and login-time user refresh from trusted group claims when available.
+- **FR-037**: CAIPE MUST provide an Identity Group Sync admin surface for provider selection, mapping cluster management, dry-run preview, matched group review, generated team review, membership diffs, sync status, errors, and skipped-user remediation.
+- **FR-038**: CAIPE MUST support mapping rule outputs that create team membership and team administrator relationships without granting agents, tools, knowledge bases, skills, or tasks unless a separate approved policy rule explicitly grants those resources.
+- **FR-039**: CAIPE MUST use immutable upstream group identifiers when available and MUST treat display names as mutable labels for matching, display, and administrator review.
+- **FR-040**: CAIPE MUST require administrator review before enabling a new group mapping cluster that can create teams or managed memberships.
+
+### Resource Authorization Matrix
+
+| Resource Type | Examples | Minimum Supported Actions | Admin Scope Examples |
+|---------------|----------|---------------------------|----------------------|
+| Organization | `organization:default` | discover, read, manage, audit | Platform administrators manage global defaults and integrations |
+| User | `user:<subject>` | read, manage, audit | User self-service for own profile; platform administrators for identity links |
+| Enterprise group | `external_group:<provider>:<id>` | discover, read, map, audit | Identity administrators manage group-to-team mappings |
+| Team | `team:<slug>` | discover, read, write, manage, audit | Team administrators manage members and team-owned grants |
+| Slack workspace | `slack_workspace:<id>` | discover, read, manage, audit | Platform or Slack administrators manage workspace-level settings |
+| Slack channel | `slack_channel:<id>` | discover, read, use, write, manage, audit | Channel administrators manage allowed agents, tools, and knowledge bases |
+| Agent | `agent:<id>` | discover, read, use, write, manage, audit | Agent administrators manage configuration and grants |
+| MCP server | `mcp_server:<id>` | discover, read, use, manage, audit | Platform administrators manage server-level registration |
+| Tool | `tool:<id-or-prefix>` | discover, read, use, manage, audit | Tool administrators manage tool grants and availability |
+| Knowledge base | `knowledge_base:<id>` | discover, read, use, write, ingest, administer, audit | KB administrators manage content and ingestion rights |
+| Document | `document:<id>` | discover, read, write, delete, share, audit | Document owners or KB administrators manage document access |
+| Skill | `skill:<id>` | discover, read, use, write, manage, audit | Skill administrators manage execution and configuration |
+| Task | `task:<id>` | discover, read, use, write, manage, audit | Task administrators manage task templates and execution rights |
+| Conversation | `conversation:<id>` | discover, read, write, share, delete, audit | Conversation owner or delegated team administrators manage sharing |
+| Admin surface | `admin_surface:<area>` | discover, read, write, manage, audit | Scoped administrators see and edit only authorized admin areas |
+| Policy | `policy:<id>` | discover, read, write, approve, manage, audit | Policy administrators author and approve relationship changes |
+| Audit view | `audit_log:<scope>` | discover, read, audit | Auditors and scoped administrators view permitted audit data |
+| Secret reference | `secret_ref:<id>` | discover, read-metadata, use, manage, audit | Secret administrators manage references without exposing values |
+| System configuration | `system_config:<area>` | discover, read, write, manage, audit | Platform administrators manage global settings |
+
+### Keycloak Realm Role Policy
+
+- **KR-001**: Keycloak realm roles SHOULD be limited to identity bootstrap, platform-wide break-glass access, migration compatibility, and coarse authenticated-user classification.
+- **KR-002**: Existing resource-specific realm roles such as team, agent, tool, task, and skill roles MAY remain during migration but MUST be documented as transitional when an equivalent ReBAC policy exists.
+- **KR-003**: ReBAC MUST become the source of truth for resource authorization once a resource type is marked ReBAC-enforced.
+- **KR-004**: The system MUST provide visibility into which roles are still active, which relationships supersede them, and which users depend on transitional roles.
+- **KR-005**: Realm-role drift MUST be detectable when roles disagree with the intended ReBAC state.
+
+### ReBAC Relationship Concepts
+
+- **RC-001**: Users can have direct relationships to resources, but team-based relationships SHOULD be preferred for maintainability.
+- **RC-002**: Enterprise groups can map to teams and membership roles, but enterprise group existence alone MUST NOT grant access to agents, tools, knowledge bases, skills, or tasks unless a policy rule explicitly grants it.
+- **RC-003**: Teams can have member and admin relationships. Team administrators can receive scoped rights to manage team-owned resources.
+- **RC-004**: Slack channels can have allowed agents, allowed tools, allowed knowledge bases, allowed teams, and channel administrators.
+- **RC-005**: Resource administrators can grant relationships only within their authorized scope and only for actions they are authorized to delegate.
+- **RC-006**: Policy rules can create automatic baseline relationships, but the system MUST show generated relationships and their source.
+
+### Identity Group Sync Model
+
+The target group-sync flow is:
+
+```text
+Okta / AD / OIDC group
+  -> ordered regex mapping cluster
+  -> CAIPE team
+  -> ReBAC team membership or team admin relationship
+  -> resource access through existing team-to-resource ReBAC relationships
+```
+
+Representative mappings:
+
+```text
+Enterprise group: CAIPE-Platform-Engineering-Members
+  -> team:platform-engineering
+  -> user:<subject> member team:platform-engineering
+
+Enterprise group: CAIPE-Platform-Engineering-Admins
+  -> team:platform-engineering
+  -> user:<subject> admin team:platform-engineering
+```
+
+Mapping clusters MUST support:
+
+- Multiple group naming conventions across providers.
+- Ordered priority so the same group cannot be resolved differently by accident.
+- Include patterns and exclude patterns.
+- Captured fields for team name, team slug, and role.
+- Role maps that translate upstream naming such as `Members`, `Admins`, `RO`, `RW`, or `Admin` into CAIPE relationships.
+- Deterministic slug normalization and collision detection.
+- Provider-specific behavior for Okta, Active Directory, and OIDC group claims.
+- Team auto-creation when a mapping is approved and no conflicting team exists.
+
+The sync modes are:
+
+- **Dry run**: Shows matched groups, teams to create, memberships to add, memberships to remove, skipped users, conflicts, warnings, and ReBAC relationship diffs without writing changes.
+- **Scheduled reconciliation**: Periodically reconciles trusted upstream groups into CAIPE teams and ReBAC relationships according to enabled mapping clusters.
+- **Login-time refresh**: Uses trusted group claims available during login to refresh that user's managed memberships quickly, while scheduled reconciliation remains the source for full group cleanup and drift detection.
+
+CAIPE MUST record these logical data records for explainability and audit:
+
+- **Identity group sync rule**: Defines provider, priority, matching rules, role mapping, target team naming, enablement status, and review status.
+- **Identity group sync run**: Records dry-run or applied run inputs, matched groups, generated changes, results, warnings, errors, and actor.
+- **External group team link**: Records which upstream group maps to which CAIPE team and whether the link is active, stale, or conflicted.
+- **Team membership source**: Records why a user has a membership or admin relationship, including manual source, synced source, upstream group, mapping rule, managed status, and last-seen status.
+
+Manual membership sources remain valid alongside synced sources. Removing a user from an upstream group removes only the relationship source managed by that upstream group. The user keeps access if another active source still grants the same team relationship.
+
+External groups MAY be represented as graph resources for explanation and audit paths, but external group existence alone MUST NOT authorize access to application resources. The authoritative access relationship remains the resolved user-to-team and team-to-resource ReBAC path.
+
+### Identity Group Sync Admin Surface
+
+CAIPE MUST provide an admin surface for identity group sync with:
+
+- Provider configuration status for Okta, Active Directory, and OIDC group claims.
+- Regex mapping cluster editor with examples, validation, priority ordering, includes, excludes, capture previews, and role-map previews.
+- Dry-run preview that lists matched groups, ignored groups, generated teams, linked teams, membership adds, membership removals, tuple changes, skipped users, and conflicts.
+- Matched group table showing provider, external group identifier, display name, matched cluster, generated team, generated role, and last sync status.
+- Team creation review for teams that do not already exist.
+- Membership diff review separating manual memberships from managed memberships.
+- Last sync status, run history, warnings, errors, skipped-user remediation, and drift findings.
+- Access checks showing whether a user received access from manual membership, Okta group, AD group, OIDC group claim, or policy rule.
+
+Access to the Identity Group Sync admin surface itself MUST be ReBAC-gated. Platform administrators can manage global sync rules. Scoped administrators can view only group-to-team mappings and sync findings for teams or resources they are allowed to administer.
+
+### Key Entities *(include if feature involves data)*
+
+- **Identity Provider**: An upstream authority such as Okta, Active Directory, or OIDC group claims that provides user and group membership information.
+- **Identity Group Mapping Cluster**: An ordered set of matching rules that transforms upstream group names or identifiers into CAIPE teams, membership roles, and optional default ReBAC relationships.
+- **Identity Group**: An external group with provider identity, display name, immutable external identifier where available, membership list, and mapping status.
+- **CAIPE Team**: A local collaboration and authorization grouping with slug, display name, administrators, members, source metadata, and related resources.
+- **Team Membership Source**: A record explaining why a user is a team member or team administrator, including manual, synced, inherited, default, or bootstrap source.
+- **Keycloak Realm Role**: A token-visible role used for bootstrap, global privileges, or transitional compatibility during migration to ReBAC.
+- **ReBAC Subject**: A user, team, team member set, team admin set, enterprise group, service account, or anonymous subject that can be granted relationships.
+- **ReBAC Resource**: Any protected object that can be discovered, read, used, changed, managed, audited, shared, or administered.
+- **ReBAC Relationship**: A typed authorization fact connecting a subject to an action on a resource.
+- **Policy Rule**: A reusable rule that generates or validates ReBAC relationships, such as default team membership, Slack channel access, or baseline team-owned resource access.
+- **Policy Change Set**: A staged set of grants and revocations awaiting validation, review, approval, or save.
+- **Policy Access Check**: A request to evaluate whether a subject can perform an action on a resource, including an explanation of allow or deny.
+- **Authorization Graph**: A visual representation of subjects, resources, relationships, inheritance paths, sync sources, and enforcement status.
+- **Slack Channel Grant**: A relationship that allows a Slack channel to use one or more agents, tools, and knowledge bases, subject to user and team permissions.
+- **Sync Run**: A dry-run or applied reconciliation attempt with matched groups, generated changes, results, errors, warnings, and audit metadata.
+- **Drift Finding**: A detected mismatch between upstream identity groups, CAIPE teams, Keycloak roles, and ReBAC relationships.
+
+### Assumptions
+
+- Okta and Active Directory group names are the initial source for automatic team creation and membership; other providers can follow the same group mapping model later.
+- When an upstream group has a stable external identifier, CAIPE treats that identifier as authoritative and uses display names only for matching and readability.
+- Manual memberships and manually created teams are valid first-class state and are not overwritten by sync unless explicitly configured.
+- ReBAC is the desired long-term authorization source for all resource decisions, while Keycloak continues to provide authentication, token issuance, and limited bootstrap roles.
+- Anonymous access is supported only for explicitly public resources and is modeled as a deliberate relationship.
+- Policy authoring requires auditability and validation before save; direct low-level relationship editing is reserved for appropriately authorized administrators.
+- Slack channel access is many-to-many: one channel can use many agents, tools, and knowledge bases, and one resource can be available in many channels.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An administrator can configure a group mapping cluster and complete a dry-run preview for at least 500 enterprise groups in under 5 minutes.
+- **SC-002**: For a representative sync run of 100 groups and 5,000 users, CAIPE reports teams to create, memberships to add, memberships to remove, skipped users, and policy changes with 100% traceability to source groups.
+- **SC-003**: At least 95% of common team onboarding cases require no manual membership edits after group sync rules are enabled.
+- **SC-004**: 100% of protected resource types listed in the Resource Authorization Matrix can be represented as ReBAC resources with at least read and manage decision checks.
+- **SC-005**: 100% of denied access checks identify either no matching allow relationship, a missing prerequisite relationship, an inactive subject, an inactive resource, or a scope boundary violation.
+- **SC-006**: A scoped administrator can complete a policy grant or revocation in the UI in under 3 minutes without typing raw relationship data.
+- **SC-007**: The all-relationships graph can load a filtered view for a selected team, user, Slack channel, or resource in under 5 seconds for typical administrative datasets.
+- **SC-008**: Slack channels can be configured with at least 10 allowed agents, 20 allowed tools, and 20 allowed knowledge bases without changing the authorization model.
+- **SC-009**: Manual team memberships survive automated sync in 100% of cases unless explicitly removed by an authorized administrator.
+- **SC-010**: Drift detection identifies mismatches between identity group membership and CAIPE team membership within one sync cycle.
+- **SC-011**: All policy changes, sync-applied relationship changes, access-check denials, and administrative overrides produce audit records sufficient to reconstruct who changed what, when, why, and from which source.
+- **SC-012**: During migration, administrators can identify every resource type as not gated, role-gated, ReBAC-shadowed, ReBAC-enforced, or deprecated from a single authorization status view.

--- a/docs/docs/specs/2026-05-11-identity-group-rebac/tasks.md
+++ b/docs/docs/specs/2026-05-11-identity-group-rebac/tasks.md
@@ -1,0 +1,376 @@
+# Tasks: Enterprise Identity Group Sync and Universal ReBAC
+
+**Input**: Design documents from `docs/docs/specs/2026-05-11-identity-group-rebac/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `mongodb-migration.md`
+
+**Tests**: Test tasks are included because the specification defines independent test criteria for every user story and the implementation plan requires Jest, Playwright, pytest, and RBAC matrix coverage.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently after the shared foundation is complete.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and does not depend on incomplete same-story work
+- **[Story]**: User story label for traceability
+- **File paths**: Every task includes exact repository paths
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the shared file layout and test fixtures needed by the identity sync and universal ReBAC work.
+
+- [ ] T001 Create Identity Group Sync API, component, and test directory skeletons in `ui/src/app/api/admin/identity-group-sync/`, `ui/src/components/admin/identity-group-sync/`, and `ui/src/lib/rbac/__tests__/identity-group-sync/`
+- [ ] T002 Create Universal ReBAC API, component, and test directory skeletons in `ui/src/app/api/admin/rebac/`, `ui/src/components/admin/rebac/`, and `ui/src/lib/rbac/__tests__/rebac/`
+- [ ] T003 Create Slack ReBAC API and test directory skeletons in `ui/src/app/api/admin/slack/channels/` and `ui/src/lib/rbac/__tests__/slack/`
+- [ ] T004 [P] Add representative identity-group fixture data in `tests/rbac/fixtures/identity_groups.ts`
+- [ ] T005 [P] Add representative Python identity-group fixture data in `tests/rbac/fixtures/identity_groups.py`
+- [ ] T006 [P] Add Slack channel multi-resource fixture data in `tests/rbac/fixtures/slack_rebac.ts`
+- [ ] T007 [P] Add universal resource fixture data in `tests/rbac/fixtures/rebac_resources.ts`
+- [ ] T008 [P] Add feature-specific E2E fixture helpers in `tests/rbac/e2e/identity-group-rebac-fixture.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement shared models, validators, OpenFGA model support, storage helpers, and authorization gates that all user stories depend on.
+
+**Critical**: No user story work should begin until this phase is complete.
+
+- [ ] T009 Define shared universal ReBAC TypeScript types in `ui/src/types/rbac-universal.ts`
+- [ ] T010 Define identity group sync TypeScript types in `ui/src/types/identity-group-sync.ts`
+- [ ] T011 Define Slack ReBAC TypeScript types in `ui/src/types/slack-rebac.ts`
+- [ ] T012 Implement MongoDB collection constants and typed helpers for new RBAC collections in `ui/src/lib/rbac/mongo-collections.ts`
+- [ ] T013 Implement deterministic team slug normalization and collision helpers in `ui/src/lib/rbac/team-slugs.ts`
+- [ ] T014 Implement standard action/resource catalog in `ui/src/lib/rbac/resource-model.ts`
+- [ ] T015 Implement shared ReBAC relationship validation and unsupported-action errors in `ui/src/lib/rbac/relationship-validator.ts`
+- [ ] T016 Implement relationship-to-OpenFGA tuple conversion helpers in `ui/src/lib/rbac/tuple-builders.ts`
+- [ ] T017 Extend OpenFGA read/write/check helpers for universal resource relations in `ui/src/lib/rbac/openfga.ts`
+- [ ] T018 Add OpenFGA model support for universal resource types and Slack channel relations in `deploy/openfga-experiment/model.fga`
+- [ ] T019 Mirror the OpenFGA authorization model changes in `deploy/openfga-experiment/init/authorization-model.json`
+- [ ] T020 Implement ReBAC admin API authorization helpers in `ui/src/app/api/admin/rebac/_lib.ts`
+- [ ] T021 Implement Identity Group Sync API authorization helpers in `ui/src/app/api/admin/identity-group-sync/_lib.ts`
+- [ ] T022 Implement Slack ReBAC API authorization helpers in `ui/src/app/api/admin/slack/channels/_lib.ts`
+- [ ] T023 Implement audit event emitters for sync, policy, graph, access-check, and Slack changes in `ui/src/lib/rbac/audit.ts`
+- [ ] T024 Implement MongoDB index initialization script for new RBAC collections in `scripts/init-rbac-mongo-indexes.ts`
+- [ ] T025 Add RBAC matrix resource/action entries for new resource types in `tests/rbac/rbac-matrix.yaml`
+- [ ] T026 Add unit tests for resource/action catalog and tuple validation in `ui/src/lib/rbac/__tests__/rebac/resource-model.test.ts`
+- [ ] T027 Add unit tests for OpenFGA tuple conversion helpers in `ui/src/lib/rbac/__tests__/rebac/tuple-builders.test.ts`
+- [ ] T028 Add documentation stubs for implementation changes in `docs/docs/security/rbac/file-map.md`
+
+**Checkpoint**: The repository has shared types, storage/index support, relationship validation, OpenFGA model coverage, admin API gates, audit helpers, and baseline tests.
+
+---
+
+## Phase 3: User Story 1 - Sync Enterprise Groups Into CAIPE Teams (Priority: P1) MVP
+
+**Goal**: Configure ordered enterprise group mapping clusters, preview dry-runs, apply approved sync, create teams, record membership sources, and materialize user-team ReBAC relationships without granting unrelated resources.
+
+**Independent Test**: Configure fixture groups and mapping rules, run a dry-run, apply it, and verify created teams, membership source records, skipped users, conflicts, and OpenFGA user-team tuples.
+
+### Tests for User Story 1
+
+- [ ] T029 [P] [US1] Add BFF contract tests for Identity Group Sync provider and rule endpoints in `ui/src/app/api/admin/identity-group-sync/__tests__/rules-route.test.ts`
+- [ ] T030 [P] [US1] Add BFF contract tests for dry-run and apply endpoints in `ui/src/app/api/admin/identity-group-sync/__tests__/sync-run-route.test.ts`
+- [ ] T031 [P] [US1] Add unit tests for regex mapping clusters, priority resolution, excludes, and slug collisions in `ui/src/lib/rbac/__tests__/identity-group-sync/rule-matcher.test.ts`
+- [ ] T032 [P] [US1] Add unit tests for source-preserving membership reconciliation in `ui/src/lib/rbac/__tests__/identity-group-sync/membership-reconciler.test.ts`
+- [ ] T033 [P] [US1] Add Playwright dry-run and apply scenario for enterprise group sync in `tests/rbac/e2e/story-identity-group-sync.spec.ts`
+
+### Implementation for User Story 1
+
+- [ ] T034 [P] [US1] Implement identity provider repository helpers in `ui/src/lib/rbac/identity-provider-store.ts`
+- [ ] T035 [P] [US1] Implement identity group sync rule repository helpers in `ui/src/lib/rbac/identity-group-sync-rule-store.ts`
+- [ ] T036 [P] [US1] Implement external group and group-team link repository helpers in `ui/src/lib/rbac/external-group-store.ts`
+- [ ] T037 [P] [US1] Implement team membership source repository helpers in `ui/src/lib/rbac/team-membership-source-store.ts`
+- [ ] T038 [US1] Implement ordered regex mapping cluster evaluator in `ui/src/lib/rbac/identity-group-rule-matcher.ts`
+- [ ] T039 [US1] Implement dry-run planner for matched groups, generated teams, membership diffs, skipped users, conflicts, and tuple diffs in `ui/src/lib/rbac/identity-group-sync-planner.ts`
+- [ ] T040 [US1] Implement apply reconciler for approved runs and OpenFGA user-team tuple writes in `ui/src/lib/rbac/identity-group-sync-reconciler.ts`
+- [ ] T041 [US1] Implement provider health endpoint in `ui/src/app/api/admin/identity-group-sync/providers/route.ts`
+- [ ] T042 [US1] Implement rule list/create endpoint in `ui/src/app/api/admin/identity-group-sync/rules/route.ts`
+- [ ] T043 [US1] Implement rule update endpoint in `ui/src/app/api/admin/identity-group-sync/rules/[ruleId]/route.ts`
+- [ ] T044 [US1] Implement dry-run endpoint in `ui/src/app/api/admin/identity-group-sync/dry-run/route.ts`
+- [ ] T045 [US1] Implement apply endpoint in `ui/src/app/api/admin/identity-group-sync/apply/route.ts`
+- [ ] T046 [US1] Implement run details endpoint in `ui/src/app/api/admin/identity-group-sync/runs/[runId]/route.ts`
+- [ ] T047 [US1] Implement skipped-user remediation endpoint in `ui/src/app/api/admin/identity-group-sync/skipped-users/[sourceId]/resolve/route.ts`
+- [ ] T048 [US1] Implement Identity Group Sync admin tab shell in `ui/src/components/admin/identity-group-sync/IdentityGroupSyncTab.tsx`
+- [ ] T049 [US1] Implement mapping cluster editor component in `ui/src/components/admin/identity-group-sync/MappingClusterEditor.tsx`
+- [ ] T050 [US1] Implement dry-run preview component with conflicts and skipped users in `ui/src/components/admin/identity-group-sync/DryRunPreview.tsx`
+- [ ] T051 [US1] Wire Identity Group Sync tab into the admin page in `ui/src/app/(app)/admin/page.tsx`
+
+**Checkpoint**: User Story 1 is independently functional as the MVP and can sync approved enterprise groups into CAIPE teams with explainable membership provenance.
+
+---
+
+## Phase 4: User Story 2 - Manage Teams and Members Manually (Priority: P1)
+
+**Goal**: Preserve manual teams and memberships as first-class sources, enforce scoped team administration, and ensure sync removes only managed sources.
+
+**Independent Test**: Create a team manually, add members/admins, run sync for overlapping users, and verify manual membership persists unless explicitly removed by an authorized admin.
+
+### Tests for User Story 2
+
+- [ ] T052 [P] [US2] Add BFF tests for manual team creation source metadata in `ui/src/app/api/admin/teams/__tests__/manual-team-source.test.ts`
+- [ ] T053 [P] [US2] Add BFF tests for manual membership source preservation in `ui/src/app/api/admin/teams/[id]/members/__tests__/membership-sources.test.ts`
+- [ ] T054 [P] [US2] Add Playwright scoped team admin membership scenario in `tests/rbac/e2e/story-manual-team-management.spec.ts`
+
+### Implementation for User Story 2
+
+- [ ] T055 [US2] Update team creation API to set source/status/owner metadata in `ui/src/app/api/admin/teams/route.ts`
+- [ ] T056 [US2] Update team detail API to return membership source summaries in `ui/src/app/api/admin/teams/[id]/route.ts`
+- [ ] T057 [US2] Update team members API to create and remove manual `team_membership_sources` records in `ui/src/app/api/admin/teams/[id]/members/route.ts`
+- [ ] T058 [US2] Implement team membership source read endpoint in `ui/src/app/api/admin/identity-group-sync/teams/[teamId]/membership-sources/route.ts`
+- [ ] T059 [US2] Implement scoped team-admin authorization checks for manual membership edits in `ui/src/lib/rbac/team-admin-guards.ts`
+- [ ] T060 [US2] Update Team Details membership UI to display manual, synced, stale, and pending identity-link sources in `ui/src/components/admin/TeamDetailsDialog.tsx`
+- [ ] T061 [US2] Add manual membership source preservation to the sync reconciler in `ui/src/lib/rbac/identity-group-sync-reconciler.ts`
+
+**Checkpoint**: Manual teams and memberships can be administered safely and remain intact across automated sync.
+
+---
+
+## Phase 5: User Story 3 - Represent Every Protected Resource in ReBAC (Priority: P1)
+
+**Goal**: Represent all protected CAIPE resources and actions in the catalog, OpenFGA model, access checker, enforcement status, and RBAC matrix.
+
+**Independent Test**: Select representative resources for every type, create read/manage checks, and verify missing relationships deny by default.
+
+### Tests for User Story 3
+
+- [ ] T062 [P] [US3] Add catalog contract tests for every protected resource type in `ui/src/app/api/admin/rebac/__tests__/catalog-route.test.ts`
+- [ ] T063 [P] [US3] Add enforcement-status contract tests in `ui/src/app/api/admin/rebac/__tests__/enforcement-status-route.test.ts`
+- [ ] T064 [P] [US3] Add RBAC matrix tests for deny-by-default and representative read/manage checks in `tests/rbac/unit/ts/universal-rebac-matrix.test.ts`
+
+### Implementation for User Story 3
+
+- [ ] T065 [US3] Implement canonical ReBAC resource discovery service in `ui/src/lib/rbac/resource-catalog.ts`
+- [ ] T066 [US3] Implement ReBAC catalog endpoint in `ui/src/app/api/admin/rebac/catalog/route.ts`
+- [ ] T067 [US3] Implement enforcement status store and helpers in `ui/src/lib/rbac/enforcement-status.ts`
+- [ ] T068 [US3] Implement enforcement status endpoint in `ui/src/app/api/admin/rebac/enforcement-status/route.ts`
+- [ ] T069 [US3] Update OpenFGA catalog endpoint to include all universal resource types in `ui/src/app/api/admin/openfga/catalog/route.ts`
+- [ ] T070 [US3] Update team resource assignment API to use universal tuple builders for agents, tools, knowledge bases, skills, and tasks in `ui/src/app/api/admin/teams/[id]/resources/route.ts`
+- [ ] T071 [US3] Update RBAC matrix fixtures with universal resource examples in `tests/rbac/fixtures/rebac_resources.ts`
+
+**Checkpoint**: Every resource type from the authorization matrix can be discovered, checked, and represented with at least read/manage enforcement metadata.
+
+---
+
+## Phase 6: User Story 4 - Create and Update ReBAC Policies in the UI (Priority: P2)
+
+**Goal**: Provide guided ReBAC policy authoring with staged grants/revocations, validation, graph interactions, atomic apply semantics, and audit records.
+
+**Independent Test**: Create a staged policy update through the UI, validate it, apply it, verify OpenFGA tuples and provenance, then revoke it.
+
+### Tests for User Story 4
+
+- [ ] T072 [P] [US4] Add change-set contract tests in `ui/src/app/api/admin/rebac/__tests__/change-sets-route.test.ts`
+- [ ] T073 [P] [US4] Add relationship validation tests for unsupported actions and privilege escalation in `ui/src/lib/rbac/__tests__/rebac/policy-change-validator.test.ts`
+- [ ] T074 [P] [US4] Add Playwright policy builder staged diff scenario in `tests/rbac/e2e/story-policy-authoring.spec.ts`
+
+### Implementation for User Story 4
+
+- [ ] T075 [P] [US4] Implement policy rule repository helpers in `ui/src/lib/rbac/policy-rule-store.ts`
+- [ ] T076 [P] [US4] Implement policy change-set repository helpers in `ui/src/lib/rbac/policy-change-set-store.ts`
+- [ ] T077 [US4] Implement change-set validator for delegated scope, action support, circular grants, and last-admin risk in `ui/src/lib/rbac/policy-change-validator.ts`
+- [ ] T078 [US4] Implement change-set create endpoint in `ui/src/app/api/admin/rebac/change-sets/route.ts`
+- [ ] T079 [US4] Implement change-set validate endpoint in `ui/src/app/api/admin/rebac/change-sets/[changeSetId]/validate/route.ts`
+- [ ] T080 [US4] Implement change-set apply endpoint with OpenFGA tuple writes and audit records in `ui/src/app/api/admin/rebac/change-sets/[changeSetId]/apply/route.ts`
+- [ ] T081 [US4] Implement relationship list endpoint for a resource in `ui/src/app/api/admin/rebac/resources/[type]/[id]/relationships/route.ts`
+- [ ] T082 [US4] Implement guided policy builder component in `ui/src/components/admin/rebac/RebacPolicyBuilder.tsx`
+- [ ] T083 [US4] Implement staged policy diff component in `ui/src/components/admin/rebac/PolicyChangeSetDiff.tsx`
+- [ ] T084 [US4] Update OpenFGA ReBAC admin tab to use validated change sets in `ui/src/components/admin/OpenFgaRebacTab.tsx`
+
+**Checkpoint**: Administrators can create, validate, apply, and revoke ReBAC relationships without typing raw tuples.
+
+---
+
+## Phase 7: User Story 5 - Visualize All Relationships and Explain Access (Priority: P2)
+
+**Goal**: Provide graph visualization, filtering, pagination, all-relationships scope, and access explanations for allow and deny outcomes.
+
+**Independent Test**: Create known resources and relationships, render all and filtered graphs, run access checks, and verify explanation paths or missing prerequisites.
+
+### Tests for User Story 5
+
+- [ ] T085 [P] [US5] Add graph endpoint contract tests for all/team/resource/subject/Slack scopes in `ui/src/app/api/admin/rebac/__tests__/graph-route.test.ts`
+- [ ] T086 [P] [US5] Add access-check explanation tests in `ui/src/app/api/admin/rebac/__tests__/check-route.test.ts`
+- [ ] T087 [P] [US5] Add Playwright graph filtering and access checker scenario in `tests/rbac/e2e/story-graph-and-access-checker.spec.ts`
+
+### Implementation for User Story 5
+
+- [ ] T088 [US5] Implement relationship graph query service with pagination and source metadata in `ui/src/lib/rbac/rebac-graph.ts`
+- [ ] T089 [US5] Implement graph endpoint with scope filters in `ui/src/app/api/admin/rebac/graph/route.ts`
+- [ ] T090 [US5] Implement access explanation service that combines OpenFGA checks and MongoDB provenance in `ui/src/lib/rbac/access-explainer.ts`
+- [ ] T091 [US5] Implement access checker endpoint in `ui/src/app/api/admin/rebac/check/route.ts`
+- [ ] T092 [US5] Update existing OpenFGA graph endpoint to delegate to universal graph service in `ui/src/app/api/admin/openfga/graph/route.ts`
+- [ ] T093 [US5] Implement graph filter controls component in `ui/src/components/admin/rebac/RebacGraphFilters.tsx`
+- [ ] T094 [US5] Implement access checker UI component in `ui/src/components/admin/rebac/RebacAccessChecker.tsx`
+- [ ] T095 [US5] Update graph editor to display source, enforcement status, and missing-prerequisite explanations in `ui/src/components/admin/OpenFgaRebacTab.tsx`
+
+**Checkpoint**: Administrators can inspect full or scoped relationship graphs and explain both allows and denies.
+
+---
+
+## Phase 8: User Story 6 - Gate Slack Channels to Multiple Agents, Tools, and Knowledge Bases (Priority: P2)
+
+**Goal**: Replace one-channel-to-one-agent assumptions with ReBAC-governed Slack channel access to multiple agents, tools, and knowledge bases.
+
+**Independent Test**: Grant one Slack channel multiple resources, invoke allowed and disallowed resources from Slack as different users, and verify channel and user resource checks are both enforced.
+
+### Tests for User Story 6
+
+- [ ] T096 [P] [US6] Add Slack channel admin API contract tests in `ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts`
+- [ ] T097 [P] [US6] Add Slack runtime ReBAC tests in `ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py`
+- [ ] T098 [P] [US6] Add Playwright Slack channel multi-resource admin scenario in `tests/rbac/e2e/story-slack-channel-rebac.spec.ts`
+
+### Implementation for User Story 6
+
+- [ ] T099 [P] [US6] Implement Slack channel grant repository helpers in `ui/src/lib/rbac/slack-channel-grant-store.ts`
+- [ ] T100 [P] [US6] Implement Slack channel ReBAC decision helpers for UI/BFF checks in `ui/src/lib/rbac/slack-channel-rebac.ts`
+- [ ] T101 [US6] Implement Slack channels list endpoint in `ui/src/app/api/admin/slack/channels/route.ts`
+- [ ] T102 [US6] Implement Slack channel resources read/write endpoint in `ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/resources/route.ts`
+- [ ] T103 [US6] Implement Slack channel access-check endpoint in `ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/access-check/route.ts`
+- [ ] T104 [US6] Implement Slack channel ReBAC admin component in `ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx`
+- [ ] T105 [US6] Implement Python Slack runtime ReBAC evaluator in `ai_platform_engineering/integrations/slack_bot/utils/slack_rebac.py`
+- [ ] T106 [US6] Integrate Slack runtime ReBAC checks into middleware in `ai_platform_engineering/integrations/slack_bot/utils/rbac_middleware.py`
+- [ ] T107 [US6] Update Slack channel mapping utilities to emit channel resource context in `ai_platform_engineering/integrations/slack_bot/utils/channel_agent_mapper.py`
+- [ ] T108 [US6] Update Slack channel-team mapper to support many resource grants in `ai_platform_engineering/integrations/slack_bot/utils/channel_team_mapper.py`
+
+**Checkpoint**: A Slack channel can expose many agents, tools, and knowledge bases, and runtime access is denied unless channel and user/resource checks pass.
+
+---
+
+## Phase 9: User Story 7 - Maintain Keycloak Realm Roles During the Transition (Priority: P3)
+
+**Goal**: Keep Keycloak roles bounded and understandable during migration while making ReBAC authoritative for resource types marked ReBAC-enforced.
+
+**Independent Test**: Compare legacy role and ReBAC decisions side by side, mark a resource ReBAC-enforced, and verify stale resource roles no longer grant access by themselves.
+
+### Tests for User Story 7
+
+- [ ] T109 [P] [US7] Add Keycloak transition helper tests in `ui/src/lib/rbac/__tests__/rebac/keycloak-transition.test.ts`
+- [ ] T110 [P] [US7] Add enforcement comparison API tests in `ui/src/app/api/rbac/__tests__/enforcement-comparison-route.test.ts`
+- [ ] T111 [P] [US7] Add RBAC matrix migration-state coverage in `tests/rbac/unit/ts/keycloak-rebac-transition.test.ts`
+
+### Implementation for User Story 7
+
+- [ ] T112 [US7] Implement Keycloak role classification and transitional-role helpers in `ui/src/lib/rbac/keycloak-transition.ts`
+- [ ] T113 [US7] Implement role-vs-ReBAC comparison service in `ui/src/lib/rbac/enforcement-comparison.ts`
+- [ ] T114 [US7] Implement enforcement comparison endpoint in `ui/src/app/api/rbac/enforcement-comparison/route.ts`
+- [ ] T115 [US7] Update task and skill role helpers to honor ReBAC-enforced resource state in `ui/src/lib/rbac/task-skill-realm-access.ts`
+- [ ] T116 [US7] Update Keycloak resource sync to stop creating permanent per-resource roles for ReBAC-enforced resources in `ui/src/lib/rbac/keycloak-resource-sync.ts`
+- [ ] T117 [US7] Update AgentGateway config template to document ReBAC shadow/enforced mode boundaries in `deploy/agentgateway/config.yaml.j2`
+- [ ] T118 [US7] Implement enforcement status UI panel in `ui/src/components/admin/rebac/RebacEnforcementStatusPanel.tsx`
+- [ ] T119 [US7] Add role drift detection helpers in `ui/src/lib/rbac/drift-detection.ts`
+
+**Checkpoint**: Administrators can see migration state, compare role and ReBAC decisions, and rely on ReBAC for resource types that are marked enforced.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+**Purpose**: Complete documentation, migration guardrails, performance checks, and end-to-end validation across the implemented stories.
+
+- [ ] T120 [P] Update RBAC architecture reference for identity sync, universal ReBAC resources, Slack channel many-to-many access, and Keycloak transition in `docs/docs/security/rbac/architecture.md`
+- [ ] T121 [P] Update RBAC workflow diagrams for dry-run/apply sync, policy authoring, graph access check, Slack invocation, and migration modes in `docs/docs/security/rbac/workflows.md`
+- [ ] T122 [P] Update RBAC usage guide with quickstart/demo steps for identity sync and policy graph administration in `docs/docs/security/rbac/usage.md`
+- [ ] T123 [P] Update RBAC file map with every new auth-relevant file in `docs/docs/security/rbac/file-map.md`
+- [ ] T124 Update OpenFGA experiment README with model migration and tuple backfill instructions in `deploy/openfga-experiment/README.md`
+- [ ] T125 Add migration/backfill operational script for membership sources and Slack grants in `scripts/backfill-universal-rebac.ts`
+- [ ] T126 Add rollback helper for source-scoped tuple deletion in `scripts/rollback-universal-rebac-tuples.ts`
+- [ ] T127 Add performance test for 500-group dry-run preview in `tests/rbac/unit/ts/identity-group-sync-performance.test.ts`
+- [ ] T128 Add performance test for filtered graph load in `tests/rbac/unit/ts/rebac-graph-performance.test.ts`
+- [ ] T129 Run and document RBAC docs validation in `tests/test_validate_rbac_docs.py`
+- [ ] T130 Run and document UI unit tests for identity sync, ReBAC, and Slack ReBAC in `ui/src/lib/rbac/__tests__/`
+- [ ] T131 Run and document Python Slack bot RBAC tests in `ai_platform_engineering/integrations/slack_bot/tests/`
+- [ ] T132 Run and document RBAC E2E tests in `tests/rbac/e2e/`
+- [ ] T133 Run and document final quality gates from `docs/docs/specs/2026-05-11-identity-group-rebac/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) has no dependencies.
+- Foundational (Phase 2) depends on Setup and blocks all user stories.
+- P1 stories (US1, US2, US3) can start after Foundation; US2 and US3 can run in parallel with US1 after shared stores and validators are stable.
+- P2 stories (US4, US5, US6) depend on Foundation and benefit from US3 resource catalog completion; US5 depends on US4 only for staged change provenance, not for basic graph reads.
+- P3 story (US7) depends on US3 enforcement status and can run after the first ReBAC-enforced resource type exists.
+- Polish depends on whichever user stories are included in the implementation increment.
+
+### User Story Dependencies
+
+- US1 is the MVP: enterprise group sync into CAIPE teams and team membership relationships.
+- US2 can be delivered independently after Foundation but must interoperate with US1 membership source records.
+- US3 can be delivered independently after Foundation and should be completed before broad policy authoring.
+- US4 depends on US3 resource/action catalog for complete validation.
+- US5 depends on Foundation for graph reads and on US3 for complete resource coverage.
+- US6 depends on US3 for Slack channel and resource types.
+- US7 depends on US3 enforcement status and migration-state semantics.
+
+### Within Each User Story
+
+- Tests should be written first and verified failing where practical.
+- Repository/model helpers before services.
+- Services before API routes.
+- API routes before UI components.
+- Runtime enforcement changes after decision helpers and tests.
+- Story checkpoint before moving to the next implementation increment.
+
+## Parallel Opportunities
+
+- Setup fixture tasks T004-T008 can run in parallel.
+- Foundation tasks T014-T016 can run in parallel after shared types T009-T011 exist.
+- Foundation tests T026-T027 can run in parallel after their target helpers are stubbed.
+- US1 repository helpers T034-T037 can run in parallel.
+- US1 tests T029-T033 can run in parallel.
+- US2 tests T052-T054 can run in parallel.
+- US3 tests T062-T064 can run in parallel.
+- US4 repository helpers T075-T076 can run in parallel.
+- US4 tests T072-T074 can run in parallel.
+- US5 tests T085-T087 can run in parallel.
+- US6 helpers T099-T100 can run in parallel, and tests T096-T098 can run in parallel.
+- US7 tests T109-T111 can run in parallel.
+- Documentation updates T120-T123 can run in parallel.
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add BFF contract tests for Identity Group Sync provider and rule endpoints in ui/src/app/api/admin/identity-group-sync/__tests__/rules-route.test.ts"
+Task: "Add BFF contract tests for dry-run and apply endpoints in ui/src/app/api/admin/identity-group-sync/__tests__/sync-run-route.test.ts"
+Task: "Add unit tests for regex mapping clusters, priority resolution, excludes, and slug collisions in ui/src/lib/rbac/__tests__/identity-group-sync/rule-matcher.test.ts"
+Task: "Add unit tests for source-preserving membership reconciliation in ui/src/lib/rbac/__tests__/identity-group-sync/membership-reconciler.test.ts"
+Task: "Add Playwright dry-run and apply scenario for enterprise group sync in tests/rbac/e2e/story-identity-group-sync.spec.ts"
+```
+
+## Parallel Example: User Story 6
+
+```bash
+Task: "Add Slack channel admin API contract tests in ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts"
+Task: "Add Slack runtime ReBAC tests in ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py"
+Task: "Add Playwright Slack channel multi-resource admin scenario in tests/rbac/e2e/story-slack-channel-rebac.spec.ts"
+Task: "Implement Slack channel grant repository helpers in ui/src/lib/rbac/slack-channel-grant-store.ts"
+Task: "Implement Slack channel ReBAC decision helpers for UI/BFF checks in ui/src/lib/rbac/slack-channel-rebac.ts"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 (US1) only.
+3. Validate dry-run, apply, membership sources, and OpenFGA team membership tuples.
+4. Demo enterprise group sync without granting any application resources from group existence alone.
+
+### Incremental Delivery
+
+1. Deliver US1 to establish identity-to-team ReBAC membership.
+2. Deliver US2 to protect manual exceptions and scoped team administration.
+3. Deliver US3 to create complete resource/action coverage.
+4. Deliver US4 and US5 to make policy authoring and explainability operable.
+5. Deliver US6 to migrate Slack channel access to many-to-many ReBAC.
+6. Deliver US7 to make Keycloak role migration state explicit and bounded.
+
+### Final Validation
+
+1. Run targeted Jest tests for identity sync, ReBAC policy APIs, graph, and Slack APIs.
+2. Run Slack bot pytest coverage for runtime ReBAC checks.
+3. Run RBAC matrix tests and Playwright E2E scenarios.
+4. Run docs validation for the canonical RBAC reference.
+5. Run the quality gates listed in `quickstart.md`.


### PR DESCRIPTION
## Summary

- Adds the Spec Kit artifacts for Enterprise Identity Group Sync and Universal ReBAC.
- Documents requirements, research decisions, API/model contracts, data model, MongoDB migration notes, quickstart, and task breakdown.
- Keeps this PR docs/spec-only so it can be reviewed independently from the comprehensive RBAC implementation branch.

## Test plan

- [x] Ran `/speckit.plan`, `/speckit.tasks`, and `/speckit.analyze` during artifact generation.
- [x] Verified the branch diff against `release/0.5.0` contains only `docs/docs/specs/2026-05-11-identity-group-rebac/`.
- [ ] CI validation on PR.


Made with [Cursor](https://cursor.com)