### PR TITLE
feat(rag): anchor slack document fresh_until to message post time

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/slack/ingestor.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/slack/ingestor.py
@@ -27,6 +27,15 @@ sync_interval = int(os.environ.get("SYNC_INTERVAL", "86400"))  # Default 24 hour
 init_delay = int(os.environ.get("INIT_DELAY_SECONDS", "0"))
 
 
+def get_message_fresh_until(message_ts: str, lookback_days: int) -> int:
+  """Calculate fresh_until based on when the message was posted.
+
+  A message should remain in the system until it falls outside the lookback window.
+  For example, with lookback_days=30, a message posted 5 days ago expires in 25 days.
+  """
+  return int(float(message_ts)) + (lookback_days * 86400)
+
+
 def ts_to_readable(timestamp):
   """Convert Unix timestamp to human-readable datetime string."""
   try:
@@ -137,7 +146,7 @@ class SlackChannelSyncer:
       logger.error(f"Error fetching messages from {channel_name}: {e}")
       return [], oldest_ts
 
-  def group_messages_by_thread(self, messages: List[Dict], channel_id: str, channel_name: str, include_bots: bool, datasource_id: str, ingestor_id: str) -> List[Document]:
+  def group_messages_by_thread(self, messages: List[Dict], channel_id: str, channel_name: str, include_bots: bool, datasource_id: str, ingestor_id: str, lookback_days: int = 30) -> List[Document]:
     """Group messages into thread documents for RAG ingestion."""
     documents = []
 
@@ -172,19 +181,19 @@ class SlackChannelSyncer:
 
     # Create documents for threads
     for thread_ts, thread_messages in threads.items():
-      doc = self._create_thread_document(thread_messages, channel_id, channel_name, thread_ts, datasource_id, ingestor_id)
+      doc = self._create_thread_document(thread_messages, channel_id, channel_name, thread_ts, datasource_id, ingestor_id, lookback_days)
       if doc:
         documents.append(doc)
 
     # Create documents for standalone messages
     for msg in standalone:
-      doc = self._create_standalone_document(msg, channel_id, channel_name, datasource_id, ingestor_id)
+      doc = self._create_standalone_document(msg, channel_id, channel_name, datasource_id, ingestor_id, lookback_days)
       if doc:
         documents.append(doc)
 
     return documents
 
-  def _create_thread_document(self, thread_messages: List[Dict], channel_id: str, channel_name: str, thread_ts: str, datasource_id: str, ingestor_id: str) -> Optional[Document]:
+  def _create_thread_document(self, thread_messages: List[Dict], channel_id: str, channel_name: str, thread_ts: str, datasource_id: str, ingestor_id: str, lookback_days: int = 30) -> Optional[Document]:
     """Create a document from a thread of messages."""
     if not thread_messages:
       return None
@@ -225,7 +234,7 @@ class SlackChannelSyncer:
       document_type="slack_thread",
       document_ingested_at=int(time.time()),
       document_id=f"slack-thread-{channel_id}-{thread_ts}",
-      fresh_until=sync_interval * 3,
+      fresh_until=get_message_fresh_until(thread_messages[-1].get("ts", "0"), lookback_days),
       title=f"Thread: {parent_text}",
       metadata={
         "channel_name": channel_name,
@@ -242,7 +251,7 @@ class SlackChannelSyncer:
 
     return Document(page_content=content, metadata=metadata.model_dump())
 
-  def _create_standalone_document(self, msg: Dict, channel_id: str, channel_name: str, datasource_id: str, ingestor_id: str) -> Optional[Document]:
+  def _create_standalone_document(self, msg: Dict, channel_id: str, channel_name: str, datasource_id: str, ingestor_id: str, lookback_days: int = 30) -> Optional[Document]:
     """Create a document from a standalone message."""
     user = msg.get("user", "Unknown")
     text = msg.get("text", "")
@@ -272,7 +281,7 @@ class SlackChannelSyncer:
       document_ingested_at=int(time.time()),
       document_id=f"slack-message-{channel_id}-{ts}",
       title=f"Message: {message_preview}",
-      fresh_until=sync_interval * 3,
+      fresh_until=get_message_fresh_until(ts, lookback_days),
       metadata={
         "channel_name": channel_name,
         "channel_id": channel_id,
@@ -371,7 +380,7 @@ async def sync_slack_channels(client: Client):
       continue
 
     # Convert messages to thread documents
-    documents = syncer.group_messages_by_thread(messages, channel_id, channel_name, include_bots, datasource_id, client.ingestor_id or "")
+    documents = syncer.group_messages_by_thread(messages, channel_id, channel_name, include_bots, datasource_id, client.ingestor_id or "", lookback_days)
 
     if not documents:
       logger.info(f"No documents created for #{channel_name}")

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/ingestion.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/ingestion.py
@@ -717,7 +717,8 @@ class DocumentProcessor:
         # Override metadata fields - this is to ensure correct association (even if doc.metadata has different values)
         document_metadata.ingestor_id = ingestor_id
         document_metadata.datasource_id = datasource_id
-        document_metadata.fresh_until = fresh_until
+        # Use per-document fresh_until if provided, otherwise fall back to batch-level value
+        document_metadata.fresh_until = document_metadata.fresh_until or fresh_until
         document_metadata.document_ingested_at = int(time.time())
 
         # Step 1b: Check if it's a structured entity and parse if needed


### PR DESCRIPTION
## Summary

- Slack messages now expire based on `message_ts + lookback_days` instead of `ingestion_time + sync_interval * 1.5`, ensuring a true rolling window of messages in the system
- Rag-server now respects per-document `fresh_until` when set by the ingestor, falling back to the batch-level value for backward compatibility
- Extracted `get_message_fresh_until()` helper for reuse

## Problem

Previously, messages ingested during the initial 30-day lookback would all expire ~36h after ingestion (since `fresh_until = now + sync_interval * 1.5`). Incremental syncs only fetch new messages, so historical messages were never refreshed and got cleaned up by the periodic cleanup job. This meant the effective retention was ~36h, not the configured `lookback_days`.

## Solution

Anchor `fresh_until` to the message's post timestamp: `fresh_until = message_ts + (lookback_days * 86400)`. A message posted 5 days ago with `lookback_days=30` will now live for 25 more days — exactly until it falls outside the rolling window.