### PR TITLE
fix(ci): increase Node heap to 8 GB for Docusaurus builds

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -38,6 +38,8 @@ jobs:
           cd docs
           npm install
       - name: Build Docusaurus site
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
         run: |
           cd docs
           npm run build

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -71,6 +71,8 @@ jobs:
           NEW_VERSION="$NEW_VERSION" node scripts/snapshot-and-prune-versions.js
 
       - name: Validate Docusaurus build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
         run: |
           cd docs
           npm run build

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -51,6 +51,8 @@ jobs:
           cd docs
           npm install
       - name: Build Docusaurus site
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
         run: |
           cd docs
           npm run build


### PR DESCRIPTION
## Summary

- Docusaurus build OOMs after adding 6 versioned snapshots (0.3.11, 0.4.8–0.4.12)
- Root cause: Node.js default heap (~1.5 GB) is too small for webpack bundling 6 versions
- Fix: set `NODE_OPTIONS=--max-old-space-size=8192` on all three build steps

## Affected workflows

- `publish-gh-pages.yml` — fixes the currently broken GH Pages deploy on `main`
- `docs-build-check.yml` — PR build check
- `docs-snapshot.yml` — snapshot validation step

## Test plan

- [ ] GH Pages build passes on this PR
- [ ] Merge unblocks the stalled docs deploy
