### PR TITLE
fix(rag): rename self.start_url to self.origin_url for Scrapy 2.16 compat

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/pyproject.toml
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "redis==6.4.0",
     "requests==2.33.0",
     "scrapy==2.16.0",
+    "twisted==26.4.0",
     "slack-sdk==3.38.0",
 ]
 

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/pytest.ini
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 python_paths = src
 addopts = -v --tb=short
 asyncio_mode = auto
+markers =
+    integration: marks tests that require network access to external sites

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -221,6 +221,11 @@ class WorkerSpider(Spider):
       return None
     return Request(url, **kwargs)
 
+  async def start(self):
+    """Generate initial request(s) based on crawl mode (Scrapy 2.16+ entry point)."""
+    for request in self.start_requests():
+      yield request
+
   def start_requests(self):
     """Generate initial request(s) based on crawl mode."""
     if not self._is_safe_crawl_url(self.origin_url, count_failure=True):

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -89,7 +89,7 @@ class WorkerSpider(Spider):
     self.crawl_request = request
     self.result_queue = result_queue
 
-    self.start_url = request.url
+    self.origin_url = request.url
     self.max_pages = request.max_pages
     self.crawl_mode = request.crawl_mode
     self.follow_external = request.follow_external_links
@@ -223,7 +223,7 @@ class WorkerSpider(Spider):
 
   def start_requests(self):
     """Generate initial request(s) based on crawl mode."""
-    if not self._is_safe_crawl_url(self.start_url, count_failure=True):
+    if not self._is_safe_crawl_url(self.origin_url, count_failure=True):
       return
 
     # Send initial progress message for JS rendering
@@ -241,16 +241,16 @@ class WorkerSpider(Spider):
       # For sitemap mode, try to discover sitemap.xml
       # First try subdirectory path, then fall back to root domain
       # For example: https://example.com/docs/ -> try /docs/sitemap.xml, then /sitemap.xml
-      parsed = urlparse(self.start_url)
-      subdirectory_base = self.start_url.rstrip("/")
+      parsed = urlparse(self.origin_url)
+      subdirectory_base = self.origin_url.rstrip("/")
       root_base = f"{parsed.scheme}://{parsed.netloc}"
 
       # Determine if we have a subdirectory path
       has_subdirectory = parsed.path and parsed.path.rstrip("/") != ""
 
       # Check if user provided a direct sitemap URL
-      if self.start_url.endswith("sitemap.xml") or self.start_url.endswith("sitemap.xml.gz"):
-        sitemap_url = self.start_url
+      if self.origin_url.endswith("sitemap.xml") or self.origin_url.endswith("sitemap.xml.gz"):
+        sitemap_url = self.origin_url
       else:
         # Try subdirectory sitemap.xml first (if there's a path)
         sitemap_url = f"{subdirectory_base}/sitemap.xml"
@@ -271,7 +271,7 @@ class WorkerSpider(Spider):
         yield request
     else:
       # Single URL or recursive mode - start with the URL
-      request = self._safe_request(self.start_url, callback=self.parse_page, errback=self.handle_error, meta=self._build_request_meta())
+      request = self._safe_request(self.origin_url, callback=self.parse_page, errback=self.handle_error, meta=self._build_request_meta())
       if request:
         yield request
 
@@ -333,7 +333,7 @@ class WorkerSpider(Spider):
     3. If all fail, raise error (don't fall back to single page crawl)
     """
     meta = failure.request.meta
-    subdirectory_base = meta.get("subdirectory_base", self.start_url.rstrip("/"))
+    subdirectory_base = meta.get("subdirectory_base", self.origin_url.rstrip("/"))
     root_base = meta.get("root_base", subdirectory_base)
     has_subdirectory = meta.get("has_subdirectory", False)
     is_root_fallback = meta.get("is_root_fallback", False)
@@ -534,7 +534,7 @@ class WorkerSpider(Spider):
     # This ensures that in recursive mode, we follow links on the actual domain we landed on
     if self.effective_domain is None:
       response_domain = urlparse(response.url).netloc
-      start_domain = urlparse(self.start_url).netloc
+      start_domain = urlparse(self.origin_url).netloc
       if response_domain != start_domain:
         self.effective_domain = response_domain
         self._log(logging.INFO, f"Detected redirect: {start_domain} -> {response_domain}, updating effective domain")
@@ -677,7 +677,7 @@ class WorkerSpider(Spider):
       if self.effective_domain:
         allowed_domain = self.effective_domain
       else:
-        allowed_domain = urlparse(self.start_url).netloc
+        allowed_domain = urlparse(self.origin_url).netloc
 
       url_domain = urlparse(url).netloc
       if url_domain != allowed_domain:
@@ -851,7 +851,7 @@ class WorkerSpider(Spider):
 
       filter_details = []
       if self.urls_filtered_external > 0:
-        original_domain = urlparse(self.start_url).netloc
+        original_domain = urlparse(self.origin_url).netloc
         effective = self.effective_domain or original_domain
         if original_domain != effective:
           filter_details.append(f"{self.urls_filtered_external} filtered as external (sitemap domain '{effective}' differs from start URL domain '{original_domain}')")
@@ -869,7 +869,7 @@ class WorkerSpider(Spider):
 
       # Suggest fix for domain mismatch
       if self.urls_filtered_external > 0 and self.effective_domain:
-        original_domain = urlparse(self.start_url).netloc
+        original_domain = urlparse(self.origin_url).netloc
         if original_domain != self.effective_domain:
           parts.append(f"Tip: The site redirects from '{original_domain}' to '{self.effective_domain}'. Try using 'https://{self.effective_domain}' as the start URL, or enable 'Follow external links' to allow cross-domain crawling.")
     else:

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/base.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/base.py
@@ -59,6 +59,11 @@ class BaseWebSpider(scrapy.Spider):
     self.pages_crawled = 0
     self.max_pages = scrape_settings.max_pages
 
+  async def start(self):
+    """Generate initial requests (Scrapy 2.16+ entry point)."""
+    for request in self.start_requests():
+      yield request
+
   def start_requests(self) -> Iterator[Request]:
     """
     Generate initial requests.

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/base.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/base.py
@@ -48,7 +48,7 @@ class BaseWebSpider(scrapy.Spider):
     """
     super().__init__(*args, **kwargs)
 
-    self.start_url = start_url
+    self.origin_url = start_url
     self.scrape_settings = scrape_settings
     self.job_id = job_id
     self.client = client
@@ -65,7 +65,7 @@ class BaseWebSpider(scrapy.Spider):
 
     Override in subclasses for custom start behavior.
     """
-    yield self._make_request(self.start_url, callback=self.parse)
+    yield self._make_request(self.origin_url, callback=self.parse)
 
   def _make_request(self, url: str, callback: Any = None, meta: Optional[dict] = None, **kwargs) -> Request:
     """
@@ -160,7 +160,7 @@ class BaseWebSpider(scrapy.Spider):
 
     # Check external links
     if not self.scrape_settings.follow_external_links:
-      start_domain = urlparse(self.start_url).netloc
+      start_domain = urlparse(self.origin_url).netloc
       url_domain = urlparse(url).netloc
       if url_domain != start_domain:
         return False

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/recursive.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/recursive.py
@@ -60,7 +60,7 @@ class RecursiveCrawlSpider(CrawlSpider):
     self.visited_urls: Set[str] = set()
 
     # Set start URLs
-    self.origin_urls = [start_url]
+    self.start_urls = [start_url]
 
     # Set allowed domains
     parsed = urlparse(start_url)
@@ -119,9 +119,14 @@ class RecursiveCrawlSpider(CrawlSpider):
 
     super().__init__(*args, **kwargs)
 
+  async def start(self):
+    """Generate initial requests (Scrapy 2.16+ entry point)."""
+    for request in self.start_requests():
+      yield request
+
   def start_requests(self) -> Iterator[Request]:
     """Generate initial requests with Playwright support."""
-    for url in self.origin_urls:
+    for url in self.start_urls:
       yield self._make_request(url, callback=self.parse_page)
 
   def _make_request(self, url: str, callback=None, **kwargs) -> Request:

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/recursive.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/recursive.py
@@ -47,7 +47,7 @@ class RecursiveCrawlSpider(CrawlSpider):
         job_manager: Job status manager
         datasource_info: Datasource metadata
     """
-    self.start_url = start_url
+    self.origin_url = start_url
     self.scrape_settings = scrape_settings
     self.job_id = job_id
     self.client = client
@@ -60,7 +60,7 @@ class RecursiveCrawlSpider(CrawlSpider):
     self.visited_urls: Set[str] = set()
 
     # Set start URLs
-    self.start_urls = [start_url]
+    self.origin_urls = [start_url]
 
     # Set allowed domains
     parsed = urlparse(start_url)
@@ -121,7 +121,7 @@ class RecursiveCrawlSpider(CrawlSpider):
 
   def start_requests(self) -> Iterator[Request]:
     """Generate initial requests with Playwright support."""
-    for url in self.start_urls:
+    for url in self.origin_urls:
       yield self._make_request(url, callback=self.parse_page)
 
   def _make_request(self, url: str, callback=None, **kwargs) -> Request:

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/single_url.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/single_url.py
@@ -22,5 +22,5 @@ class SingleUrlSpider(BaseWebSpider):
 
   def start_requests(self) -> Iterator[Request]:
     """Generate a single request for the start URL."""
-    self.logger_custom.info(f"Starting single URL scrape: {self.start_url}")
-    yield self._make_request(self.start_url, callback=self.parse)
+    self.logger_custom.info(f"Starting single URL scrape: {self.origin_url}")
+    yield self._make_request(self.origin_url, callback=self.parse)

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/sitemap.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/spiders/sitemap.py
@@ -46,7 +46,7 @@ class SitemapCrawlSpider(SitemapSpider):
         job_manager: Job status manager
         datasource_info: Datasource metadata
     """
-    self.start_url = start_url
+    self.origin_url = start_url
     self.scrape_settings = scrape_settings
     self.job_id = job_id
     self.client = client

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_crawl_integration.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_crawl_integration.py
@@ -1,0 +1,144 @@
+"""
+Integration tests that run actual Scrapy crawls against a live site.
+
+These tests verify end-to-end crawling works correctly after dependency
+upgrades (Scrapy, Twisted, etc.). They catch issues like:
+- Scrapy 2.16 start() vs start_requests() entry point changes
+- Twisted TLS/SSL incompatibilities
+- Spider attribute validation changes
+
+Requirements:
+- Network access to https://caipe.io
+- Run with: uv run pytest tests/webloader/test_crawl_integration.py -v
+
+These tests are marked with @pytest.mark.integration so they can be
+skipped in CI environments without network access.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Target site for integration tests
+TARGET_URL = "https://caipe.io"
+MAX_PAGES = 5
+
+
+def _run_crawl(crawl_mode: str, render_javascript: bool = False, url: str = TARGET_URL):
+  """
+  Run a Scrapy crawl in a subprocess and return parsed results.
+
+  Uses a subprocess to avoid Twisted reactor restart issues in pytest.
+  The subprocess runs the crawl and prints JSON results to stdout.
+  """
+  script = textwrap.dedent(f"""\
+    import json, sys, time
+    from multiprocessing import Queue
+
+    from scrapy.utils.reactor import install_reactor
+    install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
+
+    from twisted.internet import reactor
+    from scrapy.crawler import CrawlerRunner
+    from scrapy.utils.log import configure_logging
+
+    from ingestors.webloader.loader.scrapy_worker import WorkerSpider, build_spider_settings
+    from ingestors.webloader.loader.worker_types import (
+      CrawlRequest, CrawlResult, CrawlStatus, WorkerMessage, MessageType,
+    )
+
+    configure_logging({{"LOG_LEVEL": "WARNING"}})
+
+    request = CrawlRequest(
+      job_id="integration-test-{crawl_mode}",
+      url="{url}",
+      datasource_id="test-integration",
+      ingestor_id="test-ingestor",
+      crawl_mode="{crawl_mode}",
+      max_pages={MAX_PAGES},
+      max_depth=2,
+      render_javascript={render_javascript},
+      follow_external_links=False,
+      respect_robots_txt=True,
+      download_delay=0.1,
+      concurrent_requests=5,
+      page_load_timeout=15,
+    )
+
+    result_queue = Queue()
+    settings = build_spider_settings(request)
+    runner = CrawlerRunner(settings=settings)
+
+    d = runner.crawl(WorkerSpider, request=request, result_queue=result_queue)
+    d.addBoth(lambda _: reactor.stop())
+    reactor.run(installSignalHandlers=False)
+
+    # Collect results
+    result = None
+    documents = []
+    while not result_queue.empty():
+      msg_dict = result_queue.get_nowait()
+      msg = WorkerMessage.from_dict(msg_dict)
+      if msg.type == MessageType.CRAWL_RESULT:
+        result = msg.payload
+      elif msg.type == MessageType.CRAWL_DOCUMENTS:
+        documents.extend(msg.payload.get("documents", []))
+
+    output = {{
+      "result": result,
+      "document_count": len(documents),
+    }}
+    print("CRAWL_RESULT:" + json.dumps(output))
+  """)
+
+  proc = subprocess.run(
+    [sys.executable, "-c", script],
+    capture_output=True,
+    text=True,
+    timeout=60,
+    cwd=str(__import__("pathlib").Path(__file__).parents[2] / "src"),
+  )
+
+  # Parse result from stdout
+  for line in proc.stdout.splitlines():
+    if line.startswith("CRAWL_RESULT:"):
+      data = json.loads(line[len("CRAWL_RESULT:") :])
+      return data["result"], data["document_count"]
+
+  # If no result found, fail with stderr
+  raise AssertionError(f"Crawl subprocess failed to produce results.\nreturncode={proc.returncode}\nstderr (last 500 chars)={proc.stderr[-500:]}\nstdout (last 500 chars)={proc.stdout[-500:]}")
+
+
+@pytest.mark.integration
+class TestCrawlIntegration:
+  """Integration tests that perform actual crawls against caipe.io."""
+
+  def test_single_mode(self):
+    """Single URL mode should crawl exactly 1 page."""
+    result, doc_count = _run_crawl("single")
+
+    assert result is not None, "No CrawlResult received"
+    assert result["status"] in ("success", "partial"), f"Crawl failed: {result.get('fatal_error')}"
+    assert result["pages_crawled"] >= 1, f"Expected at least 1 page, got {result['pages_crawled']}"
+    assert doc_count >= 1, f"Expected at least 1 document, got {doc_count}"
+
+  def test_sitemap_mode(self):
+    """Sitemap mode should discover and crawl pages from sitemap.xml."""
+    result, doc_count = _run_crawl("sitemap")
+
+    assert result is not None, "No CrawlResult received"
+    assert result["status"] in ("success", "partial"), f"Crawl failed: {result.get('fatal_error')}"
+    assert result["pages_crawled"] >= 1, f"Expected at least 1 page from sitemap, got {result['pages_crawled']}"
+    assert doc_count >= 1, f"Expected at least 1 document, got {doc_count}"
+
+  def test_recursive_mode(self):
+    """Recursive mode should follow links and crawl multiple pages."""
+    result, doc_count = _run_crawl("recursive")
+
+    assert result is not None, "No CrawlResult received"
+    assert result["status"] in ("success", "partial"), f"Crawl failed: {result.get('fatal_error')}"
+    assert result["pages_crawled"] >= 2, f"Expected at least 2 pages in recursive mode, got {result['pages_crawled']}"
+    assert doc_count >= 2, f"Expected at least 2 documents, got {doc_count}"

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
@@ -890,6 +890,7 @@ dependencies = [
     { name = "requests" },
     { name = "scrapy" },
     { name = "slack-sdk" },
+    { name = "twisted" },
 ]
 
 [package.optional-dependencies]
@@ -929,6 +930,7 @@ requires-dist = [
     { name = "scrapy", specifier = "==2.16.0" },
     { name = "scrapy-playwright", marker = "extra == 'playwright'", specifier = "==0.0.46" },
     { name = "slack-sdk", specifier = "==3.38.0" },
+    { name = "twisted", specifier = "==26.4.0" },
 ]
 provides-extras = ["playwright", "dev"]
 
@@ -2636,7 +2638,7 @@ wheels = [
 
 [[package]]
 name = "twisted"
-version = "26.4.0rc2"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2647,9 +2649,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/44/60da409efd39860f5c7355ff844690d96168bc02eb1b06171d2fc81b80ae/twisted-26.4.0rc2.tar.gz", hash = "sha256:d1db6c391a1b6e70028c3212298178621db149a6f75555f6503da557c763406d", size = 3575417, upload-time = "2026-04-29T15:44:25.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/30/cdb6811e0853bd6d60ee6a685385b9e469db1dfdce344bc53f2e7d3fe6f4/twisted-26.4.0rc2-py3-none-any.whl", hash = "sha256:41eeb62a7f2688c634f7a1af76e225c58da48f8af1640fcb285ce386a96889e2", size = 3230408, upload-time = "2026-04-29T15:44:22.514Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
 ]
 
 [[package]]

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.15 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.16 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.15 -f your-values.yaml'}
+                  {'    --version 0.4.16 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.15 -f your-values.yaml'}
+              {'    --version 0.4.16 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.16"
+version = "0.4.16-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.16"
+version = "0.4.16.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- Scrapy 2.16.0 added validation that raises `AttributeError` if a spider has a `start_url` attribute (singular) without a non-empty `start_urls` (plural)
- All our spiders used `self.start_url` as a custom attribute to store the origin URL, which triggers this check at crawl start time
- Renamed to `self.origin_url` across all 5 affected spider files to avoid the conflict

## Impact
**Critical** — All crawl modes (single, recursive, sitemap) are broken in production. Zero pages crawled for any web ingestion request.

## Files changed
- `scrapy_worker.py` — WorkerSpider (12 references)
- `spiders/base.py` — BaseWebSpider (3 references)
- `spiders/recursive.py` — RecursiveCrawlSpider (1 reference, already had `start_urls` set correctly)
- `spiders/single_url.py` — SingleUrlSpider (2 references via inherited attribute)
- `spiders/sitemap.py` — SitemapCrawlSpider (1 reference)