### PR TITLE
fix(rag): handle list[dict] return type in _truncate_output

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py
@@ -18,6 +18,7 @@ ToolInvocationError caused the model to retry with different arguments, which
 defeated the cap.
 """
 
+import json
 import logging
 import os
 import threading
@@ -85,9 +86,23 @@ class _CapCounterMixin:
       return None
 
   @staticmethod
-  def _truncate_output(result: str, tool_name: str, max_chars: int = _DEFAULT_MAX_OUTPUT_CHARS) -> str:
-    """Truncate tool output to prevent context window overflow."""
-    if isinstance(result, str) and len(result) > max_chars:
+  # assisted-by Codex Codex-sonnet-4-6
+  def _truncate_output(result: Any, tool_name: str, max_chars: int = _DEFAULT_MAX_OUTPUT_CHARS) -> str:
+    """Truncate tool output to prevent context window overflow.
+
+    MCP tools (via langchain_mcp_adapters) return list[dict] content blocks
+    rather than plain str. Normalize to str before applying the length cap.
+    """
+    if isinstance(result, list):
+      text_parts = [
+        item["text"]
+        for item in result
+        if isinstance(item, dict) and isinstance(item.get("text"), str)
+      ]
+      result = "\n\n".join(text_parts) if text_parts else json.dumps(result, default=str)
+    elif not isinstance(result, str):
+      result = json.dumps(result, default=str)
+    if len(result) > max_chars:
       logger.info(f"{tool_name} output truncated: {len(result)} -> {max_chars} chars")
       return result[:max_chars] + f"\n\n[Output truncated — {len(result) - max_chars} chars omitted. Use the information above to answer.]"
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.15-dev.2"
+version = "0.4.15-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/tests/test_rag_tools_hard_stop.py
+++ b/tests/test_rag_tools_hard_stop.py
@@ -440,3 +440,42 @@ class TestOutputTruncation:
             result = await wrapper._arun(query="small query")
         assert result == small_result
         assert "truncated" not in result
+
+    @pytest.mark.asyncio
+    async def test_search_truncates_list_dict_result(self):
+        """SearchCapWrapper truncates list[dict] MCP content blocks (the real return type)."""
+        from ai_platform_engineering.multi_agents.platform_engineer import rag_tools as m
+        # Simulate MCP tool returning list[dict] content blocks with large text
+        big_text = "x" * (m._DEFAULT_MAX_OUTPUT_CHARS + 5000)
+        list_result = [{"type": "text", "text": big_text}]
+        wrapper, original = _make_search_wrapper(max_calls=5)
+        original.arun = AsyncMock(return_value=list_result)
+        with _patch_thread("thread-list-trunc"):
+            result = await wrapper._arun(query="big query")
+        assert isinstance(result, str)
+        assert len(result) <= m._DEFAULT_MAX_OUTPUT_CHARS + len("\n\n[Output truncated — XXXXX chars omitted. Use the information above to answer.]")
+        assert "truncated" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_fetch_truncates_list_dict_result(self):
+        """FetchDocumentCapWrapper truncates list[dict] MCP content blocks."""
+        from ai_platform_engineering.multi_agents.platform_engineer import rag_tools as m
+        big_text = "y" * (m._DEFAULT_MAX_OUTPUT_CHARS + 3000)
+        list_result = [{"type": "text", "text": big_text}]
+        wrapper, original = _make_fetch_wrapper(max_calls=5)
+        original.arun = AsyncMock(return_value=list_result)
+        with _patch_thread("thread-fetch-list-trunc"):
+            result = await wrapper._arun(document_id="doc-big")
+        assert isinstance(result, str)
+        assert "truncated" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_search_list_dict_under_limit_not_truncated(self):
+        """Small list[dict] results are serialized and returned without truncation marker."""
+        list_result = [{"type": "text", "text": "small content"}]
+        wrapper, original = _make_search_wrapper(max_calls=5)
+        original.arun = AsyncMock(return_value=list_result)
+        with _patch_thread("thread-list-no-trunc"):
+            result = await wrapper._arun(query="small query")
+        assert isinstance(result, str)
+        assert "truncated" not in result

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.15.dev2"
+version = "0.4.15.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- `_truncate_output` in `rag_tools.py` checked `isinstance(result, str)` before applying the length cap, but MCP tools (via `langchain_mcp_adapters`) return `list[dict]` content blocks, not plain strings
- The guard was always `False`, so the `RAG_MAX_OUTPUT_CHARS` truncation never fired — RAG tool results were returned at full size regardless of the configured limit
- Fix: serialize non-`str` results with `json.dumps` before the length check, so truncation applies to all return types

## Changes

- `ai_platform_engineering/multi_agents/platform_engineer/rag_tools.py`: add `import json`; update `_truncate_output` to handle `Any` input, serializing non-str values before truncating
- `tests/test_rag_tools_hard_stop.py`: add 3 regression tests covering `list[dict]` truncation path for both `SearchCapWrapper` and `FetchDocumentCapWrapper`

## Test plan

- [ ] `PYTHONPATH=. uv run pytest tests/test_rag_tools_hard_stop.py::TestOutputTruncation -v` — all 6 tests pass (3 existing str tests + 3 new list[dict] tests)
- [ ] Existing truncation tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)