### PR TITLE
fix(ci): remove invalid description field from docs workflows

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,5 +1,4 @@
 name: "[Docs] New Release Post (skeleton)"
-description: "Create a skeleton release blog post for a human to fill in"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -1,5 +1,4 @@
 name: "[Docs] Snapshot & Prune Versions"
-description: "On semver tag push: snapshot current docs as the new version, prune old snapshots, open a PR"
 
 on:
   push:


### PR DESCRIPTION
## Summary

- Removes the invalid top-level `description:` field from both `docs-snapshot.yml` and `docs-release.yml`
- GitHub Actions does not support `description` as a top-level key — it caused both workflows to fail immediately with "This run likely failed because of a workflow file issue"

## Test plan

- [ ] Merge and confirm `docs-snapshot` workflow is valid (no "workflow file issue")
- [ ] Dispatch `docs-snapshot` for `0.4.12` to fix stale docs