### PR TITLE
fix(jira): quiet MCP server logs by default

### DIFF
--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/server.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/server.py
@@ -9,6 +9,7 @@ import os
 import logging
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from mcp_jira.utils.logging import setup_logging
 
 # Import tools
 from mcp_jira.tools.jira import attachments
@@ -30,8 +31,11 @@ def main():
     # Load environment variables
     load_dotenv()
 
-    # Configure logging
-    logging.basicConfig(level=logging.DEBUG)
+    # Configure logging. Default to WARNING to avoid noisy MCP protocol logs
+    # and accidental Jira payload disclosure; opt into DEBUG locally when needed.
+    log_level_name = os.getenv("MCP_JIRA_LOG_LEVEL", "WARNING").upper()
+    log_level = getattr(logging, log_level_name, logging.WARNING)
+    setup_logging(log_level)
 
     # Get MCP configuration from environment variables
     MCP_MODE = os.getenv("MCP_MODE", "STDIO")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.14-dev.1"
+version = "0.4.14-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.14.dev1"
+version = "0.4.14.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Default Jira MCP server logging to WARNING to reduce protocol noise and lower the chance of Jira payloads appearing in normal logs.
- Keep verbose troubleshooting available via MCP_JIRA_LOG_LEVEL when needed.

## Test plan

- [x] uv --directory ai_platform_engineering/agents/jira/mcp run python -c "import mcp_jira.server; print('server import ok')"