### PR TITLE
fix(ui): persist ui, features, and interrupt_on fields in seedAgents

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.14 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.15 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.14 -f your-values.yaml'}
+                  {'    --version 0.4.15 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.14 -f your-values.yaml'}
+              {'    --version 0.4.15 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.15-dev.1"
+version = "0.4.15-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/admin/ReviewConfigEditor.tsx
+++ b/ui/src/components/admin/ReviewConfigEditor.tsx
@@ -587,7 +587,7 @@ export function ReviewConfigEditor({ target, onSaved }: ReviewConfigEditorProps)
                       onChange={(e) =>
                         updateCriterion(idx, { id: e.target.value })
                       }
-                      placeholder="no-second-person"
+                      placeholder="my-custom-rule"
                       className="font-mono text-xs h-8"
                     />
                   </div>

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -188,6 +188,9 @@ async function seedAgents(
       builtin_tools:
         (agentData.builtin_tools as DynamicAgentConfig["builtin_tools"]) ??
         undefined,
+      ui: (agentData.ui as DynamicAgentConfig["ui"]) ?? undefined,
+      features: (agentData.features as DynamicAgentConfig["features"]) ?? undefined,
+      interrupt_on: (agentData.interrupt_on as DynamicAgentConfig["interrupt_on"]) ?? undefined,
       enabled: (agentData.enabled as boolean) ?? true,
       owner_id: "system",
       is_system: false,

--- a/ui/src/lib/server/ai-review/defaults.ts
+++ b/ui/src/lib/server/ai-review/defaults.ts
@@ -31,7 +31,7 @@ const AGENT_SYSTEM_PROMPT_CRITERIA: ReviewCriterion[] = [
     severity: "error",
     weight: 2,
     micro_prompt:
-      "Does the prompt define the agent's role in 1–2 clear sentences (what it is, what it helps with)? Pass if a reader could state the agent's purpose after reading the first paragraph.",
+      "Does the prompt define the agent's role and personality in 1–3 clear sentences (who it is, what it helps with)? Pass if a reader could state the agent's purpose after reading the first paragraph.",
     expects_fix: true,
   },
   {

--- a/ui/src/lib/server/ai-review/defaults.ts
+++ b/ui/src/lib/server/ai-review/defaults.ts
@@ -68,7 +68,7 @@ const AGENT_SYSTEM_PROMPT_CRITERIA: ReviewCriterion[] = [
     severity: "info",
     weight: 1,
     micro_prompt:
-      "Does the prompt define what the agent should do when it cannot help — escalate to a human, hand off to another agent, or refuse politely? Pass if escalation/handoff behavior is described.",
+      "Does the prompt define what the agent should do when it cannot help — escalate to a user, hand off to another agent, or refuse politely? Pass if escalation/handoff behavior is described.",
     expects_fix: true,
   },
   {

--- a/ui/src/lib/server/ai-review/defaults.ts
+++ b/ui/src/lib/server/ai-review/defaults.ts
@@ -43,15 +43,7 @@ const AGENT_SYSTEM_PROMPT_CRITERIA: ReviewCriterion[] = [
       "Does the prompt enumerate between 3 and 7 explicit behavior rules or guidelines (bullet list, numbered list, or clearly delimited sentences)? Fewer than 3 is too vague; more than 7 is hard to follow.",
     expects_fix: true,
   },
-  {
-    id: "no-second-person-preamble",
-    name: "No second-person preamble",
-    severity: "warning",
-    weight: 1,
-    micro_prompt:
-      "Does the prompt avoid starting with 'You are an AI assistant…' or similar boilerplate? A direct role statement (e.g. 'Reviews infra changes') is preferred. Pass if the opening line is not a formulaic 'You are…' preamble.",
-    expects_fix: true,
-  },
+
   {
     id: "tool-action-constraints",
     name: "Mentions tool / action constraints",

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.15.dev1"
+version = "0.4.15.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- Fixes a bug where `ui`, `features`, and `interrupt_on` fields from seed agent configs were silently dropped when upserting to MongoDB
- Agent gradient themes, middleware config, and human-approval (interrupt) settings are now correctly persisted

## Changes
- `ui/src/lib/seed-config.ts`: Added `ui`, `features`, and `interrupt_on` to the document object in `seedAgents()`