### PR TITLE
fix(setup): remove invalid :- default from array expansions in setup-caipe.sh

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -101,7 +101,7 @@ fi
 
 cleanup_on_exit() {
   # Kill tracked PIDs
-  for pid in "${PF_PIDS[@]:-}"; do
+  for pid in "${PF_PIDS[@]}"; do
     kill "$pid" 2>/dev/null || true
   done
   # Fallback: kill any kubectl port-forward processes started for our services
@@ -5290,7 +5290,7 @@ monitor_port_forwards() {
     local now
     now=$(date +%s)
 
-    for i in "${!PF_PIDS[@]:-}"; do
+    for i in "${!PF_PIDS[@]}"; do
       local _pf_port
       # shellcheck disable=SC2086
       _pf_port=$(echo ${PF_SVCS[$i]} | awk '{print $3}')


### PR DESCRIPTION
## Summary

- `${!PF_PIDS[@]:-}` and `${PF_PIDS[@]:-}` are not valid bash — the `:-` default modifier cannot be applied to array index/value expansions. On some shells (reported by Shannon) this throws `invalid variable name`.
- Iterating over an empty array in bash is already a no-op, so the fallback was never needed.
- Pre-existing bug, not introduced by recent changes.

## Test plan

- [ ] `./setup-caipe.sh validate` completes without `invalid variable name` error on line 5293