### PR TITLE
fix(keycloak): skip auth-reconcile gracefully when init-scripts ConfigMap absent

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
@@ -29,6 +29,11 @@ spec:
             - /bin/sh
             - -ec
             - |
+              if [ ! -f /scripts/init-idp.sh ]; then
+                echo "[auth-reconcile] Keycloak init-scripts ConfigMap not yet deployed, skipping auth reconcile."
+                exit 0
+              fi
+
               if [ -z "${KEYCLOAK_ADMIN:-}" ] || [ -z "${KEYCLOAK_ADMIN_PASSWORD:-}" ]; then
                 echo "[auth-reconcile] Keycloak admin Secret is not available yet; skipping early reconcile."
                 exit 0
@@ -104,4 +109,5 @@ spec:
           configMap:
             name: {{ include "keycloak.fullname" . }}-init-scripts
             defaultMode: 0755
+            optional: true
 {{- end }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.1"
+version = "0.5.1-rc.13"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.1"
+version = "0.5.1rc13"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

When upgrading from a release without Keycloak to one with Keycloak for the first time, the `pre-upgrade` hook fires before the `caipe-keycloak-init-scripts` ConfigMap has ever been created. Without `optional: true` on the volume, Kubernetes refuses to start the pod entirely (volume mount error), which blocks the whole upgrade.

Two changes to `charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml`:

1. Mark the `init-scripts` ConfigMap volume as `optional: true` so the pod can start even when the ConfigMap doesn't exist yet.
2. Add an early-exit guard at the top of the shell script: if `/scripts/init-idp.sh` is absent (volume mounted but empty), log `"Keycloak init-scripts ConfigMap not yet deployed, skipping auth reconcile."` and `exit 0`.

Normal upgrades on established deployments are unaffected — the ConfigMap exists, the script runs as before.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass