### PR TITLE
[codex] docs(api): refresh CAIPE API reference

### DIFF
--- a/docs/docs/knowledge_bases/api-reference.md
+++ b/docs/docs/knowledge_bases/api-reference.md
@@ -1,0 +1,379 @@
+---
+sidebar_position: 2
+---
+
+<!-- assisted-by Codex Codex-sonnet-4-6 -->
+
+# RAG API Reference
+
+CAIPE RAG exposes a FastAPI REST API for authentication metadata, datasource and ingestion management, job tracking, graph exploration, MCP tool configuration, and MCP tool invocation. It also exposes a native MCP endpoint for agents.
+
+This page is based on `ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py` and the shared RAG models.
+
+## Base URLs
+
+| Access path | URL |
+|-------------|-----|
+| Direct RAG server | `http://localhost:9446` |
+| Swagger UI | `http://localhost:9446/docs` |
+| OpenAPI JSON | `http://localhost:9446/openapi.json` |
+| MCP endpoint | `http://localhost:9446/mcp` |
+| Through CAIPE UI BFF | `http://localhost:3000/api/rag/<rag-path>` |
+
+When using the UI BFF, omit the leading slash from the RAG path after `/api/rag/`. For example, direct `GET /v1/user/info` becomes `GET /api/rag/v1/user/info`.
+
+## Authentication and RBAC
+
+RAG supports OIDC bearer tokens, trusted network access, ingestor credentials, and anonymous read of selected identity metadata. The UI BFF forwards the current NextAuth `accessToken` to the RAG server as a bearer token when available.
+
+Role levels are hierarchical:
+
+| Role | Can do |
+|------|--------|
+| `anonymous` | Read identity metadata from `/v1/user/info`; no protected API access. |
+| `readonly` | Query and view data, graph metadata, MCP tool schemas, and invoke MCP tools. |
+| `ingestonly` | Everything `readonly` can do, plus datasource upserts, ingestor heartbeats, document ingestion, and job updates. |
+| `admin` | Everything `ingestonly` can do, plus deletion, cleanup, ontology-agent writes, MCP tool config writes, and bulk reload/cleanup operations. |
+
+Check the resolved identity and role:
+
+```bash
+curl http://localhost:9446/v1/user/info \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+Response:
+
+```json
+{
+  "email": "user@example.com",
+  "role": "readonly",
+  "is_authenticated": true,
+  "groups": ["engineering", "platform-team"],
+  "permissions": ["read"],
+  "in_trusted_network": false
+}
+```
+
+Through the UI proxy:
+
+```bash
+curl http://localhost:3000/api/rag/v1/user/info
+```
+
+## Endpoint Summary
+
+### Identity and Health
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `GET` | `/v1/user/info` | Public | Return current identity, role, groups, permissions, and trusted-network state. |
+| `GET` | `/healthz` | Public | Return service health and key runtime configuration. |
+
+### Ingestors and Datasources
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `GET` | `/v1/ingestors` | `readonly` | List registered ingestors. |
+| `POST` | `/v1/ingestor/heartbeat` | `ingestonly` | Register or refresh an ingestor and receive ingest limits. |
+| `DELETE` | `/v1/ingestor/delete?ingestor_id=<id>` | `admin` | Delete an ingestor. |
+| `POST` | `/v1/datasource` | `ingestonly` | Upsert datasource metadata. |
+| `DELETE` | `/v1/datasource?datasource_id=<id>` | `admin` | Delete a datasource. |
+| `POST` | `/v1/datasource/:datasource_id/cleanup` | `admin` | Remove stale documents for one datasource. |
+| `POST` | `/v1/datasources/cleanup` | `admin` | Remove stale documents across datasources. |
+| `GET` | `/v1/datasources?ingestor_id=<id>` | `readonly` | List datasources, optionally filtered by ingestor. |
+| `GET` | `/v1/datasource/:datasource_id/documents` | `readonly` | List documents and chunks for a datasource. Supports pagination. |
+| `GET` | `/v1/chunk/:chunk_id/content` | `readonly` | Fetch full chunk content and metadata. |
+
+Ingestor heartbeat body:
+
+```json
+{
+  "ingestor_type": "web",
+  "ingestor_name": "docs-webloader",
+  "description": "Documentation crawler",
+  "metadata": {
+    "owner": "platform-team"
+  }
+}
+```
+
+Datasource body:
+
+```json
+{
+  "datasource_id": "web:https://docs.example.com",
+  "ingestor_id": "web:docs-webloader",
+  "description": "Public documentation",
+  "source_type": "web",
+  "last_updated": 1770000000,
+  "default_chunk_size": 10000,
+  "default_chunk_overlap": 2000,
+  "reload_interval": 86400,
+  "metadata": {
+    "url": "https://docs.example.com"
+  }
+}
+```
+
+### Jobs
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `GET` | `/v1/job/:job_id` | `readonly` | Fetch one ingestion job. |
+| `GET` | `/v1/jobs/datasource/:datasource_id?status_filter=<status>` | `readonly` | List jobs for a datasource. |
+| `POST` | `/v1/jobs/batch` | `readonly` | Fetch jobs for up to 100 datasource IDs, with optional status filters. |
+| `POST` | `/v1/job?datasource_id=<id>&job_status=<status>&message=<msg>&total=<n>` | `ingestonly` | Create an ingestion job. |
+| `PATCH` | `/v1/job/:job_id?job_status=<status>&message=<msg>&total=<n>` | `ingestonly` | Update job state. |
+| `POST` | `/v1/job/:job_id/terminate` | `admin` | Terminate a job. |
+| `POST` | `/v1/job/:job_id/increment-progress?increment=<n>` | `ingestonly` | Increment processed item count. |
+| `POST` | `/v1/job/:job_id/increment-failure?increment=<n>` | `ingestonly` | Increment failure count. |
+| `POST` | `/v1/job/:job_id/increment-document-count?increment=<n>` | `ingestonly` | Increment document count. |
+| `POST` | `/v1/job/:job_id/add-errors` | `ingestonly` | Append job error messages. |
+
+Batch request:
+
+```json
+{
+  "datasource_ids": ["web:https://docs.example.com", "confluence:SPACE:1234"],
+  "status_filter": ["in_progress", "pending"]
+}
+```
+
+### Ingestion
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `POST` | `/v1/ingest/webloader/url` | `ingestonly` | Crawl and ingest a URL. |
+| `POST` | `/v1/ingest/webloader/reload` | `ingestonly` | Reload one web datasource. |
+| `POST` | `/v1/ingest/webloader/reload-all` | `admin` | Reload all web datasources. |
+| `POST` | `/v1/ingest/confluence/page` | `ingestonly` | Ingest a Confluence page, optionally with child pages. |
+| `POST` | `/v1/ingest/confluence/reload` | `ingestonly` | Reload one Confluence datasource. |
+| `POST` | `/v1/ingest/confluence/reload-all` | `admin` | Reload all Confluence datasources. |
+| `POST` | `/v1/ingest` | `ingestonly` | Ingest arbitrary LangChain documents for a datasource. |
+
+Web URL ingestion:
+
+```json
+{
+  "url": "https://docs.example.com/platform",
+  "description": "Platform docs",
+  "settings": {
+    "crawl_mode": "sitemap",
+    "max_depth": 2,
+    "max_pages": 500,
+    "render_javascript": false,
+    "respect_robots_txt": true,
+    "chunk_size": 10000,
+    "chunk_overlap": 2000
+  },
+  "reload_interval": 86400
+}
+```
+
+Confluence ingestion:
+
+```json
+{
+  "url": "https://example.atlassian.net/wiki/spaces/PLAT/pages/123456/Runbook",
+  "description": "Platform runbook",
+  "get_child_pages": true,
+  "allowed_title_patterns": ["Runbook", "How-to"],
+  "denied_title_patterns": ["Archive"]
+}
+```
+
+Document ingestion:
+
+```json
+{
+  "ingestor_id": "custom:runbook-loader",
+  "datasource_id": "custom:runbooks",
+  "job_id": "job-123",
+  "fresh_until": 1770000000,
+  "documents": [
+    {
+      "page_content": "Full document text",
+      "metadata": {
+        "document_id": "runbook-1",
+        "title": "Restart service",
+        "document_type": "runbook"
+      }
+    }
+  ]
+}
+```
+
+### Graph Exploration
+
+Graph APIs are available when Graph RAG is enabled.
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `GET` | `/v1/graph/explore/entity_type` | `readonly` | List entity types. |
+| `GET` | `/v1/graph/explore/data/entities/batch` | `readonly` | Fetch data graph entities in batch. |
+| `GET` | `/v1/graph/explore/data/relations/batch` | `readonly` | Fetch data graph relations in batch. |
+| `POST` | `/v1/graph/explore/data/entity/neighborhood` | `readonly` | Explore a data entity neighborhood. |
+| `GET` | `/v1/graph/explore/data/entity/start?n=10` | `readonly` | Fetch random data graph start nodes. |
+| `GET` | `/v1/graph/explore/data/stats` | `readonly` | Fetch data graph stats. |
+| `GET` | `/v1/graph/explore/ontology/entities/batch` | `readonly` | Fetch ontology graph entities in batch. |
+| `GET` | `/v1/graph/explore/ontology/relations/batch` | `readonly` | Fetch ontology graph relations in batch. |
+| `POST` | `/v1/graph/explore/ontology/entity/neighborhood` | `readonly` | Explore an ontology entity neighborhood. |
+| `GET` | `/v1/graph/explore/ontology/entity/start?n=10` | `readonly` | Fetch random ontology graph start nodes. |
+| `GET` | `/v1/graph/explore/ontology/stats` | `readonly` | Fetch ontology graph stats. |
+
+Neighborhood request:
+
+```json
+{
+  "entity_type": "Pod",
+  "entity_pk": "platform/api-7ccf9",
+  "depth": 1
+}
+```
+
+### Ontology Agent Proxy
+
+When Graph RAG is enabled, the RAG server reverse-proxies ontology-agent routes under `/v1/graph/ontology/agent/*`. Status is read-only; all write operations require admin.
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `GET` | `/v1/graph/ontology/agent/status` | `readonly` | Ontology agent health/status. |
+| `GET` | `/v1/graph/ontology/agent/ontology_version` | `admin` through proxy policy | Current ontology version. |
+| `POST` | `/v1/graph/ontology/agent/relation/accept/:relation_id` | `admin` | Accept a proposed relation. |
+| `POST` | `/v1/graph/ontology/agent/relation/reject/:relation_id` | `admin` | Reject a proposed relation. |
+| `POST` | `/v1/graph/ontology/agent/relation/undo_evaluation/:relation_id` | `admin` | Undo a relation evaluation. |
+| `POST` | `/v1/graph/ontology/agent/relation/evaluate/:relation_id` | `admin` | Evaluate a relation. |
+| `POST` | `/v1/graph/ontology/agent/relation/sync/:relation_id` | `admin` | Sync a relation to the ontology graph. |
+| `POST` | `/v1/graph/ontology/agent/relation/heuristics/batch` | `admin` | Batch relation heuristics. |
+| `POST` | `/v1/graph/ontology/agent/relation/evaluations/batch` | `admin` | Batch relation evaluations. |
+| `POST` | `/v1/graph/ontology/agent/regenerate_ontology` | `admin` | Regenerate ontology. |
+| `DELETE` | `/v1/graph/ontology/agent/clear` | `admin` | Clear ontology-agent data. |
+| `POST` | `/v1/graph/ontology/agent/debug/process_all` | `admin` | Debug process all relations. |
+| `POST` | `/v1/graph/ontology/agent/debug/cleanup` | `admin` | Debug cleanup. |
+
+The proxy currently treats only `GET` requests whose path ends in `/status` as read-only; other ontology-agent methods and paths require admin.
+
+### MCP Tool Configuration and Invocation
+
+| Method | Route | Role | Purpose |
+|--------|-------|------|---------|
+| `GET` | `/v1/mcp/custom-tools` | `readonly` | List custom MCP search tool configs. |
+| `POST` | `/v1/mcp/custom-tools` | `admin` | Create a custom MCP search tool. Reserved IDs cannot be created. |
+| `PUT` | `/v1/mcp/custom-tools/:tool_id` | `admin` | Update a custom tool or the seeded `search` config. |
+| `DELETE` | `/v1/mcp/custom-tools/:tool_id` | `admin` | Delete a custom tool. Reserved IDs cannot be deleted. |
+| `GET` | `/v1/mcp/builtin-tools` | `readonly` | Read built-in MCP tool enablement. |
+| `PUT` | `/v1/mcp/builtin-tools` | `admin` | Update built-in MCP tool enablement. |
+| `GET` | `/v1/mcp/tools/schema` | `readonly` | Return built-in and custom tool parameter schemas. |
+| `POST` | `/v1/mcp/invoke` | `readonly` | Invoke an MCP tool via REST. |
+
+Built-in tool IDs are reserved: `search`, `fetch_document`, and `list_datasources_and_entity_types`.
+
+Custom search tool config:
+
+```json
+{
+  "tool_id": "infra_search",
+  "description": "Search infrastructure runbooks and graph entities",
+  "parallel_searches": [
+    {
+      "label": "runbooks",
+      "datasource_ids": ["confluence:RUNBOOKS"],
+      "extra_filters": {
+        "document_type": "runbook"
+      },
+      "semantic_weight": 0.7
+    },
+    {
+      "label": "kubernetes_entities",
+      "datasource_ids": ["k8s:*"],
+      "extra_filters": {
+        "is_structured_entity": true
+      },
+      "semantic_weight": 0.5
+    }
+  ],
+  "allow_runtime_filters": true,
+  "enabled": true
+}
+```
+
+Invoke a tool through REST:
+
+```bash
+curl -X POST http://localhost:9446/v1/mcp/invoke \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_name": "search",
+    "arguments": {
+      "query": "How do I recover a stuck ArgoCD sync?",
+      "limit": 5,
+      "thought": "Find operational runbooks before answering"
+    }
+  }'
+```
+
+Response:
+
+```json
+{
+  "tool_name": "search",
+  "success": true,
+  "result": {},
+  "error": null
+}
+```
+
+## MCP Endpoint
+
+Agents can connect directly to:
+
+```text
+http://localhost:9446/mcp
+```
+
+The MCP server exposes the built-in tools enabled in `/v1/mcp/builtin-tools` plus enabled custom search tools from `/v1/mcp/custom-tools`.
+
+Core built-in tools:
+
+| Tool | Purpose |
+|------|---------|
+| `search` | Hybrid semantic and keyword search over indexed content. |
+| `fetch_document` | Fetch full content for a document ID returned by search. |
+| `list_datasources_and_entity_types` | Discover datasources and graph entity types. |
+
+Graph tools are available when Graph RAG is enabled:
+
+| Tool | Purpose |
+|------|---------|
+| `graph_explore_ontology_entity` | Explore ontology entity type schema and relationships. |
+| `graph_explore_data_entity` | Explore one data entity and its neighborhood. |
+| `graph_fetch_data_entity_details` | Fetch complete entity properties and relations. |
+| `graph_shortest_path_between_entity_types` | Find relation paths between entity types. |
+| `graph_raw_query_data` | Execute read-only Cypher against the data graph with tenant-label injection. |
+| `graph_raw_query_ontology` | Execute read-only Cypher against the ontology graph with tenant-label injection. |
+
+## UI BFF Proxy Notes
+
+The UI route `GET, POST, PUT, DELETE /api/rag/*path` proxies to the same direct RAG endpoints:
+
+| UI route | Direct RAG route |
+|----------|------------------|
+| `/api/rag/healthz` | `/healthz` |
+| `/api/rag/v1/datasources` | `/v1/datasources` |
+| `/api/rag/v1/mcp/invoke` | `/v1/mcp/invoke` |
+
+The proxy forwards query parameters on `GET` and `DELETE`, JSON bodies on `POST` and `PUT`, and the session access token as a bearer token when present.
+
+## Common Status Codes
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Successful read, update, invocation, or delete. |
+| `202` | Ingestion accepted for asynchronous processing. |
+| `401` | Missing or invalid authentication. |
+| `403` | Authenticated user lacks the required RAG role. |
+| `404` | Resource not found. |
+| `500` | Server or backing service initialization failure. |
+| `502` | UI BFF could not connect to the RAG server. |

--- a/docs/docs/knowledge_bases/index.md
+++ b/docs/docs/knowledge_bases/index.md
@@ -1,3 +1,5 @@
+<!-- assisted-by Codex Codex-sonnet-4-6 -->
+
 # Knowledge Base Systems
 
 ## Overview
@@ -75,7 +77,7 @@ docker compose --profile apps up
 | Interface | URL | Description |
 |-----------|-----|-------------|
 | Web UI | [http://localhost:9447](http://localhost:9447) | Interactive search and graph visualization |
-| API Docs | [http://localhost:9446/docs](http://localhost:9446/docs) | Swagger UI for REST API |
+| API Docs | [http://localhost:9446/docs](http://localhost:9446/docs) | Swagger UI for REST API. See [RAG API Reference](api-reference.md) for the route map and examples. |
 | MCP Endpoint | http://localhost:9446/mcp | Model Context Protocol for AI agents |
 | Neo4j Browser | [http://localhost:7474](http://localhost:7474) | Graph database explorer |
 
@@ -106,5 +108,6 @@ CAIPE RAG includes ingestors for various data sources. See [Ingestors](ingestors
 ## Further Reading
 
 - [Architecture Overview](architecture.md) - Detailed system design and data flows
+- [RAG API Reference](api-reference.md) - REST, graph, ingestion, and MCP route reference
 - [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration and deployment
 - [GitHub Discussion](https://github.com/cnoe-io/ai-platform-engineering/discussions/196) - Unified RAG design discussion

--- a/docs/docs/ui/api-reference.md
+++ b/docs/docs/ui/api-reference.md
@@ -2,697 +2,520 @@
 sidebar_position: 5
 ---
 
-# API Reference
+<!-- assisted-by Codex Codex-sonnet-4-6 -->
 
-The CAIPE UI exposes several API endpoints for programmatic access and integration with external systems.
+# CAIPE UI API Reference
 
-## Base URL
+The CAIPE UI API is a Next.js App Router backend-for-frontend (BFF). It serves the browser, enforces UI-facing auth and authorization, persists configuration in MongoDB, and proxies selected requests to the supervisor, Dynamic Agents runtime, and RAG server.
 
-- **Development**: `http://localhost:3000`
-- **Production**: `https://your-domain.com`
+This page is based on the current route files under `ui/src/app/api`.
+
+## Base URLs
+
+| Environment | Base URL |
+|-------------|----------|
+| Local UI | `http://localhost:3000` |
+| Production UI | `https://<your-caipe-ui-host>` |
+
+The BFF also calls these backend services when the corresponding features are enabled:
+
+| Service | Configuration | Default |
+|---------|---------------|---------|
+| Dynamic Agents runtime | `DYNAMIC_AGENTS_URL` | `http://localhost:8100` |
+| Legacy supervisor SSE stream | `SUPERVISOR_SSE_URL` | `http://localhost:8000/chat/stream` |
+| RAG server | `RAG_SERVER_URL` or `NEXT_PUBLIC_RAG_URL` | `http://localhost:9446` |
+| MongoDB | `MONGODB_URI` and related UI config | Required for saved chats, agents, skills, workflows, teams, settings, and admin data |
 
 ## Authentication
 
-All API endpoints (except `/api/health`) require authentication via NextAuth session cookies or Bearer tokens.
+Most BFF routes require one of these authentication paths:
 
-### Session Cookie Authentication
+| Auth path | Used by | Notes |
+|-----------|---------|-------|
+| NextAuth session cookie | Browser and regular UI calls | `withAuth` requires a session when SSO is enabled. When SSO is disabled, selected routes can fall back to `anonymous@local`. |
+| Bearer token | Programmatic chat, workflow run, and skills calls | Routes that use dual auth accept `Authorization: Bearer <token>` before falling back to the NextAuth session. |
+| Catalog API key | Read-only skills catalog access | Send `X-Caipe-Catalog-Key` for catalog API calls that support supervisor-minted keys. |
+| Session access token forwarded to RAG | `/api/rag/*` | The BFF reads the NextAuth `accessToken` and forwards it to the RAG server as `Authorization: Bearer <token>`. |
 
-```bash
-# Authenticate and get session cookie
-curl -X POST http://localhost:3000/api/auth/signin \
-  -H "Content-Type: application/json" \
-  -d '{"email": "user@example.com", "password": "password"}'
+Admin endpoints require `session.role === "admin"` unless the route explicitly supports admin-view access. In local no-SSO mode, `ALLOW_ANONYMOUS_ADMIN=true` promotes the anonymous fallback user to admin.
 
-# Use session cookie in subsequent requests
-curl http://localhost:3000/api/usecases \
-  -H "Cookie: next-auth.session-token=..."
-```
+## Response Shapes
 
-### Bearer Token Authentication (Coming Soon)
-
-```bash
-curl http://localhost:3000/api/usecases \
-  -H "Authorization: Bearer <token>"
-```
-
-## Endpoints
-
-### Health Check
-
-#### `GET /api/health`
-
-Check if the API is running and healthy.
-
-**Request:**
-
-```bash
-curl http://localhost:3000/api/health
-```
-
-**Response:**
-
-```json
-{
-  "status": "ok",
-  "timestamp": "2026-01-27T10:00:00.000Z",
-  "version": "0.2.12",
-  "caipe": {
-    "url": "http://localhost:8000",
-    "connected": true
-  }
-}
-```
-
-**Status Codes:**
-- `200 OK` - Service is healthy
-- `503 Service Unavailable` - Service is down
-
----
-
-### Use Cases
-
-#### `GET /api/usecases`
-
-Retrieve all saved use cases.
-
-**Request:**
-
-```bash
-curl http://localhost:3000/api/usecases
-```
-
-**Query Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `category` | string | No | Filter by category |
-| `tags` | string | No | Comma-separated tags to filter by |
-| `difficulty` | string | No | Filter by difficulty: `beginner`, `intermediate`, `advanced` |
-| `limit` | number | No | Maximum number of results (default: 100) |
-| `offset` | number | No | Pagination offset (default: 0) |
-
-**Example with filters:**
-
-```bash
-curl "http://localhost:3000/api/usecases?category=deployment&difficulty=beginner&limit=10"
-```
-
-**Response:**
+Many MongoDB-backed routes use the shared response helpers:
 
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "id": "uc_123abc",
-      "title": "Check Deployment Status",
-      "description": "Monitor ArgoCD application sync status and health",
-      "category": "deployment",
-      "tags": ["argocd", "kubernetes", "deployment"],
-      "prompt": "Check the status of all ArgoCD applications in production",
-      "expectedAgents": ["argocd"],
-      "difficulty": "beginner",
-      "createdAt": "2026-01-27T10:00:00.000Z",
-      "updatedAt": "2026-01-27T10:00:00.000Z"
-    }
-  ],
-  "total": 42,
-  "limit": 10,
-  "offset": 0
+  "data": {}
 }
 ```
 
-**Status Codes:**
-- `200 OK` - Success
-- `401 Unauthorized` - Not authenticated
-- `500 Internal Server Error` - Server error
-
----
-
-#### `POST /api/usecases`
-
-Create a new use case.
-
-**Request:**
-
-```bash
-curl -X POST http://localhost:3000/api/usecases \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "AWS Cost Analysis",
-    "description": "Analyze AWS spending by service and region",
-    "category": "cloud",
-    "tags": ["aws", "cost", "finops"],
-    "prompt": "Show me AWS costs for the last 30 days broken down by service",
-    "expectedAgents": ["aws"],
-    "difficulty": "intermediate"
-  }'
-```
-
-**Request Body:**
-
-```typescript
-interface CreateUseCaseRequest {
-  title: string;              // Required, 3-200 chars
-  description: string;        // Required, 10-1000 chars
-  category: string;           // Required: deployment|incident|development|cloud|other
-  tags: string[];             // Required, 1-10 tags
-  prompt: string;             // Required, 10-2000 chars
-  expectedAgents: string[];   // Required, 1-10 agents
-  difficulty: string;         // Required: beginner|intermediate|advanced
-}
-```
-
-**Response:**
+Paginated responses use:
 
 ```json
 {
   "success": true,
   "data": {
-    "id": "uc_456def",
-    "title": "AWS Cost Analysis",
-    "description": "Analyze AWS spending by service and region",
-    "category": "cloud",
-    "tags": ["aws", "cost", "finops"],
-    "prompt": "Show me AWS costs for the last 30 days broken down by service",
-    "expectedAgents": ["aws"],
-    "difficulty": "intermediate",
-    "createdAt": "2026-01-27T10:30:00.000Z",
-    "updatedAt": "2026-01-27T10:30:00.000Z"
+    "items": [],
+    "total": 0,
+    "page": 1,
+    "page_size": 20,
+    "has_more": false
   }
 }
 ```
 
-**Status Codes:**
-- `201 Created` - Use case created
-- `400 Bad Request` - Invalid input
-- `401 Unauthorized` - Not authenticated
-- `500 Internal Server Error` - Server error
-
-**Validation Errors:**
+Errors from shared middleware use:
 
 ```json
 {
   "success": false,
-  "error": "Validation failed",
-  "details": [
-    {
-      "field": "title",
-      "message": "Title must be between 3 and 200 characters"
+  "error": "Human readable message",
+  "code": "OPTIONAL_CODE"
+}
+```
+
+Proxy routes can return the backend service's native response shape instead of the wrapper above. There is no generated `/api/openapi.json` route for the UI BFF today; use this page and the route files as the source of truth. FastAPI services such as RAG and Dynamic Agents expose their own OpenAPI documents on their backend ports.
+
+## Health, Config, and Version
+
+| Method | Route | Purpose | Auth |
+|--------|-------|---------|------|
+| `GET` | `/api/health` | UI process health check. Returns `{status, service, timestamp}`. | Public |
+| `GET` | `/api/version` | Build metadata from `public/version.json` plus `package.json` version when available. | Public |
+| `GET` | `/api/config` | Client-visible UI configuration. | Public |
+| `GET` | `/api/changelog` | UI changelog data. | Public |
+| `GET` | `/api/auth/role` | Current user's role and admin visibility state. | Session |
+| `GET` | `/api/user/info` | Proxy to RAG `/v1/user/info`; forwards session access and ID tokens when present. | Session optional |
+
+## Chat and Runtime Proxies
+
+The current Dynamic Agents chat API lives under `/api/v1/chat/*`. These routes authenticate the caller, validate required fields, and transparently proxy to the Dynamic Agents backend at the same path.
+
+| Method | Route | Backend | Request | Response |
+|--------|-------|---------|---------|----------|
+| `POST` | `/api/v1/chat/stream/start` | `DYNAMIC_AGENTS_URL/api/v1/chat/stream/start` | `message`, `conversation_id`, `agent_id`, optional `protocol`, `trace_id`, `client_context` | Server-Sent Events |
+| `POST` | `/api/v1/chat/stream/resume` | `DYNAMIC_AGENTS_URL/api/v1/chat/stream/resume` | `conversation_id`, `agent_id`, `resume_data`, optional `protocol`, `trace_id` | Server-Sent Events |
+| `POST` | `/api/v1/chat/stream/cancel` | `DYNAMIC_AGENTS_URL/api/v1/chat/stream/cancel` | `conversation_id`, `agent_id` | JSON cancellation result |
+| `POST` | `/api/v1/chat/invoke` | `DYNAMIC_AGENTS_URL/api/v1/chat/invoke` | `message`, `conversation_id`, `agent_id`, optional `trace_id`, `client_context` | JSON agent result |
+| `POST` | `/api/chat/stream` | `SUPERVISOR_SSE_URL` | Legacy supervisor AG-UI payload | Server-Sent Events |
+
+Example streaming request:
+
+```bash
+curl -N -X POST http://localhost:3000/api/v1/chat/stream/start \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -d '{
+    "message": "Check the status of production ArgoCD apps",
+    "conversation_id": "conv-123",
+    "agent_id": "agent-platform-engineer"
+  }'
+```
+
+The BFF preserves the backend SSE stream and returns:
+
+```text
+Content-Type: text/event-stream
+Cache-Control: no-cache, no-transform
+Connection: keep-alive
+```
+
+### Chat History
+
+Chat history is stored in MongoDB and scoped to the current user.
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET`, `POST` | `/api/chat/conversations` | List or create conversations. |
+| `GET`, `PUT`, `DELETE` | `/api/chat/conversations/:id` | Read, rename/update, or delete a conversation. |
+| `GET`, `POST` | `/api/chat/conversations/:id/messages` | List or append messages. |
+| `GET`, `POST` | `/api/chat/conversations/:id/turns` | Read or append structured chat turns. |
+| `PATCH` | `/api/chat/conversations/:id/metadata` | Update conversation metadata. |
+| `POST` | `/api/chat/conversations/:id/archive` | Move a conversation to archive/trash. |
+| `POST` | `/api/chat/conversations/:id/restore` | Restore an archived conversation. |
+| `POST` | `/api/chat/conversations/:id/pin` | Pin or unpin a conversation. |
+| `GET`, `POST`, `PATCH` | `/api/chat/conversations/:id/share` | Manage shared conversation links. |
+| `GET` | `/api/chat/conversations/trash` | List archived or trashed conversations. |
+| `PUT` | `/api/chat/messages/:id` | Update a message. |
+| `GET` | `/api/chat/search` | Search conversation history. |
+| `GET` | `/api/chat/shared` | Resolve shared conversation data. |
+| `GET`, `POST` | `/api/chat/bookmarks` | List or create bookmarks. |
+
+## Dynamic Agent Configuration
+
+Dynamic agent configuration is stored in MongoDB. The BFF owns config writes; the Dynamic Agents backend is treated as a runtime reader.
+
+| Method | Route | Purpose | Auth |
+|--------|-------|---------|------|
+| `GET` | `/api/dynamic-agents` | List agents visible to the caller. Supports `page`, `page_size`, and `enabled_only=true`. | Session |
+| `POST` | `/api/dynamic-agents` | Create an agent. Generates `_id` as `agent-<slugified-name>`. | Admin |
+| `PUT` | `/api/dynamic-agents?id=<agent_id>` | Update allowed mutable fields. Config-driven agents are read-only. | Admin |
+| `DELETE` | `/api/dynamic-agents?id=<agent_id>` | Delete a non-system, non-config-driven agent. | Admin |
+| `GET` | `/api/dynamic-agents/agents/:id` | Fetch one agent if the caller can access it. | Session |
+| `GET` | `/api/dynamic-agents/available` | List enabled agents the caller can chat with. | Session |
+| `GET` | `/api/dynamic-agents/available-subagents?id=<agent_id>` | List valid subagents, excluding self and cyclic references. | Admin |
+| `GET` | `/api/dynamic-agents/builtin-tools` | List built-in tool definitions. | Session |
+| `GET` | `/api/dynamic-agents/middleware` | List middleware definitions. | Session |
+| `GET` | `/api/dynamic-agents/models` | List configured model options. | Session |
+| `GET` | `/api/dynamic-agents/teams` | List teams available for sharing. | Session |
+| `GET` | `/api/dynamic-agents/health` | Proxy Dynamic Agents health. | Session |
+| `POST` | `/api/dynamic-agents/chat/restart-runtime` | Restart or reload the runtime. | Session |
+
+Create agent body:
+
+```json
+{
+  "name": "Platform Engineer",
+  "description": "Helps operate platform services",
+  "system_prompt": "You are a platform engineering assistant.",
+  "model": {
+    "id": "claude-sonnet-4-20250514",
+    "provider": "anthropic-claude"
+  },
+  "visibility": "team",
+  "shared_with_teams": ["platform-team"],
+  "allowed_tools": {},
+  "builtin_tools": {
+    "fetch_url": {
+      "enabled": true,
+      "allowed_domains": "*.cisco.com"
     },
+    "workflows": ["wf-123"]
+  },
+  "subagents": [
     {
-      "field": "tags",
-      "message": "At least one tag is required"
+      "agent_id": "agent-rag-helper",
+      "name": "rag_helper",
+      "description": "Searches internal knowledge bases"
+    }
+  ],
+  "skills": [],
+  "enabled": true
+}
+```
+
+Visibility rules for subagents:
+
+| Parent visibility | Allowed subagent visibility |
+|-------------------|-----------------------------|
+| `private` | `private`, `team`, `global` |
+| `team` | `team`, `global` |
+| `global` | `global` only |
+
+## MCP Server Configuration
+
+MCP server definitions are stored in MongoDB and consumed by Dynamic Agents.
+
+| Method | Route | Purpose | Auth |
+|--------|-------|---------|------|
+| `GET` | `/api/mcp-servers` | List configured MCP servers. Supports `page` and `page_size`. | Admin |
+| `POST` | `/api/mcp-servers` | Create an MCP server config. Adds `mcp-` prefix to the submitted `id` when missing. | Admin |
+| `PUT` | `/api/mcp-servers?id=<server_id>` | Update mutable fields on a non-config-driven server. | Admin |
+| `DELETE` | `/api/mcp-servers?id=<server_id>` | Delete a non-config-driven server. | Admin |
+| `POST` | `/api/mcp-servers/probe` | Probe a server and return discovered tools or an error. | Session |
+
+Create body:
+
+```json
+{
+  "id": "github",
+  "name": "GitHub MCP",
+  "transport": "sse",
+  "endpoint": "https://mcp.example.com/github/sse",
+  "enabled": true
+}
+```
+
+For `stdio` transport, `command` is required. For `sse` and `http`, `endpoint` is required.
+
+## Workflow APIs
+
+CAIPE has two workflow-related APIs:
+
+| API | Storage | Purpose |
+|-----|---------|---------|
+| `/api/workflow-configs` and `/api/workflow-runs` | `workflow_configs`, `workflow_runs` | Current engine-backed multi-step workflows that run Dynamic Agents through AG-UI and expose run polling, events, cancellation, and resume. |
+| `/api/task-configs` | `task_configs` | Self-service task configuration consumed by the supervisor agent. This mirrors `task_config.yaml` and is separate from workflow-engine runs. |
+
+### Workflow Configs
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/api/workflow-configs` | List configs visible to the caller. Admins see all configs. |
+| `GET` | `/api/workflow-configs?id=<workflow_config_id>` | Fetch one visible config. |
+| `POST` | `/api/workflow-configs` | Create a config. |
+| `PUT` | `/api/workflow-configs?id=<workflow_config_id>` | Update a non-config-driven config owned by the caller or any config when admin. |
+| `DELETE` | `/api/workflow-configs?id=<workflow_config_id>` | Delete a non-config-driven config owned by the caller or any config when admin. |
+
+Create body:
+
+```json
+{
+  "name": "Production release check",
+  "description": "Validate deployment and recent incidents before release",
+  "visibility": "team",
+  "shared_with_teams": ["platform-team"],
+  "steps": [
+    {
+      "type": "step",
+      "display_text": "Check ArgoCD applications",
+      "agent_id": "agent-argocd",
+      "prompt": "Check sync and health for production applications. User context: {{ user_context }}",
+      "on_error": "retry",
+      "retry": {
+        "max_attempts": 2
+      },
+      "config_override": null
     }
   ]
 }
 ```
 
----
+Workflow config constraints:
 
-#### `GET /api/usecases/:id`
+| Field | Rule |
+|-------|------|
+| `name` | Required. |
+| `steps` | Required and non-empty. In v1 every entry must have `type: "step"`; parallel groups are rejected. |
+| `display_text`, `agent_id`, `prompt` | Required for every step. |
+| `on_error` | `abort`, `skip`, or `retry`. |
+| `retry.max_attempts` | Required and at least `1` when `on_error` is `retry`. |
+| `visibility` | `private`, `team`, or `global`. Team visibility requires `shared_with_teams`. |
 
-Get a specific use case by ID.
+### Workflow Runs
 
-**Request:**
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `POST` | `/api/workflow-runs` | Start a workflow run and return immediately. |
+| `GET` | `/api/workflow-runs?run_id=<run_id>` | Poll one run and include stream events keyed by step index. |
+| `GET` | `/api/workflow-runs?workflow_config_id=<workflow_config_id>` | List recent runs for one workflow config. |
+| `GET` | `/api/workflow-runs` | List recent runs visible to the caller. |
+| `PUT` | `/api/workflow-runs?id=<run_id>` | Legacy-compatible run update. |
+| `DELETE` | `/api/workflow-runs?id=<run_id>` | Delete a run and best-effort cleanup its files and events. Requires config owner or admin. |
+| `POST` | `/api/workflow-runs/:id/resume` | Resume a run waiting for human input. |
+| `POST` | `/api/workflow-runs/:id/cancel` | Cancel a running workflow. |
 
-```bash
-curl http://localhost:3000/api/usecases/uc_123abc
-```
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "id": "uc_123abc",
-    "title": "Check Deployment Status",
-    "description": "Monitor ArgoCD application sync status and health",
-    "category": "deployment",
-    "tags": ["argocd", "kubernetes", "deployment"],
-    "prompt": "Check the status of all ArgoCD applications in production",
-    "expectedAgents": ["argocd"],
-    "difficulty": "beginner",
-    "createdAt": "2026-01-27T10:00:00.000Z",
-    "updatedAt": "2026-01-27T10:00:00.000Z"
-  }
-}
-```
-
-**Status Codes:**
-- `200 OK` - Success
-- `404 Not Found` - Use case not found
-- `401 Unauthorized` - Not authenticated
-
----
-
-#### `PUT /api/usecases/:id`
-
-Update an existing use case.
-
-**Request:**
+Start a run:
 
 ```bash
-curl -X PUT http://localhost:3000/api/usecases/uc_123abc \
+curl -X POST http://localhost:3000/api/workflow-runs \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
   -d '{
-    "title": "Check ArgoCD Deployment Status (Updated)",
-    "tags": ["argocd", "kubernetes", "deployment", "monitoring"]
-  }'
-```
-
-**Request Body:**
-
-All fields are optional. Only include fields you want to update.
-
-```typescript
-interface UpdateUseCaseRequest {
-  title?: string;
-  description?: string;
-  category?: string;
-  tags?: string[];
-  prompt?: string;
-  expectedAgents?: string[];
-  difficulty?: string;
-}
-```
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "id": "uc_123abc",
-    "title": "Check ArgoCD Deployment Status (Updated)",
-    "tags": ["argocd", "kubernetes", "deployment", "monitoring"],
-    "updatedAt": "2026-01-27T11:00:00.000Z"
-  }
-}
-```
-
-**Status Codes:**
-- `200 OK` - Updated successfully
-- `400 Bad Request` - Invalid input
-- `404 Not Found` - Use case not found
-- `401 Unauthorized` - Not authenticated
-
----
-
-#### `DELETE /api/usecases/:id`
-
-Delete a use case.
-
-**Request:**
-
-```bash
-curl -X DELETE http://localhost:3000/api/usecases/uc_123abc
-```
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "message": "Use case deleted successfully"
-}
-```
-
-**Status Codes:**
-- `200 OK` - Deleted successfully
-- `404 Not Found` - Use case not found
-- `401 Unauthorized` - Not authenticated
-
----
-
-### Chat
-
-#### `POST /api/chat`
-
-Send a message to the CAIPE agent system.
-
-**Request:**
-
-```bash
-curl -X POST http://localhost:3000/api/chat \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Check the status of all ArgoCD applications",
-    "session_id": "session_123",
-    "stream": true
-  }'
-```
-
-**Request Body:**
-
-```typescript
-interface ChatRequest {
-  message: string;           // Required, user message
-  session_id?: string;       // Optional, for conversation continuity
-  stream?: boolean;          // Optional, enable SSE streaming (default: true)
-  agent?: string;            // Optional, target specific agent
-  metadata?: object;         // Optional, additional context
-}
-```
-
-**Response (Non-streaming):**
-
-```json
-{
-  "success": true,
-  "data": {
-    "session_id": "session_123",
-    "task_id": "task_456",
-    "response": "Found 15 applications. All are synced and healthy.",
-    "artifacts": [
-      {
-        "name": "final_result",
-        "type": "text",
-        "data": "..."
+    "workflow_config_id": "wf-123",
+    "user_context": "Release 2026.05.21 to production",
+    "trigger_info": {
+      "triggered_by": "webui",
+      "context": {
+        "source": "release-readiness"
       }
-    ],
-    "metadata": {
-      "agents_used": ["argocd"],
-      "execution_time_ms": 1234
     }
-  }
-}
-```
-
-**Response (Streaming):**
-
-With `stream: true`, the response is a Server-Sent Events (SSE) stream:
-
-```
-Content-Type: text/event-stream
-
-event: task
-data: {"kind":"task","data":{"state":"running","session_id":"session_123","task_id":"task_456"}}
-
-event: artifact-update
-data: {"kind":"artifact-update","data":{"artifact":{"name":"streaming_result","text":"Checking...","append":false}}}
-
-event: artifact-update
-data: {"kind":"artifact-update","data":{"artifact":{"name":"tool_notification_start","description":"Calling ArgoCD API"}}}
-
-event: artifact-update
-data: {"kind":"artifact-update","data":{"artifact":{"name":"final_result","text":"Found 15 applications..."}}}
-
-event: status-update
-data: {"kind":"status-update","data":{"final":true,"state":"completed","result":{...}}}
-```
-
-**Status Codes:**
-- `200 OK` - Success (streaming or non-streaming)
-- `400 Bad Request` - Invalid message
-- `401 Unauthorized` - Not authenticated
-- `500 Internal Server Error` - Server error
-- `503 Service Unavailable` - CAIPE supervisor not available
-
----
-
-### Agent Card
-
-#### `GET /api/agent-card`
-
-Get the CAIPE supervisor agent card (capabilities, version, etc.).
-
-**Request:**
-
-```bash
-curl http://localhost:3000/api/agent-card
-```
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "name": "CAIPE Supervisor",
-    "version": "0.2.12",
-    "description": "Multi-agent supervisor for platform engineering",
-    "capabilities": {
-      "streaming": true,
-      "a2a_protocol": "1.0",
-      "supported_agents": [
-        "argocd",
-        "aws",
-        "github",
-        "jira",
-        "pagerduty",
-        "slack"
-      ]
-    },
-    "endpoints": {
-      "chat": "/v1/chat",
-      "stream": "/v1/chat/stream",
-      "health": "/.well-known/health"
-    }
-  }
-}
-```
-
-**Status Codes:**
-- `200 OK` - Success
-- `503 Service Unavailable` - CAIPE supervisor not available
-
----
-
-## Error Responses
-
-All endpoints return errors in a consistent format:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "code": "ERROR_CODE",
-  "details": {
-    "field": "Additional context"
-  }
-}
-```
-
-### Common Error Codes
-
-| Code | HTTP Status | Description |
-|------|-------------|-------------|
-| `VALIDATION_ERROR` | 400 | Invalid request data |
-| `UNAUTHORIZED` | 401 | Not authenticated |
-| `FORBIDDEN` | 403 | Insufficient permissions |
-| `NOT_FOUND` | 404 | Resource not found |
-| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests |
-| `INTERNAL_ERROR` | 500 | Server error |
-| `SERVICE_UNAVAILABLE` | 503 | External service unavailable |
-
-## Rate Limiting
-
-API endpoints are rate-limited to prevent abuse:
-
-- **Default**: 100 requests per minute per user
-- **Chat**: 20 requests per minute per user
-- **Use Cases Write**: 10 requests per minute per user
-
-Rate limit headers are included in responses:
-
-```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1706349600
-```
-
-When rate limit is exceeded:
-
-```json
-{
-  "success": false,
-  "error": "Rate limit exceeded",
-  "code": "RATE_LIMIT_EXCEEDED",
-  "retry_after": 42
-}
-```
-
-## Pagination
-
-Endpoints that return lists support pagination:
-
-```bash
-# Get first page
-curl "http://localhost:3000/api/usecases?limit=10&offset=0"
-
-# Get second page
-curl "http://localhost:3000/api/usecases?limit=10&offset=10"
-```
-
-**Response with pagination:**
-
-```json
-{
-  "success": true,
-  "data": [...],
-  "pagination": {
-    "total": 42,
-    "limit": 10,
-    "offset": 0,
-    "has_more": true
-  }
-}
-```
-
-## Webhooks (Coming Soon)
-
-Future versions will support webhooks for real-time event notifications:
-
-- Chat message received
-- Use case created/updated
-- Agent status changed
-- Task completed
-
-## Client Libraries
-
-### JavaScript/TypeScript
-
-```typescript
-import { CaipeClient } from '@caipe/client';
-
-const client = new CaipeClient({
-  baseUrl: 'http://localhost:3000',
-  apiKey: 'your-api-key',
-});
-
-// Send chat message
-const response = await client.chat.send({
-  message: 'Check deployment status',
-  stream: false,
-});
-
-// List use cases
-const useCases = await client.useCases.list({
-  category: 'deployment',
-  limit: 10,
-});
-
-// Create use case
-const newUseCase = await client.useCases.create({
-  title: 'My Custom Use Case',
-  // ...
-});
-```
-
-### Python
-
-```python
-from caipe_client import CaipeClient
-
-client = CaipeClient(
-    base_url="http://localhost:3000",
-    api_key="your-api-key"
-)
-
-# Send chat message
-response = client.chat.send(
-    message="Check deployment status",
-    stream=False
-)
-
-# List use cases
-use_cases = client.use_cases.list(
-    category="deployment",
-    limit=10
-)
-
-# Create use case
-new_use_case = client.use_cases.create(
-    title="My Custom Use Case",
-    # ...
-)
-```
-
-## OpenAPI Specification
-
-A full OpenAPI 3.0 specification is available:
-
-```bash
-# Download OpenAPI spec
-curl http://localhost:3000/api/openapi.json > openapi.json
-
-# Generate client code
-openapi-generator generate \
-  -i openapi.json \
-  -g typescript-fetch \
-  -o ./generated-client
-```
-
-## Examples
-
-### Complete Chat Flow
-
-```bash
-#!/bin/bash
-
-# 1. Authenticate
-SESSION=$(curl -X POST http://localhost:3000/api/auth/signin \
-  -H "Content-Type: application/json" \
-  -d '{"email": "user@example.com"}' \
-  -c cookies.txt)
-
-# 2. Send chat message
-RESPONSE=$(curl -X POST http://localhost:3000/api/chat \
-  -b cookies.txt \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Check ArgoCD applications",
-    "stream": false
-  }')
-
-echo $RESPONSE | jq '.data.response'
-
-# 3. Create use case from successful interaction
-curl -X POST http://localhost:3000/api/usecases \
-  -b cookies.txt \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "Quick ArgoCD Check",
-    "description": "Fast check of all ArgoCD apps",
-    "category": "deployment",
-    "tags": ["argocd", "quick"],
-    "prompt": "Check ArgoCD applications",
-    "expectedAgents": ["argocd"],
-    "difficulty": "beginner"
   }'
 ```
 
-### Streaming Chat with curl
+Response:
+
+```json
+{
+  "run_id": "workflow-abc123",
+  "status": "running"
+}
+```
+
+Poll a run:
 
 ```bash
-curl -N -X POST http://localhost:3000/api/chat \
+curl "http://localhost:3000/api/workflow-runs?run_id=workflow-abc123" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+Run status values are `pending`, `running`, `waiting_for_input`, `completed`, `failed`, and `cancelled`. Step status values are `pending`, `running`, `completed`, `failed`, `skipped`, and `waiting_for_input`.
+
+Resume a run that is waiting for input:
+
+```bash
+curl -X POST http://localhost:3000/api/workflow-runs/workflow-abc123/resume \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -d '{
+    "step_index": 1,
+    "resume_data": "Approve the proposed restart window"
+  }'
+```
+
+Workflow runs are retained for `WORKFLOW_RUN_RETENTION_DAYS`, defaulting to `7`. Set it to `0` to disable opportunistic cleanup.
+
+### Task Configs
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/api/task-configs` | List visible task configs. |
+| `GET` | `/api/task-configs?id=<task_config_id>` | Fetch one task config. |
+| `GET` | `/api/task-configs?format=yaml` | Return configs in `task_config.yaml` compatible shape. |
+| `POST` | `/api/task-configs` | Create a user-owned task config. |
+| `PUT` | `/api/task-configs?id=<task_config_id>` | Update a config if owned by the caller, or system config when admin. |
+| `DELETE` | `/api/task-configs?id=<task_config_id>` | Delete a config if owned by the caller, or system config when admin. |
+| `GET`, `POST` | `/api/task-configs/seed` | Seed task configs. |
+
+Task config steps require `display_text`, `llm_prompt`, and `subagent`. Visibility is `private`, `team`, or `global`.
+
+## RAG Proxy
+
+The UI exposes a catch-all RAG proxy:
+
+| Method | Route | Backend |
+|--------|-------|---------|
+| `GET`, `POST`, `PUT`, `DELETE` | `/api/rag/*path` | `RAG_SERVER_URL/<path>` |
+
+Examples:
+
+```bash
+curl http://localhost:3000/api/rag/healthz
+
+curl http://localhost:3000/api/rag/v1/user/info
+
+curl -X POST http://localhost:3000/api/rag/v1/mcp/invoke \
   -H "Content-Type: application/json" \
   -d '{
-    "message": "Investigate PagerDuty incident #123",
-    "stream": true
-  }' | while read line; do
-  echo "$line"
-done
+    "tool_name": "search",
+    "arguments": {
+      "query": "How do I troubleshoot failed ArgoCD syncs?",
+      "limit": 5,
+      "thought": "Find relevant runbook material"
+    }
+  }'
 ```
 
-### Batch Create Use Cases
+The proxy forwards query parameters for `GET` and `DELETE`, JSON bodies for `POST` and `PUT`, and the current session's access token when available. For direct RAG endpoints, roles, ingestion APIs, graph APIs, and MCP tool management, see [RAG API Reference](../knowledge_bases/api-reference.md).
 
-```bash
-#!/bin/bash
+## Skills and Catalog APIs
 
-# Read use cases from JSON file
-cat use_cases.json | jq -c '.[]' | while read usecase; do
-  curl -X POST http://localhost:3000/api/usecases \
-    -H "Content-Type: application/json" \
-    -d "$usecase"
-  sleep 0.1  # Respect rate limits
-done
-```
+Skills APIs support the Skills Gateway, local skill configuration, catalog imports, scan history, and installation helpers.
 
-## Next Steps
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/api/skills` | List skills visible to the caller or catalog key. |
+| `POST` | `/api/skills/refresh` | Refresh skills from configured sources. |
+| `POST` | `/api/skills/scan-all` | Scan all configured skills. |
+| `GET` | `/api/skills/scan-history` | List scan history. |
+| `GET` | `/api/skills/supervisor-status` | Check supervisor skill status. |
+| `POST` | `/api/skills/token` | Mint or return a skills token. |
+| `GET`, `POST` | `/api/skills/seed` | Seed skills data. |
+| `GET` | `/api/skills/live-skills` | Serve live skills helper content. |
+| `GET` | `/api/skills/install.sh` | Serve install script. |
+| `GET` | `/api/skills/hooks/caipe-catalog.sh` | Serve catalog hook script. |
+| `GET` | `/api/skills/helpers/caipe-skills.py` | Serve helper script. |
+| `POST` | `/api/skills/import` | Import skill content. |
+| `POST` | `/api/skills/import-github` | Import from GitHub. |
+| `POST` | `/api/skills/templates/import` | Import a template. |
+| `POST` | `/api/skills/generate` | Generate skill content. |
+| `POST`, `GET`, `PUT`, `DELETE` | `/api/skills/configs` | Manage local skill configs. |
+| `GET`, `PUT`, `DELETE` | `/api/skills/configs/:id/files` | Manage config files. |
+| `POST` | `/api/skills/configs/:id/scan` | Scan a config. |
+| `POST` | `/api/skills/configs/:id/clone` | Clone a config. |
+| `GET` | `/api/skills/configs/:id/export` | Export a config. |
+| `GET` | `/api/skills/configs/:id/revisions` | List revisions. |
+| `GET` | `/api/skills/configs/:id/revisions/:revisionId` | Fetch one revision. |
+| `POST` | `/api/skills/configs/:id/revisions/:revisionId/restore` | Restore a revision. |
+| `GET`, `POST` | `/api/catalog-api-keys` | List and mint catalog API keys. |
+| `DELETE` | `/api/catalog-api-keys/:keyId` | Revoke a catalog API key. |
+| `GET`, `POST` | `/api/skill-hubs` | List and create skill hubs. |
+| `PATCH`, `DELETE` | `/api/skill-hubs/:id` | Update or delete a hub. |
+| `POST` | `/api/skill-hubs/:id/refresh` | Refresh a hub. |
+| `POST` | `/api/skill-hubs/crawl` | Crawl a hub. |
+| `GET` | `/api/skills/hub/:hubId/:skillId/files` | List hub skill files. |
+| `GET` | `/api/skills/hub/:hubId/:skillId/files/content` | Fetch hub skill file content. |
+| `POST` | `/api/skills/hub/:hubId/:skillId/scan` | Scan a hub skill. |
+| `GET` | `/api/skill-templates` | List skill templates. |
+| `POST` | `/api/skill-templates/:id/scan` | Scan a template. |
 
-- [Development Guide](development.md) - Build and extend the API
-- [Configuration Guide](configuration.md) - Production setup
-- [Features Guide](features.md) - UI features and capabilities
+## Settings, Policies, Reviews, Feedback, and Users
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET`, `PUT` | `/api/settings` | Read or update user settings. |
+| `PATCH` | `/api/settings/defaults` | Update default settings. |
+| `PATCH` | `/api/settings/notifications` | Update notification preferences. |
+| `PATCH` | `/api/settings/preferences` | Update user preferences. |
+| `GET`, `PUT`, `POST` | `/api/policies` | Read, update, or create policy data. |
+| `GET` | `/api/policies/seed` | Seed policy data. |
+| `GET` | `/api/review-configs` | List AI review configurations. |
+| `GET`, `PUT` | `/api/review-configs/:id` | Fetch or update a review config. |
+| `POST` | `/api/ai/assist` | AI-assisted content helper. |
+| `POST` | `/api/ai/review` | AI review helper. |
+| `GET`, `POST` | `/api/feedback` | Submit or list feedback. |
+| `GET` | `/api/users/me` | Fetch current user profile. |
+| `PUT` | `/api/users/me` | Update current user profile. |
+| `GET`, `PUT` | `/api/users/me/favorites` | Manage favorites. |
+| `GET` | `/api/users/me/insights` | Current user insights. |
+| `GET` | `/api/users/me/insights/skills` | Current user's skills insights. |
+| `GET` | `/api/users/me/stats` | Current user stats. |
+| `GET` | `/api/users/search` | Search users. |
+| `GET` | `/api/users/debug` | User debugging data. |
+| `GET`, `POST` | `/api/llm-models` | List or create LLM model entries. |
+| `PUT`, `DELETE` | `/api/llm-models` | Update or delete LLM model entries by query ID. |
+| `GET`, `POST` | `/api/nps/active`, `/api/nps` | Read active NPS campaign and submit NPS feedback. |
+
+## Admin APIs
+
+Admin APIs require admin role unless the implementation explicitly uses admin-view access.
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/api/admin/users` | List users. |
+| `GET` | `/api/admin/users/:email` | Fetch one user. |
+| `PATCH` | `/api/admin/users/:email/role` | Update user role. |
+| `GET`, `POST` | `/api/admin/teams` | List or create teams. |
+| `GET`, `PATCH`, `DELETE` | `/api/admin/teams/:id` | Manage one team. |
+| `POST`, `DELETE` | `/api/admin/teams/:id/members` | Add or remove team members. |
+| `GET` | `/api/admin/audit-logs` | List audit logs. |
+| `GET` | `/api/admin/audit-logs/export` | Export audit logs. |
+| `GET` | `/api/admin/audit-logs/owners` | List audit-log owners. |
+| `GET` | `/api/admin/audit-logs/:id/messages` | Read audit log messages. |
+| `DELETE` | `/api/admin/audit-logs/:id` | Delete an audit log. |
+| `GET` | `/api/admin/feedback` | Review submitted feedback. |
+| `GET`, `POST` | `/api/admin/metrics` | Read or write admin metrics. |
+| `GET` | `/api/admin/stats` | Admin stats overview. |
+| `GET` | `/api/admin/stats/checkpoints` | Checkpoint stats. |
+| `GET` | `/api/admin/stats/skills` | Skills stats. |
+| `GET` | `/api/admin/nps` | NPS admin overview. |
+| `POST`, `GET`, `PATCH` | `/api/admin/nps/campaigns` | Manage NPS campaigns. |
+| `GET`, `PATCH` | `/api/admin/platform-config` | Read or update platform config. |
+| `POST` | `/api/admin/migrate-conversations` | Run conversation migration. |
+| `POST`, `DELETE` | `/api/admin/skills/:source/:source_id/scan-override` | Manage skill scan overrides. |
+| `POST`, `DELETE` | `/api/admin/skills/hub/:hubId/:skillId/scan-override` | Manage hub skill scan overrides. |
+
+## Files and Utilities
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/api/files/list` | List files from the Dynamic Agents file API. |
+| `GET`, `PUT`, `DELETE` | `/api/files/content` | Read, write, or delete file content. |
+| `GET` | `/api/agents/tools` | List agent tool metadata. |
+
+## Backend Dynamic Agents REST Surface
+
+The BFF proxies a subset of the Dynamic Agents FastAPI service. Direct backend endpoints are available when you call the runtime itself:
+
+| Method | Backend route | Purpose |
+|--------|---------------|---------|
+| `GET` | `/healthz` | Liveness. |
+| `GET` | `/readyz` | Readiness. |
+| `GET` | `/debug/config` | Runtime config diagnostics. |
+| `GET` | `/debug/runtimes` | Runtime state diagnostics. |
+| `POST` | `/api/v1/chat/stream/start` | Start streaming chat. |
+| `POST` | `/api/v1/chat/stream/resume` | Resume interrupted streaming chat. |
+| `POST` | `/api/v1/chat/stream/cancel` | Cancel an active stream. |
+| `POST` | `/api/v1/chat/invoke` | Non-streaming invocation. |
+| `POST` | `/api/v1/chat/restart-runtime` | Restart runtime. |
+| `GET` | `/api/v1/conversations/:conversation_id/interrupt-state` | Read interrupt state. |
+| `POST` | `/api/v1/conversations/:conversation_id/metadata` | Ensure conversation metadata. |
+| `POST` | `/api/v1/conversations/:conversation_id/clear` | Clear conversation checkpoints. |
+| `GET` | `/api/v1/files/list` | List runtime files. |
+| `GET`, `PUT`, `DELETE` | `/api/v1/files/content` | Manage runtime file content. |
+| `DELETE` | `/api/v1/files/namespace` | Delete a runtime file namespace. |
+| `GET` | `/api/v1/builtin-tools` | List built-in tools. |
+| `POST` | `/api/v1/mcp-servers/:server_id/probe` | Probe an MCP server. |
+| `GET` | `/api/v1/middleware` | List middleware registry entries. |
+| `POST` | `/api/v1/assistant/suggest` | Assistant suggestions. |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -301,6 +301,8 @@ const sidebars: SidebarsConfig = {
           label: 'Knowledge Bases',
           items: [
             { type: 'doc', id: 'knowledge_bases/index', label: 'Overview' },
+            // assisted-by Codex Codex-sonnet-4-6
+            { type: 'doc', id: 'knowledge_bases/api-reference', label: 'API Reference' },
             { type: 'doc', id: 'knowledge_bases/architecture', label: 'Architecture' },
             { type: 'doc', id: 'knowledge_bases/ingestors', label: 'Ingestors' },
             { type: 'doc', id: 'knowledge_bases/ontology-agent', label: 'Ontology Agent' },


### PR DESCRIPTION
# Description

Refresh the API documentation so it reflects the current code-backed API surfaces instead of the stale `/api/usecases` and UI OpenAPI examples.

This change:

- replaces the CAIPE UI API reference with a current BFF reference covering auth, response shapes, chat/runtime proxies, dynamic agent config, MCP server config, workflows, task configs, skills/catalog APIs, RAG proxy, settings/users, and admin routes
- adds a dedicated Knowledge Bases RAG API reference for REST, ingestion, jobs, graph exploration, ontology-agent proxying, MCP tool config, and MCP invocation
- links the new RAG API page from the Knowledge Bases overview and sidebar

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this is a docs-only change.

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

Validation:

- `git diff --check`
- `npm ci` in `docs/`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build` in `docs/`