### PR TITLE
fix(slack-bot): skip bot thread replies to prevent duplicate responses

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -760,9 +760,11 @@ def handle_message_events(body, say, client):
 
   channel_config = config.channels[channel_id]
 
-  # Skip threaded user replies (handled by @mention); bots can post in threads
+  # Skip all thread replies — root messages are the trigger, thread history is
+  # fetched as context when processing. Responding to each reply causes duplicate
+  # invocations when a bot posts multiple follow-ups in its own thread.
   is_thread = event.get("thread_ts") is not None
-  if is_thread and not is_bot:
+  if is_thread:
     return
 
   # Skip @mentions — handled by handle_mention

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -760,9 +760,7 @@ def handle_message_events(body, say, client):
 
   channel_config = config.channels[channel_id]
 
-  # Skip all thread replies — root messages are the trigger, thread history is
-  # fetched as context when processing. Responding to each reply causes duplicate
-  # invocations when a bot posts multiple follow-ups in its own thread.
+  # Skip thread replies; only root messages trigger the agent.
   is_thread = event.get("thread_ts") is not None
   if is_thread:
     return


### PR DESCRIPTION
## Summary

- Forge was responding multiple times in a thread when a bot (e.g., a CI notification bot) posted a root message followed by thread replies
- Root cause: `handle_message_events` only skipped threaded replies from human users (`if is_thread and not is_bot`), so each bot thread reply triggered a separate agent invocation
- Fix: remove the `not is_bot` guard so all thread replies are skipped; root bot messages (no `thread_ts`) still pass through as before

## Test plan

- [ ] Verify Forge responds once to a bot-posted root message in a configured channel
- [ ] Verify Forge does NOT respond to subsequent bot replies in that same thread
- [ ] Verify Forge still responds when @mentioned in a thread
- [ ] Verify DM flows and user-initiated flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)