### PR TITLE
fix(ci): make grype pr scans retryable

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,6 +2,8 @@
 name: "Grype Scan"
 description: "Anchore Grype vulnerability scan — filesystem on all events, containers on tags. Blocking gate is GitHub Code Scanning PR diff mode, not fail-build."
 
+# assisted-by Codex Codex-sonnet-4-6
+
 # Trigger matrix:
 #   pull_request / push to main  → filesystem scan only; fail-build: false — GitHub Code Scanning
 #                                  PR diff mode is the gate (only NEW alerts block the PR)
@@ -56,7 +58,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.tag || github.ref }}
 
       - name: Run Grype scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
@@ -69,7 +72,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
-        if: always()
+        if: ${{ always() && steps.scan.outputs.sarif != '' }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
           category: "grype-filesystem"
@@ -159,7 +162,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
-        if: always()
+        if: ${{ always() && steps.scan.outputs.sarif != '' }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
           category: "grype-${{ matrix.image }}"


### PR DESCRIPTION
# Description

Fixes a Grype workflow follow-up from PR #1471. The original failed Grype run hit a GitHub API installation rate limit during SARIF upload. After the rate-limit reset, rerunning the workflow exposed a separate retryability issue: closed/merged pull requests no longer have `refs/pull/<number>/merge`, so `actions/checkout` cannot fetch the default PR merge ref.

This updates the filesystem Grype scan to checkout the pull request head repository and SHA directly, while keeping SARIF associated with `refs/pull/<number>/head` for Code Scanning. It also skips SARIF upload when the scan did not produce a SARIF file, avoiding a misleading secondary failure after checkout or scan setup errors.

Related: #1471

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/security-scan.yml"); puts "YAML OK"'`\n- `git diff --check`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'unexpected key "description"' .github/workflows/security-scan.yml`\n- Reran the failed #1471 prebuild cleanup workflows; both passed after the GitHub API rate limit reset.\n- Reran the failed #1471 Grype workflow; it still failed on the old workflow because `refs/pull/1471/merge` no longer exists after merge, which this PR fixes for future reruns.