### PR TITLE
fix(ci): use GITHUB_TOKEN for gh pr create in docs workflows

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -138,6 +138,7 @@ jobs:
       - name: Open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          WORKFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.meta.outputs.new_version }}
           PREV_VERSION: ${{ steps.meta.outputs.prev_version }}
           BLOG_FILE: ${{ steps.meta.outputs.blog_file }}
@@ -178,7 +179,7 @@ jobs:
             echo "- [ ] Upgrade Guide / Helm values diff verified"
           } > /tmp/pr-body.md
 
-          gh pr create \
+          GH_TOKEN="$WORKFLOW_TOKEN" gh pr create \
             --title "docs: release ${NEW_VERSION} blog post" \
             --base main \
             --head "$BRANCH" \

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          WORKFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.versions.outputs.new_version }}
         run: |
           BRANCH="docs/snapshot-${NEW_VERSION}"
@@ -121,7 +122,7 @@ jobs:
             echo "- [ ] Helm docs look correct"
           } > /tmp/pr-body.md
 
-          gh pr create \
+          GH_TOKEN="$WORKFLOW_TOKEN" gh pr create \
             --title "docs: snapshot ${NEW_VERSION}" \
             --base main \
             --head "$BRANCH" \


### PR DESCRIPTION
## Summary

- `docs-snapshot.yml` and `docs-release.yml` were failing at `gh pr create` with:
  ```
  pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
  ```
- Root cause: GitHub App token (`RELEASE_APP_*`) has `contents:write` but not `pull-requests:write`
- Fix: use `secrets.GITHUB_TOKEN` (passed as `WORKFLOW_TOKEN`) for the `gh pr create` call; keep the app token only for `git push` (which requires write access to the protected branch)

## Changes

- Both workflow files: added `WORKFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the Open PR step env
- Changed `GH_TOKEN="$GH_TOKEN" gh pr create` → `GH_TOKEN="$WORKFLOW_TOKEN" gh pr create`

## Test plan

- [ ] Merge this PR
- [ ] Re-dispatch `docs-snapshot.yml` for version `0.4.12` — should create a PR successfully
- [ ] Re-dispatch `docs-release.yml` for version `0.4.12` — should create a skeleton blog post PR