### PR TITLE
feat(jira): add internal service desk comments

### DIFF
--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/api/client.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/api/client.py
@@ -149,31 +149,42 @@ async def make_api_request(
                 url = f"{url}/{path}"
                 logger.debug(f"Full request URL: {url}")
 
-                method_map = {
-                    "GET": client.get,
-                    "POST": client.post,
-                    "PUT": client.put,
-                    "PATCH": client.patch,
-                    "DELETE": client.delete,
-                }
-
-                if method not in method_map:
-                    logger.error(f"Unsupported HTTP method: {method}")
-                    return (False, {"error": f"Unsupported method: {method}"})
-
-                if method in ["POST", "PUT", "PATCH"]:
-                    response = await method_map[method](
+                if method == "GET":
+                    response = await client.get(
                         url,
                         headers=headers,
                         params=params,
-                        json=data
                     )
-                else:
-                    response = await method_map[method](
+                elif method == "POST":
+                    response = await client.post(
                         url,
                         headers=headers,
-                        params=params
+                        params=params,
+                        json=data,
                     )
+                elif method == "PUT":
+                    response = await client.put(
+                        url,
+                        headers=headers,
+                        params=params,
+                        json=data,
+                    )
+                elif method == "PATCH":
+                    response = await client.patch(
+                        url,
+                        headers=headers,
+                        params=params,
+                        json=data,
+                    )
+                elif method == "DELETE":
+                    response = await client.delete(
+                        url,
+                        headers=headers,
+                        params=params,
+                    )
+                else:
+                    logger.error(f"Unsupported HTTP method: {method}")
+                    return (False, {"error": f"Unsupported method: {method}"})
 
 
                 logger.debug(f"Response status code: {response.status_code}")
@@ -243,6 +254,9 @@ async def make_api_request(
             logger.error(f"Unexpected error: {str(e)}")
             return (False, {"error": f"Unexpected error: {str(e)}"})
 
+    logger.error("Jira API request exhausted retry loop without returning a response.")
+    return (False, {"error": "Jira API request failed without a response."})
+
 
 def _get_mock_response(path: str, method: str, params: Dict, data: Dict) -> Tuple[bool, Dict[str, Any]]:
     """Generate mock responses based on the API path and method.
@@ -277,21 +291,65 @@ def _get_mock_response(path: str, method: str, params: Dict, data: Dict) -> Tupl
             else:  # Getting all comments for an issue
                 return (True, {
                     "comments": [
-                        {"id": "10000", "body": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "First comment"}]}]}, "author": {"displayName": "John Doe"}},
-                        {"id": "10001", "body": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Second comment"}]}]}, "author": {"displayName": "Jane Smith"}}
+                        {
+                            "id": "10000",
+                            "body": {
+                                "type": "doc",
+                                "version": 1,
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [{"type": "text", "text": "First comment"}],
+                                    }
+                                ],
+                            },
+                            "author": {"displayName": "John Doe"},
+                        },
+                        {
+                            "id": "10001",
+                            "body": {
+                                "type": "doc",
+                                "version": 1,
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [{"type": "text", "text": "Second comment"}],
+                                    }
+                                ],
+                            },
+                            "author": {"displayName": "Jane Smith"},
+                        }
                     ],
                     "total": 2
                 })
         elif method == "POST":
             return (True, {
                 "id": "10002",
-                "body": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "New comment"}]}]},
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "New comment"}],
+                        }
+                    ],
+                },
                 "author": {"displayName": "Current User"}
             })
         elif method == "PUT":
             return (True, {
                 "id": "10000",
-                "body": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Updated comment"}]}]}
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Updated comment"}],
+                        }
+                    ],
+                }
             })
         elif method == "DELETE":
             return (True, {})

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/server.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/server.py
@@ -88,6 +88,7 @@ def main():
     mcp.tool()(comments.get_comments)
     mcp.tool()(comments.get_comment)
     mcp.tool()(comments.add_comment)
+    mcp.tool()(comments.add_internal_comment)
     mcp.tool()(comments.update_comment)
     mcp.tool()(comments.delete_comment)
 

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/comments.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/comments.py
@@ -220,8 +220,10 @@ async def add_internal_comment(
     }
 
     # Atlassian's documented JSM Cloud API uses `public=false` to create an
-    # internal note on the customer request. The Jira Platform `/rest/api/3`
-    # comment endpoint only supports role/group visibility restrictions.
+    # internal note on the customer request:
+    # https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-issueidorkey-comment-post
+    # The Jira Platform `/rest/api/3` comment endpoint only supports role/group
+    # visibility restrictions.
     success, response = await make_api_request(
         path=f"rest/servicedeskapi/request/{issue_key}/comment",
         method="POST",

--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/comments.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/comments.py
@@ -174,6 +174,70 @@ async def add_comment(
     return json.dumps(response, indent=2, ensure_ascii=False)
 
 
+async def add_internal_comment(
+    issue_key: Annotated[str, Field(description="Jira Service Management issue key (e.g., 'PROJ-123')")],
+    body: Annotated[
+        str,
+        Field(
+            description=(
+                "The internal note text in plain text or markdown format. "
+                "This tool creates a Jira Service Management internal note that is not customer-visible."
+            )
+        ),
+    ],
+) -> str:
+    """Add an internal note to a Jira Service Management request.
+
+    Use this tool for private/internal JSM notes only. It calls the Jira Service
+    Management request comment API with ``public=false``. This is different from
+    Jira Platform's issue comment ``visibility`` field, which restricts comments
+    by Jira role/group and does not mean "internal note" versus "reply to customer".
+
+    Args:
+        issue_key: Jira Service Management issue key.
+        body: Internal note text (plain text or markdown).
+
+    Returns:
+        JSON string representing the created internal note.
+
+    Raises:
+        ValueError: If required fields missing, in read-only mode, or API request fails.
+    """
+    if MCP_JIRA_READ_ONLY:
+        error_result = {
+            "success": False,
+            "error": "Jira MCP is in read-only mode. Write operations are disabled."
+        }
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    logger.debug(
+        f"add_internal_comment called with issue_key={issue_key}, body length={len(body)}"
+    )
+
+    comment_data: Dict[str, Any] = {
+        "body": body,
+        "public": False,
+    }
+
+    # Atlassian's documented JSM Cloud API uses `public=false` to create an
+    # internal note on the customer request. The Jira Platform `/rest/api/3`
+    # comment endpoint only supports role/group visibility restrictions.
+    success, response = await make_api_request(
+        path=f"rest/servicedeskapi/request/{issue_key}/comment",
+        method="POST",
+        data=comment_data,
+    )
+
+    if not success:
+        error_result = {
+            "success": False,
+            "error": f"Failed to add internal comment to issue {issue_key}: {response}"
+        }
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
 async def update_comment(
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
     comment_id: Annotated[

--- a/ai_platform_engineering/agents/jira/mcp/tests/conftest.py
+++ b/ai_platform_engineering/agents/jira/mcp/tests/conftest.py
@@ -1,5 +1,8 @@
 """Shared pytest fixtures for Jira MCP tests."""
 
+import sys
+import types
+
 import pytest
 
 
@@ -17,6 +20,14 @@ def setup_test_environment(monkeypatch):
     monkeypatch.setenv("MCP_JIRA_SPRINTS_DELETE_PROTECTION", "false")
     monkeypatch.setenv("MCP_JIRA_BOARDS_DELETE_PROTECTION", "false")
     monkeypatch.setenv("ATLASSIAN_API_URL", "https://test.atlassian.net")
+    monkeypatch.setitem(
+        sys.modules,
+        "keyring",
+        types.SimpleNamespace(
+            get_password=lambda *args, **kwargs: None,
+            set_password=lambda *args, **kwargs: None,
+        ),
+    )
 
     # Reload the config module to pick up the new env vars
     import importlib

--- a/ai_platform_engineering/agents/jira/mcp/tests/test_client.py
+++ b/ai_platform_engineering/agents/jira/mcp/tests/test_client.py
@@ -1,0 +1,126 @@
+"""Unit tests for the Jira API client."""
+
+import importlib
+
+import pytest
+
+
+class FakeResponse:
+    """Minimal httpx response stand-in for client unit tests."""
+
+    status_code = 200
+    text = ""
+
+    def json(self):
+        return {"ok": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "expects_json"),
+    [
+        ("GET", False),
+        ("POST", True),
+        ("PUT", True),
+        ("PATCH", True),
+        ("DELETE", False),
+    ],
+)
+async def test_make_api_request_dispatches_supported_methods(
+    monkeypatch,
+    method,
+    expects_json,
+):
+    """Verify each supported HTTP method calls the typed AsyncClient method."""
+    client = importlib.import_module("mcp_jira.api.client")
+    importlib.reload(client)
+    monkeypatch.setattr(client, "MCP_JIRA_MOCK_RESPONSE", False)
+    monkeypatch.setenv("ATLASSIAN_TOKEN", "test-token")
+    monkeypatch.setenv("ATLASSIAN_EMAIL", "user@example.com")
+    monkeypatch.setenv("ATLASSIAN_API_URL", "https://test.atlassian.net")
+
+    calls = []
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, *, headers, params):
+            calls.append({"method": "GET", "url": url, "params": params, "json": None})
+            return FakeResponse()
+
+        async def post(self, url, *, headers, params, json):
+            calls.append({"method": "POST", "url": url, "params": params, "json": json})
+            return FakeResponse()
+
+        async def put(self, url, *, headers, params, json):
+            calls.append({"method": "PUT", "url": url, "params": params, "json": json})
+            return FakeResponse()
+
+        async def patch(self, url, *, headers, params, json):
+            calls.append({"method": "PATCH", "url": url, "params": params, "json": json})
+            return FakeResponse()
+
+        async def delete(self, url, *, headers, params):
+            calls.append({"method": "DELETE", "url": url, "params": params, "json": None})
+            return FakeResponse()
+
+    monkeypatch.setattr(client.httpx, "AsyncClient", FakeAsyncClient)
+
+    success, response = await client.make_api_request(
+        "rest/api/3/issue/PROJ-123",
+        method=method,
+        params={"expand": "names"},
+        data={"summary": "test"},
+    )
+
+    assert success is True
+    assert response == {"ok": True}
+    assert calls == [
+        {
+            "method": method,
+            "url": "https://test.atlassian.net/rest/api/3/issue/PROJ-123",
+            "params": {"expand": "names"},
+            "json": {"summary": "test"} if expects_json else None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_make_api_request_rejects_unsupported_method(monkeypatch):
+    """Unsupported methods should return a structured error without making a request."""
+    client = importlib.import_module("mcp_jira.api.client")
+    importlib.reload(client)
+    monkeypatch.setattr(client, "MCP_JIRA_MOCK_RESPONSE", False)
+    monkeypatch.setenv("ATLASSIAN_TOKEN", "test-token")
+    monkeypatch.setenv("ATLASSIAN_EMAIL", "user@example.com")
+    monkeypatch.setenv("ATLASSIAN_API_URL", "https://test.atlassian.net")
+
+    class FailingAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, *args, **kwargs):
+            raise AssertionError("No HTTP request should be made")
+
+    monkeypatch.setattr(client.httpx, "AsyncClient", FailingAsyncClient)
+
+    success, response = await client.make_api_request(
+        "rest/api/3/issue/PROJ-123",
+        method="OPTIONS",
+    )
+
+    assert success is False
+    assert response == {"error": "Unsupported method: OPTIONS"}

--- a/ai_platform_engineering/agents/jira/mcp/tests/test_comments.py
+++ b/ai_platform_engineering/agents/jira/mcp/tests/test_comments.py
@@ -175,6 +175,57 @@ class TestAddComment:
         assert "read-only" in result_dict["error"].lower()
 
 
+class TestAddInternalComment:
+    """Tests for add_internal_comment function."""
+
+    @pytest.mark.asyncio
+    async def test_add_internal_comment_uses_jsm_private_comment(self, monkeypatch):
+        """Test adding a Jira Service Management internal note."""
+        captured_request = {}
+
+        async def mock_request(path, method="GET", **kwargs):
+            captured_request["path"] = path
+            captured_request["method"] = method
+            captured_request["data"] = kwargs.get("data")
+            return (
+                True,
+                {
+                    "id": "10003",
+                    "body": "Initial investigation: test",
+                    "public": False,
+                },
+            )
+
+        monkeypatch.setattr("mcp_jira.tools.jira.comments.MCP_JIRA_READ_ONLY", False)
+        monkeypatch.setattr("mcp_jira.tools.jira.comments.make_api_request", mock_request)
+
+        from mcp_jira.tools.jira.comments import add_internal_comment
+
+        result = await add_internal_comment("PROJ-123", "Initial investigation: test")
+        result_dict = json.loads(result)
+
+        assert result_dict["id"] == "10003"
+        assert captured_request["path"] == "rest/servicedeskapi/request/PROJ-123/comment"
+        assert captured_request["method"] == "POST"
+        assert captured_request["data"] == {
+            "body": "Initial investigation: test",
+            "public": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_add_internal_comment_read_only(self, monkeypatch):
+        """Test that add_internal_comment returns error JSON in read-only mode."""
+        monkeypatch.setattr("mcp_jira.tools.jira.comments.MCP_JIRA_READ_ONLY", True)
+
+        from mcp_jira.tools.jira.comments import add_internal_comment
+
+        result = await add_internal_comment("PROJ-123", "Test internal note")
+        result_dict = json.loads(result)
+
+        assert result_dict["success"] is False
+        assert "read-only" in result_dict["error"].lower()
+
+
 class TestUpdateComment:
     """Tests for update_comment function."""
 

--- a/ai_platform_engineering/agents/jira/mcp/tests/test_server.py
+++ b/ai_platform_engineering/agents/jira/mcp/tests/test_server.py
@@ -1,0 +1,38 @@
+"""Unit tests for Jira MCP server registration."""
+
+import importlib
+import sys
+import types
+
+
+def test_server_registers_internal_comment_tool(monkeypatch):
+    """The MCP server should expose the dedicated JSM internal comment tool."""
+    instances = []
+
+    class FakeMCP:
+        def __init__(self, name):
+            self.name = name
+            self.registered_tools = []
+            self.run_kwargs = None
+            instances.append(self)
+
+        def tool(self):
+            def register(func):
+                self.registered_tools.append(func.__name__)
+                return func
+
+            return register
+
+        def run(self, **kwargs):
+            self.run_kwargs = kwargs
+
+    monkeypatch.setitem(sys.modules, "fastmcp", types.SimpleNamespace(FastMCP=FakeMCP))
+    monkeypatch.setenv("MCP_MODE", "stdio")
+
+    server = importlib.import_module("mcp_jira.server")
+    importlib.reload(server)
+    server.main()
+
+    assert instances
+    assert "add_internal_comment" in instances[-1].registered_tools
+    assert instances[-1].run_kwargs == {"transport": "stdio"}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.12 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.13 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.12 -f your-values.yaml'}
+                  {'    --version 0.4.13 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.12 -f your-values.yaml'}
+              {'    --version 0.4.13 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13"
+version = "0.4.13-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13"
+version = "0.4.13.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Adds a dedicated Jira MCP tool for Jira Service Management internal notes using the documented request comment API with `public: false`.
- Registers the tool so agents can avoid customer-visible comments when posting internal JSM notes.
- Adds focused coverage for the internal-comment payload, MCP registration, and Jira client HTTP method dispatch.

## Notes

- The Jira client request dispatch was changed from a dynamic `method_map` lookup to explicit HTTP method branches. This is primarily a typing/readability fix: static analysis could not infer the callable type from `method_map[method](...)`.
- The explicit branches preserve REST semantics: `GET` and `DELETE` send query parameters via `params`, while `POST`, `PUT`, and `PATCH` send request bodies via `json=data`.

## Test plan

- [x] `uv run pytest tests/test_comments.py tests/test_client.py tests/test_server.py -q` from `ai_platform_engineering/agents/jira/mcp`
- [x] `uv run ruff check` on the touched Jira MCP files