### PR TITLE
fix(keycloak): reconcile caipe-platform client secret via platformClient.secretRef

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -349,6 +349,78 @@ json.dump(client, sys.stdout)
 
 _reconcile_caipe_ui_client_secret
 
+_reconcile_caipe_platform_client_secret() {
+  local PLATFORM_CLIENT_SECRET="${KEYCLOAK_PLATFORM_CLIENT_SECRET:-}"
+  local PLATFORM_CLIENT_ID="caipe-platform"
+
+  if [ -z "${PLATFORM_CLIENT_SECRET}" ]; then
+    echo "[init-idp] KEYCLOAK_PLATFORM_CLIENT_SECRET not set — leaving ${PLATFORM_CLIENT_ID} client_secret unchanged."
+    return 0
+  fi
+
+  echo "[init-idp] Reconciling client_secret on '${PLATFORM_CLIENT_ID}' from KEYCLOAK_PLATFORM_CLIENT_SECRET ..."
+  if [ -z "${AUTH:-}" ]; then
+    local _tok
+    _tok=$(curl -sf -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+      -d "grant_type=password&client_id=admin-cli&username=${KEYCLOAK_ADMIN:-admin}&password=${KEYCLOAK_ADMIN_PASSWORD:-admin}" 2>/dev/null \
+      | grep -o '"access_token" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+    if [ -z "${_tok}" ]; then
+      echo "[init-idp]   ERROR: could not acquire admin token — cannot reconcile ${PLATFORM_CLIENT_ID} client_secret." >&2
+      return 1
+    fi
+    AUTH="Authorization: Bearer ${_tok}"
+  fi
+
+  local PLATFORM_CLIENT_UUID
+  PLATFORM_CLIENT_UUID=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/clients?clientId=${PLATFORM_CLIENT_ID}" 2>/dev/null \
+    | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"/\1/')
+
+  if [ -z "${PLATFORM_CLIENT_UUID}" ]; then
+    echo "[init-idp]   ERROR: client ${PLATFORM_CLIENT_ID} not found — cannot reconcile client_secret." >&2
+    return 1
+  fi
+
+  local PLATFORM_CLIENT_JSON
+  PLATFORM_CLIENT_JSON=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/clients/${PLATFORM_CLIENT_UUID}" 2>/dev/null || echo "")
+  if [ -z "${PLATFORM_CLIENT_JSON}" ]; then
+    echo "[init-idp]   ERROR: could not fetch client ${PLATFORM_CLIENT_ID} — cannot reconcile client_secret." >&2
+    return 1
+  fi
+
+  local UPDATED_PLATFORM_CLIENT_JSON
+  UPDATED_PLATFORM_CLIENT_JSON=$(printf '%s' "${PLATFORM_CLIENT_JSON}" | \
+    KEYCLOAK_PLATFORM_CLIENT_SECRET="${PLATFORM_CLIENT_SECRET}" \
+    python3 -c '
+import json
+import os
+import sys
+
+client = json.load(sys.stdin)
+client["secret"] = os.environ["KEYCLOAK_PLATFORM_CLIENT_SECRET"]
+client["publicClient"] = False
+client.setdefault("protocol", "openid-connect")
+json.dump(client, sys.stdout)
+' 2>/dev/null)
+
+  if [ -z "${UPDATED_PLATFORM_CLIENT_JSON}" ]; then
+    echo "[init-idp]   ERROR: failed to render patched ${PLATFORM_CLIENT_ID} client JSON." >&2
+    return 1
+  fi
+
+  curl -sf -X PUT -H "${AUTH}" -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms/${REALM}/clients/${PLATFORM_CLIENT_UUID}" \
+    -d "${UPDATED_PLATFORM_CLIENT_JSON}" >/dev/null \
+    && echo "[init-idp]   ${PLATFORM_CLIENT_ID} client_secret reconciled." \
+    || {
+      echo "[init-idp]   ERROR: failed to update ${PLATFORM_CLIENT_ID} client_secret." >&2
+      return 1
+    }
+}
+
+_reconcile_caipe_platform_client_secret
+
 # The Web UI BFF calls the Slack bot admin API with a Keycloak
 # client_credentials token. The same caipe-ui confidential client is used for
 # NextAuth's browser sign-in flow, so patch it idempotently rather than relying

--- a/charts/ai-platform-engineering/charts/keycloak/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/_helpers.tpl
@@ -85,6 +85,20 @@ CAIPE UI client-secret K8s Secret name.
 {{- end }}
 
 {{/*
+CAIPE Platform client-secret K8s Secret name.
+- explicit user-provided existing Secret wins
+- else if ESO is enabled for platformClient, the chart owns a Secret named
+  <fullname>-platform-client
+*/}}
+{{- define "keycloak.platformClientSecretName" -}}
+{{- if .Values.platformClient.secretRef }}
+{{- .Values.platformClient.secretRef }}
+{{- else }}
+{{- include "keycloak.fullname" . }}-platform-client
+{{- end }}
+{{- end }}
+
+{{/*
 IdP client-secret K8s Secret name.
 - explicit user-provided existing Secret wins
 - else if ESO is enabled for IdP, the chart owns a Secret named <fullname>-idp

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
@@ -107,6 +107,13 @@ spec:
                   name: {{ include "keycloak.uiClientSecretName" . }}
                   key: {{ .Values.uiClient.secretKey | default "OIDC_CLIENT_SECRET" | quote }}
             {{- end }}
+            {{- if or .Values.platformClient.secretRef .Values.platformClient.externalSecret.enabled }}
+            - name: KEYCLOAK_PLATFORM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keycloak.platformClientSecretName" . }}
+                  key: {{ .Values.platformClient.secretKey | default "KEYCLOAK_ADMIN_CLIENT_SECRET" | quote }}
+            {{- end }}
             - name: IDP_ACCESS_GROUP
               value: {{ .Values.idp.accessGroup | quote }}
             - name: IDP_ADMIN_GROUP

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-init-idp.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-init-idp.yaml
@@ -88,6 +88,13 @@ spec:
                   name: {{ include "keycloak.uiClientSecretName" . }}
                   key: {{ .Values.uiClient.secretKey | default "OIDC_CLIENT_SECRET" | quote }}
             {{- end }}
+            {{- if or .Values.platformClient.secretRef .Values.platformClient.externalSecret.enabled }}
+            - name: KEYCLOAK_PLATFORM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keycloak.platformClientSecretName" . }}
+                  key: {{ .Values.platformClient.secretKey | default "KEYCLOAK_ADMIN_CLIENT_SECRET" | quote }}
+            {{- end }}
             - name: IDP_ACCESS_GROUP
               value: {{ .Values.idp.accessGroup | quote }}
             - name: IDP_ADMIN_GROUP

--- a/charts/ai-platform-engineering/charts/keycloak/templates/platform-client-external-secret.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/platform-client-external-secret.yaml
@@ -1,0 +1,30 @@
+{{- /*
+ExternalSecret for the caipe-platform OIDC client_secret.
+
+The Secret is consumed by init-idp/auth-reconcile as KEYCLOAK_PLATFORM_CLIENT_SECRET
+and pushed into Keycloak through the Admin API. Do not place this value in the
+realm ConfigMap; rendered ConfigMaps are not an appropriate secret boundary.
+*/ -}}
+{{- if .Values.platformClient.externalSecret.enabled }}
+apiVersion: external-secrets.io/{{ .Values.externalSecretsApiVersion | default "v1beta1" }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak.platformClientSecretName" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.platformClient.externalSecret.refreshInterval | default "1h" | quote }}
+  secretStoreRef:
+    name: {{ .Values.platformClient.externalSecret.secretStoreRef.name }}
+    kind: {{ .Values.platformClient.externalSecret.secretStoreRef.kind }}
+  target:
+    name: {{ include "keycloak.platformClientSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.platformClient.secretKey | default "KEYCLOAK_ADMIN_CLIENT_SECRET" | quote }}
+      remoteRef:
+        key: {{ required "platformClient.externalSecret.remoteRef.key is required" .Values.platformClient.externalSecret.remoteRef.key | quote }}
+        {{- if .Values.platformClient.externalSecret.remoteRef.property }}
+        property: {{ .Values.platformClient.externalSecret.remoteRef.property | quote }}
+        {{- end }}
+{{- end }}

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -115,6 +115,25 @@ uiClient:
       key: ""
       property: ""
 
+# ---------- CAIPE Platform OIDC client ----------
+# The `caipe-platform` confidential client is used by caipe-ui for admin API
+# calls (KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform, KEYCLOAK_ADMIN_CLIENT_SECRET).
+# Production installs should source the client secret from Kubernetes/ESO so
+# init-idp can reconcile the existing Keycloak client without placing the secret
+# in the realm ConfigMap.
+platformClient:
+  secretRef: ""
+  secretKey: "KEYCLOAK_ADMIN_CLIENT_SECRET"
+  externalSecret:
+    enabled: false
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "vault"
+      kind: "ClusterSecretStore"
+    remoteRef:
+      key: ""
+      property: ""
+
 # ---------- Upstream Identity Provider (generic OIDC) ----------
 # Configures an external IDP broker (e.g. Okta, Azure AD, Duo SSO).
 # Three ways to provide IDP_CLIENT_SECRET:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.1-rc.25"
+version = "0.5.1-rc.26"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.1rc25"
+version = "0.5.1rc26"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Adds `platformClient.secretRef` support to the Keycloak chart so the `caipe-platform` OIDC client secret can be sourced from an existing Kubernetes Secret (or ESO) and reconciled into Keycloak via the Admin API during `init-idp` / `auth-reconcile`.

Without this, the Teams & Users admin page fails with a 401 `invalid_grant: Invalid user credentials` because `caipe-ui` reads `KEYCLOAK_ADMIN_CLIENT_SECRET` from its environment to obtain a service-account token via `admin-cli`, but the secret in Keycloak was never explicitly set to match.

### Changes

- **`values.yaml`** — new `platformClient` block (`secretRef`, `secretKey`, `externalSecret`) mirroring the existing `uiClient` pattern
- **`templates/_helpers.tpl`** — new `keycloak.platformClientSecretName` helper
- **`templates/job-init-idp.yaml`** — inject `KEYCLOAK_PLATFORM_CLIENT_SECRET` env from the resolved secret when `platformClient.secretRef` or ESO is configured
- **`templates/job-auth-reconcile.yaml`** — same injection so upgrades also reconcile the secret
- **`scripts/init-idp.sh`** — new `_reconcile_caipe_platform_client_secret()` function that patches the `caipe-platform` client secret via the Keycloak Admin API (idempotent; no-ops if env var is unset)
- **`templates/platform-client-external-secret.yaml`** — new optional ExternalSecret template for ESO-managed installations

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass