### PR TITLE
ci(helm): normalize local chart deps for rc packages

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -132,6 +132,90 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+      - name: Write local chart version normalizer
+        if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
+        run: |
+          cat > /tmp/normalize-local-chart-tree-versions.py <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[1])
+          chart_version = sys.argv[2]
+          app_version = sys.argv[3]
+
+
+          def replace_scalar(line: str, key: str, value: str) -> str:
+              match = re.match(rf"^(\s*{re.escape(key)}:\s*)(.*?)(\s*#.*)?$", line)
+              if not match:
+                  return line
+              return f"{match.group(1)}{value}{match.group(3) or ''}"
+
+
+          def repository_value(line: str) -> str:
+              value = line.split(":", 1)[1].strip()
+              return value.strip("\"'")
+
+
+          def update_chart(path: Path) -> None:
+              original = path.read_text()
+              lines = original.splitlines()
+
+              for index, line in enumerate(lines):
+                  if line.startswith("version:"):
+                      lines[index] = replace_scalar(line, "version", chart_version)
+                      break
+
+              for index, line in enumerate(lines):
+                  if line.startswith("appVersion:"):
+                      lines[index] = replace_scalar(line, "appVersion", app_version)
+                      break
+
+              try:
+                  deps_index = next(index for index, line in enumerate(lines) if line == "dependencies:")
+              except StopIteration:
+                  path.write_text("\n".join(lines) + ("\n" if original.endswith("\n") else ""))
+                  return
+
+              index = deps_index + 1
+              while index < len(lines):
+                  if lines[index] and not lines[index].startswith((" ", "\t", "-")):
+                      break
+                  if not re.match(r"^\s*-\s+name:\s*", lines[index]):
+                      index += 1
+                      continue
+
+                  start = index
+                  index += 1
+                  while index < len(lines):
+                      if re.match(r"^\s*-\s+name:\s*", lines[index]):
+                          break
+                      if lines[index] and not lines[index].startswith((" ", "\t")):
+                          break
+                      index += 1
+
+                  block = lines[start:index]
+                  repository = next(
+                      (repository_value(line) for line in block if re.match(r"^\s*repository:\s*", line)),
+                      "",
+                  )
+                  is_local_dependency = repository == "" or repository.startswith("file://")
+                  if not is_local_dependency:
+                      continue
+
+                  for dep_index in range(start, index):
+                      if re.match(r"^\s*version:\s*", lines[dep_index]):
+                          lines[dep_index] = replace_scalar(lines[dep_index], "version", chart_version)
+                          break
+
+              path.write_text("\n".join(lines) + ("\n" if original.endswith("\n") else ""))
+
+
+          for chart in sorted(root.rglob("Chart.yaml")):
+              update_chart(chart)
+              print(f"normalized {chart}")
+          PY
+
       - name: Package rag-stack chart
         if: steps.detect.outputs.rag-stack-changed == 'true'
         env:
@@ -151,6 +235,8 @@ jobs:
             echo "rag-stack appVersion is $CHART_APP_VERSION, expected $APP_VERSION"
             exit 1
           fi
+
+          python3 /tmp/normalize-local-chart-tree-versions.py "charts/rag-stack" "$TAG_VERSION" "$APP_VERSION"
 
           mkdir -p ./packaged-charts
           helm dependency update charts/rag-stack/
@@ -175,6 +261,9 @@ jobs:
             echo "ai-platform-engineering appVersion is $CHART_APP_VERSION, expected $APP_VERSION"
             exit 1
           fi
+
+          python3 /tmp/normalize-local-chart-tree-versions.py "charts/rag-stack" "$TAG_VERSION" "$APP_VERSION"
+          python3 /tmp/normalize-local-chart-tree-versions.py "charts/ai-platform-engineering" "$TAG_VERSION" "$APP_VERSION"
 
           mkdir -p ./packaged-charts
           helm dependency update charts/rag-stack/


### PR DESCRIPTION
## Summary

- Normalize local chart and local dependency versions during tagged Helm RC packaging.
- Ensure `ai-platform-engineering` RC packages embed matching local subchart metadata instead of stale/prod-resolved versions.

## Test plan

- [x] ReadLints on `.github/workflows/ci-helm.yml`
- [x] `git diff --check -- .github/workflows/ci-helm.yml`


Made with [Cursor](https://cursor.com)