### PR TITLE
fix(agent-runtime): guard delete_by_key_prefix against InMemoryStore

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -398,8 +398,9 @@ class AgentRuntime:
         # Agent A's skill files if Agent B has no skills of its own (because
         # the seeding block below is skipped when self.config.skills is empty).
         if self._resolve_backend_type() == BACKEND_STORE and self._store:
-            fs_ns = self._resolve_fs_namespace()
-            self._store.delete_by_key_prefix(fs_ns, "/skills/")
+            if hasattr(self._store, "delete_by_key_prefix"):
+                fs_ns = self._resolve_fs_namespace()
+                self._store.delete_by_key_prefix(fs_ns, "/skills/")
 
         if self.config.skills:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13-dev.1"
+version = "0.4.13-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13.dev1"
+version = "0.4.13.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- `delete_by_key_prefix` only exists on `MongoDBGridFSStore`; calling it on `InMemoryStore` (used in ephemeral/test contexts) raises `AttributeError` and causes a 500 on every runtime initialization
- Add `if hasattr(self._store, "delete_by_key_prefix"):` guard so the skill-file cleanup is a no-op on store backends that don't implement it
- One-line change, no behaviour change for production deployments backed by MongoDB

## Root cause

`agent_runtime.py` unconditionally calls `self._store.delete_by_key_prefix(...)` to clear stale skill files before seeding. The check `_resolve_backend_type() == BACKEND_STORE` does not filter out `InMemoryStore` — it only checks the configured backend type, not the actual object. `InMemoryStore` (LangGraph's default in-memory store) has no such method.

## Test plan

- [ ] Agents using `InMemoryStore` (ephemeral contexts) initialize without error
- [ ] Agents using `MongoDBGridFSStore` (production) continue to clear stale skill files correctly
- [ ] No regressions in skill seeding behaviour

## Validation

Deployed to a dev environment and ran a full suite of agent smoke tests. Tests that were previously failing with `AttributeError: 'InMemoryStore' object has no attribute 'delete_by_key_prefix'` all passed. No errors in pod logs.