### PR TITLE
fix(jira): create internal comments via platform API to fix authentication error

### DIFF
--- a/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/comments.py
+++ b/ai_platform_engineering/agents/jira/mcp/mcp_jira/tools/jira/comments.py
@@ -188,10 +188,11 @@ async def add_internal_comment(
 ) -> str:
     """Add an internal note to a Jira Service Management request.
 
-    Use this tool for private/internal JSM notes only. It calls the Jira Service
-    Management request comment API with ``public=false``. This is different from
-    Jira Platform's issue comment ``visibility`` field, which restricts comments
-    by Jira role/group and does not mean "internal note" versus "reply to customer".
+    Use this tool for private/internal JSM notes only. It calls the Jira Platform
+    comment API with the Jira Service Management ``sd.public.comment`` entity
+    property set to ``internal=true``. This is different from Jira Platform's
+    issue comment ``visibility`` field, which restricts comments by Jira
+    role/group and does not mean "internal note" versus "reply to customer".
 
     Args:
         issue_key: Jira Service Management issue key.
@@ -214,18 +215,39 @@ async def add_internal_comment(
         f"add_internal_comment called with issue_key={issue_key}, body length={len(body)}"
     )
 
-    comment_data: Dict[str, Any] = {
-        "body": body,
-        "public": False,
+    adf_body = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": body
+                    }
+                ]
+            }
+        ]
     }
 
-    # Atlassian's documented JSM Cloud API uses `public=false` to create an
-    # internal note on the customer request:
-    # https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-issueidorkey-comment-post
-    # The Jira Platform `/rest/api/3` comment endpoint only supports role/group
-    # visibility restrictions.
+    comment_data: Dict[str, Any] = {
+        "body": adf_body,
+        "properties": [
+            {
+                "key": "sd.public.comment",
+                "value": {
+                    "internal": True,
+                },
+            }
+        ],
+    }
+
+    # JSM also supports `public=false` on `/rest/servicedeskapi`, but that path
+    # can fail for issues without portal-origin request context. Atlassian's
+    # platform comment API supports internal notes through this entity property.
     success, response = await make_api_request(
-        path=f"rest/servicedeskapi/request/{issue_key}/comment",
+        path=f"rest/api/3/issue/{issue_key}/comment",
         method="POST",
         data=comment_data,
     )

--- a/ai_platform_engineering/agents/jira/mcp/tests/test_comments.py
+++ b/ai_platform_engineering/agents/jira/mcp/tests/test_comments.py
@@ -179,7 +179,7 @@ class TestAddInternalComment:
     """Tests for add_internal_comment function."""
 
     @pytest.mark.asyncio
-    async def test_add_internal_comment_uses_jsm_private_comment(self, monkeypatch):
+    async def test_add_internal_comment_uses_platform_internal_property(self, monkeypatch):
         """Test adding a Jira Service Management internal note."""
         captured_request = {}
 
@@ -191,8 +191,7 @@ class TestAddInternalComment:
                 True,
                 {
                     "id": "10003",
-                    "body": "Initial investigation: test",
-                    "public": False,
+                    "body": kwargs.get("data", {}).get("body"),
                 },
             )
 
@@ -205,12 +204,20 @@ class TestAddInternalComment:
         result_dict = json.loads(result)
 
         assert result_dict["id"] == "10003"
-        assert captured_request["path"] == "rest/servicedeskapi/request/PROJ-123/comment"
+        assert captured_request["path"] == "rest/api/3/issue/PROJ-123/comment"
         assert captured_request["method"] == "POST"
-        assert captured_request["data"] == {
-            "body": "Initial investigation: test",
-            "public": False,
-        }
+        assert captured_request["data"]["body"]["type"] == "doc"
+        assert captured_request["data"]["body"]["content"][0]["content"][0]["text"] == (
+            "Initial investigation: test"
+        )
+        assert captured_request["data"]["properties"] == [
+            {
+                "key": "sd.public.comment",
+                "value": {
+                    "internal": True,
+                },
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_add_internal_comment_read_only(self, monkeypatch):

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.16 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.17 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.16 -f your-values.yaml'}
+                  {'    --version 0.4.17 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.16 -f your-values.yaml'}
+              {'    --version 0.4.17 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.17"
+version = "0.4.17-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.17"
+version = "0.4.17.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

This PR exists because `jira_add_internal_comment` was hitting a Jira Service Management request endpoint failure when trying to create an internal note:

```text
HTTP 404
errorMessage: "Either you don't have access to this request type, or it doesn't exist."
i18nKey: "sd.customerview.error.vpOriginMissing"
```

That error comes from the JSM customer-request API path, which can reject API-created comments when Jira cannot resolve the issue as an accessible portal request/request type for the API user. For programmatic internal notes, Atlassian also supports using the Jira platform comment API with the `sd.public.comment` entity property set to `internal: true`.

This changes the internal-comment tool to use that platform API marker so MCP-created internal notes avoid the JSM portal-origin/request-type validation failure.

## Test plan

- [x] `uv run pytest tests/test_comments.py -q` from `ai_platform_engineering/agents/jira/mcp`
- [x] also used a script to test whether an internal note was effectively posted to a ticket 