### PR TITLE
fix(chat): add configurable conversation history persistence to /invoke endpoint

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
@@ -61,6 +61,13 @@ class Settings(BaseSettings):
     # Maximum allowed TTL (0 = no cap, infinite allowed)
     max_fs_ttl_seconds: int = 0
 
+    # /invoke endpoint persistence
+    # When False (default), each /invoke call uses an ephemeral in-memory runtime that is
+    # discarded after the request — no MongoDB writes, no conversation history across calls.
+    # Set to True to use the shared MongoDB-backed runtime cache, enabling multi-turn
+    # conversation history via /invoke at the cost of additional MongoDB load.
+    invoke_persist_history: bool = False
+
     # Runtime
     agent_runtime_ttl_seconds: int = 60  # 60s inactivity TTL for agent runtimes
     # Max concurrent cached runtimes. Each costs ~15-20MB (with shared clients).

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -1,6 +1,7 @@
 """Chat endpoint for Dynamic Agents with SSE streaming."""
 
 import logging
+from contextlib import AsyncExitStack
 from typing import Any, AsyncGenerator
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -438,61 +439,61 @@ async def chat_invoke(
     cache = get_runtime_cache()
     cache.set_mongo_service(mongo)
 
-    async def _run(runtime) -> dict:
-        encoder = get_encoder("custom")
-
-        async for _frame in runtime.stream(
-            request.message, request.conversation_id, user.email, request.trace_id, encoder
-        ):
-            pass  # Frames are SSE strings, we don't need them for invoke
-
-        interrupt = await runtime.has_pending_interrupt(request.conversation_id)
-        if interrupt:
-            interrupt_type = interrupt.get("type", "unknown")
-            return JSONResponse(
-                status_code=400,
-                content={
-                    "success": False,
-                    "error": (
-                        "Agent requires human interaction which is not supported via the invoke endpoint. "
-                        "Use the streaming chat endpoint or consider disabling tool approvals "
-                        "and the user input tool for this agent."
-                    ),
-                    "interrupt_type": interrupt_type,
-                    "agent_id": agent.id,
-                    "conversation_id": request.conversation_id,
-                    "trace_id": request.trace_id,
-                },
-            )
-
-        return {
-            "success": True,
-            "content": encoder.get_accumulated_content(),
-            "thinking": encoder.get_thinking_content() or None,
-            "agent_id": agent.id,
-            "conversation_id": request.conversation_id,
-            "trace_id": request.trace_id,
-        }
-
     try:
-        if persist_history:
-            runtime = await cache.get_or_create(
-                agent,
-                mcp_servers,
-                request.conversation_id,
-                user=user,
-                client_context=request.client_context,
-            )
-            return await _run(runtime)
-        else:
-            async with cache.ephemeral(
-                agent,
-                mcp_servers,
-                request.conversation_id,
-                user=user,
-                client_context=request.client_context,
-            ) as runtime:
-                return await _run(runtime)
+        async with AsyncExitStack() as stack:
+            if persist_history:
+                runtime = await cache.get_or_create(
+                    agent,
+                    mcp_servers,
+                    request.conversation_id,
+                    user=user,
+                    client_context=request.client_context,
+                )
+            else:
+                runtime = await stack.enter_async_context(
+                    cache.ephemeral(
+                        agent,
+                        mcp_servers,
+                        request.conversation_id,
+                        user=user,
+                        client_context=request.client_context,
+                    )
+                )
+
+            encoder = get_encoder("custom")
+
+            async for _frame in runtime.stream(
+                request.message, request.conversation_id, user.email, request.trace_id, encoder
+            ):
+                pass  # Frames are SSE strings, we don't need them for invoke
+
+            interrupt = await runtime.has_pending_interrupt(request.conversation_id)
+            if interrupt:
+                interrupt_type = interrupt.get("type", "unknown")
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "success": False,
+                        "error": (
+                            "Agent requires human interaction which is not supported via the invoke endpoint. "
+                            "Use the streaming chat endpoint or consider disabling tool approvals "
+                            "and the user input tool for this agent."
+                        ),
+                        "interrupt_type": interrupt_type,
+                        "agent_id": agent.id,
+                        "conversation_id": request.conversation_id,
+                        "trace_id": request.trace_id,
+                    },
+                )
+
+            return {
+                "success": True,
+                "content": encoder.get_accumulated_content(),
+                "thinking": encoder.get_thinking_content() or None,
+                "agent_id": agent.id,
+                "conversation_id": request.conversation_id,
+                "trace_id": request.trace_id,
+            }
 
     except RuntimeCapacityError as e:
         logger.warning(f"Agent runtime at capacity for invoke: {e}")

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -431,49 +431,50 @@ async def chat_invoke(
     cache.set_mongo_service(mongo)
 
     try:
-        async with cache.ephemeral(
+        runtime = await cache.get_or_create(
             agent,
             mcp_servers,
             request.conversation_id,
             user=user,
             client_context=request.client_context,
-        ) as runtime:
-            # Use custom encoder for invoke — we just need accumulated content
-            encoder = get_encoder("custom")
+        )
 
-            async for _frame in runtime.stream(
-                request.message, request.conversation_id, user.email, request.trace_id, encoder
-            ):
-                pass  # Frames are SSE strings, we don't need them for invoke
+        # Use custom encoder for invoke — we just need accumulated content
+        encoder = get_encoder("custom")
 
-            # Check if the agent was interrupted (HITL: tool approval or user input form)
-            interrupt = await runtime.has_pending_interrupt(request.conversation_id)
-            if interrupt:
-                interrupt_type = interrupt.get("type", "unknown")
-                return JSONResponse(
-                    status_code=400,
-                    content={
-                        "success": False,
-                        "error": (
-                            "Agent requires human interaction which is not supported via the invoke endpoint. "
-                            "Use the streaming chat endpoint or consider disabling tool approvals "
-                            "and the user input tool for this agent."
-                        ),
-                        "interrupt_type": interrupt_type,
-                        "agent_id": agent.id,
-                        "conversation_id": request.conversation_id,
-                        "trace_id": request.trace_id,
-                    },
-                )
+        async for _frame in runtime.stream(
+            request.message, request.conversation_id, user.email, request.trace_id, encoder
+        ):
+            pass  # Frames are SSE strings, we don't need them for invoke
 
-            return {
-                "success": True,
-                "content": encoder.get_accumulated_content(),
-                "thinking": encoder.get_thinking_content() or None,
-                "agent_id": agent.id,
-                "conversation_id": request.conversation_id,
-                "trace_id": request.trace_id,
-            }
+        # Check if the agent was interrupted (HITL: tool approval or user input form)
+        interrupt = await runtime.has_pending_interrupt(request.conversation_id)
+        if interrupt:
+            interrupt_type = interrupt.get("type", "unknown")
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "success": False,
+                    "error": (
+                        "Agent requires human interaction which is not supported via the invoke endpoint. "
+                        "Use the streaming chat endpoint or consider disabling tool approvals "
+                        "and the user input tool for this agent."
+                    ),
+                    "interrupt_type": interrupt_type,
+                    "agent_id": agent.id,
+                    "conversation_id": request.conversation_id,
+                    "trace_id": request.trace_id,
+                },
+            )
+
+        return {
+            "success": True,
+            "content": encoder.get_accumulated_content(),
+            "thinking": encoder.get_thinking_content() or None,
+            "agent_id": agent.id,
+            "conversation_id": request.conversation_id,
+            "trace_id": request.trace_id,
+        }
 
     except Exception as e:
         logger.exception(f"Error invoking agent '{agent.name}'")

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -419,6 +419,10 @@ async def chat_invoke(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
+    # Apply config_override if provided (deep merge, validated)
+    if request.config_override:
+        agent = apply_config_override(agent, request.config_override)
+
     # Get MCP servers for this agent and its subagents
     mcp_servers = mongo.get_agent_mcp_servers(agent)
 
@@ -476,6 +480,18 @@ async def chat_invoke(
             "trace_id": request.trace_id,
         }
 
+    except RuntimeCapacityError as e:
+        logger.warning(f"Agent runtime at capacity for invoke: {e}")
+        return JSONResponse(
+            status_code=503,
+            content={
+                "success": False,
+                "error": "This agent is at capacity right now. Please try again in a moment.",
+                "agent_id": agent.id,
+                "conversation_id": request.conversation_id,
+                "trace_id": request.trace_id,
+            },
+        )
     except Exception as e:
         logger.exception(f"Error invoking agent '{agent.name}'")
         return JSONResponse(

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from dynamic_agents.auth.auth import get_user_context
+from dynamic_agents.config import get_settings
 from dynamic_agents.log_config import conversation_id_var
 from dynamic_agents.models import ChatRequest, ClientContext, DynamicAgentConfig, UserContext
 from dynamic_agents.services.mongo import MongoDBService, get_mongo_service
@@ -426,24 +427,18 @@ async def chat_invoke(
     # Get MCP servers for this agent and its subagents
     mcp_servers = mongo.get_agent_mcp_servers(agent)
 
-    logger.info(f"Invoke request: agent={agent.name}, user={user.email}, trace_id={request.trace_id or 'auto'}")
+    settings = get_settings()
+    persist_history = settings.invoke_persist_history
 
-    # Collect all content from streaming
+    logger.info(
+        f"Invoke request: agent={agent.name}, user={user.email}, "
+        f"trace_id={request.trace_id or 'auto'}, persist_history={persist_history}"
+    )
+
     cache = get_runtime_cache()
-
-    # Set MongoDB service for subagent resolution
     cache.set_mongo_service(mongo)
 
-    try:
-        runtime = await cache.get_or_create(
-            agent,
-            mcp_servers,
-            request.conversation_id,
-            user=user,
-            client_context=request.client_context,
-        )
-
-        # Use custom encoder for invoke — we just need accumulated content
+    async def _run(runtime) -> dict:
         encoder = get_encoder("custom")
 
         async for _frame in runtime.stream(
@@ -451,7 +446,6 @@ async def chat_invoke(
         ):
             pass  # Frames are SSE strings, we don't need them for invoke
 
-        # Check if the agent was interrupted (HITL: tool approval or user input form)
         interrupt = await runtime.has_pending_interrupt(request.conversation_id)
         if interrupt:
             interrupt_type = interrupt.get("type", "unknown")
@@ -479,6 +473,26 @@ async def chat_invoke(
             "conversation_id": request.conversation_id,
             "trace_id": request.trace_id,
         }
+
+    try:
+        if persist_history:
+            runtime = await cache.get_or_create(
+                agent,
+                mcp_servers,
+                request.conversation_id,
+                user=user,
+                client_context=request.client_context,
+            )
+            return await _run(runtime)
+        else:
+            async with cache.ephemeral(
+                agent,
+                mcp_servers,
+                request.conversation_id,
+                user=user,
+                client_context=request.client_context,
+            ) as runtime:
+                return await _run(runtime)
 
     except RuntimeCapacityError as e:
         logger.warning(f"Agent runtime at capacity for invoke: {e}")

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -123,6 +123,11 @@ config:
   MONGODB_DATABASE: "caipe"
   # Agent runtime TTL in seconds (purged after this much inactivity)
   AGENT_RUNTIME_TTL_SECONDS: "60"
+  # Set to "true" to enable multi-turn conversation history via POST /invoke.
+  # When false (default), each /invoke call uses an ephemeral in-memory runtime
+  # with no MongoDB writes. Enable only if callers reuse conversation_id across
+  # /invoke calls and require history — it increases MongoDB load.
+  INVOKE_PERSIST_HISTORY: "false"
   # CORS origins (JSON array format for Pydantic)
   CORS_ORIGINS: '["*"]'
   # Tracing disabled by default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13-dev.2"
+version = "0.4.13-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13.dev2"
+version = "0.4.13.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- \`POST /api/v1/chat/invoke\` was using \`cache.ephemeral()\`, which creates a throw-away \`MemorySaver\` checkpointer per request, so the agent had no memory of prior turns even when the caller reused the same \`conversation_id\`
- Adds \`INVOKE_PERSIST_HISTORY\` env var (default: \`false\`) to control persistence: when \`false\` (default), each \`/invoke\` call remains ephemeral with no MongoDB writes; when \`true\`, the shared MongoDB-backed runtime cache is used, enabling multi-turn conversation history
- Uses \`AsyncExitStack\` so the ephemeral/persistent branch only controls how the runtime is acquired — the handler body is unified and runs the same code path either way
- Add \`apply_config_override\` call that was missing from \`chat_invoke\` (parity with streaming endpoints)
- Catch \`RuntimeCapacityError\` explicitly and return 503 instead of falling through to 500 (parity with streaming endpoints)
- Helm chart \`values.yaml\` updated with \`INVOKE_PERSIST_HISTORY: "false"\` and documentation of the trade-off

## Test plan

- [ ] Multi-turn \`/invoke\` conversation retains context across calls with the same \`conversation_id\` when \`INVOKE_PERSIST_HISTORY=true\`
- [ ] Default behaviour (\`INVOKE_PERSIST_HISTORY=false\`) is fully ephemeral — no MongoDB writes, no history across calls
- [ ] Single-turn \`/invoke\` calls continue to work as before under both settings
- [ ] HITL interrupt path (tool approval / user input form) still returns HTTP 400 with correct payload
- [ ] Streaming endpoint (\`/stream\`) unaffected

## Validation

Deployed two successive prebuild images to a dev environment with \`INVOKE_PERSIST_HISTORY=true\` and ran the following checks:

**Multi-turn conversation history**

Issued two \`/invoke\` calls with the same \`conversation_id\`:
- Turn 1: introduced a piece of information
- Turn 2: asked the agent to recall it

Before the fix, turn 2 had no memory of turn 1. After the fix, the agent correctly recalled the information from the prior turn — confirming that the MongoDB-backed runtime persists conversation state across calls when the env var is enabled.

**Smoke tests**

Ran the full suite of agent smoke tests against the patched deployment. All \`POST /api/v1/chat/invoke\` calls returned \`200 OK\` with no errors in the pod logs. Pod logs confirmed \`persist_history=True\` was being read from the env var correctly.

**No regressions observed** — streaming endpoint, HITL interrupt path, and all other agent invocations continued to function normally throughout testing.