### PR TITLE
feat(dynamic-agents): add curl builtin tool for PUT/POST/PATCH/DELETE support

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -203,6 +203,20 @@ class FetchUrlToolConfig(BaseModel):
     )
 
 
+class CurlToolConfig(BaseModel):
+    """Configuration for the curl built-in tool."""
+
+    enabled: bool = Field(False, description="Whether the tool is enabled")
+    allowed_domains: str = Field(
+        default="*",
+        description=(
+            "Comma-separated domain patterns. "
+            "Use * for all, *.domain.com for subdomains, or exact domain. "
+            "Empty string blocks all domains."
+        ),
+    )
+
+
 class CurrentDatetimeToolConfig(BaseModel):
     """Configuration for the current_datetime built-in tool."""
 
@@ -247,6 +261,10 @@ class BuiltinToolsConfig(BaseModel):
     fetch_url: FetchUrlToolConfig | None = Field(
         None,
         description="Configuration for the fetch_url tool (fetches content from URLs)",
+    )
+    curl: CurlToolConfig | None = Field(
+        None,
+        description="Configuration for the curl tool (HTTP requests including PUT/POST/PATCH/DELETE)",
     )
     current_datetime: CurrentDatetimeToolConfig | None = Field(
         None,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -43,6 +43,7 @@ from dynamic_agents.models import (
     UserContext,
 )
 from dynamic_agents.services.builtin_tools import (
+    create_curl_tool,
     create_current_datetime_tool,
     create_fetch_url_tool,
     create_format_file_tool,
@@ -500,6 +501,13 @@ class AgentRuntime:
             allowed_domains = fetch_url_config.allowed_domains or "*"
             tools.append(create_fetch_url_tool(allowed_domains=allowed_domains))
             config_summary["fetch_url"] = {"allowed_domains": allowed_domains}
+
+        # curl tool (disabled by default) — supports PUT/POST/PATCH/DELETE
+        curl_config = config.builtin_tools.curl
+        if curl_config and curl_config.enabled:
+            allowed_domains = curl_config.allowed_domains or "*"
+            tools.append(create_curl_tool(allowed_domains=allowed_domains))
+            config_summary["curl"] = {"allowed_domains": allowed_domains}
 
         # current_datetime tool (enabled by default)
         current_datetime_config = config.builtin_tools.current_datetime

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -45,6 +45,24 @@ def get_builtin_tool_definitions() -> list[BuiltinToolDefinition]:
             ],
         ),
         BuiltinToolDefinition(
+            id="curl",
+            name="Curl",
+            description="Executes HTTP requests (GET, POST, PUT, PATCH, DELETE) via curl — use when you need to call write APIs",
+            enabled_by_default=False,
+            config_fields=[
+                BuiltinToolConfigField(
+                    name="allowed_domains",
+                    type="string",
+                    label="Allowed Domains",
+                    description=(
+                        "Comma-separated domain patterns. Use * for all, *.domain.com for subdomains, or exact domain."
+                    ),
+                    default="*",
+                    required=False,
+                ),
+            ],
+        ),
+        BuiltinToolDefinition(
             id="current_datetime",
             name="Current Date/Time",
             description="Returns the current date and time in various formats and timezones",
@@ -239,6 +257,117 @@ def create_fetch_url_tool(allowed_domains: str = "*"):
         return _fetch_url_content(url, format, timeout)
 
     return fetch_url
+
+
+def create_curl_tool(allowed_domains: str = "*"):
+    """Create a curl tool with domain restrictions.
+
+    Supports all HTTP methods (GET, POST, PUT, PATCH, DELETE). Use this
+    when agents need to call write APIs that fetch_url cannot handle.
+
+    Args:
+        allowed_domains: Comma-separated domain patterns (same ACL as fetch_url).
+
+    Returns:
+        A LangChain tool that wraps curl with domain ACL and https-only enforcement.
+    """
+    import shlex
+    import subprocess
+
+    CURL_TIMEOUT = 300
+
+    @tool
+    def curl(
+        command: str,
+        thought: str = "",
+        timeout: int = CURL_TIMEOUT,
+        strip_html: bool = False,
+    ) -> str:
+        """Execute an HTTP request via curl (https:// only).
+
+        Use this for all HTTP operations that require a method other than GET,
+        or when you need fine-grained control over headers and request body:
+        POST, PUT, PATCH, DELETE, and file downloads.
+
+        Args:
+            command: Curl command to run (e.g., "curl -s -X PUT https://api.example.com/resource -d '{}'")
+            thought: Brief reasoning for why you're making this request
+            timeout: Command timeout in seconds (default: 300)
+            strip_html: If True, strip HTML tags and return plain text
+
+        Returns:
+            Command output as string, or "ERROR: <message>" on failure.
+
+        Examples:
+            # PUT request with JSON body
+            curl("curl -s -X PUT https://api.example.com/resource -H 'Content-Type: application/json' -d '{\"status\":\"done\"}'")
+
+            # POST with auth header
+            curl("curl -s -X POST https://api.example.com/items -H 'Authorization: Bearer TOKEN' -d '{\"name\":\"test\"}'")
+
+            # GET request (alternative to fetch_url)
+            curl("curl -s https://api.example.com/data")
+        """
+        try:
+            args = shlex.split(command)
+        except ValueError as e:
+            return f"ERROR: Failed to parse command: {e}"
+
+        if not args or args[0] != "curl":
+            args = ["curl"] + args
+
+        # Enforce https-only
+        for token in args[1:]:
+            if "://" in token and not token.startswith("https://"):
+                scheme = token.split("://")[0] + "://"
+                return (
+                    f"The URL scheme '{scheme}' is not supported.\n\n"
+                    "**Only `https://` URLs are allowed.**\n\n"
+                    f"Please use an `https://` endpoint instead of `{token.split('?')[0]}`."
+                )
+
+        # Check domain ACL (same logic as fetch_url)
+        for token in args[1:]:
+            if token.startswith("https://"):
+                try:
+                    parsed = urlparse(token)
+                    domain = parsed.netloc.lower()
+                    if ":" in domain:
+                        domain = domain.split(":")[0]
+                    is_allowed, error_msg = is_domain_allowed(domain, allowed_domains)
+                    if not is_allowed:
+                        logger.warning(f"curl domain blocked: {domain} (patterns: {allowed_domains})")
+                        return f"ERROR: {error_msg}"
+                except Exception as e:
+                    return f"ERROR: Failed to parse URL: {e}"
+                break
+
+        try:
+            result = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+            output = result.stdout
+            if result.stderr:
+                output = (output + "\n" + result.stderr) if output else result.stderr
+            if result.returncode != 0:
+                return f"ERROR: {output}" if output else "ERROR: Command failed"
+            if not output:
+                return "Success (no output)"
+            if strip_html:
+                try:
+                    soup = BeautifulSoup(output, "html.parser")
+                    for tag in soup(["script", "style"]):
+                        tag.decompose()
+                    return soup.get_text(separator="\n", strip=True)
+                except Exception:
+                    pass
+            return output
+        except subprocess.TimeoutExpired:
+            return f"ERROR: Command timed out after {timeout} seconds"
+        except FileNotFoundError:
+            return "ERROR: curl command not found — ensure curl is installed"
+        except Exception as e:
+            return f"ERROR: {e}"
+
+    return curl
 
 
 def create_current_datetime_tool():
@@ -635,6 +764,7 @@ def create_format_file_tool(store, namespace_factory):
 
 __all__ = [
     "create_fetch_url_tool",
+    "create_curl_tool",
     "create_current_datetime_tool",
     "create_user_info_tool",
     "create_wait_tool",

--- a/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
@@ -1,4 +1,5 @@
 import importlib
+from unittest.mock import MagicMock, patch
 
 
 def test_self_identity_returns_agent_id() -> None:
@@ -26,3 +27,52 @@ def test_self_identity_returns_agent_id() -> None:
         "model_provider": "test-provider",
         "gradient_theme": "ocean",
     }
+
+
+def test_create_curl_tool_blocks_http() -> None:
+    create_curl_tool = getattr(
+        importlib.import_module("dynamic_agents.services.builtin_tools"),
+        "create_curl_tool",
+    )
+    curl_tool = create_curl_tool(allowed_domains="*")
+    result = curl_tool.invoke({"command": "curl -s http://example.com/api"})
+    assert "not supported" in result.lower() or "ERROR" in result
+
+
+def test_create_curl_tool_blocks_disallowed_domain() -> None:
+    create_curl_tool = getattr(
+        importlib.import_module("dynamic_agents.services.builtin_tools"),
+        "create_curl_tool",
+    )
+    curl_tool = create_curl_tool(allowed_domains="*.example.com")
+    result = curl_tool.invoke({"command": "curl -s https://evil.com/api"})
+    assert "ERROR" in result
+    assert "evil.com" in result
+
+
+def test_create_curl_tool_success() -> None:
+    create_curl_tool = getattr(
+        importlib.import_module("dynamic_agents.services.builtin_tools"),
+        "create_curl_tool",
+    )
+    curl_tool = create_curl_tool(allowed_domains="*")
+    mock_result = MagicMock()
+    mock_result.stdout = '{"status": "ok"}'
+    mock_result.stderr = ""
+    mock_result.returncode = 0
+    with patch("subprocess.run", return_value=mock_result):
+        result = curl_tool.invoke({"command": "curl -s https://api.example.com/status"})
+    assert result == '{"status": "ok"}'
+
+
+def test_curl_tool_in_builtin_tool_definitions() -> None:
+    get_builtin_tool_definitions = getattr(
+        importlib.import_module("dynamic_agents.services.builtin_tools"),
+        "get_builtin_tool_definitions",
+    )
+    definitions = get_builtin_tool_definitions()
+    ids = [d.id for d in definitions]
+    assert "curl" in ids
+    curl_def = next(d for d in definitions if d.id == "curl")
+    assert curl_def.enabled_by_default is False
+    assert any(f.name == "allowed_domains" for f in curl_def.config_fields)


### PR DESCRIPTION
## Summary

- The `fetch_url` builtin tool for dynamic agents only supports GET requests; agents that need to call write APIs (PUT, POST, PATCH, DELETE) had no way to do so
- The supervisor/multi-agent stack already has a `curl` tool (added in PR #1242) but it was never wired into the dynamic agents builtin tools system
- This PR adds `curl` as a first-class builtin tool for dynamic agents, matching the same domain ACL and https-only guard pattern already used by `fetch_url`

## Changes

- **`models.py`**: `CurlToolConfig` model with `enabled`/`allowed_domains` fields; `BuiltinToolsConfig.curl` field
- **`builtin_tools.py`**: `create_curl_tool()` factory with domain ACL (same pattern as `create_fetch_url_tool`), https-only enforcement, `strip_html` support, and exposed via `get_builtin_tool_definitions()` for UI discovery
- **`agent_runtime.py`**: wire `curl` into `_build_builtin_tools()` alongside `fetch_url`
- **`test_builtin_tools.py`**: 4 new tests — http-blocking, domain ACL, successful execution, tool definition discovery

## Configuration

Enable for an agent via `builtin_tools.curl.enabled: true` (disabled by default, same as `fetch_url`). Optionally scope to specific domains via `allowed_domains`.

## Test plan

- [ ] `pytest ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py` — all 5 tests pass
- [ ] Agent with `curl` enabled can execute PUT/POST requests
- [ ] Agent with `curl` disabled does not have the tool available
- [ ] Domain ACL blocks requests to non-allowed domains
- [ ] `http://` URLs are rejected with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)