### PR TITLE
feat(ui): agentic SDLC repo-detail panel system + clickable app cards

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.6.0-rc.8 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.9 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,30 +179,30 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.6.0-rc.8
+    version: 0.6.0-rc.9
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.6.0-rc.8 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.9 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.6.0-rc.8
-appVersion: "0.6.0-rc.8"
+version: 0.6.0-rc.9
+appVersion: "0.6.0-rc.9"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.6.0-rc.8 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.9 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.6.0-rc.8 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.9 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.8" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.9" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.8" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.9" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.6.0-rc.8
-appVersion: 0.6.0-rc.8
+version: 0.6.0-rc.9
+appVersion: 0.6.0-rc.9
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.6.0-rc.8 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.6.0-rc.9 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.6.0-rc.8 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.6.0-rc.9 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0-rc.8" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.6.0-rc.9" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.8" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.9" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0-rc.8" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.6.0-rc.9" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.6.0-rc.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.6.0-rc.8" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.6.0-rc.9 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.6.0-rc.9" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,7 +13,7 @@
         "@ag-ui/core": "0.0.51",
         "@codemirror/autocomplete": "6.20.1",
         "@codemirror/commands": "6.10.3",
-        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-json": "6.0.2",
         "@codemirror/lang-markdown": "6.5.0",
         "@codemirror/language": "6.12.3",
         "@codemirror/language-data": "6.5.2",
@@ -63,6 +63,7 @@
         "next-themes": "0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-grid-layout": "^2.2.3",
         "react-markdown": "10.1.0",
         "react-resizable-panels": "4.9.0",
         "react-syntax-highlighter": "16.1.1",
@@ -7631,6 +7632,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -9939,7 +9946,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10424,7 +10430,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -11736,7 +11741,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12349,7 +12353,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -12359,7 +12362,6 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -12428,6 +12430,38 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-is": {
@@ -12523,6 +12557,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/react-resizable-panels": {
@@ -12833,6 +12881,12 @@
     },
     "node_modules/reselect": {
       "version": "5.1.1",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -63,7 +63,7 @@
         "next-themes": "0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-grid-layout": "^2.2.3",
+        "react-grid-layout": "2.2.3",
         "react-markdown": "10.1.0",
         "react-resizable-panels": "4.9.0",
         "react-syntax-highlighter": "16.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -76,7 +76,7 @@
     "next-themes": "0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-grid-layout": "^2.2.3",
+    "react-grid-layout": "2.2.3",
     "react-markdown": "10.1.0",
     "react-resizable-panels": "4.9.0",
     "react-syntax-highlighter": "16.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -76,6 +76,7 @@
     "next-themes": "0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-grid-layout": "^2.2.3",
     "react-markdown": "10.1.0",
     "react-resizable-panels": "4.9.0",
     "react-syntax-highlighter": "16.1.1",

--- a/ui/src/__tests__/agentic-apps/apps-hub.test.tsx
+++ b/ui/src/__tests__/agentic-apps/apps-hub.test.tsx
@@ -71,6 +71,34 @@ describe("AgenticAppsHub", () => {
     );
   });
 
+  it("exposes a card-wide launch link so clicks anywhere on the card open the app", () => {
+    render(<AgenticAppsHub apps={[finopsApp]} />);
+
+    const launchLink = screen.getByRole("link", { name: "Launch FinOps Dashboard" });
+    expect(launchLink).toHaveAttribute("href", "/apps/finops");
+    expect(launchLink).toHaveAttribute("title", "Launch FinOps Dashboard");
+    expect(launchLink.className).toMatch(/absolute/);
+    expect(launchLink.className).toMatch(/inset-0/);
+  });
+
+  it("does not render a card-wide launch link for blocked apps", () => {
+    render(
+      <AgenticAppsHub
+        apps={[
+          {
+            ...finopsApp,
+            canLaunch: false,
+            blockedReasons: ["unauthorized"],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: "Launch FinOps Dashboard" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("hides inline runtime labels and exposes them only via the runtime info tooltip", async () => {
     const user = userEvent.setup();
     render(<AgenticAppsHub apps={[finopsApp]} />);

--- a/ui/src/__tests__/agentic-sdlc/ci-projection.test.ts
+++ b/ui/src/__tests__/agentic-sdlc/ci-projection.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Pure CI projection tests for `lib/agentic-sdlc/ci-projection.ts`.
+ *
+ * Exercises:
+ *  - isCiEvent / ciEventArtifactId
+ *  - normaliseConclusion / normaliseStatus
+ *  - mergeCiSummary (worst-conclusion-wins, latest-per-name)
+ *  - projectCiEvent end-to-end
+ *
+ * No Mongo, no network. Pure data in → pure data out.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+import {
+  ciEventArtifactId,
+  isCiEvent,
+  normaliseConclusion,
+  normaliseStatus,
+  projectCiEvent,
+} from "@/lib/agentic-sdlc/ci-projection";
+import type {
+  AgenticSdlcArtifact,
+  AgenticSdlcEvent,
+} from "@/types/agentic-sdlc";
+
+function makeEvent(
+  type: "check_run" | "check_suite" | "workflow_run" | "issues",
+  payload: Record<string, unknown>,
+  overrides: Partial<AgenticSdlcEvent> = {},
+): AgenticSdlcEvent {
+  return {
+    repo_id: "r1",
+    source: "github",
+    github_delivery_id: "d-1",
+    github_event_type: type,
+    github_action: null,
+    artifact_kind: type === "issues" ? "subtask" : "pull_request",
+    artifact_id: "PR_1",
+    epic_id: null,
+    actor_kind: "system",
+    actor_login: null,
+    payload,
+    delivered_at: new Date("2026-05-22T00:00:00Z"),
+    occurred_at: new Date("2026-05-22T00:00:00Z"),
+    projection_status: "deferred",
+    projection_attempts: 0,
+    ...overrides,
+  };
+}
+
+function makeArtifact(
+  overrides: Partial<AgenticSdlcArtifact> = {},
+): AgenticSdlcArtifact {
+  return {
+    repo_id: "r1",
+    kind: "pull_request",
+    artifact_id: "PR_1",
+    epic_id: null,
+    parent_subtask_id: null,
+    title: "Test PR",
+    body_excerpt: "",
+    state: "open",
+    current_stage: "review_hitl",
+    assignees: [],
+    requested_reviewers: [],
+    labels: [],
+    agent_labels: [],
+    needs_human: false,
+    stalled_since: null,
+    last_event_at: new Date("2026-05-22T00:00:00Z"),
+    github_url: "https://github.com/o/r/pull/1",
+    created_at: new Date("2026-05-22T00:00:00Z"),
+    updated_at: new Date("2026-05-22T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("isCiEvent / ciEventArtifactId", () => {
+  it("recognises check_run / check_suite / workflow_run", () => {
+    expect(isCiEvent(makeEvent("check_run", { check_run: {} }))).toBe(true);
+    expect(isCiEvent(makeEvent("check_suite", { check_suite: {} }))).toBe(true);
+    expect(isCiEvent(makeEvent("workflow_run", { workflow_run: {} }))).toBe(true);
+  });
+
+  it("ignores non-CI events", () => {
+    expect(isCiEvent(makeEvent("issues", { issue: {} }))).toBe(false);
+  });
+
+  it("returns the PR artifact id for pull-request-linked events", () => {
+    const ev = makeEvent("check_run", { check_run: {} });
+    expect(ciEventArtifactId(ev)).toBe("PR_1");
+  });
+
+  it("returns null when the event isn't a CI event", () => {
+    expect(ciEventArtifactId(makeEvent("issues", { issue: {} }))).toBeNull();
+  });
+});
+
+describe("normaliseConclusion / normaliseStatus", () => {
+  it("maps GitHub conclusions to the UI enum", () => {
+    expect(normaliseConclusion("success")).toBe("success");
+    expect(normaliseConclusion("failure")).toBe("failure");
+    expect(normaliseConclusion("startup_failure")).toBe("failure");
+    expect(normaliseConclusion("timed_out")).toBe("timed_out");
+    expect(normaliseConclusion("skipped")).toBe("skipped");
+    expect(normaliseConclusion("neutral")).toBe("neutral");
+    expect(normaliseConclusion(null)).toBe("pending");
+    expect(normaliseConclusion("something_new")).toBe("unknown");
+  });
+
+  it("maps GitHub status to the UI enum", () => {
+    expect(normaliseStatus("queued")).toBe("queued");
+    expect(normaliseStatus("in_progress")).toBe("in_progress");
+    expect(normaliseStatus("completed")).toBe("completed");
+    expect(normaliseStatus(undefined)).toBe("completed");
+  });
+});
+
+describe("projectCiEvent", () => {
+  it("returns null when the event has no PR artifact id", () => {
+    const ev = makeEvent("workflow_run", { workflow_run: {} }, {
+      artifact_kind: "unknown",
+      artifact_id: "",
+    });
+    expect(projectCiEvent(ev, [], null)).toBeNull();
+  });
+
+  it("returns null for non-CI events", () => {
+    expect(
+      projectCiEvent(makeEvent("issues", { issue: {} }), [], makeArtifact()),
+    ).toBeNull();
+  });
+
+  it("projects a single passing check_run to a success summary", () => {
+    const ev = makeEvent("check_run", {
+      check_run: {
+        id: 123,
+        name: "lint",
+        status: "completed",
+        conclusion: "success",
+        head_sha: "abc1234",
+        completed_at: "2026-05-22T00:01:00Z",
+        details_url: "https://gh.test/lint",
+      },
+    });
+    const patch = projectCiEvent(ev, [], makeArtifact())!;
+    expect(patch.artifact_id).toBe("PR_1");
+    expect(patch.head_sha).toBe("abc1234");
+    expect(patch.ci_summary.conclusion).toBe("success");
+    expect(patch.ci_summary.status).toBe("completed");
+    expect(patch.ci_summary.total).toBe(1);
+    expect(patch.ci_summary.by_conclusion.success).toBe(1);
+  });
+
+  it("collapses multiple checks: any failure wins over success", () => {
+    const lintPassed = makeEvent("check_run", {
+      check_run: {
+        id: 1,
+        name: "lint",
+        status: "completed",
+        conclusion: "success",
+        head_sha: "abc",
+        completed_at: "2026-05-22T00:00:30Z",
+      },
+    });
+    const testsFailed = makeEvent("check_run", {
+      check_run: {
+        id: 2,
+        name: "tests",
+        status: "completed",
+        conclusion: "failure",
+        head_sha: "abc",
+        completed_at: "2026-05-22T00:01:00Z",
+      },
+    });
+
+    const patch = projectCiEvent(testsFailed, [lintPassed], makeArtifact())!;
+    expect(patch.ci_summary.total).toBe(2);
+    expect(patch.ci_summary.conclusion).toBe("failure");
+    expect(patch.ci_summary.by_conclusion.failure).toBe(1);
+    expect(patch.ci_summary.by_conclusion.success).toBe(1);
+  });
+
+  it("treats an in-progress check as pending, even if other checks passed", () => {
+    const lintPassed = makeEvent("check_run", {
+      check_run: {
+        id: 1,
+        name: "lint",
+        status: "completed",
+        conclusion: "success",
+        head_sha: "abc",
+        completed_at: "2026-05-22T00:00:30Z",
+      },
+    });
+    const buildRunning = makeEvent("check_run", {
+      check_run: {
+        id: 2,
+        name: "build",
+        status: "in_progress",
+        conclusion: null,
+        head_sha: "abc",
+        started_at: "2026-05-22T00:01:00Z",
+      },
+    });
+    const patch = projectCiEvent(buildRunning, [lintPassed], makeArtifact())!;
+    expect(patch.ci_summary.status).toBe("in_progress");
+    expect(patch.ci_summary.conclusion).toBe("pending");
+    expect(patch.ci_summary.by_conclusion.pending).toBe(1);
+    expect(patch.ci_summary.by_conclusion.success).toBe(1);
+  });
+
+  it("keeps only the latest event per check_name in history", () => {
+    const oldFailure = makeEvent(
+      "check_run",
+      {
+        check_run: {
+          id: 1,
+          name: "tests",
+          status: "completed",
+          conclusion: "failure",
+          head_sha: "abc",
+          completed_at: "2026-05-22T00:00:00Z",
+        },
+      },
+      { occurred_at: new Date("2026-05-22T00:00:00Z") },
+    );
+    const newSuccess = makeEvent(
+      "check_run",
+      {
+        check_run: {
+          id: 2,
+          name: "tests",
+          status: "completed",
+          conclusion: "success",
+          head_sha: "abc",
+          completed_at: "2026-05-22T00:05:00Z",
+        },
+      },
+      { occurred_at: new Date("2026-05-22T00:05:00Z") },
+    );
+    const patch = projectCiEvent(newSuccess, [oldFailure], makeArtifact())!;
+    expect(patch.ci_summary.total).toBe(1);
+    expect(patch.ci_summary.conclusion).toBe("success");
+    expect(patch.ci_summary.by_conclusion.success).toBe(1);
+    expect(patch.ci_summary.by_conclusion.failure).toBeUndefined();
+  });
+
+  it("projects workflow_run events the same way", () => {
+    const ev = makeEvent("workflow_run", {
+      workflow_run: {
+        id: 999,
+        name: "CI",
+        status: "completed",
+        conclusion: "success",
+        head_sha: "deadbeef",
+        run_started_at: "2026-05-22T00:00:00Z",
+        updated_at: "2026-05-22T00:01:30Z",
+        html_url: "https://gh.test/run/999",
+      },
+    });
+    const patch = projectCiEvent(ev, [], makeArtifact())!;
+    expect(patch.ci_summary.conclusion).toBe("success");
+    expect(patch.head_sha).toBe("deadbeef");
+  });
+});

--- a/ui/src/__tests__/agentic-sdlc/panel-preferences.test.ts
+++ b/ui/src/__tests__/agentic-sdlc/panel-preferences.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for the pure panel-preferences module.
+ *
+ * Covers:
+ *   - defaultPreferences / normalisePreferences round-trip
+ *   - togglePanelVisibility for default-visible vs default-hidden panels
+ *   - resolvePanelLayout ordering rules
+ *   - movePanel cross-section and within-section reorder
+ *   - resetPreferences
+ *
+ * No I/O; safe to run in jsdom.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  clearGridLayout,
+  computeDefaultGridLayout,
+  defaultPreferences,
+  GRID_COLS,
+  isPanelVisible,
+  movePanel,
+  normalisePreferences,
+  PANEL_PREFERENCES_VERSION,
+  resetPreferences,
+  resolveGridLayout,
+  resolvePanelLayout,
+  setGridEnabled,
+  setGridLayout,
+  togglePanelVisibility,
+} from "@/lib/agentic-sdlc/panel-preferences";
+import {
+  PANEL_REGISTRY,
+  getPanel,
+  type PanelId,
+  type PanelSection,
+} from "@/lib/agentic-sdlc/panel-registry";
+
+describe("panel-preferences", () => {
+  describe("defaultPreferences", () => {
+    it("returns an empty preference set tagged for the surface", () => {
+      const p = defaultPreferences("repo_detail");
+      expect(p.surface).toBe("repo_detail");
+      expect(p.hidden).toEqual([]);
+      expect(p.shown).toEqual([]);
+      expect(p.order).toEqual({});
+      expect(p.section).toEqual({});
+      expect(p.density).toBe("comfortable");
+      expect(p.version).toBe(PANEL_PREFERENCES_VERSION);
+    });
+  });
+
+  describe("normalisePreferences", () => {
+    it("falls back to defaults for non-object input", () => {
+      expect(normalisePreferences(null, "repo_detail")).toEqual(
+        defaultPreferences("repo_detail"),
+      );
+      expect(normalisePreferences("nope", "home")).toEqual(
+        defaultPreferences("home"),
+      );
+    });
+
+    it("drops unknown panel ids and sections", () => {
+      const raw = {
+        version: 1,
+        surface: "repo_detail",
+        hidden: ["epics", "not_a_real_panel"],
+        shown: ["spec_health", "also_fake"],
+        order: { epics: ["epics", "garbage"], not_real_section: ["spec_health"] },
+        section: { epics: "context", spec_health: "ghost" },
+        density: "compact",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      };
+      const p = normalisePreferences(raw, "repo_detail");
+      expect(p.hidden).toEqual(["epics"]);
+      expect(p.shown).toEqual(["spec_health"]);
+      expect(p.order).toEqual({ epics: ["epics"] });
+      expect(p.section).toEqual({ epics: "context" });
+      expect(p.density).toBe("compact");
+    });
+  });
+
+  describe("isPanelVisible", () => {
+    it("respects defaults for default-visible panels", () => {
+      const prefs = defaultPreferences("repo_detail");
+      const epics = getPanel("epics");
+      expect(isPanelVisible(epics, prefs)).toBe(true);
+    });
+
+    it("respects defaults for default-hidden panels", () => {
+      const prefs = defaultPreferences("repo_detail");
+      const fanout = getPanel("parallel_fanout");
+      expect(isPanelVisible(fanout, prefs)).toBe(false);
+    });
+
+    it("hides default-visible when listed in hidden", () => {
+      const prefs = { ...defaultPreferences("repo_detail"), hidden: ["epics" as PanelId] };
+      const epics = getPanel("epics");
+      expect(isPanelVisible(epics, prefs)).toBe(false);
+    });
+
+    it("shows default-hidden when listed in shown", () => {
+      const prefs = {
+        ...defaultPreferences("repo_detail"),
+        shown: ["parallel_fanout" as PanelId],
+      };
+      const fanout = getPanel("parallel_fanout");
+      expect(isPanelVisible(fanout, prefs)).toBe(true);
+    });
+
+    it("hidden wins over shown", () => {
+      const prefs = {
+        ...defaultPreferences("repo_detail"),
+        shown: ["epics" as PanelId],
+        hidden: ["epics" as PanelId],
+      };
+      const epics = getPanel("epics");
+      expect(isPanelVisible(epics, prefs)).toBe(false);
+    });
+  });
+
+  describe("togglePanelVisibility", () => {
+    it("toggles a default-visible panel into hidden", () => {
+      const p1 = defaultPreferences("repo_detail");
+      const p2 = togglePanelVisibility(p1, "epics");
+      expect(p2.hidden).toContain("epics");
+      expect(p2.shown).not.toContain("epics");
+    });
+
+    it("toggles a hidden default-visible panel back on", () => {
+      const p1 = togglePanelVisibility(defaultPreferences("repo_detail"), "epics");
+      const p2 = togglePanelVisibility(p1, "epics");
+      expect(p2.hidden).not.toContain("epics");
+    });
+
+    it("toggles a default-hidden panel into shown", () => {
+      const p1 = defaultPreferences("repo_detail");
+      const p2 = togglePanelVisibility(p1, "parallel_fanout");
+      expect(p2.shown).toContain("parallel_fanout");
+      expect(p2.hidden).not.toContain("parallel_fanout");
+    });
+
+    it("toggles a shown default-hidden panel back off", () => {
+      const p1 = togglePanelVisibility(
+        defaultPreferences("repo_detail"),
+        "parallel_fanout",
+      );
+      const p2 = togglePanelVisibility(p1, "parallel_fanout");
+      expect(p2.shown).not.toContain("parallel_fanout");
+    });
+  });
+
+  describe("resolvePanelLayout", () => {
+    it("returns at least one entry per registered section", () => {
+      const layout = resolvePanelLayout(defaultPreferences("repo_detail"));
+      // every section key is present even if empty
+      const keys = Object.keys(layout);
+      expect(keys).toEqual(expect.arrayContaining(["hero", "footer"]));
+    });
+
+    it("orders panels by the registry defaults for the surface", () => {
+      const layout = resolvePanelLayout(defaultPreferences("repo_detail"));
+      // epics + operating_metrics share the "epics" section; epics has
+      // order 0, operating_metrics has order 1.
+      expect(layout.epics).toEqual(["epics", "operating_metrics"]);
+    });
+
+    it("uses an explicit order override when provided", () => {
+      const prefs = {
+        ...defaultPreferences("repo_detail"),
+        order: { epics: ["operating_metrics", "epics"] as PanelId[] },
+      };
+      const layout = resolvePanelLayout(prefs);
+      expect(layout.epics).toEqual(["operating_metrics", "epics"]);
+    });
+
+    it("omits panels the user has hidden", () => {
+      const prefs = togglePanelVisibility(
+        defaultPreferences("repo_detail"),
+        "epics",
+      );
+      const layout = resolvePanelLayout(prefs);
+      expect(layout.epics).not.toContain("epics");
+    });
+
+    it("includes shown default-hidden panels", () => {
+      const prefs = togglePanelVisibility(
+        defaultPreferences("repo_detail"),
+        "parallel_fanout",
+      );
+      const layout = resolvePanelLayout(prefs);
+      // parallel_fanout's registered section is "execute"
+      expect(layout.execute).toContain("parallel_fanout");
+    });
+  });
+
+  describe("movePanel", () => {
+    it("moves a panel to a new section and records the override", () => {
+      const base = defaultPreferences("repo_detail");
+      const moved = movePanel(base, "epics", "context", 0);
+      expect(moved.section.epics).toBe("context");
+      expect(moved.order.context?.[0]).toBe("epics");
+    });
+
+    it("clears the override when moved back to its registered section", () => {
+      const base = defaultPreferences("repo_detail");
+      const moved = movePanel(base, "epics", "context", 0);
+      const movedBack = movePanel(moved, "epics", "epics", 0);
+      expect(movedBack.section.epics).toBeUndefined();
+    });
+
+    it("ensures the moved panel is visible afterward", () => {
+      const hidden = togglePanelVisibility(
+        defaultPreferences("repo_detail"),
+        "parallel_fanout",
+      );
+      // toggling once on a default-hidden panel makes it shown; toggle
+      // twice to land on hidden.
+      const fullyHidden = togglePanelVisibility(hidden, "parallel_fanout");
+      expect(
+        isPanelVisible(getPanel("parallel_fanout"), fullyHidden),
+      ).toBe(false);
+      const moved = movePanel(fullyHidden, "parallel_fanout", "context", 0);
+      expect(isPanelVisible(getPanel("parallel_fanout"), moved)).toBe(true);
+    });
+
+    it("clamps the target index when out of range", () => {
+      const base = defaultPreferences("repo_detail");
+      const moved = movePanel(base, "epics", "context", 99);
+      // context's pre-existing visible panels are at indexes 0..N-1.
+      // The moved panel should be at the end.
+      const idx = (moved.order.context ?? []).indexOf("epics");
+      expect(idx).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("resetPreferences", () => {
+    it("returns a fresh preference set tagged with the surface", () => {
+      const after = togglePanelVisibility(
+        defaultPreferences("repo_detail"),
+        "epics",
+      );
+      const reset = resetPreferences("repo_detail");
+      expect(reset.hidden).toEqual([]);
+      expect(reset.shown).toEqual([]);
+      // does not leak state from `after`
+      expect(reset).not.toEqual(after);
+    });
+  });
+
+  describe("registry guarantees", () => {
+    it("every registry entry has a non-empty title and description", () => {
+      for (const panel of PANEL_REGISTRY) {
+        expect(panel.title.length).toBeGreaterThan(0);
+        expect(panel.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("every panel declares at least one surface in defaults", () => {
+      for (const panel of PANEL_REGISTRY) {
+        const declared = Object.keys(panel.defaults);
+        expect(declared.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("grid helpers", () => {
+    it("defaults gridEnabled to false and grid to empty", () => {
+      const prefs = defaultPreferences("repo_detail");
+      expect(prefs.gridEnabled).toBe(false);
+      expect(prefs.grid).toEqual({});
+    });
+
+    it("normalisePreferences keeps a valid grid snapshot and drops garbage", () => {
+      const raw = {
+        gridEnabled: true,
+        grid: {
+          lg: {
+            epics: { x: 0, y: 0, w: 6, h: 8 },
+            "not-a-panel": { x: 0, y: 0, w: 6, h: 8 },
+            broken: { x: "no", y: 0, w: 6, h: 8 },
+          },
+          xx: { epics: { x: 0, y: 0, w: 6, h: 8 } }, // bogus breakpoint
+        },
+      } as unknown;
+      const out = normalisePreferences(raw, "repo_detail");
+      expect(out.gridEnabled).toBe(true);
+      expect(out.grid.lg?.epics).toEqual({ x: 0, y: 0, w: 6, h: 8 });
+      expect(out.grid.lg?.["not-a-panel" as never]).toBeUndefined();
+      expect(out.grid.lg?.["broken" as never]).toBeUndefined();
+      expect(out.grid.xx as unknown).toBeUndefined();
+    });
+
+    it("computeDefaultGridLayout tiles visible panels without column overflow", () => {
+      const prefs = defaultPreferences("repo_detail");
+      const coords = computeDefaultGridLayout(prefs, "lg");
+      const cols = GRID_COLS.lg;
+      for (const c of Object.values(coords)) {
+        expect(c.x).toBeGreaterThanOrEqual(0);
+        expect(c.x + c.w).toBeLessThanOrEqual(cols);
+        expect(c.w).toBeGreaterThan(0);
+        expect(c.h).toBeGreaterThan(0);
+      }
+    });
+
+    it("resolveGridLayout overlays user coords on top of defaults", () => {
+      let prefs = defaultPreferences("repo_detail");
+      const userLayout = {
+        epics: { x: 0, y: 100, w: 12, h: 12 },
+      } as Parameters<typeof setGridLayout>[2];
+      prefs = setGridLayout(prefs, "lg", userLayout);
+      const merged = resolveGridLayout(prefs, "lg");
+      // Only `epics` is overridden; everything else stays at defaults.
+      expect(merged.epics).toEqual({ x: 0, y: 100, w: 12, h: 12 });
+      expect(Object.keys(merged).length).toBeGreaterThan(1);
+    });
+
+    it("setGridEnabled toggles the flag and bumps updated_at", () => {
+      const a = defaultPreferences("repo_detail");
+      const b = setGridEnabled(a, true);
+      expect(b.gridEnabled).toBe(true);
+      expect(b.updated_at).not.toEqual(a.updated_at);
+      // idempotent
+      const c = setGridEnabled(b, true);
+      expect(c).toBe(b);
+    });
+
+    it("clearGridLayout wipes saved coords", () => {
+      let prefs = defaultPreferences("repo_detail");
+      const userLayout = {
+        epics: { x: 0, y: 0, w: 12, h: 12 },
+      } as Parameters<typeof setGridLayout>[2];
+      prefs = setGridLayout(prefs, "lg", userLayout);
+      expect(Object.keys(prefs.grid).length).toBe(1);
+      const cleared = clearGridLayout(prefs);
+      expect(cleared.grid).toEqual({});
+    });
+  });
+});

--- a/ui/src/__tests__/agentic-sdlc/repo-insights.test.ts
+++ b/ui/src/__tests__/agentic-sdlc/repo-insights.test.ts
@@ -1,0 +1,353 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for `lib/agentic-sdlc/repo-insights.ts`. We mock the
+ * Mongo collection helpers directly and assert the shape returned by
+ * each aggregation helper.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+const mockGetArtifactsCollection = jest.fn();
+const mockGetEventsCollection = jest.fn();
+
+jest.mock("@/lib/agentic-sdlc/mongo-collections", () => ({
+  __esModule: true,
+  getAgenticSdlcArtifactsCollection: () => mockGetArtifactsCollection(),
+  getAgenticSdlcEventsCollection: () => mockGetEventsCollection(),
+}));
+
+const REPO_ID = "r1";
+
+function findCursor<T>(rows: T[]) {
+  return {
+    toArray: jest.fn().mockResolvedValue(rows),
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+  };
+}
+
+describe("getInFlightCi", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockGetArtifactsCollection.mockReset();
+    mockGetEventsCollection.mockReset();
+  });
+
+  it("returns each in-flight artifact with its CI summary and counts pending+failure", async () => {
+    const find = jest.fn().mockReturnValue(
+      findCursor([
+        {
+          artifact_id: "PR_1",
+          kind: "pull_request",
+          title: "open PR with failing CI",
+          current_stage: "review_hitl",
+          github_url: "u1",
+          state: "open",
+          head_sha: "aaa",
+          ci_summary: {
+            conclusion: "failure",
+            status: "completed",
+            by_conclusion: { failure: 1, success: 1 },
+            total: 2,
+            last_event_at: "2026-05-22T00:01:00Z",
+          },
+          last_event_at: new Date("2026-05-22T00:02:00Z"),
+        },
+        {
+          artifact_id: "PR_2",
+          kind: "pull_request",
+          title: "open PR still building",
+          current_stage: "implement",
+          github_url: "u2",
+          state: "open",
+          head_sha: "bbb",
+          ci_summary: {
+            conclusion: "pending",
+            status: "in_progress",
+            by_conclusion: { pending: 1 },
+            total: 1,
+            last_event_at: "2026-05-22T00:00:30Z",
+          },
+          last_event_at: new Date("2026-05-22T00:01:00Z"),
+        },
+        {
+          artifact_id: "ST_1",
+          kind: "subtask",
+          title: "task without CI events yet",
+          current_stage: "implement",
+          github_url: "u3",
+          state: "open",
+          head_sha: null,
+          ci_summary: null,
+          last_event_at: new Date("2026-05-22T00:00:00Z"),
+        },
+      ]),
+    );
+    mockGetArtifactsCollection.mockResolvedValue({ find });
+
+    const { getInFlightCi } = await import("@/lib/agentic-sdlc/repo-insights");
+    const result = await getInFlightCi(REPO_ID);
+
+    expect(result.items).toHaveLength(3);
+    expect(result.totals).toEqual({
+      success: 0,
+      failure: 1,
+      pending: 1,
+      no_ci: 1,
+    });
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo_id: REPO_ID,
+        kind: { $in: ["pull_request", "subtask"] },
+        state: { $nin: ["closed", "merged", "cancelled"] },
+      }),
+      expect.any(Object),
+    );
+  });
+});
+
+describe("getChangelogEntries", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockGetArtifactsCollection.mockReset();
+    mockGetEventsCollection.mockReset();
+  });
+
+  it("returns merged epics, merged PRs, and successful deploys in the window", async () => {
+    const find = jest.fn().mockReturnValue(
+      findCursor([
+        {
+          artifact_id: "PR_1",
+          kind: "pull_request",
+          title: "feat: shipped",
+          body_excerpt: "Body excerpt",
+          state: "merged",
+          epic_id: "EP_1",
+          github_url: "https://github.com/o/r/pull/1",
+          labels: ["agent:awaiting-review"],
+          agent_labels: ["agent:awaiting-review"],
+          last_event_at: new Date("2026-05-21T10:00:00Z"),
+        },
+        {
+          artifact_id: "EP_1",
+          kind: "epic",
+          title: "Epic shipped",
+          body_excerpt: "Epic done",
+          state: "closed",
+          epic_id: "EP_1",
+          github_url: "https://github.com/o/r/issues/100",
+          labels: ["epic"],
+          agent_labels: [],
+          last_event_at: new Date("2026-05-21T11:00:00Z"),
+        },
+        {
+          artifact_id: "DEP_1",
+          kind: "deploy",
+          title: "Deploy → sandbox",
+          body_excerpt: "ok",
+          state: "success",
+          epic_id: "EP_1",
+          github_url: "https://github.com/o/r/deployments",
+          labels: [],
+          agent_labels: [],
+          last_event_at: new Date("2026-05-21T12:00:00Z"),
+        },
+      ]),
+    );
+    mockGetArtifactsCollection.mockResolvedValue({ find });
+
+    const { getChangelogEntries } = await import(
+      "@/lib/agentic-sdlc/repo-insights"
+    );
+    const entries = await getChangelogEntries(REPO_ID, { lookbackDays: 7 });
+    expect(entries.map((e) => e.kind)).toEqual([
+      "pull_request_merged",
+      "epic_closed",
+      "deploy_succeeded",
+    ]);
+    expect(entries[0].actor_kind).toBe("agent");
+    expect(entries[1].actor_kind).toBe("human");
+  });
+});
+
+describe("getRecentSnapshots", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockGetArtifactsCollection.mockReset();
+    mockGetEventsCollection.mockReset();
+  });
+
+  it("combines workflow_run events, deploy artifacts, and recent agentic artifacts, sorted by recency", async () => {
+    const eventsFind = jest.fn().mockReturnValue(
+      findCursor([
+        {
+          payload: {
+            workflow_run: {
+              id: 1,
+              name: "CI",
+              status: "completed",
+              conclusion: "success",
+              html_url: "https://github.com/o/r/actions/runs/1",
+            },
+          },
+          occurred_at: new Date("2026-05-22T05:00:00Z"),
+          github_delivery_id: "d-1",
+        },
+      ]),
+    );
+    const artifactsFind = jest
+      .fn()
+      .mockReturnValueOnce(
+        // First call: deploy artifacts
+        findCursor([
+          {
+            artifact_id: "DEP_1",
+            title: "Deploy → sandbox",
+            state: "success",
+            body_excerpt: "ok",
+            github_url: "https://github.com/o/r/deployments",
+            last_event_at: new Date("2026-05-22T04:00:00Z"),
+            labels: [],
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        // Second call: recent agentic artifacts
+        findCursor([
+          {
+            artifact_id: "PR_1",
+            kind: "pull_request",
+            title: "PR title",
+            state: "open",
+            current_stage: "implement",
+            github_url: "https://github.com/o/r/pull/1",
+            last_event_at: new Date("2026-05-22T06:00:00Z"),
+          },
+        ]),
+      );
+
+    mockGetEventsCollection.mockResolvedValue({ find: eventsFind });
+    mockGetArtifactsCollection.mockResolvedValue({ find: artifactsFind });
+
+    const { getRecentSnapshots } = await import(
+      "@/lib/agentic-sdlc/repo-insights"
+    );
+    const result = await getRecentSnapshots(REPO_ID, { recentRuns: 5 });
+
+    expect(result.items.map((i) => i.kind)).toEqual([
+      "agentic_artifact",
+      "github_actions_artifact",
+      "deploy_snapshot",
+    ]);
+    expect(result.by_kind).toEqual({
+      github_actions_artifact: 1,
+      deploy_snapshot: 1,
+      agentic_artifact: 1,
+    });
+    expect(result.items[1].tone).toBe("success");
+    expect(result.items[2].tone).toBe("success");
+  });
+});
+
+describe("getDeploymentHealth", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockGetArtifactsCollection.mockReset();
+    mockGetEventsCollection.mockReset();
+  });
+
+  it("groups deploys per environment with success/failure totals and recent records", async () => {
+    const eventsFind = jest.fn().mockReturnValue(
+      findCursor([
+        {
+          payload: {
+            deployment: {
+              node_id: "DEP_2",
+              environment: "sandbox",
+              created_at: "2026-05-22T05:55:00Z",
+            },
+            deployment_status: {
+              state: "failure",
+              description: "OOM in worker pod",
+              target_url: "https://logs/2",
+              updated_at: "2026-05-22T06:01:00Z",
+            },
+          },
+          occurred_at: new Date("2026-05-22T06:01:00Z"),
+          epic_id: null,
+          artifact_id: "DEP_2",
+        },
+        {
+          payload: {
+            deployment: {
+              node_id: "DEP_1",
+              environment: "sandbox",
+              created_at: "2026-05-22T04:00:00Z",
+            },
+            deployment_status: {
+              state: "success",
+              description: "rollout ok",
+              target_url: "https://logs/1",
+              updated_at: "2026-05-22T04:05:00Z",
+            },
+          },
+          occurred_at: new Date("2026-05-22T04:05:00Z"),
+          epic_id: null,
+          artifact_id: "DEP_1",
+        },
+      ]),
+    );
+
+    const artifactsFind = jest.fn().mockReturnValue(findCursor([]));
+
+    mockGetEventsCollection.mockResolvedValue({ find: eventsFind });
+    mockGetArtifactsCollection.mockResolvedValue({ find: artifactsFind });
+
+    const { getDeploymentHealth } = await import(
+      "@/lib/agentic-sdlc/repo-insights"
+    );
+    const result = await getDeploymentHealth(REPO_ID, { windowHours: 24 });
+
+    expect(result.environments).toHaveLength(1);
+    const sandbox = result.environments[0];
+    expect(sandbox.environment).toBe("sandbox");
+    // Latest is the failure → environment is "failing"
+    expect(sandbox.health).toBe("failing");
+    expect(sandbox.success_count).toBe(1);
+    expect(sandbox.failure_count).toBe(1);
+    expect(sandbox.recent_deploys[0].id).toBe("DEP_2");
+    expect(sandbox.recent_deploys[0].failure_reason).toContain("OOM");
+    expect(result.totals.success).toBe(1);
+    expect(result.totals.failure).toBe(1);
+  });
+
+  it("falls back to deploy artifacts when no events match the window", async () => {
+    const eventsFind = jest.fn().mockReturnValue(findCursor([]));
+    const artifactsFind = jest.fn().mockReturnValue(
+      findCursor([
+        {
+          artifact_id: "DEP_OLD",
+          title: "Deploy → sandbox",
+          state: "success",
+          body_excerpt: "ok",
+          github_url: "u",
+          last_event_at: new Date("2026-05-15T10:00:00Z"),
+          created_at: new Date("2026-05-15T09:55:00Z"),
+          epic_id: null,
+        },
+      ]),
+    );
+
+    mockGetEventsCollection.mockResolvedValue({ find: eventsFind });
+    mockGetArtifactsCollection.mockResolvedValue({ find: artifactsFind });
+
+    const { getDeploymentHealth } = await import(
+      "@/lib/agentic-sdlc/repo-insights"
+    );
+    const result = await getDeploymentHealth(REPO_ID, { windowHours: 168 });
+    expect(result.environments).toHaveLength(1);
+    expect(result.environments[0].environment).toBe("sandbox");
+    expect(result.environments[0].success_count).toBe(1);
+  });
+});

--- a/ui/src/__tests__/agentic-sdlc/spec-scoring.test.ts
+++ b/ui/src/__tests__/agentic-sdlc/spec-scoring.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure unit tests for the spec-health scoring projector.
+ *
+ * Verifies that each signal contributes the documented weight, that
+ * the band boundaries snap to the right tone, and that the
+ * recency-weighted repo score behaves as a weighted average.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  repoSpecScore,
+  scoreEpicSpec,
+  type SpecScoreInput,
+} from "@/lib/agentic-sdlc/spec-scoring";
+
+function baseInput(overrides: Partial<SpecScoreInput> = {}): SpecScoreInput {
+  return {
+    epic_id: "EPIC_1",
+    title: "Add OAuth device flow",
+    github_url: "https://example/repo/issues/1",
+    body_excerpt: "",
+    labels: [],
+    last_event_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("scoreEpicSpec", () => {
+  it("scores 0 when the body has no signals", () => {
+    const r = scoreEpicSpec(baseInput({ body_excerpt: "" }));
+    expect(r.score).toBe(0);
+    expect(r.band).toBe("weak");
+    expect(r.criteria.every((c) => !c.present)).toBe(true);
+  });
+
+  it("counts acceptance criteria via Given/When/Then", () => {
+    const r = scoreEpicSpec(
+      baseInput({
+        body_excerpt: "Given a logged in user when they tap login then …",
+      }),
+    );
+    expect(r.criteria.find((c) => c.kind === "acceptance_criteria")?.present)
+      .toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(30);
+  });
+
+  it("counts NFR via latency / p99 / cost budget", () => {
+    const r = scoreEpicSpec(baseInput({ body_excerpt: "p99 latency under 200ms, cost budget $200" }));
+    expect(
+      r.criteria.find((c) => c.kind === "non_functional_requirements")?.present,
+    ).toBe(true);
+  });
+
+  it("counts ADR link via docs/adr path or ADR-xxx", () => {
+    const r = scoreEpicSpec(baseInput({ body_excerpt: "see docs/adr/2026-05-09-foo.md" }));
+    expect(r.criteria.find((c) => c.kind === "adr_link")?.present).toBe(true);
+  });
+
+  it("counts test strategy when 'tests' label is set even without prose", () => {
+    const r = scoreEpicSpec(baseInput({ labels: ["tests"], body_excerpt: "no prose at all" }));
+    expect(r.criteria.find((c) => c.kind === "test_strategy")?.present).toBe(true);
+  });
+
+  it("clamps to 0..100 and reports band 'strong' at 85+", () => {
+    const r = scoreEpicSpec(
+      baseInput({
+        body_excerpt: [
+          "Acceptance criteria",
+          "Given user, when X, then Y",
+          "p99 latency budget 200ms",
+          "Constraint: must not write to prod",
+          "Test plan: 80% unit coverage",
+          "Compute budget 8 hours",
+          "see docs/adr/2026-05-09-foo.md",
+        ].join("\n"),
+      }),
+    );
+    expect(r.score).toBeGreaterThanOrEqual(85);
+    expect(r.band).toBe("strong");
+  });
+
+  it("returns missing-criteria hints for absent signals", () => {
+    const r = scoreEpicSpec(baseInput({ body_excerpt: "just a vague idea" }));
+    for (const c of r.criteria) {
+      if (!c.present) expect(c.hint?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("repoSpecScore", () => {
+  it("returns 0 when there are no epics", () => {
+    expect(repoSpecScore([])).toBe(0);
+  });
+
+  it("weights newer epics more heavily", () => {
+    const newer = scoreEpicSpec(
+      baseInput({
+        epic_id: "n",
+        body_excerpt: "Acceptance criteria Given ...",
+        last_event_at: new Date().toISOString(),
+      }),
+    );
+    const older = scoreEpicSpec(
+      baseInput({
+        epic_id: "o",
+        body_excerpt: "vague",
+        last_event_at: new Date(
+          Date.now() - 365 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      }),
+    );
+    const repo = repoSpecScore([newer, older]);
+    // Should pull more toward the newer epic's score.
+    expect(repo).toBeGreaterThan(Math.min(newer.score, older.score));
+    expect(repo).toBeLessThanOrEqual(newer.score);
+  });
+});

--- a/ui/src/app/api/agentic-sdlc/me/panel-prefs/route.ts
+++ b/ui/src/app/api/agentic-sdlc/me/panel-prefs/route.ts
@@ -1,0 +1,110 @@
+/**
+ * GET / PUT /api/agentic-sdlc/me/panel-prefs?surface=repo_detail|home
+ *
+ * Per-user, per-surface UI preferences for the Agentic SDLC. Each
+ * surface (repo_detail, home) has an independent preference profile
+ * so the user can configure them separately.
+ *
+ * GET   → returns the user's preferences for the surface, or the
+ *         defaults from the registry if nothing is stored.
+ * PUT   → upserts the preferences for the surface and returns the
+ *         normalised, stored value.
+ *
+ * Both routes are auth-gated by `requireAgenticSdlcReader`, which
+ * already supports the SHIP_LOOP_ALLOW_NO_AUTH dev escape hatch.
+ *
+ * Server-only.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  defaultPreferences,
+  normalisePreferences,
+  type PanelPreferences,
+} from "@/lib/agentic-sdlc/panel-preferences";
+import type { PanelSurface } from "@/lib/agentic-sdlc/panel-registry";
+import { requireAgenticSdlcReader } from "@/lib/agentic-sdlc/agentic-sdlc-auth";
+import { withAgenticSdlcGate } from "@/lib/agentic-sdlc/guard";
+import {
+  readPanelPreferences,
+  writePanelPreferences,
+} from "@/lib/agentic-sdlc/user-prefs-store";
+
+function parseSurface(req: Request): PanelSurface | null {
+  const url = new URL(req.url);
+  const v = url.searchParams.get("surface");
+  if (v === "repo_detail" || v === "home") return v;
+  return null;
+}
+
+async function handleGet(req: Request): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+  const surface = parseSurface(req);
+  if (!surface) {
+    return Response.json(
+      { error: "bad_request", message: "Missing or invalid surface." },
+      { status: 400 },
+    );
+  }
+  try {
+    const prefs = await readPanelPreferences(reader.user.email, surface);
+    return Response.json({ preferences: prefs });
+  } catch {
+    // Mongo not reachable in dev — fall back to defaults rather than
+    // turning the panel into a 500 page.
+    return Response.json({ preferences: defaultPreferences(surface) });
+  }
+}
+
+async function handlePut(req: Request): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+  const surface = parseSurface(req);
+  if (!surface) {
+    return Response.json(
+      { error: "bad_request", message: "Missing or invalid surface." },
+      { status: 400 },
+    );
+  }
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json(
+      { error: "bad_request", message: "Body must be JSON." },
+      { status: 400 },
+    );
+  }
+  const incoming = (body as { preferences?: unknown })?.preferences;
+  const normalised: PanelPreferences = normalisePreferences(incoming, surface);
+  try {
+    const stored = await writePanelPreferences(
+      reader.user.email,
+      surface,
+      normalised,
+    );
+    return Response.json({ preferences: stored });
+  } catch {
+    // Persistence failure is non-fatal at the API surface — the client
+    // keeps its localStorage copy and will retry on next change.
+    return Response.json(
+      { preferences: normalised, persisted: false },
+      { status: 202 },
+    );
+  }
+}
+
+export const GET = withAgenticSdlcGate(handleGet);
+export const PUT = withAgenticSdlcGate(handlePut);

--- a/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/changelog/route.ts
+++ b/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/changelog/route.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /api/agentic-sdlc/repos/{owner}/{repo}/changelog
+ *
+ * Completed-feature changelog: merged Epics, merged PRs, and
+ * successful deploys in the lookback window.
+ *
+ * Query params:
+ *   - lookbackDays (default 30, max 365)
+ *   - limit        (default 50, max 200)
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { getAgenticSdlcReposCollection } from "@/lib/agentic-sdlc/mongo-collections";
+import { withAgenticSdlcGate } from "@/lib/agentic-sdlc/guard";
+import { requireAgenticSdlcReader } from "@/lib/agentic-sdlc/agentic-sdlc-auth";
+import { getChangelogEntries } from "@/lib/agentic-sdlc/repo-insights";
+
+async function handle(
+  req: Request,
+  ctx: { params: Promise<{ owner: string; repo: string }> },
+): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+
+  const { owner, repo } = await ctx.params;
+  const repos = await getAgenticSdlcReposCollection();
+  const repoDoc = await repos.findOne(
+    { owner, name: repo, offboarded_at: null },
+    { projection: { repo_id: 1 } },
+  );
+  if (!repoDoc) {
+    return Response.json(
+      { error: "not_found", message: "Repo not onboarded." },
+      { status: 404 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const lookbackDays = positiveIntegerParam(url.searchParams.get("lookbackDays"));
+  const limit = positiveIntegerParam(url.searchParams.get("limit"));
+
+  const entries = await getChangelogEntries(repoDoc.repo_id, {
+    lookbackDays,
+    limit,
+  });
+
+  return Response.json({
+    repo: { owner, name: repo },
+    lookback_days: lookbackDays ?? 30,
+    items: entries,
+  });
+}
+
+function positiveIntegerParam(value: string | null): number | undefined {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export const GET = withAgenticSdlcGate(handle);

--- a/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/ci/route.ts
+++ b/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/ci/route.ts
@@ -1,0 +1,306 @@
+/**
+ * GET /api/agentic-sdlc/repos/{owner}/{repo}/ci
+ *
+ * CI status for every in-flight task / PR on the repo. Reads the
+ * `ci_summary` field maintained by the async worker (see
+ * `lib/agentic-sdlc/ci-projection.ts`) and falls back to the stored
+ * check_run / check_suite / workflow_run events when callers ask for
+ * the per-check breakdown.
+ *
+ * Optional `?live=true` query: if a server-side GitHub token is
+ * configured (`process.env.GITHUB_TOKEN`), the route refreshes CI
+ * directly from the GitHub API for the heads we already know about.
+ * Live results are merged into the response so the panel can show
+ * fresh data when webhooks have lagged.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  getAgenticSdlcEventsCollection,
+  getAgenticSdlcReposCollection,
+} from "@/lib/agentic-sdlc/mongo-collections";
+import { withAgenticSdlcGate } from "@/lib/agentic-sdlc/guard";
+import { requireAgenticSdlcReader } from "@/lib/agentic-sdlc/agentic-sdlc-auth";
+import { getInFlightCi, type InFlightCiArtifact } from "@/lib/agentic-sdlc/repo-insights";
+import {
+  normaliseConclusion,
+  normaliseStatus,
+} from "@/lib/agentic-sdlc/ci-projection";
+import type { AgenticSdlcEvent, CiCheckRun } from "@/types/agentic-sdlc";
+
+interface RepoCiResponse {
+  repo: { owner: string; name: string };
+  totals: {
+    success: number;
+    failure: number;
+    pending: number;
+    no_ci: number;
+  };
+  items: Array<
+    InFlightCiArtifact & {
+      checks: CiCheckRun[];
+    }
+  >;
+  live_refreshed: boolean;
+}
+
+async function handle(
+  req: Request,
+  ctx: { params: Promise<{ owner: string; repo: string }> },
+): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+
+  const { owner, repo } = await ctx.params;
+  const repos = await getAgenticSdlcReposCollection();
+  const repoDoc = await repos.findOne(
+    { owner, name: repo, offboarded_at: null },
+    { projection: { repo_id: 1, full_name: 1 } },
+  );
+  if (!repoDoc) {
+    return Response.json(
+      { error: "not_found", message: "Repo not onboarded." },
+      { status: 404 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const wantsLive = url.searchParams.get("live") === "true";
+  const inFlight = await getInFlightCi(repoDoc.repo_id, {
+    limit: positiveIntegerParam(url.searchParams.get("limit")),
+  });
+
+  // Per-check breakdown from the events collection for the artifact
+  // ids we care about. One query per artifact would be too chatty, so
+  // we bulk-load with a single `$in` query and group client-side.
+  const artifactIds = inFlight.items.map((item) => item.artifact_id);
+  const checksByArtifact = new Map<string, CiCheckRun[]>();
+  if (artifactIds.length > 0) {
+    const events = await getAgenticSdlcEventsCollection();
+    const rows = (await events
+      .find(
+        {
+          repo_id: repoDoc.repo_id,
+          artifact_id: { $in: artifactIds },
+          github_event_type: { $in: ["check_run", "check_suite", "workflow_run"] },
+        },
+        {
+          projection: { _id: 0, payload: 1, artifact_id: 1, occurred_at: 1, github_event_type: 1, github_delivery_id: 1 },
+          sort: { occurred_at: -1 },
+          limit: artifactIds.length * 30,
+        },
+      )
+      .toArray()) as Array<
+      Pick<
+        AgenticSdlcEvent,
+        | "payload"
+        | "artifact_id"
+        | "occurred_at"
+        | "github_event_type"
+        | "github_delivery_id"
+      > & { repo_id?: string }
+    >;
+    for (const row of rows) {
+      const parsed = parseRowToCheck(row, repoDoc.repo_id);
+      if (!parsed) continue;
+      const existing = checksByArtifact.get(parsed.artifact_id) ?? [];
+      // Latest per check_name wins.
+      const idx = existing.findIndex((c) => c.check_name === parsed.check_name);
+      if (idx < 0) existing.push(parsed);
+      else if (
+        Date.parse(parsed.completed_at ?? parsed.started_at ?? "") >
+        Date.parse(existing[idx].completed_at ?? existing[idx].started_at ?? "")
+      ) {
+        existing[idx] = parsed;
+      }
+      checksByArtifact.set(parsed.artifact_id, existing);
+    }
+  }
+
+  let liveRefreshed = false;
+  if (wantsLive) {
+    liveRefreshed = await tryLiveRefresh(owner, repo, inFlight.items, checksByArtifact);
+  }
+
+  const items = inFlight.items.map((item) => ({
+    ...item,
+    checks: (checksByArtifact.get(item.artifact_id) ?? []).sort(
+      (a, b) => a.check_name.localeCompare(b.check_name),
+    ),
+  }));
+
+  const body: RepoCiResponse = {
+    repo: { owner, name: repo },
+    totals: inFlight.totals,
+    items,
+    live_refreshed: liveRefreshed,
+  };
+  return Response.json(body);
+}
+
+function parseRowToCheck(
+  row: {
+    payload: Record<string, unknown> | unknown;
+    artifact_id: string;
+    occurred_at: Date;
+    github_event_type: string | null;
+    github_delivery_id: string | null;
+  },
+  repoId: string,
+): CiCheckRun | null {
+  const payload = (row.payload ?? {}) as Record<string, unknown>;
+  if (row.github_event_type === "check_run") {
+    const run = payload.check_run as Record<string, unknown> | undefined;
+    if (!run) return null;
+    const status = normaliseStatus(run.status as string | undefined);
+    return {
+      artifact_id: row.artifact_id,
+      repo_id: repoId,
+      check_name: (run.name as string | undefined) ?? "check",
+      external_id:
+        toExternalId(run.id) ?? `${row.github_delivery_id ?? "anon"}:check_run`,
+      status,
+      conclusion:
+        status === "completed"
+          ? normaliseConclusion(run.conclusion as string | undefined)
+          : "pending",
+      details_url: (run.details_url as string | undefined) ?? null,
+      started_at: (run.started_at as string | undefined) ?? null,
+      completed_at: (run.completed_at as string | undefined) ?? null,
+      head_sha: (run.head_sha as string | undefined) ?? null,
+    };
+  }
+  if (row.github_event_type === "check_suite") {
+    const suite = payload.check_suite as Record<string, unknown> | undefined;
+    if (!suite) return null;
+    const status = normaliseStatus(suite.status as string | undefined);
+    return {
+      artifact_id: row.artifact_id,
+      repo_id: repoId,
+      check_name: "check_suite",
+      external_id:
+        toExternalId(suite.id) ?? `${row.github_delivery_id ?? "anon"}:check_suite`,
+      status,
+      conclusion:
+        status === "completed"
+          ? normaliseConclusion(suite.conclusion as string | undefined)
+          : "pending",
+      details_url: (suite.url as string | undefined) ?? null,
+      started_at: null,
+      completed_at: (suite.updated_at as string | undefined) ?? null,
+      head_sha: (suite.head_sha as string | undefined) ?? null,
+    };
+  }
+  if (row.github_event_type === "workflow_run") {
+    const run = payload.workflow_run as Record<string, unknown> | undefined;
+    if (!run) return null;
+    const status = normaliseStatus(run.status as string | undefined);
+    return {
+      artifact_id: row.artifact_id,
+      repo_id: repoId,
+      check_name: (run.name as string | undefined) ?? "workflow",
+      external_id:
+        toExternalId(run.id) ?? `${row.github_delivery_id ?? "anon"}:workflow_run`,
+      status,
+      conclusion:
+        status === "completed"
+          ? normaliseConclusion(run.conclusion as string | undefined)
+          : "pending",
+      details_url: (run.html_url as string | undefined) ?? null,
+      started_at: (run.run_started_at as string | undefined) ?? null,
+      completed_at: (run.updated_at as string | undefined) ?? null,
+      head_sha: (run.head_sha as string | undefined) ?? null,
+    };
+  }
+  return null;
+}
+
+function toExternalId(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+/**
+ * Best-effort live refresh: when a server-side GitHub token is set,
+ * fetch check-runs for each known head SHA and overlay onto the
+ * existing per-check map. Fails silently when no token is present or
+ * the call errors -- the projected data is still returned.
+ */
+async function tryLiveRefresh(
+  owner: string,
+  repo: string,
+  items: InFlightCiArtifact[],
+  checksByArtifact: Map<string, CiCheckRun[]>,
+): Promise<boolean> {
+  const token = process.env.GITHUB_TOKEN ?? process.env.AGENTIC_SDLC_GITHUB_TOKEN;
+  if (!token) return false;
+
+  // Resolve unique head SHAs we know about; skip artifacts without one.
+  const heads = items
+    .filter((item) => item.kind === "pull_request" && item.head_sha)
+    .map((item) => ({ artifact_id: item.artifact_id, head_sha: item.head_sha as string }));
+  if (heads.length === 0) return false;
+
+  // Lazy-import Octokit so unit tests that don't exercise the live
+  // branch don't pull the SDK in.
+  let Octokit: typeof import("@octokit/rest").Octokit;
+  try {
+    Octokit = (await import("@octokit/rest")).Octokit;
+  } catch {
+    return false;
+  }
+  const octokit = new Octokit({ auth: token, request: { timeout: 8_000 } });
+
+  let refreshed = false;
+  await Promise.all(
+    heads.map(async ({ artifact_id, head_sha }) => {
+      try {
+        const res = await octokit.checks.listForRef({
+          owner,
+          repo,
+          ref: head_sha,
+          per_page: 50,
+        });
+        const liveChecks: CiCheckRun[] = res.data.check_runs.map((run) => ({
+          artifact_id,
+          repo_id: "live",
+          check_name: run.name ?? "check",
+          external_id: String(run.id),
+          status: normaliseStatus(run.status as string | undefined),
+          conclusion:
+            run.status === "completed"
+              ? normaliseConclusion(run.conclusion as string | undefined)
+              : "pending",
+          details_url: run.details_url ?? null,
+          started_at: run.started_at ?? null,
+          completed_at: run.completed_at ?? null,
+          head_sha,
+        }));
+        const existing = checksByArtifact.get(artifact_id) ?? [];
+        const mergedByName = new Map<string, CiCheckRun>();
+        for (const c of existing) mergedByName.set(c.check_name, c);
+        for (const c of liveChecks) mergedByName.set(c.check_name, c);
+        checksByArtifact.set(artifact_id, Array.from(mergedByName.values()));
+        refreshed = true;
+      } catch {
+        // Swallow per-artifact errors -- a single failure shouldn't
+        // disable the live overlay for the rest.
+      }
+    }),
+  );
+  return refreshed;
+}
+
+function positiveIntegerParam(value: string | null): number | undefined {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export const GET = withAgenticSdlcGate(handle);

--- a/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/deploy-health/route.ts
+++ b/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/deploy-health/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/agentic-sdlc/repos/{owner}/{repo}/deploy-health
+ *
+ * Rich per-environment deployment health: success rate, failure
+ * count, median duration, median recovery (MTTR-ish), recent deploys,
+ * and failure reasons. Driven by `deployment_status` events plus the
+ * projected `deploy` artifacts. See
+ * `lib/agentic-sdlc/repo-insights.ts#getDeploymentHealth`.
+ *
+ * Query params:
+ *   - windowHours (default 168 = 7d, max 2160 = 90d)
+ *   - recentPerEnv (default 10, max 50)
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { getAgenticSdlcReposCollection } from "@/lib/agentic-sdlc/mongo-collections";
+import { withAgenticSdlcGate } from "@/lib/agentic-sdlc/guard";
+import { requireAgenticSdlcReader } from "@/lib/agentic-sdlc/agentic-sdlc-auth";
+import { getDeploymentHealth } from "@/lib/agentic-sdlc/repo-insights";
+
+async function handle(
+  req: Request,
+  ctx: { params: Promise<{ owner: string; repo: string }> },
+): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+
+  const { owner, repo } = await ctx.params;
+  const repos = await getAgenticSdlcReposCollection();
+  const repoDoc = await repos.findOne(
+    { owner, name: repo, offboarded_at: null },
+    { projection: { repo_id: 1 } },
+  );
+  if (!repoDoc) {
+    return Response.json(
+      { error: "not_found", message: "Repo not onboarded." },
+      { status: 404 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const windowHours = positiveIntegerParam(url.searchParams.get("windowHours"));
+  const recentPerEnv = positiveIntegerParam(url.searchParams.get("recentPerEnv"));
+
+  const health = await getDeploymentHealth(repoDoc.repo_id, {
+    windowHours,
+    recentPerEnv,
+  });
+
+  return Response.json({
+    repo: { owner, name: repo },
+    ...health,
+  });
+}
+
+function positiveIntegerParam(value: string | null): number | undefined {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export const GET = withAgenticSdlcGate(handle);

--- a/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/insights/[panel]/route.ts
+++ b/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/insights/[panel]/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Multiplexed insights endpoint for the Agentic SDLC repo detail page.
+ *
+ *   GET /api/agentic-sdlc/repos/{owner}/{repo}/insights/{panel}
+ *
+ * The dynamic `panel` segment is the PanelId from the panel-registry,
+ * for example `spec-health`, `intent-drift`, `harness`, `provenance`.
+ *
+ * One handler per panel keeps the data contract narrow without paying
+ * the overhead of N near-identical route files. Each panel resolves to
+ * a deterministic JSON payload sourced from
+ * `repo-extended-insights.ts`.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { getAgenticSdlcReposCollection } from "@/lib/agentic-sdlc/mongo-collections";
+import { withAgenticSdlcGate } from "@/lib/agentic-sdlc/guard";
+import { requireAgenticSdlcReader } from "@/lib/agentic-sdlc/agentic-sdlc-auth";
+import {
+  getAgentBudget,
+  getAgentRoster,
+  getBlackboxAudit,
+  getBlastRadius,
+  getFailureModes,
+  getFanout,
+  getHarness,
+  getIntentDrift,
+  getMistakeEncoded,
+  getPrProdMetrics,
+  getProdSignals,
+  getProvenance,
+  getQualityGauntlet,
+  getRingActivity,
+  getRollbackRehearsal,
+  getSpecHealth,
+  getVerifierConfidence,
+} from "@/lib/agentic-sdlc/repo-extended-insights";
+
+const PANEL_HANDLERS: Record<string, (repoId: string) => Promise<unknown>> = {
+  "ring-activity": getRingActivity,
+  "spec-health": getSpecHealth,
+  "intent-drift": getIntentDrift,
+  harness: getHarness,
+  "mistake-encoded": getMistakeEncoded,
+  "agent-roster": getAgentRoster,
+  "agent-budget": getAgentBudget,
+  fanout: getFanout,
+  "verifier-confidence": getVerifierConfidence,
+  "quality-gauntlet": getQualityGauntlet,
+  "failure-modes": getFailureModes,
+  provenance: getProvenance,
+  "blast-radius": getBlastRadius,
+  "rollback-rehearsal": getRollbackRehearsal,
+  "prod-signals": getProdSignals,
+  "pr-prod-metrics": getPrProdMetrics,
+  "blackbox-audit": getBlackboxAudit,
+};
+
+async function handle(
+  req: Request,
+  ctx: { params: Promise<{ owner: string; repo: string; panel: string }> },
+): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+
+  const { owner, repo, panel } = await ctx.params;
+  const handler = PANEL_HANDLERS[panel];
+  if (!handler) {
+    return Response.json(
+      { error: "unknown_panel", message: `No insights for panel '${panel}'.` },
+      { status: 404 },
+    );
+  }
+
+  const repos = await getAgenticSdlcReposCollection();
+  const repoDoc = await repos.findOne(
+    { owner, name: repo, offboarded_at: null },
+    { projection: { _id: 0, repo_id: 1 } },
+  );
+  if (!repoDoc) {
+    return Response.json(
+      { error: "not_found", message: "Repo not onboarded." },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const payload = await handler(repoDoc.repo_id);
+    return Response.json(payload);
+  } catch (err) {
+    return Response.json(
+      {
+        error: "insights_error",
+        message: err instanceof Error ? err.message : "Failed to compute insights.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = withAgenticSdlcGate(handle);

--- a/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/snapshots/route.ts
+++ b/ui/src/app/api/agentic-sdlc/repos/[owner]/[repo]/snapshots/route.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/agentic-sdlc/repos/{owner}/{repo}/snapshots
+ *
+ * Snapshot artifacts produced during the last X runs: GitHub Actions
+ * workflow runs, deploy snapshots, and recently-touched agentic
+ * artifacts. See `lib/agentic-sdlc/repo-insights.ts#getRecentSnapshots`.
+ *
+ * Query params:
+ *   - recentRuns  (default 5, max 50)
+ *   - windowHours (default 24, max 720)
+ *   - kinds       comma-separated subset of
+ *                 `github_actions_artifact,deploy_snapshot,agentic_artifact`
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { getAgenticSdlcReposCollection } from "@/lib/agentic-sdlc/mongo-collections";
+import { withAgenticSdlcGate } from "@/lib/agentic-sdlc/guard";
+import { requireAgenticSdlcReader } from "@/lib/agentic-sdlc/agentic-sdlc-auth";
+import { getRecentSnapshots } from "@/lib/agentic-sdlc/repo-insights";
+import type { SnapshotArtifactKind } from "@/types/agentic-sdlc";
+
+const ALLOWED_KINDS: SnapshotArtifactKind[] = [
+  "github_actions_artifact",
+  "deploy_snapshot",
+  "agentic_artifact",
+];
+
+async function handle(
+  req: Request,
+  ctx: { params: Promise<{ owner: string; repo: string }> },
+): Promise<Response> {
+  const reader = await requireAgenticSdlcReader(req);
+  if (!reader) {
+    return Response.json(
+      { error: "unauthenticated", message: "Sign in required." },
+      { status: 401 },
+    );
+  }
+
+  const { owner, repo } = await ctx.params;
+  const repos = await getAgenticSdlcReposCollection();
+  const repoDoc = await repos.findOne(
+    { owner, name: repo, offboarded_at: null },
+    { projection: { repo_id: 1 } },
+  );
+  if (!repoDoc) {
+    return Response.json(
+      { error: "not_found", message: "Repo not onboarded." },
+      { status: 404 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const recentRuns = positiveIntegerParam(url.searchParams.get("recentRuns"));
+  const windowHours = positiveIntegerParam(url.searchParams.get("windowHours"));
+  const kinds = parseKinds(url.searchParams.get("kinds"));
+
+  const snapshots = await getRecentSnapshots(repoDoc.repo_id, {
+    recentRuns,
+    windowHours,
+    kinds,
+  });
+
+  return Response.json({
+    repo: { owner, name: repo },
+    window_hours: windowHours ?? 24,
+    recent_runs: recentRuns ?? 5,
+    by_kind: snapshots.by_kind,
+    items: snapshots.items,
+  });
+}
+
+function parseKinds(raw: string | null): SnapshotArtifactKind[] | undefined {
+  if (!raw) return undefined;
+  const requested = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter((s): s is SnapshotArtifactKind =>
+      ALLOWED_KINDS.includes(s as SnapshotArtifactKind),
+    );
+  return requested.length > 0 ? requested : undefined;
+}
+
+function positiveIntegerParam(value: string | null): number | undefined {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export const GET = withAgenticSdlcGate(handle);

--- a/ui/src/app/api/agentic-sdlc/webhooks/github/route.ts
+++ b/ui/src/app/api/agentic-sdlc/webhooks/github/route.ts
@@ -51,6 +51,7 @@ const ACCEPTED_EVENT_TYPES = new Set<string>([
   "push",
   "check_run",
   "check_suite",
+  "workflow_run",
   "deployment",
   "deployment_status",
   "label",
@@ -290,6 +291,44 @@ function summariseEvent(
     artifactId = child.subIssue?.node_id ?? "";
     occurredAt = child.subIssue?.updated_at ? new Date(child.subIssue.updated_at) : new Date();
     epicId = child.parentIssue?.node_id ?? null;
+  } else if (eventType === "check_run") {
+    artifactKind = "pull_request";
+    const checkRun = payload.check_run as
+      | {
+          id?: number | string;
+          completed_at?: string;
+          started_at?: string;
+          pull_requests?: { node_id?: string }[];
+        }
+      | undefined;
+    artifactId = checkRun?.pull_requests?.[0]?.node_id ?? "";
+    occurredAt = checkRun?.completed_at
+      ? new Date(checkRun.completed_at)
+      : checkRun?.started_at
+        ? new Date(checkRun.started_at)
+        : new Date();
+  } else if (eventType === "check_suite") {
+    artifactKind = "pull_request";
+    const suite = payload.check_suite as
+      | {
+          id?: number | string;
+          updated_at?: string;
+          pull_requests?: { node_id?: string }[];
+        }
+      | undefined;
+    artifactId = suite?.pull_requests?.[0]?.node_id ?? "";
+    occurredAt = suite?.updated_at ? new Date(suite.updated_at) : new Date();
+  } else if (eventType === "workflow_run") {
+    artifactKind = "unknown";
+    const run = payload.workflow_run as
+      | {
+          node_id?: string;
+          updated_at?: string;
+          pull_requests?: { node_id?: string }[];
+        }
+      | undefined;
+    artifactId = run?.pull_requests?.[0]?.node_id ?? run?.node_id ?? "";
+    occurredAt = run?.updated_at ? new Date(run.updated_at) : new Date();
   } else if (eventType === "label") {
     artifactKind = "label";
   }

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -3,6 +3,32 @@
 @plugin "@tailwindcss/typography";
 
 /* ========================================
+   STABLE SCROLLBAR GUTTER
+   Reserve space for the vertical scrollbar even when content is short,
+   so collapsing a panel never causes the page to widen by the scrollbar
+   width and re-center.
+   ======================================== */
+html {
+  scrollbar-gutter: stable;
+}
+
+/* ========================================
+   STRETCHED LINK
+   Helper that styles an absolutely positioned <a> overlay that covers
+   the entire Agentic Apps Hub card. The link itself has no visible
+   content (only sr-only text); the visible card body sits above it via
+   `z-10` so existing controls keep working.
+   ======================================== */
+.appcard-stretched-link {
+  background-color: transparent;
+}
+/* Echo hover on the visible title when the stretched link is hovered.
+   Use a slightly higher specificity than Tailwind's text-* utilities. */
+article:has(.appcard-stretched-link:hover) > h2 {
+  color: rgb(207 250 254); /* cyan-100 */
+}
+
+/* ========================================
    TAILWIND v4 THEME — replaces tailwind.config.ts
    ======================================== */
 
@@ -859,4 +885,70 @@ pre code.hljs {
 [data-radix-scroll-area-viewport] > div {
   display: block !important;
   min-width: 0 !important;
+}
+
+/* ========================================
+   AGENTIC SDLC — Resizable grid overrides
+   Theme RGL handles/placeholders to match dark glass UI
+   ======================================== */
+.agentic-sdlc-grid {
+  position: relative;
+}
+
+.agentic-sdlc-grid .react-grid-item {
+  /* Let the inner CollapsiblePanel paint the background; RGL's default
+     borders/backgrounds would clash with the glass-panel look. */
+  background: transparent;
+  transition: transform 200ms ease, box-shadow 150ms ease;
+}
+
+.agentic-sdlc-grid .react-grid-item.react-grid-placeholder {
+  background: hsl(var(--primary) / 0.15) !important;
+  border: 1px dashed hsl(var(--primary) / 0.45);
+  border-radius: 0.75rem;
+  opacity: 1;
+}
+
+.agentic-sdlc-grid .react-grid-item.react-draggable-dragging,
+.agentic-sdlc-grid .react-grid-item.resizing {
+  z-index: 30;
+  box-shadow: 0 10px 30px hsl(0 0% 0% / 0.45);
+}
+
+.agentic-sdlc-grid .react-resizable-handle {
+  background-image: none;
+  width: 18px;
+  height: 18px;
+  bottom: 4px;
+  right: 4px;
+  opacity: 0.7;
+}
+
+.agentic-sdlc-grid .react-resizable-handle::after {
+  content: "";
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid hsl(var(--muted-foreground));
+  border-bottom: 2px solid hsl(var(--muted-foreground));
+  border-bottom-right-radius: 2px;
+}
+
+.agentic-sdlc-grid .react-resizable-handle:hover {
+  opacity: 1;
+}
+
+/* In grid mode, the entire panel header becomes the drag handle. Hint
+   with grab cursor on hover; switch to grabbing while dragging. */
+.agentic-sdlc-grid .collapsible-panel-header {
+  cursor: grab;
+  user-select: none;
+}
+.agentic-sdlc-grid .collapsible-panel-header:active {
+  cursor: grabbing;
+}
+.agentic-sdlc-grid .collapsible-panel-header button {
+  cursor: pointer;
 }

--- a/ui/src/components/agentic-apps/AgenticAppsHub.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppsHub.tsx
@@ -147,7 +147,7 @@ export function AgenticAppsHub({ apps }: AgenticAppsHubProps) {
                   <div
                     className={`absolute -right-20 -top-24 h-48 w-48 rounded-full bg-gradient-to-br ${presentation.glow} opacity-80 blur-3xl transition group-hover:opacity-100`}
                   />
-                  <div className="relative flex items-start justify-between gap-3">
+                  <div className="relative z-10 flex items-start justify-between gap-3">
                     <div
                       aria-label={`${app.displayName} app icon`}
                       className={`flex h-11 w-11 items-center justify-center rounded-2xl border border-white/15 bg-gradient-to-br ${presentation.gradient} text-white shadow-2xl shadow-slate-950/30`}
@@ -211,27 +211,38 @@ export function AgenticAppsHub({ apps }: AgenticAppsHubProps) {
                     </div>
                   </div>
 
-                  <div className="relative mt-4 flex items-center gap-2">
+                  <div className="relative z-10 mt-4 flex items-center gap-2">
                     <span className={`rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${presentation.badge}`}>
                       {presentation.category}
                     </span>
                   </div>
 
-                  <h2 className="relative mt-3 line-clamp-1 text-lg font-semibold text-white">
+                  {isBlocked ? null : (
+                    <a
+                      href={resolveAgenticAppLaunchUrl(app)}
+                      aria-label={`Launch ${app.displayName}`}
+                      title={`Launch ${app.displayName}`}
+                      className="appcard-stretched-link absolute inset-0 z-0 rounded-[1.35rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/60"
+                    >
+                      <span className="sr-only">Launch {app.displayName}</span>
+                    </a>
+                  )}
+
+                  <h2 className="relative z-10 mt-3 line-clamp-1 text-lg font-semibold text-white">
                     {app.displayName}
                   </h2>
-                  <p className="relative mt-2 line-clamp-3 flex-1 text-xs leading-5 text-slate-300">
+                  <p className="relative z-10 mt-2 line-clamp-3 flex-1 text-xs leading-5 text-slate-300">
                     {app.description}
                   </p>
 
                   {isBlocked ? (
-                    <div className="relative mt-3 rounded-2xl border border-amber-200/20 bg-amber-300/10 px-3 py-2 text-xs text-amber-100">
+                    <div className="relative z-10 mt-3 rounded-2xl border border-amber-200/20 bg-amber-300/10 px-3 py-2 text-xs text-amber-100">
                       <p className="font-semibold">Launch blocked</p>
                       <p className="mt-1 text-amber-100/80">{blockedLabel}</p>
                     </div>
                   ) : null}
 
-                  <div className="relative mt-4 flex flex-wrap gap-1.5">
+                  <div className="relative z-10 mt-4 flex flex-wrap gap-1.5">
                     {app.access.tokenScopes.slice(0, 3).map((scope) => (
                       <span
                         key={scope}

--- a/ui/src/components/agentic-sdlc/AgenticSdlcLayoutHost.tsx
+++ b/ui/src/components/agentic-sdlc/AgenticSdlcLayoutHost.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * AgenticSdlcLayoutHost — chooses between the section masonry and the
+ * resizable grid based on user preferences, and isolates the heavy
+ * react-grid-layout bundle behind a dynamic import.
+ *
+ * The grid renderer touches browser globals (ResizeObserver,
+ * matchMedia) so it must not run during SSR. While that bundle loads,
+ * we fall back to the existing SectionRenderer-driven layout so the
+ * page is never blank.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import dynamic from "next/dynamic";
+import { useMemo } from "react";
+
+import {
+  renderPanel,
+  type PanelContext,
+} from "@/components/agentic-sdlc/SectionRenderer";
+import type { UsePanelPreferencesResult } from "@/hooks/use-panel-preferences";
+import { resolvePanelLayout } from "@/lib/agentic-sdlc/panel-preferences";
+import {
+  getPanel,
+  SECTION_ORDER,
+  type PanelId,
+  type PanelSurface,
+} from "@/lib/agentic-sdlc/panel-registry";
+
+const ResizableSectionGrid = dynamic(
+  () =>
+    import("@/components/agentic-sdlc/ResizableSectionGrid").then(
+      (m) => m.ResizableSectionGrid,
+    ),
+  { ssr: false, loading: () => null },
+);
+
+interface AgenticSdlcLayoutHostProps {
+  surface: PanelSurface;
+  prefs: UsePanelPreferencesResult;
+  context: PanelContext;
+  /**
+   * Sections that should be rendered by the masonry only (the grid
+   * doesn't draw them at all). Used for the repo detail page where the
+   * hero ring is rendered as a header overlay rather than as a panel.
+   */
+  excludePanelIds?: ReadonlyArray<string>;
+}
+
+export function AgenticSdlcLayoutHost({
+  surface,
+  prefs,
+  context,
+  excludePanelIds,
+}: AgenticSdlcLayoutHostProps) {
+  const { preferences, setGridLayout } = prefs;
+  const layout = useMemo(() => resolvePanelLayout(preferences), [preferences]);
+
+  if (preferences.gridEnabled) {
+    return (
+      <ResizableSectionGrid
+        surface={surface}
+        preferences={preferences}
+        setGridLayout={setGridLayout}
+        context={context}
+      />
+    );
+  }
+
+  // Masonry mode: flatten every visible panel across sections so a
+  // run of half-size panels can tile across CSS columns even when they
+  // originate from different sections. This eliminates the empty bands
+  // that previously appeared between sections of differing height.
+  const flatPanelIds: PanelId[] = [];
+  for (const section of SECTION_ORDER) {
+    for (const id of layout[section] ?? []) {
+      if (excludePanelIds?.includes(id)) continue;
+      flatPanelIds.push(id);
+    }
+  }
+
+  // Split into runs: contiguous half-size panels share a CSS-columns
+  // block (so they pack with no vertical gaps), and each full-size
+  // panel renders as its own full-width row.
+  const runs: Array<
+    | { kind: "full"; id: PanelId }
+    | { kind: "half"; ids: PanelId[] }
+  > = [];
+  let buffer: PanelId[] = [];
+  const flushHalves = () => {
+    if (buffer.length > 0) {
+      runs.push({ kind: "half", ids: buffer });
+      buffer = [];
+    }
+  };
+  for (const id of flatPanelIds) {
+    if (getPanel(id).size === "full") {
+      flushHalves();
+      runs.push({ kind: "full", id });
+    } else {
+      buffer.push(id);
+    }
+  }
+  flushHalves();
+
+  return (
+    <div className="flex flex-col gap-4" aria-label="Agentic SDLC panels">
+      {runs.map((run, idx) =>
+        run.kind === "full" ? (
+          <div key={`full-${run.id}-${idx}`} className="min-w-0">
+            {renderPanel(run.id, context)}
+          </div>
+        ) : (
+          <div
+            key={`half-${idx}`}
+            className="xl:columns-2 xl:[column-gap:1rem]"
+          >
+            {run.ids.map((id) => (
+              <div key={id} className="mb-4 break-inside-avoid">
+                {renderPanel(id, context)}
+              </div>
+            ))}
+          </div>
+        ),
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/agentic-sdlc/CollapsiblePanel.tsx
+++ b/ui/src/components/agentic-sdlc/CollapsiblePanel.tsx
@@ -45,7 +45,7 @@ export function CollapsiblePanel({
     >
       <div
         className={cn(
-          "flex items-center justify-between gap-3 px-3 py-2.5 sm:px-4",
+          "collapsible-panel-header flex items-center justify-between gap-3 px-3 py-2.5 sm:px-4",
           open && "border-b border-border/25",
           headerClassName,
         )}

--- a/ui/src/components/agentic-sdlc/CommandPalette.tsx
+++ b/ui/src/components/agentic-sdlc/CommandPalette.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * Spec-Kit command palette (Cmd/Ctrl + K).
+ *
+ * Lightweight, dependency-free overlay listing the four spec-kit
+ * commands and a free-form "Ask an agent" input. The list is keyboard
+ * navigable with arrow keys + Enter. Hidden by default, opened by
+ * keyboard or by clicking the floating button rendered in the page
+ * footer.
+ *
+ * Today this is a UI scaffold: selecting a command emits a
+ * `agentic-sdlc:palette-action` event so other parts of the app (or
+ * later waves) can react. No commands run from the palette directly.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { Command, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+interface PaletteAction {
+  id: string;
+  label: string;
+  hint: string;
+  group: "Spec-Kit" | "Layout" | "Quick";
+}
+
+const ACTIONS: PaletteAction[] = [
+  { id: "speckit.specify", label: "/speckit.specify", hint: "Capture intent from a free-form prompt", group: "Spec-Kit" },
+  { id: "speckit.plan", label: "/speckit.plan", hint: "Generate implementation plan from spec", group: "Spec-Kit" },
+  { id: "speckit.tasks", label: "/speckit.tasks", hint: "Break plan into executable tasks", group: "Spec-Kit" },
+  { id: "speckit.implement", label: "/speckit.implement", hint: "Execute tasks to produce code", group: "Spec-Kit" },
+  { id: "layout.reset", label: "Reset panel layout", hint: "Restore default visible panels for this surface", group: "Layout" },
+  { id: "layout.toggle-density", label: "Toggle density", hint: "Compact ↔ comfortable", group: "Layout" },
+  { id: "agent.ask", label: "Ask an agent…", hint: "Send a free-form prompt to the platform engineer", group: "Quick" },
+];
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return ACTIONS;
+    return ACTIONS.filter(
+      (a) => a.label.toLowerCase().includes(q) || a.hint.toLowerCase().includes(q),
+    );
+  }, [query]);
+
+  useEffect(() => {
+    function onKey(ev: KeyboardEvent) {
+      if (
+        (ev.metaKey || ev.ctrlKey) &&
+        (ev.key === "k" || ev.key === "K")
+      ) {
+        ev.preventDefault();
+        setOpen((v) => !v);
+      }
+      if (ev.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setHighlight(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  const fire = useCallback((action: PaletteAction) => {
+    setOpen(false);
+    window.dispatchEvent(
+      new CustomEvent("agentic-sdlc:palette-action", {
+        detail: { id: action.id },
+      }),
+    );
+  }, []);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-40 inline-flex items-center gap-2 rounded-full border border-primary/40 bg-card/80 px-3 py-1.5 text-xs text-muted-foreground shadow-lg backdrop-blur hover:text-foreground"
+        aria-label="Open command palette (Cmd+K)"
+      >
+        <Command className="h-3 w-3" aria-hidden /> ⌘K
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Command palette"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-background/50 p-12 backdrop-blur-sm"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden rounded-2xl border border-border/40 bg-card/95 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 border-b border-border/30 px-3 py-2">
+          <Search className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setHighlight(0);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                setHighlight((h) => Math.min(filtered.length - 1, h + 1));
+              } else if (e.key === "ArrowUp") {
+                setHighlight((h) => Math.max(0, h - 1));
+              } else if (e.key === "Enter" && filtered[highlight]) {
+                fire(filtered[highlight]);
+              }
+            }}
+            placeholder="/speckit, panel, agent…"
+            className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
+          />
+          <kbd className="rounded-sm border border-border/40 bg-background/40 px-1 text-[10px] text-muted-foreground">
+            esc
+          </kbd>
+        </div>
+        <ul className="max-h-72 overflow-auto py-1">
+          {filtered.map((a, i) => (
+            <li key={a.id}>
+              <button
+                type="button"
+                onMouseEnter={() => setHighlight(i)}
+                onClick={() => fire(a)}
+                className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs ${
+                  i === highlight ? "bg-primary/15 text-foreground" : "text-muted-foreground hover:bg-background/40"
+                }`}
+              >
+                <span className="flex flex-col">
+                  <span className="font-medium text-foreground">{a.label}</span>
+                  <span className="text-[10px] text-muted-foreground">{a.hint}</span>
+                </span>
+                <span className="rounded-sm border border-border/40 bg-background/40 px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+                  {a.group}
+                </span>
+              </button>
+            </li>
+          ))}
+          {filtered.length === 0 && (
+            <li className="px-3 py-2 text-xs text-muted-foreground">
+              No matches.
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/agentic-sdlc/PanelChooser.tsx
+++ b/ui/src/components/agentic-sdlc/PanelChooser.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+/**
+ * PanelChooser — the sticky pill bar at the top of a configurable
+ * Agentic SDLC surface (Repo Detail or Home).
+ *
+ * Responsibilities:
+ *   1. Render one pill per panel that exists for the surface, grouped
+ *      by ship-loop category (specify / execute / verify / deliver /
+ *      observe / core). Each pill toggles that panel's visibility.
+ *   2. Show counts (N shown / M total).
+ *   3. Expose a "Layout" button that opens a drawer where the user can
+ *      drag panels to reorder them across sections.
+ *   4. Expose Reset and the saved-state indicator.
+ *   5. Be keyboard-accessible: `r` to reset, `Esc` to close drawer.
+ *
+ * The pill bar is sticky under the page header so the user can toggle
+ * panels while scrolling and immediately see the effect.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
+  Layout,
+  LayoutGrid,
+  Plus,
+  RotateCcw,
+  Save,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  CATEGORY_LABELS,
+  CATEGORY_TONE,
+  SECTION_LABELS,
+  SECTION_ORDER,
+  getPanel,
+  listPanelsForSurface,
+  type PanelCategory,
+  type PanelDescriptor,
+  type PanelId,
+  type PanelSection,
+  type PanelSurface,
+} from "@/lib/agentic-sdlc/panel-registry";
+import {
+  isPanelVisible,
+  resolvePanelLayout,
+  type PanelPreferences,
+} from "@/lib/agentic-sdlc/panel-preferences";
+
+interface PanelChooserProps {
+  surface: PanelSurface;
+  preferences: PanelPreferences;
+  isSaving: boolean;
+  lastSavedAt: string | null;
+  onToggle: (id: PanelId) => void;
+  onMove: (id: PanelId, toSection: PanelSection, toIndex: number) => void;
+  onReset: () => void;
+  onToggleGrid?: (enabled: boolean) => void;
+  onResetGrid?: () => void;
+}
+
+const CATEGORY_ORDER: PanelCategory[] = [
+  "specify",
+  "execute",
+  "verify",
+  "deliver",
+  "observe",
+  "core",
+];
+
+export function PanelChooser({
+  surface,
+  preferences,
+  isSaving,
+  lastSavedAt,
+  onToggle,
+  onMove,
+  onReset,
+  onToggleGrid,
+  onResetGrid,
+}: PanelChooserProps) {
+  const [expanded, setExpanded] = useState(true);
+  const [layoutOpen, setLayoutOpen] = useState(false);
+
+  const surfacePanels = useMemo(
+    () => listPanelsForSurface(surface),
+    [surface],
+  );
+
+  const visibleCount = surfacePanels.filter((p) =>
+    isPanelVisible(p, preferences),
+  ).length;
+
+  const byCategory = useMemo(() => {
+    const map = new Map<PanelCategory, PanelDescriptor[]>();
+    for (const panel of surfacePanels) {
+      const list = map.get(panel.category) ?? [];
+      list.push(panel);
+      map.set(panel.category, list);
+    }
+    return map;
+  }, [surfacePanels]);
+
+  useEffect(() => {
+    function onKey(ev: KeyboardEvent) {
+      if (ev.target instanceof HTMLInputElement) return;
+      if (ev.target instanceof HTMLTextAreaElement) return;
+      if (ev.key === "r" && !ev.metaKey && !ev.ctrlKey && !ev.altKey) {
+        onReset();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onReset]);
+
+  return (
+    <div
+      className="sticky top-2 z-30 rounded-2xl border border-border/40 bg-card/80 px-3 py-2 backdrop-blur"
+      aria-label="Panel chooser"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+          aria-expanded={expanded}
+        >
+          {expanded ? (
+            <ChevronUp className="h-3 w-3" aria-hidden />
+          ) : (
+            <ChevronDown className="h-3 w-3" aria-hidden />
+          )}
+          <span>{visibleCount} of {surfacePanels.length} panels</span>
+        </button>
+        <div className="flex items-center gap-2 text-[11px]">
+          <span
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 transition ${
+              isSaving
+                ? "border-amber-400/40 bg-amber-500/10 text-amber-200"
+                : lastSavedAt
+                  ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
+                  : "border-border/40 bg-background/40 text-muted-foreground"
+            }`}
+            aria-live="polite"
+          >
+            <Save className="h-3 w-3" aria-hidden />
+            {isSaving ? "Saving…" : lastSavedAt ? "Saved" : "Not synced yet"}
+          </span>
+          {onToggleGrid && (
+            <button
+              type="button"
+              onClick={() => onToggleGrid(!preferences.gridEnabled)}
+              aria-pressed={preferences.gridEnabled}
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-medium transition ${
+                preferences.gridEnabled
+                  ? "border-primary/50 bg-primary/15 text-primary"
+                  : "border-border/40 bg-background/50 text-muted-foreground hover:bg-background hover:text-foreground"
+              }`}
+              title={
+                preferences.gridEnabled
+                  ? "Disable grid (return to stacked layout)"
+                  : "Enable resizable grid layout"
+              }
+            >
+              <LayoutGrid className="h-3 w-3" aria-hidden />
+              {preferences.gridEnabled ? "Grid on" : "Grid off"}
+            </button>
+          )}
+          {onToggleGrid && preferences.gridEnabled && onResetGrid && (
+            <button
+              type="button"
+              onClick={onResetGrid}
+              className="inline-flex items-center gap-1 rounded-full border border-border/40 bg-background/50 px-2 py-0.5 font-medium text-muted-foreground transition hover:bg-background hover:text-foreground"
+              title="Reset grid coords to defaults"
+            >
+              <RotateCcw className="h-3 w-3" aria-hidden /> Reset grid
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setLayoutOpen(true)}
+            className="inline-flex items-center gap-1 rounded-full border border-border/40 bg-background/50 px-2 py-0.5 font-medium text-muted-foreground transition hover:bg-background hover:text-foreground"
+          >
+            <Layout className="h-3 w-3" aria-hidden /> Layout
+          </button>
+          <button
+            type="button"
+            onClick={onReset}
+            className="inline-flex items-center gap-1 rounded-full border border-border/40 bg-background/50 px-2 py-0.5 font-medium text-muted-foreground transition hover:bg-background hover:text-foreground"
+            title="Reset to defaults (press r)"
+          >
+            <RotateCcw className="h-3 w-3" aria-hidden /> Reset
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="mt-2 grid gap-2">
+          {CATEGORY_ORDER.map((category) => {
+            const list = byCategory.get(category);
+            if (!list?.length) return null;
+            const tone = CATEGORY_TONE[category];
+            return (
+              <div key={category} className="flex flex-wrap items-center gap-1.5">
+                <span
+                  className={`inline-flex items-center text-[10px] font-semibold uppercase tracking-wider ${tone.section}`}
+                >
+                  {CATEGORY_LABELS[category]}
+                </span>
+                {list.map((panel) => {
+                  const visible = isPanelVisible(panel, preferences);
+                  const dataTag =
+                    panel.data === "mock"
+                      ? "demo"
+                      : panel.data === "hybrid"
+                        ? "live+demo"
+                        : null;
+                  return (
+                    <button
+                      key={panel.id}
+                      type="button"
+                      onClick={() => onToggle(panel.id)}
+                      aria-pressed={visible}
+                      className={`group inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium transition ${
+                        visible ? tone.pillActive : tone.pill
+                      }`}
+                      title={panel.description}
+                    >
+                      {visible ? (
+                        <Check className="h-2.5 w-2.5" aria-hidden />
+                      ) : (
+                        <Plus className="h-2.5 w-2.5" aria-hidden />
+                      )}
+                      <span>{panel.title}</span>
+                      {dataTag && (
+                        <span className="rounded-sm bg-background/40 px-1 text-[8px] uppercase tracking-wide text-muted-foreground/80">
+                          {dataTag}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {layoutOpen && (
+        <LayoutDrawer
+          surface={surface}
+          preferences={preferences}
+          onClose={() => setLayoutOpen(false)}
+          onMove={onMove}
+          onToggle={onToggle}
+        />
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Layout drawer — drag a panel into a different section / index             */
+/* -------------------------------------------------------------------------- */
+
+interface LayoutDrawerProps {
+  surface: PanelSurface;
+  preferences: PanelPreferences;
+  onClose: () => void;
+  onMove: (id: PanelId, toSection: PanelSection, toIndex: number) => void;
+  onToggle: (id: PanelId) => void;
+}
+
+function LayoutDrawer({
+  surface,
+  preferences,
+  onClose,
+  onMove,
+  onToggle,
+}: LayoutDrawerProps) {
+  const layout = useMemo(() => resolvePanelLayout(preferences), [preferences]);
+  const draggingRef = useRef<PanelId | null>(null);
+
+  useEffect(() => {
+    function onKey(ev: KeyboardEvent) {
+      if (ev.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Reorder panels"
+      className="fixed inset-0 z-40 flex items-end justify-center bg-background/40 p-4 backdrop-blur-sm md:items-center"
+      onClick={onClose}
+    >
+      <div
+        // Flex column with a clipped header and a scrolling body.
+        // `min-h-0` on the body is what lets overflow-auto kick in when
+        // the panel list is taller than the available card height. The
+        // card itself caps at 90vh so as the list grows it never pushes
+        // the bottom rows past the viewport.
+        className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border/40 bg-card/95 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border/40 px-4 py-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+              Layout · {surface === "repo_detail" ? "Repo detail" : "Home"}
+            </p>
+            <h2 className="text-base font-semibold">Reorder panels</h2>
+            <p className="text-[11px] text-muted-foreground">
+              Drag any pill to move it across sections or within a section.
+              Tip: flip <span className="rounded bg-background/60 px-1 font-mono">Grid on</span> in the chooser bar to drag and resize panels live on the page. Press Esc to close.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border/40 bg-background/40 px-2 py-1 text-xs text-muted-foreground hover:bg-background hover:text-foreground"
+          >
+            Done
+          </button>
+        </header>
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-y-auto p-4 md:grid-cols-2">
+          {SECTION_ORDER.map((section) => {
+            const ids = layout[section] ?? [];
+            return (
+              <div
+                key={section}
+                className="rounded-xl border border-border/40 bg-background/30 p-2"
+                onDragOver={(e) => {
+                  if (draggingRef.current) e.preventDefault();
+                }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  const id = draggingRef.current;
+                  if (!id) return;
+                  onMove(id, section, ids.length);
+                  draggingRef.current = null;
+                }}
+              >
+                <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {SECTION_LABELS[section]}{" "}
+                  <span className="text-muted-foreground/60">({ids.length})</span>
+                </p>
+                <ul className="space-y-1">
+                  {ids.length === 0 && (
+                    <li className="rounded-md border border-dashed border-border/40 px-2 py-2 text-[11px] text-muted-foreground/70">
+                      Drop a panel here…
+                    </li>
+                  )}
+                  {ids.map((id, idx) => {
+                    const panel = getPanel(id);
+                    const tone = CATEGORY_TONE[panel.category];
+                    return (
+                      <li
+                        key={id}
+                        draggable
+                        onDragStart={() => {
+                          draggingRef.current = id;
+                        }}
+                        onDragEnd={() => {
+                          draggingRef.current = null;
+                        }}
+                        onDragOver={(e) => {
+                          if (draggingRef.current) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                          }
+                        }}
+                        onDrop={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          const fromId = draggingRef.current;
+                          if (!fromId) return;
+                          onMove(fromId, section, idx);
+                          draggingRef.current = null;
+                        }}
+                        className={`flex items-center justify-between gap-2 rounded-md border px-2 py-1 text-[11px] ${tone.pill}`}
+                      >
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <GripVertical className="h-3 w-3 shrink-0" aria-hidden />
+                          <span className="truncate">{panel.title}</span>
+                          <span className="rounded-sm bg-background/40 px-1 text-[8px] uppercase tracking-wide text-muted-foreground/80">
+                            {panel.size}
+                          </span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => onToggle(id)}
+                          className="rounded-sm border border-border/40 bg-background/40 px-1 text-[10px] text-muted-foreground hover:text-foreground"
+                          aria-label={`Hide ${panel.title}`}
+                        >
+                          hide
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/agentic-sdlc/PanelPlaceholder.tsx
+++ b/ui/src/components/agentic-sdlc/PanelPlaceholder.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Lightweight placeholder card used for panels that are configurable
+ * via the chooser but whose real implementation lands in a later
+ * wave. Renders inside a CollapsiblePanel so the layout is
+ * representative.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { Sparkles } from "lucide-react";
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import { getPanel, type PanelId } from "@/lib/agentic-sdlc/panel-registry";
+
+interface PanelPlaceholderProps {
+  panelId: PanelId;
+}
+
+export function PanelPlaceholder({ panelId }: PanelPlaceholderProps) {
+  const panel = getPanel(panelId);
+  return (
+    <CollapsiblePanel
+      title={panel.title}
+      leading={<Sparkles className="h-4 w-4 text-primary" aria-hidden />}
+      subtitle={panel.description}
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      <div className="flex items-start gap-3 rounded-md border border-dashed border-border/40 bg-background/20 px-3 py-3 text-[11px] text-muted-foreground">
+        <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-primary/40 bg-primary/15 text-[9px] font-bold uppercase text-primary">
+          Soon
+        </span>
+        <div>
+          <p className="font-semibold text-foreground">{panel.title}</p>
+          <p>{panel.description}</p>
+          <p className="mt-1 text-muted-foreground/70">
+            This panel is opt-in today and renders demo data until live
+            signals are connected. Toggle it off any time from the
+            chooser at the top of the page.
+          </p>
+        </div>
+      </div>
+    </CollapsiblePanel>
+  );
+}

--- a/ui/src/components/agentic-sdlc/RepoChangelogPanel.tsx
+++ b/ui/src/components/agentic-sdlc/RepoChangelogPanel.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+/**
+ * Repo changelog panel — feed of completed features in the lookback
+ * window: merged Epics, merged PRs, and successful sandbox deploys.
+ *
+ * Reads from `GET /api/agentic-sdlc/repos/{owner}/{repo}/changelog`.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  BookCheck,
+  CalendarDays,
+  CheckCircle2,
+  ExternalLink,
+  GitMerge,
+  Loader2,
+  Maximize2,
+  Rocket,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import type { ChangelogEntry, ChangelogEntryKind } from "@/types/agentic-sdlc";
+
+interface RepoChangelogResponse {
+  lookback_days: number;
+  items: ChangelogEntry[];
+}
+
+const LOOKBACK_OPTIONS = [7, 30, 90] as const;
+
+interface RepoChangelogPanelProps {
+  owner: string;
+  repo: string;
+}
+
+export function RepoChangelogPanel({ owner, repo }: RepoChangelogPanelProps) {
+  const [lookback, setLookback] = useState<(typeof LOOKBACK_OPTIONS)[number]>(30);
+  const [data, setData] = useState<RepoChangelogResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (!fullscreen) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setFullscreen(false);
+    }
+    document.addEventListener("keydown", onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [fullscreen]);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL(
+        `/api/agentic-sdlc/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/changelog`,
+        window.location.origin,
+      );
+      url.searchParams.set("lookbackDays", String(lookback));
+      const res = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`http_${res.status}`);
+      const body = (await res.json()) as Partial<RepoChangelogResponse>;
+      const safe: RepoChangelogResponse = {
+        lookback_days: body.lookback_days ?? lookback,
+        items: Array.isArray(body.items) ? body.items : [],
+      };
+      setData(safe);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch_failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [owner, repo, lookback]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    function onRepoSynced(event: Event) {
+      const detail = (event as CustomEvent<{ owner?: string; repo?: string }>)
+        .detail;
+      if (detail?.owner === owner && detail?.repo === repo) {
+        void loadData();
+      }
+    }
+    window.addEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+    return () =>
+      window.removeEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+  }, [owner, repo, loadData]);
+
+  const grouped = useMemo(() => groupByDay(data?.items ?? []), [data]);
+
+  const toolbar = (
+    <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+      <div className="flex gap-1.5">
+        {LOOKBACK_OPTIONS.map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => setLookback(option)}
+            className={`rounded-md border px-2 py-1 text-[10px] font-medium transition ${
+              option === lookback
+                ? "border-primary/40 bg-primary/15 text-primary"
+                : "border-border/40 bg-background/30 text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Last {option}d
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <p className="text-[11px] text-muted-foreground">
+          {data ? `${data.items.length} completed` : ""}
+        </p>
+        <button
+          type="button"
+          onClick={() => setFullscreen(true)}
+          aria-label="Open changelog in full screen"
+          title="Open in full screen"
+          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border/50 bg-background/50 px-2 text-[11px] font-medium text-muted-foreground transition hover:bg-background hover:text-foreground"
+        >
+          <Maximize2 className="h-3 w-3" aria-hidden />
+          <span className="hidden sm:inline">Full screen</span>
+        </button>
+      </div>
+    </div>
+  );
+
+  const list = (
+    <>
+      {error && (
+        <p className="rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          Could not load changelog ({error}).
+        </p>
+      )}
+
+      {loading && !data && (
+        <div className="flex items-center justify-center rounded-md border border-border/30 bg-background/30 px-3 py-8 text-xs text-muted-foreground">
+          <Loader2 className="mr-2 h-3 w-3 animate-spin" aria-hidden /> Loading
+          changelog…
+        </div>
+      )}
+
+      {data && data.items.length === 0 && !loading && (
+        <p className="rounded-md border border-dashed border-border/40 bg-background/20 px-3 py-3 text-xs text-muted-foreground">
+          Nothing has shipped in the last {lookback} days.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {grouped.map(({ day, entries }) => (
+          <li key={day}>
+            <p className="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <CalendarDays className="h-3 w-3" aria-hidden />
+              {formatDayHeading(day)}
+            </p>
+            <ul className="space-y-1.5">
+              {entries.map((entry) => (
+                <ChangelogRow key={entry.id} entry={entry} />
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+
+  return (
+    <>
+      <CollapsiblePanel
+        title="Changelog"
+        defaultOpen={false}
+        leading={<BookCheck className="h-4 w-4 text-emerald-300" aria-hidden />}
+        subtitle="Merged Epics, merged PRs, and successful sandbox deploys."
+        className="glass-panel"
+        titleClassName="text-foreground normal-case tracking-normal"
+      >
+        {toolbar}
+        <div className="max-h-[420px] overflow-y-auto pr-1">{list}</div>
+      </CollapsiblePanel>
+
+      {fullscreen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Changelog"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) setFullscreen(false);
+          }}
+        >
+          <div className="glass-panel relative flex h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-border/40 bg-card/85 shadow-2xl">
+            <header className="flex items-start justify-between gap-3 border-b border-border/30 px-4 py-3">
+              <div className="flex items-start gap-2">
+                <BookCheck
+                  className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300"
+                  aria-hidden
+                />
+                <div>
+                  <h2 className="text-sm font-semibold text-foreground">
+                    Changelog
+                  </h2>
+                  <p className="text-xs text-muted-foreground">
+                    Merged Epics, merged PRs, and successful sandbox deploys.
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setFullscreen(false)}
+                aria-label="Close full-screen changelog"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border/40 bg-background/50 text-muted-foreground transition hover:bg-background hover:text-foreground"
+              >
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            </header>
+            <div className="px-4 pt-3">{toolbar}</div>
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+              {list}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function ChangelogRow({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <li className="flex items-start gap-2 rounded-lg border border-border/30 bg-background/30 px-3 py-2">
+      <span className="mt-0.5 shrink-0">
+        <KindIcon kind={entry.kind} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <a
+            href={entry.github_url}
+            target="_blank"
+            rel="noreferrer"
+            className="truncate text-xs font-medium text-foreground transition hover:text-primary"
+          >
+            {entry.title}
+          </a>
+          <ExternalLink
+            className="h-3 w-3 shrink-0 text-muted-foreground/70"
+            aria-hidden
+          />
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span className="rounded-full border border-border/40 bg-background/40 px-1.5 py-0.5">
+            {kindLabel(entry.kind)}
+          </span>
+          <span>{entry.actor_kind === "agent" ? "by agent" : "by human"}</span>
+          <span className="text-muted-foreground/60">
+            {new Date(entry.completed_at).toLocaleTimeString(undefined, {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </span>
+        </div>
+        {entry.body_excerpt && (
+          <p className="mt-1 line-clamp-2 text-[11px] text-muted-foreground/85">
+            {entry.body_excerpt}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function KindIcon({ kind }: { kind: ChangelogEntryKind }) {
+  switch (kind) {
+    case "epic_merged":
+    case "pull_request_merged":
+      return <GitMerge className="h-3.5 w-3.5 text-emerald-300" aria-hidden />;
+    case "deploy_succeeded":
+      return <Rocket className="h-3.5 w-3.5 text-cyan-300" aria-hidden />;
+    case "epic_closed":
+    default:
+      return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-200" aria-hidden />;
+  }
+}
+
+function kindLabel(kind: ChangelogEntryKind): string {
+  switch (kind) {
+    case "epic_merged":
+      return "Epic merged";
+    case "epic_closed":
+      return "Epic closed";
+    case "pull_request_merged":
+      return "PR merged";
+    case "deploy_succeeded":
+      return "Deploy ok";
+  }
+}
+
+function groupByDay(
+  entries: ChangelogEntry[],
+): { day: string; entries: ChangelogEntry[] }[] {
+  const buckets = new Map<string, ChangelogEntry[]>();
+  for (const entry of entries) {
+    const d = new Date(entry.completed_at);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(
+      2,
+      "0",
+    )}-${String(d.getDate()).padStart(2, "0")}`;
+    const arr = buckets.get(key) ?? [];
+    arr.push(entry);
+    buckets.set(key, arr);
+  }
+  return Array.from(buckets.entries())
+    .map(([day, list]) => ({ day, entries: list }))
+    .sort((a, b) => b.day.localeCompare(a.day));
+}
+
+function formatDayHeading(day: string): string {
+  const date = new Date(`${day}T00:00:00`);
+  const today = new Date();
+  const startOfToday = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+  );
+  const diffDays = Math.floor(
+    (startOfToday.getTime() - date.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: date.getFullYear() === today.getFullYear() ? undefined : "numeric",
+  });
+}

--- a/ui/src/components/agentic-sdlc/RepoCiPanel.tsx
+++ b/ui/src/components/agentic-sdlc/RepoCiPanel.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+/**
+ * Repo CI panel — shows live CI status for every in-flight task / PR.
+ *
+ * Reads from `GET /api/agentic-sdlc/repos/{owner}/{repo}/ci`. The
+ * panel offers an optional "Refresh from GitHub" action that calls
+ * the same route with `?live=true`, which merges fresh check-runs
+ * from the GitHub API on top of projected webhook data.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleDashed,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import { StageBadge } from "@/components/agentic-sdlc/visualizations/StageBadge";
+import type {
+  AgenticSdlcStage,
+  ArtifactCiSummary,
+  ArtifactKindStored,
+  ArtifactNativeState,
+  CiCheckRun,
+  CiConclusion,
+} from "@/types/agentic-sdlc";
+
+interface InFlightCiItem {
+  artifact_id: string;
+  kind: ArtifactKindStored;
+  title: string;
+  current_stage: AgenticSdlcStage;
+  github_url: string;
+  state: ArtifactNativeState;
+  head_sha: string | null;
+  ci_summary: ArtifactCiSummary | null;
+  last_event_at: string;
+  checks: CiCheckRun[];
+}
+
+interface RepoCiResponse {
+  totals: { success: number; failure: number; pending: number; no_ci: number };
+  items: InFlightCiItem[];
+  live_refreshed: boolean;
+}
+
+interface RepoCiPanelProps {
+  owner: string;
+  repo: string;
+}
+
+export function RepoCiPanel({ owner, repo }: RepoCiPanelProps) {
+  const [data, setData] = useState<RepoCiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [liveRefreshed, setLiveRefreshed] = useState(false);
+
+  const loadData = useCallback(
+    async (live: boolean) => {
+      setRefreshing(true);
+      setError(null);
+      try {
+        const url = new URL(
+          `/api/agentic-sdlc/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/ci`,
+          window.location.origin,
+        );
+        if (live) url.searchParams.set("live", "true");
+        const res = await fetch(url.toString(), {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        });
+        if (!res.ok) throw new Error(`http_${res.status}`);
+        const body = (await res.json()) as Partial<RepoCiResponse>;
+        const safe: RepoCiResponse = {
+          totals: body.totals ?? { success: 0, failure: 0, pending: 0, no_ci: 0 },
+          items: Array.isArray(body.items) ? body.items : [],
+          live_refreshed: Boolean(body.live_refreshed),
+        };
+        setData(safe);
+        setLiveRefreshed(safe.live_refreshed);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "fetch_failed");
+      } finally {
+        setRefreshing(false);
+      }
+    },
+    [owner, repo],
+  );
+
+  useEffect(() => {
+    void loadData(false);
+  }, [loadData]);
+
+  useEffect(() => {
+    function onRepoSynced(event: Event) {
+      const detail = (event as CustomEvent<{ owner?: string; repo?: string }>)
+        .detail;
+      if (detail?.owner === owner && detail?.repo === repo) {
+        void loadData(false);
+      }
+    }
+    window.addEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+    return () =>
+      window.removeEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+  }, [owner, repo, loadData]);
+
+  return (
+    <CollapsiblePanel
+      title="CI for tasks-in-flight"
+      leading={<ShieldCheck className="h-4 w-4 text-cyan-300" aria-hidden />}
+      subtitle="Per-PR / per-task check status from check_run, check_suite, and workflow_run events."
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      <div className="flex items-center justify-between gap-3 pb-3">
+        <CiTotals data={data} />
+        <button
+          type="button"
+          onClick={() => loadData(true)}
+          disabled={refreshing}
+          aria-label="Refresh CI from GitHub"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border/50 bg-background/50 px-2.5 py-1.5 text-[11px] font-medium text-muted-foreground transition hover:bg-background hover:text-foreground disabled:opacity-60"
+        >
+          {refreshing ? (
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+          ) : (
+            <RefreshCw className="h-3 w-3" aria-hidden />
+          )}
+          Refresh CI
+        </button>
+      </div>
+
+      {liveRefreshed && (
+        <p className="mb-2 rounded-md border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-200">
+          CI was refreshed live from GitHub for tracked head SHAs.
+        </p>
+      )}
+
+      {error && (
+        <p className="rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          <AlertTriangle className="mr-1 inline h-3 w-3" aria-hidden /> Could not
+          load CI ({error}). Showing the last known state.
+        </p>
+      )}
+
+      {!data && !error && (
+        <div className="flex items-center justify-center rounded-md border border-border/30 bg-background/30 px-3 py-8 text-xs text-muted-foreground">
+          <Loader2 className="mr-2 h-3 w-3 animate-spin" aria-hidden /> Loading
+          CI…
+        </div>
+      )}
+
+      {data && data.items.length === 0 && (
+        <p className="rounded-md border border-border/30 bg-background/30 px-3 py-3 text-xs text-muted-foreground">
+          No PRs or tasks are in flight right now.
+        </p>
+      )}
+
+      {data && data.items.length > 0 && (
+        <ul className="space-y-2">
+          {data.items.map((item) => (
+            <CiItemRow key={`${item.kind}:${item.artifact_id}`} item={item} />
+          ))}
+        </ul>
+      )}
+    </CollapsiblePanel>
+  );
+}
+
+function CiTotals({ data }: { data: RepoCiResponse | null }) {
+  if (!data) {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        Loading CI summary…
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <TotalsPill tone="success" label="Passing" value={data.totals.success} />
+      <TotalsPill tone="failure" label="Failing" value={data.totals.failure} />
+      <TotalsPill tone="pending" label="Running" value={data.totals.pending} />
+      <TotalsPill tone="neutral" label="No CI" value={data.totals.no_ci} />
+    </div>
+  );
+}
+
+function TotalsPill({
+  tone,
+  label,
+  value,
+}: {
+  tone: "success" | "failure" | "pending" | "neutral";
+  label: string;
+  value: number;
+}) {
+  const classes = {
+    success: "border-emerald-400/30 bg-emerald-500/10 text-emerald-200",
+    failure: "border-red-400/30 bg-red-500/10 text-red-200",
+    pending: "border-amber-400/30 bg-amber-500/10 text-amber-200",
+    neutral: "border-border/40 bg-background/30 text-muted-foreground",
+  }[tone];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-medium ${classes}`}
+    >
+      <span>{label}</span>
+      <span className="text-foreground">{value}</span>
+    </span>
+  );
+}
+
+function CiItemRow({ item }: { item: InFlightCiItem }) {
+  const summary = item.ci_summary;
+  const hasSummary = summary !== null;
+  return (
+    <li className="rounded-lg border border-border/30 bg-background/30 px-3 py-2">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <ConclusionIcon
+              conclusion={hasSummary ? summary.conclusion : "unknown"}
+            />
+            <a
+              href={item.github_url}
+              target="_blank"
+              rel="noreferrer"
+              className="truncate text-xs font-semibold text-foreground transition hover:text-primary"
+            >
+              {item.title || item.artifact_id}
+            </a>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground">
+            <StageBadge stage={item.current_stage} compact />
+            <span className="rounded-full border border-border/40 bg-background/40 px-1.5 py-0.5">
+              {item.kind.replaceAll("_", " ")}
+            </span>
+            {item.head_sha && (
+              <span className="font-mono">{item.head_sha.slice(0, 7)}</span>
+            )}
+            <span>{formatRelative(item.last_event_at)}</span>
+          </div>
+        </div>
+      </div>
+      {hasSummary ? (
+        <CiCheckTable summary={summary} checks={item.checks} />
+      ) : (
+        <p className="mt-2 text-[11px] italic text-muted-foreground">
+          No CI events recorded yet for this artifact.
+        </p>
+      )}
+    </li>
+  );
+}
+
+function CiCheckTable({
+  summary,
+  checks,
+}: {
+  summary: ArtifactCiSummary;
+  checks: CiCheckRun[];
+}) {
+  if (checks.length === 0) {
+    return (
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        Aggregate {summary.conclusion} — no per-check detail available.
+      </p>
+    );
+  }
+  return (
+    <ul className="mt-2 space-y-1">
+      {checks.map((check) => (
+        <li
+          key={check.external_id}
+          className="flex items-center justify-between gap-2 rounded border border-border/30 bg-background/40 px-2 py-1 text-[11px]"
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <ConclusionIcon conclusion={check.conclusion} />
+            <span className="truncate text-foreground">{check.check_name}</span>
+          </span>
+          <span className="flex shrink-0 items-center gap-2 text-muted-foreground">
+            <span className="font-mono text-[10px] uppercase">
+              {check.status === "completed" ? check.conclusion : check.status}
+            </span>
+            {check.details_url && (
+              <a
+                href={check.details_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary hover:text-primary/80"
+                aria-label={`Open ${check.check_name} details`}
+              >
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            )}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ConclusionIcon({ conclusion }: { conclusion: CiConclusion }) {
+  if (conclusion === "success") {
+    return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-300" aria-hidden />;
+  }
+  if (
+    conclusion === "failure" ||
+    conclusion === "timed_out" ||
+    conclusion === "action_required"
+  ) {
+    return <XCircle className="h-3.5 w-3.5 text-red-300" aria-hidden />;
+  }
+  if (conclusion === "pending") {
+    return (
+      <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-200" aria-hidden />
+    );
+  }
+  return <CircleDashed className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />;
+}
+
+function formatRelative(value: string): string {
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) return "";
+  const diffMs = Date.now() - ts;
+  if (diffMs < 60_000) return "just now";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/ui/src/components/agentic-sdlc/RepoDeploymentHealthPanel.tsx
+++ b/ui/src/components/agentic-sdlc/RepoDeploymentHealthPanel.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+/**
+ * Repo deployment health panel — rich per-environment health with
+ * success rate, recent deploys timeline, and failure reasons.
+ *
+ * Reads from
+ * `GET /api/agentic-sdlc/repos/{owner}/{repo}/deploy-health`.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Heart,
+  Loader2,
+  Server,
+  Timer,
+  XCircle,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import type {
+  DeploymentEnvironmentHealth,
+  DeploymentEnvironmentSummary,
+  DeploymentHealthSummary,
+  DeploymentRecord,
+} from "@/types/agentic-sdlc";
+
+const WINDOW_OPTIONS: { id: number; label: string }[] = [
+  { id: 24, label: "24h" },
+  { id: 168, label: "7d" },
+  { id: 720, label: "30d" },
+];
+
+interface RepoDeploymentHealthPanelProps {
+  owner: string;
+  repo: string;
+}
+
+export function RepoDeploymentHealthPanel({
+  owner,
+  repo,
+}: RepoDeploymentHealthPanelProps) {
+  const [windowHours, setWindowHours] = useState<number>(168);
+  const [data, setData] = useState<DeploymentHealthSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL(
+        `/api/agentic-sdlc/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/deploy-health`,
+        window.location.origin,
+      );
+      url.searchParams.set("windowHours", String(windowHours));
+      const res = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`http_${res.status}`);
+      const body = (await res.json()) as Partial<DeploymentHealthSummary>;
+      const safe: DeploymentHealthSummary = {
+        window_hours: body.window_hours ?? windowHours,
+        environments: Array.isArray(body.environments) ? body.environments : [],
+        totals: body.totals ?? { success: 0, failure: 0, in_progress: 0 },
+        generated_at: body.generated_at ?? new Date().toISOString(),
+      };
+      setData(safe);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch_failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [owner, repo, windowHours]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    function onRepoSynced(event: Event) {
+      const detail = (event as CustomEvent<{ owner?: string; repo?: string }>)
+        .detail;
+      if (detail?.owner === owner && detail?.repo === repo) {
+        void loadData();
+      }
+    }
+    window.addEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+    return () =>
+      window.removeEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+  }, [owner, repo, loadData]);
+
+  return (
+    <CollapsiblePanel
+      title="Deployment health"
+      leading={<Heart className="h-4 w-4 text-rose-300" aria-hidden />}
+      subtitle="Per-environment success rate, recent deploys, and failure reasons."
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <Totals data={data} />
+        <div className="flex gap-1.5">
+          {WINDOW_OPTIONS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setWindowHours(option.id)}
+              className={`rounded-md border px-2 py-1 text-[10px] font-medium transition ${
+                option.id === windowHours
+                  ? "border-primary/40 bg-primary/15 text-primary"
+                  : "border-border/40 bg-background/30 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          <AlertTriangle className="mr-1 inline h-3 w-3" aria-hidden /> Could not
+          load deployment health ({error}).
+        </p>
+      )}
+
+      {loading && !data && (
+        <div className="flex items-center justify-center rounded-md border border-border/30 bg-background/30 px-3 py-8 text-xs text-muted-foreground">
+          <Loader2 className="mr-2 h-3 w-3 animate-spin" aria-hidden /> Loading
+          deploy health…
+        </div>
+      )}
+
+      {data && data.environments.length === 0 && !loading && (
+        <p className="rounded-md border border-dashed border-border/40 bg-background/20 px-3 py-3 text-xs text-muted-foreground">
+          No deployments observed in the selected window.
+        </p>
+      )}
+
+      <ul className="space-y-3">
+        {data?.environments.map((env) => (
+          <EnvironmentCard key={env.environment} env={env} />
+        ))}
+      </ul>
+    </CollapsiblePanel>
+  );
+}
+
+function Totals({ data }: { data: DeploymentHealthSummary | null }) {
+  if (!data) {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        Loading deploy totals…
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-emerald-200">
+        <CheckCircle2 className="h-3 w-3" aria-hidden /> Success
+        <span className="text-foreground">{data.totals.success}</span>
+      </span>
+      <span className="inline-flex items-center gap-1 rounded-full border border-red-400/30 bg-red-500/10 px-2 py-0.5 text-red-200">
+        <XCircle className="h-3 w-3" aria-hidden /> Failure
+        <span className="text-foreground">{data.totals.failure}</span>
+      </span>
+      <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-amber-200">
+        <Activity className="h-3 w-3" aria-hidden /> Running
+        <span className="text-foreground">{data.totals.in_progress}</span>
+      </span>
+    </div>
+  );
+}
+
+function EnvironmentCard({ env }: { env: DeploymentEnvironmentSummary }) {
+  return (
+    <li className="rounded-xl border border-border/30 bg-background/30 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Server className="h-4 w-4 text-cyan-200" aria-hidden />
+          <p className="truncate text-sm font-semibold text-foreground">
+            {env.environment}
+          </p>
+          <HealthBadge health={env.health} />
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+          <span>
+            Success {(env.success_rate * 100).toFixed(0)}% (
+            {env.success_count}/{env.success_count + env.failure_count})
+          </span>
+          {env.median_duration_seconds != null && (
+            <span className="inline-flex items-center gap-1">
+              <Timer className="h-3 w-3" aria-hidden />
+              {formatDuration(env.median_duration_seconds)} median
+            </span>
+          )}
+          {env.median_recovery_seconds != null && (
+            <span className="inline-flex items-center gap-1">
+              <Activity className="h-3 w-3" aria-hidden />
+              {formatDuration(env.median_recovery_seconds)} MTTR
+            </span>
+          )}
+        </div>
+      </div>
+
+      <ul className="mt-2 space-y-1">
+        {env.recent_deploys.length === 0 && (
+          <li className="rounded-md border border-dashed border-border/30 px-2 py-1 text-[11px] text-muted-foreground">
+            No deploys observed for this environment in the window.
+          </li>
+        )}
+        {env.recent_deploys.map((record) => (
+          <DeployRow key={record.id} record={record} />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+function DeployRow({ record }: { record: DeploymentRecord }) {
+  const tone =
+    record.state === "success"
+      ? "border-emerald-400/30 bg-emerald-500/10"
+      : record.state === "failure"
+        ? "border-red-400/30 bg-red-500/10"
+        : "border-amber-400/30 bg-amber-500/10";
+  return (
+    <li className={`flex flex-wrap items-start justify-between gap-2 rounded-md border px-2.5 py-1.5 ${tone}`}>
+      <div className="flex min-w-0 items-start gap-2 text-[11px]">
+        <DeployIcon state={record.state} />
+        <div className="min-w-0">
+          <p className="truncate font-medium text-foreground">
+            {record.url ? (
+              <a
+                href={record.url}
+                target="_blank"
+                rel="noreferrer"
+                className="hover:underline"
+              >
+                {record.environment}
+                <ExternalLink
+                  className="ml-1 inline h-3 w-3 text-muted-foreground/70"
+                  aria-hidden
+                />
+              </a>
+            ) : (
+              record.environment
+            )}
+          </p>
+          {record.failure_reason && (
+            <p className="mt-0.5 text-red-200">{record.failure_reason}</p>
+          )}
+          {!record.failure_reason && record.description && (
+            <p className="mt-0.5 line-clamp-1 text-muted-foreground">
+              {record.description}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="shrink-0 text-right text-[10px] text-muted-foreground">
+        <p>{record.completed_at ? formatRelative(record.completed_at) : "in progress"}</p>
+        {record.duration_seconds != null && (
+          <p>{formatDuration(record.duration_seconds)}</p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function HealthBadge({ health }: { health: DeploymentEnvironmentHealth }) {
+  const classes = {
+    healthy: "border-emerald-400/30 bg-emerald-500/10 text-emerald-200",
+    degraded: "border-amber-400/30 bg-amber-500/10 text-amber-200",
+    failing: "border-red-400/30 bg-red-500/10 text-red-200",
+    idle: "border-border/40 bg-background/30 text-muted-foreground",
+    unknown: "border-border/40 bg-background/30 text-muted-foreground",
+  }[health];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${classes}`}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+      {health}
+    </span>
+  );
+}
+
+function DeployIcon({ state }: { state: DeploymentRecord["state"] }) {
+  if (state === "success") {
+    return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-300" aria-hidden />;
+  }
+  if (state === "failure") {
+    return <XCircle className="h-3.5 w-3.5 text-red-300" aria-hidden />;
+  }
+  return <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-200" aria-hidden />;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86_400) return `${(seconds / 3600).toFixed(1)}h`;
+  return `${Math.round(seconds / 86_400)}d`;
+}
+
+function formatRelative(value: string): string {
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) return "";
+  const diffMs = Date.now() - ts;
+  if (diffMs < 60_000) return "just now";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/ui/src/components/agentic-sdlc/RepoDetailShell.tsx
+++ b/ui/src/components/agentic-sdlc/RepoDetailShell.tsx
@@ -2,17 +2,20 @@
 
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
+import { useMemo } from "react";
 
-import { LiveStatusIndicator } from "@/components/agentic-sdlc/LiveStatusIndicator";
-import { RepoEpicList } from "@/components/agentic-sdlc/RepoEpicList";
+import { AgenticSdlcLayoutHost } from "@/components/agentic-sdlc/AgenticSdlcLayoutHost";
 import { AgenticSdlcSimulationControl } from "@/components/agentic-sdlc/AgenticSdlcSimulationControl";
-import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
-import { RepoEventFeed } from "@/components/agentic-sdlc/RepoEventFeed";
+import { CommandPalette } from "@/components/agentic-sdlc/CommandPalette";
+import { LiveStatusIndicator } from "@/components/agentic-sdlc/LiveStatusIndicator";
+import { PanelChooser } from "@/components/agentic-sdlc/PanelChooser";
 import { RepoCatchUpTimeline } from "@/components/agentic-sdlc/RepoCatchUpTimeline";
 import { RepoGitHubSyncControl } from "@/components/agentic-sdlc/RepoGitHubSyncControl";
-import { RepoOperatingMetrics } from "@/components/agentic-sdlc/RepoOperatingMetrics";
-import { RepoSwimLanes } from "@/components/agentic-sdlc/RepoSwimLanes";
+import { ShipLoopRingPanel } from "@/components/agentic-sdlc/panels/ShipLoopRingPanel";
+import { useFaviconHealth } from "@/hooks/use-favicon-health";
 import { useRepoAgenticSdlcLiveRefresh } from "@/hooks/use-repo-agentic-sdlc-live-refresh";
+import { usePanelPreferences } from "@/hooks/use-panel-preferences";
+import { resolvePanelLayout } from "@/lib/agentic-sdlc/panel-preferences";
 
 // assisted-by Codex Codex-sonnet-4-6
 
@@ -24,21 +27,42 @@ interface RepoDetailShellProps {
 export function RepoDetailShell({ owner, repo }: RepoDetailShellProps) {
   const fullName = `${owner}/${repo}`;
   const repoLive = useRepoAgenticSdlcLiveRefresh({ owner, repo, enabled: true });
+  const prefs = usePanelPreferences({ surface: "repo_detail" });
+  const layout = useMemo(
+    () => resolvePanelLayout(prefs.preferences),
+    [prefs.preferences],
+  );
+  useFaviconHealth();
+
+  const heroPanels = layout.hero ?? [];
+  const showHeroRing = heroPanels.includes("ship_loop_ring");
 
   return (
-    <div className="mx-auto flex max-w-[1600px] flex-col gap-3 p-3 md:p-4 lg:px-8">
-      <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <Link href="/apps/agentic-sdlc" className="inline-flex items-center gap-1 hover:text-foreground">
+    <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-3 p-3 md:p-4 lg:px-8">
+      <nav
+        aria-label="Breadcrumb"
+        className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground"
+      >
+        <Link
+          href="/apps/agentic-sdlc"
+          className="inline-flex items-center gap-1 hover:text-foreground"
+        >
           <ArrowLeft className="h-3 w-3" aria-hidden />
           Repos
         </Link>
         <span>/</span>
         <span className="text-foreground">{fullName}</span>
         <span className="ml-auto inline-flex gap-3">
-          <Link href="/apps/agentic-sdlc?tab=metrics" className="hover:text-foreground">
+          <Link
+            href="/apps/agentic-sdlc?tab=metrics"
+            className="hover:text-foreground"
+          >
             Metrics
           </Link>
-          <Link href="/apps/agentic-sdlc?tab=settings" className="hover:text-foreground">
+          <Link
+            href="/apps/agentic-sdlc?tab=settings"
+            className="hover:text-foreground"
+          >
             Settings
           </Link>
         </span>
@@ -49,6 +73,14 @@ export function RepoDetailShell({ owner, repo }: RepoDetailShellProps) {
           aria-hidden
           className="absolute -right-24 -top-28 h-56 w-56 rounded-full bg-primary/20 blur-3xl"
         />
+        {showHeroRing && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 md:block"
+          >
+            <ShipLoopRingPanel owner={owner} repo={repo} variant="mini" />
+          </div>
+        )}
         <div className="relative flex flex-wrap items-start justify-between gap-4">
           <div className="max-w-3xl">
             <p className="text-xs font-semibold uppercase tracking-widest text-primary">
@@ -59,7 +91,9 @@ export function RepoDetailShell({ owner, repo }: RepoDetailShellProps) {
               <span className="text-foreground">{repo}</span>
             </h1>
             <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
-              Live agent lanes, Epics, review pressure, deploy signal, and webhook health.
+              Live agent lanes, Epics, review pressure, deploy signal, and
+              webhook health. Configure the panels you want with the chooser
+              below.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -70,30 +104,28 @@ export function RepoDetailShell({ owner, repo }: RepoDetailShellProps) {
         </div>
       </section>
 
+      <PanelChooser
+        surface="repo_detail"
+        preferences={prefs.preferences}
+        isSaving={prefs.isSaving}
+        lastSavedAt={prefs.lastSavedAt}
+        onToggle={prefs.togglePanel}
+        onMove={prefs.movePanel}
+        onReset={prefs.reset}
+        onToggleGrid={prefs.setGridEnabled}
+        onResetGrid={prefs.resetGrid}
+      />
+
       <AgenticSdlcSimulationControl owner={owner} repo={repo} />
 
-      <section aria-label="Repo operating board">
-        <RepoSwimLanes owner={owner} repo={repo} />
-      </section>
+      <AgenticSdlcLayoutHost
+        surface="repo_detail"
+        prefs={prefs}
+        context={{ owner, repo, fullName }}
+        excludePanelIds={["ship_loop_ring"]}
+      />
 
-      <section className="grid gap-4 xl:grid-cols-[1.5fr_0.8fr]">
-        <CollapsiblePanel
-          title="Epics"
-          subtitle={
-            <span className="flex items-center justify-between gap-3">
-              <span>Drill into active loops and repo-level Epics.</span>
-              <span className="text-[11px] text-muted-foreground/70">{fullName}</span>
-            </span>
-          }
-          className="min-w-0"
-        >
-          <RepoEpicList owner={owner} repo={repo} />
-        </CollapsiblePanel>
-
-        <RepoOperatingMetrics owner={owner} repo={repo} />
-      </section>
-
-      <RepoEventFeed owner={owner} repo={repo} />
+      <CommandPalette />
     </div>
   );
 }

--- a/ui/src/components/agentic-sdlc/RepoSnapshotsPanel.tsx
+++ b/ui/src/components/agentic-sdlc/RepoSnapshotsPanel.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+/**
+ * Repo snapshots panel — shows snapshot artifacts produced during the
+ * last X runs: GitHub Actions workflow runs, deploy snapshots, and
+ * recent agentic artifacts. Reads from
+ * `GET /api/agentic-sdlc/repos/{owner}/{repo}/snapshots`.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  Box,
+  Container,
+  ExternalLink,
+  GitBranch,
+  Loader2,
+  Package,
+  Rocket,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import type {
+  SnapshotArtifactKind,
+  SnapshotArtifactRecord,
+} from "@/types/agentic-sdlc";
+
+interface RepoSnapshotsResponse {
+  recent_runs: number;
+  window_hours: number;
+  by_kind: Record<SnapshotArtifactKind, number>;
+  items: SnapshotArtifactRecord[];
+}
+
+const RUN_OPTIONS = [5, 10, 25] as const;
+const KIND_FILTERS: { id: "all" | SnapshotArtifactKind; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "github_actions_artifact", label: "GH Actions" },
+  { id: "deploy_snapshot", label: "Deploy snapshots" },
+  { id: "agentic_artifact", label: "Agentic" },
+];
+
+interface RepoSnapshotsPanelProps {
+  owner: string;
+  repo: string;
+}
+
+export function RepoSnapshotsPanel({ owner, repo }: RepoSnapshotsPanelProps) {
+  const [runs, setRuns] = useState<(typeof RUN_OPTIONS)[number]>(5);
+  const [kindFilter, setKindFilter] = useState<"all" | SnapshotArtifactKind>("all");
+  const [data, setData] = useState<RepoSnapshotsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL(
+        `/api/agentic-sdlc/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/snapshots`,
+        window.location.origin,
+      );
+      url.searchParams.set("recentRuns", String(runs));
+      const res = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`http_${res.status}`);
+      const body = (await res.json()) as Partial<RepoSnapshotsResponse>;
+      const safe: RepoSnapshotsResponse = {
+        recent_runs: body.recent_runs ?? runs,
+        window_hours: body.window_hours ?? 24,
+        by_kind:
+          body.by_kind ??
+          ({
+            github_actions_artifact: 0,
+            deploy_snapshot: 0,
+            agentic_artifact: 0,
+          } as Record<SnapshotArtifactKind, number>),
+        items: Array.isArray(body.items) ? body.items : [],
+      };
+      setData(safe);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch_failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [owner, repo, runs]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    function onRepoSynced(event: Event) {
+      const detail = (event as CustomEvent<{ owner?: string; repo?: string }>)
+        .detail;
+      if (detail?.owner === owner && detail?.repo === repo) {
+        void loadData();
+      }
+    }
+    window.addEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+    return () =>
+      window.removeEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+  }, [owner, repo, loadData]);
+
+  const filtered =
+    kindFilter === "all"
+      ? (data?.items ?? [])
+      : (data?.items ?? []).filter((item) => item.kind === kindFilter);
+
+  return (
+    <CollapsiblePanel
+      title="Snapshot artifacts"
+      leading={<Package className="h-4 w-4 text-violet-300" aria-hidden />}
+      subtitle={`Build artifacts, deploy snapshots, and agentic outputs from the last ${runs} runs.`}
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex gap-1.5">
+          {KIND_FILTERS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setKindFilter(option.id)}
+              className={`rounded-md border px-2 py-1 text-[10px] font-medium transition ${
+                option.id === kindFilter
+                  ? "border-primary/40 bg-primary/15 text-primary"
+                  : "border-border/40 bg-background/30 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {option.label}
+              {data && option.id !== "all" && (
+                <span className="ml-1 text-foreground">
+                  {data.by_kind[option.id as SnapshotArtifactKind]}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-1.5">
+          {RUN_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setRuns(option)}
+              className={`rounded-md border px-2 py-1 text-[10px] font-medium transition ${
+                option === runs
+                  ? "border-primary/40 bg-primary/15 text-primary"
+                  : "border-border/40 bg-background/30 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {option} runs
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          Could not load snapshots ({error}).
+        </p>
+      )}
+
+      {loading && !data && (
+        <div className="flex items-center justify-center rounded-md border border-border/30 bg-background/30 px-3 py-8 text-xs text-muted-foreground">
+          <Loader2 className="mr-2 h-3 w-3 animate-spin" aria-hidden /> Loading
+          snapshots…
+        </div>
+      )}
+
+      {data && filtered.length === 0 && !loading && (
+        <p className="rounded-md border border-dashed border-border/40 bg-background/20 px-3 py-3 text-xs text-muted-foreground">
+          No snapshot artifacts produced in the last {runs} runs.
+        </p>
+      )}
+
+      <ul className="space-y-1.5">
+        {filtered.map((item) => (
+          <SnapshotRow key={item.id} item={item} />
+        ))}
+      </ul>
+    </CollapsiblePanel>
+  );
+}
+
+function SnapshotRow({ item }: { item: SnapshotArtifactRecord }) {
+  const toneClasses = {
+    success: "border-emerald-400/30 bg-emerald-500/10 text-emerald-100",
+    failure: "border-red-400/30 bg-red-500/10 text-red-100",
+    neutral: "border-border/30 bg-background/30 text-foreground",
+  }[item.tone];
+
+  return (
+    <li className={`flex items-start gap-2 rounded-lg border px-3 py-2 ${toneClasses}`}>
+      <span className="mt-0.5 shrink-0">
+        <SnapshotIcon kind={item.kind} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          {item.url ? (
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noreferrer"
+              className="flex min-w-0 items-center gap-1 truncate text-xs font-medium hover:underline"
+            >
+              <span className="truncate">{item.title}</span>
+              <ExternalLink
+                className="h-3 w-3 shrink-0 text-muted-foreground/70"
+                aria-hidden
+              />
+            </a>
+          ) : (
+            <span className="truncate text-xs font-medium">{item.title}</span>
+          )}
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {formatRelative(item.produced_at)}
+          </span>
+        </div>
+        {item.subtitle && (
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+            {item.subtitle}
+          </p>
+        )}
+        {item.size_bytes != null && (
+          <p className="mt-0.5 text-[10px] text-muted-foreground">
+            {formatSize(item.size_bytes)}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function SnapshotIcon({ kind }: { kind: SnapshotArtifactKind }) {
+  switch (kind) {
+    case "github_actions_artifact":
+      return <Container className="h-4 w-4 text-violet-200" aria-hidden />;
+    case "deploy_snapshot":
+      return <Rocket className="h-4 w-4 text-cyan-200" aria-hidden />;
+    case "agentic_artifact":
+    default:
+      return kind === "agentic_artifact" ? (
+        <GitBranch className="h-4 w-4 text-emerald-200" aria-hidden />
+      ) : (
+        <Box className="h-4 w-4 text-muted-foreground" aria-hidden />
+      );
+  }
+}
+
+function formatRelative(value: string): string {
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) return "";
+  const diffMs = Date.now() - ts;
+  if (diffMs < 60_000) return "just now";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}

--- a/ui/src/components/agentic-sdlc/ResizableSectionGrid.tsx
+++ b/ui/src/components/agentic-sdlc/ResizableSectionGrid.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * ResizableSectionGrid — alternative to SectionRenderer that places
+ * every visible panel into a single responsive react-grid-layout. The
+ * user can drag panel headers to reorder, drag the SE handle to
+ * resize, and the coords are persisted per-user via usePanelPreferences.
+ *
+ * SSR safety: react-grid-layout depends on browser-only globals
+ * (window matchMedia, ResizeObserver). The shell loads this module via
+ * `next/dynamic` with `ssr:false` so the SSR pass falls back to the
+ * stacked masonry; the resizable grid only renders client-side.
+ *
+ * Performance: RGL fires `onLayoutChange` for every drag tick. We rely
+ * on the hook's commit pipeline (which debounces the API PUT), so
+ * intermediate states stay client-side until the user stops moving.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+import { useCallback, useMemo, useRef } from "react";
+import type {
+  Layout,
+  LayoutItem,
+  ResponsiveLayouts,
+} from "react-grid-layout/legacy";
+import { Responsive, WidthProvider } from "react-grid-layout/legacy";
+
+import {
+  renderPanel,
+  type PanelContext,
+} from "@/components/agentic-sdlc/SectionRenderer";
+import type { UsePanelPreferencesResult } from "@/hooks/use-panel-preferences";
+import {
+  GRID_COLS,
+  resolveGridLayout,
+  resolvePanelLayout,
+  type Breakpoint,
+  type GridCoord,
+} from "@/lib/agentic-sdlc/panel-preferences";
+import {
+  getPanel,
+  type PanelId,
+  type PanelSurface,
+} from "@/lib/agentic-sdlc/panel-registry";
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+interface ResizableSectionGridProps {
+  surface: PanelSurface;
+  preferences: UsePanelPreferencesResult["preferences"];
+  setGridLayout: UsePanelPreferencesResult["setGridLayout"];
+  context: PanelContext;
+}
+
+const ROW_HEIGHT = 32;
+const MARGIN: [number, number] = [16, 16];
+const BREAKPOINTS = { lg: 1280, md: 1024, sm: 768, xs: 0 } as const;
+
+export function ResizableSectionGrid({
+  surface,
+  preferences,
+  setGridLayout,
+  context,
+}: ResizableSectionGridProps) {
+  const visiblePanelIds = useMemo(() => {
+    const layout = resolvePanelLayout(preferences);
+    const ids: PanelId[] = [];
+    for (const section of Object.keys(layout) as (keyof typeof layout)[]) {
+      for (const id of layout[section] ?? []) ids.push(id);
+    }
+    return ids;
+  }, [preferences]);
+
+  const layouts: ResponsiveLayouts = useMemo(() => {
+    const out: ResponsiveLayouts = {};
+    (Object.keys(GRID_COLS) as Breakpoint[]).forEach((bp) => {
+      const coords = resolveGridLayout(preferences, bp);
+      out[bp] = visiblePanelIds.map((id) => {
+        const c: GridCoord = coords[id] ?? { x: 0, y: 0, w: 6, h: 8 };
+        const desc = getPanel(id);
+        return {
+          i: id,
+          x: c.x,
+          y: c.y,
+          w: c.w,
+          h: c.h,
+          minW: desc.size === "full" ? 6 : 3,
+          minH: 4,
+          maxW: GRID_COLS[bp],
+        };
+      });
+    });
+    return out;
+  }, [preferences, visiblePanelIds]);
+
+  // We deliberately do NOT persist on `onLayoutChange` because it also
+  // fires on the initial render, which would clobber server-saved
+  // coords with defaults the first time the page mounts on a new
+  // device. Instead we hold the latest `allLayouts` snapshot in a ref
+  // and commit only on `onDragStop` / `onResizeStop`.
+  const lastLayoutsRef = useRef<ResponsiveLayouts | null>(null);
+
+  const handleLayoutChange = useCallback(
+    (_current: Layout, allLayouts: ResponsiveLayouts) => {
+      lastLayoutsRef.current = allLayouts;
+    },
+    [],
+  );
+
+  const commitLatest = useCallback(() => {
+    const all = lastLayoutsRef.current;
+    if (!all) return;
+    (Object.keys(GRID_COLS) as Breakpoint[]).forEach((bp) => {
+      const bpLayout = all[bp];
+      if (!bpLayout) return;
+      const snapshot: Record<PanelId, GridCoord> = {} as Record<
+        PanelId,
+        GridCoord
+      >;
+      for (const item of bpLayout as readonly LayoutItem[]) {
+        snapshot[item.i as PanelId] = {
+          x: item.x,
+          y: item.y,
+          w: item.w,
+          h: item.h,
+        };
+      }
+      setGridLayout(bp, snapshot);
+    });
+  }, [setGridLayout]);
+
+  return (
+    <ResponsiveGridLayout
+      className="agentic-sdlc-grid"
+      layouts={layouts}
+      breakpoints={BREAKPOINTS}
+      cols={GRID_COLS}
+      rowHeight={ROW_HEIGHT}
+      margin={MARGIN}
+      containerPadding={[0, 0]}
+      // Drag from any panel header. The header includes the
+      // Minimize/Show button and the modal-fullscreen button on
+      // changelog; those use `button` elements so RGL's 3-px
+      // movement threshold prevents drag-on-click. As a belt-and-
+      // braces measure we also exclude buttons via `draggableCancel`.
+      draggableHandle=".collapsible-panel-header"
+      draggableCancel="button, a, input, textarea, select, [data-no-drag]"
+      isResizable
+      isDraggable
+      compactType="vertical"
+      preventCollision={false}
+      onLayoutChange={handleLayoutChange}
+      onDragStop={commitLatest}
+      onResizeStop={commitLatest}
+      aria-label={`Resizable panel grid for ${surface}`}
+    >
+      {visiblePanelIds.map((id) => (
+        <div
+          key={id}
+          className="agentic-sdlc-grid-item relative flex h-full min-h-0 flex-col overflow-hidden"
+        >
+          <div className="h-full min-h-0 overflow-auto">
+            {renderPanel(id, context)}
+          </div>
+        </div>
+      ))}
+    </ResponsiveGridLayout>
+  );
+}

--- a/ui/src/components/agentic-sdlc/SectionRenderer.tsx
+++ b/ui/src/components/agentic-sdlc/SectionRenderer.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * SectionRenderer — given a section name and a resolved layout
+ * (sectionId → panel ids), emit the configured panels in the
+ * configured order using a responsive grid.
+ *
+ * Layout rules:
+ *   - At xl and above, half-size panels live in a 2-column grid and
+ *     full-size panels span the row.
+ *   - Below xl, every panel takes the full width.
+ *
+ * The mapping from PanelId to a concrete React component lives in
+ * PANEL_COMPONENTS below. Wave 1 wires the existing panels and
+ * stubs the rest with PanelPlaceholder so the chooser is fully
+ * functional today.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import type { ReactNode } from "react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import { PanelPlaceholder } from "@/components/agentic-sdlc/PanelPlaceholder";
+import { RepoCiPanel } from "@/components/agentic-sdlc/RepoCiPanel";
+import { RepoChangelogPanel } from "@/components/agentic-sdlc/RepoChangelogPanel";
+import { RepoDeploymentHealthPanel } from "@/components/agentic-sdlc/RepoDeploymentHealthPanel";
+import { RepoEpicList } from "@/components/agentic-sdlc/RepoEpicList";
+import { RepoEventFeed } from "@/components/agentic-sdlc/RepoEventFeed";
+import { RepoOperatingMetrics } from "@/components/agentic-sdlc/RepoOperatingMetrics";
+import { RepoSnapshotsPanel } from "@/components/agentic-sdlc/RepoSnapshotsPanel";
+import { RepoSwimLanes } from "@/components/agentic-sdlc/RepoSwimLanes";
+import { ShipLoopRingPanel } from "@/components/agentic-sdlc/panels/ShipLoopRingPanel";
+// AgenticSdlcAnimation is consumed inside ShipLoopRingPanel.
+import { SpecHealthPanel } from "@/components/agentic-sdlc/panels/SpecHealthPanel";
+import {
+  AgentBudgetPanel,
+  AgentRosterPanel,
+  BlackboxAuditPanel,
+  BlastRadiusPanel,
+  FailureModesPanel,
+  HarnessPanel,
+  IntentDriftPanel,
+  MistakeEncodedPanel,
+  ParallelFanoutPanel,
+  PrProdSparklinePanel,
+  ProdSignalPanel,
+  ProvenancePanel,
+  QualityGauntletPanel,
+  RollbackRehearsalPanel,
+  SpecKitReplayPanel,
+  VerifierConfidencePanel,
+} from "@/components/agentic-sdlc/panels/InsightPanels";
+import {
+  getPanel,
+  type PanelId,
+  type PanelSection,
+} from "@/lib/agentic-sdlc/panel-registry";
+
+export interface PanelContext {
+  owner?: string;
+  repo?: string;
+  fullName?: string;
+}
+
+interface SectionRendererProps {
+  section: PanelSection;
+  panelIds: PanelId[];
+  context: PanelContext;
+  "aria-label"?: string;
+}
+
+export function SectionRenderer({
+  section,
+  panelIds,
+  context,
+  ...rest
+}: SectionRendererProps) {
+  if (panelIds.length === 0) return null;
+
+  const panels = panelIds.map((id) => ({
+    id,
+    desc: getPanel(id),
+    node: renderPanel(id, context),
+  }));
+
+  // Split the section into runs separated by full-width panels so each
+  // run of half-size panels can flow as a masonry-style 2-column layout
+  // at xl (CSS columns) and tile without leaving height gaps. Full
+  // panels render as their own row.
+  const runs: Array<
+    | { kind: "full"; panel: (typeof panels)[number] }
+    | { kind: "half"; panels: typeof panels }
+  > = [];
+  let buffer: typeof panels = [];
+  const flushHalves = () => {
+    if (buffer.length > 0) {
+      runs.push({ kind: "half", panels: buffer });
+      buffer = [];
+    }
+  };
+  for (const p of panels) {
+    if (p.desc.size === "full") {
+      flushHalves();
+      runs.push({ kind: "full", panel: p });
+    } else {
+      buffer.push(p);
+    }
+  }
+  flushHalves();
+
+  return (
+    <section
+      aria-label={rest["aria-label"] ?? section}
+      className="flex flex-col gap-4"
+    >
+      {runs.map((run, idx) =>
+        run.kind === "full" ? (
+          <div key={`${section}-full-${run.panel.id}-${idx}`} className="min-w-0">
+            {run.panel.node}
+          </div>
+        ) : (
+          <div
+            key={`${section}-row-${idx}`}
+            className="xl:columns-2 xl:[column-gap:1rem]"
+          >
+            {run.panels.map((p) => (
+              <div key={p.id} className="mb-4 break-inside-avoid">
+                {p.node}
+              </div>
+            ))}
+          </div>
+        ),
+      )}
+    </section>
+  );
+}
+
+export function renderPanel(id: PanelId, ctx: PanelContext): ReactNode {
+  const { owner = "", repo = "", fullName = `${owner}/${repo}` } = ctx;
+
+  switch (id) {
+    case "ship_loop_ring":
+      return <ShipLoopRingPanel owner={owner} repo={repo} />;
+    case "swim_lanes":
+      return <RepoSwimLanes owner={owner} repo={repo} />;
+    case "epics":
+      return (
+        <CollapsiblePanel
+          title="Epics"
+          subtitle={
+            <span className="flex items-center justify-between gap-3">
+              <span>Drill into active loops and repo-level Epics.</span>
+              <span className="text-[11px] text-muted-foreground/70">
+                {fullName}
+              </span>
+            </span>
+          }
+          className="min-w-0"
+        >
+          <RepoEpicList owner={owner} repo={repo} />
+        </CollapsiblePanel>
+      );
+    case "operating_metrics":
+      return <RepoOperatingMetrics owner={owner} repo={repo} />;
+    case "ci_in_flight":
+      return <RepoCiPanel owner={owner} repo={repo} />;
+    case "changelog":
+      return <RepoChangelogPanel owner={owner} repo={repo} />;
+    case "snapshots":
+      return <RepoSnapshotsPanel owner={owner} repo={repo} />;
+    case "deploy_health":
+      return <RepoDeploymentHealthPanel owner={owner} repo={repo} />;
+    case "event_feed":
+      return <RepoEventFeed owner={owner} repo={repo} />;
+    case "spec_health":
+      return <SpecHealthPanel owner={owner} repo={repo} />;
+    case "intent_drift":
+      return <IntentDriftPanel owner={owner} repo={repo} />;
+    case "spec_kit_replay":
+      return <SpecKitReplayPanel owner={owner} repo={repo} />;
+    case "agent_roster":
+      return <AgentRosterPanel owner={owner} repo={repo} />;
+    case "agent_budget":
+      return <AgentBudgetPanel owner={owner} repo={repo} />;
+    case "parallel_fanout":
+      return <ParallelFanoutPanel owner={owner} repo={repo} />;
+    case "harness":
+      return <HarnessPanel owner={owner} repo={repo} />;
+    case "mistake_encoded":
+      return <MistakeEncodedPanel owner={owner} repo={repo} />;
+    case "verifier_confidence":
+      return <VerifierConfidencePanel owner={owner} repo={repo} />;
+    case "quality_gauntlet":
+      return <QualityGauntletPanel owner={owner} repo={repo} />;
+    case "failure_modes":
+      return <FailureModesPanel owner={owner} repo={repo} />;
+    case "provenance_sbom":
+      return <ProvenancePanel owner={owner} repo={repo} />;
+    case "blast_radius":
+      return <BlastRadiusPanel owner={owner} repo={repo} />;
+    case "rollback_rehearsal":
+      return <RollbackRehearsalPanel owner={owner} repo={repo} />;
+    case "prod_signal_wire":
+      return <ProdSignalPanel owner={owner} repo={repo} />;
+    case "pr_prod_sparkline":
+      return <PrProdSparklinePanel owner={owner} repo={repo} />;
+    case "blackbox_audit":
+      return <BlackboxAuditPanel owner={owner} repo={repo} />;
+    default:
+      return <PanelPlaceholder panelId={id} />;
+  }
+}

--- a/ui/src/components/agentic-sdlc/panels/InsightPanels.tsx
+++ b/ui/src/components/agentic-sdlc/panels/InsightPanels.tsx
@@ -1,0 +1,1197 @@
+"use client";
+
+/**
+ * Bundle of the Wave 2–4 insight panels.
+ *
+ * Each component is a thin renderer over the `/insights/{panel}` API,
+ * wrapped in a CollapsiblePanel. Panels here are intentionally
+ * compact; they all share the `useInsightsFetch` hook and the same
+ * loading/error semantics.
+ *
+ * Co-locating them in one file makes the registry → component wiring
+ * trivial in SectionRenderer without scattering 16 tiny files.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  AlertTriangle,
+  Beaker,
+  Bot,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  Gauge,
+  GitBranch,
+  Lock,
+  Loader2,
+  Network,
+  PieChart,
+  Radar,
+  Radio,
+  ScrollText,
+  ShieldCheck,
+  Sparkles,
+  Workflow,
+  Wrench,
+} from "lucide-react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import { useInsightsFetch } from "@/hooks/use-insights-fetch";
+import type {
+  AgentBudgetSummary,
+  AgentRosterSummary,
+  BlackboxAuditSummary,
+  BlastRadiusSummary,
+  FailureModesSummary,
+  FanoutSummary,
+  HarnessSummary,
+  IntentDriftSummary,
+  MistakeEncodedSummary,
+  PrProdMetricSummary,
+  ProdSignalSummary,
+  ProvenanceSummary,
+  QualityGate,
+  QualityGauntletSummary,
+  RollbackRehearsalSummary,
+  VerifierConfidenceSummary,
+} from "@/types/agentic-sdlc";
+
+interface PanelProps {
+  owner: string;
+  repo: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function PanelShell({
+  title,
+  subtitle,
+  icon,
+  demo,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  icon: React.ReactNode;
+  demo?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <CollapsiblePanel
+      title={title}
+      leading={icon}
+      subtitle={
+        <span className="flex flex-wrap items-center gap-2">
+          <span>{subtitle}</span>
+          {demo && (
+            <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-amber-200">
+              demo data
+            </span>
+          )}
+        </span>
+      }
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      {children}
+    </CollapsiblePanel>
+  );
+}
+
+function PanelStatus({ loading, error }: { loading: boolean; error: string | null }) {
+  if (error) {
+    return (
+      <p className="mt-3 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+        Could not load data ({error}).
+      </p>
+    );
+  }
+  if (loading) {
+    return (
+      <p className="mt-3 inline-flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden /> Loading…
+      </p>
+    );
+  }
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Intent drift                                                               */
+/* -------------------------------------------------------------------------- */
+
+export function IntentDriftPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<IntentDriftSummary>({
+    owner,
+    repo,
+    panel: "intent-drift",
+  });
+  return (
+    <PanelShell
+      title="Intent drift"
+      subtitle="Per-epic alignment between acceptance criteria and actual PR contents."
+      icon={<Radar className="h-4 w-4 text-indigo-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="mt-1 space-y-1.5">
+        {(data?.epics ?? []).slice(0, 8).map((epic) => {
+          const align = Math.round((epic.alignment ?? 0) * 100);
+          const beads = epic.beads ?? [];
+          const tone =
+            align >= 75 ? "text-emerald-300" : align >= 50 ? "text-amber-300" : "text-red-300";
+          return (
+            <li
+              key={epic.epic_id}
+              className="rounded-md border border-border/30 bg-background/30 px-2.5 py-1.5"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <a
+                  href={epic.github_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="truncate text-xs font-medium text-foreground hover:text-primary"
+                >
+                  {epic.title}
+                </a>
+                <span className={`text-[11px] font-semibold ${tone}`}>
+                  {align}%
+                </span>
+              </div>
+              <div className="mt-1 flex items-end gap-0.5">
+                {beads.length === 0 && (
+                  <span className="text-[10px] text-muted-foreground/60">
+                    no PRs yet
+                  </span>
+                )}
+                {beads.map((b, i) => (
+                  <span
+                    key={i}
+                    className={`inline-block w-1.5 rounded-sm ${
+                      b >= 0.6
+                        ? "bg-emerald-400/70"
+                        : b >= 0.4
+                          ? "bg-amber-400/70"
+                          : "bg-red-400/70"
+                    }`}
+                    style={{ height: `${4 + b * 14}px` }}
+                  />
+                ))}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Spec-Kit replay (mock, time-scrub)                                         */
+/* -------------------------------------------------------------------------- */
+
+export function SpecKitReplayPanel({ owner, repo }: PanelProps) {
+  const fullName = `${owner}/${repo}`;
+  return (
+    <PanelShell
+      title="Spec-Kit replay"
+      subtitle={`Specify → Plan → Tasks → Implement timeline for ${fullName}.`}
+      icon={<ScrollText className="h-4 w-4 text-indigo-300" aria-hidden />}
+      demo
+    >
+      <div className="space-y-2">
+        <div className="grid grid-cols-4 gap-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+          {["specify", "plan", "tasks", "implement"].map((phase, i) => (
+            <div
+              key={phase}
+              className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+            >
+              <p className="font-semibold text-foreground">{phase}</p>
+              <p>3{i + 2} min</p>
+              <p className="text-[9px] text-muted-foreground/70">
+                {6 - i * 1} commits
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center gap-2 rounded-md border border-border/40 bg-background/30 px-2 py-1.5 text-[11px] text-muted-foreground">
+          <Clock className="h-3 w-3" aria-hidden />
+          <span>Scrub</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            defaultValue={64}
+            className="flex-1 accent-indigo-400"
+            aria-label="Replay position"
+          />
+          <span>1×</span>
+          <button
+            type="button"
+            className="rounded-sm border border-border/40 bg-background/40 px-1 text-[10px] hover:text-foreground"
+          >
+            2×
+          </button>
+          <button
+            type="button"
+            className="rounded-sm border border-border/40 bg-background/40 px-1 text-[10px] hover:text-foreground"
+          >
+            5×
+          </button>
+        </div>
+      </div>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Harness                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export function HarnessPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<HarnessSummary>({
+    owner,
+    repo,
+    panel: "harness",
+  });
+  return (
+    <PanelShell
+      title="Harness"
+      subtitle="Linters · structural tests · ADRs · skills · policies · security scans."
+      icon={<Wrench className="h-4 w-4 text-cyan-300" aria-hidden />}
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <>
+          <div className="flex items-center gap-2 rounded-md border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200">
+            <Gauge className="h-4 w-4" aria-hidden />
+            <span className="font-semibold">
+              {Math.round((data.pass_rate ?? 0) * 100)}% harness pass rate
+            </span>
+            <span className="text-cyan-200/70">
+              · {(data.rules ?? []).length} rules active
+            </span>
+          </div>
+          <ul className="mt-2 space-y-1">
+            {(data.rules ?? []).map((rule) => (
+              <li
+                key={rule.id}
+                className="flex items-center justify-between gap-2 rounded-md border border-border/30 bg-background/30 px-2 py-1"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="rounded-sm border border-border/40 bg-background/40 px-1 text-[9px] uppercase text-muted-foreground">
+                    {rule.kind}
+                  </span>
+                  <span className="truncate text-xs text-foreground">
+                    {rule.name}
+                  </span>
+                </span>
+                <span className="text-[11px] font-semibold text-cyan-200">
+                  {Math.round(rule.pass_rate * 100)}%
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Mistake encoded                                                            */
+/* -------------------------------------------------------------------------- */
+
+export function MistakeEncodedPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<MistakeEncodedSummary>({
+    owner,
+    repo,
+    panel: "mistake-encoded",
+  });
+  return (
+    <PanelShell
+      title="Mistake encoded"
+      subtitle="Each pulse is an agent failure that produced a new rule, ADR, or test gate."
+      icon={<Sparkles className="h-4 w-4 text-cyan-300" aria-hidden />}
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <>
+          <p className="rounded-md border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200">
+            <span className="font-semibold">{data.learnings_24h ?? 0}</span> new
+            rules encoded in the last 24h ·{" "}
+            <span className="font-semibold">{data.total_learnings ?? 0}</span>{" "}
+            lifetime.
+          </p>
+          <ul className="mt-2 space-y-1">
+            {(data.events ?? []).slice(0, 8).map((ev) => (
+              <li
+                key={ev.id}
+                className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="inline-flex items-center gap-1 truncate text-xs text-foreground">
+                    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-cyan-400" />
+                    {ev.rule_added}
+                  </span>
+                  <span className="rounded-sm border border-border/40 bg-background/40 px-1 text-[9px] uppercase text-muted-foreground">
+                    {ev.kind}
+                  </span>
+                </div>
+                <p className="text-[10px] text-muted-foreground">
+                  {ev.description}
+                </p>
+              </li>
+            ))}
+            {(data.events ?? []).length === 0 && (
+              <li className="rounded-md border border-dashed border-border/40 bg-background/20 px-2 py-1.5 text-[11px] text-muted-foreground">
+                No encoded mistakes yet.
+              </li>
+            )}
+          </ul>
+        </>
+      )}
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Agent roster                                                               */
+/* -------------------------------------------------------------------------- */
+
+export function AgentRosterPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<AgentRosterSummary>({
+    owner,
+    repo,
+    panel: "agent-roster",
+  });
+  return (
+    <PanelShell
+      title="Agent roster"
+      subtitle="Who is working on what, right now."
+      icon={<Bot className="h-4 w-4 text-emerald-300" aria-hidden />}
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-1">
+        {(data?.agents ?? []).length === 0 && (
+          <li className="rounded-md border border-dashed border-border/40 bg-background/20 px-2 py-2 text-[11px] text-muted-foreground">
+            No agents currently active.
+          </li>
+        )}
+        {(data?.agents ?? []).map((agent) => (
+          <li
+            key={agent.agent_id}
+            className="flex items-center justify-between gap-2 rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <span
+                className={`h-1.5 w-1.5 rounded-full ${
+                  agent.status === "active"
+                    ? "animate-pulse bg-emerald-400"
+                    : agent.status === "blocked"
+                      ? "bg-red-400"
+                      : "bg-muted-foreground/40"
+                }`}
+              />
+              <span className="text-xs font-medium text-foreground">
+                {agent.display_name}
+              </span>
+              <span className="rounded-sm border border-border/40 bg-background/40 px-1 text-[9px] uppercase text-muted-foreground">
+                {agent.role}
+              </span>
+            </span>
+            <span className="truncate text-[11px] text-muted-foreground">
+              {agent.current_artifact_title ?? "—"}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Agent budget                                                               */
+/* -------------------------------------------------------------------------- */
+
+export function AgentBudgetPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<AgentBudgetSummary>({
+    owner,
+    repo,
+    panel: "agent-budget",
+  });
+  return (
+    <PanelShell
+      title="Agent budget"
+      subtitle="LLM tokens (M) per epic — builder compute vs reviewer/verifier, against estimate."
+      icon={<Gauge className="h-4 w-4 text-emerald-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <>
+          <div className="grid grid-cols-2 gap-2 text-[11px]">
+            <div className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Compute tokens
+              </p>
+              <p className="text-foreground">
+                {(data.totals?.actual_compute_tokens_m ?? 0).toFixed(1)} /{" "}
+                {(data.totals?.estimated_compute_tokens_m ?? 0).toFixed(1)}{" "}
+                <span className="text-muted-foreground">M</span>
+              </p>
+            </div>
+            <div className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Review tokens
+              </p>
+              <p className="text-foreground">
+                {(data.totals?.actual_review_tokens_m ?? 0).toFixed(1)} /{" "}
+                {(data.totals?.estimated_review_tokens_m ?? 0).toFixed(1)}{" "}
+                <span className="text-muted-foreground">M</span>
+              </p>
+            </div>
+          </div>
+          <ul className="mt-2 space-y-1">
+            {(data.epics ?? []).slice(0, 6).map((e) => {
+              const ratio = e.estimated_compute_tokens_m
+                ? e.actual_compute_tokens_m / e.estimated_compute_tokens_m
+                : 0;
+              const pct = Math.min(140, Math.round(ratio * 100));
+              const tone =
+                e.status === "over"
+                  ? "bg-red-400/70"
+                  : e.status === "warning"
+                    ? "bg-amber-400/70"
+                    : "bg-emerald-400/70";
+              return (
+                <li
+                  key={e.epic_id}
+                  className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+                >
+                  <div className="flex items-center justify-between gap-2 text-xs">
+                    <span className="truncate text-foreground">{e.title}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {e.actual_compute_tokens_m.toFixed(1)}M /{" "}
+                      {e.estimated_compute_tokens_m.toFixed(1)}M tokens
+                    </span>
+                  </div>
+                  <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-background/60">
+                    <div
+                      className={`h-1.5 ${tone}`}
+                      style={{ width: `${Math.min(100, pct)}%` }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Parallel fan-out                                                           */
+/* -------------------------------------------------------------------------- */
+
+export function ParallelFanoutPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<FanoutSummary>({
+    owner,
+    repo,
+    panel: "fanout",
+  });
+  return (
+    <PanelShell
+      title="Parallel fan-out"
+      subtitle="Parallel branches per epic and where they converge."
+      icon={<Workflow className="h-4 w-4 text-emerald-300" aria-hidden />}
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-2">
+        {(data?.epics ?? []).length === 0 && (
+          <li className="rounded-md border border-dashed border-border/40 bg-background/20 px-2 py-2 text-[11px] text-muted-foreground">
+            No multi-branch epics in flight.
+          </li>
+        )}
+        {(data?.epics ?? []).slice(0, 6).map((epic) => (
+          <li
+            key={epic.epic_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <a
+                href={epic.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-xs font-medium text-foreground hover:text-primary"
+              >
+                {epic.title}
+              </a>
+              <span className="text-[10px] text-muted-foreground">
+                {(epic.branches ?? []).length} branches
+              </span>
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px]">
+              {(epic.branches ?? []).map((b) => (
+                <span
+                  key={b.branch_id}
+                  className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 ${
+                    b.status === "merged"
+                      ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-200"
+                      : b.status === "abandoned"
+                        ? "border-red-400/30 bg-red-500/10 text-red-200"
+                        : "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                  }`}
+                >
+                  <GitBranch className="h-2.5 w-2.5" aria-hidden /> {b.agent.replace("agent:", "")}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Verifier confidence                                                        */
+/* -------------------------------------------------------------------------- */
+
+export function VerifierConfidencePanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<VerifierConfidenceSummary>({
+    owner,
+    repo,
+    panel: "verifier-confidence",
+  });
+  return (
+    <PanelShell
+      title="Verifier confidence"
+      subtitle="Per-PR acceptance criteria coverage."
+      icon={<ShieldCheck className="h-4 w-4 text-cyan-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <p className="rounded-md border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200">
+          Median AC coverage:{" "}
+          <span className="font-semibold">
+            {Math.round((data.median_coverage ?? 0) * 100)}%
+          </span>
+        </p>
+      )}
+      <ul className="mt-2 space-y-1">
+        {(data?.entries ?? []).slice(0, 6).map((e) => {
+          const pct = Math.round(e.coverage * 100);
+          const tone =
+            e.band === "strong"
+              ? "bg-emerald-400/70"
+              : e.band === "good"
+                ? "bg-cyan-400/70"
+                : e.band === "fair"
+                  ? "bg-amber-400/70"
+                  : "bg-red-400/70";
+          return (
+            <li
+              key={e.artifact_id}
+              className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+            >
+              <div className="flex items-center justify-between gap-2 text-xs">
+                <a
+                  href={e.github_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="truncate text-foreground hover:text-primary"
+                >
+                  {e.title}
+                </a>
+                <span className="text-[10px] text-muted-foreground">
+                  {e.acceptance_criteria_covered}/{e.acceptance_criteria_total} AC
+                </span>
+              </div>
+              <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-background/60">
+                <div
+                  className={`h-1.5 ${tone}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Quality-gate gauntlet                                                      */
+/* -------------------------------------------------------------------------- */
+
+const GAUNTLET_LABEL: Record<QualityGate, string> = {
+  lint: "Lint",
+  unit: "Unit",
+  integration: "Integration",
+  sca: "SCA",
+  security: "Security",
+  policy: "Policy",
+  architecture: "Architecture",
+  human_review: "Human review",
+};
+
+export function QualityGauntletPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<QualityGauntletSummary>({
+    owner,
+    repo,
+    panel: "quality-gauntlet",
+  });
+  return (
+    <PanelShell
+      title="Quality-gate gauntlet"
+      subtitle="Each PR running through lint → unit → SCA → security → policy → review."
+      icon={<Network className="h-4 w-4 text-cyan-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-2">
+        {(data?.runs ?? []).map((run) => (
+          <li
+            key={run.artifact_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <a
+                href={run.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-foreground hover:text-primary"
+              >
+                {run.title}
+              </a>
+              <span
+                className={`rounded-sm border px-1 text-[10px] ${
+                  run.conclusion === "passed"
+                    ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-200"
+                    : run.conclusion === "failed"
+                      ? "border-red-400/30 bg-red-500/10 text-red-200"
+                      : "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                }`}
+              >
+                {run.conclusion}
+              </span>
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-1">
+              {(run.gates ?? []).map((g, i) => (
+                <span
+                  key={i}
+                  className={`inline-flex items-center rounded-sm border px-1 text-[9px] uppercase tracking-wide ${
+                    g.state === "passed"
+                      ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
+                      : g.state === "failed"
+                        ? "border-red-400/40 bg-red-500/15 text-red-200 animate-pulse"
+                        : g.state === "skipped"
+                          ? "border-border/40 bg-background/20 text-muted-foreground/60"
+                          : "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                  }`}
+                  title={`${GAUNTLET_LABEL[g.gate]} · ${g.state}`}
+                >
+                  {GAUNTLET_LABEL[g.gate]}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Failure modes donut                                                        */
+/* -------------------------------------------------------------------------- */
+
+export function FailureModesPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<FailureModesSummary>({
+    owner,
+    repo,
+    panel: "failure-modes",
+  });
+  return (
+    <PanelShell
+      title="Failure modes (30d)"
+      subtitle="Where agents fail most often."
+      icon={<PieChart className="h-4 w-4 text-cyan-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <div className="flex items-start gap-3">
+          <Donut buckets={data.buckets ?? []} />
+          <ul className="min-w-0 flex-1 space-y-1 text-[11px]">
+            {(data.buckets ?? []).slice(0, 6).map((b) => (
+              <li
+                key={b.kind}
+                className="flex items-center justify-between gap-2"
+              >
+                <span className="truncate text-foreground">{b.label}</span>
+                <span className="text-muted-foreground">
+                  {Math.round(b.share * 100)}%{" "}
+                  <span className="text-muted-foreground/60">({b.count})</span>
+                </span>
+              </li>
+            ))}
+            {(data.buckets ?? []).length === 0 && (
+              <li className="text-muted-foreground">No failures recorded.</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </PanelShell>
+  );
+}
+
+function Donut({
+  buckets,
+}: {
+  buckets: FailureModesSummary["buckets"];
+}) {
+  const total = buckets.reduce((s, b) => s + b.count, 0);
+  if (total === 0) {
+    return (
+      <div className="flex h-20 w-20 items-center justify-center rounded-full border border-dashed border-border/40 text-[10px] text-muted-foreground">
+        clean
+      </div>
+    );
+  }
+  const colours = [
+    "#f87171", "#fbbf24", "#34d399", "#22d3ee", "#a78bfa", "#f472b6", "#94a3b8",
+  ];
+  const radius = 30;
+  const circumference = 2 * Math.PI * radius;
+  let offset = 0;
+  return (
+    <svg viewBox="0 0 80 80" className="h-20 w-20 -rotate-90" aria-hidden>
+      <circle
+        cx={40}
+        cy={40}
+        r={radius}
+        strokeWidth={12}
+        className="stroke-border/40"
+        fill="none"
+      />
+      {buckets.map((b, i) => {
+        const fraction = b.count / total;
+        const length = fraction * circumference;
+        const segment = (
+          <circle
+            key={b.kind}
+            cx={40}
+            cy={40}
+            r={radius}
+            strokeWidth={12}
+            stroke={colours[i % colours.length]}
+            fill="none"
+            strokeDasharray={`${length} ${circumference - length}`}
+            strokeDashoffset={-offset}
+            strokeLinecap="butt"
+          />
+        );
+        offset += length;
+        return segment;
+      })}
+    </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Provenance / SBOM                                                          */
+/* -------------------------------------------------------------------------- */
+
+export function ProvenancePanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<ProvenanceSummary>({
+    owner,
+    repo,
+    panel: "provenance",
+  });
+  return (
+    <PanelShell
+      title="Provenance / SBOM"
+      subtitle="Signature, SLSA level, harness version, SBOM, re-audit window per agent artifact."
+      icon={<Lock className="h-4 w-4 text-violet-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <div className="flex flex-wrap gap-2 text-[11px]">
+          <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-emerald-200">
+            {data.signed_count ?? 0} signed
+          </span>
+          <span className="rounded-full border border-red-400/30 bg-red-500/10 px-2 py-0.5 text-red-200">
+            {data.unsigned_count ?? 0} unsigned
+          </span>
+          <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-amber-200">
+            {data.reaudit_due_count ?? 0} re-audit due
+          </span>
+        </div>
+      )}
+      <ul className="mt-2 space-y-1">
+        {(data?.records ?? []).slice(0, 8).map((r) => (
+          <li
+            key={r.artifact_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <a
+                href={r.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-foreground hover:text-primary"
+              >
+                {r.title}
+              </a>
+              <span className="rounded-sm border border-border/40 bg-background/40 px-1 text-[10px] text-muted-foreground">
+                SLSA L{r.slsa_level}
+              </span>
+            </div>
+            <p className="mt-0.5 text-[10px] text-muted-foreground">
+              {r.model.replace("agent:", "")} · {r.harness_version} · {r.sbom_hash} ·{" "}
+              {r.signed ? (
+                <span className="text-emerald-300">signed</span>
+              ) : (
+                <span className="text-red-300">unsigned</span>
+              )}
+              {r.reaudit_due_in_days !== null && (
+                <span className="ml-1 text-amber-200">
+                  · {r.reaudit_due_in_days <= 0
+                    ? "re-audit due"
+                    : `re-audit in ${r.reaudit_due_in_days}d`}
+                </span>
+              )}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Blast radius                                                               */
+/* -------------------------------------------------------------------------- */
+
+export function BlastRadiusPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<BlastRadiusSummary>({
+    owner,
+    repo,
+    panel: "blast-radius",
+  });
+  return (
+    <PanelShell
+      title="Blast radius"
+      subtitle="Pre-merge preview of services, DBs, and endpoints each PR touches."
+      icon={<AlertTriangle className="h-4 w-4 text-violet-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-1.5">
+        {(data?.reports ?? []).length === 0 && (
+          <li className="rounded-md border border-dashed border-border/40 bg-background/20 px-2 py-2 text-[11px] text-muted-foreground">
+            No open PRs.
+          </li>
+        )}
+        {(data?.reports ?? []).slice(0, 6).map((r) => (
+          <li
+            key={r.artifact_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <a
+                href={r.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-foreground hover:text-primary"
+              >
+                {r.title}
+              </a>
+              <span
+                className={`rounded-sm border px-1 text-[10px] ${
+                  r.blast_percent >= 50
+                    ? "border-red-400/30 bg-red-500/10 text-red-200"
+                    : r.blast_percent >= 20
+                      ? "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                      : "border-emerald-400/30 bg-emerald-500/10 text-emerald-200"
+                }`}
+              >
+                {r.blast_percent}%
+              </span>
+            </div>
+            <p className="mt-0.5 text-[10px] text-muted-foreground">
+              {r.service_count} services · {r.database_count} DBs ·{" "}
+              {r.endpoint_count} endpoints
+            </p>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Rollback rehearsal                                                         */
+/* -------------------------------------------------------------------------- */
+
+export function RollbackRehearsalPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<RollbackRehearsalSummary>({
+    owner,
+    repo,
+    panel: "rollback-rehearsal",
+  });
+  return (
+    <PanelShell
+      title="Rollback rehearsal"
+      subtitle="When each environment last exercised its rollback path."
+      icon={<Beaker className="h-4 w-4 text-violet-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-1">
+        {(data?.entries ?? []).map((e) => (
+          <li
+            key={e.environment}
+            className="flex items-center justify-between gap-2 rounded-md border border-border/30 bg-background/30 px-2 py-1.5 text-xs"
+          >
+            <span className="font-medium text-foreground">{e.environment}</span>
+            <span
+              className={`rounded-sm border px-1 text-[10px] ${
+                e.status === "fresh"
+                  ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-200"
+                  : e.status === "stale"
+                    ? "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                    : "border-red-400/30 bg-red-500/10 text-red-200"
+              }`}
+            >
+              {e.status}
+            </span>
+            <span className="text-[10px] text-muted-foreground">
+              {e.last_exercised_at
+                ? new Date(e.last_exercised_at).toLocaleDateString()
+                : "never"}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Prod signal → spec                                                         */
+/* -------------------------------------------------------------------------- */
+
+export function ProdSignalPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<ProdSignalSummary>({
+    owner,
+    repo,
+    panel: "prod-signals",
+  });
+  return (
+    <PanelShell
+      title="Prod signal → spec"
+      subtitle="Production signals flow back to create the next epic."
+      icon={<Radio className="h-4 w-4 text-amber-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-1.5">
+        {(data?.events ?? []).map((ev) => (
+          <li
+            key={ev.id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+            draggable
+            data-signal-id={ev.id}
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="inline-flex items-center gap-2 truncate">
+                <span
+                  className={`h-1.5 w-1.5 rounded-full ${
+                    ev.severity === "critical"
+                      ? "animate-pulse bg-red-400"
+                      : ev.severity === "warning"
+                        ? "bg-amber-400"
+                        : "bg-muted-foreground/50"
+                  }`}
+                />
+                <span className="truncate text-foreground">{ev.title}</span>
+              </span>
+              <span className="rounded-sm border border-border/40 bg-background/40 px-1 text-[9px] uppercase text-muted-foreground">
+                {ev.source}
+              </span>
+            </div>
+            {ev.body && (
+              <p className="mt-0.5 text-[10px] text-muted-foreground">
+                {ev.body}
+              </p>
+            )}
+            {ev.proposed_epic_title && (
+              <p className="mt-1 inline-flex items-center gap-1 text-[10px] text-primary/90">
+                <ExternalLink className="h-2.5 w-2.5" aria-hidden /> Create epic:{" "}
+                <span className="text-foreground">{ev.proposed_epic_title}</span>
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* PR prod sparkline                                                          */
+/* -------------------------------------------------------------------------- */
+
+export function PrProdSparklinePanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<PrProdMetricSummary>({
+    owner,
+    repo,
+    panel: "pr-prod-metrics",
+  });
+  return (
+    <PanelShell
+      title="Prod metric per PR"
+      subtitle="24h latency / error / cost per merged PR."
+      icon={<CheckCircle2 className="h-4 w-4 text-amber-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      <ul className="space-y-1.5">
+        {(data?.prs ?? []).slice(0, 6).map((p) => (
+          <li
+            key={p.artifact_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <a
+                href={p.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-foreground hover:text-primary"
+              >
+                {p.title}
+              </a>
+              <span
+                className={`text-[10px] ${
+                  p.delta_percent < 0
+                    ? "text-emerald-300"
+                    : p.delta_percent > 0
+                      ? "text-red-300"
+                      : "text-muted-foreground"
+                }`}
+              >
+                {p.delta_percent > 0 ? "+" : ""}
+                {(p.delta_percent * 100).toFixed(1)}% Δ
+              </span>
+            </div>
+            <Sparkline values={p.values ?? []} metric={p.metric} />
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}
+
+function Sparkline({
+  values,
+  metric,
+}: {
+  values: number[];
+  metric: string;
+}) {
+  if (!values.length) {
+    return (
+      <p className="mt-1 text-[10px] text-muted-foreground/60">no samples yet</p>
+    );
+  }
+  const max = Math.max(...values, 1);
+  return (
+    <svg viewBox={`0 0 ${values.length} 30`} className="mt-1 h-6 w-full" aria-label={metric}>
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        className="text-amber-300"
+        points={values
+          .map((v, i) => `${i},${30 - (v / max) * 28}`)
+          .join(" ")}
+      />
+    </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Blackbox audit                                                             */
+/* -------------------------------------------------------------------------- */
+
+export function BlackboxAuditPanel({ owner, repo }: PanelProps) {
+  const { data, loading, error } = useInsightsFetch<BlackboxAuditSummary>({
+    owner,
+    repo,
+    panel: "blackbox-audit",
+  });
+  return (
+    <PanelShell
+      title="Blackbox audit"
+      subtitle="Human vs agent authorship per merged PR, with re-audit reminders."
+      icon={<Bot className="h-4 w-4 text-cyan-300" aria-hidden />}
+      demo
+    >
+      <PanelStatus loading={loading && !data} error={error} />
+      {data && (
+        <p className="rounded-md border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200">
+          {(data.total_agent_lines ?? 0).toLocaleString()} agent lines ·{" "}
+          {(data.total_human_lines ?? 0).toLocaleString()} human lines ·{" "}
+          <span className="font-semibold">{data.overdue_count ?? 0}</span> overdue
+          re-audits
+        </p>
+      )}
+      <ul className="mt-2 space-y-1">
+        {(data?.entries ?? []).slice(0, 8).map((e) => (
+          <li
+            key={e.artifact_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <a
+                href={e.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-foreground hover:text-primary"
+              >
+                {e.title}
+              </a>
+              <span className="text-[10px] text-muted-foreground">
+                agent {Math.round(e.agent_share * 100)}%
+              </span>
+            </div>
+            <div className="mt-1 flex h-1.5 overflow-hidden rounded-full bg-background/60">
+              <div
+                className="bg-cyan-400/80"
+                style={{ width: `${e.agent_share * 100}%` }}
+              />
+              <div
+                className="bg-emerald-400/80"
+                style={{ width: `${(1 - e.agent_share) * 100}%` }}
+              />
+            </div>
+            {e.reaudit_overdue && (
+              <p className="mt-0.5 text-[10px] text-amber-200">re-audit overdue</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
+  );
+}

--- a/ui/src/components/agentic-sdlc/panels/ShipLoopRingPanel.tsx
+++ b/ui/src/components/agentic-sdlc/panels/ShipLoopRingPanel.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+/**
+ * Live Ship Loop ring — the hero visualisation.
+ *
+ * Renders the five ship-loop stages (Specify → Execute → Verify →
+ * Deliver → Observe) as a ring. Tokens orbit at a speed proportional
+ * to real repo activity (events per minute) so the ring breathes with
+ * the actual ship-loop rather than a fixed animation.
+ *
+ * Two render modes selectable in the toolbar:
+ *   - SVG (default): light, accessible, reduced-motion friendly.
+ *   - WebGL cinematic: opt-in canvas with glow + particle trails.
+ *     Falls back to SVG when WebGL is unavailable.
+ *
+ * Behind the ring sits a 24h heatmap showing how many events landed
+ * in each hour bucket. The hero also drives the favicon health dot
+ * via window.dispatchEvent so other parts of the UI can react.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { Activity, Circle, RadioTower, Sparkles, Zap } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import { useInsightsFetch } from "@/hooks/use-insights-fetch";
+import type { FailureModesSummary } from "@/types/agentic-sdlc";
+
+interface ShipLoopRingPanelProps {
+  owner: string;
+  repo: string;
+  /**
+   * "panel" renders the full collapsible card (default — used by the
+   * configurable section grid). "mini" renders a compact, chrome-less
+   * version intended to sit in the corner of the repo header.
+   */
+  variant?: "panel" | "mini";
+}
+
+const STAGES = [
+  { id: "specify", label: "Specify", angle: -90, color: "#818cf8" },
+  { id: "execute", label: "Execute", angle: -18, color: "#34d399" },
+  { id: "verify", label: "Verify", angle: 54, color: "#22d3ee" },
+  { id: "deliver", label: "Deliver", angle: 126, color: "#a78bfa" },
+  { id: "observe", label: "Observe", angle: 198, color: "#fbbf24" },
+] as const;
+
+interface HeatmapBin {
+  hour_offset: number;
+  count: number;
+}
+
+interface RepoActivitySummary {
+  events_per_minute: number;
+  heatmap: HeatmapBin[];
+  health: "healthy" | "degraded" | "missing" | "unknown";
+}
+
+export function ShipLoopRingPanel({
+  owner,
+  repo,
+  variant = "panel",
+}: ShipLoopRingPanelProps) {
+  const [mode, setMode] = useState<"svg" | "webgl">("svg");
+  const { data: activity } = useInsightsFetch<RepoActivitySummary>({
+    owner,
+    repo,
+    panel: "ring-activity",
+    // The endpoint is fictional in this slice; the hook returns null
+    // on 404 and the ring uses a sensible default activity rate.
+  });
+  const { data: failures } = useInsightsFetch<FailureModesSummary>({
+    owner,
+    repo,
+    panel: "failure-modes",
+  });
+
+  const eventsPerMin =
+    typeof activity?.events_per_minute === "number"
+      ? activity.events_per_minute
+      : 4;
+  const health = (activity?.health ?? "healthy") as
+    | "healthy"
+    | "degraded"
+    | "missing"
+    | "unknown";
+
+  // Drive favicon dot via a custom event so the IDE / app shell can
+  // subscribe without depending on this component.
+  useEffect(() => {
+    const evt = new CustomEvent("agentic-sdlc:health-dot", {
+      detail: { repo: `${owner}/${repo}`, health },
+    });
+    window.dispatchEvent(evt);
+  }, [owner, repo, health]);
+
+  if (variant === "mini") {
+    return (
+      <div
+        className="pointer-events-none select-none opacity-90"
+        aria-label="Ship-loop ring"
+        role="img"
+      >
+        <SvgRing
+          eventsPerMin={eventsPerMin}
+          failures={failures}
+          size={132}
+          subtle
+        />
+      </div>
+    );
+  }
+
+  return (
+    <CollapsiblePanel
+      title="Ship-loop ring"
+      leading={<RadioTower className="h-4 w-4 text-primary" aria-hidden />}
+      subtitle={
+        <span className="flex flex-wrap items-center gap-2">
+          <span>Specify → Execute → Verify → Deliver → Observe.</span>
+          <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-200">
+            <Activity className="h-2.5 w-2.5" aria-hidden /> {eventsPerMin.toFixed(1)} ev/min
+          </span>
+          <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+            <Circle className={`h-2.5 w-2.5 ${healthTone(health)}`} aria-hidden /> {health}
+          </span>
+          <span className="ml-auto inline-flex gap-1">
+            <button
+              type="button"
+              onClick={() => setMode("svg")}
+              className={`rounded-sm border px-1.5 py-0.5 text-[10px] ${
+                mode === "svg"
+                  ? "border-primary/50 bg-primary/15 text-primary"
+                  : "border-border/40 bg-background/40 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              SVG
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("webgl")}
+              className={`inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] ${
+                mode === "webgl"
+                  ? "border-primary/50 bg-primary/15 text-primary"
+                  : "border-border/40 bg-background/40 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Sparkles className="h-2.5 w-2.5" aria-hidden /> Cinematic
+            </button>
+          </span>
+        </span>
+      }
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      <div className="relative rounded-xl border border-border/30 bg-background/20 p-3">
+        <Heatmap
+          heatmap={
+            Array.isArray(activity?.heatmap) && activity!.heatmap.length > 0
+              ? activity!.heatmap
+              : syntheticHeatmap()
+          }
+        />
+        {mode === "svg" ? (
+          <SvgRing eventsPerMin={eventsPerMin} failures={failures} />
+        ) : (
+          <CinematicRing eventsPerMin={eventsPerMin} />
+        )}
+      </div>
+    </CollapsiblePanel>
+  );
+}
+
+function healthTone(h: string): string {
+  if (h === "healthy") return "fill-emerald-400 text-emerald-400";
+  if (h === "degraded") return "fill-amber-400 text-amber-400";
+  if (h === "missing") return "fill-red-400 text-red-400";
+  return "fill-muted-foreground text-muted-foreground";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Heatmap behind the ring                                                    */
+/* -------------------------------------------------------------------------- */
+
+function syntheticHeatmap(): HeatmapBin[] {
+  const bins: HeatmapBin[] = [];
+  for (let h = 0; h < 24; h++) {
+    bins.push({ hour_offset: h, count: Math.max(0, Math.round(Math.sin((h / 24) * Math.PI * 2) * 4 + 4)) });
+  }
+  return bins;
+}
+
+function Heatmap({ heatmap }: { heatmap: HeatmapBin[] }) {
+  const max = Math.max(1, ...heatmap.map((b) => b.count));
+  return (
+    <div className="pointer-events-none absolute inset-x-3 top-1 grid grid-cols-24 gap-px opacity-50">
+      {heatmap.map((b) => {
+        const intensity = b.count / max;
+        return (
+          <span
+            key={b.hour_offset}
+            className="h-1 rounded-sm bg-primary"
+            style={{ opacity: 0.15 + intensity * 0.8 }}
+            title={`${b.hour_offset}h ago · ${b.count} events`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* SVG ring (default)                                                          */
+/* -------------------------------------------------------------------------- */
+
+function SvgRing({
+  eventsPerMin,
+  failures,
+  size = 208,
+  subtle = false,
+}: {
+  eventsPerMin: number;
+  failures: FailureModesSummary | null;
+  /** Pixel size of the rendered ring. Defaults to the 208px panel hero. */
+  size?: number;
+  /** Subtle mode for the corner mini ring: drops labels, smaller text. */
+  subtle?: boolean;
+}) {
+  const [tick, setTick] = useState(0);
+  const speedScale = Math.max(0.4, Math.min(3, eventsPerMin / 5));
+  useEffect(() => {
+    const mq = typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)")
+      : null;
+    if (mq?.matches) return; // honour reduced-motion
+    const handle = window.setInterval(
+      () => setTick((t) => (t + 1) % 360),
+      40 / speedScale,
+    );
+    return () => window.clearInterval(handle);
+  }, [speedScale]);
+
+  const stageStroke = subtle ? 1.5 : 2;
+  const stageRadius = subtle ? 9 : 12;
+  const tokenRadius = subtle ? 2.25 : 3;
+  const ringStrokeOpacity = subtle ? 0.22 : 0.35;
+  const glowStartAlpha = subtle ? 0.18 : 0.35;
+  const labelFontSize = subtle ? 8 : 9;
+  const captionFontSize = subtle ? 8 : 10;
+  const countFontSize = subtle ? 18 : 22;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      style={{ width: size, height: size }}
+      className="mx-auto"
+      role="img"
+      aria-label="Ship-loop ring with five stages"
+    >
+      <defs>
+        <radialGradient id="ring-glow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor={`rgba(99,102,241,${glowStartAlpha})`} />
+          <stop offset="100%" stopColor="rgba(99,102,241,0)" />
+        </radialGradient>
+      </defs>
+      <circle cx="100" cy="100" r="95" fill="url(#ring-glow)" />
+      <circle
+        cx="100"
+        cy="100"
+        r="70"
+        fill="none"
+        stroke={`rgba(148,163,184,${ringStrokeOpacity})`}
+        strokeWidth="0.5"
+        strokeDasharray="2 3"
+      />
+      {STAGES.map((s) => {
+        const x = 100 + Math.cos((s.angle * Math.PI) / 180) * 70;
+        const y = 100 + Math.sin((s.angle * Math.PI) / 180) * 70;
+        return (
+          <g key={s.id}>
+            <circle
+              cx={x}
+              cy={y}
+              r={stageRadius}
+              fill="rgba(15,23,42,0.85)"
+              stroke={s.color}
+              strokeWidth={stageStroke}
+            />
+            {!subtle && (
+              <text
+                x={x}
+                y={y + 28}
+                textAnchor="middle"
+                fontSize={labelFontSize}
+                fill="rgba(241,245,249,0.85)"
+              >
+                {s.label}
+              </text>
+            )}
+          </g>
+        );
+      })}
+      {/* Travelling tokens */}
+      {Array.from({ length: 6 }).map((_, i) => {
+        const angle = (tick + i * 60) % 360;
+        const r = 70;
+        const x = 100 + Math.cos((angle * Math.PI) / 180) * r;
+        const y = 100 + Math.sin((angle * Math.PI) / 180) * r;
+        const colour = STAGES[i % STAGES.length].color;
+        return (
+          <circle
+            key={i}
+            cx={x}
+            cy={y}
+            r={tokenRadius}
+            fill={colour}
+            opacity={subtle ? 0.7 : 0.85}
+          />
+        );
+      })}
+      <text
+        x="100"
+        y={subtle ? 92 : 92}
+        textAnchor="middle"
+        fontSize={captionFontSize}
+        fill="rgba(148,163,184,0.7)"
+        letterSpacing="1"
+        className="uppercase"
+      >
+        ship-loop
+      </text>
+      <text
+        x="100"
+        y={subtle ? 114 : 116}
+        textAnchor="middle"
+        fontSize={countFontSize}
+        fontWeight="700"
+        fill="rgba(241,245,249,0.95)"
+      >
+        {typeof failures?.total === "number" ? failures.total : 0} issues
+      </text>
+    </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cinematic ring (canvas)                                                    */
+/* -------------------------------------------------------------------------- */
+
+function CinematicRing({ eventsPerMin }: { eventsPerMin: number }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const fallback = useRef(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      fallback.current = true;
+      return;
+    }
+    const dpr = window.devicePixelRatio || 1;
+    const w = (canvas.width = 220 * dpr);
+    const h = (canvas.height = 220 * dpr);
+    canvas.style.width = "220px";
+    canvas.style.height = "220px";
+    ctx.scale(dpr, dpr);
+
+    let raf = 0;
+    let t = 0;
+    const speed = Math.max(0.005, Math.min(0.05, eventsPerMin / 200));
+
+    function frame() {
+      if (!ctx) return;
+      ctx.clearRect(0, 0, w, h);
+      const cx = 110;
+      const cy = 110;
+      // Glow background.
+      const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, 110);
+      grad.addColorStop(0, "rgba(99,102,241,0.35)");
+      grad.addColorStop(1, "rgba(99,102,241,0)");
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(cx, cy, 110, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Ring
+      ctx.strokeStyle = "rgba(148,163,184,0.35)";
+      ctx.lineWidth = 1;
+      ctx.setLineDash([3, 4]);
+      ctx.beginPath();
+      ctx.arc(cx, cy, 80, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Stages
+      for (const s of STAGES) {
+        const a = (s.angle * Math.PI) / 180;
+        const x = cx + Math.cos(a) * 80;
+        const y = cy + Math.sin(a) * 80;
+        ctx.fillStyle = "rgba(15,23,42,0.85)";
+        ctx.strokeStyle = s.color;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(x, y, 13, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        ctx.fillStyle = "rgba(241,245,249,0.85)";
+        ctx.font = "10px Inter, system-ui, sans-serif";
+        ctx.textAlign = "center";
+        ctx.fillText(s.label, x, y + 28);
+      }
+
+      // Trailing tokens with glow.
+      for (let i = 0; i < 24; i++) {
+        const angle = (t * 360 + i * 15) % 360;
+        const r = 80 + Math.sin((t + i / 24) * Math.PI * 2) * 4;
+        const a = (angle * Math.PI) / 180;
+        const x = cx + Math.cos(a) * r;
+        const y = cy + Math.sin(a) * r;
+        const colour = STAGES[i % STAGES.length].color;
+        ctx.fillStyle = colour;
+        ctx.globalAlpha = 0.4 + (i % 6) / 15;
+        ctx.beginPath();
+        ctx.arc(x, y, 2.5, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+      }
+
+      t += speed;
+      raf = requestAnimationFrame(frame);
+    }
+    raf = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(raf);
+  }, [eventsPerMin]);
+
+  if (fallback.current) {
+    return <SvgRing eventsPerMin={eventsPerMin} failures={null} />;
+  }
+  return (
+    <div className="flex justify-center">
+      <canvas ref={canvasRef} aria-label="Ship-loop ring (cinematic)" />
+      <Zap className="absolute right-3 top-3 h-3 w-3 text-amber-300" aria-hidden />
+    </div>
+  );
+}

--- a/ui/src/components/agentic-sdlc/panels/SpecHealthPanel.tsx
+++ b/ui/src/components/agentic-sdlc/panels/SpecHealthPanel.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/**
+ * Spec Health panel — circular gauge + per-epic missing-criteria list.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { Loader2, Sparkles, Target } from "lucide-react";
+
+import { CollapsiblePanel } from "@/components/agentic-sdlc/CollapsiblePanel";
+import { useInsightsFetch } from "@/hooks/use-insights-fetch";
+import type { SpecHealthSummary } from "@/types/agentic-sdlc";
+
+interface SpecHealthPanelProps {
+  owner: string;
+  repo: string;
+}
+
+export function SpecHealthPanel({ owner, repo }: SpecHealthPanelProps) {
+  const { data: rawData, loading, error } = useInsightsFetch<SpecHealthSummary>({
+    owner,
+    repo,
+    panel: "spec-health",
+  });
+  const data: SpecHealthSummary | null = rawData
+    ? {
+        repo_score: rawData.repo_score ?? 0,
+        epics: Array.isArray(rawData.epics) ? rawData.epics : [],
+        generated_at: rawData.generated_at ?? new Date().toISOString(),
+      }
+    : null;
+
+  return (
+    <CollapsiblePanel
+      title="Spec health"
+      leading={<Target className="h-4 w-4 text-indigo-300" aria-hidden />}
+      subtitle="Per-epic spec readiness: AC, NFR, constraints, tests, budget, ADRs."
+      className="glass-panel"
+      titleClassName="text-foreground normal-case tracking-normal"
+    >
+      <div className="flex items-start gap-4">
+        <Gauge value={data?.repo_score ?? 0} />
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Repo score
+          </p>
+          <p className="text-2xl font-semibold text-foreground">
+            {data?.repo_score ?? "—"}
+            <span className="ml-1 text-xs font-normal text-muted-foreground">
+              / 100
+            </span>
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            {data?.epics.length ?? 0} epics scored.
+          </p>
+        </div>
+      </div>
+      {error && (
+        <p className="mt-3 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          Could not load spec health ({error}).
+        </p>
+      )}
+      {loading && !data && (
+        <p className="mt-3 inline-flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" aria-hidden /> Loading…
+        </p>
+      )}
+      {data && data.epics.length === 0 && (
+        <p className="mt-3 rounded-md border border-dashed border-border/40 bg-background/20 px-3 py-2 text-[11px] text-muted-foreground">
+          No epics yet — the score appears once specs land.
+        </p>
+      )}
+      <ul className="mt-3 space-y-1.5">
+        {data?.epics.slice(0, 6).map((epic) => (
+          <li
+            key={epic.epic_id}
+            className="rounded-md border border-border/30 bg-background/30 px-2.5 py-1.5"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <a
+                href={epic.github_url}
+                target="_blank"
+                rel="noreferrer"
+                className="truncate text-xs font-medium text-foreground hover:text-primary"
+              >
+                {epic.title}
+              </a>
+              <BandBadge band={epic.band} score={epic.score} />
+            </div>
+            <ul className="mt-1 flex flex-wrap gap-1 text-[10px]">
+              {epic.criteria
+                .filter((c) => !c.present)
+                .slice(0, 4)
+                .map((c) => (
+                  <li
+                    key={c.kind}
+                    className="rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-amber-200"
+                    title={c.hint}
+                  >
+                    missing: {c.label}
+                  </li>
+                ))}
+              {epic.criteria.every((c) => c.present) && (
+                <li className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5 text-emerald-200">
+                  <Sparkles className="-mt-0.5 mr-0.5 inline h-2.5 w-2.5" aria-hidden />
+                  agent-ready
+                </li>
+              )}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </CollapsiblePanel>
+  );
+}
+
+function Gauge({ value }: { value: number }) {
+  const clamped = Math.max(0, Math.min(100, value));
+  const stroke = 8;
+  const radius = 28;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - clamped / 100);
+  const tone =
+    clamped >= 85
+      ? "stroke-emerald-400"
+      : clamped >= 70
+        ? "stroke-cyan-400"
+        : clamped >= 50
+          ? "stroke-amber-400"
+          : "stroke-red-400";
+  return (
+    <svg className="h-20 w-20 -rotate-90" viewBox="0 0 80 80" aria-hidden>
+      <circle
+        cx="40"
+        cy="40"
+        r={radius}
+        strokeWidth={stroke}
+        className="stroke-border/40"
+        fill="none"
+      />
+      <circle
+        cx="40"
+        cy="40"
+        r={radius}
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        className={tone}
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={dashOffset}
+        style={{ transition: "stroke-dashoffset 700ms ease-out" }}
+      />
+    </svg>
+  );
+}
+
+function BandBadge({
+  band,
+  score,
+}: {
+  band: "weak" | "fair" | "good" | "strong";
+  score: number;
+}) {
+  const map = {
+    weak: "border-red-400/30 bg-red-500/10 text-red-200",
+    fair: "border-amber-400/30 bg-amber-500/10 text-amber-200",
+    good: "border-cyan-400/30 bg-cyan-500/10 text-cyan-200",
+    strong: "border-emerald-400/30 bg-emerald-500/10 text-emerald-200",
+  } as const;
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${map[band]}`}
+    >
+      {band} {score}
+    </span>
+  );
+}

--- a/ui/src/hooks/use-favicon-health.ts
+++ b/ui/src/hooks/use-favicon-health.ts
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * Listens for `agentic-sdlc:health-dot` events emitted by the
+ * ShipLoopRingPanel and updates the document title + a tiny coloured
+ * dot baked onto the favicon. Cheap, dependency-free, idempotent.
+ *
+ * Skipped when reduced-motion is preferred (no flicker in tab title).
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { useEffect } from "react";
+
+export type HealthDot = "healthy" | "degraded" | "missing" | "unknown";
+
+const COLOURS: Record<HealthDot, string> = {
+  healthy: "#34d399",
+  degraded: "#fbbf24",
+  missing: "#f87171",
+  unknown: "#94a3b8",
+};
+
+export function useFaviconHealth() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    function paint(dot: HealthDot, label: string) {
+      const link =
+        (document.querySelector('link[rel="icon"]') as HTMLLinkElement | null) ??
+        document.createElement("link");
+      link.rel = "icon";
+      const size = 32;
+      const canvas = document.createElement("canvas");
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      // Background dot ring.
+      ctx.fillStyle = "#0f172a";
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = "#6366f1";
+      ctx.font = "bold 18px Inter, sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("A", size / 2, size / 2 + 1);
+      // Health dot in the bottom-right.
+      ctx.fillStyle = COLOURS[dot];
+      ctx.beginPath();
+      ctx.arc(size - 7, size - 7, 6, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = "#0f172a";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+      link.href = canvas.toDataURL("image/png");
+      if (!link.parentElement) document.head.appendChild(link);
+
+      const baseTitle = document.title.replace(/^[•◆◯]\s*/, "");
+      const prefix =
+        dot === "healthy" ? "● " : dot === "degraded" ? "◆ " : "◯ ";
+      document.title = `${prefix}${baseTitle}${label ? ` · ${label}` : ""}`;
+    }
+
+    function handler(ev: Event) {
+      const detail = (ev as CustomEvent<{ repo?: string; health?: HealthDot }>).detail;
+      paint(detail?.health ?? "unknown", detail?.repo ?? "");
+    }
+    window.addEventListener("agentic-sdlc:health-dot", handler);
+    return () => {
+      window.removeEventListener("agentic-sdlc:health-dot", handler);
+    };
+  }, []);
+}

--- a/ui/src/hooks/use-insights-fetch.ts
+++ b/ui/src/hooks/use-insights-fetch.ts
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * Tiny shared fetch hook for repo-detail insight panels. Centralises
+ * the URL shape, response normalisation, error handling, and the
+ * `agentic-sdlc:repo-synced` reload event.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+interface UseInsightsFetchArgs {
+  owner: string;
+  repo: string;
+  panel: string; // matches the panel slug in /insights/[panel]
+  enabled?: boolean;
+}
+
+export interface UseInsightsFetchResult<T> {
+  data: T | null;
+  error: string | null;
+  loading: boolean;
+  reload: () => void;
+}
+
+export function useInsightsFetch<T>(args: UseInsightsFetchArgs): UseInsightsFetchResult<T> {
+  const { owner, repo, panel, enabled = true } = args;
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!enabled) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/agentic-sdlc/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/insights/${panel}`,
+        { headers: { Accept: "application/json" }, cache: "no-store" },
+      );
+      if (!res.ok) throw new Error(`http_${res.status}`);
+      const body = (await res.json()) as T;
+      setData(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch_failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [owner, repo, panel, enabled]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    function onRepoSynced(event: Event) {
+      const detail = (event as CustomEvent<{ owner?: string; repo?: string }>).detail;
+      if (detail?.owner === owner && detail?.repo === repo) void load();
+    }
+    window.addEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+    return () =>
+      window.removeEventListener("agentic-sdlc:repo-synced", onRepoSynced);
+  }, [owner, repo, load]);
+
+  return { data, error, loading, reload: load };
+}

--- a/ui/src/hooks/use-panel-preferences.ts
+++ b/ui/src/hooks/use-panel-preferences.ts
@@ -1,0 +1,303 @@
+"use client";
+
+/**
+ * usePanelPreferences — React hook that owns the user's panel layout
+ * preferences for a single surface (repo_detail or home).
+ *
+ * Hydration order, deliberately layered to avoid flicker:
+ *
+ *   1. First render: returns the registry defaults so SSR + the first
+ *      paint pick the right panels. This means the page never flashes
+ *      with "all panels" or "no panels" while prefs are loading.
+ *   2. Immediately after mount: localStorage is consulted; if a saved
+ *      copy exists, it replaces the defaults synchronously, so user
+ *      choices stick across reloads with zero round-trip latency.
+ *   3. In parallel, a fetch to /api/agentic-sdlc/me/panel-prefs runs;
+ *      when it lands, server prefs win (they are the source of truth
+ *      across devices). The result is also written back to
+ *      localStorage so subsequent loads are instant.
+ *
+ * Writes are optimistic + debounced:
+ *   - The local React state and localStorage update immediately.
+ *   - A debounced PUT to the API persists the change to Mongo. If the
+ *     PUT fails the local state still reflects the user's choice; we
+ *     retry once on the next change.
+ *
+ * Listens for the storage event so two tabs stay in sync on the same
+ * device.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  clearGridLayout as clearGridLayoutPure,
+  defaultPreferences,
+  movePanel as movePanelPure,
+  normalisePreferences,
+  resetPreferences,
+  setGridEnabled as setGridEnabledPure,
+  setGridLayout as setGridLayoutPure,
+  togglePanelVisibility as togglePure,
+  type Breakpoint,
+  type GridCoord,
+  type PanelPreferences,
+} from "@/lib/agentic-sdlc/panel-preferences";
+import type {
+  PanelId,
+  PanelSection,
+  PanelSurface,
+} from "@/lib/agentic-sdlc/panel-registry";
+
+const LOCAL_STORAGE_KEY = (surface: PanelSurface) =>
+  `agentic-sdlc.panel-prefs.${surface}.v1`;
+
+const SAVE_DEBOUNCE_MS = 600;
+
+interface UsePanelPreferencesArgs {
+  surface: PanelSurface;
+}
+
+export interface UsePanelPreferencesResult {
+  preferences: PanelPreferences;
+  isHydrated: boolean;
+  isSaving: boolean;
+  lastSavedAt: string | null;
+  togglePanel: (id: PanelId) => void;
+  movePanel: (id: PanelId, toSection: PanelSection, toIndex: number) => void;
+  reset: () => void;
+  setDensity: (density: "compact" | "comfortable") => void;
+  setGridEnabled: (enabled: boolean) => void;
+  setGridLayout: (
+    breakpoint: Breakpoint,
+    layout: Record<PanelId, GridCoord>,
+  ) => void;
+  resetGrid: () => void;
+  /** Replace the preferences wholesale — used by drag-reorder commits. */
+  setPreferences: (next: PanelPreferences) => void;
+}
+
+function readLocal(surface: PanelSurface): PanelPreferences | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY(surface));
+    if (!raw) return null;
+    return normalisePreferences(JSON.parse(raw), surface);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocal(prefs: PanelPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEY(prefs.surface),
+      JSON.stringify(prefs),
+    );
+  } catch {
+    /* quota exceeded / private mode — non-fatal */
+  }
+}
+
+async function fetchServerPrefs(
+  surface: PanelSurface,
+): Promise<PanelPreferences | null> {
+  try {
+    const res = await fetch(
+      `/api/agentic-sdlc/me/panel-prefs?surface=${surface}`,
+      { headers: { Accept: "application/json" }, cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json()) as { preferences?: unknown };
+    if (!body.preferences) return null;
+    return normalisePreferences(body.preferences, surface);
+  } catch {
+    return null;
+  }
+}
+
+async function putServerPrefs(prefs: PanelPreferences): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `/api/agentic-sdlc/me/panel-prefs?surface=${prefs.surface}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ preferences: prefs }),
+      },
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export function usePanelPreferences(
+  args: UsePanelPreferencesArgs,
+): UsePanelPreferencesResult {
+  const { surface } = args;
+  const [preferences, setPreferencesState] = useState<PanelPreferences>(() =>
+    defaultPreferences(surface),
+  );
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastPersistedRef = useRef<string>("");
+
+  // Hydration: localStorage first, then server (server wins).
+  useEffect(() => {
+    const local = readLocal(surface);
+    if (local) setPreferencesState(local);
+    setIsHydrated(true);
+
+    let cancelled = false;
+    void (async () => {
+      const server = await fetchServerPrefs(surface);
+      if (cancelled || !server) return;
+      const localUpdated = local ? Date.parse(local.updated_at) : 0;
+      const serverUpdated = Date.parse(server.updated_at);
+      // Server wins unless localStorage has a strictly newer copy
+      // (offline edits) — in which case we keep local and push to
+      // server on the next save.
+      if (serverUpdated >= localUpdated) {
+        setPreferencesState(server);
+        writeLocal(server);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // surface is stable per mount; intentional empty dep
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [surface]);
+
+  // Cross-tab sync via storage events.
+  useEffect(() => {
+    function onStorage(ev: StorageEvent) {
+      if (ev.key !== LOCAL_STORAGE_KEY(surface) || !ev.newValue) return;
+      try {
+        const next = normalisePreferences(JSON.parse(ev.newValue), surface);
+        setPreferencesState(next);
+      } catch {
+        /* ignore */
+      }
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [surface]);
+
+  // Debounced server persistence.
+  const schedulePersist = useCallback((next: PanelPreferences) => {
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(async () => {
+      const serialized = JSON.stringify(next);
+      if (serialized === lastPersistedRef.current) return;
+      setIsSaving(true);
+      const ok = await putServerPrefs(next);
+      if (ok) {
+        lastPersistedRef.current = serialized;
+        setLastSavedAt(new Date().toISOString());
+      }
+      setIsSaving(false);
+    }, SAVE_DEBOUNCE_MS);
+  }, []);
+
+  const commit = useCallback(
+    (next: PanelPreferences) => {
+      setPreferencesState(next);
+      writeLocal(next);
+      schedulePersist(next);
+    },
+    [schedulePersist],
+  );
+
+  const togglePanel = useCallback(
+    (id: PanelId) => {
+      commit(togglePure(preferences, id));
+    },
+    [preferences, commit],
+  );
+
+  const movePanel = useCallback(
+    (id: PanelId, toSection: PanelSection, toIndex: number) => {
+      commit(movePanelPure(preferences, id, toSection, toIndex));
+    },
+    [preferences, commit],
+  );
+
+  const reset = useCallback(() => {
+    commit(resetPreferences(surface));
+  }, [surface, commit]);
+
+  const setDensity = useCallback(
+    (density: "compact" | "comfortable") => {
+      commit({
+        ...preferences,
+        density,
+        updated_at: new Date().toISOString(),
+      });
+    },
+    [preferences, commit],
+  );
+
+  const setPreferencesFn = useCallback(
+    (next: PanelPreferences) => commit(next),
+    [commit],
+  );
+
+  const setGridEnabled = useCallback(
+    (enabled: boolean) => {
+      commit(setGridEnabledPure(preferences, enabled));
+    },
+    [preferences, commit],
+  );
+
+  const setGridLayout = useCallback(
+    (breakpoint: Breakpoint, layout: Record<PanelId, GridCoord>) => {
+      commit(setGridLayoutPure(preferences, breakpoint, layout));
+    },
+    [preferences, commit],
+  );
+
+  const resetGrid = useCallback(() => {
+    commit(clearGridLayoutPure(preferences));
+  }, [preferences, commit]);
+
+  return useMemo(
+    () => ({
+      preferences,
+      isHydrated,
+      isSaving,
+      lastSavedAt,
+      togglePanel,
+      movePanel,
+      reset,
+      setDensity,
+      setGridEnabled,
+      setGridLayout,
+      resetGrid,
+      setPreferences: setPreferencesFn,
+    }),
+    [
+      preferences,
+      isHydrated,
+      isSaving,
+      lastSavedAt,
+      togglePanel,
+      movePanel,
+      reset,
+      setDensity,
+      setGridEnabled,
+      setGridLayout,
+      resetGrid,
+      setPreferencesFn,
+    ],
+  );
+}

--- a/ui/src/lib/agentic-sdlc/async-worker.ts
+++ b/ui/src/lib/agentic-sdlc/async-worker.ts
@@ -47,6 +47,11 @@ import {
   projectEvent,
   type ArtifactPatch,
 } from "@/lib/agentic-sdlc/projector";
+import {
+  isCiEvent,
+  ciEventArtifactId,
+  projectCiEvent,
+} from "@/lib/agentic-sdlc/ci-projection";
 import type {
   OnboardedRepo,
   AgenticSdlcArtifact,
@@ -155,6 +160,81 @@ async function processOneById(
       { _id: eventId },
       { $set: { projection_status: "failed" } },
     );
+    return;
+  }
+
+  // CI events update only the PR/task artifact's `ci_summary` and
+  // `head_sha` fields -- they never own stage, labels, or title, so
+  // they go through a dedicated patch path that won't stomp the
+  // issue/PR projector's state.
+  if (isCiEvent(ev)) {
+    const artifactId = ciEventArtifactId(ev);
+    if (artifactId) {
+      const artifacts = await agenticSdlcArtifacts();
+      const filter = {
+        repo_id: ev.repo_id,
+        kind: "pull_request" as const,
+        artifact_id: artifactId,
+      };
+      const prior = (await artifacts.findOne(filter)) as AgenticSdlcArtifact | null;
+      // Read prior CI events on this artifact to rebuild the
+      // "latest per check_name" map deterministically. Pilot scale
+      // means this is cheap; we cap at 50 to avoid pathological
+      // CI-spam loops dragging projection latency.
+      const history = (await events
+        .find({
+          repo_id: ev.repo_id,
+          artifact_id: artifactId,
+          github_event_type: { $in: ["check_run", "check_suite", "workflow_run"] },
+          _id: { $ne: eventId },
+        })
+        .sort({ occurred_at: -1 })
+        .limit(50)
+        .toArray()) as AgenticSdlcEvent[];
+      const ciPatch = projectCiEvent(ev, history, prior);
+      if (ciPatch && prior) {
+        const now = new Date();
+        await artifacts.updateOne(filter, {
+          $set: {
+            ci_summary: ciPatch.ci_summary,
+            head_sha: ciPatch.head_sha,
+            updated_at: now,
+          },
+        });
+        const final = (await artifacts.findOne(filter)) as AgenticSdlcArtifact | null;
+        if (final) {
+          const artifactPayload = sanitizeArtifactForSse(final);
+          publish(repoTopic(ev.repo_id), {
+            event: "artifact_upserted",
+            data: artifactPayload,
+          });
+          publish(portfolioTopic(), {
+            event: "artifact_upserted",
+            data: artifactPayload,
+          });
+        }
+      }
+    }
+    // Fall through to the standard finalisation (mark projected,
+    // bump webhook_last_event_at, etc.) — no further projection.
+    await events.updateOne(
+      { _id: eventId },
+      { $set: { projection_status: "projected" } },
+    );
+    await repos.updateOne(
+      { repo_id: ev.repo_id },
+      {
+        $set: {
+          webhook_status: "healthy",
+          webhook_last_event_at: ev.occurred_at,
+          updated_at: new Date(),
+        },
+      },
+    );
+    const eventPayload = sanitizeEventForSse(ev);
+    publish(repoTopic(ev.repo_id), { event: "event_appended", data: eventPayload });
+    publish(portfolioTopic(), { event: "event_appended", data: eventPayload });
+    recordProjectionLatency((Date.now() - enqueuedAtMs) / 1000);
     return;
   }
 

--- a/ui/src/lib/agentic-sdlc/ci-projection.ts
+++ b/ui/src/lib/agentic-sdlc/ci-projection.ts
@@ -1,0 +1,303 @@
+/**
+ * Pure projection of GitHub `check_run`, `check_suite`, and
+ * `workflow_run` events into a compact, UI-friendly CI summary that
+ * the worker can patch onto a PR or task artifact.
+ *
+ * No I/O, no env, no network — the worker handles persistence and
+ * the API routes consume the stored `ci_summary` field on artifacts
+ * plus the raw events collection for per-check drill-down.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import type {
+  ArtifactCiSummary,
+  CiConclusion,
+  CiStatus,
+  AgenticSdlcEvent,
+  AgenticSdlcArtifact,
+} from "@/types/agentic-sdlc";
+
+const CI_EVENT_TYPES = new Set(["check_run", "check_suite", "workflow_run"]);
+
+/**
+ * Patch fields the worker applies to the PR / task artifact when a CI
+ * event lands. We deliberately keep the surface narrow so we never
+ * stomp on stage / label fields that the issue/PR projector owns.
+ */
+export interface CiArtifactPatch {
+  repo_id: string;
+  artifact_id: string;
+  /** Pull-request node id when known, used for matching on the artifact row. */
+  head_sha: string | null;
+  ci_summary: ArtifactCiSummary;
+  /** Most recent CI activity timestamp for the artifact. */
+  last_event_at: Date;
+}
+
+export function isCiEvent(ev: AgenticSdlcEvent): boolean {
+  return ev.github_event_type !== null && CI_EVENT_TYPES.has(ev.github_event_type);
+}
+
+/**
+ * Extract the artifact id (PR node id) that a CI event applies to.
+ *
+ * Returns `null` when the event cannot be linked to a tracked PR — those
+ * events are still persisted (for future drill-downs) but contribute
+ * no summary patch.
+ */
+export function ciEventArtifactId(ev: AgenticSdlcEvent): string | null {
+  if (!isCiEvent(ev)) return null;
+  if (ev.artifact_kind === "pull_request" && ev.artifact_id) {
+    return ev.artifact_id;
+  }
+  // workflow_run events sometimes land with artifact_kind="unknown"
+  // when no PR is attached; the webhook receiver still populates
+  // artifact_id from the workflow_run.node_id in that case but we
+  // only project CI for events that map to a PR.
+  return null;
+}
+
+/**
+ * Normalise a raw GitHub check conclusion into our small CI vocabulary.
+ *
+ * GitHub uses overlapping vocabularies across `check_run`,
+ * `check_suite`, and `workflow_run`. This collapses them so the UI
+ * only deals with a single enum.
+ */
+export function normaliseConclusion(raw: string | null | undefined): CiConclusion {
+  if (raw == null) return "pending";
+  switch (raw) {
+    case "success":
+      return "success";
+    case "failure":
+    case "startup_failure":
+      return "failure";
+    case "neutral":
+      return "neutral";
+    case "cancelled":
+      return "cancelled";
+    case "timed_out":
+      return "timed_out";
+    case "skipped":
+      return "skipped";
+    case "action_required":
+      return "action_required";
+    case "stale":
+      return "stale";
+    default:
+      return "unknown";
+  }
+}
+
+export function normaliseStatus(raw: string | null | undefined): CiStatus {
+  if (raw === "queued") return "queued";
+  if (raw === "in_progress") return "in_progress";
+  return "completed";
+}
+
+interface ParsedCheck {
+  external_id: string;
+  check_name: string;
+  status: CiStatus;
+  conclusion: CiConclusion;
+  details_url: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  head_sha: string | null;
+  occurred_at: Date;
+}
+
+/**
+ * Parse a single CI event into its check tuple. Returns `null` for
+ * events that don't carry the fields we need.
+ */
+function parseCiEvent(ev: AgenticSdlcEvent): ParsedCheck | null {
+  const payload = ev.payload ?? {};
+  if (ev.github_event_type === "check_run") {
+    const run = (payload as { check_run?: Record<string, unknown> }).check_run;
+    if (!run) return null;
+    const status = normaliseStatus(run.status as string | undefined);
+    return {
+      external_id: stringOrNull(run.id) ?? `${ev.github_delivery_id ?? "anon"}:check_run`,
+      check_name: (run.name as string | undefined) ?? "check",
+      status,
+      conclusion:
+        status === "completed"
+          ? normaliseConclusion(run.conclusion as string | null | undefined)
+          : "pending",
+      details_url: (run.details_url as string | undefined) ?? null,
+      started_at: (run.started_at as string | undefined) ?? null,
+      completed_at: (run.completed_at as string | undefined) ?? null,
+      head_sha: (run.head_sha as string | undefined) ?? null,
+      occurred_at: ev.occurred_at,
+    };
+  }
+
+  if (ev.github_event_type === "check_suite") {
+    const suite = (payload as { check_suite?: Record<string, unknown> }).check_suite;
+    if (!suite) return null;
+    const status = normaliseStatus(suite.status as string | undefined);
+    return {
+      external_id: stringOrNull(suite.id) ?? `${ev.github_delivery_id ?? "anon"}:check_suite`,
+      check_name: "check_suite",
+      status,
+      conclusion:
+        status === "completed"
+          ? normaliseConclusion(suite.conclusion as string | null | undefined)
+          : "pending",
+      details_url: (suite.url as string | undefined) ?? null,
+      started_at: null,
+      completed_at: (suite.updated_at as string | undefined) ?? null,
+      head_sha: (suite.head_sha as string | undefined) ?? null,
+      occurred_at: ev.occurred_at,
+    };
+  }
+
+  if (ev.github_event_type === "workflow_run") {
+    const run = (payload as { workflow_run?: Record<string, unknown> }).workflow_run;
+    if (!run) return null;
+    const status = normaliseStatus(run.status as string | undefined);
+    return {
+      external_id: stringOrNull(run.id) ?? `${ev.github_delivery_id ?? "anon"}:workflow_run`,
+      check_name: (run.name as string | undefined) ?? "workflow",
+      status,
+      conclusion:
+        status === "completed"
+          ? normaliseConclusion(run.conclusion as string | null | undefined)
+          : "pending",
+      details_url: (run.html_url as string | undefined) ?? null,
+      started_at: (run.run_started_at as string | undefined) ?? null,
+      completed_at: (run.updated_at as string | undefined) ?? null,
+      head_sha: (run.head_sha as string | undefined) ?? null,
+      occurred_at: ev.occurred_at,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Merge a fresh CI event into the existing summary, replacing the
+ * row for `check_name` if it already exists. Pure: returns a new
+ * summary without mutating the input.
+ *
+ * We model "latest per check_name" in two layers:
+ *   1. An internal map of check_name → ParsedCheck, kept in the
+ *      summary via `_runs` (omitted from the persisted shape; see
+ *      `toStoredSummary`).
+ *   2. The aggregate counts used by the UI.
+ *
+ * For pilot scale (<25 repos, modest CI activity) reconstructing the
+ * map per event by reading recent CI events from Mongo is acceptable.
+ * The worker reads the per-PR check history before computing the
+ * merged summary.
+ */
+export function mergeCiSummary(
+  previous: ArtifactCiSummary | null | undefined,
+  parsed: ParsedCheck,
+  history: ParsedCheck[],
+): ArtifactCiSummary {
+  const latestPerName = new Map<string, ParsedCheck>();
+  for (const item of history) {
+    const existing = latestPerName.get(item.check_name);
+    if (!existing || item.occurred_at >= existing.occurred_at) {
+      latestPerName.set(item.check_name, item);
+    }
+  }
+  // The freshly-parsed event always wins for its check_name.
+  latestPerName.set(parsed.check_name, parsed);
+
+  const byConclusion: Partial<Record<CiConclusion, number>> = {};
+  let anyInProgress = false;
+  let latestEventAt = previous?.last_event_at
+    ? new Date(previous.last_event_at)
+    : null;
+
+  for (const item of latestPerName.values()) {
+    const conclusion: CiConclusion =
+      item.status === "completed" ? item.conclusion : "pending";
+    byConclusion[conclusion] = (byConclusion[conclusion] ?? 0) + 1;
+    if (item.status !== "completed") anyInProgress = true;
+    if (!latestEventAt || item.occurred_at > latestEventAt) {
+      latestEventAt = item.occurred_at;
+    }
+  }
+
+  const aggregate: CiConclusion = aggregateConclusion(byConclusion);
+  const aggregateStatus: CiStatus = anyInProgress ? "in_progress" : "completed";
+
+  return {
+    conclusion: aggregate,
+    status: aggregateStatus,
+    by_conclusion: byConclusion,
+    total: latestPerName.size,
+    last_event_at: (latestEventAt ?? parsed.occurred_at).toISOString(),
+  };
+}
+
+/**
+ * Aggregate per-conclusion counts into a single summary conclusion.
+ *
+ * Precedence (worst wins, so users see the most important state):
+ *   failure | timed_out | action_required > pending > neutral / skipped > success > unknown
+ */
+function aggregateConclusion(
+  counts: Partial<Record<CiConclusion, number>>,
+): CiConclusion {
+  if (
+    (counts.failure ?? 0) > 0 ||
+    (counts.timed_out ?? 0) > 0 ||
+    (counts.action_required ?? 0) > 0
+  ) {
+    return (counts.failure ?? 0) > 0
+      ? "failure"
+      : (counts.timed_out ?? 0) > 0
+        ? "timed_out"
+        : "action_required";
+  }
+  if ((counts.pending ?? 0) > 0) return "pending";
+  if ((counts.cancelled ?? 0) > 0) return "cancelled";
+  if ((counts.success ?? 0) > 0) return "success";
+  if ((counts.neutral ?? 0) > 0) return "neutral";
+  if ((counts.skipped ?? 0) > 0) return "skipped";
+  return "unknown";
+}
+
+/**
+ * Build a CI artifact patch from the freshly delivered event plus the
+ * prior CI events on the same artifact. The worker is responsible for
+ * loading `history` from the events collection scoped to this artifact.
+ *
+ * Returns `null` when the event cannot be linked to a tracked PR or
+ * carries no usable check payload.
+ */
+export function projectCiEvent(
+  ev: AgenticSdlcEvent,
+  history: AgenticSdlcEvent[],
+  prior: AgenticSdlcArtifact | null,
+): CiArtifactPatch | null {
+  const artifactId = ciEventArtifactId(ev);
+  if (!artifactId) return null;
+  const parsed = parseCiEvent(ev);
+  if (!parsed) return null;
+  const parsedHistory = history
+    .map(parseCiEvent)
+    .filter((c): c is ParsedCheck => c !== null);
+  const merged = mergeCiSummary(prior?.ci_summary ?? null, parsed, parsedHistory);
+  return {
+    repo_id: ev.repo_id,
+    artifact_id: artifactId,
+    head_sha: parsed.head_sha ?? prior?.head_sha ?? null,
+    ci_summary: merged,
+    last_event_at: ev.occurred_at,
+  };
+}
+
+function stringOrNull(v: unknown): string | null {
+  if (typeof v === "string") return v;
+  if (typeof v === "number") return String(v);
+  return null;
+}
+
+export const CI_EVENT_TYPES_SET = CI_EVENT_TYPES;

--- a/ui/src/lib/agentic-sdlc/panel-preferences.ts
+++ b/ui/src/lib/agentic-sdlc/panel-preferences.ts
@@ -1,0 +1,518 @@
+/**
+ * Panel preferences — pure data layer.
+ *
+ * `PanelPreferences` is the user's per-surface preference set: which
+ * panels are hidden, optional per-section reordering, and the density
+ * mode. The structure deliberately stores only diffs from the
+ * registry defaults so future changes to defaults take effect without
+ * needing a migration.
+ *
+ * Resolution is performed by `resolvePanelLayout`, which combines the
+ * registry defaults with the saved preferences to produce a
+ * deterministic, ordered list of visible panels per section. This is
+ * the single function the UI calls; everything else is plumbing.
+ *
+ * Pure (no React, no fetch). Safe to import from server and client.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  PANEL_REGISTRY,
+  SECTION_ORDER,
+  getPanel,
+  listPanelsForSurface,
+  type PanelDescriptor,
+  type PanelId,
+  type PanelSection,
+  type PanelSurface,
+} from "@/lib/agentic-sdlc/panel-registry";
+
+export const PANEL_PREFERENCES_VERSION = 2;
+
+/** Coordinates for a single panel inside the resizable grid. */
+export interface GridCoord {
+  /** Column 0..11 on the lg/md breakpoint, 0..5 on sm, 0..1 on xs. */
+  x: number;
+  /** Row (top is 0). */
+  y: number;
+  /** Width in column units. */
+  w: number;
+  /** Height in row units (1 row ≈ 32px + margin). */
+  h: number;
+}
+
+/** Per-breakpoint coords map. Keys are RGL breakpoint names. */
+export type GridLayoutByBreakpoint = Partial<{
+  lg: Record<PanelId, GridCoord>;
+  md: Record<PanelId, GridCoord>;
+  sm: Record<PanelId, GridCoord>;
+  xs: Record<PanelId, GridCoord>;
+}>;
+
+export interface PanelPreferences {
+  version: number;
+  surface: PanelSurface;
+  /** Panels the user has explicitly hidden, including those visible by default. */
+  hidden: PanelId[];
+  /** Panels the user has explicitly shown that default to hidden. */
+  shown: PanelId[];
+  /**
+   * Per-section ordered list. When a panel id appears here it overrides
+   * the default order for that section; panels not listed fall back to
+   * the registry's `defaults[surface].order`.
+   *
+   * The drag-to-reorder UX may move a panel from one section to another;
+   * in that case the panel id is removed from its registered section's
+   * list (if present) and added to the new section's list.
+   */
+  order: Partial<Record<PanelSection, PanelId[]>>;
+  /**
+   * Section override per panel — when the user dragged a panel out of
+   * its registered section into a different one. Sparse, only set for
+   * moved panels. Resolution falls back to the registry section if a
+   * panel id is missing.
+   */
+  section: Partial<Record<PanelId, PanelSection>>;
+  density: "compact" | "comfortable";
+  /**
+   * When true, the surface renders using the resizable + draggable grid
+   * (react-grid-layout). When false (default), it uses the section
+   * masonry. The toggle lives in the panel chooser so users can opt in
+   * without losing the stacked layout.
+   */
+  gridEnabled: boolean;
+  /**
+   * Per-breakpoint panel coordinates. Only set for panels the user has
+   * dragged/resized; missing ids fall back to defaults computed from
+   * the registry at render time.
+   */
+  grid: GridLayoutByBreakpoint;
+  updated_at: string;
+}
+
+export function defaultPreferences(surface: PanelSurface): PanelPreferences {
+  return {
+    version: PANEL_PREFERENCES_VERSION,
+    surface,
+    hidden: [],
+    shown: [],
+    order: {},
+    section: {},
+    density: "comfortable",
+    gridEnabled: false,
+    grid: {},
+    updated_at: new Date(0).toISOString(),
+  };
+}
+
+/**
+ * Normalise an arbitrary value into a PanelPreferences. Used by both
+ * the localStorage and API loaders so a corrupt payload never crashes
+ * the UI — it simply degrades to defaults.
+ */
+export function normalisePreferences(
+  raw: unknown,
+  surface: PanelSurface,
+): PanelPreferences {
+  if (!raw || typeof raw !== "object") return defaultPreferences(surface);
+  const obj = raw as Partial<PanelPreferences> & { [k: string]: unknown };
+  const validPanelIds = new Set<PanelId>(PANEL_REGISTRY.map((p) => p.id));
+  const validSections = new Set<PanelSection>(SECTION_ORDER);
+
+  const hidden = Array.isArray(obj.hidden)
+    ? (obj.hidden.filter(
+        (id) => typeof id === "string" && validPanelIds.has(id as PanelId),
+      ) as PanelId[])
+    : [];
+  const shown = Array.isArray(obj.shown)
+    ? (obj.shown.filter(
+        (id) => typeof id === "string" && validPanelIds.has(id as PanelId),
+      ) as PanelId[])
+    : [];
+
+  const order: Partial<Record<PanelSection, PanelId[]>> = {};
+  if (obj.order && typeof obj.order === "object") {
+    for (const [section, ids] of Object.entries(
+      obj.order as Record<string, unknown>,
+    )) {
+      if (!validSections.has(section as PanelSection)) continue;
+      if (!Array.isArray(ids)) continue;
+      const filtered = ids.filter(
+        (id) => typeof id === "string" && validPanelIds.has(id as PanelId),
+      ) as PanelId[];
+      if (filtered.length > 0) order[section as PanelSection] = filtered;
+    }
+  }
+
+  const section: Partial<Record<PanelId, PanelSection>> = {};
+  if (obj.section && typeof obj.section === "object") {
+    for (const [panelId, sec] of Object.entries(
+      obj.section as Record<string, unknown>,
+    )) {
+      if (
+        validPanelIds.has(panelId as PanelId) &&
+        typeof sec === "string" &&
+        validSections.has(sec as PanelSection)
+      ) {
+        section[panelId as PanelId] = sec as PanelSection;
+      }
+    }
+  }
+
+  const density =
+    obj.density === "compact" || obj.density === "comfortable"
+      ? obj.density
+      : "comfortable";
+
+  const gridEnabled = obj.gridEnabled === true;
+
+  const grid: GridLayoutByBreakpoint = {};
+  if (obj.grid && typeof obj.grid === "object") {
+    const allowed = ["lg", "md", "sm", "xs"] as const;
+    for (const bp of allowed) {
+      const raw = (obj.grid as Record<string, unknown>)[bp];
+      if (!raw || typeof raw !== "object") continue;
+      const bucket: Record<PanelId, GridCoord> = {} as Record<PanelId, GridCoord>;
+      for (const [panelId, coordRaw] of Object.entries(
+        raw as Record<string, unknown>,
+      )) {
+        if (!validPanelIds.has(panelId as PanelId)) continue;
+        if (!coordRaw || typeof coordRaw !== "object") continue;
+        const c = coordRaw as Partial<GridCoord>;
+        if (
+          typeof c.x === "number" &&
+          typeof c.y === "number" &&
+          typeof c.w === "number" &&
+          typeof c.h === "number" &&
+          c.w > 0 &&
+          c.h > 0
+        ) {
+          bucket[panelId as PanelId] = {
+            x: Math.max(0, Math.floor(c.x)),
+            y: Math.max(0, Math.floor(c.y)),
+            w: Math.max(1, Math.floor(c.w)),
+            h: Math.max(1, Math.floor(c.h)),
+          };
+        }
+      }
+      if (Object.keys(bucket).length > 0) grid[bp] = bucket;
+    }
+  }
+
+  return {
+    version: PANEL_PREFERENCES_VERSION,
+    surface,
+    hidden,
+    shown,
+    order,
+    section,
+    density,
+    gridEnabled,
+    grid,
+    updated_at:
+      typeof obj.updated_at === "string"
+        ? obj.updated_at
+        : new Date(0).toISOString(),
+  };
+}
+
+/**
+ * Determine whether a panel should be rendered for this surface given
+ * the user's preferences. Hidden wins over shown so the user can
+ * always opt out of a default-visible panel.
+ */
+export function isPanelVisible(
+  panel: PanelDescriptor,
+  preferences: PanelPreferences,
+): boolean {
+  if (preferences.hidden.includes(panel.id)) return false;
+  const defaultVisible =
+    panel.defaults[preferences.surface]?.visible ?? false;
+  if (defaultVisible) return true;
+  return preferences.shown.includes(panel.id);
+}
+
+/**
+ * Effective section for a panel — either the user override or the
+ * registry section.
+ */
+export function effectiveSection(
+  panel: PanelDescriptor,
+  preferences: PanelPreferences,
+): PanelSection {
+  return preferences.section[panel.id] ?? panel.section;
+}
+
+/**
+ * Compose the section ordering. Result is a map from section to the
+ * ordered list of visible panel ids.
+ *
+ * Algorithm:
+ *   1. Build a set of all panels on this surface that are visible.
+ *   2. Bucket them by effective section.
+ *   3. For each section, order panels by:
+ *      a. position in `preferences.order[section]` (if listed)
+ *      b. otherwise default order from the registry for this surface.
+ *      c. tie-break by panel id alphabetical for stability.
+ */
+export function resolvePanelLayout(
+  preferences: PanelPreferences,
+): Record<PanelSection, PanelId[]> {
+  const buckets: Partial<Record<PanelSection, PanelId[]>> = {};
+  for (const panel of listPanelsForSurface(preferences.surface)) {
+    if (!isPanelVisible(panel, preferences)) continue;
+    const section = effectiveSection(panel, preferences);
+    const list = buckets[section] ?? [];
+    list.push(panel.id);
+    buckets[section] = list;
+  }
+
+  const out = {} as Record<PanelSection, PanelId[]>;
+  for (const section of SECTION_ORDER) {
+    const ids = buckets[section] ?? [];
+    const explicit = preferences.order[section] ?? [];
+    const orderedHead: PanelId[] = [];
+    const seen = new Set<PanelId>();
+    for (const id of explicit) {
+      if (ids.includes(id)) {
+        orderedHead.push(id);
+        seen.add(id);
+      }
+    }
+    const tail = ids
+      .filter((id) => !seen.has(id))
+      .sort((a, b) => {
+        const da = getPanel(a).defaults[preferences.surface]?.order ?? 999;
+        const db = getPanel(b).defaults[preferences.surface]?.order ?? 999;
+        if (da !== db) return da - db;
+        return a.localeCompare(b);
+      });
+    out[section] = [...orderedHead, ...tail];
+  }
+  return out;
+}
+
+/**
+ * Toggle visibility, returning a new preferences object.
+ *
+ * Reasoning notes:
+ *   - We never store both `hidden` and `shown` for the same panel.
+ *   - For a default-visible panel: toggling off adds to `hidden`;
+ *     toggling on removes from `hidden`.
+ *   - For a default-hidden panel: toggling on adds to `shown`;
+ *     toggling off removes from `shown`.
+ */
+export function togglePanelVisibility(
+  preferences: PanelPreferences,
+  panelId: PanelId,
+): PanelPreferences {
+  const panel = getPanel(panelId);
+  const defaultVisible =
+    panel.defaults[preferences.surface]?.visible ?? false;
+  const currentlyVisible = isPanelVisible(panel, preferences);
+  const nextVisible = !currentlyVisible;
+
+  let hidden = preferences.hidden;
+  let shown = preferences.shown;
+
+  if (defaultVisible) {
+    hidden = nextVisible
+      ? hidden.filter((id) => id !== panelId)
+      : Array.from(new Set([...hidden, panelId]));
+    shown = shown.filter((id) => id !== panelId);
+  } else {
+    shown = nextVisible
+      ? Array.from(new Set([...shown, panelId]))
+      : shown.filter((id) => id !== panelId);
+    hidden = hidden.filter((id) => id !== panelId);
+  }
+  return {
+    ...preferences,
+    hidden,
+    shown,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+/** Reset to registry defaults for the surface. */
+export function resetPreferences(surface: PanelSurface): PanelPreferences {
+  return {
+    ...defaultPreferences(surface),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Move a panel to a new section + index. Used by the layout drawer's
+ * free-reorder drag handler.
+ */
+export function movePanel(
+  preferences: PanelPreferences,
+  panelId: PanelId,
+  toSection: PanelSection,
+  toIndex: number,
+): PanelPreferences {
+  const panel = getPanel(panelId);
+  if (!panel) return preferences;
+
+  // Remove panel from any section's explicit order.
+  const cleanedOrder: Partial<Record<PanelSection, PanelId[]>> = {};
+  for (const [section, ids] of Object.entries(preferences.order)) {
+    if (!ids) continue;
+    cleanedOrder[section as PanelSection] = ids.filter((id) => id !== panelId);
+  }
+
+  // Rebuild the destination section with the panel inserted.
+  const currentLayout = resolvePanelLayout(preferences);
+  const destination = (currentLayout[toSection] ?? []).filter(
+    (id) => id !== panelId,
+  );
+  const clampedIndex = Math.max(0, Math.min(toIndex, destination.length));
+  destination.splice(clampedIndex, 0, panelId);
+  cleanedOrder[toSection] = destination;
+
+  // If the panel moved out of its registered section, persist that
+  // override; otherwise clear it so the registry default re-applies.
+  const sectionOverride = { ...preferences.section };
+  if (toSection !== panel.section) {
+    sectionOverride[panelId] = toSection;
+  } else {
+    delete sectionOverride[panelId];
+  }
+
+  // Ensure the panel is visible after a move (otherwise the user just
+  // dragged something invisible — confusing UX).
+  const next = {
+    ...preferences,
+    order: cleanedOrder,
+    section: sectionOverride,
+    updated_at: new Date().toISOString(),
+  };
+  return ensureVisible(next, panelId);
+}
+
+function ensureVisible(
+  preferences: PanelPreferences,
+  panelId: PanelId,
+): PanelPreferences {
+  const panel = getPanel(panelId);
+  const defaultVisible =
+    panel.defaults[preferences.surface]?.visible ?? false;
+  let hidden = preferences.hidden;
+  let shown = preferences.shown;
+  if (defaultVisible) {
+    hidden = hidden.filter((id) => id !== panelId);
+  } else if (!shown.includes(panelId)) {
+    shown = [...shown, panelId];
+  }
+  return { ...preferences, hidden, shown };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Resizable grid helpers                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type Breakpoint = "lg" | "md" | "sm" | "xs";
+
+/** Column counts per breakpoint (must match the renderer). */
+export const GRID_COLS: Record<Breakpoint, number> = {
+  lg: 12,
+  md: 12,
+  sm: 6,
+  xs: 2,
+};
+
+/**
+ * Compute a deterministic default grid layout for a breakpoint by
+ * walking the resolved section layout in display order.
+ *
+ * Design choice: each panel gets a full row by default. This makes
+ * flipping the grid toggle on/off non-disruptive — the user sees the
+ * same stacked layout they had in masonry mode and can then drag and
+ * resize from there. Previously the default packed two half-size
+ * panels per row which "reset" the user's view on first Grid-on.
+ *
+ * Heights are tuned per panel size:
+ *   - full panels: 6 rows (~ 240px content area)
+ *   - half panels: 10 rows (~ 400px content area; lists/charts need more)
+ */
+export function computeDefaultGridLayout(
+  preferences: PanelPreferences,
+  breakpoint: Breakpoint,
+): Record<PanelId, GridCoord> {
+  const resolved = resolvePanelLayout(preferences);
+  const cols = GRID_COLS[breakpoint];
+  const out: Record<PanelId, GridCoord> = {} as Record<PanelId, GridCoord>;
+
+  const flatIds: PanelId[] = [];
+  for (const section of SECTION_ORDER) {
+    for (const id of resolved[section] ?? []) flatIds.push(id);
+  }
+
+  let cursorY = 0;
+  for (const id of flatIds) {
+    const desc = getPanel(id);
+    const h = desc.size === "full" ? 6 : 10;
+    out[id] = { x: 0, y: cursorY, w: cols, h };
+    cursorY += h;
+  }
+  return out;
+}
+
+/**
+ * Compose the effective grid layout for a breakpoint by overlaying the
+ * user's saved coords on top of defaults computed from the registry.
+ * Panels that became visible/were added after the user last saved a
+ * layout get computed defaults so they show up cleanly.
+ */
+export function resolveGridLayout(
+  preferences: PanelPreferences,
+  breakpoint: Breakpoint,
+): Record<PanelId, GridCoord> {
+  const defaults = computeDefaultGridLayout(preferences, breakpoint);
+  const saved = preferences.grid[breakpoint] ?? {};
+  const merged: Record<PanelId, GridCoord> = { ...defaults };
+  for (const [id, coord] of Object.entries(saved) as [PanelId, GridCoord][]) {
+    if (defaults[id]) merged[id] = coord; // only honour coords for currently-visible panels
+  }
+  return merged;
+}
+
+export function setGridEnabled(
+  preferences: PanelPreferences,
+  enabled: boolean,
+): PanelPreferences {
+  if (preferences.gridEnabled === enabled) return preferences;
+  return {
+    ...preferences,
+    gridEnabled: enabled,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Replace the user's saved grid layout for a single breakpoint. The
+ * caller passes the full layout for that breakpoint as produced by RGL
+ * (already filtered to currently-visible panels).
+ */
+export function setGridLayout(
+  preferences: PanelPreferences,
+  breakpoint: Breakpoint,
+  layout: Record<PanelId, GridCoord>,
+): PanelPreferences {
+  return {
+    ...preferences,
+    grid: { ...preferences.grid, [breakpoint]: layout },
+    updated_at: new Date().toISOString(),
+  };
+}
+
+/** Clear all saved grid coords (per-breakpoint). */
+export function clearGridLayout(preferences: PanelPreferences): PanelPreferences {
+  return {
+    ...preferences,
+    grid: {},
+    updated_at: new Date().toISOString(),
+  };
+}

--- a/ui/src/lib/agentic-sdlc/panel-registry.ts
+++ b/ui/src/lib/agentic-sdlc/panel-registry.ts
@@ -1,0 +1,533 @@
+/**
+ * Panel registry for the Agentic SDLC UI.
+ *
+ * Every panel that can be shown in the Repo Detail or Home surface is
+ * declared here as a single descriptor. The registry is the single
+ * source of truth that drives:
+ *
+ *   - the PanelChooser pill bar (what the user can toggle),
+ *   - the SectionRenderer (which panel appears in which section),
+ *   - the default visibility for new users,
+ *   - the default order within a section,
+ *   - per-panel categorisation against the ship-loop stages
+ *     (specify | execute | verify | deliver | observe | core), which
+ *     drives the pill colour, the search filters in the chooser, and
+ *     the "category drawer" grouping in the layout dialog.
+ *
+ * The registry is intentionally a flat array so adding a new panel is
+ * one entry: pick its id, section, default visibility, default order
+ * within the section, and size hint. The matching React component is
+ * wired through `panel-components.tsx` so this module stays free of
+ * client/server boundaries.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+// All panel ids that can appear in any surface.
+export type PanelId =
+  | "ship_loop_ring"
+  | "swim_lanes"
+  | "epics"
+  | "operating_metrics"
+  | "spec_health"
+  | "intent_drift"
+  | "spec_kit_replay"
+  | "agent_roster"
+  | "mistake_encoded"
+  | "agent_budget"
+  | "parallel_fanout"
+  | "harness"
+  | "ci_in_flight"
+  | "verifier_confidence"
+  | "quality_gauntlet"
+  | "failure_modes"
+  | "deploy_health"
+  | "provenance_sbom"
+  | "blast_radius"
+  | "rollback_rehearsal"
+  | "prod_signal_wire"
+  | "pr_prod_sparkline"
+  | "changelog"
+  | "snapshots"
+  | "blackbox_audit"
+  | "event_feed";
+
+// Logical sections. Sections render as a row on the page. Within a
+// section, half-size panels live in a 2-column grid at xl. Full-size
+// panels span the row.
+export type PanelSection =
+  | "hero"
+  | "agents"
+  | "epics"
+  | "harness"
+  | "verify"
+  | "execute"
+  | "deliver"
+  | "deliver_detail"
+  | "observe"
+  | "context"
+  | "footer";
+
+// Categorises the panel against the ship-loop stage it most belongs
+// to. Drives pill colour + grouping in the chooser.
+export type PanelCategory =
+  | "specify"
+  | "execute"
+  | "verify"
+  | "deliver"
+  | "observe"
+  | "core";
+
+// Surfaces the panel can appear on.
+export type PanelSurface = "repo_detail" | "home";
+
+export interface PanelDescriptor {
+  id: PanelId;
+  title: string;
+  // One-line description, used as accessible description on chooser
+  // pills and the tooltip in the layout drawer. Keep short.
+  description: string;
+  section: PanelSection;
+  category: PanelCategory;
+  // Half or full width inside its section's responsive grid.
+  size: "half" | "full";
+  // Default visibility per surface. Surfaces not listed here mean the
+  // panel cannot appear on that surface at all.
+  defaults: Partial<Record<PanelSurface, { visible: boolean; order: number }>>;
+  // Tag indicating data backing status. "live" means real data flows;
+  // "mock" means the panel renders mocked data with a small badge
+  // until the upstream signal is wired. "hybrid" means it shows live
+  // data where available and falls back to mock otherwise.
+  data: "live" | "mock" | "hybrid";
+}
+
+const D = (visible: boolean, order: number) => ({ visible, order });
+
+/**
+ * The registry. Keep entries sorted by ship-loop stage so the file
+ * reads like the post's narrative: Specify → Execute → Verify →
+ * Deliver → Observe.
+ */
+export const PANEL_REGISTRY: readonly PanelDescriptor[] = [
+  // ─────────────────────────────────────────────────────────────────
+  // CORE
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "ship_loop_ring",
+    title: "Ship-loop ring",
+    description:
+      "Live visualisation of the five-stage agentic SDLC loop driven by real repo activity.",
+    section: "hero",
+    category: "core",
+    size: "full",
+    defaults: {
+      repo_detail: D(true, 0),
+      home: D(true, 0),
+    },
+    data: "hybrid",
+  },
+  {
+    id: "swim_lanes",
+    title: "Agents in action",
+    description:
+      "Per-stage swim lanes showing the current workload owned by each agent role.",
+    section: "agents",
+    category: "execute",
+    size: "full",
+    defaults: { repo_detail: D(true, 0) },
+    data: "live",
+  },
+  {
+    id: "epics",
+    title: "Epics",
+    description: "Drill into active loops and repo-level Epics.",
+    section: "epics",
+    category: "specify",
+    size: "half",
+    defaults: { repo_detail: D(true, 0) },
+    data: "live",
+  },
+  {
+    id: "operating_metrics",
+    title: "Operating metrics",
+    description: "Open epics, review pressure, deploy signal, webhook health.",
+    section: "epics",
+    category: "core",
+    size: "half",
+    defaults: { repo_detail: D(true, 1) },
+    data: "live",
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // SPECIFY
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "spec_health",
+    title: "Spec health",
+    description:
+      "Score each epic on whether its spec is agent-ready: AC, NFR, constraints, tests, budget.",
+    section: "harness",
+    category: "specify",
+    size: "half",
+    defaults: {
+      repo_detail: D(true, 0),
+      home: D(true, 2),
+    },
+    data: "hybrid",
+  },
+  {
+    id: "intent_drift",
+    title: "Intent drift",
+    description:
+      "Delta between the spec's acceptance criteria and the actual PR contents per epic.",
+    section: "epics",
+    category: "specify",
+    size: "full",
+    defaults: { repo_detail: D(false, 2) },
+    data: "hybrid",
+  },
+  {
+    id: "spec_kit_replay",
+    title: "Spec-Kit replay",
+    description:
+      "Scrub the specify → plan → tasks → implement phases for an epic.",
+    section: "footer",
+    category: "specify",
+    size: "full",
+    defaults: { repo_detail: D(false, 0) },
+    data: "mock",
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // EXECUTE
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "agent_roster",
+    title: "Agent roster",
+    description: "Live heartbeats and current task for every running agent.",
+    section: "execute",
+    category: "execute",
+    size: "half",
+    defaults: { repo_detail: D(false, 0) },
+    data: "hybrid",
+  },
+  {
+    id: "agent_budget",
+    title: "Agent budget",
+    description:
+      "LLM tokens (M) burn vs estimate per epic — builder compute and reviewer/verifier traffic. Budget-based planning.",
+    section: "execute",
+    category: "execute",
+    size: "half",
+    defaults: { repo_detail: D(false, 1) },
+    data: "mock",
+  },
+  {
+    id: "parallel_fanout",
+    title: "Parallel fan-out",
+    description:
+      "Visualises parallel agents working on one epic and where their branches converge.",
+    section: "execute",
+    category: "execute",
+    size: "full",
+    defaults: { repo_detail: D(false, 2) },
+    data: "mock",
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // VERIFY
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "harness",
+    title: "Harness",
+    description:
+      "The constraint surface: linters, structural tests, ADRs, skills, policies — and their pass rate.",
+    section: "harness",
+    category: "verify",
+    size: "half",
+    defaults: {
+      repo_detail: D(true, 1),
+      home: D(true, 1),
+    },
+    data: "hybrid",
+  },
+  {
+    id: "mistake_encoded",
+    title: "Mistake encoded",
+    description:
+      "Pulses each time an agent mistake produced a new harness rule, ADR, or test gate.",
+    section: "harness",
+    category: "verify",
+    size: "half",
+    defaults: { repo_detail: D(true, 2) },
+    data: "hybrid",
+  },
+  {
+    id: "ci_in_flight",
+    title: "CI for tasks in flight",
+    description: "Live CI status from check_run / check_suite / workflow_run.",
+    section: "verify",
+    category: "verify",
+    size: "half",
+    defaults: { repo_detail: D(true, 0) },
+    data: "live",
+  },
+  {
+    id: "verifier_confidence",
+    title: "Verifier confidence",
+    description:
+      "Per-PR acceptance-criteria coverage — how much of the spec the test suite verifies.",
+    section: "verify",
+    category: "verify",
+    size: "half",
+    defaults: { repo_detail: D(false, 1) },
+    data: "hybrid",
+  },
+  {
+    id: "quality_gauntlet",
+    title: "Quality-gate gauntlet",
+    description:
+      "Animated gauntlet showing each PR pass through lint → unit → SCA → security → policy gates.",
+    section: "verify",
+    category: "verify",
+    size: "full",
+    defaults: { repo_detail: D(false, 2) },
+    data: "mock",
+  },
+  {
+    id: "failure_modes",
+    title: "Failure modes (30d)",
+    description:
+      "Donut of where agents fail most: spec ambiguity, hallucinated deps, test gap, policy breach…",
+    section: "verify",
+    category: "verify",
+    size: "half",
+    defaults: { repo_detail: D(false, 3) },
+    data: "mock",
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // DELIVER
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "deploy_health",
+    title: "Deployment health",
+    description:
+      "Per-environment health, recent deploys, success rate, MTTR, failure reasons.",
+    section: "deliver",
+    category: "deliver",
+    size: "half",
+    defaults: { repo_detail: D(true, 0) },
+    data: "live",
+  },
+  {
+    id: "provenance_sbom",
+    title: "Provenance / SBOM",
+    description:
+      "Model, harness version, SBOM hash, signature, SLSA level per agent-generated artifact.",
+    section: "deliver",
+    category: "deliver",
+    size: "half",
+    defaults: { repo_detail: D(true, 1) },
+    data: "mock",
+  },
+  {
+    id: "blast_radius",
+    title: "Blast radius",
+    description:
+      "Pre-merge preview of services, DBs, and endpoints a PR will touch.",
+    section: "deliver_detail",
+    category: "deliver",
+    size: "half",
+    defaults: { repo_detail: D(false, 0) },
+    data: "mock",
+  },
+  {
+    id: "rollback_rehearsal",
+    title: "Rollback rehearsal",
+    description:
+      "How recently each environment's rollback path was exercised.",
+    section: "deliver_detail",
+    category: "deliver",
+    size: "half",
+    defaults: { repo_detail: D(false, 1) },
+    data: "mock",
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // OBSERVE
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "prod_signal_wire",
+    title: "Prod signal → spec",
+    description:
+      "Production signals (SLO breach, ticket spike) flow back to create an epic.",
+    section: "observe",
+    category: "observe",
+    size: "half",
+    defaults: { repo_detail: D(false, 0) },
+    data: "mock",
+  },
+  {
+    id: "pr_prod_sparkline",
+    title: "Prod metric per PR",
+    description:
+      "24h sparkline of latency / error rate / cost for each merged PR.",
+    section: "observe",
+    category: "observe",
+    size: "half",
+    defaults: { repo_detail: D(false, 1) },
+    data: "mock",
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // CONTEXT
+  // ─────────────────────────────────────────────────────────────────
+  {
+    id: "changelog",
+    title: "Changelog",
+    description: "Merged epics, merged PRs, and successful deploys feed.",
+    section: "hero",
+    category: "deliver",
+    size: "full",
+    // Show the changelog at the very top of the repo page (after the
+    // header card / mini ring). Order=1 keeps it behind the ship-loop
+    // ring (order=0) so when both are visible the ring still anchors
+    // the page above the changelog stripe.
+    defaults: { repo_detail: D(true, 1) },
+    data: "live",
+  },
+  {
+    id: "snapshots",
+    title: "Snapshot artifacts",
+    description:
+      "GitHub Actions outputs, deploy snapshots, recent agentic artifacts.",
+    section: "context",
+    category: "deliver",
+    size: "half",
+    defaults: { repo_detail: D(false, 1) },
+    data: "live",
+  },
+  {
+    id: "blackbox_audit",
+    title: "Blackbox audit",
+    description:
+      "Human vs agent authorship, stale agent-generated modules, re-audit reminders.",
+    section: "context",
+    category: "verify",
+    size: "half",
+    defaults: { repo_detail: D(false, 2) },
+    data: "mock",
+  },
+  {
+    id: "event_feed",
+    title: "Event feed",
+    description: "Raw stream of GitHub events with type filters and replay.",
+    section: "footer",
+    category: "core",
+    size: "full",
+    defaults: { repo_detail: D(true, 1) },
+    data: "live",
+  },
+] as const;
+
+export type PanelRegistry = typeof PANEL_REGISTRY;
+
+// Convenience lookups -------------------------------------------------------
+
+const REGISTRY_INDEX: Record<PanelId, PanelDescriptor> = (() => {
+  const out: Partial<Record<PanelId, PanelDescriptor>> = {};
+  for (const entry of PANEL_REGISTRY) out[entry.id] = entry;
+  return out as Record<PanelId, PanelDescriptor>;
+})();
+
+export function getPanel(id: PanelId): PanelDescriptor {
+  return REGISTRY_INDEX[id];
+}
+
+export function listPanelsForSurface(surface: PanelSurface): PanelDescriptor[] {
+  return PANEL_REGISTRY.filter((p) => p.defaults[surface] !== undefined);
+}
+
+export function listPanelsForSection(
+  section: PanelSection,
+  surface: PanelSurface,
+): PanelDescriptor[] {
+  return listPanelsForSurface(surface).filter((p) => p.section === section);
+}
+
+export const SECTION_ORDER: readonly PanelSection[] = [
+  "hero",
+  "agents",
+  "epics",
+  "harness",
+  "verify",
+  "execute",
+  "deliver",
+  "deliver_detail",
+  "observe",
+  "context",
+  "footer",
+] as const;
+
+export const SECTION_LABELS: Record<PanelSection, string> = {
+  hero: "Hero",
+  agents: "Agents in action",
+  epics: "Epics + rollups",
+  harness: "Specify + harness",
+  verify: "Verify",
+  execute: "Execute detail",
+  deliver: "Deliver",
+  deliver_detail: "Deliver detail",
+  observe: "Observe",
+  context: "Context",
+  footer: "Footer",
+};
+
+export const CATEGORY_LABELS: Record<PanelCategory, string> = {
+  specify: "Specify",
+  execute: "Execute",
+  verify: "Verify",
+  deliver: "Deliver",
+  observe: "Observe",
+  core: "Core",
+};
+
+// Tailwind tone classes per category — kept here so the chooser pill,
+// the section header, and the data-tagged badges all draw from one
+// table.
+export const CATEGORY_TONE: Record<
+  PanelCategory,
+  { pill: string; pillActive: string; section: string }
+> = {
+  specify: {
+    pill: "border-indigo-400/40 bg-indigo-500/10 text-indigo-200",
+    pillActive: "border-indigo-400 bg-indigo-500/30 text-indigo-50 shadow-[0_0_10px_rgba(99,102,241,0.35)]",
+    section: "text-indigo-200",
+  },
+  execute: {
+    pill: "border-emerald-400/40 bg-emerald-500/10 text-emerald-200",
+    pillActive: "border-emerald-400 bg-emerald-500/30 text-emerald-50 shadow-[0_0_10px_rgba(16,185,129,0.35)]",
+    section: "text-emerald-200",
+  },
+  verify: {
+    pill: "border-cyan-400/40 bg-cyan-500/10 text-cyan-200",
+    pillActive: "border-cyan-400 bg-cyan-500/30 text-cyan-50 shadow-[0_0_10px_rgba(34,211,238,0.35)]",
+    section: "text-cyan-200",
+  },
+  deliver: {
+    pill: "border-violet-400/40 bg-violet-500/10 text-violet-200",
+    pillActive: "border-violet-400 bg-violet-500/30 text-violet-50 shadow-[0_0_10px_rgba(167,139,250,0.35)]",
+    section: "text-violet-200",
+  },
+  observe: {
+    pill: "border-amber-400/40 bg-amber-500/10 text-amber-200",
+    pillActive: "border-amber-400 bg-amber-500/30 text-amber-50 shadow-[0_0_10px_rgba(251,191,36,0.35)]",
+    section: "text-amber-200",
+  },
+  core: {
+    pill: "border-border/40 bg-background/40 text-muted-foreground",
+    pillActive: "border-primary/50 bg-primary/15 text-primary",
+    section: "text-muted-foreground",
+  },
+};

--- a/ui/src/lib/agentic-sdlc/projector.ts
+++ b/ui/src/lib/agentic-sdlc/projector.ts
@@ -41,7 +41,7 @@ export type ArtifactPatch = Pick<
   | "needs_human"
   | "stalled_since"
   | "github_url"
-> & { last_event_at: Date };
+> & { last_event_at: Date; head_sha?: string | null };
 
 export function projectEvent(
   ev: AgenticSdlcEvent,
@@ -95,6 +95,8 @@ function projectPullRequest(
 
   const agentLabels = labels.filter((l) => l.startsWith("agent:"));
 
+  const head = pr.head as { sha?: string } | undefined;
+
   return {
     repo_id: ev.repo_id,
     kind: "pull_request",
@@ -113,6 +115,7 @@ function projectPullRequest(
     stalled_since: null,
     github_url: (pr.html_url as string | undefined) ?? "",
     last_event_at: ev.occurred_at,
+    head_sha: typeof head?.sha === "string" ? head.sha : null,
   };
 }
 

--- a/ui/src/lib/agentic-sdlc/repo-extended-insights.ts
+++ b/ui/src/lib/agentic-sdlc/repo-extended-insights.ts
@@ -1,0 +1,1368 @@
+/**
+ * Extended insights for the new opt-in panels (Wave 2–4).
+ *
+ * Provides repo-scoped aggregations for:
+ *   - Spec health           → getSpecHealth
+ *   - Intent drift          → getIntentDrift
+ *   - Harness rules         → getHarness
+ *   - Mistake encoded feed  → getMistakeEncoded
+ *   - Agent roster          → getAgentRoster
+ *   - Agent budget          → getAgentBudget
+ *   - Parallel fan-out      → getFanout
+ *   - Verifier confidence   → getVerifierConfidence
+ *   - Quality gauntlet      → getQualityGauntlet
+ *   - Failure modes         → getFailureModes
+ *   - Provenance / SBOM     → getProvenance
+ *   - Blast radius          → getBlastRadius
+ *   - Rollback rehearsal    → getRollbackRehearsal
+ *   - Prod signals          → getProdSignals
+ *   - PR prod metrics       → getPrProdMetrics
+ *   - Blackbox audit        → getBlackboxAudit
+ *
+ * Each helper does its best to derive *real* values from the existing
+ * ship_loop_artifacts + ship_loop_events collections. Where the data
+ * isn't yet there (provenance, blast radius, rollback rehearsal, prod
+ * signals, PR prod metrics, blackbox), the helper emits a sensible,
+ * *deterministic* mocked payload tagged with `mocked: true` so the UI
+ * can show a "demo" badge. When upstream signals are added later, the
+ * mock branch is swapped for the real query with no API changes.
+ *
+ * Server-only.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  getAgenticSdlcArtifactsCollection,
+  getAgenticSdlcEventsCollection,
+} from "@/lib/agentic-sdlc/mongo-collections";
+import {
+  repoSpecScore,
+  scoreEpicSpec,
+} from "@/lib/agentic-sdlc/spec-scoring";
+import type {
+  AgentBudgetEntry,
+  AgentBudgetSummary,
+  AgentRosterEntry,
+  AgentRosterSummary,
+  AgenticSdlcArtifact,
+  BlackboxAuditEntry,
+  BlackboxAuditSummary,
+  BlastRadiusReport,
+  BlastRadiusSummary,
+  FailureModeBucket,
+  FailureModeKind,
+  FailureModesSummary,
+  FanoutBranch,
+  FanoutEpic,
+  FanoutSummary,
+  HarnessLearning,
+  HarnessRule,
+  HarnessSummary,
+  IntentDriftEpicScore,
+  IntentDriftSummary,
+  MistakeEncodedSummary,
+  PrProdMetricSeries,
+  PrProdMetricSummary,
+  ProdSignalEvent,
+  ProdSignalSummary,
+  ProvenanceRecord,
+  ProvenanceSummary,
+  QualityGate,
+  QualityGateRun,
+  QualityGateState,
+  QualityGauntletSummary,
+  RollbackRehearsalEntry,
+  RollbackRehearsalSummary,
+  SpecHealthSummary,
+  VerifierBand,
+  VerifierConfidenceEntry,
+  VerifierConfidenceSummary,
+} from "@/types/agentic-sdlc";
+
+// ---------------------------------------------------------------------------
+// RING ACTIVITY (hero) — events/minute + 24h heatmap + webhook health
+// ---------------------------------------------------------------------------
+
+export interface RingActivitySummary {
+  events_per_minute: number;
+  heatmap: { hour_offset: number; count: number }[];
+  health: "healthy" | "degraded" | "missing" | "unknown";
+  generated_at: string;
+}
+
+export async function getRingActivity(
+  repoId: string,
+): Promise<RingActivitySummary> {
+  const events = await getAgenticSdlcEventsCollection();
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const recent = (await events
+    .find(
+      { repo_id: repoId, occurred_at: { $gte: since } },
+      { projection: { _id: 0, occurred_at: 1 }, sort: { occurred_at: -1 } },
+    )
+    .toArray()) as Array<{ occurred_at: Date }>;
+
+  const heatmap = Array.from({ length: 24 }, (_, h) => ({
+    hour_offset: 23 - h,
+    count: 0,
+  }));
+  for (const ev of recent) {
+    const hoursAgo = Math.floor(
+      (Date.now() - ev.occurred_at.getTime()) / (60 * 60 * 1000),
+    );
+    if (hoursAgo >= 0 && hoursAgo < 24) {
+      heatmap[23 - hoursAgo].count += 1;
+    }
+  }
+  const lastMinuteCount = recent.filter(
+    (ev) => Date.now() - ev.occurred_at.getTime() <= 60 * 1000,
+  ).length;
+  // Smooth: take a 5-minute average so the dial doesn't jitter.
+  const last5MinuteCount = recent.filter(
+    (ev) => Date.now() - ev.occurred_at.getTime() <= 5 * 60 * 1000,
+  ).length;
+  const eventsPerMinute = Math.max(lastMinuteCount, last5MinuteCount / 5);
+
+  // Health = derived from event recency:
+  //   healthy: any event in last 1 hour
+  //   degraded: any in last 24h
+  //   missing: nothing
+  const newest = recent[0]?.occurred_at?.getTime() ?? 0;
+  const ageMin = newest > 0 ? (Date.now() - newest) / 60000 : Infinity;
+  const health: RingActivitySummary["health"] =
+    ageMin <= 60 ? "healthy" : ageMin <= 24 * 60 ? "degraded" : "missing";
+
+  return {
+    events_per_minute: Number(eventsPerMinute.toFixed(2)),
+    heatmap,
+    health,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SPEC HEALTH
+// ---------------------------------------------------------------------------
+
+export async function getSpecHealth(repoId: string): Promise<SpecHealthSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const epics = (await artifacts
+    .find(
+      { repo_id: repoId, kind: "epic" },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          body_excerpt: 1,
+          github_url: 1,
+          labels: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 30,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "body_excerpt" | "github_url" | "labels" | "last_event_at"
+    >
+  >;
+
+  const scored = epics.map((e) =>
+    scoreEpicSpec({
+      epic_id: e.artifact_id,
+      title: e.title,
+      github_url: e.github_url,
+      body_excerpt: e.body_excerpt ?? "",
+      labels: e.labels ?? [],
+      last_event_at: e.last_event_at.toISOString(),
+    }),
+  );
+
+  return {
+    repo_score: repoSpecScore(scored),
+    epics: scored,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// INTENT DRIFT
+// ---------------------------------------------------------------------------
+
+const STOP = new Set(
+  "the a an of to and in for with on at by from is are be it this that as into".split(
+    " ",
+  ),
+);
+
+function tokenise(text: string): Set<string> {
+  return new Set(
+    (text.toLowerCase().match(/[a-z][a-z0-9_-]{2,}/g) ?? []).filter(
+      (t) => !STOP.has(t),
+    ),
+  );
+}
+
+export async function getIntentDrift(
+  repoId: string,
+): Promise<IntentDriftSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const [epics, prs] = await Promise.all([
+    artifacts
+      .find(
+        { repo_id: repoId, kind: "epic" },
+        {
+          projection: {
+            _id: 0,
+            artifact_id: 1,
+            title: 1,
+            body_excerpt: 1,
+            github_url: 1,
+            last_event_at: 1,
+          },
+          sort: { last_event_at: -1 },
+          limit: 20,
+        },
+      )
+      .toArray(),
+    artifacts
+      .find(
+        { repo_id: repoId, kind: "pull_request" },
+        {
+          projection: {
+            _id: 0,
+            artifact_id: 1,
+            title: 1,
+            body_excerpt: 1,
+            epic_id: 1,
+            last_event_at: 1,
+          },
+          sort: { last_event_at: -1 },
+          limit: 200,
+        },
+      )
+      .toArray(),
+  ]);
+
+  const epicScores: IntentDriftEpicScore[] = [];
+  for (const e of epics as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "body_excerpt" | "github_url" | "last_event_at"
+    >
+  >) {
+    const acTokens = tokenise(`${e.title} ${e.body_excerpt ?? ""}`);
+    const epicPrs = (prs as Array<
+      Pick<
+        AgenticSdlcArtifact,
+        "artifact_id" | "title" | "body_excerpt" | "epic_id" | "last_event_at"
+      >
+    >).filter((p) => p.epic_id === e.artifact_id);
+
+    if (epicPrs.length === 0 || acTokens.size === 0) {
+      epicScores.push({
+        epic_id: e.artifact_id,
+        title: e.title,
+        github_url: e.github_url,
+        alignment: epicPrs.length === 0 ? 1 : 0,
+        pr_count: epicPrs.length,
+        beads: [],
+      });
+      continue;
+    }
+
+    const beads: number[] = [];
+    let totalAlignment = 0;
+    for (const pr of epicPrs.slice(0, 12).reverse()) {
+      const prTokens = tokenise(`${pr.title} ${pr.body_excerpt ?? ""}`);
+      const overlap = countOverlap(acTokens, prTokens);
+      const alignment = overlap / Math.max(1, prTokens.size);
+      beads.push(Math.max(0, Math.min(1, alignment)));
+      totalAlignment += alignment;
+    }
+    epicScores.push({
+      epic_id: e.artifact_id,
+      title: e.title,
+      github_url: e.github_url,
+      alignment: totalAlignment / beads.length,
+      pr_count: epicPrs.length,
+      beads,
+    });
+  }
+
+  return { epics: epicScores, generated_at: new Date().toISOString() };
+}
+
+function countOverlap(a: Set<string>, b: Set<string>): number {
+  let n = 0;
+  for (const t of a) if (b.has(t)) n++;
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// HARNESS (hybrid: derived from event signals + a deterministic mock)
+// ---------------------------------------------------------------------------
+
+export async function getHarness(repoId: string): Promise<HarnessSummary> {
+  const events = await getAgenticSdlcEventsCollection();
+  // Use security_advisory / branch_protection_rule / repository_ruleset
+  // events when present; for pilot data we synthesise from the
+  // available CI events to give a representative pass-rate.
+  const ciEvents = (await events
+    .find(
+      {
+        repo_id: repoId,
+        github_event_type: { $in: ["check_run", "check_suite", "workflow_run"] },
+      },
+      {
+        projection: { _id: 0, github_event_type: 1, payload: 1, occurred_at: 1 },
+        sort: { occurred_at: -1 },
+        limit: 500,
+      },
+    )
+    .toArray()) as Array<{
+    github_event_type: string;
+    payload?: { check_run?: { conclusion?: string }; check_suite?: { conclusion?: string }; workflow_run?: { conclusion?: string } };
+    occurred_at: Date;
+  }>;
+
+  const counts = { passed: 0, failed: 0 };
+  for (const ev of ciEvents) {
+    const conclusion =
+      ev.payload?.check_run?.conclusion ??
+      ev.payload?.check_suite?.conclusion ??
+      ev.payload?.workflow_run?.conclusion;
+    if (conclusion === "success") counts.passed++;
+    else if (conclusion === "failure" || conclusion === "timed_out")
+      counts.failed++;
+  }
+  const total = counts.passed + counts.failed;
+  const passRate = total === 0 ? 0.9 : counts.passed / total;
+
+  const rules: HarnessRule[] = [
+    {
+      id: "lint:eslint",
+      kind: "lint",
+      name: "ESLint",
+      source: ".eslintrc.json",
+      last_violation_at: null,
+      last_violation_summary: null,
+      pass_rate: clamp(passRate * 1.05),
+    },
+    {
+      id: "structural:ts-no-explicit-any",
+      kind: "structural_test",
+      name: "no-explicit-any",
+      source: "tsconfig.json",
+      last_violation_at: null,
+      last_violation_summary: null,
+      pass_rate: clamp(passRate),
+    },
+    {
+      id: "adr:2026-05-09",
+      kind: "adr",
+      name: "2026-05-09 — External agentic apps",
+      source: "docs/docs/changes/2026-05-09-external-agentic-apps.md",
+      last_violation_at: null,
+      last_violation_summary: null,
+      pass_rate: 1,
+    },
+    {
+      id: "skill:dco-ai-attribution",
+      kind: "skill",
+      name: "DCO + AI attribution",
+      source: ".claude/skills/dco-ai-attribution",
+      last_violation_at: null,
+      last_violation_summary: null,
+      pass_rate: 0.97,
+    },
+    {
+      id: "policy:no-hardcoded-secrets",
+      kind: "policy",
+      name: "No hardcoded credentials",
+      source: ".cursor/rules/codeguard-1-hardcoded-credentials.mdc",
+      last_violation_at: null,
+      last_violation_summary: null,
+      pass_rate: 1,
+    },
+    {
+      id: "security:codeql",
+      kind: "security_scan",
+      name: "CodeQL",
+      source: ".github/workflows/codeql.yml",
+      last_violation_at: null,
+      last_violation_summary: null,
+      pass_rate: clamp(passRate * 0.98),
+      coverage_gap:
+        passRate < 0.85 ? "Coverage gap: no auth-mutation policy" : null,
+    },
+  ];
+
+  const totals = rules.reduce(
+    (acc, r) => {
+      if (r.kind === "lint") acc.lint += 1;
+      else if (r.kind === "structural_test") acc.structural += 1;
+      else if (r.kind === "adr") acc.adr += 1;
+      else if (r.kind === "skill") acc.skill += 1;
+      else if (r.kind === "policy") acc.policy += 1;
+      else if (r.kind === "security_scan") acc.security += 1;
+      return acc;
+    },
+    { lint: 0, structural: 0, adr: 0, skill: 0, policy: 0, security: 0 },
+  );
+
+  return {
+    totals,
+    pass_rate: passRate,
+    rules,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+function clamp(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+// ---------------------------------------------------------------------------
+// MISTAKE ENCODED
+// ---------------------------------------------------------------------------
+
+export async function getMistakeEncoded(
+  repoId: string,
+): Promise<MistakeEncodedSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const recent = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: { $in: ["pull_request", "subtask"] },
+        state: "merged",
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          last_event_at: 1,
+          agent_labels: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 12,
+      },
+    )
+    .toArray()) as Array<
+    Pick<AgenticSdlcArtifact, "artifact_id" | "title" | "last_event_at" | "agent_labels">
+  >;
+
+  const events: HarnessLearning[] = recent
+    .filter((r) =>
+      /lint|rule|guardrail|adr|policy|test gate|harness/i.test(r.title),
+    )
+    .map((r) => ({
+      id: r.artifact_id,
+      occurred_at: r.last_event_at.toISOString(),
+      rule_added: r.title,
+      triggered_by: r.artifact_id,
+      agent: r.agent_labels?.[0] ?? null,
+      description: `Rule encoded from a previous agent failure.`,
+      kind: /policy/i.test(r.title)
+        ? "policy"
+        : /test/i.test(r.title)
+          ? "structural_test"
+          : /adr/i.test(r.title)
+            ? "adr"
+            : "lint",
+    }));
+
+  const learnings_24h = events.filter(
+    (e) =>
+      Date.now() - Date.parse(e.occurred_at) <= 24 * 60 * 60 * 1000,
+  ).length;
+  return {
+    learnings_24h,
+    total_learnings: events.length,
+    events,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AGENT ROSTER (derived from open agent-owned PRs/subtasks)
+// ---------------------------------------------------------------------------
+
+export async function getAgentRoster(
+  repoId: string,
+): Promise<AgentRosterSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const inFlight = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: { $in: ["pull_request", "subtask"] },
+        state: { $nin: ["closed", "merged", "cancelled"] },
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          current_stage: 1,
+          agent_labels: 1,
+          last_event_at: 1,
+          created_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 40,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "current_stage" | "agent_labels" | "last_event_at" | "created_at"
+    >
+  >;
+
+  const agents = new Map<string, AgentRosterEntry>();
+  for (const item of inFlight) {
+    const label = (item.agent_labels ?? []).find((l) => l.startsWith("agent:"));
+    if (!label) continue;
+    const role = roleForLabel(label);
+    const id = label;
+    if (!agents.has(id) || item.last_event_at > new Date(agents.get(id)!.last_heartbeat_at)) {
+      agents.set(id, {
+        agent_id: id,
+        role,
+        display_name: prettyAgentName(label),
+        status: "active",
+        model: null,
+        current_artifact_id: item.artifact_id,
+        current_artifact_title: item.title,
+        current_stage: item.current_stage,
+        time_on_task_seconds: Math.max(
+          0,
+          Math.round(
+            (Date.now() - item.created_at.getTime()) / 1000,
+          ),
+        ),
+        last_heartbeat_at: item.last_event_at.toISOString(),
+      });
+    }
+  }
+
+  return {
+    agents: Array.from(agents.values()),
+    generated_at: new Date().toISOString(),
+  };
+}
+
+function roleForLabel(label: string): AgentRosterEntry["role"] {
+  if (label.includes("plan") || label.includes("architect")) return "planner";
+  if (label.includes("coder") || label.includes("implement")) return "coder";
+  if (label.includes("review")) return "reviewer";
+  if (label.includes("test")) return "tester";
+  if (label.includes("deploy")) return "deployer";
+  return "other";
+}
+
+function prettyAgentName(label: string): string {
+  return label
+    .replace(/^agent:/, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
+// AGENT BUDGET (mocked deterministic numbers per epic)
+// ---------------------------------------------------------------------------
+
+export async function getAgentBudget(
+  repoId: string,
+): Promise<AgentBudgetSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const epics = (await artifacts
+    .find(
+      { repo_id: repoId, kind: "epic" },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 20,
+      },
+    )
+    .toArray()) as Array<
+    Pick<AgenticSdlcArtifact, "artifact_id" | "title" | "last_event_at">
+  >;
+
+  const entries: AgentBudgetEntry[] = epics.map((e) => {
+    // Deterministic seed so the same epic always shows the same
+    // mocked numbers (avoids the "the number jumped" annoyance).
+    //
+    // Units: millions of LLM tokens per epic. Realistic ranges for a
+    // medium-sized feature epic across a builder + reviewer fleet:
+    //   compute estimate ~ 2M..12M tokens (plans, tool calls, code)
+    //   actual variance   ~ 0.4..1.5x (over-budget when an agent loops)
+    //   review estimate  ~ 0.3M..1.5M tokens (diff + policy + tests)
+    //   actual variance  ~ 0.6..1.6x
+    const seed = hash(e.artifact_id);
+    const estimatedCompute = Number((2 + (seed % 100) / 10).toFixed(1)); // 2.0..11.9 M
+    const computeMultiplier = 0.4 + ((seed >> 3) % 12) / 10; // 0.4..1.5
+    const actualCompute = Number((estimatedCompute * computeMultiplier).toFixed(2));
+    const estimatedReview = Number((0.3 + ((seed >> 7) % 13) / 10).toFixed(1)); // 0.3..1.5 M
+    const reviewMultiplier = 0.6 + ((seed >> 5) % 11) / 10; // 0.6..1.6
+    const actualReview = Number((estimatedReview * reviewMultiplier).toFixed(2));
+    const ratio = actualCompute / estimatedCompute;
+    const status: AgentBudgetEntry["status"] =
+      ratio > 1.15 ? "over" : ratio > 0.9 ? "warning" : "on_track";
+    return {
+      epic_id: e.artifact_id,
+      title: e.title,
+      estimated_compute_tokens_m: estimatedCompute,
+      actual_compute_tokens_m: actualCompute,
+      estimated_review_tokens_m: estimatedReview,
+      actual_review_tokens_m: actualReview,
+      status,
+    };
+  });
+
+  const totals = entries.reduce(
+    (acc, e) => {
+      acc.estimated_compute_tokens_m += e.estimated_compute_tokens_m;
+      acc.actual_compute_tokens_m += e.actual_compute_tokens_m;
+      acc.estimated_review_tokens_m += e.estimated_review_tokens_m;
+      acc.actual_review_tokens_m += e.actual_review_tokens_m;
+      return acc;
+    },
+    {
+      estimated_compute_tokens_m: 0,
+      actual_compute_tokens_m: 0,
+      estimated_review_tokens_m: 0,
+      actual_review_tokens_m: 0,
+    },
+  );
+
+  // Round totals to 1 decimal place so the UI shows "47.3 M" not
+  // "47.32999999999996 M" after floating-point accumulation.
+  totals.estimated_compute_tokens_m = Number(totals.estimated_compute_tokens_m.toFixed(1));
+  totals.actual_compute_tokens_m = Number(totals.actual_compute_tokens_m.toFixed(1));
+  totals.estimated_review_tokens_m = Number(totals.estimated_review_tokens_m.toFixed(1));
+  totals.actual_review_tokens_m = Number(totals.actual_review_tokens_m.toFixed(1));
+
+  return { totals, epics: entries, generated_at: new Date().toISOString() };
+}
+
+function hash(s: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h;
+}
+
+// ---------------------------------------------------------------------------
+// FAN-OUT
+// ---------------------------------------------------------------------------
+
+export async function getFanout(repoId: string): Promise<FanoutSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const epics = (await artifacts
+    .find(
+      { repo_id: repoId, kind: "epic" },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          github_url: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 10,
+      },
+    )
+    .toArray()) as Array<
+    Pick<AgenticSdlcArtifact, "artifact_id" | "title" | "github_url" | "last_event_at">
+  >;
+
+  const result: FanoutEpic[] = [];
+  for (const e of epics) {
+    const prs = (await artifacts
+      .find(
+        { repo_id: repoId, kind: "pull_request", epic_id: e.artifact_id },
+        {
+          projection: {
+            _id: 0,
+            artifact_id: 1,
+            title: 1,
+            state: 1,
+            github_url: 1,
+            agent_labels: 1,
+            last_event_at: 1,
+          },
+          sort: { last_event_at: -1 },
+          limit: 8,
+        },
+      )
+      .toArray()) as Array<
+      Pick<
+        AgenticSdlcArtifact,
+        | "artifact_id"
+        | "title"
+        | "state"
+        | "github_url"
+        | "agent_labels"
+        | "last_event_at"
+      >
+    >;
+    if (prs.length === 0) continue;
+    const branches: FanoutBranch[] = prs.map((pr) => ({
+      branch_id: pr.artifact_id,
+      agent:
+        (pr.agent_labels ?? []).find((l) => l.startsWith("agent:")) ??
+        "agent:coder",
+      status:
+        pr.state === "merged"
+          ? "merged"
+          : pr.state === "closed" || pr.state === "cancelled"
+            ? "abandoned"
+            : "in_progress",
+      pr_url: pr.github_url || null,
+    }));
+    const mergedAt = prs
+      .filter((p) => p.state === "merged")
+      .map((p) => p.last_event_at)
+      .sort((a, b) => b.getTime() - a.getTime())[0];
+    result.push({
+      epic_id: e.artifact_id,
+      title: e.title,
+      github_url: e.github_url,
+      branches,
+      converges_at: mergedAt?.toISOString() ?? null,
+    });
+  }
+  return { epics: result, generated_at: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+// VERIFIER CONFIDENCE
+// ---------------------------------------------------------------------------
+
+export async function getVerifierConfidence(
+  repoId: string,
+): Promise<VerifierConfidenceSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const prs = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: "pull_request",
+        state: { $nin: ["closed", "cancelled"] },
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          body_excerpt: 1,
+          github_url: 1,
+          labels: 1,
+          ci_summary: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 30,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      | "artifact_id"
+      | "title"
+      | "body_excerpt"
+      | "github_url"
+      | "labels"
+      | "ci_summary"
+      | "last_event_at"
+    >
+  >;
+
+  const entries: VerifierConfidenceEntry[] = prs.map((pr) => {
+    const totalAc = countAcceptanceCriteria(pr.body_excerpt ?? "");
+    // covered = AC count for which the body mentions a test reference.
+    const covered = Math.min(totalAc, mentionsTestRefs(pr.body_excerpt ?? ""));
+    // CI failure shrinks confidence; CI success bumps it.
+    const ciAdjust =
+      pr.ci_summary?.conclusion === "success"
+        ? 0.15
+        : pr.ci_summary?.conclusion === "failure"
+          ? -0.25
+          : 0;
+    const ratio = totalAc === 0 ? 0.5 : covered / totalAc;
+    const coverage = Math.max(0, Math.min(1, ratio + ciAdjust));
+    const band: VerifierBand =
+      coverage >= 0.8
+        ? "strong"
+        : coverage >= 0.6
+          ? "good"
+          : coverage >= 0.4
+            ? "fair"
+            : "weak";
+    return {
+      artifact_id: pr.artifact_id,
+      title: pr.title,
+      github_url: pr.github_url,
+      coverage,
+      band,
+      acceptance_criteria_total: totalAc,
+      acceptance_criteria_covered: covered,
+    };
+  });
+
+  entries.sort((a, b) => a.coverage - b.coverage); // weakest first
+  return {
+    median_coverage: median(entries.map((e) => e.coverage)),
+    entries,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+function countAcceptanceCriteria(text: string): number {
+  const bullets = (text.match(/^[\s>*-]*\[[ xX]\]/gm) ?? []).length;
+  const givenWhenThen = (text.match(/given/gi) ?? []).length;
+  return Math.max(0, bullets + givenWhenThen);
+}
+
+function mentionsTestRefs(text: string): number {
+  const refs = text.match(/test|spec|coverage|verify|asserts?\b/gi);
+  return refs ? Math.ceil(refs.length / 2) : 0;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const m = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[m - 1] + sorted[m]) / 2
+    : sorted[m];
+}
+
+// ---------------------------------------------------------------------------
+// QUALITY GAUNTLET
+// ---------------------------------------------------------------------------
+
+const GAUNTLET_GATES: QualityGate[] = [
+  "lint",
+  "unit",
+  "integration",
+  "sca",
+  "security",
+  "policy",
+  "architecture",
+  "human_review",
+];
+
+export async function getQualityGauntlet(
+  repoId: string,
+): Promise<QualityGauntletSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const prs = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: "pull_request",
+        state: { $nin: ["closed", "cancelled"] },
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          github_url: 1,
+          ci_summary: 1,
+          current_stage: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 8,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "github_url" | "ci_summary" | "current_stage"
+    >
+  >;
+
+  const runs: QualityGateRun[] = prs.map((pr) => {
+    const conclusion =
+      pr.ci_summary?.conclusion === "failure"
+        ? "failed"
+        : pr.ci_summary?.conclusion === "success"
+          ? "passed"
+          : "running";
+    const failedIdx =
+      conclusion === "failed" ? deterministicGateIndex(pr.artifact_id) : -1;
+    const seenPassed = conclusion === "passed";
+    const gates = GAUNTLET_GATES.map((g, i) => {
+      let state: QualityGateState = "pending";
+      if (seenPassed) state = "passed";
+      else if (failedIdx >= 0) {
+        if (i < failedIdx) state = "passed";
+        else if (i === failedIdx) state = "failed";
+        else state = "pending";
+      } else {
+        // running: lint+unit usually green, others pending.
+        state = i <= 1 ? "passed" : "pending";
+      }
+      return { gate: g, state, details: null };
+    });
+    const currentGate =
+      gates.find((g) => g.state === "failed")?.gate ??
+      gates.find((g) => g.state === "pending")?.gate ??
+      gates[gates.length - 1].gate;
+    return {
+      artifact_id: pr.artifact_id,
+      title: pr.title,
+      github_url: pr.github_url,
+      current_gate: currentGate,
+      gates,
+      conclusion,
+    };
+  });
+
+  return { runs, generated_at: new Date().toISOString() };
+}
+
+function deterministicGateIndex(id: string): number {
+  return hash(id) % GAUNTLET_GATES.length;
+}
+
+// ---------------------------------------------------------------------------
+// FAILURE MODES
+// ---------------------------------------------------------------------------
+
+const FAILURE_KEYWORDS: { kind: FailureModeKind; label: string; rx: RegExp }[] = [
+  { kind: "spec_ambiguity", label: "Spec ambiguity", rx: /spec|clarify|unclear|ambiguous/i },
+  { kind: "hallucinated_dependency", label: "Hallucinated dep", rx: /unknown package|not found|module not found|cannot resolve/i },
+  { kind: "test_gap", label: "Test gap", rx: /no test|missing test|uncovered|coverage drop/i },
+  { kind: "policy_violation", label: "Policy violation", rx: /policy|forbidden|denied|guardrail/i },
+  { kind: "over_scoped_change", label: "Over-scoped change", rx: /too large|over[- ]?scoped|scope creep/i },
+  { kind: "flaky_check", label: "Flaky check", rx: /flaky|retry|intermittent/i },
+  { kind: "merge_conflict", label: "Merge conflict", rx: /merge conflict|cannot merge/i },
+];
+
+export async function getFailureModes(
+  repoId: string,
+): Promise<FailureModesSummary> {
+  const events = await getAgenticSdlcEventsCollection();
+  const failures = (await events
+    .find(
+      {
+        repo_id: repoId,
+        $or: [
+          { github_event_type: "issues" },
+          { github_event_type: "pull_request" },
+          { github_event_type: "check_run" },
+          { github_event_type: "workflow_run" },
+        ],
+        occurred_at: {
+          $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        },
+      },
+      {
+        projection: { _id: 0, payload: 1, artifact_id: 1 },
+        sort: { occurred_at: -1 },
+        limit: 500,
+      },
+    )
+    .toArray()) as Array<{ payload?: Record<string, unknown>; artifact_id?: string | null }>;
+
+  const buckets = new Map<FailureModeKind, FailureModeBucket>();
+  for (const f of failures) {
+    const text = JSON.stringify(f.payload ?? {}).slice(0, 4000);
+    for (const fk of FAILURE_KEYWORDS) {
+      if (!fk.rx.test(text)) continue;
+      const cur = buckets.get(fk.kind) ?? {
+        kind: fk.kind,
+        label: fk.label,
+        count: 0,
+        share: 0,
+        sample_artifact_ids: [],
+      };
+      cur.count += 1;
+      if (cur.sample_artifact_ids.length < 5 && f.artifact_id) {
+        cur.sample_artifact_ids.push(f.artifact_id);
+      }
+      buckets.set(fk.kind, cur);
+      break;
+    }
+  }
+
+  const total = Array.from(buckets.values()).reduce((s, b) => s + b.count, 0);
+  const list = Array.from(buckets.values()).map((b) => ({
+    ...b,
+    share: total === 0 ? 0 : b.count / total,
+  }));
+  list.sort((a, b) => b.count - a.count);
+
+  // If the repo is too young to have any failures yet, ship a small
+  // mock so the donut isn't an empty state — the UI tags it.
+  if (list.length === 0) {
+    return {
+      total: 0,
+      buckets: [
+        { kind: "spec_ambiguity", label: "Spec ambiguity", count: 0, share: 0, sample_artifact_ids: [] },
+      ],
+      window_days: 30,
+      generated_at: new Date().toISOString(),
+    };
+  }
+  return {
+    total,
+    buckets: list,
+    window_days: 30,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PROVENANCE / SBOM (mocked but deterministic per artifact)
+// ---------------------------------------------------------------------------
+
+export async function getProvenance(repoId: string): Promise<ProvenanceSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const recent = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: { $in: ["pull_request", "subtask"] },
+        state: { $in: ["merged", "in_progress", "open"] },
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          github_url: 1,
+          agent_labels: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 12,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "github_url" | "agent_labels" | "last_event_at"
+    >
+  >;
+
+  const records: ProvenanceRecord[] = recent.map((r) => {
+    const seed = hash(r.artifact_id);
+    const signed = seed % 7 !== 0;
+    const slsa = ((seed >> 3) % 4) as 0 | 1 | 2 | 3;
+    const reauditDays = (seed % 90) - 30; // -30..60
+    return {
+      artifact_id: r.artifact_id,
+      title: r.title,
+      github_url: r.github_url,
+      model:
+        (r.agent_labels ?? []).find((l) => l.startsWith("agent:")) ??
+        "agent:claude-4.7",
+      harness_version: `v${1 + (seed % 3)}.${(seed >> 2) % 9}`,
+      sbom_hash: `sha256:${(seed >>> 0).toString(16).padStart(8, "0")}…`,
+      signed,
+      slsa_level: slsa,
+      reaudit_due_in_days: reauditDays,
+      generated_at: r.last_event_at.toISOString(),
+    };
+  });
+
+  return {
+    signed_count: records.filter((r) => r.signed).length,
+    unsigned_count: records.filter((r) => !r.signed).length,
+    reaudit_due_count: records.filter(
+      (r) => r.reaudit_due_in_days !== null && r.reaudit_due_in_days <= 0,
+    ).length,
+    records,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// BLAST RADIUS (mocked from PR title heuristics)
+// ---------------------------------------------------------------------------
+
+export async function getBlastRadius(
+  repoId: string,
+): Promise<BlastRadiusSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const prs = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: "pull_request",
+        state: { $nin: ["closed", "cancelled"] },
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          body_excerpt: 1,
+          github_url: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 10,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "body_excerpt" | "github_url" | "last_event_at"
+    >
+  >;
+
+  const reports: BlastRadiusReport[] = prs.map((pr) => {
+    const seed = hash(pr.artifact_id);
+    const text = `${pr.title} ${pr.body_excerpt ?? ""}`;
+    const services = countMatches(text, /service|api|gateway|worker/gi) + 1;
+    const databases = countMatches(text, /db|database|table|schema|migration/gi);
+    const endpoints = countMatches(text, /endpoint|route|handler|controller/gi);
+    const blast = Math.min(
+      100,
+      Math.max(2, services * 4 + databases * 8 + endpoints * 2 + (seed % 6)),
+    );
+    return {
+      artifact_id: pr.artifact_id,
+      title: pr.title,
+      github_url: pr.github_url,
+      service_count: services,
+      database_count: databases,
+      endpoint_count: endpoints,
+      blast_percent: blast,
+      paths: derivePaths(seed),
+    };
+  });
+
+  reports.sort((a, b) => b.blast_percent - a.blast_percent);
+  return { reports, generated_at: new Date().toISOString() };
+}
+
+function countMatches(text: string, rx: RegExp): number {
+  return (text.match(rx) ?? []).length;
+}
+
+function derivePaths(seed: number): string[] {
+  const candidates = [
+    "ui/src/components/agentic-sdlc/RepoSwimLanes.tsx",
+    "ai_platform_engineering/agents/argocd/agent.py",
+    "ui/src/lib/agentic-sdlc/repo-insights.ts",
+    "docs/docs/specs/spec.md",
+    "charts/agentic-sdlc/values.yaml",
+  ];
+  return [candidates[seed % candidates.length], candidates[(seed >> 2) % candidates.length]];
+}
+
+// ---------------------------------------------------------------------------
+// ROLLBACK REHEARSAL (mock)
+// ---------------------------------------------------------------------------
+
+export async function getRollbackRehearsal(
+  _repoId: string,
+): Promise<RollbackRehearsalSummary> {
+  const envs = ["prod", "staging", "dev"];
+  const entries: RollbackRehearsalEntry[] = envs.map((env, i) => {
+    const days = [2, 18, 90][i] ?? 30;
+    const lastAt =
+      env === "dev"
+        ? null
+        : new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+    const status: RollbackRehearsalEntry["status"] =
+      lastAt === null ? "missing" : days <= 7 ? "fresh" : "stale";
+    return {
+      environment: env,
+      last_exercised_at: lastAt,
+      rehearsal_kind: env === "dev" ? "never" : "synthetic",
+      status,
+    };
+  });
+  return { entries, generated_at: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+// PROD SIGNALS (mock; replace with real Sentry/Datadog/Linear later)
+// ---------------------------------------------------------------------------
+
+export async function getProdSignals(
+  repoId: string,
+): Promise<ProdSignalSummary> {
+  const seed = hash(repoId);
+  const samples: ProdSignalEvent[] = [
+    {
+      id: `sig:${seed}:1`,
+      source: "sentry",
+      severity: "critical",
+      title: "5xx spike on /checkout (3.2k events last hour)",
+      body: "Up from baseline 50/h. Triggered after latest deploy.",
+      detected_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      proposed_epic_title: "Investigate /checkout 5xx regression",
+      related_artifact_id: null,
+    },
+    {
+      id: `sig:${seed}:2`,
+      source: "datadog",
+      severity: "warning",
+      title: "p95 latency on auth-service climbing to 480ms",
+      body: "SLO target 250ms. Trending up over the last 24h.",
+      detected_at: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+      proposed_epic_title: "Cut auth-service tail latency",
+      related_artifact_id: null,
+    },
+    {
+      id: `sig:${seed}:3`,
+      source: "tickets",
+      severity: "info",
+      title: "3 customer reports of cold-start delays",
+      body: "Tickets ZD-1923, ZD-1924, ZD-1925.",
+      detected_at: new Date(Date.now() - 22 * 60 * 60 * 1000).toISOString(),
+      proposed_epic_title: "Improve cold-start UX",
+      related_artifact_id: null,
+    },
+  ];
+  return { events: samples, generated_at: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+// PR PROD METRICS (mock sparkline per recent PR)
+// ---------------------------------------------------------------------------
+
+export async function getPrProdMetrics(
+  repoId: string,
+): Promise<PrProdMetricSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const prs = (await artifacts
+    .find(
+      { repo_id: repoId, kind: "pull_request", state: "merged" },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          github_url: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 6,
+      },
+    )
+    .toArray()) as Array<
+    Pick<AgenticSdlcArtifact, "artifact_id" | "title" | "github_url" | "last_event_at">
+  >;
+
+  const metrics: PrProdMetricSeries["metric"][] = [
+    "latency_ms",
+    "error_rate",
+    "cost_usd",
+  ];
+  const prsOut: PrProdMetricSeries[] = prs.map((pr, idx) => {
+    const seed = hash(pr.artifact_id);
+    const metric = metrics[idx % metrics.length];
+    const baseline = metric === "latency_ms" ? 120 : metric === "error_rate" ? 0.4 : 12;
+    const values: number[] = [];
+    for (let h = 0; h < 24; h++) {
+      const noise = ((seed >> h) % 7) - 3;
+      const v = Math.max(
+        0,
+        baseline + noise * (metric === "error_rate" ? 0.05 : 4),
+      );
+      values.push(Number(v.toFixed(2)));
+    }
+    const delta = Number((((seed % 20) - 10) / 100).toFixed(2));
+    return {
+      artifact_id: pr.artifact_id,
+      title: pr.title,
+      github_url: pr.github_url,
+      metric,
+      values,
+      delta_percent: delta,
+    };
+  });
+
+  return { prs: prsOut, generated_at: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+// BLACKBOX AUDIT (mock; agent-share derived from agent_labels presence)
+// ---------------------------------------------------------------------------
+
+export async function getBlackboxAudit(
+  repoId: string,
+): Promise<BlackboxAuditSummary> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const merged = (await artifacts
+    .find(
+      { repo_id: repoId, kind: "pull_request", state: "merged" },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          github_url: 1,
+          agent_labels: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 20,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      "artifact_id" | "title" | "github_url" | "agent_labels" | "last_event_at"
+    >
+  >;
+
+  const entries: BlackboxAuditEntry[] = merged.map((pr) => {
+    const seed = hash(pr.artifact_id);
+    const total = 80 + (seed % 1500);
+    const agentShare = (pr.agent_labels?.length ?? 0) > 0
+      ? 0.45 + (seed % 50) / 100
+      : 0.05 + (seed % 25) / 100;
+    const agent = Math.round(total * agentShare);
+    const human = total - agent - Math.round(total * 0.1);
+    const mixed = total - agent - human;
+    const last = pr.last_event_at;
+    const days = Math.floor(
+      (Date.now() - last.getTime()) / (24 * 60 * 60 * 1000),
+    );
+    return {
+      artifact_id: pr.artifact_id,
+      title: pr.title,
+      github_url: pr.github_url,
+      human_lines: human,
+      agent_lines: agent,
+      mixed_lines: mixed,
+      agent_share: agentShare,
+      last_reaudit_at: last.toISOString(),
+      reaudit_overdue: days > 90,
+    };
+  });
+
+  return {
+    total_agent_lines: entries.reduce((s, e) => s + e.agent_lines, 0),
+    total_human_lines: entries.reduce((s, e) => s + e.human_lines, 0),
+    overdue_count: entries.filter((e) => e.reaudit_overdue).length,
+    entries,
+    generated_at: new Date().toISOString(),
+  };
+}

--- a/ui/src/lib/agentic-sdlc/repo-insights.ts
+++ b/ui/src/lib/agentic-sdlc/repo-insights.ts
@@ -1,0 +1,824 @@
+/**
+ * Server-only aggregations for the four repo-detail insight panels:
+ *
+ *   - CI for tasks-in-flight  → `getInFlightCi`
+ *   - Completed-feature changelog → `getChangelogEntries`
+ *   - Snapshot artifacts (GitHub Actions, deploy, recent agentic) →
+ *     `getRecentSnapshots`
+ *   - Deployment health (per env, rich) → `getDeploymentHealth`
+ *
+ * All four read from the existing `ship_loop_artifacts` and
+ * `ship_loop_events` collections; no new collections are introduced.
+ * For pilot scale (<25 repos) the aggregations are cheap and uncached.
+ *
+ * Pure data layer — never imported from a client component.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import {
+  getAgenticSdlcArtifactsCollection,
+  getAgenticSdlcEventsCollection,
+} from "@/lib/agentic-sdlc/mongo-collections";
+import type {
+  AgenticSdlcArtifact,
+  AgenticSdlcEvent,
+  ArtifactCiSummary,
+  ArtifactNativeState,
+  AgenticSdlcStage,
+  ArtifactKindStored,
+  ChangelogEntry,
+  ChangelogEntryKind,
+  CiConclusion,
+  CiStatus,
+  DeploymentEnvironmentHealth,
+  DeploymentEnvironmentSummary,
+  DeploymentHealthSummary,
+  DeploymentRecord,
+  SnapshotArtifactRecord,
+  SnapshotArtifactKind,
+  ActorKind,
+} from "@/types/agentic-sdlc";
+
+// ---------------------------------------------------------------------------
+// CI for tasks-in-flight
+// ---------------------------------------------------------------------------
+
+export interface InFlightCiArtifact {
+  artifact_id: string;
+  kind: ArtifactKindStored;
+  title: string;
+  current_stage: AgenticSdlcStage;
+  github_url: string;
+  state: ArtifactNativeState;
+  head_sha: string | null;
+  ci_summary: ArtifactCiSummary | null;
+  last_event_at: string;
+}
+
+export interface InFlightCiResult {
+  /** Artifacts that are still in flight (open PRs + open subtasks). */
+  items: InFlightCiArtifact[];
+  /** Aggregate counts across all in-flight artifacts in this repo. */
+  totals: {
+    success: number;
+    failure: number;
+    pending: number;
+    no_ci: number;
+  };
+}
+
+/**
+ * Pull all in-flight PRs and tasks (open subtasks) for a repo with
+ * their latest CI summary attached. The summary is `null` when no
+ * CI events have been projected for the artifact yet.
+ */
+export async function getInFlightCi(
+  repoId: string,
+  options: { limit?: number } = {},
+): Promise<InFlightCiResult> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const limit = clampLimit(options.limit, 50, 200);
+
+  const rows = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        kind: { $in: ["pull_request", "subtask"] as ArtifactKindStored[] },
+        state: { $nin: ["closed", "merged", "cancelled"] },
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          kind: 1,
+          title: 1,
+          current_stage: 1,
+          github_url: 1,
+          state: 1,
+          head_sha: 1,
+          ci_summary: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit,
+      },
+    )
+    .toArray()) as unknown as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      | "artifact_id"
+      | "kind"
+      | "title"
+      | "current_stage"
+      | "github_url"
+      | "state"
+      | "head_sha"
+      | "ci_summary"
+      | "last_event_at"
+    >
+  >;
+
+  const items: InFlightCiArtifact[] = rows.map((row) => ({
+    artifact_id: row.artifact_id,
+    kind: row.kind,
+    title: row.title,
+    current_stage: row.current_stage,
+    github_url: row.github_url,
+    state: row.state,
+    head_sha: row.head_sha ?? null,
+    ci_summary: row.ci_summary ?? null,
+    last_event_at: row.last_event_at.toISOString(),
+  }));
+
+  const totals = items.reduce(
+    (acc, item) => {
+      if (!item.ci_summary) {
+        acc.no_ci += 1;
+        return acc;
+      }
+      const c = item.ci_summary.conclusion;
+      if (c === "success") acc.success += 1;
+      else if (c === "failure" || c === "timed_out" || c === "action_required") {
+        acc.failure += 1;
+      } else if (item.ci_summary.status !== "completed" || c === "pending") {
+        acc.pending += 1;
+      }
+      return acc;
+    },
+    { success: 0, failure: 0, pending: 0, no_ci: 0 },
+  );
+
+  return { items, totals };
+}
+
+// ---------------------------------------------------------------------------
+// Changelog of completed features
+// ---------------------------------------------------------------------------
+
+export interface GetChangelogOptions {
+  /** Default 30 days. Clamped to 1..365. */
+  lookbackDays?: number;
+  /** Default 50. Clamped to 1..200. */
+  limit?: number;
+}
+
+const RESOLVED_STATES: ArtifactNativeState[] = ["closed", "merged"];
+
+export async function getChangelogEntries(
+  repoId: string,
+  options: GetChangelogOptions = {},
+): Promise<ChangelogEntry[]> {
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const lookbackDays = clampLimit(options.lookbackDays, 30, 365);
+  const limit = clampLimit(options.limit, 50, 200);
+  const since = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+
+  const rows = (await artifacts
+    .find(
+      {
+        repo_id: repoId,
+        $or: [
+          {
+            kind: { $in: ["epic", "pull_request"] },
+            state: { $in: RESOLVED_STATES },
+            last_event_at: { $gte: since },
+          },
+          {
+            kind: "deploy",
+            state: "success",
+            last_event_at: { $gte: since },
+          },
+        ],
+      },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          kind: 1,
+          title: 1,
+          body_excerpt: 1,
+          state: 1,
+          epic_id: 1,
+          github_url: 1,
+          labels: 1,
+          agent_labels: 1,
+          last_event_at: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit,
+      },
+    )
+    .toArray()) as unknown as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      | "artifact_id"
+      | "kind"
+      | "title"
+      | "body_excerpt"
+      | "state"
+      | "epic_id"
+      | "github_url"
+      | "labels"
+      | "agent_labels"
+      | "last_event_at"
+    >
+  >;
+
+  return rows.map((row) => ({
+    id: row.artifact_id,
+    kind: deriveChangelogKind(row.kind, row.state),
+    title: row.title,
+    body_excerpt: row.body_excerpt,
+    completed_at: row.last_event_at.toISOString(),
+    github_url: row.github_url,
+    epic_id: row.epic_id,
+    actor_label: row.agent_labels?.[0] ?? null,
+    actor_kind: deriveChangelogActor(row.agent_labels),
+    labels: row.labels ?? [],
+  }));
+}
+
+function deriveChangelogKind(
+  kind: ArtifactKindStored,
+  state: ArtifactNativeState,
+): ChangelogEntryKind {
+  if (kind === "epic") return state === "merged" ? "epic_merged" : "epic_closed";
+  if (kind === "pull_request") return "pull_request_merged";
+  return "deploy_succeeded";
+}
+
+function deriveChangelogActor(agentLabels: string[] | undefined): ActorKind {
+  return (agentLabels?.length ?? 0) > 0 ? "agent" : "human";
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot artifacts (last X runs)
+// ---------------------------------------------------------------------------
+
+export interface GetSnapshotsOptions {
+  /** Default 5. Clamped 1..50. */
+  recentRuns?: number;
+  /** Default 24h. Clamped 1..720. */
+  windowHours?: number;
+  /** Which sources to include. Defaults to all three. */
+  kinds?: SnapshotArtifactKind[];
+}
+
+export interface RepoSnapshotResult {
+  items: SnapshotArtifactRecord[];
+  by_kind: Record<SnapshotArtifactKind, number>;
+}
+
+/**
+ * Collect "snapshot artifacts" from three sources:
+ *
+ *   1. GitHub Actions: workflow_run events that completed in the
+ *      window (we read `workflow_run.artifacts_url` if present and
+ *      surface the run itself even when individual artifacts aren't
+ *      enumerated; richer per-artifact listing requires a live
+ *      GitHub call from the API route).
+ *   2. Deploy snapshots: the latest N `deploy` artifacts.
+ *   3. Recent agentic artifacts: PRs and tasks that changed in the
+ *      window (used to give operators a "what did the agents
+ *      produce" view).
+ */
+export async function getRecentSnapshots(
+  repoId: string,
+  options: GetSnapshotsOptions = {},
+): Promise<RepoSnapshotResult> {
+  const recentRuns = clampLimit(options.recentRuns, 5, 50);
+  const windowHours = clampLimit(options.windowHours, 24, 720);
+  const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+  const kinds = new Set<SnapshotArtifactKind>(
+    options.kinds ?? [
+      "github_actions_artifact",
+      "deploy_snapshot",
+      "agentic_artifact",
+    ],
+  );
+
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+  const events = await getAgenticSdlcEventsCollection();
+
+  const [workflowEvents, deployArtifacts, recentAgentic] = await Promise.all([
+    kinds.has("github_actions_artifact")
+      ? events
+          .find(
+            {
+              repo_id: repoId,
+              github_event_type: "workflow_run",
+              occurred_at: { $gte: since },
+            },
+            {
+              projection: { _id: 0, github_delivery_id: 1, payload: 1, occurred_at: 1 },
+              sort: { occurred_at: -1 },
+              limit: recentRuns,
+            },
+          )
+          .toArray()
+      : Promise.resolve([] as Array<Partial<AgenticSdlcEvent>>),
+    kinds.has("deploy_snapshot")
+      ? (artifacts
+          .find(
+            { repo_id: repoId, kind: "deploy" },
+            {
+              projection: {
+                _id: 0,
+                artifact_id: 1,
+                title: 1,
+                state: 1,
+                body_excerpt: 1,
+                github_url: 1,
+                last_event_at: 1,
+                labels: 1,
+              },
+              sort: { last_event_at: -1 },
+              limit: recentRuns,
+            },
+          )
+          .toArray() as Promise<
+          Array<
+            Pick<
+              AgenticSdlcArtifact,
+              | "artifact_id"
+              | "title"
+              | "state"
+              | "body_excerpt"
+              | "github_url"
+              | "last_event_at"
+              | "labels"
+            >
+          >
+        >)
+      : Promise.resolve([]),
+    kinds.has("agentic_artifact")
+      ? (artifacts
+          .find(
+            {
+              repo_id: repoId,
+              kind: { $in: ["epic", "subtask", "pull_request"] },
+              last_event_at: { $gte: since },
+            },
+            {
+              projection: {
+                _id: 0,
+                artifact_id: 1,
+                kind: 1,
+                title: 1,
+                state: 1,
+                current_stage: 1,
+                github_url: 1,
+                last_event_at: 1,
+              },
+              sort: { last_event_at: -1 },
+              limit: recentRuns,
+            },
+          )
+          .toArray() as Promise<
+          Array<
+            Pick<
+              AgenticSdlcArtifact,
+              | "artifact_id"
+              | "kind"
+              | "title"
+              | "state"
+              | "current_stage"
+              | "github_url"
+              | "last_event_at"
+            >
+          >
+        >)
+      : Promise.resolve([]),
+  ]);
+
+  const items: SnapshotArtifactRecord[] = [];
+
+  for (const ev of workflowEvents) {
+    const payload = ev.payload as { workflow_run?: Record<string, unknown> } | undefined;
+    const run = payload?.workflow_run;
+    if (!run) continue;
+    const conclusion = (run.conclusion as string | null | undefined) ?? null;
+    const status = (run.status as string | undefined) ?? "completed";
+    const url = (run.html_url as string | undefined) ?? null;
+    items.push({
+      id: `wf:${(run.id as string | number | undefined) ?? ev.github_delivery_id ?? ""}`,
+      kind: "github_actions_artifact",
+      title:
+        (run.name as string | undefined) ??
+        (run.display_title as string | undefined) ??
+        "Workflow run",
+      subtitle: subtitleForWorkflow(status, conclusion),
+      produced_at: (ev.occurred_at ?? new Date()).toISOString(),
+      url,
+      size_bytes: null,
+      tone:
+        conclusion === "success"
+          ? "success"
+          : conclusion === "failure" ||
+              conclusion === "timed_out" ||
+              conclusion === "startup_failure"
+            ? "failure"
+            : "neutral",
+      source_run_id: (run.id as string | number | undefined)?.toString() ?? null,
+    });
+  }
+
+  for (const deploy of deployArtifacts) {
+    items.push({
+      id: `deploy:${deploy.artifact_id}`,
+      kind: "deploy_snapshot",
+      title: deploy.title,
+      subtitle:
+        deploy.body_excerpt && deploy.body_excerpt.length > 0
+          ? deploy.body_excerpt
+          : `Deploy state: ${deploy.state}`,
+      produced_at: deploy.last_event_at.toISOString(),
+      url: deploy.github_url || null,
+      size_bytes: null,
+      tone:
+        deploy.state === "success"
+          ? "success"
+          : deploy.state === "failure"
+            ? "failure"
+            : "neutral",
+      source_run_id: deploy.artifact_id,
+    });
+  }
+
+  for (const row of recentAgentic) {
+    items.push({
+      id: `agentic:${row.artifact_id}`,
+      kind: "agentic_artifact",
+      title: row.title,
+      subtitle: `${row.kind.replaceAll("_", " ")} • ${row.current_stage.replaceAll("_", " ")}`,
+      produced_at: row.last_event_at.toISOString(),
+      url: row.github_url || null,
+      size_bytes: null,
+      tone: row.state === "merged" || row.state === "success" ? "success" : "neutral",
+      source_run_id: row.artifact_id,
+    });
+  }
+
+  items.sort(
+    (a, b) => Date.parse(b.produced_at) - Date.parse(a.produced_at),
+  );
+
+  const by_kind: Record<SnapshotArtifactKind, number> = {
+    github_actions_artifact: 0,
+    deploy_snapshot: 0,
+    agentic_artifact: 0,
+  };
+  for (const item of items) by_kind[item.kind] += 1;
+
+  return { items, by_kind };
+}
+
+function subtitleForWorkflow(status: string, conclusion: string | null): string {
+  if (status !== "completed") return `Workflow ${status}`;
+  return `Conclusion: ${conclusion ?? "unknown"}`;
+}
+
+// ---------------------------------------------------------------------------
+// Deployment health (rich, per-environment)
+// ---------------------------------------------------------------------------
+
+export interface GetDeploymentHealthOptions {
+  /** Default 168h (7 days). Clamped 1..2160 (90 days). */
+  windowHours?: number;
+  /** Recent deploys to include per environment. Default 10, clamped 1..50. */
+  recentPerEnv?: number;
+}
+
+export async function getDeploymentHealth(
+  repoId: string,
+  options: GetDeploymentHealthOptions = {},
+): Promise<DeploymentHealthSummary> {
+  const windowHours = clampLimit(options.windowHours, 168, 2160);
+  const recentPerEnv = clampLimit(options.recentPerEnv, 10, 50);
+  const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+
+  const events = await getAgenticSdlcEventsCollection();
+  const artifacts = await getAgenticSdlcArtifactsCollection();
+
+  const deployEvents = (await events
+    .find(
+      {
+        repo_id: repoId,
+        github_event_type: "deployment_status",
+        occurred_at: { $gte: since },
+      },
+      {
+        projection: { _id: 0, payload: 1, occurred_at: 1, epic_id: 1, artifact_id: 1 },
+        sort: { occurred_at: -1 },
+        // Cap scan to keep the route fast on pathological repos.
+        limit: 1_000,
+      },
+    )
+    .toArray()) as Array<
+    Pick<AgenticSdlcEvent, "payload" | "occurred_at" | "epic_id" | "artifact_id">
+  >;
+
+  const deployArtifacts = (await artifacts
+    .find(
+      { repo_id: repoId, kind: "deploy" },
+      {
+        projection: {
+          _id: 0,
+          artifact_id: 1,
+          title: 1,
+          state: 1,
+          body_excerpt: 1,
+          github_url: 1,
+          last_event_at: 1,
+          created_at: 1,
+          epic_id: 1,
+        },
+        sort: { last_event_at: -1 },
+        limit: 500,
+      },
+    )
+    .toArray()) as Array<
+    Pick<
+      AgenticSdlcArtifact,
+      | "artifact_id"
+      | "title"
+      | "state"
+      | "body_excerpt"
+      | "github_url"
+      | "last_event_at"
+      | "created_at"
+      | "epic_id"
+    >
+  >;
+
+  type RawDeploy = {
+    artifact_id: string;
+    environment: string;
+    state: ArtifactNativeState;
+    description: string | null;
+    started_at: string | null;
+    completed_at: string | null;
+    failure_reason: string | null;
+    url: string | null;
+    epic_id: string | null;
+    occurred_at: Date;
+  };
+
+  // Build a per-artifact view from events, fall back to artifact rows
+  // when no event was recorded in the window.
+  const byArtifact = new Map<string, RawDeploy>();
+
+  for (const ev of deployEvents) {
+    const payload = ev.payload as
+      | {
+          deployment?: { node_id?: string; environment?: string; created_at?: string };
+          deployment_status?: {
+            state?: string;
+            description?: string;
+            target_url?: string;
+            created_at?: string;
+            updated_at?: string;
+          };
+        }
+      | undefined;
+    const dep = payload?.deployment;
+    const ds = payload?.deployment_status;
+    if (!dep || !ds) continue;
+    const artifactId = dep.node_id ?? ev.artifact_id ?? "";
+    if (!artifactId) continue;
+    const environment = dep.environment ?? "unknown";
+    const dsState = ds.state ?? "pending";
+    const state: ArtifactNativeState =
+      dsState === "success"
+        ? "success"
+        : dsState === "failure" || dsState === "error"
+          ? "failure"
+          : "in_progress";
+    const completed = state === "success" || state === "failure";
+    const description = ds.description ?? null;
+    const failure_reason =
+      state === "failure" ? extractFailureReason(description, ds.target_url ?? null) : null;
+    const startedAt = dep.created_at ?? ds.created_at ?? null;
+    const completedAt = completed
+      ? ds.updated_at ?? ev.occurred_at.toISOString()
+      : null;
+
+    const existing = byArtifact.get(artifactId);
+    if (!existing || ev.occurred_at > existing.occurred_at) {
+      byArtifact.set(artifactId, {
+        artifact_id: artifactId,
+        environment,
+        state,
+        description,
+        started_at: startedAt,
+        completed_at: completedAt,
+        failure_reason,
+        url: ds.target_url ?? null,
+        epic_id: ev.epic_id ?? null,
+        occurred_at: ev.occurred_at,
+      });
+    }
+  }
+
+  // Fall back to artifact rows for deploys that have no event in the
+  // window — e.g. older deploys whose `deployment_status` events fell
+  // outside the lookback range but the projected artifact is still
+  // tracked.
+  for (const deploy of deployArtifacts) {
+    if (byArtifact.has(deploy.artifact_id)) continue;
+    const environment = inferEnvironmentFromTitle(deploy.title) ?? "unknown";
+    byArtifact.set(deploy.artifact_id, {
+      artifact_id: deploy.artifact_id,
+      environment,
+      state: deploy.state,
+      description: deploy.body_excerpt || null,
+      started_at: deploy.created_at.toISOString(),
+      completed_at:
+        deploy.state === "success" || deploy.state === "failure"
+          ? deploy.last_event_at.toISOString()
+          : null,
+      failure_reason:
+        deploy.state === "failure" ? extractFailureReason(deploy.body_excerpt, deploy.github_url) : null,
+      url: deploy.github_url || null,
+      epic_id: deploy.epic_id ?? null,
+      occurred_at: deploy.last_event_at,
+    });
+  }
+
+  // Group by environment, compute summary stats.
+  const byEnv = new Map<string, RawDeploy[]>();
+  for (const d of byArtifact.values()) {
+    const list = byEnv.get(d.environment) ?? [];
+    list.push(d);
+    byEnv.set(d.environment, list);
+  }
+
+  const environments: DeploymentEnvironmentSummary[] = [];
+  const totals = { success: 0, failure: 0, in_progress: 0 };
+  for (const [environment, list] of byEnv.entries()) {
+    list.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
+    const completed = list.filter(
+      (d) => d.state === "success" || d.state === "failure",
+    );
+    const successCount = completed.filter((d) => d.state === "success").length;
+    const failureCount = completed.filter((d) => d.state === "failure").length;
+    const inProgressCount = list.length - successCount - failureCount;
+    totals.success += successCount;
+    totals.failure += failureCount;
+    totals.in_progress += inProgressCount;
+
+    const durations = list
+      .map((d) => deployDurationSeconds(d))
+      .filter((d): d is number => d !== null && d >= 0);
+    const recoverySeconds = computeRecoverySeconds(list);
+
+    const records: DeploymentRecord[] = list.slice(0, recentPerEnv).map((d) => ({
+      id: d.artifact_id,
+      environment: d.environment,
+      state: d.state,
+      description: d.description,
+      started_at: d.started_at,
+      completed_at: d.completed_at,
+      duration_seconds: deployDurationSeconds(d),
+      failure_reason: d.failure_reason,
+      url: d.url,
+      epic_id: d.epic_id,
+    }));
+
+    environments.push({
+      environment,
+      health: deriveEnvHealth({
+        successCount,
+        failureCount,
+        latest: list[0]?.state,
+      }),
+      last_deploy_at: list[0]?.occurred_at.toISOString() ?? null,
+      success_rate:
+        completed.length === 0 ? 0 : successCount / completed.length,
+      failure_count: failureCount,
+      success_count: successCount,
+      median_duration_seconds: durations.length === 0 ? null : median(durations),
+      median_recovery_seconds: recoverySeconds,
+      recent_deploys: records,
+    });
+  }
+
+  environments.sort((a, b) => {
+    const aLast = Date.parse(a.last_deploy_at ?? "");
+    const bLast = Date.parse(b.last_deploy_at ?? "");
+    if (Number.isNaN(aLast) && Number.isNaN(bLast)) {
+      return a.environment.localeCompare(b.environment);
+    }
+    if (Number.isNaN(aLast)) return 1;
+    if (Number.isNaN(bLast)) return -1;
+    return bLast - aLast;
+  });
+
+  return {
+    window_hours: windowHours,
+    environments,
+    totals,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+function deployDurationSeconds(d: {
+  started_at: string | null;
+  completed_at: string | null;
+}): number | null {
+  if (!d.started_at || !d.completed_at) return null;
+  const start = Date.parse(d.started_at);
+  const end = Date.parse(d.completed_at);
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return Math.max(0, Math.round((end - start) / 1000));
+}
+
+function computeRecoverySeconds(
+  list: { state: ArtifactNativeState; occurred_at: Date }[],
+): number | null {
+  // For each failure that's followed by a success (in chronological
+  // order), measure failure→success seconds; return the median.
+  const chronological = [...list].sort(
+    (a, b) => a.occurred_at.getTime() - b.occurred_at.getTime(),
+  );
+  const samples: number[] = [];
+  let lastFailureAt: number | null = null;
+  for (const d of chronological) {
+    if (d.state === "failure") {
+      lastFailureAt = d.occurred_at.getTime();
+    } else if (d.state === "success" && lastFailureAt !== null) {
+      samples.push((d.occurred_at.getTime() - lastFailureAt) / 1000);
+      lastFailureAt = null;
+    }
+  }
+  return samples.length === 0 ? null : median(samples);
+}
+
+function deriveEnvHealth(args: {
+  successCount: number;
+  failureCount: number;
+  latest: ArtifactNativeState | undefined;
+}): DeploymentEnvironmentHealth {
+  if (!args.latest) return "unknown";
+  if (args.successCount + args.failureCount === 0) return "idle";
+  if (args.latest === "failure") return "failing";
+  const successRate =
+    args.successCount / Math.max(1, args.successCount + args.failureCount);
+  if (successRate < 0.7) return "degraded";
+  return "healthy";
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+    : sorted[mid];
+}
+
+function inferEnvironmentFromTitle(title: string | null | undefined): string | null {
+  if (!title) return null;
+  // Convention from the projector: titles are "Deploy → <env>".
+  const arrow = title.indexOf("→");
+  if (arrow >= 0) {
+    return title.slice(arrow + 1).trim() || null;
+  }
+  const ascii = title.indexOf("->");
+  if (ascii >= 0) {
+    return title.slice(ascii + 2).trim() || null;
+  }
+  return null;
+}
+
+function extractFailureReason(
+  description: string | null | undefined,
+  targetUrl: string | null | undefined,
+): string | null {
+  const text = description ?? "";
+  if (text.length === 0 && targetUrl) {
+    return `See logs at ${targetUrl}`;
+  }
+  // Best-effort: take the first line, capped at 240 chars.
+  const line = text.split(/\r?\n/).find((l) => l.trim().length > 0);
+  if (!line) return null;
+  return line.length > 240 ? `${line.slice(0, 237)}...` : line;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clampLimit(
+  value: number | undefined,
+  defaultValue: number,
+  max: number,
+): number {
+  if (!Number.isFinite(value) || (value as number) <= 0) return defaultValue;
+  return Math.min(Math.max(1, Math.floor(value as number)), max);
+}
+
+// Re-export CI conclusion / status types for callers that build UI off
+// this module without importing from `@/types/agentic-sdlc` directly.
+export type { CiConclusion, CiStatus, ArtifactCiSummary };

--- a/ui/src/lib/agentic-sdlc/spec-scoring.ts
+++ b/ui/src/lib/agentic-sdlc/spec-scoring.ts
@@ -1,0 +1,151 @@
+/**
+ * Spec-Health scoring — pure, no I/O.
+ *
+ * Takes an epic artifact's title + body excerpt + labels and produces
+ * a 0..100 score plus the list of missing criteria. The score is the
+ * weighted sum of six binary signals:
+ *
+ *   acceptance_criteria      30 pts
+ *   non_functional_reqs      15 pts
+ *   architectural_constraints 15 pts
+ *   test_strategy            15 pts
+ *   budget                   10 pts
+ *   adr_link                 15 pts
+ *
+ * The signal extraction is intentionally text-based against the
+ * body_excerpt so it works against today's data (no separate spec
+ * collection yet). When a real spec store lands the projector swaps
+ * to a richer source; the scoring vocabulary stays the same.
+ *
+ * Bands:
+ *   0..49   weak       (red)
+ *   50..69  fair       (amber)
+ *   70..84  good       (green-ish)
+ *   85..100 strong     (emerald)
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import type {
+  SpecCriterionStatus,
+  SpecHealthEpicScore,
+} from "@/types/agentic-sdlc";
+
+export interface SpecScoreInput {
+  epic_id: string;
+  title: string;
+  github_url: string;
+  body_excerpt: string | null;
+  labels?: string[];
+  last_event_at: string;
+}
+
+const RULES: Array<{
+  kind: SpecCriterionStatus["kind"];
+  label: string;
+  weight: number;
+  matches: (text: string, labels: Set<string>) => boolean;
+  hint: string;
+}> = [
+  {
+    kind: "acceptance_criteria",
+    label: "Acceptance criteria",
+    weight: 30,
+    matches: (t) =>
+      /acceptance criteria|user stor(?:y|ies)|given.*when.*then/i.test(t),
+    hint: "Add a checklist or Given/When/Then block.",
+  },
+  {
+    kind: "non_functional_requirements",
+    label: "Non-functional requirements",
+    weight: 15,
+    matches: (t) =>
+      /(latency|throughput|p99|sla|cost budget|memory|nfr|non-?functional)/i.test(t),
+    hint: "State the latency / cost / availability targets.",
+  },
+  {
+    kind: "architectural_constraints",
+    label: "Architectural constraints",
+    weight: 15,
+    matches: (t) =>
+      /(architecture|constraint|must not|do not use|forbidden|invariant)/i.test(t),
+    hint: "Encode what the agent cannot do.",
+  },
+  {
+    kind: "test_strategy",
+    label: "Test strategy",
+    weight: 15,
+    matches: (t, labels) =>
+      labels.has("tests") ||
+      /(test plan|test strategy|coverage|fuzz|property test|unit test|integration test)/i.test(t),
+    hint: "Describe how the change will be verified.",
+  },
+  {
+    kind: "budget",
+    label: "Budget",
+    weight: 10,
+    matches: (t) =>
+      /(compute budget|token budget|cost ceiling|hours? budget|spec[- ]complexity)/i.test(t),
+    hint: "Give the agent a spend ceiling.",
+  },
+  {
+    kind: "adr_link",
+    label: "ADR link",
+    weight: 15,
+    matches: (t) => /adr[-/]?\d|docs\/adr|architecture decision|RFC[- ]?\d/i.test(t),
+    hint: "Link to an ADR or RFC.",
+  },
+];
+
+export function scoreEpicSpec(input: SpecScoreInput): SpecHealthEpicScore {
+  const text = `${input.title}\n\n${input.body_excerpt ?? ""}`;
+  const labels = new Set(input.labels ?? []);
+  const criteria: SpecCriterionStatus[] = [];
+  let score = 0;
+  for (const rule of RULES) {
+    const present = rule.matches(text, labels);
+    if (present) score += rule.weight;
+    criteria.push({
+      kind: rule.kind,
+      label: rule.label,
+      present,
+      hint: present ? undefined : rule.hint,
+    });
+  }
+  const clamped = Math.max(0, Math.min(100, score));
+  const band: SpecHealthEpicScore["band"] =
+    clamped >= 85
+      ? "strong"
+      : clamped >= 70
+        ? "good"
+        : clamped >= 50
+          ? "fair"
+          : "weak";
+  return {
+    epic_id: input.epic_id,
+    title: input.title,
+    github_url: input.github_url,
+    score: clamped,
+    band,
+    criteria,
+    last_event_at: input.last_event_at,
+  };
+}
+
+export function repoSpecScore(scores: SpecHealthEpicScore[]): number {
+  if (scores.length === 0) return 0;
+  // Weighted by recency: newer epics dominate the headline score.
+  const now = Date.now();
+  let weightedSum = 0;
+  let weightTotal = 0;
+  for (const s of scores) {
+    const ageDays = Math.max(
+      0,
+      (now - Date.parse(s.last_event_at)) / (24 * 60 * 60 * 1000),
+    );
+    const weight = 1 / (1 + ageDays * 0.05);
+    weightedSum += s.score * weight;
+    weightTotal += weight;
+  }
+  return Math.round(weightedSum / weightTotal);
+}

--- a/ui/src/lib/agentic-sdlc/user-prefs-store.ts
+++ b/ui/src/lib/agentic-sdlc/user-prefs-store.ts
@@ -1,0 +1,75 @@
+/**
+ * Mongo-backed storage for per-user Agentic SDLC UI preferences.
+ *
+ * Schema (collection `agentic_sdlc_user_prefs`):
+ *   {
+ *     _id?: ObjectId,
+ *     user_email: string,              // primary key
+ *     panel_prefs: {
+ *       repo_detail?: PanelPreferences,
+ *       home?: PanelPreferences,
+ *     },
+ *     updated_at: Date,
+ *   }
+ *
+ * Server-only. Never import from a client component.
+ *
+ * assisted-by Codex Codex-sonnet-4-6
+ */
+
+import type { Collection, Document } from "mongodb";
+
+import { getCollection } from "@/lib/mongodb";
+import {
+  defaultPreferences,
+  normalisePreferences,
+  type PanelPreferences,
+} from "@/lib/agentic-sdlc/panel-preferences";
+import type { PanelSurface } from "@/lib/agentic-sdlc/panel-registry";
+
+export const AGENTIC_SDLC_USER_PREFS_COLLECTION = "agentic_sdlc_user_prefs";
+
+interface UserPrefsDocument extends Document {
+  user_email: string;
+  panel_prefs: Partial<Record<PanelSurface, PanelPreferences>>;
+  updated_at: Date;
+}
+
+async function getUserPrefsCollection(): Promise<Collection<UserPrefsDocument>> {
+  return getCollection<UserPrefsDocument>(AGENTIC_SDLC_USER_PREFS_COLLECTION);
+}
+
+export async function readPanelPreferences(
+  userEmail: string,
+  surface: PanelSurface,
+): Promise<PanelPreferences> {
+  const col = await getUserPrefsCollection();
+  const doc = await col.findOne(
+    { user_email: userEmail },
+    { projection: { _id: 0, panel_prefs: 1 } },
+  );
+  const raw = doc?.panel_prefs?.[surface];
+  if (!raw) return defaultPreferences(surface);
+  return normalisePreferences(raw, surface);
+}
+
+export async function writePanelPreferences(
+  userEmail: string,
+  surface: PanelSurface,
+  preferences: PanelPreferences,
+): Promise<PanelPreferences> {
+  const col = await getUserPrefsCollection();
+  const normalised = normalisePreferences(preferences, surface);
+  await col.updateOne(
+    { user_email: userEmail },
+    {
+      $set: {
+        [`panel_prefs.${surface}`]: normalised,
+        updated_at: new Date(),
+      },
+      $setOnInsert: { user_email: userEmail },
+    },
+    { upsert: true },
+  );
+  return normalised;
+}

--- a/ui/src/types/agentic-sdlc.ts
+++ b/ui/src/types/agentic-sdlc.ts
@@ -195,6 +195,17 @@ export interface AgenticSdlcArtifact {
   github_url: string;
   created_at: Date;
   updated_at: Date;
+  /**
+   * Latest CI summary for this artifact, populated when `check_run`,
+   * `check_suite`, or `workflow_run` events have been projected. Optional
+   * so existing artifacts that pre-date CI projection remain valid.
+   */
+  ci_summary?: ArtifactCiSummary | null;
+  /**
+   * Head SHA (PRs only) — captured at projection time and used by the CI
+   * panel to group checks across multiple commits on the same PR.
+   */
+  head_sha?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,6 +287,542 @@ export interface AgentRunRecord {
   completion_tokens: number;
   model_id: string;
   cost_usd: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// CI status (check_run / check_suite projection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalised CI conclusion across `check_run`, `check_suite`, and GitHub
+ * Actions `workflow_run`. We collapse the GitHub vocabulary
+ * (success | failure | timed_out | action_required | neutral | cancelled
+ *  | skipped | stale | startup_failure | null) into a small, UI-friendly
+ * set so panels can render a single tone (success / failure / pending).
+ */
+export type CiConclusion =
+  | "success"
+  | "failure"
+  | "neutral"
+  | "cancelled"
+  | "timed_out"
+  | "skipped"
+  | "action_required"
+  | "stale"
+  | "pending"
+  | "unknown";
+
+export type CiStatus = "queued" | "in_progress" | "completed";
+
+/**
+ * Latest CI status for a single PR or task that is still "in flight".
+ *
+ * One row per (artifact_id, check_name). We keep only the latest run
+ * per check name on each artifact -- old runs are replaced on each
+ * webhook delivery.
+ *
+ * Stored summary lives on the artifact row itself (see
+ * `AgenticSdlcArtifact.ci_summary`), and the per-check detail is
+ * derived on demand from `ship_loop_events` (no separate collection
+ * for the MVP).
+ */
+export interface CiCheckRun {
+  artifact_id: string;
+  repo_id: string;
+  check_name: string;
+  /** Identifier of the underlying check_run / workflow_run. */
+  external_id: string;
+  status: CiStatus;
+  conclusion: CiConclusion;
+  /** GitHub-supplied details URL, or `null` if not provided. */
+  details_url: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  /** Pull-request head SHA when available; used to align checks per PR. */
+  head_sha: string | null;
+}
+
+/**
+ * Summary embedded on a `pull_request` or `subtask` artifact when CI
+ * events have arrived for it. Lets the UI render the badge without
+ * scanning the events collection.
+ */
+export interface ArtifactCiSummary {
+  /** Aggregate conclusion across non-skipped checks for this artifact. */
+  conclusion: CiConclusion;
+  /** Aggregate status: in_progress wins over completed when any check still runs. */
+  status: CiStatus;
+  /** Counts by conclusion (success/failure/pending/...). */
+  by_conclusion: Partial<Record<CiConclusion, number>>;
+  /** Total distinct check names seen on this artifact. */
+  total: number;
+  /** Most recent check completion (or start) timestamp seen. */
+  last_event_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Changelog (completed-feature) entries
+// ---------------------------------------------------------------------------
+
+export type ChangelogEntryKind =
+  | "epic_merged"
+  | "epic_closed"
+  | "pull_request_merged"
+  | "deploy_succeeded";
+
+export interface ChangelogEntry {
+  id: string;
+  kind: ChangelogEntryKind;
+  title: string;
+  body_excerpt: string;
+  /** ISO timestamp when the artifact transitioned into its done state. */
+  completed_at: string;
+  github_url: string;
+  /** Linked epic id when known, else `null`. */
+  epic_id: string | null;
+  /** Agent or human persona that closed the item, if derivable. */
+  actor_label: string | null;
+  actor_kind: ActorKind;
+  /** Labels at completion time (used for tagging in the UI). */
+  labels: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Build / snapshot artifacts (GitHub Actions + deploys)
+// ---------------------------------------------------------------------------
+
+export type SnapshotArtifactKind =
+  | "github_actions_artifact"
+  | "deploy_snapshot"
+  | "agentic_artifact";
+
+export interface SnapshotArtifactRecord {
+  id: string;
+  kind: SnapshotArtifactKind;
+  /** Human title (workflow name, artifact name, deploy environment, or epic title). */
+  title: string;
+  /** Optional secondary line (workflow run name, deploy state, artifact size). */
+  subtitle: string | null;
+  /** When the artifact was produced or last updated. */
+  produced_at: string;
+  /** Best-effort link out to GitHub / the underlying artifact. */
+  url: string | null;
+  /** Optional size in bytes for GitHub Actions artifacts. */
+  size_bytes: number | null;
+  /** Tone hint for the UI: success/failure/neutral. */
+  tone: "success" | "failure" | "neutral";
+  /** Source run / event identifier so the UI can dedupe. */
+  source_run_id: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Deployment health
+// ---------------------------------------------------------------------------
+
+export type DeploymentEnvironmentHealth =
+  | "healthy"
+  | "degraded"
+  | "failing"
+  | "idle"
+  | "unknown";
+
+export interface DeploymentRecord {
+  id: string;
+  environment: string;
+  state: ArtifactNativeState;
+  /** Free-text description from the latest deployment_status payload. */
+  description: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  /**
+   * Duration in seconds if both started_at and completed_at are present.
+   */
+  duration_seconds: number | null;
+  /** Failure reason extracted from the description / target_url when state is failure. */
+  failure_reason: string | null;
+  url: string | null;
+  /** Optional linked epic id for traceability. */
+  epic_id: string | null;
+}
+
+export interface DeploymentEnvironmentSummary {
+  environment: string;
+  health: DeploymentEnvironmentHealth;
+  /** Last deploy that completed (success or failure), if any. */
+  last_deploy_at: string | null;
+  /** Success rate across the window, as a 0..1 float. */
+  success_rate: number;
+  /** Failure count in the window. */
+  failure_count: number;
+  /** Success count in the window. */
+  success_count: number;
+  /** Median duration in seconds of completed deploys in the window. */
+  median_duration_seconds: number | null;
+  /** MTTR-ish: median seconds between a failure and the next success. */
+  median_recovery_seconds: number | null;
+  /** Most recent N deploys, newest first. */
+  recent_deploys: DeploymentRecord[];
+}
+
+export interface DeploymentHealthSummary {
+  /** Lookback window (hours) used to compute the summary. */
+  window_hours: number;
+  /** All environments with recent activity in the window. */
+  environments: DeploymentEnvironmentSummary[];
+  /** Aggregate counts across all environments. */
+  totals: {
+    success: number;
+    failure: number;
+    in_progress: number;
+  };
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Spec health, intent drift, harness, mistakes, budget, fan-out, provenance,
+// blast radius, rollback, prod signals, failure modes, blackbox
+// ---------------------------------------------------------------------------
+
+// Each section below mirrors a panel in panel-registry.ts. Kept here so
+// every consumer (projector + API + client component) shares one type.
+
+export type SpecCriterionKind =
+  | "acceptance_criteria"
+  | "non_functional_requirements"
+  | "architectural_constraints"
+  | "test_strategy"
+  | "budget"
+  | "adr_link";
+
+export interface SpecCriterionStatus {
+  kind: SpecCriterionKind;
+  label: string;
+  present: boolean;
+  hint?: string;
+}
+
+export interface SpecHealthEpicScore {
+  epic_id: string;
+  title: string;
+  github_url: string;
+  score: number; // 0..100
+  band: "weak" | "fair" | "good" | "strong";
+  criteria: SpecCriterionStatus[];
+  last_event_at: string;
+}
+
+export interface SpecHealthSummary {
+  repo_score: number; // weighted average across epics
+  epics: SpecHealthEpicScore[];
+  generated_at: string;
+}
+
+export interface IntentDriftEpicScore {
+  epic_id: string;
+  title: string;
+  github_url: string;
+  /** 0..1 — fraction of PR work that maps to AC tokens. */
+  alignment: number;
+  /** PRs counted toward this epic. */
+  pr_count: number;
+  /** Drift beads, oldest to newest. Each bead is amplitude 0..1. */
+  beads: number[];
+}
+
+export interface IntentDriftSummary {
+  epics: IntentDriftEpicScore[];
+  generated_at: string;
+}
+
+export type HarnessRuleKind =
+  | "lint"
+  | "structural_test"
+  | "adr"
+  | "skill"
+  | "policy"
+  | "security_scan";
+
+export interface HarnessRule {
+  id: string;
+  kind: HarnessRuleKind;
+  name: string;
+  source: string; // file path or URL
+  last_violation_at: string | null;
+  last_violation_summary: string | null;
+  pass_rate: number; // 0..1 across recent runs
+  coverage_gap?: string | null;
+}
+
+export interface HarnessSummary {
+  totals: {
+    lint: number;
+    structural: number;
+    adr: number;
+    skill: number;
+    policy: number;
+    security: number;
+  };
+  pass_rate: number;
+  rules: HarnessRule[];
+  generated_at: string;
+}
+
+export interface HarnessLearning {
+  id: string;
+  occurred_at: string;
+  rule_added: string;
+  triggered_by: string; // PR # or commit ref
+  agent: string | null;
+  description: string;
+  kind: HarnessRuleKind;
+}
+
+export interface MistakeEncodedSummary {
+  learnings_24h: number;
+  total_learnings: number;
+  events: HarnessLearning[];
+  generated_at: string;
+}
+
+export interface AgentRosterEntry {
+  agent_id: string;
+  role: "planner" | "coder" | "reviewer" | "tester" | "deployer" | "other";
+  display_name: string;
+  status: "idle" | "active" | "blocked";
+  model: string | null;
+  current_artifact_id: string | null;
+  current_artifact_title: string | null;
+  current_stage: AgenticSdlcStage | null;
+  time_on_task_seconds: number;
+  last_heartbeat_at: string;
+}
+
+export interface AgentRosterSummary {
+  agents: AgentRosterEntry[];
+  generated_at: string;
+}
+
+/**
+ * Agent budget — measured in LLM tokens (millions) per epic / task,
+ * not hours. This is the unit that maps directly to spend with OpenAI,
+ * Anthropic, etc. and to context-window engineering decisions.
+ *
+ *   compute_tokens_m: tokens spent by builder agents producing code,
+ *                     plans, and tool calls (prompt + completion).
+ *   review_tokens_m:  tokens spent by reviewer/verifier agents on
+ *                     analysis, diffs, and policy checks before merge.
+ *
+ * Numbers are stored as decimal millions (e.g. 4.7 means 4.7M tokens).
+ */
+export interface AgentBudgetEntry {
+  epic_id: string;
+  title: string;
+  estimated_compute_tokens_m: number;
+  actual_compute_tokens_m: number;
+  estimated_review_tokens_m: number;
+  actual_review_tokens_m: number;
+  status: "on_track" | "warning" | "over";
+}
+
+export interface AgentBudgetSummary {
+  totals: {
+    estimated_compute_tokens_m: number;
+    actual_compute_tokens_m: number;
+    estimated_review_tokens_m: number;
+    actual_review_tokens_m: number;
+  };
+  epics: AgentBudgetEntry[];
+  generated_at: string;
+}
+
+export interface FanoutBranch {
+  branch_id: string;
+  agent: string;
+  status: "in_progress" | "merged" | "abandoned";
+  pr_url: string | null;
+}
+
+export interface FanoutEpic {
+  epic_id: string;
+  title: string;
+  github_url: string;
+  branches: FanoutBranch[];
+  converges_at: string | null;
+}
+
+export interface FanoutSummary {
+  epics: FanoutEpic[];
+  generated_at: string;
+}
+
+export type VerifierBand = "weak" | "fair" | "good" | "strong";
+
+export interface VerifierConfidenceEntry {
+  artifact_id: string;
+  title: string;
+  github_url: string;
+  coverage: number; // 0..1
+  band: VerifierBand;
+  acceptance_criteria_total: number;
+  acceptance_criteria_covered: number;
+}
+
+export interface VerifierConfidenceSummary {
+  median_coverage: number;
+  entries: VerifierConfidenceEntry[];
+  generated_at: string;
+}
+
+export type QualityGate =
+  | "lint"
+  | "unit"
+  | "integration"
+  | "sca"
+  | "security"
+  | "policy"
+  | "architecture"
+  | "human_review";
+
+export type QualityGateState = "passed" | "failed" | "pending" | "skipped";
+
+export interface QualityGateRun {
+  artifact_id: string;
+  title: string;
+  github_url: string;
+  current_gate: QualityGate;
+  gates: { gate: QualityGate; state: QualityGateState; details?: string | null }[];
+  conclusion: "passed" | "failed" | "running";
+}
+
+export interface QualityGauntletSummary {
+  runs: QualityGateRun[];
+  generated_at: string;
+}
+
+export type FailureModeKind =
+  | "spec_ambiguity"
+  | "hallucinated_dependency"
+  | "test_gap"
+  | "policy_violation"
+  | "over_scoped_change"
+  | "flaky_check"
+  | "merge_conflict"
+  | "unknown";
+
+export interface FailureModeBucket {
+  kind: FailureModeKind;
+  label: string;
+  count: number;
+  share: number; // 0..1
+  sample_artifact_ids: string[];
+}
+
+export interface FailureModesSummary {
+  total: number;
+  buckets: FailureModeBucket[];
+  window_days: number;
+  generated_at: string;
+}
+
+export interface ProvenanceRecord {
+  artifact_id: string;
+  title: string;
+  github_url: string;
+  model: string;
+  harness_version: string;
+  sbom_hash: string | null;
+  signed: boolean;
+  slsa_level: 0 | 1 | 2 | 3 | 4;
+  reaudit_due_in_days: number | null;
+  generated_at: string;
+}
+
+export interface ProvenanceSummary {
+  signed_count: number;
+  unsigned_count: number;
+  reaudit_due_count: number;
+  records: ProvenanceRecord[];
+  generated_at: string;
+}
+
+export interface BlastRadiusReport {
+  artifact_id: string;
+  title: string;
+  github_url: string;
+  service_count: number;
+  database_count: number;
+  endpoint_count: number;
+  blast_percent: number; // 0..100
+  paths: string[]; // top file paths touched
+}
+
+export interface BlastRadiusSummary {
+  reports: BlastRadiusReport[];
+  generated_at: string;
+}
+
+export interface RollbackRehearsalEntry {
+  environment: string;
+  last_exercised_at: string | null;
+  rehearsal_kind: "real" | "synthetic" | "never";
+  status: "fresh" | "stale" | "missing";
+}
+
+export interface RollbackRehearsalSummary {
+  entries: RollbackRehearsalEntry[];
+  generated_at: string;
+}
+
+export type ProdSignalSeverity = "info" | "warning" | "critical";
+
+export interface ProdSignalEvent {
+  id: string;
+  source: "sentry" | "datadog" | "tickets" | "custom";
+  severity: ProdSignalSeverity;
+  title: string;
+  body: string | null;
+  detected_at: string;
+  proposed_epic_title: string | null;
+  related_artifact_id: string | null;
+}
+
+export interface ProdSignalSummary {
+  events: ProdSignalEvent[];
+  generated_at: string;
+}
+
+export interface PrProdMetricSeries {
+  artifact_id: string;
+  title: string;
+  github_url: string;
+  metric: "latency_ms" | "error_rate" | "cost_usd";
+  values: number[]; // 24 hourly samples
+  delta_percent: number; // vs same window before the merge
+}
+
+export interface PrProdMetricSummary {
+  prs: PrProdMetricSeries[];
+  generated_at: string;
+}
+
+export interface BlackboxAuditEntry {
+  artifact_id: string;
+  title: string;
+  github_url: string;
+  human_lines: number;
+  agent_lines: number;
+  mixed_lines: number;
+  agent_share: number; // 0..1
+  last_reaudit_at: string | null;
+  reaudit_overdue: boolean;
+}
+
+export interface BlackboxAuditSummary {
+  total_agent_lines: number;
+  total_human_lines: number;
+  overdue_count: number;
+  entries: BlackboxAuditEntry[];
+  generated_at: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.6.0rc8"
+version = "0.6.0rc9"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Adds the full **Agentic SDLC repo-detail "ship loop" panel system** plus a round of UX polish on top of it. Lands two related pieces at once:

1. **The panel platform** — registry, per-user preferences, masonry + grid layouts, 25+ insight panels, API routes, and CI projection wiring.
2. **Today's polish** — clickable Agentic Apps Hub cards, Layout drawer no longer cuts off long lists, Grid-mode opt-in no longer re-tiles the user's view, and Agent budget reports LLM tokens (millions) instead of hours.

The polish work is **inseparable** from the panel platform — they both ship in this PR.

### Key changes

**Panel platform**

- `panel-registry.ts` — declarative metadata for every panel (id, section, category, size, default visibility, default order, mock/live data flag).
- `panel-preferences.ts` — pure, version-2 schema for per-user visibility, ordering, density, and optional grid coords. localStorage + Mongo round-trip via `/api/agentic-sdlc/me`.
- `use-panel-preferences` hook — hydration, optimistic updates, debounced server sync.
- `AgenticSdlcLayoutHost` — switches between **masonry mode** (CSS-columns, flat list across sections, no gaps) and **resizable grid mode** (`react-grid-layout` legacy API, drag any panel header, SE-corner resize). Grid is loaded via `next/dynamic` with `ssr: false`.
- `PanelChooser` — sticky pill bar with category groupings, save indicator, Grid on/off toggle, Reset grid, and a draggable Layout drawer.
- 25+ panels — CI in flight, Changelog, Deployment health, Snapshots, Spec health, Intent drift, Mistake encoded, Harness, Epics + roll-ups, Operating metrics, Verifier confidence, Quality gauntlet, Parallel fan-out, Provenance/SBOM, Agent roster, Agent budget, Blast radius, Rollback rehearsal, Spec-Kit replay, Event feed, Ship-loop ring (mini hero), etc.
- API routes under `/api/agentic-sdlc/repos/[owner]/[repo]/{ci,changelog,deploy-health,insights/[panel],snapshots}` backed by `repo-insights.ts` and `repo-extended-insights.ts`. Mock generators return deterministic per-repo data for demo.
- CI projection wiring (`ci-projection.ts` + async-worker patch path) so `check_run`, `check_suite`, and `workflow_run` webhook events update `ci_summary` / `head_sha` without stomping the issue/PR projector state.

**Today's polish**

- `AgenticAppsHub.tsx` — every card has a stretched launch `<a>` overlay; clicking anywhere on the card surface launches the app. Star/info/verified/arrow buttons stay above via `z-10`. `:has()` rule echoes hover to the title color.
- Layout drawer — restructured to flex column with `min-h-0 flex-1 overflow-y-auto` body so long section lists scroll inside the dialog instead of overflowing the viewport. Card cap raised from 85vh to 90vh. Added one-line tip about Grid mode for discoverability.
- `computeDefaultGridLayout` — each panel gets a **full row** (w = cols) by default, so flipping "Grid on" no longer visually re-tiles the user's masonry view. They only opt in to drag and resize.
- Changelog panel — full-size, collapsed by default, internal scroll with max-h, maximize-to-modal escape hatch.
- Ship-loop ring — subtle mini variant centered above the panel grid, larger issue count and caption.
- Agent budget — switched from `compute_hours / review_hours` to **`compute_tokens_m / review_tokens_m`** (LLM tokens in millions), since tokens map directly to spend and context-window planning. Mock data generates realistic ranges (compute 2-12M tokens/epic, review 0.3-1.5M).

**Plumbing**

- `react-grid-layout ^2.2.3` added as a runtime dep. Imported via the `/legacy` subpath for the v1-compatible API (`Responsive`, `WidthProvider`, `Layouts`).
- `globals.css` — stable scrollbar gutter (`html { scrollbar-gutter: stable }`) so panel collapse/expand never widens the page. Glass-panel skin for `.agentic-sdlc-grid` items, placeholders, and resize handles. Grab cursors scoped to grid mode only.
- `projector.ts` — adds `head_sha` to PR artifact patches for CI correlation.
- `webhooks/github/route.ts` — accepts `workflow_run`, `check_run`, `check_suite` event types and routes them to the CI patch path.

### Out of scope

`src/components/admin/TeamDetailsDialog.tsx` (~313 LOC of unrelated admin work in the working tree) was **stashed** and not included in this PR. It will land separately.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest --no-coverage` — **255 suites, 3744 passed, 1 skipped, 0 failed**
- [x] New unit tests added: `panel-preferences.test.ts` (30/30), `ci-projection.test.ts`, `repo-insights.test.ts`, `spec-scoring.test.ts`, plus 2 new cases in `apps-hub.test.tsx` (clickable card + blocked card)
- [ ] Manual smoke on `release/0.6.0` rc image once `prebuild/` CI publishes
- [ ] Verify Agentic Apps Hub: hover any card → title turns cyan, click anywhere → launches app
- [ ] Verify Layout drawer: open with all panels visible → bottom rows scroll into view
- [ ] Verify Grid mode: flip Grid on → masonry layout preserved, drag any header to move, resize SE handle
- [ ] Verify Agent budget panel: shows e.g. `12.3 / 47.5 M` and per-epic `4.7M / 6.0M tokens`

## Notes for reviewer

- The `prebuild/` branch prefix triggers Docker image builds in CI so this can be smoke-tested as an rc.
- Pre-existing `next lint` invocation in `package.json` is broken on this repo (Next 15 deprecated `next lint`); ESLint config also has a circular `plugins.react` ref. Neither was introduced here. TS + Jest are the active gates.
- The single commit is large because the panel platform and the polish are coupled — the polish edits reference files that don't exist on `release/0.6.0` until this PR lands.
