### PR TITLE
fix(security): close active CodeQL alerts

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/scripts/get_token.py
+++ b/ai_platform_engineering/knowledge_bases/rag/scripts/get_token.py
@@ -5,11 +5,12 @@ Get a Bearer token using OAuth2 client credentials flow.
 Usage:
     python scripts/get_token.py --issuer https://your-idp/realms/myrealm \
                                  --client-id my-client \
-                                 --client-secret my-secret
+                                 --client-secret my-secret \
+                                 --output-file /tmp/rag-ingestor-token
 
     # Or pick up values from env:
     OIDC_ISSUER=... INGESTOR_OIDC_CLIENT_ID=... INGESTOR_OIDC_CLIENT_SECRET=... \
-        python scripts/get_token.py
+        python scripts/get_token.py --output-file /tmp/rag-ingestor-token
 """
 import argparse
 import os
@@ -41,15 +42,30 @@ def get_token(issuer: str, client_id: str, client_secret: str) -> str:
     return resp.json()["access_token"]
 
 
-def main():
+def write_token_file(path: str, token: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write(token)
+            handle.write("\n")
+    finally:
+        if fd != -1:
+            os.close(fd)
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(description="Fetch a Bearer token via client credentials")
     parser.add_argument("--issuer", default=os.getenv("OIDC_ISSUER") or os.getenv("INGESTOR_OIDC_ISSUER"))
     parser.add_argument("--client-id", default=os.getenv("INGESTOR_OIDC_CLIENT_ID") or os.getenv("OIDC_CLIENT_ID"))
     parser.add_argument("--client-secret", default=os.getenv("INGESTOR_OIDC_CLIENT_SECRET") or os.getenv("OIDC_CLIENT_SECRET"))
     parser.add_argument(
-        "--print-token",
-        action="store_true",
-        help="Print the bearer token to stdout. Use only in a trusted shell.",
+        "--output-file",
+        help="Write the bearer token to this file with mode 0600.",
     )
     args = parser.parse_args()
 
@@ -57,14 +73,16 @@ def main():
     if missing:
         print(f"Error: missing required args: {', '.join(missing)}", file=sys.stderr)
         parser.print_help()
-        sys.exit(1)
+        return 1
 
     token = get_token(args.issuer, args.client_id, args.client_secret)
-    if args.print_token:
-        print(token)  # lgtm[py/clear-text-logging-sensitive-data]
+    if args.output_file:
+        write_token_file(args.output_file, token)
+        print(f"Token written to {args.output_file} with file mode 0600.", file=sys.stderr)
     else:
-        print("Token acquired. Re-run with --print-token only in a trusted shell.", file=sys.stderr)
+        print("Token acquired. Re-run with --output-file PATH to store it in a 0600 file.", file=sys.stderr)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/ai_platform_engineering/skills_middleware/router.py
+++ b/ai_platform_engineering/skills_middleware/router.py
@@ -27,6 +27,20 @@ logger = logging.getLogger(__name__)
 
 # assisted-by Codex Codex-sonnet-4-6
 CATALOG_API_KEY_HEADER = os.getenv("CAIPE_CATALOG_API_KEY_HEADER", "X-Caipe-Catalog-Key").strip() or "X-Caipe-Catalog-Key"
+_ALLOWED_SCAN_SEVERITIES = frozenset({"critical", "high", "medium", "low", "info"})
+
+
+def _safe_scan_severity(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    severity = value.strip().lower()
+    return severity if severity in _ALLOWED_SCAN_SEVERITIES else None
+
+
+def _safe_scan_exit_code(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
 
 
 def _gitlab_api_host() -> str:
@@ -74,10 +88,8 @@ def _is_gitlab_host(host: str, configured: str) -> bool:
     return False
 
 
-def _scan_summary_for_response(result: dict[str, Any]) -> str:
+def _scan_summary_for_response(exit_code: int | None, max_severity: str | None) -> str:
     """Return scanner status without exposing raw process output."""
-    exit_code = result.get("exit_code")
-    max_severity = result.get("max_severity")
     if exit_code not in (0, None):
         if max_severity:
             return f"skill-scanner reported findings up to {max_severity} severity"
@@ -530,8 +542,8 @@ async def scan_skill_content(
     try:
         tmp_root = write_single_skill_to_temp_tree(body.name.strip(), body.content)
         result = run_scan_all_on_directory(tmp_root)
-    except Exception as e:
-        logger.warning("scan-content failed for %s: %s", body.name, e)
+    except Exception as exc:
+        logger.warning("scan-content failed for %s (%s)", body.name, type(exc).__name__)
         return {
             "passed": True,
             "blocked": False,
@@ -554,10 +566,13 @@ async def scan_skill_content(
             "summary": "skill-scanner not available",
         }
 
+    exit_code = _safe_scan_exit_code(result.get("exit_code"))
+    max_severity = _safe_scan_severity(result.get("max_severity"))
+
     blocked = False
-    if result.get("exit_code") not in (0, None):
+    if exit_code not in (0, None):
         if gate == "strict" and fail_on:
-            blocked = severity_meets_threshold(result.get("max_severity"), fail_on)
+            blocked = severity_meets_threshold(max_severity, fail_on)
         elif gate == "strict":
             blocked = True
 
@@ -575,7 +590,7 @@ async def scan_skill_content(
         "passed": not blocked,
         "blocked": blocked,
         "scan_status": scan_status,
-        "max_severity": result.get("max_severity"),
-        "exit_code": result.get("exit_code"),
-        "summary": _scan_summary_for_response(result),
+        "max_severity": max_severity,
+        "exit_code": exit_code,
+        "summary": _scan_summary_for_response(exit_code, max_severity),
     }

--- a/charts/ai-platform-engineering/data/skills/caipe-skills.py
+++ b/charts/ai-platform-engineering/data/skills/caipe-skills.py
@@ -513,10 +513,8 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         body = _fetch(url, api_key=api_key)
-    except urllib.error.HTTPError as exc:
-        sys.stderr.write(
-            f"caipe-skills: HTTP {exc.code} from {safe_base_url}; response body withheld\n"
-        )
+    except urllib.error.HTTPError:
+        sys.stderr.write("caipe-skills: catalog request failed; response body withheld\n")
         return 1
     except urllib.error.URLError as exc:
         sys.stderr.write(f"caipe-skills: network error: {_redact_sensitive_text(exc.reason)}\n")

--- a/charts/ai-platform-engineering/data/skills/caipe-skills.py
+++ b/charts/ai-platform-engineering/data/skills/caipe-skills.py
@@ -514,13 +514,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         body = _fetch(url, api_key=api_key)
     except urllib.error.HTTPError as exc:
-        # Surface the catalog's own error body when present (helpful for 401/403).
-        try:
-            detail = _redact_sensitive_text(exc.read().decode("utf-8", errors="replace"))
-        except Exception:
-            detail = ""
         sys.stderr.write(
-            f"caipe-skills: HTTP {exc.code} from {safe_base_url}: {detail}\n"
+            f"caipe-skills: HTTP {exc.code} from {safe_base_url}; response body withheld\n"
         )
         return 1
     except urllib.error.URLError as exc:

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.13 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.14 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.13 -f your-values.yaml'}
+                  {'    --version 0.4.14 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.13 -f your-values.yaml'}
+              {'    --version 0.4.14 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.13-dev.9"
+version = "0.4.13-dev.10"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.14"
+version = "0.4.14-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/tests/test_caipe_skills_helper.py
+++ b/tests/test_caipe_skills_helper.py
@@ -1,5 +1,6 @@
 # Copyright 2025 CNOE Contributors
 # SPDX-License-Identifier: Apache-2.0
+# assisted-by Codex Codex-sonnet-4-6
 
 """Smoke tests for charts/.../skills/caipe-skills.py.
 
@@ -22,6 +23,7 @@ import importlib.util
 import io
 import json
 import sys
+import urllib.error
 from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Any
@@ -240,6 +242,37 @@ def test_invalid_base_url_emits_json_error_envelope(
     assert rc == 0
     payload = json.loads(out)
     assert "Invalid base_url" in payload["error"]
+
+
+def test_http_error_response_body_is_withheld(
+    helper: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setenv("CAIPE_CATALOG_KEY", "key")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    def fail_with_sensitive_body(url: str, *, api_key: str) -> str:
+        raise urllib.error.HTTPError(
+            url,
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b'{"password":"super-secret","detail":"denied"}'),
+        )
+
+    monkeypatch.setattr(helper, "_fetch", fail_with_sensitive_body)
+
+    rc, out = _run(helper, ["--base-url", "https://catalog.example.com"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert out == ""
+    assert "HTTP 403" in captured.err
+    assert "response body withheld" in captured.err
+    assert "password" not in captured.err
+    assert "super-secret" not in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_caipe_skills_helper.py
+++ b/tests/test_caipe_skills_helper.py
@@ -269,7 +269,7 @@ def test_http_error_response_body_is_withheld(
     captured = capsys.readouterr()
     assert rc == 1
     assert out == ""
-    assert "HTTP 403" in captured.err
+    assert "catalog request failed" in captured.err
     assert "response body withheld" in captured.err
     assert "password" not in captured.err
     assert "super-secret" not in captured.err

--- a/tests/test_get_token_script.py
+++ b/tests/test_get_token_script.py
@@ -1,0 +1,76 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+# assisted-by Codex Codex-sonnet-4-6
+
+"""Tests for the RAG token helper script."""
+
+from __future__ import annotations
+
+import importlib.util
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "ai_platform_engineering"
+    / "knowledge_bases"
+    / "rag"
+    / "scripts"
+    / "get_token.py"
+)
+
+
+def _load_script() -> Any:
+    spec = importlib.util.spec_from_file_location("rag_get_token_script", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_token_file_uses_owner_only_mode(tmp_path: Path) -> None:
+    script = _load_script()
+    output_file = tmp_path / "token.txt"
+
+    script.write_token_file(str(output_file), "secret-token")
+
+    assert output_file.read_text(encoding="utf-8") == "secret-token\n"
+    assert stat.S_IMODE(output_file.stat().st_mode) == 0o600
+
+
+def test_main_writes_token_without_printing_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script = _load_script()
+    output_file = tmp_path / "token.txt"
+    monkeypatch.setattr(script, "get_token", lambda issuer, client_id, client_secret: "secret-token")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "get_token.py",
+            "--issuer",
+            "https://issuer.example.com",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "client-secret",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    rc = script.main()
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert "secret-token" not in captured.err
+    assert output_file.read_text(encoding="utf-8") == "secret-token\n"

--- a/tests/test_skill_scan_content_response.py
+++ b/tests/test_skill_scan_content_response.py
@@ -1,0 +1,78 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+# assisted-by Codex Codex-sonnet-4-6
+
+"""Tests for sanitized skill scan-content responses."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+
+def test_scan_response_helpers_accept_only_bounded_values() -> None:
+    import ai_platform_engineering.skills_middleware.router as router_module
+
+    assert router_module._safe_scan_severity(" HIGH ") == "high"
+    assert router_module._safe_scan_severity("Traceback: secret high") is None
+    assert router_module._safe_scan_severity(None) is None
+    assert router_module._safe_scan_exit_code(1) == 1
+    assert router_module._safe_scan_exit_code(True) is None
+    assert router_module._safe_scan_exit_code("1") is None
+
+
+def test_scan_content_response_omits_raw_scanner_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import ai_platform_engineering.skills_middleware.hub_skill_scan as hub_skill_scan
+    import ai_platform_engineering.skills_middleware.router as router_module
+    import ai_platform_engineering.skills_middleware.skill_scanner_runner as scanner_runner
+
+    scan_root = tmp_path / "scan-root"
+    scan_root.mkdir()
+    persisted: dict[str, object] = {}
+    raw_result = {
+        "skipped": False,
+        "exit_code": 1,
+        "max_severity": "HIGH",
+        "stdout": "Traceback with secret-token",
+        "stderr": "password=super-secret",
+        "duration_sec": 0.1,
+    }
+    monkeypatch.setenv("SKILL_SCANNER_GATE", "strict")
+    monkeypatch.setenv("SKILL_SCANNER_FAIL_ON", "medium")
+    monkeypatch.setattr(scanner_runner, "write_single_skill_to_temp_tree", lambda name, content: scan_root)
+    monkeypatch.setattr(scanner_runner, "run_scan_all_on_directory", lambda root: raw_result)
+    monkeypatch.setattr(
+        hub_skill_scan,
+        "_persist_scan_run",
+        lambda config_id, result, **kwargs: persisted.update(
+            {"config_id": config_id, "result": result, "kwargs": kwargs}
+        ),
+    )
+
+    response = asyncio.run(
+        router_module.scan_skill_content(
+            router_module.ScanContentBody(name="unsafe", content="# skill", config_id="cfg-1"),
+            router_module.CatalogAuthContext(bypass_entitlement=True),
+        )
+    )
+
+    assert response == {
+        "passed": False,
+        "blocked": True,
+        "scan_status": "flagged",
+        "max_severity": "high",
+        "exit_code": 1,
+        "summary": "skill-scanner reported findings up to high severity",
+    }
+    assert "Traceback" not in str(response)
+    assert "secret-token" not in str(response)
+    assert "super-secret" not in str(response)
+    assert persisted["config_id"] == "cfg-1"

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.14"
+version = "0.4.14.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.13.dev9"
+version = "0.4.13.dev10"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Closes the active CodeQL findings currently open on `main`:

- https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/12969: stop echoing catalog HTTP response bodies from `caipe-skills.py`.
- https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/42: remove bearer-token stdout printing from `get_token.py`; tokens can now be written to a 0600 file.
- https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/37: bound scan-content API responses to sanitized severity/exit-code fields and avoid logging raw scan exceptions.

This intentionally keeps persisted scanner output available for internal audit records, while the API response only exposes bounded status fields. The large remaining Code Scanning count is still dominated by stale Grype SARIF categories from historical filesystem/container scans; this PR handles the real CodeQL code fixes so those alerts can close when CodeQL reruns on this branch and main.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Verification

- `uv run ruff check ai_platform_engineering/knowledge_bases/rag/scripts/get_token.py ai_platform_engineering/skills_middleware/router.py charts/ai-platform-engineering/data/skills/caipe-skills.py tests/test_caipe_skills_helper.py tests/test_get_token_script.py tests/test_skill_scan_content_response.py`
- `uv run pytest tests/test_caipe_skills_helper.py tests/test_get_token_script.py tests/test_skill_scan_content_response.py -v` (30 passed)
