### PR TITLE
feat(curl): add allow_non_public_urls option to curl builtin tool

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -247,6 +247,10 @@ class CurlToolConfig(BaseModel):
         default=True,
         description="If True (default), reject non-https:// URLs.",
     )
+    allow_non_public_urls: bool = Field(
+        default=False,
+        description="If True, allow URLs that resolve to private/internal IP addresses. Off by default (SSRF protection).",
+    )
 
 
 class CurrentDatetimeToolConfig(BaseModel):

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -634,8 +634,9 @@ class AgentRuntime:
         if curl_config and curl_config.enabled:
             allowed_domains = curl_config.allowed_domains or "*"
             https_only = curl_config.https_only if curl_config.https_only is not None else True
-            tools.append(create_curl_tool(allowed_domains=allowed_domains, https_only=https_only))
-            config_summary["curl"] = {"allowed_domains": allowed_domains, "https_only": https_only}
+            allow_non_public_urls = curl_config.allow_non_public_urls if curl_config.allow_non_public_urls is not None else False
+            tools.append(create_curl_tool(allowed_domains=allowed_domains, https_only=https_only, allow_non_public_urls=allow_non_public_urls))
+            config_summary["curl"] = {"allowed_domains": allowed_domains, "https_only": https_only, "allow_non_public_urls": allow_non_public_urls}
 
         # current_datetime tool (enabled by default)
         current_datetime_config = config.builtin_tools.current_datetime

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -137,6 +137,17 @@ def get_builtin_tool_definitions() -> list[BuiltinToolDefinition]:
                     default=True,
                     required=False,
                 ),
+                BuiltinToolConfigField(
+                    name="allow_non_public_urls",
+                    type="boolean",
+                    label="Allow Non-Public URLs",
+                    description=(
+                        "If enabled, allow curl to reach URLs that resolve to private/internal IP addresses. "
+                        "Disabled by default (SSRF protection). Only enable for agents that need internal network access."
+                    ),
+                    default=False,
+                    required=False,
+                ),
             ],
         ),
         BuiltinToolDefinition(
@@ -350,7 +361,7 @@ def create_fetch_url_tool(allowed_domains: str = "*"):
     return fetch_url
 
 
-def create_curl_tool(allowed_domains: str = "*", https_only: bool = True):
+def create_curl_tool(allowed_domains: str = "*", https_only: bool = True, allow_non_public_urls: bool = False):
     """Create a curl tool with domain restrictions.
 
     Supports all HTTP methods (GET, POST, PUT, PATCH, DELETE). Use this
@@ -359,6 +370,8 @@ def create_curl_tool(allowed_domains: str = "*", https_only: bool = True):
     Args:
         allowed_domains: Comma-separated domain patterns (same ACL as fetch_url).
         https_only: If True (default), reject non-https URLs.
+        allow_non_public_urls: If True, skip SSRF IP routing validation so the tool can
+            reach private/internal addresses. Off by default.
 
     Returns:
         A LangChain tool that wraps curl with domain ACL and optional https-only enforcement.
@@ -418,14 +431,23 @@ def create_curl_tool(allowed_domains: str = "*", https_only: bool = True):
                     logger.warning(f"curl blocked non-https URL: {token.split('?')[0]}")
                     return msg
 
-        # Check domain ACL and SSRF protection (same validation as fetch_url)
+        # Check domain ACL and SSRF protection
         for token in args[1:]:
             if token.startswith("https://") or token.startswith("http://"):
                 try:
-                    is_valid, error_msg, domain = _validate_fetch_url(token, allowed_domains)
-                    if not is_valid:
-                        logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
-                        return f"ERROR: {error_msg}"
+                    if allow_non_public_urls:
+                        # Skip IP routing check; still enforce domain ACL
+                        parsed = urlparse(token)
+                        domain = (parsed.hostname or "").lower()
+                        is_allowed, error_msg = is_domain_allowed(domain, allowed_domains)
+                        if not is_allowed:
+                            logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
+                            return f"ERROR: {error_msg}"
+                    else:
+                        is_valid, error_msg, domain = _validate_fetch_url(token, allowed_domains)
+                        if not is_valid:
+                            logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
+                            return f"ERROR: {error_msg}"
                 except Exception as e:
                     return f"ERROR: Failed to parse URL: {e}"
                 break

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -72,15 +72,16 @@ def _is_publicly_routable_host(hostname: str) -> tuple[bool, str]:
     return True, ""
 
 
-def _validate_fetch_url(url: str, allowed_domains: str) -> tuple[bool, str, str]:
+def _validate_fetch_url(url: str, allowed_domains: str, allow_non_public_urls: bool = False) -> tuple[bool, str, str]:
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
         return False, "Invalid URL - must start with http:// or https://", ""
 
     domain = (parsed.hostname or "").lower()
-    is_routable, route_error = _is_publicly_routable_host(domain)
-    if not is_routable:
-        return False, f"URL host must resolve only to publicly routable IP addresses: {route_error}", domain
+    if not allow_non_public_urls:
+        is_routable, route_error = _is_publicly_routable_host(domain)
+        if not is_routable:
+            return False, f"URL host must resolve only to publicly routable IP addresses: {route_error}", domain
 
     is_allowed, error_msg = is_domain_allowed(domain, allowed_domains)
     if not is_allowed:
@@ -435,19 +436,10 @@ def create_curl_tool(allowed_domains: str = "*", https_only: bool = True, allow_
         for token in args[1:]:
             if token.startswith("https://") or token.startswith("http://"):
                 try:
-                    if allow_non_public_urls:
-                        # Skip IP routing check; still enforce domain ACL
-                        parsed = urlparse(token)
-                        domain = (parsed.hostname or "").lower()
-                        is_allowed, error_msg = is_domain_allowed(domain, allowed_domains)
-                        if not is_allowed:
-                            logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
-                            return f"ERROR: {error_msg}"
-                    else:
-                        is_valid, error_msg, domain = _validate_fetch_url(token, allowed_domains)
-                        if not is_valid:
-                            logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
-                            return f"ERROR: {error_msg}"
+                    is_valid, error_msg, domain = _validate_fetch_url(token, allowed_domains, allow_non_public_urls)
+                    if not is_valid:
+                        logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
+                        return f"ERROR: {error_msg}"
                 except Exception as e:
                     return f"ERROR: Failed to parse URL: {e}"
                 break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.14-dev.2"
+version = "0.4.14-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.14.dev2"
+version = "0.4.14.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Add a new per-agent config field `allow_non_public_urls` (default: `false`) to the `curl` builtin tool
- When enabled, the SSRF IP routing check is bypassed so agents can reach private/internal endpoints; domain ACL validation still applies
- `fetch_url` is unchanged — this opt-out is curl-only
- The new field is surfaced in the agent configuration UI alongside the existing `https_only` and `allowed_domains` fields

## Changes

- `models.py`: add `allow_non_public_urls` field to `CurlToolConfig`
- `builtin_tools.py`: expose field in `BuiltinToolDefinition`; add param to `create_curl_tool()`; when enabled, skip `_validate_fetch_url` IP check and perform only domain ACL check
- `agent_runtime.py`: wire `allow_non_public_urls` from config through to `create_curl_tool()` and include in `config_summary` logging

## Test plan

- [ ] Existing `test_builtin_tools.py` tests pass (all 9 green)
- [ ] Agent with `allow_non_public_urls: false` (default) still blocks private IPs as before
- [ ] Agent with `allow_non_public_urls: true` can reach a URL resolving to a private IP
- [ ] Domain ACL still blocks disallowed domains even when `allow_non_public_urls: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)