### PR TITLE
fix(slack-bot): detect root messages by comparing ts to thread_ts

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -758,9 +758,11 @@ def handle_message_events(body, say, client):
 
   channel_config = config.channels[channel_id]
 
-  # Skip thread replies; only root messages trigger the agent.
-  is_thread = event.get("thread_ts") is not None
-  if is_thread:
+  # Skip true thread replies (ts != thread_ts). Root messages can have
+  # thread_ts populated by Slack when a follow-up arrives before the socket
+  # event is delivered, so checking thread_ts is not None is too broad.
+  is_thread_reply = event.get("thread_ts") is not None and event.get("thread_ts") != event.get("ts")
+  if is_thread_reply:
     return
 
   # Skip @mentions — handled by handle_mention

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18-dev.1"
+version = "0.4.18-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18.dev1"
+version = "0.4.18.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in #1417 where the `handle_message_events` thread-skip guard was changed from `if is_thread and not is_bot` to `if is_thread`
- The new guard incorrectly skips root bot messages when Slack has already populated `thread_ts` on them (which happens when a follow-up message is posted before the socket event is delivered)
- Replaces `thread_ts is not None` with `thread_ts is not None and thread_ts != ts` — the correct way to distinguish a true thread reply from a root message

## How it works

Slack root messages always have `ts == thread_ts`. Genuine thread replies have `ts != thread_ts`. The old check (`thread_ts is not None`) fired for both, silently dropping root bot messages that arrived with `thread_ts` already set by Slack.

## Test plan

- [ ] Bot channels configured with `bots.listen: message` receive and process root bot messages as before
- [ ] True thread replies from bots are still skipped (no duplicate responses)
- [ ] User messages in threads continue to be handled via `handle_mention`

🤖 Generated with [Claude Code](https://claude.com/claude-code)