### PR TITLE
fix(agentic-apps): include missing release app config updates

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.6.0-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.4 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,30 +179,30 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.6.0-rc.3
+    version: 0.6.0-rc.4
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.6.0-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.4 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.6.0-rc.3
-appVersion: "0.6.0-rc.3"
+version: 0.6.0-rc.4
+appVersion: "0.6.0-rc.4"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.6.0-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.4 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/app-configmap.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/app-configmap.yaml
@@ -1,7 +1,8 @@
 {{- $hasModels := and .Values.appConfig.models (gt (len .Values.appConfig.models) 0) }}
 {{- $hasMcpServers := and .Values.appConfig.mcp_servers (gt (len .Values.appConfig.mcp_servers) 0) }}
 {{- $hasAgents := and .Values.appConfig.agents (gt (len .Values.appConfig.agents) 0) }}
-{{- if or $hasModels $hasMcpServers $hasAgents }}
+{{- $hasAgenticApps := and .Values.appConfig.agentic_apps (or .Values.appConfig.agentic_apps.packages .Values.appConfig.agentic_apps.installations) }}
+{{- if or $hasModels $hasMcpServers $hasAgents $hasAgenticApps }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,5 +33,14 @@ data:
       {{- toYaml .Values.appConfig.agents | nindent 6 }}
     {{- else }}
     agents: []
+    {{- end }}
+
+    {{- if $hasAgenticApps }}
+    agentic_apps:
+      {{- toYaml .Values.appConfig.agentic_apps | nindent 6 }}
+    {{- else }}
+    agentic_apps:
+      packages: []
+      installations: []
     {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -62,7 +62,8 @@ spec:
           {{- $hasModels := and .Values.appConfig.models (gt (len .Values.appConfig.models) 0) }}
           {{- $hasMcpServers := and .Values.appConfig.mcp_servers (gt (len .Values.appConfig.mcp_servers) 0) }}
           {{- $hasAgents := and .Values.appConfig.agents (gt (len .Values.appConfig.agents) 0) }}
-          {{- $hasAppConfig := or $hasModels $hasMcpServers $hasAgents }}
+          {{- $hasAgenticApps := and .Values.appConfig.agentic_apps (or .Values.appConfig.agentic_apps.packages .Values.appConfig.agentic_apps.installations) }}
+          {{- $hasAppConfig := or $hasModels $hasMcpServers $hasAgents $hasAgenticApps }}
           env:
             {{- if $hasAppConfig }}
             - name: APP_CONFIG_PATH

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -337,3 +337,9 @@ appConfig:
   #   allowed_tools:
   #     github: []
   #   enabled: true
+
+  # External agentic app package and installation seed data.
+  # Rendered into APP_CONFIG_PATH with models, MCP servers, and agents.
+  agentic_apps:
+    packages: []
+    installations: []

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.6.0-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.4 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.4" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.4" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.6.0-rc.3
-appVersion: 0.6.0-rc.3
+version: 0.6.0-rc.4
+appVersion: 0.6.0-rc.4
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.6.0-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.4 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.6.0-rc.3 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.6.0-rc.4 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0-rc.3" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.6.0-rc.4" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.4" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0-rc.3" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.6.0-rc.4" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.6.0-rc.3 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.3" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.4" # Do NOT modify. It will be updated automatically using the release workflow

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1569,9 +1569,7 @@ services:
     # visibility timeout + redrive policy handle the retry.
     restart: unless-stopped
     profiles:
-      - agentic-sdlc
       - sqs-webhook
-      - caipe-ui
 
   ####################################################################################################
   #                                      Dynamic Agents                                              #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/__tests__/agentic-sdlc/highlight-timing.test.ts
+++ b/ui/src/__tests__/agentic-sdlc/highlight-timing.test.ts
@@ -1,7 +1,17 @@
-import { REPO_UPDATE_HIGHLIGHT_MS } from "@/lib/agentic-sdlc/highlight-timing";
+import {
+  REPO_UPDATE_HIGHLIGHT_CLASS,
+  REPO_UPDATE_HIGHLIGHT_MS,
+} from "@/lib/agentic-sdlc/highlight-timing";
 
 describe("Agentic SDLC highlight timing", () => {
   it("keeps repo update halos visible for 30 seconds", () => {
     expect(REPO_UPDATE_HIGHLIGHT_MS).toBe(30_000);
+  });
+
+  it("uses a subtle event highlight instead of a full-row flashing pulse", () => {
+    expect(REPO_UPDATE_HIGHLIGHT_CLASS).toContain("ring-1");
+    expect(REPO_UPDATE_HIGHLIGHT_CLASS).not.toContain("ring-2");
+    expect(REPO_UPDATE_HIGHLIGHT_CLASS).not.toContain("animate-pulse");
+    expect(REPO_UPDATE_HIGHLIGHT_CLASS).not.toContain("90px");
   });
 });

--- a/ui/src/lib/agentic-sdlc/highlight-timing.ts
+++ b/ui/src/lib/agentic-sdlc/highlight-timing.ts
@@ -4,7 +4,7 @@ export const REPO_UPDATE_HIGHLIGHT_MS = 30_000;
 export const TRON_HALO_COLOR = "#00f5ff";
 
 export const REPO_UPDATE_HIGHLIGHT_CLASS =
-  "relative overflow-visible ring-2 ring-[var(--repo-update-halo)] bg-cyan-400/10 shadow-[0_0_18px_var(--repo-update-halo),0_0_48px_var(--repo-update-halo),0_0_90px_rgba(0,245,255,0.28)] before:pointer-events-none before:absolute before:-inset-1 before:rounded-[inherit] before:border before:border-[var(--repo-update-halo)] before:shadow-[0_0_28px_var(--repo-update-halo)] before:content-[''] motion-safe:animate-pulse";
+  "relative overflow-visible ring-1 ring-[var(--repo-update-halo)]/60 bg-cyan-400/5 shadow-[0_0_10px_rgba(0,245,255,0.22),0_0_24px_rgba(0,245,255,0.12)] before:pointer-events-none before:absolute before:-inset-0.5 before:rounded-[inherit] before:border before:border-[var(--repo-update-halo)]/35 before:shadow-[0_0_12px_rgba(0,245,255,0.16)] before:content-['']";
 
 export function repoUpdateHighlightStyle(
   haloColor: string,

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.6.0rc3"
+version = "0.6.0rc4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Render `agentic_apps` seed data through the CAIPE UI chart app config so packaged/installed external apps are available on release/0.6.0.
- Keep the SQS webhook receiver out of unrelated local dev profiles.
- Carry over the subtler Agentic SDLC repo update highlight and its focused test.

## Test plan

- [x] `npm test -- highlight-timing.test.ts --runInBand`
- [x] `helm template caipe-ui charts/ai-platform-engineering/charts/caipe-ui --set 'global.vpa.enabled=false' --set 'global.image.tag=release-test' --set 'appConfig.agentic_apps.packages[0].id=test-package' --set 'appConfig.agentic_apps.installations[0].id=test-install' >/dev/null`


Made with [Cursor](https://cursor.com)