### PR TITLE
fix(escalation): use last email match for VictorOps on-call lookup

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
@@ -113,9 +113,11 @@ def _ping_victorops_oncall(
 
     oncall_email = None
     if full_text:
-      email_match = re.search(r"[a-zA-Z0-9.+-]+@[\w-]+\.[\w.]+", full_text)
-      if email_match:
-        oncall_email = email_match.group(0).strip(".")
+      # Use the last email match — the agent lists reasoning before its final answer,
+      # so the correct on-call address appears last (not first).
+      email_matches = re.findall(r"[a-zA-Z0-9.+-]+@[\w-]+\.[\w.]+", full_text)
+      if email_matches:
+        oncall_email = email_matches[-1].strip(".")
 
     if not oncall_email:
       logger.warning(f"[{thread_ts}] VictorOps: no email found in AI response for team {team}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13-dev.3"
+version = "0.4.13-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13.dev3"
+version = "0.4.13.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- The VictorOps on-call agent sometimes reasons through multiple on-call shifts (e.g. US and PL) before concluding with the correct person, producing a response that contains more than one email address
- `re.search` was used to extract the email, which always picks the **first** match — tagging the wrong person
- Changed to `re.findall` and select the **last** match, since the agent consistently places its final answer at the end of its response

## Test plan

- [ ] Trigger a "Get help" escalation in a channel configured with VictorOps
- [ ] Verify the correct (current) on-call person is tagged
- [ ] Verify single-email responses are unaffected