### PR TITLE
fix(ui): default interrupt_on to empty object instead of undefined in seed config

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
@@ -21,6 +21,17 @@ from dynamic_agents.models import (
 logger = logging.getLogger(__name__)
 
 
+def _strip_nulls(doc: dict) -> dict:
+    """Strip None values from a MongoDB document before pydantic construction.
+
+    Pydantic only applies default_factory when a key is absent — an explicit
+    None passed as a kwarg bypasses the default. Stripping nulls here lets
+    fields like interrupt_on recover their default when stored as null in
+    older documents.
+    """
+    return {k: v for k, v in doc.items() if v is not None}
+
+
 class MongoDBService:
     """MongoDB service for reading dynamic agent and MCP server configs."""
 
@@ -95,10 +106,7 @@ class MongoDBService:
         """Get a dynamic agent config by ID."""
         doc = self._get_agents_collection().find_one({"_id": agent_id})
         if doc:
-            # Strip None values so pydantic default_factory applies for missing fields.
-            # Without this, explicit null values stored in MongoDB (e.g. interrupt_on: null)
-            # bypass field defaults and cause ValidationError.
-            return DynamicAgentConfig(**{k: v for k, v in doc.items() if v is not None})
+            return DynamicAgentConfig(**_strip_nulls(doc))
         return None
 
     # =========================================================================
@@ -109,13 +117,13 @@ class MongoDBService:
         """Get an MCP server config by ID."""
         doc = self._get_servers_collection().find_one({"_id": server_id})
         if doc:
-            return MCPServerConfig(**doc)
+            return MCPServerConfig(**_strip_nulls(doc))
         return None
 
     def get_servers_by_ids(self, server_ids: list[str]) -> list[MCPServerConfig]:
         """Get multiple MCP servers by their IDs."""
         docs = self._get_servers_collection().find({"_id": {"$in": server_ids}})
-        return [MCPServerConfig(**doc) for doc in docs]
+        return [MCPServerConfig(**_strip_nulls(doc)) for doc in docs]
 
     def get_agent_mcp_servers(self, agent: DynamicAgentConfig) -> list[MCPServerConfig]:
         """Get MCP servers for an agent AND all its subagents.

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
@@ -95,7 +95,10 @@ class MongoDBService:
         """Get a dynamic agent config by ID."""
         doc = self._get_agents_collection().find_one({"_id": agent_id})
         if doc:
-            return DynamicAgentConfig(**doc)
+            # Strip None values so pydantic default_factory applies for missing fields.
+            # Without this, explicit null values stored in MongoDB (e.g. interrupt_on: null)
+            # bypass field defaults and cause ValidationError.
+            return DynamicAgentConfig(**{k: v for k, v in doc.items() if v is not None})
         return None
 
     # =========================================================================

--- a/ai_platform_engineering/dynamic_agents/tests/test_mongo_get_agent.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mongo_get_agent.py
@@ -1,0 +1,91 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MongoDBService.get_agent null-field handling.
+
+Regression test for: DynamicAgentConfig(**doc) receiving explicit None
+for fields stored as null in MongoDB, which bypassed pydantic
+default_factory and raised ValidationError.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dynamic_agents.models import DynamicAgentConfig
+from dynamic_agents.services.mongo import MongoDBService
+
+
+def _make_service() -> MongoDBService:
+    service = MongoDBService.__new__(MongoDBService)
+    service.settings = MagicMock()
+    service._db = MagicMock()
+    return service
+
+
+def _mock_find_one(service: MongoDBService, doc: dict):
+    collection = MagicMock()
+    collection.find_one.return_value = doc
+    service._get_agents_collection = MagicMock(return_value=collection)
+
+
+def _minimal_doc(**overrides) -> dict:
+    base = {
+        "_id": "test-agent",
+        "id": "test-agent",
+        "name": "Test Agent",
+        "model": {"provider": "aws-bedrock", "id": "anthropic.claude-3-sonnet"},
+        "system_prompt": "You are a test agent.",
+        "owner_id": "system",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_get_agent_with_null_interrupt_on_does_not_raise():
+    """Existing MongoDB docs with interrupt_on: null must not raise ValidationError."""
+    service = _make_service()
+    _mock_find_one(service, _minimal_doc(interrupt_on=None))
+
+    agent = service.get_agent("test-agent")
+
+    assert agent is not None
+    assert isinstance(agent, DynamicAgentConfig)
+
+
+def test_get_agent_with_null_interrupt_on_applies_default():
+    """interrupt_on: null should resolve to the field's default_factory value."""
+    service = _make_service()
+    _mock_find_one(service, _minimal_doc(interrupt_on=None))
+
+    agent = service.get_agent("test-agent")
+
+    assert agent.interrupt_on == {"builtin": {"request_user_input": True}}
+
+
+def test_get_agent_with_explicit_interrupt_on_preserved():
+    """Explicit interrupt_on values stored in MongoDB are not stripped."""
+    custom = {"builtin": {"request_user_input": False}}
+    service = _make_service()
+    _mock_find_one(service, _minimal_doc(interrupt_on=custom))
+
+    agent = service.get_agent("test-agent")
+
+    assert agent.interrupt_on == custom
+
+
+def test_get_agent_with_other_null_fields_applies_defaults():
+    """Other nullable fields (e.g. features, ui) with null also get defaults applied."""
+    service = _make_service()
+    _mock_find_one(service, _minimal_doc(features=None, ui=None))
+
+    agent = service.get_agent("test-agent")
+
+    assert agent is not None
+    assert isinstance(agent, DynamicAgentConfig)
+
+
+def test_get_agent_returns_none_when_not_found():
+    service = _make_service()
+    _mock_find_one(service, None)
+
+    assert service.get_agent("missing-agent") is None

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.16 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.17 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.16 -f your-values.yaml'}
+                  {'    --version 0.4.17 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.16 -f your-values.yaml'}
+              {'    --version 0.4.17 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.17"
+version = "0.4.17-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -190,8 +190,7 @@ async function seedAgents(
         undefined,
       ui: (agentData.ui as DynamicAgentConfig["ui"]) ?? undefined,
       features: (agentData.features as DynamicAgentConfig["features"]) ?? undefined,
-      interrupt_on:
-        (agentData.interrupt_on as DynamicAgentConfig["interrupt_on"]) ?? {},
+      interrupt_on: (agentData.interrupt_on as DynamicAgentConfig["interrupt_on"]) ?? undefined,
       enabled: (agentData.enabled as boolean) ?? true,
       owner_id: "system",
       is_system: false,

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -190,7 +190,8 @@ async function seedAgents(
         undefined,
       ui: (agentData.ui as DynamicAgentConfig["ui"]) ?? undefined,
       features: (agentData.features as DynamicAgentConfig["features"]) ?? undefined,
-      interrupt_on: (agentData.interrupt_on as DynamicAgentConfig["interrupt_on"]) ?? undefined,
+      interrupt_on:
+        (agentData.interrupt_on as DynamicAgentConfig["interrupt_on"]) ?? {},
       enabled: (agentData.enabled as boolean) ?? true,
       owner_id: "system",
       is_system: false,

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.17"
+version = "0.4.17.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Changes the default value of `interrupt_on` in the agent seed config from `undefined` to `{}` (empty object). This ensures downstream code that expects an object type for `interrupt_on` doesn't receive `undefined`, preventing potential runtime errors or unexpected behavior when seeding agents.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass