### PR TITLE
fix(slack-bot): parse attachment.blocks in extract_message_text

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
@@ -184,6 +184,25 @@ def build_delta_context(
   return "\n".join(lines)
 
 
+def _extract_blocks_text(blocks: list, content_parts: list) -> None:
+  """Extract text from a list of Slack Block Kit blocks into content_parts."""
+  for block in blocks:
+    if block.get("type") == "section" and block.get("text"):
+      block_text = block["text"].get("text", "")
+      if block_text and block_text not in content_parts:
+        content_parts.append(block_text)
+    elif block.get("type") == "context":
+      for element in block.get("elements", []):
+        if element.get("type") == "mrkdwn":
+          elem_text = element.get("text", "")
+          if elem_text and elem_text not in content_parts:
+            content_parts.append(elem_text)
+    elif block.get("type") == "header" and block.get("text"):
+      header_text = block["text"].get("text", "")
+      if header_text and header_text not in content_parts:
+        content_parts.append(f"**{header_text}**")
+
+
 def extract_message_text(event: Dict[str, Any]) -> str:
   """Extract comprehensive message text from a Slack event."""
   content_parts = []
@@ -193,21 +212,7 @@ def extract_message_text(event: Dict[str, Any]) -> str:
     content_parts.append(text)
 
   if event.get("blocks"):
-    for block in event.get("blocks", []):
-      if block.get("type") == "section" and block.get("text"):
-        block_text = block["text"].get("text", "")
-        if block_text and block_text not in content_parts:
-          content_parts.append(block_text)
-      elif block.get("type") == "context":
-        for element in block.get("elements", []):
-          if element.get("type") == "mrkdwn":
-            elem_text = element.get("text", "")
-            if elem_text and elem_text not in content_parts:
-              content_parts.append(elem_text)
-      elif block.get("type") == "header" and block.get("text"):
-        header_text = block["text"].get("text", "")
-        if header_text and header_text not in content_parts:
-          content_parts.append(f"**{header_text}**")
+    _extract_blocks_text(event.get("blocks", []), content_parts)
 
   if event.get("attachments"):
     for attachment in event.get("attachments", []):
@@ -225,20 +230,7 @@ def extract_message_text(event: Dict[str, Any]) -> str:
             content_parts.append(f"{field_title}: {field_value}")
       # Some integrations post with text="" and all content inside
       # attachment.blocks (nested Block Kit).
-      for block in attachment.get("blocks", []):
-        if block.get("type") == "section" and block.get("text"):
-          block_text = block["text"].get("text", "")
-          if block_text and block_text not in content_parts:
-            content_parts.append(block_text)
-        elif block.get("type") == "context":
-          for element in block.get("elements", []):
-            if element.get("type") == "mrkdwn":
-              elem_text = element.get("text", "")
-              if elem_text and elem_text not in content_parts:
-                content_parts.append(elem_text)
-        elif block.get("type") == "header" and block.get("text"):
-          header_text = block["text"].get("text", "")
-          if header_text and header_text not in content_parts:
-            content_parts.append(f"**{header_text}**")
+      if attachment.get("blocks"):
+        _extract_blocks_text(attachment.get("blocks", []), content_parts)
 
   return "\n".join(content_parts).strip()

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
@@ -223,5 +223,22 @@ def extract_message_text(event: Dict[str, Any]) -> str:
           field_value = field.get("value", "")
           if field_title or field_value:
             content_parts.append(f"{field_title}: {field_value}")
+      # Some integrations (e.g. Splunk Observability Cloud) post with text=""
+      # and all content inside attachment.blocks (nested Block Kit).
+      for block in attachment.get("blocks", []):
+        if block.get("type") == "section" and block.get("text"):
+          block_text = block["text"].get("text", "")
+          if block_text and block_text not in content_parts:
+            content_parts.append(block_text)
+        elif block.get("type") == "context":
+          for element in block.get("elements", []):
+            if element.get("type") == "mrkdwn":
+              elem_text = element.get("text", "")
+              if elem_text and elem_text not in content_parts:
+                content_parts.append(elem_text)
+        elif block.get("type") == "header" and block.get("text"):
+          header_text = block["text"].get("text", "")
+          if header_text and header_text not in content_parts:
+            content_parts.append(f"**{header_text}**")
 
   return "\n".join(content_parts).strip()

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_context.py
@@ -223,8 +223,8 @@ def extract_message_text(event: Dict[str, Any]) -> str:
           field_value = field.get("value", "")
           if field_title or field_value:
             content_parts.append(f"{field_title}: {field_value}")
-      # Some integrations (e.g. Splunk Observability Cloud) post with text=""
-      # and all content inside attachment.blocks (nested Block Kit).
+      # Some integrations post with text="" and all content inside
+      # attachment.blocks (nested Block Kit).
       for block in attachment.get("blocks", []):
         if block.get("type") == "section" and block.get("text"):
           block_text = block["text"].get("text", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13-dev.5"
+version = "0.4.13-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13.dev5"
+version = "0.4.13.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- `extract_message_text()` in `slack_context.py` did not parse `attachment.blocks` (nested Block Kit inside attachments)
- Some alert integrations post `bot_message` events with `text: ""` and all content inside `attachments[].blocks`
- This caused `extract_message_text()` to return `""`, and `_route_to_agent()` silently bailed at the empty-text guard — bot never responded

## Changes

Adds block parsing for blocks nested inside `attachments[]`, using the same `section`/`context`/`header` extraction already applied to top-level event blocks.

## Test plan

- [x] `make lint` passes
- [ ] Deploy to staging and verify bot responds to alerts that post with `text: ""` and content in `attachment.blocks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)