### PR TITLE
fix(caipe-ui): add initContainers support to deployment template

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -139,6 +139,18 @@ vpa:
     memory: 128Mi
   maxAllowed: {}
 
+# Additional init containers for the Deployment.
+# Runs before the main container starts. Useful for pre-creating directories
+# needed by subPath volume mounts on runtimes (e.g. kind) that do not
+# auto-create missing parent paths.
+initContainers: []
+# - name: init-skill-dirs
+#   image: busybox:1.36
+#   command: ["sh", "-c", "mkdir -p /data/skills/my-skill"]
+#   volumeMounts:
+#     - name: skill-data-dir
+#       mountPath: /data
+
 # Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo


### PR DESCRIPTION
## Summary

- Adds `{{- with .Values.initContainers }}` block to `caipe-ui/templates/deployment.yaml`
- Documents `initContainers: []` in `caipe-ui/values.yaml` with usage example

## Problem

On **kind clusters** (and other runtimes that don't use overlayfs), containerd does not auto-create missing parent directories for `subPath` file bind mounts. When skill template ConfigMap keys are mounted via `subPath` into `/app/data/skills/<skill-name>/SKILL.md`, the container fails to start with:

```
runc create failed: unable to start container process: error during container init:
error mounting ... to rootfs at "/app/data/skills/aws-cost-analysis/SKILL.md":
mount ...: not a directory
```

Exit code 128 (StartError), resulting in CrashLoopBackOff.

EKS and other overlayfs-based runtimes handle this transparently, so the issue only surfaces on kind/VM deployments.

## Fix

Expose `initContainers` as a first-class values field, consistent with how `volumes` and `volumeMounts` are already supported. Deployers on kind clusters can use a busybox init container to pre-create the skill directory structure in an emptyDir before the main container starts:

```yaml
caipe-ui:
  initContainers:
    - name: init-skill-dirs
      image: busybox:1.36
      command: ["sh", "-c", "mkdir -p /skill-data/skills/aws-cost-analysis"]
      volumeMounts:
        - name: skill-data-dir
          mountPath: /skill-data
  volumes:
    - name: skill-data-dir
      emptyDir: {}
  volumeMounts:
    - name: skill-data-dir
      mountPath: /app/data
```

## Test plan

- [ ] `helm template` renders `initContainers` when set; omits the field when empty
- [ ] caipe-demo (kind cluster) deploys cleanly with the init container pre-creating skill dirs
- [ ] EKS deployments (dev/preview/prod) unaffected — `initContainers: []` renders nothing

Generated with [Claude Code](https://claude.com/claude-code)
