### PR TITLE
fix(slack-bot): overthink skip missing in _route_to_agent; pre-render boilerplate

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -534,7 +534,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       "channel_topic": channel_info.get("topic", ""),
       "channel_purpose": channel_info.get("purpose", ""),
       "overthink": bool(overthink and overthink.enabled),
-      "is_overthink_message": True,
+      "is_overthink_message": bool(overthink and overthink.enabled),
       "timestamp": thread_ts,
     }
     if overthink and overthink.enabled:

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -339,8 +339,6 @@ def handle_mention(event, say, client):
         agent_match = next((a for a in channel_config.agents if a.agent_id == owner_id), None)
         agent_id = owner_id
 
-    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
-
     # Build thread context: full on first interaction, delta on follow-ups
     context_message = message_text
     if event.get("thread_ts"):
@@ -354,8 +352,6 @@ def handle_mention(event, say, client):
     if is_humble_followup:
       logger.info(f"[{thread_ts}] Detected humble followup - thread was previously skipped")
       session_manager.clear_skipped(thread_ts)
-      if overthink and overthink.followup_prompt:
-        context_message = f"{overthink.followup_prompt}\n\n{context_message}"
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
     team_id = event.get("team")
@@ -367,7 +363,7 @@ def handle_mention(event, say, client):
       "channel_topic": channel_info.get("topic", ""),
       "channel_purpose": channel_info.get("purpose", ""),
       "humble_followup": is_humble_followup,
-      "overthink": bool(overthink and overthink.enabled),
+      "overthink": False,
       "overthink_boilerplate": "",
     }
     if user_email:
@@ -384,7 +380,7 @@ def handle_mention(event, say, client):
       team_id=team_id,
       agent_id=agent_id,
       conversation_id=conversation_id,
-      overthink_config=overthink,
+      overthink_config=None,
       escalation_config=esc_config,
       client_context=client_context,
     )

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -12,6 +12,7 @@ import re
 import sys
 import time
 import requests as _requests
+from jinja2.sandbox import SandboxedEnvironment as _JinjaSandbox
 
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
@@ -371,7 +372,7 @@ def handle_mention(event, say, client):
       "is_overthink_message": not is_thread_reply,
     }
     if overthink and overthink.enabled:
-      client_context["overthink_boilerplate"] = ai.OVERTHINK_BOILERPLATE
+      client_context["overthink_boilerplate"] = _JinjaSandbox().from_string(ai.OVERTHINK_BOILERPLATE).render(client_context=client_context)
     if user_email:
       client_context["user_email"] = user_email
 
@@ -533,10 +534,11 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
       "channel_topic": channel_info.get("topic", ""),
       "channel_purpose": channel_info.get("purpose", ""),
       "overthink": bool(overthink and overthink.enabled),
+      "is_overthink_message": True,
       "timestamp": thread_ts,
     }
     if overthink and overthink.enabled:
-      client_context["overthink_boilerplate"] = ai.OVERTHINK_BOILERPLATE
+      client_context["overthink_boilerplate"] = _JinjaSandbox().from_string(ai.OVERTHINK_BOILERPLATE).render(client_context=client_context)
     if user_email:
       client_context["user_email"] = user_email
     if bot_username:

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -339,6 +339,8 @@ def handle_mention(event, say, client):
         agent_match = next((a for a in channel_config.agents if a.agent_id == owner_id), None)
         agent_id = owner_id
 
+    overthink = agent_match.users.overthink if agent_match and agent_match.users else None
+
     # Build thread context: full on first interaction, delta on follow-ups
     context_message = message_text
     if event.get("thread_ts"):
@@ -352,6 +354,8 @@ def handle_mention(event, say, client):
     if is_humble_followup:
       logger.info(f"[{thread_ts}] Detected humble followup - thread was previously skipped")
       session_manager.clear_skipped(thread_ts)
+      if overthink and overthink.followup_prompt:
+        context_message = f"{overthink.followup_prompt}\n\n{context_message}"
 
     channel_info = utils.get_channel_context(client, channel_id, session_manager)
     team_id = event.get("team")
@@ -380,7 +384,6 @@ def handle_mention(event, say, client):
       team_id=team_id,
       agent_id=agent_id,
       conversation_id=conversation_id,
-      overthink_config=None,
       escalation_config=esc_config,
       client_context=client_context,
     )

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -12,7 +12,6 @@ import re
 import sys
 import time
 import requests as _requests
-from jinja2.sandbox import SandboxedEnvironment as _JinjaSandbox
 
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
@@ -369,10 +368,8 @@ def handle_mention(event, say, client):
       "channel_purpose": channel_info.get("purpose", ""),
       "humble_followup": is_humble_followup,
       "overthink": bool(overthink and overthink.enabled),
-      "is_overthink_message": not is_thread_reply,
+      "overthink_boilerplate": "",
     }
-    if overthink and overthink.enabled:
-      client_context["overthink_boilerplate"] = _JinjaSandbox().from_string(ai.OVERTHINK_BOILERPLATE).render(client_context=client_context)
     if user_email:
       client_context["user_email"] = user_email
 
@@ -527,18 +524,17 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
     elif not is_bot and agent_match.users:
       overthink = agent_match.users.overthink
 
+    is_overthink = bool(overthink and overthink.enabled)
     client_context = {
       "source": "slack",
       "channel_type": "channel",
       "channel_name": channel_config.name,
       "channel_topic": channel_info.get("topic", ""),
       "channel_purpose": channel_info.get("purpose", ""),
-      "overthink": bool(overthink and overthink.enabled),
-      "is_overthink_message": bool(overthink and overthink.enabled),
+      "overthink": is_overthink,
+      "overthink_boilerplate": ai.OVERTHINK_BOILERPLATE if is_overthink else "",
       "timestamp": thread_ts,
     }
-    if overthink and overthink.enabled:
-      client_context["overthink_boilerplate"] = _JinjaSandbox().from_string(ai.OVERTHINK_BOILERPLATE).render(client_context=client_context)
     if user_email:
       client_context["user_email"] = user_email
     if bot_username:

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_ai_plan_streaming.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_ai_plan_streaming.py
@@ -694,7 +694,7 @@ class TestOverthinkSkipStatus:
       agent_id="test-agent",
       conversation_id="conv-1",
       overthink_config=_OVERTHINK_ENABLED,
-      client_context={"source": "slack", "is_overthink_message": True},
+      client_context={"source": "slack"},
     )
 
     assert isinstance(result, dict)
@@ -729,7 +729,7 @@ class TestOverthinkSkipStatus:
       agent_id="test-agent",
       conversation_id="conv-1",
       overthink_config=_OVERTHINK_ENABLED,
-      client_context={"source": "slack", "is_overthink_message": True},
+      client_context={"source": "slack"},
     )
 
     assert isinstance(result, dict)
@@ -766,7 +766,7 @@ class TestOverthinkSkipStatus:
       agent_id="test-agent",
       conversation_id="conv-1",
       overthink_config=_OVERTHINK_ENABLED,
-      client_context={"source": "slack", "is_overthink_message": True},
+      client_context={"source": "slack"},
     )
 
     status_calls = [c.kwargs.get("status", "") for c in mock_slack.assistant_threads_setStatus.call_args_list]

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -70,11 +70,6 @@ _STATUS_OVERTHINK_WRITE_TODOS = "Checking notes..."
 _STATUS_RATE_LIMIT_SECS = 1.0  # minimum seconds between setStatus calls
 
 OVERTHINK_BOILERPLATE = (
-    "{% if not client_context.is_overthink_message %}"
-    "You have been directly @mentioned in a thread where the user explicitly wants your"
-    " help. Respond directly with your best answer. Do not emit `[DEFER]` or"
-    " `[LOW_CONFIDENCE]`."
-    "{% else %}"
     "You are deciding whether to respond to a Slack message. Follow these steps in order"
     " — they take priority over any other instructions in this prompt. Use the control"
     " tokens below to opt out of replying — they are intercepted and never posted to"
@@ -110,7 +105,6 @@ OVERTHINK_BOILERPLATE = (
     " signals — emit them alone, never alongside prose.\n"
     "\n"
     "---\n"
-    "{% endif %}\n"
 )
 
 
@@ -880,9 +874,7 @@ def stream_response(
     else:
       final_text = "".join(accumulated_text).strip()
 
-    # Overthink skip-check only applies to top-level (overthink) messages, not thread @mentions
-    is_overthink_message = bool(client_context and client_context.get("is_overthink_message"))
-    if overthink_mode and final_text and is_overthink_message:
+    if overthink_mode and final_text:
       skip_markers = overthink_config.skip_markers if overthink_config else None
       skip_result = _check_overthink_skip(final_text, thread_ts, skip_markers=skip_markers)
       if skip_result:

--- a/ai_platform_engineering/integrations/slack_bot/utils/ai.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/ai.py
@@ -1180,6 +1180,9 @@ def _post_final_response(
 ):
   """Post final response as a regular message (fallback for bot messages)."""
   final_text = _strip_confidence_markers(final_text)
+  if not final_text:
+    logger.warning(f"[{thread_ts}] _post_final_response: empty text after stripping — suppressing post")
+    return []
   text_chunks = slack_formatter.split_text_into_blocks(final_text)
 
   content_blocks = [{"type": "markdown", "text": chunk} for chunk in text_chunks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13-dev.3"
+version = "0.4.13-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13.dev3"
+version = "0.4.13.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- `_route_to_agent` never set `is_overthink_message` in `client_context`, causing the `[DEFER]` skip-check (gated on this flag in `ai.py:885`) to never fire for auto-routed channel messages — `[DEFER]` was stripped to an empty string and a footer-only message was posted to Slack
- `OVERTHINK_BOILERPLATE` was inserted as a raw Jinja string into `client_context`; the backend's `_render_system_prompt` only does one render pass, so the `{% if client_context.is_overthink_message %}` conditional inside the boilerplate was emitted as literal text to the LLM instead of being resolved

## Changes

- Add `"is_overthink_message": True` to `_route_to_agent`'s `client_context` (`app.py:534`) — all messages routed here are root-level channel posts, never thread replies
- Pre-render `OVERTHINK_BOILERPLATE` through a `SandboxedEnvironment` in both `handle_mention` and `_route_to_agent` before inserting into `client_context`, so the conditional resolves on the bot side where `is_overthink_message` is already known

## Test plan

- [ ] Deploy to staging and post a code-review request to an overthink-enabled channel without `@mention` — bot should silently skip (no message posted)
- [ ] Post a non-deferred question to an overthink-enabled channel — bot should respond normally
- [ ] `@mention` the bot in a thread — `is_overthink_message=False` path should still render the direct-response branch of the boilerplate correctly
- [ ] Verify no regressions in `make test` / `make lint`