### PR TITLE
fix(security): close reopened code scanning alerts

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -75,7 +75,9 @@ jobs:
         if: ${{ always() && steps.scan.outputs.sarif != '' }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-          category: "grype-filesystem"
+          # Keep this stable as "grype": GitHub Code Scanning correlates SARIF
+          # by category, and renaming it leaves old alerts orphaned.
+          category: "grype"
           # On pull_request events the default checkout produces a merge commit
           # (refs/pull/N/merge), but GitHub Code Scanning PR checks require the
           # analysis to be associated with refs/pull/N/head + the head commit SHA.

--- a/ai_platform_engineering/knowledge_bases/rag/scripts/get_token.py
+++ b/ai_platform_engineering/knowledge_bases/rag/scripts/get_token.py
@@ -69,9 +69,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    missing = [name for name, val in [("--issuer", args.issuer), ("--client-id", args.client_id), ("--client-secret", args.client_secret)] if not val]
-    if missing:
-        print(f"Error: missing required args: {', '.join(missing)}", file=sys.stderr)
+    if not (args.issuer and args.client_id and args.client_secret):
+        print("Error: one or more required arguments are missing.", file=sys.stderr)
         parser.print_help()
         return 1
 

--- a/ai_platform_engineering/skills_middleware/skill_scanner_runner.py
+++ b/ai_platform_engineering/skills_middleware/skill_scanner_runner.py
@@ -79,13 +79,13 @@ def run_scan_all_on_directory(target_dir: Path) -> dict[str, Any]:
             "duration_sec": time.time() - t0,
             "max_severity": "high",
         }
-    except Exception as e:
-        logger.warning("skill-scanner execution failed: %s", e)
+    except Exception as exc:
+        logger.warning("skill-scanner execution failed: %s", type(exc).__name__)
         return {
             "skipped": False,
             "exit_code": -2,
             "stdout": "",
-            "stderr": str(e)[:2000],
+            "stderr": "skill-scanner execution failed",
             "duration_sec": time.time() - t0,
             "max_severity": None,
         }

--- a/ai_platform_engineering/skills_middleware/tests/test_skill_scanner_runner.py
+++ b/ai_platform_engineering/skills_middleware/tests/test_skill_scanner_runner.py
@@ -5,7 +5,15 @@
 
 """Unit tests for skill_scanner_runner path validation."""
 
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
 from ai_platform_engineering.skills_middleware.skill_scanner_runner import (
+    run_scan_all_on_directory,
     write_single_skill_to_temp_tree,
 )
 
@@ -55,3 +63,26 @@ class TestWriteSingleSkillToTempTree:
         assert root.is_dir()
         # Should be inside a temp directory
         assert "config-scan-" in root.name
+
+
+def test_run_scan_all_sanitizes_execution_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(
+        "ai_platform_engineering.skills_middleware.skill_scanner_runner.shutil.which",
+        lambda name: "/usr/local/bin/skill-scanner",
+    )
+
+    def raise_secret_error(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("token=super-secret")
+
+    monkeypatch.setattr(subprocess, "run", raise_secret_error)
+
+    with caplog.at_level(logging.WARNING):
+        result = run_scan_all_on_directory(tmp_path)
+
+    assert result["exit_code"] == -2
+    assert result["stderr"] == "skill-scanner execution failed"
+    assert "super-secret" not in caplog.text

--- a/tests/test_get_token_script.py
+++ b/tests/test_get_token_script.py
@@ -74,3 +74,36 @@ def test_main_writes_token_without_printing_it(
     assert captured.out == ""
     assert "secret-token" not in captured.err
     assert output_file.read_text(encoding="utf-8") == "secret-token\n"
+
+
+def test_main_reports_missing_required_args_generically(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script = _load_script()
+    for name in (
+        "OIDC_ISSUER",
+        "INGESTOR_OIDC_ISSUER",
+        "INGESTOR_OIDC_CLIENT_ID",
+        "OIDC_CLIENT_ID",
+        "INGESTOR_OIDC_CLIENT_SECRET",
+        "OIDC_CLIENT_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "get_token.py",
+            "--issuer",
+            "https://issuer.example.com",
+            "--client-id",
+            "client",
+        ],
+    )
+
+    rc = script.main()
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.err.splitlines()[0] == "Error: one or more required arguments are missing."


### PR DESCRIPTION
# Description

Fixes the two CodeQL alerts that reopened on `main` after #1474 merged:

- https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/15433
- https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning/15434

Also restores the filesystem Grype SARIF category from `grype-filesystem` back to the historical `grype` category. GitHub Code Scanning correlates SARIF alerts by tool/category/ref; renaming the category orphaned the older filesystem Grype alerts, which is why the Security tab count was not dropping even after fixes merged. The next `main` filesystem scan after this merges should supersede the old `grype` analysis and close alerts that are no longer present.

What was missing:

- The missing-argument path in `get_token.py` still built and logged a list derived from `client_secret` state, so CodeQL treated it as clear-text logging of sensitive data.
- `skill_scanner_runner.py` still copied raw exception text into the scanner result dict, which CodeQL treated as stack-trace/exception data that could flow to the scan-content API response.
- The Grype filesystem scan category had been renamed, so old `grype` alerts were no longer being updated by new scans.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Verification

- `uv run ruff check ai_platform_engineering/knowledge_bases/rag/scripts/get_token.py ai_platform_engineering/skills_middleware/skill_scanner_runner.py ai_platform_engineering/skills_middleware/router.py tests/test_get_token_script.py tests/test_skill_scan_content_response.py ai_platform_engineering/skills_middleware/tests/test_skill_scanner_runner.py`
- `uv run pytest tests/test_get_token_script.py tests/test_skill_scan_content_response.py ai_platform_engineering/skills_middleware/tests/test_skill_scanner_runner.py -v`
