### PR TITLE
feat(dynamic-agents): add sliding-window 5xx error rate check to /readyz

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/metrics/http_middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/metrics/http_middleware.py
@@ -5,6 +5,8 @@ No JWT parsing — auth is handled by the UI gateway in 0.4.0.
 
 import logging
 import time
+from collections import deque
+from threading import Lock
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -16,7 +18,31 @@ from dynamic_agents.metrics.agent_metrics import metrics
 logger = logging.getLogger(__name__)
 
 # Paths that we skip tracking (but still serve)
-_EXCLUDED = frozenset({"/health", "/ready", "/healthz", "/", "/metrics"})
+_EXCLUDED = frozenset({"/health", "/ready", "/healthz", "/readyz", "/", "/metrics"})
+
+# Sliding window tracking for 5xx error rate used by /readyz.
+# Stores True (5xx/error) or False (non-5xx) for the last N requests.
+_WINDOW_SIZE = 20
+_ERROR_THRESHOLD = 0.5  # fail readyz if ≥50% of window are errors
+_READYZ_MIN_REQUESTS = 5  # don't penalise startup — require at least this many samples
+
+_error_window: deque[bool] = deque(maxlen=_WINDOW_SIZE)
+_error_window_lock = Lock()
+
+
+def record_response_outcome(is_error: bool) -> None:
+    with _error_window_lock:
+        _error_window.append(is_error)
+
+
+def get_error_rate() -> tuple[float, int]:
+    """Return (error_rate, sample_count) from the current sliding window."""
+    with _error_window_lock:
+        window = list(_error_window)
+    count = len(window)
+    if count == 0:
+        return 0.0, 0
+    return sum(window) / count, count
 
 
 class PrometheusHTTPMiddleware(BaseHTTPMiddleware):
@@ -57,6 +83,7 @@ class PrometheusHTTPMiddleware(BaseHTTPMiddleware):
             raise
         finally:
             metrics.active_requests.dec()
+            record_response_outcome(status in ("5xx", "error"))
             duration = time.monotonic() - start
             # Normalise path to avoid cardinality explosion:
             # /api/v1/agents/<id>/chat → /api/v1/agents/:id/chat

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/health.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/health.py
@@ -3,8 +3,14 @@
 import time
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 
 from dynamic_agents.config import Settings, get_settings
+from dynamic_agents.metrics.http_middleware import (
+    _READYZ_MIN_REQUESTS,
+    _ERROR_THRESHOLD,
+    get_error_rate,
+)
 from dynamic_agents.services.mongo import MongoDBService, get_mongo_service
 from dynamic_agents.services.runtime_cache import get_runtime_cache
 
@@ -33,12 +39,27 @@ async def health_check(
 @router.get("/readyz")
 async def readiness_check(
     mongo: MongoDBService = Depends(get_mongo_service),
-) -> dict:
-    """Readiness probe — returns 200 if the service is ready to accept traffic."""
-    if mongo._client is not None:
-        return {"ready": True}
-    else:
-        return {"ready": False, "error": "MongoDB not connected"}
+) -> JSONResponse:
+    """Readiness probe — returns 200 if ready, 503 if unhealthy.
+
+    Fails if MongoDB is disconnected OR if the sliding-window 5xx error rate
+    exceeds the threshold (requires a minimum number of samples so startup is
+    not penalised).
+    """
+    if mongo._client is None:
+        return JSONResponse(status_code=503, content={"ready": False, "error": "MongoDB not connected"})
+
+    error_rate, sample_count = get_error_rate()
+    if sample_count >= _READYZ_MIN_REQUESTS and error_rate >= _ERROR_THRESHOLD:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "ready": False,
+                "error": f"High 5xx error rate: {error_rate:.0%} of last {sample_count} requests",
+            },
+        )
+
+    return JSONResponse(status_code=200, content={"ready": True})
 
 
 @router.get("/debug/config")

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -84,9 +84,9 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /healthz
+    path: /readyz
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 3
   failureThreshold: 3

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.16 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.4.17 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.4.16 -f your-values.yaml'}
+                  {'    --version 0.4.17 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.4.16 -f your-values.yaml'}
+              {'    --version 0.4.17 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.17"
+version = "0.4.17-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.17"
+version = "0.4.17.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Adds a thread-safe sliding-window (last 20 requests) to `PrometheusHTTPMiddleware` that tracks whether each response was a 5xx/error
- Updates `/readyz` to return 503 if ≥50% of the window are errors (with a minimum floor of 5 samples so startup is not penalised)
- Updates the `dynamic-agents` Helm chart default readiness probe to point at `/readyz` instead of `/healthz`

## Motivation

Previously `/readyz` only checked MongoDB connectivity. This meant pods that were technically "up" but returning 500s on real traffic would still pass readiness, causing Kubernetes to cut over traffic to broken pods during a rollout.

With `maxUnavailable: 0`, a pod that fails readiness is never promoted to serve traffic — old pods stay up and the rollout stalls until the issue is resolved or rolled back.

## Test plan

- [ ] Start the dynamic-agents service locally, send >5 requests that return 5xx — confirm `GET /readyz` returns 503
- [ ] Verify that non-5xx traffic (or fewer than 5 requests total) does not fail readiness
- [ ] Verify `/healthz` still returns 200 regardless of error rate (liveness probe unaffected)
- [ ] Deploy to dev environment and confirm rolling update stalls when a bad image is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)