### PR TITLE
fix(ci): always run image builds on tag push regardless of actor

### DIFF
--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -25,7 +25,6 @@ concurrency:
 
 jobs:
   load-config:
-    if: github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]'
     runs-on: ubuntu-latest
     outputs:
       rag_components: ${{ steps.read-config.outputs.rag_components }}

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -32,8 +32,7 @@ concurrency:
 jobs:
   load-config:
     runs-on: ubuntu-latest
-    if: (github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]') &&
-      (always())
+    if: always()
     outputs:
       all_agents: ${{ steps.read-config.outputs.all_agents }}
       agent_build_args: ${{ steps.read-config.outputs.agent_build_args }}

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -26,7 +26,6 @@ concurrency:
 
 jobs:
   determine-changes:
-    if: github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]'
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -25,7 +25,6 @@ concurrency:
 
 jobs:
   determine-changes:
-    if: github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]'
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -32,8 +32,7 @@ concurrency:
 jobs:
   load-config:
     runs-on: ubuntu-latest
-    if: (github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]') &&
-      (always())
+    if: always()
     outputs:
       all_agents: ${{ steps.read-config.outputs.all_agents }}
     steps:

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -44,7 +44,6 @@ concurrency:
 
 jobs:
   determine-changes:
-    if: github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]'
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -27,12 +27,9 @@ jobs:
   determine-changes:
     runs-on: ubuntu-latest
     if: |
-      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]') &&
-      (
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/')) ||
-        (github.event_name == 'workflow_dispatch')
-      )
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/')) ||
+      (github.event_name == 'workflow_dispatch')
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
       should_retag: ${{ steps.set-outputs.outputs.should_retag }}

--- a/.github/workflows/ci-supervisor-agent.yml
+++ b/.github/workflows/ci-supervisor-agent.yml
@@ -32,12 +32,9 @@ jobs:
   determine-changes:
     runs-on: ubuntu-latest
     if: |
-      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]') &&
-      (
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/')) ||
-        (github.event_name == 'workflow_dispatch')
-      )
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/')) ||
+      (github.event_name == 'workflow_dispatch')
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
       should_retag: ${{ steps.set-outputs.outputs.should_retag }}


### PR DESCRIPTION
## Root cause

Release \`0.4.13\` was published with no images built because the \`determine-changes\` / \`load-config\` jobs in all 8 CI image-build workflows had an \`if:\` guard that skipped execution when \`github.actor == 'caipe-release-bot[bot]'\`:

\`\`\`yaml
if: (github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]') &&
    (push+tag || pull_request || workflow_dispatch)
\`\`\`

\`release-manual.yml\` pushes release tags authenticated as the caipe-release-bot GitHub App, so every release tag push hit this guard and skipped all image builds. \`release-finalize.yml\` treats \`skipped\` workflow conclusions as OK, so the release was published anyway.

## Fix

The actor guard is moved inside a branch that only applies to \`pull_request\` and \`workflow_dispatch\` events. Tag push events now always run, regardless of actor:

\`\`\`yaml
if: (push+tag) ||
    (actor != bot && (pull_request || workflow_dispatch))
\`\`\`

## ⚠️ Open question — needs discussion before merge

**Side effect:** dev tags (e.g. \`0.4.12-dev.13\`) are also pushed by caipe-release-bot via \`auto-tag.yml\`. With this fix, every dev tag push would also trigger all 8 CI image-build workflows. Given dev tags are created multiple times per day, this could mean a lot of extra CI runs.

Two options to consider:

1. **Merge as-is** — dev tag pushes also build images (more CI, but consistent behaviour)
2. **Tighten the condition** — only allow tag pushes where the tag is a clean semver release (no \`-dev.\`, \`-rc.\`, etc.):
   \`\`\`yaml
   if: |
     (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
      && !contains(github.ref, '-')) ||
     (github.actor != 'github-actions[bot]' && github.actor != 'caipe-release-bot[bot]' && ...)
   \`\`\`

**Also needs clarification:** What was the original intent of adding the \`caipe-release-bot[bot]\` actor guard to the CI workflows in the first place? Understanding that may point to the right long-term fix.

## Affected workflows

- \`ci-supervisor-agent.yml\`
- \`ci-slack-bot.yml\`
- \`ci-a2a-sub-agent.yml\`
- \`ci-mcp-sub-agent.yml\`
- \`ci-a2a-rag.yml\`
- \`ci-dynamic-agents.yml\`
- \`ci-skill-scanner.yml\`
- \`ci-caipe-ui.yml\`

## Test plan

- [ ] Decide on option 1 vs option 2 above
- [ ] Merge this PR (or update condition for option 2)
- [ ] Re-run the 0.4.13 image-build CI workflows manually via \`workflow_dispatch\` (tag_version=0.4.13) to backfill missing images
- [ ] Verify next release tag push triggers all 8 CI workflows without skipping \`determine-changes\`