### PR TITLE
feat(caipe-ui): configurable default agent (#1378)

### DIFF
--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -686,6 +686,10 @@ caipe-ui:
   config:
     # CAIPE Supervisor URL - automatically configured to use the supervisor-agent service
     A2A_BASE_URL: "http://ai-platform-engineering-supervisor-agent:8000"
+    # Bootstrap default agent for new chats. Overridden at runtime by Admin → Settings UI.
+    # Set to a dynamic agent ID to pre-configure the default without manual admin action.
+    # Leave empty to use the supervisor (Platform Engineer) as default.
+    DEFAULT_AGENT_ID: ""
     # Skills template directory (mounted from ConfigMap)
     SKILLS_DIR: "/app/data/skills"
     # Live-skills skill template (mounted from ConfigMap "skills-live-skills").

--- a/docs/docs/features/admin-settings.md
+++ b/docs/docs/features/admin-settings.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 3
+---
+
+# Admin Settings
+
+The Admin Dashboard is the operator surface for managing CAIPE UI behavior,
+access, metrics, and policy controls. Admin settings are available from the
+`Admin` tab in the main navigation and are grouped so operators can find
+routine tasks without scanning a long row of unrelated tabs.
+
+![Admin Dashboard settings layout](./images/admin-settings.svg)
+
+## Admin Dashboard Sections
+
+The top-level Admin Dashboard categories are:
+
+| Category | Tabs | Purpose |
+|----------|------|---------|
+| `System` | `Default Agent`, `AI Review`, `Skills` | Configure core CAIPE behavior and system-level agent features. |
+| `Users & Teams` | `Users`, `Teams` | Review users, assign roles, and manage collaboration groups. |
+| `Insights` | `Feedback`, `NPS`, `Statistics` | Inspect user feedback, satisfaction trends, and product usage. |
+| `Metrics & Health` | `Metrics`, `Health` | Check platform telemetry and service health. |
+| `Security & Policy` | `Audit Logs`, `Policy` | Review administrative activity and policy controls. |
+
+Some tabs only appear when the related feature is enabled or when the current
+user has full admin access. Read-only admin viewers can inspect supported
+dashboard areas but cannot save administrative changes.
+
+## Default Agent
+
+`System` → `Default Agent` controls which agent opens when a user starts a new
+chat. This setting is useful when an installation wants new conversations to
+start with a specialized dynamic agent instead of the supervisor.
+
+The selector always includes `Default CAIPE Supervisor`. Choosing this option
+means new chats use the built-in supervisor flow rather than a dynamic agent.
+
+When dynamic agents are available, each registered agent appears in the same
+selector. Choosing one and clicking `Save` stores that agent as the runtime
+default for new chats.
+
+## Precedence
+
+The runtime admin setting takes precedence over bootstrap configuration:
+
+1. If an admin saves a default agent in the UI, CAIPE uses that persisted value.
+2. If no UI value has been saved, CAIPE can fall back to the `DEFAULT_AGENT_ID`
+   deployment value.
+3. If neither is configured, new chats use `Default CAIPE Supervisor`.
+
+When CAIPE is currently using `DEFAULT_AGENT_ID`, the UI displays a note that
+saving from the Admin Dashboard will override the bootstrap default at runtime.
+
+## Missing Agents
+
+If a previously saved default dynamic agent is no longer available, the
+Default Agent panel warns administrators and new chats fall back to the
+supervisor. Pick another available agent or choose `Default CAIPE Supervisor`
+and save to clear the stale runtime setting.
+
+## Access Control
+
+Only full admins can change the Default Agent setting. Non-admin or read-only
+admin users can view the configured value, but the selector is disabled and
+the `Save` action is hidden.
+
+Admin access is determined by the UI authentication and role configuration.
+For SSO-enabled deployments, role and view access come from configured identity
+groups. In local or no-SSO development, avoid granting anonymous admin access
+unless the environment explicitly requires it.
+
+## Related Pages
+
+- [Custom Agents](./custom-agents.md)
+- [BYO A2A Agents & MCP Servers](./byo-agents.md)
+- [Skills](./skills/README.md)

--- a/docs/docs/features/images/admin-settings.svg
+++ b/docs/docs/features/images/admin-settings.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="594" height="330" viewBox="0 0 594 330" role="img" aria-labelledby="title desc">
+  <title id="title">Admin Dashboard Settings Layout</title>
+  <desc id="desc">Illustration of the Admin Dashboard with grouped category tabs and the Default Agent settings panel.</desc>
+  <defs>
+    <linearGradient id="page" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b0f1a" />
+      <stop offset="1" stop-color="#05070d" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#12162a" />
+      <stop offset="1" stop-color="#090b16" />
+    </linearGradient>
+    <linearGradient id="active" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#15c3b0" />
+      <stop offset="1" stop-color="#0ea68f" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="16" stdDeviation="18" flood-color="#000000" flood-opacity="0.35" />
+    </filter>
+  </defs>
+
+  <rect width="594" height="330" rx="10" fill="url(#page)" />
+
+  <text x="8" y="20" fill="#f5f7fb" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Admin Dashboard</text>
+  <text x="8" y="39" fill="#8f98ad" font-family="Inter, Arial, sans-serif" font-size="8">Manage users, teams, monitor usage, and track platform metrics</text>
+
+  <g filter="url(#shadow)">
+    <rect x="8" y="58" width="130" height="70" rx="8" fill="url(#card)" stroke="#262b42" />
+    <text x="19" y="84" fill="#dce2ef" font-family="Inter, Arial, sans-serif" font-size="7" font-weight="600">Total Users</text>
+    <text x="19" y="106" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">1</text>
+    <text x="19" y="120" fill="#8290a8" font-family="Inter, Arial, sans-serif" font-size="7">DAU: 1 | MAU: 1</text>
+
+    <rect x="151" y="58" width="130" height="70" rx="8" fill="url(#card)" stroke="#262b42" />
+    <text x="162" y="84" fill="#dce2ef" font-family="Inter, Arial, sans-serif" font-size="7" font-weight="600">Conversations</text>
+    <text x="162" y="106" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">6</text>
+    <text x="162" y="120" fill="#8290a8" font-family="Inter, Arial, sans-serif" font-size="7">Today: +6</text>
+
+    <rect x="294" y="58" width="130" height="70" rx="8" fill="url(#card)" stroke="#262b42" />
+    <text x="305" y="84" fill="#dce2ef" font-family="Inter, Arial, sans-serif" font-size="7" font-weight="600">Messages</text>
+    <text x="305" y="106" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">4</text>
+    <text x="305" y="120" fill="#8290a8" font-family="Inter, Arial, sans-serif" font-size="7">Today: +4</text>
+
+    <rect x="437" y="58" width="130" height="70" rx="8" fill="url(#card)" stroke="#262b42" />
+    <text x="448" y="84" fill="#dce2ef" font-family="Inter, Arial, sans-serif" font-size="7" font-weight="600">Shared (Web)</text>
+    <text x="448" y="106" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">0</text>
+    <text x="448" y="120" fill="#8290a8" font-family="Inter, Arial, sans-serif" font-size="7">0.0% of all conversations</text>
+  </g>
+
+  <g font-family="Inter, Arial, sans-serif" font-size="7.5" font-weight="600">
+    <rect x="8" y="146" width="55" height="18" rx="9" fill="url(#active)" />
+    <text x="25" y="158" fill="#ffffff">System</text>
+    <circle cx="18" cy="155" r="3" fill="none" stroke="#ffffff" stroke-width="1" />
+
+    <rect x="70" y="146" width="76" height="18" rx="9" fill="#1d2233" />
+    <text x="89" y="158" fill="#8f98ad">Users &amp; Teams</text>
+
+    <rect x="153" y="146" width="58" height="18" rx="9" fill="#1d2233" />
+    <text x="173" y="158" fill="#8f98ad">Insights</text>
+
+    <rect x="218" y="146" width="84" height="18" rx="9" fill="#1d2233" />
+    <text x="235" y="158" fill="#8f98ad">Metrics &amp; Health</text>
+
+    <rect x="309" y="146" width="96" height="18" rx="9" fill="#1d2233" />
+    <text x="326" y="158" fill="#8f98ad">Security &amp; Policy</text>
+  </g>
+
+  <rect x="8" y="173" width="559" height="18" rx="5" fill="#202638" />
+  <g font-family="Inter, Arial, sans-serif" font-size="8" font-weight="600">
+    <rect x="16" y="176" width="88" height="12" rx="4" fill="#0b0d14" />
+    <text x="33" y="185" fill="#ffffff">Default Agent</text>
+    <circle cx="25" cy="182" r="3" fill="none" stroke="#ffffff" stroke-width="1" />
+    <text x="124" y="185" fill="#8f98ad">AI Review</text>
+    <text x="188" y="185" fill="#8f98ad">Skills</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="8" y="204" width="559" height="98" rx="8" fill="url(#card)" stroke="#262b42" />
+    <text x="30" y="236" fill="#f5f7fb" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="700">Default Agent</text>
+    <text x="30" y="255" fill="#8f98ad" font-family="Inter, Arial, sans-serif" font-size="7.5">Select which agent new chats open with. Admins can override this at runtime; it takes precedence over DEFAULT_AGENT_ID.</text>
+
+    <text x="30" y="280" fill="#e3e8f4" font-family="Inter, Arial, sans-serif" font-size="8" font-weight="600">Default agent for new chats</text>
+    <rect x="178" y="266" width="198" height="22" rx="5" fill="#080b12" stroke="#242a3d" />
+    <text x="194" y="281" fill="#f5f7fb" font-family="Inter, Arial, sans-serif" font-size="8">Basic SRE</text>
+    <path d="M358 274l5 5 5-5" fill="none" stroke="#8f98ad" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" />
+
+    <rect x="30" y="306" width="54" height="22" rx="6" fill="#12a391" opacity="0.62" />
+    <text x="50" y="321" fill="#c8fff4" font-family="Inter, Arial, sans-serif" font-size="8" font-weight="700">Save</text>
+  </g>
+</svg>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -287,6 +287,7 @@ const sidebars: SidebarsConfig = {
           items: [
             { type: 'doc', id: 'ui/index', label: 'Overview' },
             { type: 'doc', id: 'ui/features', label: 'Features' },
+            { type: 'doc', id: 'features/admin-settings', label: 'Admin Settings' },
             { type: 'doc', id: 'ui/auth-flow', label: 'Authentication Flow' },
             { type: 'doc', id: 'ui/configuration', label: 'Configuration' },
             { type: 'doc', id: 'ui/customization', label: 'Customization & Branding' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.12-dev.10"
+version = "0.4.12-dev.11"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -57,6 +57,14 @@ jest.mock('@/components/admin/HealthTab', () => ({
   HealthTab: () => <div data-testid="health-tab">HealthTab</div>,
 }));
 
+jest.mock('@/components/admin/ReviewConfigsTab', () => ({
+  ReviewConfigsTab: () => <div data-testid="review-configs-tab">ReviewConfigsTab</div>,
+}));
+
+jest.mock('@/components/admin/PlatformSettingsTab', () => ({
+  PlatformSettingsTab: () => <div data-testid="platform-settings-tab">PlatformSettingsTab</div>,
+}));
+
 jest.mock('@/components/admin/SkillMetricsCards', () => ({
   VisibilityBreakdown: () => <div />,
   CategoryBreakdown: () => <div />,
@@ -395,6 +403,36 @@ describe('Admin Dashboard Page', () => {
       await waitFor(() => {
         expect(screen.getByText('Remove Admin')).toBeInTheDocument();
       });
+    });
+
+    it('groups admin tabs by category and moves system tabs into the first category', async () => {
+      render(<AdminPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('System')).toBeInTheDocument();
+      });
+
+      const categoryButtons = ['System', 'Users & Teams', 'Insights', 'Metrics & Health', 'Security & Policy']
+        .map((label) => screen.getByRole('button', { name: label }));
+      expect(categoryButtons[0]).toHaveTextContent('System');
+
+      fireEvent.click(screen.getByRole('button', { name: 'System' }));
+      expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+        'Default Agent',
+        'AI Review',
+        'Skills',
+      ]);
+      expect(screen.getByRole('tab', { name: /skills/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /ai review/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /default agent/i })).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: /settings/i })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /metrics & health/i }));
+
+      expect(screen.getByRole('tab', { name: /metrics/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /health/i })).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: /skills/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: /ai review/i })).not.toBeInTheDocument();
     });
   });
 

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { motion } from "framer-motion";
-import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X, FileText, Shield, HelpCircle, Globe, RefreshCw, Settings } from "lucide-react";
+import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X, FileText, Shield, HelpCircle, Globe, RefreshCw, Settings, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AuthGuard } from "@/components/auth-guard";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -200,6 +200,79 @@ interface Team {
 
 const VALID_TABS = ['users', 'teams', 'stats', 'skills', 'feedback', 'nps', 'metrics', 'health', 'policy', 'audit-logs', 'ai-review', 'settings'];
 
+type CategoryKey = 'system' | 'people' | 'insights' | 'platform' | 'security';
+type TabGate = 'always' | 'feedback' | 'nps' | 'admin' | 'audit-admin';
+
+interface AdminTabConfig {
+  value: string;
+  label: string;
+  icon: LucideIcon;
+  gate: TabGate;
+}
+
+interface AdminCategoryConfig {
+  key: CategoryKey;
+  label: string;
+  icon: LucideIcon;
+  tabs: AdminTabConfig[];
+}
+
+const ADMIN_CATEGORIES: AdminCategoryConfig[] = [
+  {
+    key: 'system',
+    label: 'System',
+    icon: Settings,
+    tabs: [
+      { value: 'settings', label: 'Default Agent', icon: Settings, gate: 'admin' },
+      { value: 'ai-review', label: 'AI Review', icon: ShieldCheck, gate: 'admin' },
+      { value: 'skills', label: 'Skills', icon: Layers, gate: 'always' },
+    ],
+  },
+  {
+    key: 'people',
+    label: 'Users & Teams',
+    icon: Users,
+    tabs: [
+      { value: 'users', label: 'Users', icon: Users, gate: 'always' },
+      { value: 'teams', label: 'Teams', icon: UsersIcon, gate: 'always' },
+    ],
+  },
+  {
+    key: 'insights',
+    label: 'Insights',
+    icon: TrendingUp,
+    tabs: [
+      { value: 'feedback', label: 'Feedback', icon: ThumbsUp, gate: 'feedback' },
+      { value: 'nps', label: 'NPS', icon: Star, gate: 'nps' },
+      { value: 'stats', label: 'Statistics', icon: TrendingUp, gate: 'always' },
+    ],
+  },
+  {
+    key: 'platform',
+    label: 'Metrics & Health',
+    icon: Activity,
+    tabs: [
+      { value: 'metrics', label: 'Metrics', icon: Activity, gate: 'always' },
+      { value: 'health', label: 'Health', icon: Database, gate: 'always' },
+    ],
+  },
+  {
+    key: 'security',
+    label: 'Security & Policy',
+    icon: Shield,
+    tabs: [
+      { value: 'audit-logs', label: 'Audit Logs', icon: FileText, gate: 'audit-admin' },
+      { value: 'policy', label: 'Policy', icon: Shield, gate: 'admin' },
+    ],
+  },
+];
+
+function categoryForTab(tab: string): CategoryKey {
+  return ADMIN_CATEGORIES.find((category) =>
+    category.tabs.some((item) => item.value === tab)
+  )?.key ?? 'people';
+}
+
 function AdminPage() {
   const { status } = useSession();
   const searchParams = useSearchParams();
@@ -207,6 +280,8 @@ function AdminPage() {
   const pathname = usePathname();
   const { isAdmin } = useAdminRole();
   const auditLogsEnabled = getConfig('auditLogsEnabled');
+  const feedbackEnabled = getConfig('feedbackEnabled');
+  const npsEnabled = getConfig('npsEnabled');
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [globalOverview, setGlobalOverview] = useState<AdminStats['overview'] | null>(null);
   const [skillStats, setSkillStats] = useState<SkillMetricsAdmin | null>(null);
@@ -225,6 +300,56 @@ function AdminPage() {
   const [activeTab, setActiveTab] = useState(
     initialTab && VALID_TABS.includes(initialTab) ? initialTab : 'users'
   );
+  const initialCategory = searchParams.get('cat') as CategoryKey | null;
+  const [activeCategory, setActiveCategory] = useState<CategoryKey>(
+    initialCategory && ADMIN_CATEGORIES.some((category) => category.key === initialCategory)
+      ? initialCategory
+      : categoryForTab(activeTab)
+  );
+  const isTabVisible = useCallback((tab: AdminTabConfig): boolean => {
+    switch (tab.gate) {
+      case 'feedback':
+        return feedbackEnabled;
+      case 'nps':
+        return npsEnabled;
+      case 'admin':
+        return isAdmin;
+      case 'audit-admin':
+        return auditLogsEnabled && isAdmin;
+      case 'always':
+      default:
+        return true;
+    }
+  }, [auditLogsEnabled, feedbackEnabled, isAdmin, npsEnabled]);
+  const visibleCategories = useMemo(
+    () =>
+      ADMIN_CATEGORIES
+        .map((category) => ({
+          ...category,
+          tabs: category.tabs.filter(isTabVisible),
+        }))
+        .filter((category) => category.tabs.length > 0),
+    [isTabVisible]
+  );
+  const visibleTabsForCategory = useMemo(
+    () =>
+      visibleCategories.find((category) => category.key === activeCategory)?.tabs
+      ?? visibleCategories[0]?.tabs
+      ?? [],
+    [activeCategory, visibleCategories]
+  );
+  const handleCategoryChange = useCallback((categoryKey: CategoryKey) => {
+    const category = visibleCategories.find((item) => item.key === categoryKey);
+    const firstTab = category?.tabs[0];
+    if (!category || !firstTab) return;
+
+    setActiveCategory(categoryKey);
+    setActiveTab(firstTab.value);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('cat', categoryKey);
+    params.set('tab', firstTab.value);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [pathname, router, searchParams, visibleCategories]);
   const [createTeamDialogOpen, setCreateTeamDialogOpen] = useState(false);
   const [teamDetailsOpen, setTeamDetailsOpen] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<TeamType | null>(null);
@@ -814,81 +939,47 @@ function AdminPage() {
             {/* Tabbed Content */}
             <Tabs value={activeTab} onValueChange={(tab) => {
               setActiveTab(tab);
+              const nextCategory = categoryForTab(tab);
+              setActiveCategory(nextCategory);
               const params = new URLSearchParams(searchParams.toString());
+              params.set('cat', nextCategory);
               params.set('tab', tab);
               router.replace(`${pathname}?${params.toString()}`, { scroll: false });
             }} className="space-y-4">
-              <TabsList className={`grid w-full ${(() => {
-                const n = 6
-                  + (getConfig('feedbackEnabled') ? 1 : 0)
-                  + (getConfig('npsEnabled') ? 1 : 0)
-                  + (auditLogsEnabled && isAdmin ? 1 : 0)
-                  + (isAdmin ? 1 : 0)
-                  + (isAdmin ? 1 : 0)
-                  + (isAdmin ? 1 : 0); // settings tab
-                const cols: Record<number, string> = { 6: 'grid-cols-6', 7: 'grid-cols-7', 8: 'grid-cols-8', 9: 'grid-cols-9', 10: 'grid-cols-10', 11: 'grid-cols-11' };
-                return cols[n] ?? 'grid-cols-6';
-              })()}`}>
-                <TabsTrigger value="users" className="gap-2">
-                  <Users className="h-4 w-4" />
-                  Users
-                </TabsTrigger>
-                <TabsTrigger value="teams" className="gap-2">
-                  <UsersIcon className="h-4 w-4" />
-                  Teams
-                </TabsTrigger>
-                <TabsTrigger value="skills" className="gap-2">
-                  <Layers className="h-4 w-4" />
-                  Skills
-                </TabsTrigger>
-                {getConfig('feedbackEnabled') && (
-                <TabsTrigger value="feedback" className="gap-2">
-                  <ThumbsUp className="h-4 w-4" />
-                  Feedback
-                </TabsTrigger>
-                )}
-                {getConfig('npsEnabled') && (
-                <TabsTrigger value="nps" className="gap-2">
-                  <Star className="h-4 w-4" />
-                  NPS
-                </TabsTrigger>
-                )}
-                <TabsTrigger value="stats" className="gap-2">
-                  <TrendingUp className="h-4 w-4" />
-                  Statistics
-                </TabsTrigger>
-                <TabsTrigger value="metrics" className="gap-2">
-                  <Activity className="h-4 w-4" />
-                  Metrics
-                </TabsTrigger>
-                <TabsTrigger value="health" className="gap-2">
-                  <Database className="h-4 w-4" />
-                  Health
-                </TabsTrigger>
-                {auditLogsEnabled && isAdmin && (
-                  <TabsTrigger value="audit-logs" className="gap-2">
-                    <FileText className="h-4 w-4" />
-                    Audit Logs
-                  </TabsTrigger>
-                )}
-                {isAdmin && (
-                  <TabsTrigger value="policy" className="gap-2">
-                    <Shield className="h-4 w-4" />
-                    Policy
-                  </TabsTrigger>
-                )}
-                {isAdmin && (
-                  <TabsTrigger value="ai-review" className="gap-2">
-                    <ShieldCheck className="h-4 w-4" />
-                    AI Review
-                  </TabsTrigger>
-                )}
-                {isAdmin && (
-                  <TabsTrigger value="settings" className="gap-2">
-                    <Settings className="h-4 w-4" />
-                    Settings
-                  </TabsTrigger>
-                )}
+              <div className="flex flex-wrap gap-1.5">
+                {visibleCategories.map((category) => {
+                  const Icon = category.icon;
+                  const selected = category.key === activeCategory;
+                  return (
+                    <button
+                      key={category.key}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => handleCategoryChange(category.key)}
+                      className={cn(
+                        "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+                        selected
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+                      )}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      {category.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <TabsList className="flex w-full justify-start gap-0 overflow-x-auto">
+                {visibleTabsForCategory.map((tab) => {
+                  const Icon = tab.icon;
+                  return (
+                    <TabsTrigger key={tab.value} value={tab.value} className="gap-1.5 shrink-0">
+                      <Icon className="h-4 w-4" />
+                      {tab.label}
+                    </TabsTrigger>
+                  );
+                })}
               </TabsList>
 
               {/* User Management Tab */}
@@ -1248,7 +1339,7 @@ function AdminPage() {
               </TabsContent>
 
               {/* Feedback Tab */}
-              {getConfig('feedbackEnabled') && <TabsContent value="feedback" className="space-y-4">
+              {feedbackEnabled && <TabsContent value="feedback" className="space-y-4">
                 {/* Filters */}
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 flex-wrap">
@@ -1481,7 +1572,7 @@ function AdminPage() {
               </TabsContent>}
 
               {/* NPS Tab */}
-              {getConfig('npsEnabled') && <TabsContent value="nps" className="space-y-4">
+              {npsEnabled && <TabsContent value="nps" className="space-y-4">
                 {/* Campaign Management */}
                 {isAdmin && (
                   <Card>

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { motion } from "framer-motion";
-import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X, FileText, Shield, HelpCircle, Globe, RefreshCw } from "lucide-react";
+import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X, FileText, Shield, HelpCircle, Globe, RefreshCw, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AuthGuard } from "@/components/auth-guard";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -35,6 +35,7 @@ import { CrawlConsoleDialog } from "@/components/admin/CrawlConsoleDialog";
 import { CrawlConsoleHeaderPill } from "@/components/admin/CrawlConsoleHeaderPill";
 import { UserDetailPanel } from "@/components/admin/UserDetailPanel";
 import { SupervisorSkillsStatusSection } from "@/components/admin/SupervisorSkillsStatusSection";
+import { PlatformSettingsTab } from "@/components/admin/PlatformSettingsTab";
 import { useAdminRole } from "@/hooks/use-admin-role";
 import { getConfig } from "@/lib/config";
 import { apiClient } from "@/lib/api-client";
@@ -197,7 +198,7 @@ interface Team {
   }>;
 }
 
-const VALID_TABS = ['users', 'teams', 'stats', 'skills', 'feedback', 'nps', 'metrics', 'health', 'policy', 'audit-logs', 'ai-review'];
+const VALID_TABS = ['users', 'teams', 'stats', 'skills', 'feedback', 'nps', 'metrics', 'health', 'policy', 'audit-logs', 'ai-review', 'settings'];
 
 function AdminPage() {
   const { status } = useSession();
@@ -823,7 +824,8 @@ function AdminPage() {
                   + (getConfig('npsEnabled') ? 1 : 0)
                   + (auditLogsEnabled && isAdmin ? 1 : 0)
                   + (isAdmin ? 1 : 0)
-                  + (isAdmin ? 1 : 0);
+                  + (isAdmin ? 1 : 0)
+                  + (isAdmin ? 1 : 0); // settings tab
                 const cols: Record<number, string> = { 6: 'grid-cols-6', 7: 'grid-cols-7', 8: 'grid-cols-8', 9: 'grid-cols-9', 10: 'grid-cols-10', 11: 'grid-cols-11' };
                 return cols[n] ?? 'grid-cols-6';
               })()}`}>
@@ -879,6 +881,12 @@ function AdminPage() {
                   <TabsTrigger value="ai-review" className="gap-2">
                     <ShieldCheck className="h-4 w-4" />
                     AI Review
+                  </TabsTrigger>
+                )}
+                {isAdmin && (
+                  <TabsTrigger value="settings" className="gap-2">
+                    <Settings className="h-4 w-4" />
+                    Settings
                   </TabsTrigger>
                 )}
               </TabsList>
@@ -2530,6 +2538,13 @@ function AdminPage() {
               {isAdmin && (
                 <TabsContent value="ai-review" className="space-y-4">
                   <ReviewConfigsTab />
+                </TabsContent>
+              )}
+
+              {/* Platform Settings (admin only) */}
+              {isAdmin && (
+                <TabsContent value="settings" className="space-y-4">
+                  <PlatformSettingsTab isAdmin={isAdmin} />
                 </TabsContent>
               )}
             </Tabs>

--- a/ui/src/app/api/admin/platform-config/route.ts
+++ b/ui/src/app/api/admin/platform-config/route.ts
@@ -1,0 +1,52 @@
+// GET /api/admin/platform-config — read platform-wide config (any authenticated user)
+// PATCH /api/admin/platform-config — update platform config (admin only)
+
+// assisted-by claude code claude-sonnet-4-6
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCollection } from '@/lib/mongodb';
+import { withAuth, withErrorHandler, requireAdmin } from '@/lib/api-middleware';
+
+const CONFIG_ID = 'platform_settings';
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  return await withAuth(request, async () => {
+    const col = await getCollection('platform_config');
+    const doc = await col.findOne({ _id: CONFIG_ID as any });
+
+    const defaultAgentId: string | null = (doc as any)?.default_agent_id ?? null;
+    const envFallback = process.env.DEFAULT_AGENT_ID || null;
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        default_agent_id: defaultAgentId ?? envFallback,
+        source: defaultAgentId ? 'db' : (envFallback ? 'env' : 'fallback'),
+      },
+    });
+  });
+});
+
+export const PATCH = withErrorHandler(async (request: NextRequest) => {
+  return await withAuth(request, async (_req, user, session) => {
+    requireAdmin(session);
+
+    const body = await request.json().catch(() => ({}));
+    const agentId: string | null = body.default_agent_id ?? null;
+
+    const col = await getCollection('platform_config');
+    await col.updateOne(
+      { _id: CONFIG_ID as any },
+      {
+        $set: {
+          default_agent_id: agentId,
+          updated_at: new Date(),
+          updated_by: user.email,
+        },
+      },
+      { upsert: true },
+    );
+
+    return NextResponse.json({ success: true, data: { default_agent_id: agentId } });
+  });
+});

--- a/ui/src/components/admin/PlatformSettingsTab.tsx
+++ b/ui/src/components/admin/PlatformSettingsTab.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+// assisted-by claude code claude-sonnet-4-6
+
+import React, { useEffect, useState } from "react";
+import { Loader2, Save, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import type { DynamicAgentConfig } from "@/types/dynamic-agent";
+
+interface PlatformSettingsTabProps {
+  isAdmin: boolean;
+}
+
+export function PlatformSettingsTab({ isAdmin }: PlatformSettingsTabProps) {
+  const [agents, setAgents] = useState<DynamicAgentConfig[]>([]);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [savedAgentId, setSavedAgentId] = useState<string | null>(null);
+  const [loadingAgents, setLoadingAgents] = useState(true);
+  const [loadingConfig, setLoadingConfig] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<'success' | 'error' | null>(null);
+  const [configSource, setConfigSource] = useState<string>('fallback');
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/dynamic-agents/available').then((r) => r.json()).catch(() => ({ data: [] })),
+      fetch('/api/admin/platform-config').then((r) => r.json()).catch(() => ({ success: false })),
+    ]).then(([agentsRes, configRes]) => {
+      setAgents(agentsRes.data || []);
+      setLoadingAgents(false);
+
+      if (configRes.success) {
+        const id = configRes.data.default_agent_id ?? null;
+        setSelectedAgentId(id);
+        setSavedAgentId(id);
+        setConfigSource(configRes.data.source || 'fallback');
+      }
+      setLoadingConfig(false);
+    });
+  }, []);
+
+  const handleSave = async () => {
+    if (!isAdmin) return;
+    setSaving(true);
+    setSaveResult(null);
+    try {
+      const res = await fetch('/api/admin/platform-config', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ default_agent_id: selectedAgentId }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setSavedAgentId(selectedAgentId);
+        setConfigSource('db');
+        setSaveResult('success');
+        setTimeout(() => setSaveResult(null), 3000);
+      } else {
+        setSaveResult('error');
+      }
+    } catch {
+      setSaveResult('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selectedAgent = agents.find((a) => a._id === selectedAgentId);
+  const savedAgentMissing = savedAgentId && !agents.find((a) => a._id === savedAgentId);
+
+  if (loadingConfig || loadingAgents) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Default Agent</CardTitle>
+          <CardDescription>
+            Select which agent new chats open with. Admins can override this at runtime;
+            it takes precedence over the <code>DEFAULT_AGENT_ID</code> Helm value.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {savedAgentMissing && (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-600 dark:text-amber-400 text-sm">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              The previously configured default agent is no longer available. New chats will fall back to the supervisor.
+            </div>
+          )}
+
+          {configSource === 'env' && (
+            <p className="text-xs text-muted-foreground">
+              Currently using <code>DEFAULT_AGENT_ID</code> env var as bootstrap default. Saving here overrides it at runtime.
+            </p>
+          )}
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Default agent for new chats</label>
+            <select
+              value={selectedAgentId ?? ''}
+              onChange={(e) => setSelectedAgentId(e.target.value || null)}
+              disabled={!isAdmin}
+              className="w-full max-w-sm h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+            >
+              <option value="">None — use supervisor (Platform Engineer)</option>
+              {agents.map((a) => (
+                <option key={a._id} value={a._id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+            {selectedAgent && (
+              <p className="text-xs text-muted-foreground">{selectedAgent.description}</p>
+            )}
+          </div>
+
+          {isAdmin && (
+            <div className="flex items-center gap-3 pt-2">
+              <Button
+                onClick={handleSave}
+                disabled={saving || selectedAgentId === savedAgentId}
+                size="sm"
+                className="gap-2"
+              >
+                {saving ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                Save
+              </Button>
+              {saveResult === 'success' && (
+                <span className="flex items-center gap-1.5 text-sm text-green-600 dark:text-green-400">
+                  <CheckCircle2 className="h-4 w-4" />
+                  Saved
+                </span>
+              )}
+              {saveResult === 'error' && (
+                <span className="text-sm text-destructive">Failed to save. Try again.</span>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/components/admin/PlatformSettingsTab.tsx
+++ b/ui/src/components/admin/PlatformSettingsTab.tsx
@@ -107,9 +107,9 @@ export function PlatformSettingsTab({ isAdmin }: PlatformSettingsTabProps) {
               value={selectedAgentId ?? ''}
               onChange={(e) => setSelectedAgentId(e.target.value || null)}
               disabled={!isAdmin}
-              className="w-full max-w-sm h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+              className="w-full max-w-sm h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60 md:ml-4"
             >
-              <option value="">None — use supervisor (Platform Engineer)</option>
+              <option value="">Default CAIPE Supervisor</option>
               {agents.map((a) => (
                 <option key={a._id} value={a._id}>
                   {a.name}

--- a/ui/src/components/admin/__tests__/PlatformSettingsTab.test.tsx
+++ b/ui/src/components/admin/__tests__/PlatformSettingsTab.test.tsx
@@ -3,26 +3,48 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { PlatformSettingsTab } from '../PlatformSettingsTab';
+
+const defaultAgents = [
+  { _id: 'sre', name: 'Basic SRE', description: 'Handles SRE workflows' },
+  { _id: 'kb', name: 'Knowledge Base Agent', description: 'Answers from KBs' },
+];
+
+function mockFetch({
+  agents = defaultAgents,
+  config = { success: true, data: { default_agent_id: null } },
+  patch = { success: true },
+}: {
+  agents?: Array<{ _id: string; name: string; description?: string }>;
+  config?: { success: boolean; data?: { default_agent_id?: string | null; source?: string } };
+  patch?: { success: boolean };
+} = {}) {
+  global.fetch = jest.fn((url: RequestInfo | URL, init?: RequestInit) => {
+    const href = String(url);
+    if (href.includes('/api/dynamic-agents/available')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({ data: agents }),
+      } as Response);
+    }
+    if (href.includes('/api/admin/platform-config') && init?.method === 'PATCH') {
+      return Promise.resolve({
+        json: () => Promise.resolve(patch),
+      } as Response);
+    }
+    if (href.includes('/api/admin/platform-config')) {
+      return Promise.resolve({
+        json: () => Promise.resolve(config),
+      } as Response);
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${href}`));
+  });
+}
 
 describe('PlatformSettingsTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    global.fetch = jest.fn((url: RequestInfo | URL) => {
-      const href = String(url);
-      if (href.includes('/api/dynamic-agents/available')) {
-        return Promise.resolve({
-          json: () => Promise.resolve({ data: [{ _id: 'sre', name: 'Basic SRE' }] }),
-        } as Response);
-      }
-      if (href.includes('/api/admin/platform-config')) {
-        return Promise.resolve({
-          json: () => Promise.resolve({ success: true, data: { default_agent_id: null } }),
-        } as Response);
-      }
-      return Promise.reject(new Error(`Unexpected fetch: ${href}`));
-    });
+    mockFetch();
   });
 
   it('labels the supervisor option as Default CAIPE Supervisor', async () => {
@@ -31,5 +53,67 @@ describe('PlatformSettingsTab', () => {
     await waitFor(() => {
       expect(screen.getByRole('option', { name: 'Default CAIPE Supervisor' })).toBeInTheDocument();
     });
+  });
+
+  it('selects the configured default dynamic agent and shows its description', async () => {
+    mockFetch({ config: { success: true, data: { default_agent_id: 'sre' } } });
+
+    render(<PlatformSettingsTab isAdmin />);
+
+    const select = await screen.findByRole('combobox');
+    expect(select).toHaveValue('sre');
+    expect(screen.getByText('Handles SRE workflows')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('disables default-agent editing for read-only users', async () => {
+    render(<PlatformSettingsTab isAdmin={false} />);
+
+    const select = await screen.findByRole('combobox');
+    expect(select).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+  });
+
+  it('warns when the saved default agent is no longer available', async () => {
+    mockFetch({ config: { success: true, data: { default_agent_id: 'deleted-agent' } } });
+
+    render(<PlatformSettingsTab isAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/previously configured default agent is no longer available/i))
+        .toBeInTheDocument();
+    });
+  });
+
+  it('shows when the default came from the DEFAULT_AGENT_ID environment value', async () => {
+    mockFetch({ config: { success: true, data: { default_agent_id: 'sre', source: 'env' } } });
+
+    render(<PlatformSettingsTab isAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/env var as bootstrap default/i)).toBeInTheDocument();
+      expect(screen.getAllByText('DEFAULT_AGENT_ID')).toHaveLength(2);
+    });
+  });
+
+  it('saves the supervisor fallback as a null default_agent_id', async () => {
+    mockFetch({ config: { success: true, data: { default_agent_id: 'sre' } } });
+
+    render(<PlatformSettingsTab isAdmin />);
+
+    const select = await screen.findByRole('combobox');
+    fireEvent.change(select, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/admin/platform-config',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ default_agent_id: null }),
+        })
+      );
+    });
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
   });
 });

--- a/ui/src/components/admin/__tests__/PlatformSettingsTab.test.tsx
+++ b/ui/src/components/admin/__tests__/PlatformSettingsTab.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { PlatformSettingsTab } from '../PlatformSettingsTab';
+
+describe('PlatformSettingsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn((url: RequestInfo | URL) => {
+      const href = String(url);
+      if (href.includes('/api/dynamic-agents/available')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({ data: [{ _id: 'sre', name: 'Basic SRE' }] }),
+        } as Response);
+      }
+      if (href.includes('/api/admin/platform-config')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({ success: true, data: { default_agent_id: null } }),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${href}`));
+    });
+  });
+
+  it('labels the supervisor option as Default CAIPE Supervisor', async () => {
+    render(<PlatformSettingsTab isAdmin />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Default CAIPE Supervisor' })).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -21,8 +21,22 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const [defaultAgentId, setDefaultAgentId] = useState<string | null>(null);
+  const [defaultAgentName, setDefaultAgentName] = useState<string>("New Chat");
 
   const dynamicAgentsEnabled = getConfig("dynamicAgentsEnabled");
+
+  // Fetch configured default agent on mount
+  useEffect(() => {
+    fetch('/api/admin/platform-config')
+      .then((r) => r.json())
+      .catch(() => ({ success: false }))
+      .then((data) => {
+        if (data.success && data.data.default_agent_id) {
+          setDefaultAgentId(data.data.default_agent_id);
+        }
+      });
+  }, []);
 
   // Fetch available dynamic agents when dropdown opens
   useEffect(() => {
@@ -37,7 +51,13 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
           throw new Error("Failed to fetch agents");
         }
         const data = await response.json();
-        setAgents(data.data || []);
+        const fetched: DynamicAgentConfig[] = data.data || [];
+        setAgents(fetched);
+        // Update default agent display name now that we have the full list
+        if (defaultAgentId) {
+          const found = fetched.find((a) => a._id === defaultAgentId);
+          if (found) setDefaultAgentName(found.name);
+        }
       } catch (err) {
         console.error("Error fetching dynamic agents:", err);
         setError("Failed to load agents");
@@ -47,7 +67,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
     };
 
     fetchAgents();
-  }, [dropdownOpen, dynamicAgentsEnabled]);
+  }, [dropdownOpen, dynamicAgentsEnabled, defaultAgentId]);
 
   // Close dropdown on click outside
   useEffect(() => {
@@ -79,8 +99,8 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   }, [dropdownOpen]);
 
   const handleMainClick = () => {
-    // Main button always creates Platform Engineer chat
-    onNewChat(undefined);
+    // Route to configured default agent (or supervisor when none configured)
+    onNewChat(defaultAgentId ?? undefined);
   };
 
   const handleDropdownToggle = (e: React.MouseEvent) => {
@@ -134,7 +154,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
         size="default"
       >
         <Plus className="h-4 w-4 shrink-0" />
-        <span className="whitespace-nowrap">New Chat</span>
+        <span className="whitespace-nowrap">{defaultAgentName}</span>
       </Button>
     );
   }
@@ -154,7 +174,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
           size="default"
         >
           <Plus className="h-4 w-4 shrink-0" />
-          <span className="whitespace-nowrap">New Chat</span>
+          <span className="whitespace-nowrap">{defaultAgentName}</span>
         </Button>
 
         {/* Dropdown trigger */}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.12.dev10"
+version = "0.4.12.dev11"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

<img width="1333" height="668" alt="Screenshot 2026-05-14 at 10 25 13 PM" src="https://github.com/user-attachments/assets/32f4e135-a07c-438a-a05b-1127222ac89a" />


Implements spec: [docs/docs/specs/2026-05-08-default-agent-config/spec.md](docs/docs/specs/2026-05-08-default-agent-config/spec.md)



- **GET/PATCH `/api/admin/platform-config`** — reads/writes `default_agent_id` from MongoDB `platform_config` collection. Resolution order: DB → `DEFAULT_AGENT_ID` env var → supervisor fallback
- **Admin → Settings tab** — dynamic agent dropdown (admin-only), shows warning when saved agent is deleted
- **`NewChatButton`** — fetches configured default on mount; main button routes to default agent; label reflects agent name
- **Helm `DEFAULT_AGENT_ID`** — new `caipe-ui.config` key for deploy-time bootstrap default (empty by default, preserves backward compat)

## Test plan

- [ ] Deploy with no config → new chat opens supervisor (backward compat)
- [ ] Admin → Settings → pick a dynamic agent → Save → open new chat → routes to chosen agent
- [ ] Admin → Settings → "None (use supervisor)" → Save → reverts to supervisor
- [ ] Deploy with `DEFAULT_AGENT_ID: "<id>"` → first boot routes to that agent with no admin action
- [ ] DB setting wins over `DEFAULT_AGENT_ID` env var when both are present
- [ ] New Chat button label matches configured agent name
- [ ] Delete the configured agent → Settings shows warning badge
- [ ] Non-admin cannot PATCH platform-config (403)

Closes #1378

🤖 Generated with [Claude Code](https://claude.com/claude-code)