### PR TITLE
fix(docs): update Meeting Recordings link to YouTube in community page and footer

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -238,7 +238,7 @@ const config: Config = {
             },
             {
               label: 'Meeting Recordings',
-              href: 'https://github.com/cnoe-io/agentic-ai/wiki/Meeting-Recordings',
+              href: 'https://www.youtube.com/@cnoe-community',
             },
             {
               label: 'CNOE Agentic AI SIG Governance',

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -29,7 +29,7 @@ const CHANNELS = [
     title: 'Meeting Recordings',
     description: 'Catch up on past community meetings and demos.',
     cta: 'Watch recordings',
-    href: 'https://github.com/cnoe-io/agentic-ai/wiki/Meeting-Recordings',
+    href: 'https://www.youtube.com/@cnoe-community',
     note: null,
     noteHref: null,
   },


### PR DESCRIPTION
## Summary

PR #1395 updated the markdown files but missed the two locations that actually drive the published `/community` page:

- `docs/src/pages/community.tsx` — the React component rendered at `/community` (the page users see)
- `docs/docusaurus.config.ts` — the footer "Meeting Recordings" link

Both still pointed to `https://github.com/cnoe-io/agentic-ai/wiki/Meeting-Recordings`.

## Test plan

- [ ] Verify https://cnoe-io.github.io/ai-platform-engineering/community shows YouTube link for Meeting Recordings
- [ ] Verify footer "Meeting Recordings" link points to YouTube channel