### PR TITLE
fix(dynamic-agents): wire KEYCLOAK_URL/OIDC_ISSUER env, randomize setup-caipe MongoDB/Langfuse passwords

### DIFF
--- a/ai_platform_engineering/dynamic_agents/pyproject.toml
+++ b/ai_platform_engineering/dynamic_agents/pyproject.toml
@@ -17,7 +17,11 @@ dependencies = [
     "requests==2.33.0",
     "beautifulsoup4==4.13.4",
     "jinja2==3.1.6",
-    "prometheus-client==0.22.1",
+    "prometheus-client==0.23.1",
+    # JWKS-based JWT validation in dynamic_agents.auth.jwks_validate
+    # (vendored from ai_platform_engineering.utils.auth so the DA image
+    # does not need to install the entire shared package).
+    "pyjwt[crypto]==2.12.0",
 ]
 
 [project.optional-dependencies]

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/access.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/access.py
@@ -4,7 +4,31 @@ This module provides access control checks for conversations.
 Agent visibility checks have been moved to the Next.js gateway.
 """
 
-from dynamic_agents.models import UserContext
+import logging
+
+from dynamic_agents.models import DynamicAgentConfig, UserContext, VisibilityType
+
+logger = logging.getLogger(__name__)
+
+
+def can_view_agent(agent: DynamicAgentConfig, user: UserContext) -> bool:
+    if user.is_admin:
+        return True
+    if agent.owner_id == user.email:
+        return True
+    if agent.visibility == VisibilityType.GLOBAL:
+        return True
+    if agent.visibility == VisibilityType.TEAM:
+        if agent.shared_with_teams:
+            return any(team in (user.groups or []) for team in agent.shared_with_teams)
+    return False
+
+
+def can_use_agent(agent: DynamicAgentConfig, user: UserContext) -> bool:
+    if not agent.enabled:
+        return False
+
+    return can_view_agent(agent, user)
 
 
 def can_access_conversation(conversation: dict, user: UserContext) -> bool:
@@ -15,6 +39,7 @@ def can_access_conversation(conversation: dict, user: UserContext) -> bool:
     - User owns the conversation
     - TODO: Conversation is shared with user
     """
+
     if user.is_admin:
         return True
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/auth.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/auth.py
@@ -78,3 +78,19 @@ async def get_user_context(
             status_code=400,
             detail="Malformed X-User-Context header",
         )
+
+
+# Alias for backward compatibility with routes that import get_current_user
+get_current_user = get_user_context
+
+
+async def require_admin(
+    user: UserContext = Depends(get_user_context),
+) -> UserContext:
+    """Require admin role for the endpoint."""
+    if not user.is_admin:
+        raise HTTPException(
+            status_code=403,
+            detail="Admin role required",
+        )
+    return user

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/jwks_validate.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/jwks_validate.py
@@ -1,0 +1,142 @@
+"""Self-contained JWKS-backed JWT validator for the dynamic-agents service.
+
+This is a vendored copy of ``ai_platform_engineering.utils.auth.jwks_validate``
+because the dynamic-agents Docker image only ships the ``dynamic_agents``
+package — the shared ``ai_platform_engineering.utils.*`` namespace is not
+installed inside the runtime container, so the original ``import`` fails with
+``ModuleNotFoundError`` and ``JwtAuthMiddleware`` rejects every Bearer token
+as ``bearer_invalid``.
+
+Reads ``KEYCLOAK_URL``, ``KEYCLOAK_REALM``, and ``KEYCLOAK_AUDIENCE`` from the
+environment to build the issuer URL and JWKS URI. ``PyJWKClient`` caches keys
+in-memory with rotation support (``JWKS_TTL_SECONDS``, default 600s).
+
+Algorithms are an explicit allow-list (``RS256``, ``ES256``) per the workspace
+crypto policy — never ``none`` or HS-family on Keycloak-issued tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import jwt
+from jwt import InvalidTokenError, PyJWKClient, PyJWKClientError
+
+logger = logging.getLogger(__name__)
+
+
+_JWKS_TTL_SECONDS = int(os.environ.get("JWKS_TTL_SECONDS", "600"))
+
+_jwks_clients: dict[str, PyJWKClient] = {}
+
+
+def _kc_base_url() -> str:
+    return os.environ.get("KEYCLOAK_URL", "http://localhost:7080").rstrip("/")
+
+
+def _kc_realm() -> str:
+    return os.environ.get("KEYCLOAK_REALM", "caipe")
+
+
+def _kc_issuer() -> str:
+    """The issuer string MUST exactly match the ``iss`` claim Keycloak puts
+    in the token. In a Docker-Compose dev stack Keycloak is reached at
+    ``http://keycloak:7080`` from inside the network but ``KC_HOSTNAME`` is
+    set to ``http://localhost:7080`` so browser-facing redirects work — and
+    that hostname also goes into the ``iss`` claim. Prefer ``OIDC_ISSUER``
+    (browser-facing, matches the token) and fall back to deriving from
+    ``KEYCLOAK_URL`` for back-compat with deployments where they coincide.
+    """
+    explicit = os.environ.get("OIDC_ISSUER") or os.environ.get("KEYCLOAK_ISSUER")
+    if explicit:
+        return explicit.rstrip("/")
+    return f"{_kc_base_url()}/realms/{_kc_realm()}"
+
+
+def _kc_jwks_uri() -> str:
+    """JWKS URI is fetched server-to-server, so prefer the in-cluster URL
+    (``KEYCLOAK_URL``/``OIDC_DISCOVERY_URL``) instead of the browser-facing
+    issuer — otherwise the in-container fetch hits ``localhost:7080`` and
+    the connection fails.
+    """
+    explicit = os.environ.get("KEYCLOAK_JWKS_URL") or os.environ.get("OIDC_JWKS_URL")
+    if explicit:
+        return explicit
+    return f"{_kc_base_url()}/realms/{_kc_realm()}/protocol/openid-connect/certs"
+
+
+def _kc_audience() -> list[str] | str | None:
+    """Audience(s) to enforce.
+
+    Spec 104: tokens minted by the Slack bot's OBO exchange now carry
+    ``aud=agentgateway`` (so they can hit AGW directly). Tokens minted
+    by the BFF for UI-driven calls still carry ``aud=caipe-platform``.
+    The dynamic-agents service sits in front of both flows, so we accept
+    either by passing a list to ``jwt.decode``: PyJWT treats a list as
+    "the token's ``aud`` MUST contain at least one of these".
+
+    Empty / None disables the audience check (still dev-only).
+    """
+    raw = (
+        os.environ.get("KEYCLOAK_AUDIENCE")
+        or os.environ.get("OIDC_AUDIENCE")
+        or "caipe-platform,agentgateway"
+    )
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        return None
+    return parts if len(parts) > 1 else parts[0]
+
+
+def _get_jwks_client(jwks_uri: str | None = None) -> PyJWKClient:
+    uri = jwks_uri or _kc_jwks_uri()
+    client = _jwks_clients.get(uri)
+    if client is None:
+        client = PyJWKClient(uri, cache_keys=True, lifespan=_JWKS_TTL_SECONDS)
+        _jwks_clients[uri] = client
+    return client
+
+
+def _algorithms() -> list[str]:
+    return ["RS256", "ES256"]
+
+
+def validate_bearer_jwt(token: str) -> dict[str, Any]:
+    """Validate ``token`` against the configured Keycloak realm's JWKS.
+
+    Returns the decoded claims on success; raises ``InvalidTokenError`` (or a
+    subclass — ``ExpiredSignatureError``, ``InvalidAudienceError``, …) on
+    failure. Callers MUST translate any raised error to HTTP 401.
+    """
+    if not isinstance(token, str) or not token:
+        raise InvalidTokenError("empty bearer token")
+
+    try:
+        signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
+    except PyJWKClientError as exc:
+        logger.warning("JWKS lookup failed for incoming token: %s", exc)
+        raise InvalidTokenError(f"unable to fetch signing key: {exc}") from exc
+
+    options = {"require": ["exp", "iat", "iss", "sub"]}
+    audience = _kc_audience()
+    return jwt.decode(  # type: ignore[no-any-return]
+        token,
+        signing_key.key,
+        algorithms=_algorithms(),
+        issuer=_kc_issuer(),
+        audience=audience if audience else None,
+        options=options if audience else {**options, "verify_aud": False},
+    )
+
+
+def reset_jwks_cache_for_tests() -> None:
+    _jwks_clients.clear()
+
+
+__all__ = [
+    "InvalidTokenError",
+    "reset_jwks_cache_for_tests",
+    "validate_bearer_jwt",
+]

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/jwt_middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/jwt_middleware.py
@@ -1,0 +1,143 @@
+"""Starlette middleware that validates incoming Bearer JWTs against Keycloak.
+
+Spec 102 Phase 8 / T102.
+
+For every request:
+
+1. If the incoming request carries an ``Authorization: Bearer <jwt>``
+   header, validate the JWT against Keycloak's JWKS endpoint
+   (``OIDC_DISCOVERY_URL`` / ``OIDC_ISSUER`` / ``OIDC_AUDIENCE``).
+2. On success, set ``current_user_token`` ContextVar so downstream
+   ``services/mcp_client.py`` will forward this exact token (no
+   re-mint, no swap) to ``agentgateway`` and downstream MCP servers.
+3. On failure (expired / wrong-issuer / wrong-audience / signature
+   mismatch), respond 401 immediately with a structured JSON body so
+   the BFF can render a meaningful UI error. The request never reaches
+   route handlers.
+4. If there is **no** ``Authorization`` header at all, this middleware
+   is intentionally lenient: it lets the request through and the
+   existing ``auth.get_user_context`` dependency handles the
+   ``X-User-Context`` legacy path. This is the rollout-safety hatch
+   so the BFF can keep sending the trusted-header form for now;
+   migrating the BFF to send Bearer is the matching change in
+   ``ui/src/lib/da-proxy.ts``.
+
+The two-path lenience MUST be removed once the BFF migration is
+complete — at which point we hard-fail on no-bearer (FR-004 from
+spec 102, Story 6 acceptance scenario 3).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from dynamic_agents.auth.token_context import current_traceparent, current_user_token
+
+logger = logging.getLogger(__name__)
+
+# Module-level toggle: when SET (any non-empty string), every request MUST
+# carry a valid Bearer token; X-User-Context becomes invalid. This is the
+# kill-switch we flip after the BFF migration in ui/src/lib/da-proxy.ts.
+# Default OFF (lenient) so this rollout step does not break the live stack.
+DA_REQUIRE_BEARER = os.environ.get("DA_REQUIRE_BEARER", "").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+# Probe / observability endpoints must stay reachable without auth so Docker
+# healthchecks and Prometheus scrapes do not flap when bearer enforcement is on.
+PUBLIC_PATHS = frozenset({"/healthz", "/readyz", "/metrics"})
+
+
+def _validate_bearer_or_none(token: str) -> dict | None:
+    """Validate JWT against Keycloak; return claims dict on success, None on failure.
+
+    Uses the vendored ``dynamic_agents.auth.jwks_validate`` helper so the
+    runtime image (which only ships the ``dynamic_agents`` package) can
+    validate tokens without importing the broader
+    ``ai_platform_engineering.utils.*`` namespace. Lazy import keeps cold
+    starts fast and avoids pulling crypto deps until the first Bearer
+    request hits the gate.
+    """
+    try:
+        from dynamic_agents.auth.jwks_validate import validate_bearer_jwt
+
+        return validate_bearer_jwt(token)  # type: ignore[no-any-return]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Bearer token validation failed: %s", exc)
+        return None
+
+
+class JwtAuthMiddleware(BaseHTTPMiddleware):
+    """Validate incoming Bearer JWTs and bind ``current_user_token``.
+
+    See module docstring for the rollout-safety lenience policy.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if request.method == "OPTIONS" or request.url.path in PUBLIC_PATHS:
+            return await call_next(request)
+
+        authorization = request.headers.get("authorization", "")
+        token: str | None = None
+
+        if authorization.lower().startswith("bearer "):
+            raw = authorization[7:].strip()
+            if raw:
+                claims = _validate_bearer_or_none(raw)
+                if claims is None:
+                    # Reject hard: the caller sent a Bearer header but it
+                    # was invalid. Do NOT silently fall through to
+                    # X-User-Context — that would let an attacker bypass
+                    # JWT validation by appending a forged trusted header.
+                    body = json.dumps(
+                        {
+                            "error": "Invalid or expired bearer token",
+                            "code": "bearer_invalid",
+                            "reason": "bearer_invalid",
+                            "action": "sign_in",
+                        }
+                    ).encode("utf-8")
+                    return Response(
+                        content=body,
+                        status_code=401,
+                        media_type="application/json",
+                    )
+                token = raw
+                # Spec 104: surface `active_team` + `aud` in middleware
+                # logs so production triage of "no tools" / "wrong team"
+                # incidents doesn't require decoding the JWT by hand.
+                logger.info(
+                    "Bearer token validated: sub=%s aud=%s active_team=%s",
+                    claims.get("sub"),
+                    claims.get("aud"),
+                    claims.get("active_team"),
+                )
+        elif DA_REQUIRE_BEARER:
+            body = json.dumps(
+                {
+                    "error": "Authentication required (Bearer token)",
+                    "code": "missing_bearer",
+                    "reason": "not_signed_in",
+                    "action": "sign_in",
+                }
+            ).encode("utf-8")
+            return Response(
+                content=body, status_code=401, media_type="application/json"
+            )
+
+        traceparent = request.headers.get("traceparent")
+        trace_ctx_token = current_traceparent.set(traceparent if traceparent else None)
+        ctx_token = current_user_token.set(token)
+        try:
+            return await call_next(request)
+        finally:
+            current_user_token.reset(ctx_token)
+            current_traceparent.reset(trace_ctx_token)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/keycloak_authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/keycloak_authz.py
@@ -1,0 +1,84 @@
+"""Keycloak PDP wrapper for Dynamic Agents.
+
+Spec 102 Phase 8 / T104.
+
+Thin re-export of the shared
+``ai_platform_engineering.utils.auth.keycloak_authz`` helper, plus a
+DA-specific dependency factory that constructs
+``dynamic_agent:<agent_id>`` resources at call time. This lets route
+handlers stay clean::
+
+    @app.post("/v1/chat/stream/start")
+    async def start_chat(
+        agent_id: str,
+        _: AuthzDecision = Depends(require_da_permission(agent_id, "invoke")),
+    ): ...
+
+The underlying helper handles cache, PDP unavailability fallback, and
+audit-event emission; we only wrap it to give DA-specific handlers a
+shorter call site.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+from ai_platform_engineering.utils.auth import keycloak_authz as _shared
+from fastapi import HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+
+# Re-export for convenience so DA code only imports from this module.
+require_rbac_permission = _shared.require_rbac_permission
+AuthzDecision = _shared.AuthzDecision
+AuthzReason = getattr(_shared, "AuthzReason", None)
+
+
+def require_da_permission(
+    agent_id: str,
+    scope: str,
+) -> Callable[[Request], Awaitable[_shared.AuthzDecision]]:
+    """Build a FastAPI dependency that gates on ``dynamic_agent:<agent_id>#scope``.
+
+    Reads the bearer from the per-request ContextVar set by
+    ``JwtAuthMiddleware``, calls the shared PDP helper, and raises
+    ``HTTPException(403)`` on deny so the handler stays untouched.
+    """
+    resource = f"dynamic_agent:{agent_id}"
+
+    async def _dependency(request: Request) -> _shared.AuthzDecision:
+        from dynamic_agents.auth.token_context import current_user_token
+
+        token = current_user_token.get()
+        if not token:
+            # JwtAuthMiddleware lets unauthenticated requests through (for
+            # the X-User-Context legacy path), but PDP-gated routes always
+            # require a real Bearer.
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "error": "Authentication required",
+                    "code": "missing_bearer",
+                    "reason": "not_signed_in",
+                    "action": "sign_in",
+                },
+            )
+
+        decision = await require_rbac_permission(token, resource, scope)
+        if not decision.allowed:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Permission denied",
+                    "code": "rbac_denied",
+                    "reason": getattr(decision, "reason", "pdp_denied"),
+                    "action": "contact_admin",
+                    "resource": resource,
+                    "scope": scope,
+                },
+            )
+        return decision
+
+    return _dependency

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/obo_exchange.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/obo_exchange.py
@@ -1,0 +1,207 @@
+"""OBO (On-Behalf-Of) token exchange for Dynamic Agents.
+
+Spec 102 Phase 8 / T105.
+
+Mints an OBO token via Keycloak token-exchange (RFC 8693) so that
+outbound calls from DA to ``agentgateway`` and downstream MCP servers
+carry the **user's** identity (``sub=<user>``, ``act.sub=<dynamic-agents-svc>``)
+rather than the DA service account's.
+
+Today the runtime simply forwards whatever Bearer JWT the BFF sent us
+(see ``services/mcp_client.py`` factory). Token exchange becomes
+mandatory when:
+
+- The downstream resource (e.g. an MCP server) requires a different
+  audience than the BFF-issued token.
+- We need an `act.sub` chain so the audit trail reflects the DA
+  service identity in addition to the user.
+
+This module exposes a single ``async def impersonate_user(user_token,
+target_audience)`` helper. It caches results per ``(user_sub, audience)``
+with a 30s safety margin before expiry. The cache is in-memory and
+per-process, which is consistent with the supervisor's OBO cache; a
+shared Redis cache is tracked as a follow-up in spec 102's
+``research.md`` "Open follow-ups" section.
+
+Env vars consumed:
+
+- ``KEYCLOAK_DA_CLIENT_ID``: client id for the dynamic-agents service
+  (defaults to ``dynamic-agents`` to match Helm + compose).
+- ``KEYCLOAK_DA_CLIENT_SECRET``: client secret for the same.
+- ``OIDC_ISSUER`` (or ``OIDC_DISCOVERY_URL``): used to resolve the
+  token endpoint.
+
+If any of these are missing, ``impersonate_user`` returns ``None`` and
+logs one WARNING per process startup; callers MUST treat ``None`` as
+"forward the original token unchanged" so that local development
+without OBO wired still works.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_CACHE_SAFETY_MARGIN_SECONDS = 30
+_OBO_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+_warned_once = False
+
+
+@dataclass(frozen=True)
+class _CacheKey:
+    user_sub: str
+    audience: str
+
+
+@dataclass
+class _CacheEntry:
+    token: str
+    expires_at: float
+
+
+_obo_cache: dict[_CacheKey, _CacheEntry] = {}
+
+
+def _resolve_token_endpoint() -> Optional[str]:
+    """Resolve the Keycloak token endpoint from issuer or discovery URL."""
+    issuer = os.environ.get("OIDC_ISSUER", "").strip()
+    if issuer:
+        return f"{issuer.rstrip('/')}/protocol/openid-connect/token"
+    discovery = os.environ.get("OIDC_DISCOVERY_URL", "").strip()
+    if discovery:
+        # Allow either a bare issuer base or the full well-known URL
+        if discovery.endswith("/.well-known/openid-configuration"):
+            base = discovery[: -len("/.well-known/openid-configuration")]
+        else:
+            base = discovery.rstrip("/")
+        return f"{base}/protocol/openid-connect/token"
+    return None
+
+
+def _client_credentials() -> Optional[tuple[str, str]]:
+    """Resolve dynamic-agents client credentials from env."""
+    client_id = os.environ.get("KEYCLOAK_DA_CLIENT_ID", "dynamic-agents").strip()
+    client_secret = os.environ.get("KEYCLOAK_DA_CLIENT_SECRET", "").strip()
+    if not client_id or not client_secret:
+        return None
+    return client_id, client_secret
+
+
+def _user_sub_from_token(token: str) -> Optional[str]:
+    """Extract the user sub claim from an unverified JWT (cache-key only).
+
+    Validation already happened in JwtAuthMiddleware; here we only need a
+    stable per-user identifier to key the cache. We deliberately decode
+    without verification (and without pulling jose / pyjwt into DA's
+    runtime dependency surface) — the cache key would still be valid
+    even for a forged token, because the OBO exchange itself rejects
+    unsigned tokens.
+    """
+    import base64
+    import json as _json
+
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1]
+        # Pad for urlsafe base64.
+        padding = "=" * (-len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(payload_b64 + padding)
+        claims = _json.loads(decoded)
+        sub = claims.get("sub")
+        return str(sub) if sub else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def impersonate_user(
+    user_token: str,
+    target_audience: str,
+) -> Optional[str]:
+    """Mint an OBO token for ``target_audience`` on behalf of the user.
+
+    Returns the new access token on success, ``None`` if OBO is not
+    configured or the exchange failed. Callers MUST fall through to
+    forwarding ``user_token`` unchanged on ``None``.
+    """
+    global _warned_once
+
+    creds = _client_credentials()
+    endpoint = _resolve_token_endpoint()
+    if creds is None or endpoint is None:
+        if not _warned_once:
+            logger.warning(
+                "OBO not configured (missing KEYCLOAK_DA_CLIENT_SECRET or "
+                "OIDC_ISSUER); falling back to forwarding the user token unchanged"
+            )
+            _warned_once = True
+        return None
+
+    user_sub = _user_sub_from_token(user_token)
+    if user_sub is None:
+        # Cannot key the cache; fall back to forwarding the original.
+        return None
+
+    key = _CacheKey(user_sub=user_sub, audience=target_audience)
+    cached = _obo_cache.get(key)
+    now = time.time()
+    if cached and cached.expires_at > now + _TOKEN_CACHE_SAFETY_MARGIN_SECONDS:
+        return cached.token
+
+    client_id, client_secret = creds
+    data = {
+        "grant_type": _OBO_GRANT_TYPE,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "subject_token": user_token,
+        "subject_token_type": _SUBJECT_TOKEN_TYPE,
+        "audience": target_audience,
+        "requested_token_type": _SUBJECT_TOKEN_TYPE,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            resp = await client.post(
+                endpoint,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        if resp.status_code != 200:
+            logger.warning(
+                "OBO exchange failed: status=%s body=%s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            return None
+        payload = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("OBO exchange raised: %s", exc)
+        return None
+
+    access_token = payload.get("access_token")
+    expires_in = int(payload.get("expires_in", 60))
+    if not access_token:
+        return None
+
+    _obo_cache[key] = _CacheEntry(
+        token=access_token,
+        expires_at=now + expires_in,
+    )
+    return access_token
+
+
+def clear_obo_cache() -> None:
+    """Test helper: drop all cached OBO tokens."""
+    _obo_cache.clear()
+    global _warned_once
+    _warned_once = False

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
@@ -1,0 +1,439 @@
+"""OpenFGA authorization checks for Dynamic Agent execution."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from fastapi import HTTPException
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+
+from dynamic_agents.auth.token_context import current_traceparent, current_user_token
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STORE_NAME = "caipe-openfga"
+AUDIT_COLLECTION = "audit_events"
+OPENFGA_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+OPENFGA_EMAIL_PRINCIPAL_PATTERN = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$")
+SUBJECT_SALT = os.getenv("AUDIT_SUBJECT_SALT", "caipe-098-audit")
+TRACEPARENT_PATTERN = re.compile(r"^00-([a-f0-9]{32})-([a-f0-9]{16})-[a-f0-9]{2}$")
+_audit_mongo_client: MongoClient | None = None
+_audit_indexes_ensured = False
+_audit_client_lock = threading.Lock()
+_audit_indexes_lock = threading.Lock()
+
+
+def _error_detail(error: str, code: str, reason: str, action: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": error,
+        "code": code,
+        "reason": reason,
+        "action": action,
+    }
+
+
+def _raise_authz(status_code: int, error: str, code: str, reason: str, action: str) -> None:
+    raise HTTPException(
+        status_code=status_code,
+        detail=_error_detail(error, code, reason, action),
+    )
+
+
+def _is_valid_openfga_id(value: str | None) -> bool:
+    return bool(value and OPENFGA_ID_PATTERN.fullmatch(value))
+
+
+def _hash_subject(subject: str) -> str:
+    digest = hashlib.sha256(f"{SUBJECT_SALT}:{subject}".encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _get_audit_mongo_client() -> MongoClient | None:
+    """Return a MongoDB client for audit writes when Mongo is configured."""
+    global _audit_mongo_client
+    uri = os.getenv("MONGODB_URI", "").strip()
+    if not uri:
+        return None
+    if _audit_mongo_client is not None:
+        return _audit_mongo_client
+    with _audit_client_lock:
+        if _audit_mongo_client is not None:
+            return _audit_mongo_client
+        try:
+            _audit_mongo_client = MongoClient(
+                uri,
+                serverSelectionTimeoutMS=3000,
+                retryWrites=False,
+                tz_aware=True,
+            )
+            _audit_mongo_client.admin.command("ping")
+        except PyMongoError as exc:
+            logger.warning("MongoDB unavailable for Dynamic Agents authz audit: %s", exc)
+            _audit_mongo_client = None
+    return _audit_mongo_client
+
+
+def _ensure_audit_indexes(client: MongoClient) -> None:
+    """Create lightweight audit indexes once per process."""
+    global _audit_indexes_ensured
+    if _audit_indexes_ensured:
+        return
+    with _audit_indexes_lock:
+        if _audit_indexes_ensured:
+            return
+        database = os.getenv("MONGODB_DATABASE", "caipe")
+        try:
+            coll = client[database][AUDIT_COLLECTION]
+            coll.create_index([("ts", -1)])
+            coll.create_index([("type", 1), ("ts", -1)])
+            coll.create_index([("subject_hash", 1), ("ts", -1)])
+            coll.create_index([("source", 1), ("ts", -1)])
+            coll.create_index([("correlation_id", 1)])
+            _audit_indexes_ensured = True
+        except PyMongoError as exc:
+            logger.warning("Failed to ensure Dynamic Agents authz audit indexes: %s", exc)
+
+
+def _persist_openfga_rebac_audit(event: dict[str, Any]) -> None:
+    """Best-effort insert into the unified audit_events collection."""
+    client = _get_audit_mongo_client()
+    if client is None:
+        return
+    document = dict(event)
+    ts = document.get("ts")
+    if isinstance(ts, str):
+        try:
+            document["ts"] = datetime.fromisoformat(ts)
+        except ValueError:
+            document["ts"] = datetime.now(UTC)
+    try:
+        _ensure_audit_indexes(client)
+        database = os.getenv("MONGODB_DATABASE", "caipe")
+        client[database][AUDIT_COLLECTION].insert_one(document)
+    except PyMongoError as exc:
+        logger.warning("Failed to persist Dynamic Agents authz audit event: %s", exc)
+
+
+def _parse_traceparent(value: str | None) -> tuple[str, str] | None:
+    if not value:
+        return None
+    match = TRACEPARENT_PATTERN.fullmatch(value.strip().lower())
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _new_span_id() -> str:
+    return os.urandom(8).hex()
+
+
+def _child_traceparent(parent_traceparent: str | None) -> tuple[str | None, str | None, str | None]:
+    parsed = _parse_traceparent(parent_traceparent)
+    if not parsed:
+        return None, None, None
+    trace_id, parent_span_id = parsed
+    span_id = _new_span_id()
+    return trace_id, span_id, f"00-{trace_id}-{span_id}-01"
+
+
+def _openfga_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    traceparent = current_traceparent.get()
+    if traceparent:
+        headers["traceparent"] = traceparent
+    return headers
+
+
+def _otel_attr(key: str, value: Any) -> dict[str, Any]:
+    if isinstance(value, bool):
+        return {"key": key, "value": {"boolValue": value}}
+    if isinstance(value, int | float):
+        return {"key": key, "value": {"doubleValue": float(value)}}
+    return {"key": key, "value": {"stringValue": str(value)}}
+
+
+async def _export_authz_span(
+    *,
+    name: str,
+    trace_id: str | None,
+    span_id: str | None,
+    parent_span_id: str | None,
+    start_ns: int,
+    end_ns: int,
+    attributes: dict[str, Any],
+) -> None:
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "").strip()
+    enabled = os.getenv("AUTHZ_TRACING_ENABLED", "").strip().lower() in {"1", "true", "yes"}
+    if not enabled or not endpoint or not trace_id or not span_id:
+        return
+
+    span: dict[str, Any] = {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": name,
+        "kind": 2,
+        "startTimeUnixNano": str(start_ns),
+        "endTimeUnixNano": str(end_ns),
+        "attributes": [
+            _otel_attr("audit.type", "openfga_rebac"),
+            _otel_attr("authz.pdp", "openfga"),
+            *[_otel_attr(key, value) for key, value in attributes.items() if value is not None],
+        ],
+    }
+    if parent_span_id:
+        span["parentSpanId"] = parent_span_id
+
+    body = {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        _otel_attr("service.name", os.getenv("OTEL_SERVICE_NAME", "dynamic-agents")),
+                        _otel_attr("deployment.environment", os.getenv("ENVIRONMENT", "development")),
+                    ]
+                },
+                "scopeSpans": [{"scope": {"name": "dynamic_agents.authz"}, "spans": [span]}],
+            }
+        ]
+    }
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            await client.post(endpoint, json=body)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to export Dynamic Agents authz span: %s", exc)
+
+
+def _log_openfga_rebac_audit(
+    *,
+    subject: str,
+    agent_id: str,
+    outcome: str,
+    reason_code: str,
+) -> None:
+    """Emit a privacy-aware OpenFGA ReBAC audit event from the DA runtime."""
+    parsed_trace = _parse_traceparent(current_traceparent.get())
+    trace_id = parsed_trace[0] if parsed_trace else None
+    span_id = parsed_trace[1] if parsed_trace else None
+    event = {
+        "audit_event_id": str(uuid.uuid4()),
+        "ts": datetime.now(UTC).isoformat(),
+        "type": "openfga_rebac",
+        "tenant_id": os.getenv("TENANT_ID", "default"),
+        "subject_hash": _hash_subject(subject),
+        "action": "dynamic_agent#use",
+        "outcome": outcome,
+        "reason_code": reason_code,
+        "correlation_id": str(uuid.uuid4()),
+        "component": "dynamic_agent",
+        "resource_ref": f"agent:{agent_id}",
+        "pdp": "openfga",
+        "source": "dynamic_agents",
+        "trace_id": trace_id,
+        "span_id": span_id,
+    }
+    _persist_openfga_rebac_audit(event)
+    logger.info(json.dumps(event, separators=(",", ":")))
+
+
+def _decode_subject_from_validated_token(token: str) -> str | None:
+    body = _decode_payload_from_validated_token(token)
+    sub = body.get("sub") if body else None
+    return sub if isinstance(sub, str) else None
+
+
+def _decode_payload_from_validated_token(token: str) -> dict[str, Any] | None:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(f"{payload}{padding}")
+        body = json.loads(decoded.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def _normalize_email_principal(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if OPENFGA_EMAIL_PRINCIPAL_PATTERN.fullmatch(normalized) else None
+
+
+def _openfga_http_url() -> str:
+    base_url = os.getenv("OPENFGA_HTTP", "").strip().rstrip("/")
+    if not base_url:
+        raise RuntimeError("OPENFGA_HTTP is not set")
+    return base_url
+
+
+def _openfga_store_name() -> str:
+    return os.getenv("OPENFGA_STORE_NAME", "").strip() or DEFAULT_STORE_NAME
+
+
+async def _get_openfga_store_id(client: httpx.AsyncClient, base_url: str) -> str:
+    explicit_store_id = os.getenv("OPENFGA_STORE_ID", "").strip()
+    if explicit_store_id:
+        return explicit_store_id
+
+    response = await client.get(f"{base_url}/stores", headers=_openfga_headers())
+    response.raise_for_status()
+    body = response.json()
+    store_name = _openfga_store_name()
+    for store in body.get("stores", []):
+        if store.get("name") == store_name and store.get("id"):
+            return str(store["id"])
+    raise RuntimeError(f"OpenFGA store {store_name} was not found")
+
+
+async def _check_agent_use(subject: str, agent_id: str) -> bool:
+    base_url = _openfga_http_url()
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        store_id = await _get_openfga_store_id(client, base_url)
+        response = await client.post(
+            f"{base_url}/stores/{store_id}/check",
+            headers=_openfga_headers(),
+            json={
+                "tuple_key": {
+                    "user": f"user:{subject}",
+                    "relation": "can_use",
+                    "object": f"agent:{agent_id}",
+                }
+            },
+        )
+        response.raise_for_status()
+        body = response.json()
+        return bool(body.get("allowed"))
+
+
+async def require_agent_use_permission(agent_id: str) -> None:
+    """Require the current bearer token subject to have can_use on an agent."""
+    if not _is_valid_openfga_id(agent_id):
+        _raise_authz(
+            400,
+            "Invalid agent identifier",
+            "invalid_agent_id",
+            "invalid_request",
+            "fix_request",
+        )
+
+    token = current_user_token.get()
+    if not token:
+        _raise_authz(
+            401,
+            "Bearer token is required",
+            "missing_bearer",
+            "not_signed_in",
+            "sign_in",
+        )
+
+    payload = _decode_payload_from_validated_token(token)
+    subject = payload.get("sub") if payload else None
+    if not _is_valid_openfga_id(subject):
+        _raise_authz(
+            401,
+            "Bearer token subject could not be verified",
+            "bearer_invalid",
+            "bearer_invalid",
+            "sign_in",
+        )
+
+    email_principal = _normalize_email_principal(payload.get("email") if payload else None)
+    principal_candidates = [subject]
+    if email_principal:
+        principal_candidates.append(email_principal)
+
+    parent_traceparent = current_traceparent.get()
+    trace_id, span_id, child_traceparent = _child_traceparent(parent_traceparent)
+    trace_ctx_token = None
+    if child_traceparent:
+        trace_ctx_token = current_traceparent.set(child_traceparent)
+    start_ns = time.time_ns()
+
+    def reset_trace_context() -> None:
+        nonlocal trace_ctx_token
+        if trace_ctx_token is not None:
+            current_traceparent.reset(trace_ctx_token)
+            trace_ctx_token = None
+
+    try:
+        allowed = False
+        for candidate in principal_candidates:
+            allowed = await _check_agent_use(candidate, agent_id)
+            if allowed:
+                break
+    except Exception as exc:
+        logger.warning("OpenFGA agent-use check failed for agent=%s: %s", agent_id, exc)
+        _log_openfga_rebac_audit(
+            subject=subject,
+            agent_id=agent_id,
+            outcome="deny",
+            reason_code="DENY_PDP_UNAVAILABLE",
+        )
+        reset_trace_context()
+        _raise_authz(
+            503,
+            "Authorization service is temporarily unavailable. Please try again in a moment.",
+            "PDP_UNAVAILABLE",
+            "pdp_unavailable",
+            "retry",
+        )
+    finally:
+        end_ns = time.time_ns()
+        await _export_authz_span(
+            name="authz.dynamic_agents.agent_use",
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_span_id=_parse_traceparent(parent_traceparent)[1]
+            if _parse_traceparent(parent_traceparent)
+            else None,
+            start_ns=start_ns,
+            end_ns=end_ns,
+            attributes={
+                "authz.action": "can_use",
+                "authz.resource": "dynamic_agent",
+                "authz.agent_id": agent_id,
+                "authz.tenant_id": os.getenv("TENANT_ID", "default"),
+            },
+        )
+
+    if allowed:
+        _log_openfga_rebac_audit(
+            subject=subject,
+            agent_id=agent_id,
+            outcome="allow",
+            reason_code="OK",
+        )
+        reset_trace_context()
+        return
+
+    if not allowed:
+        _log_openfga_rebac_audit(
+            subject=subject,
+            agent_id=agent_id,
+            outcome="deny",
+            reason_code="DENY_NO_CAPABILITY",
+        )
+        reset_trace_context()
+        _raise_authz(
+            403,
+            "Permission denied",
+            "agent#use",
+            "pdp_denied",
+            "contact_admin",
+        )

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/token_context.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/token_context.py
@@ -1,0 +1,30 @@
+"""Per-request bearer token context for Dynamic Agents.
+
+Spec 102 Phase 8 / T101.
+
+This is the DA-local mirror of the supervisor's
+``ai_platform_engineering.utils.auth.token_context.current_bearer_token``.
+It exists in this package so the DA's own auth middleware and httpx client
+factory can be wired together without taking a circular dependency on
+the supervisor package.
+
+The middleware (``jwt_middleware.JwtAuthMiddleware``) sets
+``current_user_token`` on every request after validating the incoming
+Bearer JWT against Keycloak JWKS. The MCP client factory in
+``services/mcp_client.py`` reads it on every outbound request to forward
+the user's identity to ``agentgateway`` and downstream MCP servers.
+
+Each asyncio Task inherits a copy of the ContextVar context, so
+concurrent requests are fully isolated.
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
+current_user_token: ContextVar[Optional[str]] = ContextVar(
+    "current_user_token", default=None
+)
+
+current_traceparent: ContextVar[Optional[str]] = ContextVar(
+    "current_traceparent", default=None
+)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
@@ -74,15 +74,15 @@ class Settings(BaseSettings):
     # Recommendation: (pod_memory_mb - 150) / 20, e.g. 512MB pod → 18 runtimes.
     agent_runtime_max_cache_size: int = 20
 
-    # CAIPE UI Server (for workflow tools, etc.)
-    caipe_api_url: str = ""  # e.g. "http://caipe-ui:3000"
+    # Seed configuration path (for MCP servers and agents loaded at startup)
+    seed_config_path: str | None = None
 
-    # OAuth2 client credentials for authenticating to the UI server
-    oauth2_token_url: str = ""
-    oauth2_client_id: str = ""
-    oauth2_client_secret: str = ""
-    oauth2_scope: str = ""
-    oauth2_audience: str = ""
+    # When set, MCP HTTP/SSE clients use this base URL (e.g. http://agentgateway:4000/mcp/{server_id})
+    agent_gateway_url: str | None = None
+
+    # CAIPE credential service API used when USE_IMPERSONATION_TOKENS=true.
+    credential_api_url: str | None = None
+    credential_service_audience: str = "caipe-credential-service"
 
 
 @lru_cache

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
@@ -128,8 +128,18 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
-    # Add Prometheus metrics middleware (serves /metrics, tracks request duration)
+    # Prometheus HTTP metrics middleware (from main). Mounted BEFORE the
+    # JWT auth middleware so failed-auth and CORS-preflight requests are
+    # still observable.
     app.add_middleware(PrometheusHTTPMiddleware)
+
+    # Spec 102 Phase 8 / T103: validate incoming Bearer JWTs against
+    # Keycloak and bind current_user_token so the MCP httpx factory can
+    # forward the user identity to agentgateway. Mounted AFTER CORS so
+    # CORS preflights are not auth-gated.
+    from dynamic_agents.auth.jwt_middleware import JwtAuthMiddleware
+
+    app.add_middleware(JwtAuthMiddleware)
 
     # Mount routes
     app.include_router(health.router)
@@ -174,6 +184,26 @@ def create_app() -> FastAPI:
             "version": "0.1.0",
             "docs": "/docs",
         }
+
+    # Spec 102 Phase 11.2 — expose Prometheus metrics so the RBAC PDP
+    # cache hit/miss + decision counters set in
+    # ai_platform_engineering.utils.auth.metrics are scrapeable. The
+    # endpoint is intentionally NOT auth-gated (matches supervisor's
+    # /metrics convention; restrict via NetworkPolicy in production).
+    try:
+        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+        from starlette.responses import Response
+
+        @app.get("/metrics", include_in_schema=False)
+        async def metrics() -> Response:
+            return Response(
+                content=generate_latest(),
+                media_type=CONTENT_TYPE_LATEST,
+            )
+    except ImportError:
+        logger.warning(
+            "prometheus_client not installed; /metrics endpoint disabled"
+        )
 
     return app
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -46,6 +46,12 @@ class UserContext(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     email: str
+    name: str | None = None
+    groups: list[str] = []
+    is_admin: bool = False
+    raw_claims: dict[str, Any] = {}
+    access_token: str | None = Field(default=None, repr=False)
+    obo_jwt: str | None = Field(default=None, repr=False)
 
 
 # =============================================================================
@@ -64,6 +70,21 @@ class MCPServerConfigBase(BaseModel):
     args: list[str] | None = Field(None, description="Args for stdio transport")
     env: dict[str, str] | None = Field(None, description="Env vars for stdio transport")
     enabled: bool = Field(True, description="Whether the server is enabled")
+    credential_sources: list["MCPCredentialSource"] | None = Field(
+        None,
+        description="Server-side credential refs to resolve for MCP connections.",
+    )
+
+
+class MCPCredentialSource(BaseModel):
+    """Credential source metadata for MCP server connection setup."""
+
+    kind: Literal["secret_ref", "provider_connection"] = Field(..., description="Credential source type")
+    target: Literal["env", "header"] = Field(..., description="Where to inject the resolved credential")
+    name: str = Field(..., description="Environment variable or header name")
+    secret_ref: str | None = Field(None, description="Credential secret_ref id")
+    provider_connection_id: str | None = Field(None, description="Provider connection id")
+    provider: str | None = Field(None, description="Provider key for JWT subject-owned provider connection")
 
 
 class MCPServerConfig(MCPServerConfigBase):
@@ -587,6 +608,7 @@ class AgentContext(BaseModel):
     user_groups: list[str] = []
     agent_config_id: str
     session_id: str
+    obo_jwt: str | None = None
 
 
 # =============================================================================

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/agents.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/agents.py
@@ -1,0 +1,335 @@
+"""CRUD endpoints for Dynamic Agent configurations."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from dynamic_agents.auth.access import can_view_agent
+from dynamic_agents.auth.auth import UserContext, get_current_user, require_admin
+from dynamic_agents.models import (
+    ApiResponse,
+    DynamicAgentConfigCreate,
+    DynamicAgentConfigUpdate,
+    PaginatedResponse,
+    SubAgentRef,
+    VisibilityType,
+)
+from dynamic_agents.services.mongo import MongoDBService, get_mongo_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+def validate_subagent_visibility(
+    parent_visibility: VisibilityType,
+    subagents: list[SubAgentRef],
+    mongo: MongoDBService,
+) -> tuple[bool, str | None]:
+    """Validate that subagents have compatible visibility with parent.
+
+    Rules:
+    - Private agent → can use private, team, or global subagents
+    - Team agent → can use team or global subagents
+    - Global agent → can only use global subagents
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    if not subagents:
+        return True, None
+
+    for subagent_ref in subagents:
+        subagent = mongo.get_agent(subagent_ref.agent_id)
+        if not subagent:
+            return False, f'Subagent "{subagent_ref.agent_id}" not found'
+
+        sub_vis = subagent.visibility
+
+        # Global parent can only use global subagents
+        if parent_visibility == VisibilityType.GLOBAL and sub_vis != VisibilityType.GLOBAL:
+            return (
+                False,
+                f'Global agents can only use global subagents. "{subagent.name}" is {sub_vis.value}.',
+            )
+
+        # Team parent can use team or global subagents
+        if parent_visibility == VisibilityType.TEAM and sub_vis == VisibilityType.PRIVATE:
+            return (
+                False,
+                f'Team agents can only use team or global subagents. "{subagent.name}" is private.',
+            )
+
+        # Private parent can use any visibility - no restrictions
+
+    return True, None
+
+
+@router.get("", response_model=PaginatedResponse)
+async def list_agents(
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    user: UserContext = Depends(get_current_user),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> PaginatedResponse:
+    """List dynamic agents visible to the current user.
+
+    Returns:
+        - Global agents (visibility=global)
+        - Team agents where user is a member (visibility=team)
+        - User's own agents (visibility=private)
+        - Admins see all agents
+    """
+    # Use the service method to list agents
+    agents = mongo.list_agents(
+        user_id=user.email,
+        user_teams=user.groups,
+        include_disabled=user.is_admin,
+        admin_view=user.is_admin,
+        user=user,
+    )
+
+    # Apply pagination
+    total = len(agents)
+    total_pages = (total + limit - 1) // limit if total > 0 else 1
+    start = (page - 1) * limit
+    end = start + limit
+    paginated = agents[start:end]
+
+    return PaginatedResponse(
+        items=[a.model_dump(by_alias=True) for a in paginated],
+        total=total,
+        page=page,
+        limit=limit,
+        total_pages=total_pages,
+    )
+
+
+@router.post("", response_model=ApiResponse)
+async def create_agent(
+    config: DynamicAgentConfigCreate,
+    user: UserContext = Depends(require_admin),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> ApiResponse:
+    """Create a new dynamic agent configuration.
+
+    Requires admin role.
+    """
+    # Validate subagent visibility compatibility
+    if config.subagents:
+        is_valid, error = validate_subagent_visibility(
+            config.visibility,
+            config.subagents,
+            mongo,
+        )
+        if not is_valid:
+            raise HTTPException(status_code=400, detail=error)
+
+    try:
+        agent = mongo.create_agent(config, owner_id=user.email)
+    except ValueError as e:
+        # Reserved name or duplicate slug
+        raise HTTPException(status_code=409, detail=str(e))
+
+    logger.info(f"Created dynamic agent '{config.name}' ({agent.id}) by {user.email}")
+
+    return ApiResponse(
+        success=True,
+        data=agent.model_dump(by_alias=True),
+    )
+
+
+@router.get("/{agent_id}", response_model=ApiResponse)
+async def get_agent(
+    agent_id: str,
+    user: UserContext = Depends(get_current_user),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> ApiResponse:
+    """Get a dynamic agent configuration by ID."""
+    agent = mongo.get_agent(agent_id)
+
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    # Check visibility
+    if not can_view_agent(agent, user):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    return ApiResponse(
+        success=True,
+        data=agent.model_dump(by_alias=True),
+    )
+
+
+@router.patch("/{agent_id}", response_model=ApiResponse)
+async def update_agent(
+    agent_id: str,
+    update: DynamicAgentConfigUpdate,
+    user: UserContext = Depends(require_admin),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> ApiResponse:
+    """Update a dynamic agent configuration.
+
+    Requires admin role. Config-driven agents cannot be updated.
+    """
+    agent = mongo.get_agent(agent_id)
+
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    # Block updates to config-driven agents
+    if agent.config_driven:
+        raise HTTPException(
+            status_code=403,
+            detail="Config-driven agents cannot be modified. Update config.yaml instead.",
+        )
+
+    # Determine final values for visibility validation
+    final_visibility = update.visibility if update.visibility is not None else agent.visibility
+    final_subagents = update.subagents if update.subagents is not None else agent.subagents
+
+    # Validate subagent visibility compatibility
+    if final_subagents:
+        is_valid, error = validate_subagent_visibility(
+            final_visibility,
+            final_subagents,
+            mongo,
+        )
+        if not is_valid:
+            raise HTTPException(status_code=400, detail=error)
+
+    updated = mongo.update_agent(agent_id, update)
+    if not updated:
+        raise HTTPException(status_code=500, detail="Failed to update agent")
+
+    logger.info(f"Updated dynamic agent '{agent_id}' by {user.email}")
+
+    return ApiResponse(
+        success=True,
+        data=updated.model_dump(by_alias=True),
+    )
+
+
+@router.delete("/{agent_id}", response_model=ApiResponse)
+async def delete_agent(
+    agent_id: str,
+    user: UserContext = Depends(require_admin),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> ApiResponse:
+    """Delete a dynamic agent configuration.
+
+    Requires admin role. System agents and config-driven agents cannot be deleted.
+    """
+    agent = mongo.get_agent(agent_id)
+
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    if agent.is_system:
+        raise HTTPException(
+            status_code=400,
+            detail="System agents cannot be deleted",
+        )
+
+    if agent.config_driven:
+        raise HTTPException(
+            status_code=403,
+            detail="Config-driven agents cannot be deleted. Remove from config.yaml instead.",
+        )
+
+    deleted = mongo.delete_agent(agent_id)
+    if not deleted:
+        raise HTTPException(status_code=500, detail="Failed to delete agent")
+
+    logger.info(f"Deleted dynamic agent '{agent_id}' by {user.email}")
+
+    return ApiResponse(success=True, data={"deleted": agent_id})
+
+
+@router.get("/{agent_id}/available-subagents", response_model=ApiResponse)
+async def list_available_subagents(
+    agent_id: str,
+    user: UserContext = Depends(require_admin),
+    mongo: MongoDBService = Depends(get_mongo_service),
+) -> ApiResponse:
+    """List agents that can be configured as subagents for the given agent.
+
+    Returns all enabled agents except:
+    - The agent itself (can't delegate to itself)
+    - Agents that would create a circular reference
+
+    Requires admin role.
+    """
+    # Get the parent agent
+    parent_agent = mongo.get_agent(agent_id)
+    if not parent_agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    # Get all enabled agents
+    all_agents = mongo.list_agents(
+        user_id=user.email,
+        user_teams=user.groups,
+        include_disabled=False,
+        admin_view=True,
+    )
+
+    # Find agents that would create a cycle
+    ancestors = _get_ancestor_agent_ids(agent_id, mongo)
+
+    # Filter out self and ancestors
+    available = []
+    for agent in all_agents:
+        if agent.id == agent_id:
+            continue  # Can't delegate to self
+        if agent.id in ancestors:
+            continue  # Would create a cycle
+        available.append(
+            {
+                "id": agent.id,
+                "name": agent.name,
+                "description": agent.description,
+                "visibility": agent.visibility.value,
+            }
+        )
+
+    return ApiResponse(
+        success=True,
+        data={"agents": available},
+    )
+
+
+def _get_ancestor_agent_ids(agent_id: str, mongo: MongoDBService) -> set[str]:
+    """Get all agent IDs that have this agent as a subagent (directly or indirectly).
+
+    Used for cycle detection - we can't add an ancestor as a subagent because
+    it would create A -> B -> A cycle.
+    """
+    ancestors: set[str] = set()
+
+    # Get all agents and build a reverse lookup
+    all_agents = mongo.list_agents(admin_view=True, include_disabled=True)
+
+    # Build a map: child_id -> set of parent_ids
+    child_to_parents: dict[str, set[str]] = {}
+    for agent in all_agents:
+        for subagent_ref in agent.subagents:
+            if subagent_ref.agent_id not in child_to_parents:
+                child_to_parents[subagent_ref.agent_id] = set()
+            child_to_parents[subagent_ref.agent_id].add(agent.id)
+
+    # BFS to find all ancestors
+    queue = [agent_id]
+    visited: set[str] = set()
+
+    while queue:
+        current = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+
+        parents = child_to_parents.get(current, set())
+        for parent_id in parents:
+            ancestors.add(parent_id)
+            queue.append(parent_id)
+
+    return ancestors

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from dynamic_agents.auth.auth import get_user_context
+from dynamic_agents.auth.openfga_authz import require_agent_use_permission
 from dynamic_agents.config import get_settings
 from dynamic_agents.log_config import conversation_id_var
 from dynamic_agents.models import ChatRequest, ClientContext, DynamicAgentConfig, UserContext
@@ -250,7 +251,9 @@ async def chat_start_stream(
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
 
-    # Get agent config (access control is handled by the gateway)
+    await require_agent_use_permission(request.agent_id)
+
+    # Get agent config after the runtime policy check passes.
     agent = mongo.get_agent(request.agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -364,7 +367,9 @@ async def chat_resume_stream(
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
 
-    # Get agent config (access control is handled by the gateway)
+    await require_agent_use_permission(request.agent_id)
+
+    # Get agent config after the runtime policy check passes.
     agent = mongo.get_agent(request.agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -418,7 +423,9 @@ async def chat_invoke(
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
 
-    # Get agent config (access control is handled by the gateway)
+    await require_agent_use_permission(request.agent_id)
+
+    # Get agent config after the runtime policy check passes.
     agent = mongo.get_agent(request.agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -54,12 +54,14 @@ from dynamic_agents.services.builtin_tools import (
     create_wait_tool,
     create_workflow_tools,
 )
+from dynamic_agents.services.credential_exchange import CredentialExchangeClient
 from dynamic_agents.services.gridfs_store import MongoDBGridFSStore
 from dynamic_agents.services.llm_clients import get_llm
 from dynamic_agents.services.mcp_client import (
     build_mcp_connections,
     filter_tools_by_allowed,
     get_tools_with_resilience,
+    resolve_mcp_connections_credential_refs,
     wrap_tools_with_error_handling,
 )
 from dynamic_agents.services.middleware import build_middleware
@@ -169,6 +171,30 @@ class AgentRuntime:
         self._mongo_service = mongo_service
         self._user = user
         self._client_context = client_context
+        # Spec 102 Phase 8 / T107: prefer the per-request bearer from
+        # current_user_token (set by JwtAuthMiddleware) so the same token
+        # the BFF authenticated us with is forwarded to MCP servers.
+        # Fall back to UserContext-attached fields for backward compat
+        # with the X-User-Context legacy path.
+        from dynamic_agents.auth.token_context import current_user_token as _ctx_tok
+
+        ctx_token = _ctx_tok.get()
+        legacy_token = (user.obo_jwt or user.access_token) if user else None
+        self._auth_bearer: str | None = ctx_token or legacy_token
+        # Spec 104: never silently substitute the dynamic-agents service
+        # account token here — the runtime must run with the user's OBO
+        # token so AgentGateway/OpenFGA can evaluate the signed active-team
+        # context. If we have nothing, log loudly and let the
+        # downstream call 401; we'd rather fail closed than show the user
+        # tools that belong to the SA.
+        if self._auth_bearer is None:
+            logger.warning(
+                "AgentRuntime for '%s' has no user JWT (ctx_token + legacy both empty); "
+                "outbound MCP calls will be unauthenticated and AgentGateway will reject them. "
+                "This usually means JwtAuthMiddleware was bypassed or the BFF stripped the "
+                "Authorization header.",
+                config.name,
+            )
         self._session_id = session_id
         self._graph = None
 
@@ -287,6 +313,17 @@ class AgentRuntime:
             ttl = max_ttl
         return ttl
 
+    def _credential_exchange_client(self) -> CredentialExchangeClient | None:
+        """Create a credential API client when impersonation token resolution is configured."""
+
+        if not self.settings.credential_api_url or not self._auth_bearer:
+            return None
+        return CredentialExchangeClient(
+            base_url=self.settings.credential_api_url,
+            audience=self.settings.credential_service_audience,
+            token_provider=lambda: self._auth_bearer or "",
+        )
+
     async def initialize(self) -> None:
         """Build the DeepAgent graph with tools and instructions."""
         if self._initialized:
@@ -304,8 +341,18 @@ class AgentRuntime:
             logger.info(f"Agent '{self.config.name}' has no MCP tools configured")
             tools = []
         else:
-            # 1a. Fetch relevant MCP server configs
-            connections = build_mcp_connections(self.mcp_servers, server_ids)
+            connections = build_mcp_connections(
+                self.mcp_servers,
+                server_ids,
+                agent_gateway_url=self.settings.agent_gateway_url,
+                auth_bearer=self._auth_bearer,
+                agent_id=self.config.id,
+            )
+            connections = await resolve_mcp_connections_credential_refs(
+                self.mcp_servers,
+                connections,
+                credential_client=self._credential_exchange_client(),
+            )
 
             if not connections:
                 logger.warning(f"Agent '{self.config.name}': no valid MCP connections found")
@@ -826,9 +873,21 @@ class AgentRuntime:
         tools: list = []
 
         # 1. Build MCP tools from subagent's allowed_tools config
-        server_ids = [sid for sid, val in subagent_config.allowed_tools.items() if val is not False]
+        #    Inherit parent's AG routing and auth (FR-038f)
+        server_ids = list(subagent_config.allowed_tools.keys())
         if server_ids:
-            connections = build_mcp_connections(self.mcp_servers, server_ids)
+            connections = build_mcp_connections(
+                self.mcp_servers,
+                server_ids,
+                agent_gateway_url=self.settings.agent_gateway_url,
+                auth_bearer=self._auth_bearer,
+                agent_id=subagent_config.id,
+            )
+            connections = await resolve_mcp_connections_credential_refs(
+                self.mcp_servers,
+                connections,
+                credential_client=self._credential_exchange_client(),
+            )
             if connections:
                 # Use resilient connection so one failing server doesn't break the subagent
                 all_tools, failed, failed_errors = await get_tools_with_resilience(connections)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/config.yaml
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/config.yaml
@@ -1,0 +1,90 @@
+# Dynamic Agents Seed Configuration
+# Generated from caipe-preview Kubernetes cluster
+
+# =============================================================================
+# Available LLM Models
+# =============================================================================
+
+models:
+  - description: Fast, efficient Claude 4.5 Haiku via AWS Bedrock
+    model_id: global.anthropic.claude-haiku-4-5-20251001-v1:0
+    name: Claude 4.5 Haiku (Bedrock)
+    provider: aws-bedrock
+
+  - description: Balanced performance Claude Sonnet 4 via AWS Bedrock
+    model_id: global.anthropic.claude-sonnet-4-20250514-v1:0
+    name: Claude Sonnet 4 (Bedrock)
+    provider: aws-bedrock
+
+  - description: Latest Claude Sonnet 4.5 via AWS Bedrock
+    model_id: global.anthropic.claude-sonnet-4-5-20250929-v1:0
+    name: Claude Sonnet 4.5 (Bedrock)
+    provider: aws-bedrock
+
+  - description: Claude 3.5 Sonnet v2 via AWS Bedrock
+    model_id: global.anthropic.claude-3-5-sonnet-20241022-v2:0
+    name: Claude 3.5 Sonnet v2 (Bedrock)
+    provider: aws-bedrock
+
+  - description: GPT-4o via Azure OpenAI
+    model_id: gpt-4o
+    name: GPT-4o (Azure)
+    provider: azure-openai
+
+  - description: Fast, cost-effective GPT-4o Mini via Azure OpenAI
+    model_id: gpt-4o-mini
+    name: GPT-4o Mini (Azure)
+    provider: azure-openai
+
+# =============================================================================
+# Seed MCP Servers
+# =============================================================================
+# Note: Production cluster endpoints below are disabled for local dev.
+# Enable only for Kubernetes deployments where these services exist.
+
+mcp_servers:
+  - description: GitHub repositories and pull requests
+    enabled: true
+    endpoint: ${GITHUB_MCP_URL:-http://localhost:8082}
+    id: github
+    name: GitHub
+    transport: http
+
+  - description: ArgoCD application and deployment management
+    enabled: true
+    endpoint: ${ARGOCD_MCP_URL:-http://localhost:18002/mcp}
+    id: argocd
+    name: ArgoCD
+    transport: http
+
+  - description: Jira issue tracking and project management
+    enabled: true
+    endpoint: ${JIRA_MCP_URL:-http://localhost:18004/mcp}
+    id: jira
+    name: Jira
+    transport: http
+    credential_sources:
+      - kind: provider_connection
+        name: X-CAIPE-Provider-Token
+        provider: atlassian
+        target: header
+
+  - description: PagerDuty incident management
+    enabled: true
+    endpoint: ${PAGERDUTY_MCP_URL:-http://localhost:18006/mcp}
+    id: pagerduty
+    name: PagerDuty
+    transport: http
+
+  - description: Knowledge Base tools
+    enabled: true
+    endpoint: ${RAG_SERVER_MCP_URL:-http://localhost:9446/mcp}
+    id: knowledge-base
+    name: Knowledge Base
+    transport: http
+
+# =============================================================================
+# Seed Agents
+# =============================================================================
+
+agents: []

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/keycloak_sync.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/keycloak_sync.py
@@ -1,0 +1,119 @@
+"""Keycloak Admin API sync for dynamic agent authz resources.
+
+OpenFGA is the authoritative resource-grant store. This service keeps only the
+Keycloak Authorization Services resource registration needed by legacy clients;
+it no longer creates per-agent realm roles such as ``agent_user:<id>``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class KeycloakSyncService:
+  """Register Keycloak authz resources for dynamic agents."""
+
+  def __init__(self) -> None:
+    self._base = os.getenv("KEYCLOAK_URL", "http://localhost:7080").rstrip("/")
+    self._realm = os.getenv("KEYCLOAK_REALM", "caipe")
+    self._admin_client_id = os.getenv("KEYCLOAK_ADMIN_CLIENT_ID", "").strip()
+    self._admin_client_secret = (os.getenv("KEYCLOAK_ADMIN_CLIENT_SECRET") or "").strip()
+    self._authz_client_id = os.getenv("KEYCLOAK_AUTHZ_CLIENT_ID", "").strip()
+
+  @property
+  def enabled(self) -> bool:
+    return bool(self._admin_client_id and self._admin_client_secret)
+
+  def _admin_token(self) -> str:
+    url = f"{self._base}/realms/{self._realm}/protocol/openid-connect/token"
+    data = {
+      "grant_type": "client_credentials",
+      "client_id": self._admin_client_id,
+      "client_secret": self._admin_client_secret,
+    }
+    with httpx.Client(timeout=15.0) as client:
+      r = client.post(url, data=data)
+      r.raise_for_status()
+      return str(r.json()["access_token"])
+
+  def _headers(self) -> dict[str, str]:
+    return {"Authorization": f"Bearer {self._admin_token()}"}
+
+  def _client_uuid(self, client_id: str) -> str | None:
+    url = f"{self._base}/admin/realms/{self._realm}/clients"
+    with httpx.Client(timeout=15.0) as client:
+      r = client.get(url, params={"clientId": client_id}, headers=self._headers())
+      r.raise_for_status()
+      items = r.json()
+      if isinstance(items, list) and items:
+        cid = items[0].get("id")
+        return str(cid) if cid else None
+    return None
+
+  def _delete_authz_resource_by_name(self, client_uuid: str, name: str) -> None:
+    base = f"{self._base}/admin/realms/{self._realm}/clients/{client_uuid}/authz/resource-server/resource"
+    with httpx.Client(timeout=15.0) as client:
+      r = client.get(base, params={"name": name}, headers=self._headers())
+      r.raise_for_status()
+      rows = r.json() if isinstance(r.json(), list) else []
+      for row in rows:
+        if not isinstance(row, dict):
+          continue
+        rid = row.get("id") or row.get("_id")
+        if row.get("name") == name and rid:
+          dr = client.delete(f"{base}/{rid}", headers=self._headers())
+          if dr.status_code not in (200, 204, 404):
+            dr.raise_for_status()
+          return
+
+  def sync_agent_resource(self, agent_id: str, agent_name: str, visibility: str) -> None:
+    if not self.enabled:
+      logger.debug("Keycloak sync skipped: admin client credentials not configured")
+      return
+    if not self._authz_client_id:
+      return
+    c_uuid = self._client_uuid(self._authz_client_id)
+    if not c_uuid:
+      logger.warning("Keycloak authz client %r not found — skipping resource sync", self._authz_client_id)
+      return
+    scope_names = ["view", "invoke", "configure", "delete"]
+    res_name = f"dynamic_agent:{agent_id}"
+    base = f"{self._base}/admin/realms/{self._realm}/clients/{c_uuid}/authz/resource-server/resource"
+    payload: dict[str, Any] = {
+      "name": res_name,
+      "displayName": agent_name,
+      "type": "dynamic_agent",
+      "attributes": {"visibility": [visibility], "agent_id": [agent_id]},
+      "uris": [],
+      "scopes": [{"name": n} for n in scope_names],
+    }
+    with httpx.Client(timeout=20.0) as client:
+      r = client.post(base, json=payload, headers=self._headers())
+      if r.status_code == 409:
+        return
+      r.raise_for_status()
+
+  def remove_agent_resource(self, agent_id: str) -> None:
+    if not self.enabled:
+      return
+    if not self._authz_client_id:
+      return
+    c_uuid = self._client_uuid(self._authz_client_id)
+    if c_uuid:
+      self._delete_authz_resource_by_name(c_uuid, f"dynamic_agent:{agent_id}")
+
+
+_sync_singleton: KeycloakSyncService | None = None
+
+
+def get_keycloak_sync_service() -> KeycloakSyncService:
+  global _sync_singleton
+  if _sync_singleton is None:
+    _sync_singleton = KeycloakSyncService()
+  return _sync_singleton

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
@@ -1,57 +1,243 @@
 """MCP Client wrapper for Dynamic Agents."""
 
 import asyncio
+import base64
+import hashlib
+import hmac
+import json
 import logging
-from typing import Any
+import os
+import ssl
+import time
+from typing import Any, Callable
 
+import httpx
 from langchain_core.tools import BaseTool, StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
+from dynamic_agents.auth.token_context import current_user_token
 from dynamic_agents.models import MCPServerConfig, TransportType
+from dynamic_agents.services.credential_exchange import CredentialExchangeClient
+from dynamic_agents.services.mcp_endpoint_normalizer import (
+    normalize_mcp_endpoint_for_server,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def build_mcp_connection_config(server: MCPServerConfig) -> dict[str, Any]:
+def _gateway_mcp_server_ids() -> set[str]:
+    """Return MCP server IDs that should be reached through AgentGateway."""
+    raw = os.getenv("AGENT_GATEWAY_MCP_SERVER_IDS", "jira")
+    values = {item.strip() for item in raw.split(",") if item.strip()}
+    return values or {"jira"}
+
+
+def _agent_gateway_base_url() -> str | None:
+    """Resolve the AgentGateway base URL from env.
+
+    Returns the origin (e.g. ``http://agentgateway:4000``) without a
+    ``/mcp`` suffix. ``None`` when no override is set — in that case the
+    normaliser has no anchor and self-heal is a no-op.
+    """
+    raw = (os.getenv("AGENT_GATEWAY_URL") or os.getenv("AGENTGATEWAY_URL") or "").strip()
+    if not raw:
+        return None
+    # Tolerate operators who set the URL with or without `/mcp`. The
+    # normaliser only matches on origin, but having a clean base keeps
+    # log lines readable.
+    return raw[: -len("/mcp")] if raw.rstrip("/").endswith("/mcp") else raw.rstrip("/")
+
+
+def _heal_endpoint(server: MCPServerConfig) -> str | None:
+    """Self-heal stale AgentGateway endpoints at read time.
+
+    Background: ``POST/PUT /api/mcp-servers`` (BFF) now normalises
+    endpoints on save, but Mongo can still hold legacy rows where an
+    admin saved ``http://agentgateway:4000/mcp`` (the bare base) instead
+    of ``http://agentgateway:4000/mcp/<id>``. Those rows produce
+    ``HTTP 404 Not Found from http://agentgateway:4000/mcp`` on every
+    probe and tool call because AgentGateway routes by path prefix.
+
+    Self-healing here means probe/runtime works even before the legacy
+    row is repaired in Mongo (via the repair script or by re-saving).
+    """
+    base = _agent_gateway_base_url()
+    if not base:
+        return server.endpoint
+    return normalize_mcp_endpoint_for_server(server.endpoint, server.id, base)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def build_agent_context_headers(agent_id: str, *, now: int | None = None) -> dict[str, str]:
+    """Build signed AgentGateway context headers for per-agent tool policy.
+
+    The bridge only trusts this context when both Dynamic Agents and the bridge
+    share ``CAIPE_AGENT_CONTEXT_HMAC_SECRET``. Without that secret we omit the
+    headers and the gateway falls back to coarse user-level authorization.
+    """
+    secret = os.getenv("CAIPE_AGENT_CONTEXT_HMAC_SECRET", "").strip()
+    if not secret:
+        return {}
+    issued_at = int(now if now is not None else time.time())
+    payload = {
+        "agent_id": agent_id,
+        "iat": issued_at,
+        "exp": issued_at + 300,
+    }
+    encoded = _b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    signature = hmac.new(secret.encode(), encoded.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-CAIPE-Agent-Context": encoded,
+        "X-CAIPE-Agent-Context-Signature": signature,
+    }
+
+
+def build_httpx_client_factory() -> Callable[..., httpx.AsyncClient]:
+    """Build an httpx.AsyncClient factory that injects the per-request user JWT.
+
+    Spec 102 Phase 8 / T106. Mirror of the supervisor's
+    ``base_langgraph_agent._build_httpx_client_factory``: each MCP HTTP
+    connection opened by ``langchain-mcp-adapters`` calls this factory,
+    which reads ``current_user_token`` (set by ``JwtAuthMiddleware``)
+    and forwards it as ``Authorization: Bearer <token>``. This is the
+    fix for the live HTTP 401 from agentgateway because the runtime no
+    longer relies on the (token-less) X-User-Context header for
+    outbound auth.
+
+    Honors ``CUSTOM_CA_BUNDLE`` / ``REQUESTS_CA_BUNDLE`` /
+    ``SSL_CERT_FILE`` and ``SSL_VERIFY=false`` for parity with the
+    supervisor stack.
+    """
+    ca_bundle = (
+        os.getenv("CUSTOM_CA_BUNDLE")
+        or os.getenv("REQUESTS_CA_BUNDLE")
+        or os.getenv("SSL_CERT_FILE")
+    )
+    ssl_verify = os.getenv("SSL_VERIFY", "true").lower()
+    if ca_bundle and os.path.exists(ca_bundle):
+        verify: Any = ssl.create_default_context(cafile=ca_bundle)
+    elif ssl_verify == "false":
+        logger.warning(
+            "SSL_VERIFY=false: disabling TLS verification for MCP HTTP transport. "
+            "Insecure; dev only."
+        )
+        verify = False
+    else:
+        verify = True
+
+    def _factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        merged = dict(headers or {})
+        token = current_user_token.get()
+        if token:
+            merged["Authorization"] = f"Bearer {token}"
+        return httpx.AsyncClient(
+            headers=merged,
+            timeout=timeout or httpx.Timeout(30.0),
+            auth=auth,
+            verify=verify,
+        )
+
+    return _factory
+
+
+def build_mcp_connection_config(
+    server: MCPServerConfig,
+    *,
+    agent_gateway_url: str | None = None,
+    auth_bearer: str | None = None,
+    agent_id: str | None = None,
+) -> dict[str, Any]:
     """Build connection config dict for MultiServerMCPClient.
 
     Args:
         server: MCP server configuration
+        agent_gateway_url: When set, HTTP/SSE targets use ``{base}/mcp/{server.id}`` instead of direct endpoints.
+        auth_bearer: Optional Bearer token for AG or upstream MCP.
 
     Returns:
         Connection config dict compatible with langchain_mcp_adapters
     """
+    headers: dict[str, str] = {}
+    if auth_bearer:
+        headers["Authorization"] = f"Bearer {auth_bearer}"
+    if agent_id:
+        headers.update(build_agent_context_headers(agent_id))
+
+    # Spec 102 Phase 8 / T106: also attach the httpx_client_factory so the
+    # per-request user JWT (from current_user_token ContextVar) is injected
+    # on every outbound connection, even after this config is built.
+    factory = build_httpx_client_factory()
+    token = current_user_token.get()
+    if token and "Authorization" not in headers:
+        headers["Authorization"] = f"Bearer {token}"
+
+    def attach_headers(cfg: dict[str, Any]) -> dict[str, Any]:
+        cfg = {**cfg, "httpx_client_factory": factory}
+        if not headers:
+            return cfg
+        return {**cfg, "headers": {**cfg.get("headers", {}), **headers}}
+
+    # Self-heal stale AgentGateway endpoints (e.g. bare
+    # ``http://agentgateway:4000/mcp`` written by an older save path)
+    # before we hand the URL to the transport. See ``_heal_endpoint``.
+    healed_endpoint = _heal_endpoint(server)
     if server.transport == TransportType.SSE:
-        return {
-            "url": server.endpoint,
-            "transport": "sse",
-        }
-    elif server.transport == TransportType.HTTP:
-        return {
-            "url": server.endpoint,
-            "transport": "streamable_http",
-        }
-    else:  # stdio
-        config: dict[str, Any] = {
-            "command": server.command,
-            "transport": "stdio",
-        }
-        if server.args:
-            config["args"] = server.args
-        if server.env:
-            config["env"] = server.env
-        return config
+        url = (
+            f"{agent_gateway_url.rstrip('/')}/mcp/{server.id}"
+            if agent_gateway_url and healed_endpoint
+            else healed_endpoint
+        )
+        return attach_headers(
+            {
+                "url": url,
+                "transport": "sse",
+            }
+        )
+    if server.transport == TransportType.HTTP:
+        url = (
+            f"{agent_gateway_url.rstrip('/')}/mcp/{server.id}"
+            if agent_gateway_url and healed_endpoint
+            else healed_endpoint
+        )
+        return attach_headers(
+            {
+                "url": url,
+                "transport": "streamable_http",
+            }
+        )
+    config: dict[str, Any] = {
+        "command": server.command,
+        "transport": "stdio",
+    }
+    if server.args:
+        config["args"] = server.args
+    if server.env:
+        config["env"] = server.env
+    return config
 
 
 def build_mcp_connections(
     servers: list[MCPServerConfig],
     server_ids: list[str],
+    *,
+    agent_gateway_url: str | None = None,
+    auth_bearer: str | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Build MCP connections dict for MultiServerMCPClient.
 
     Args:
         servers: List of all available MCP server configs
         server_ids: List of server IDs to include
+        agent_gateway_url: Optional Agent Gateway base URL for HTTP/SSE MCP routing.
+        auth_bearer: Optional OBO/user JWT for Authorization header on MCP requests.
 
     Returns:
         Dict mapping server_id to connection config
@@ -59,6 +245,8 @@ def build_mcp_connections(
     connections: dict[str, dict[str, Any]] = {}
 
     server_map = {s.id: s for s in servers}
+    gateway_ids = _gateway_mcp_server_ids() if agent_gateway_url else set()
+    gateway_all = "all" in gateway_ids
 
     for server_id in server_ids:
         server = server_map.get(server_id)
@@ -69,9 +257,95 @@ def build_mcp_connections(
             logger.warning(f"MCP server '{server_id}' is disabled, skipping")
             continue
 
-        connections[server_id] = build_mcp_connection_config(server)
+        connections[server_id] = build_mcp_connection_config(
+            server,
+            agent_gateway_url=agent_gateway_url if (gateway_all or server_id in gateway_ids) else None,
+            auth_bearer=auth_bearer,
+            agent_id=agent_id,
+        )
 
     return connections
+
+
+def _use_impersonation_tokens() -> bool:
+    return os.getenv("USE_IMPERSONATION_TOKENS", "false").strip().lower() == "true"
+
+
+async def resolve_mcp_credential_refs(
+    server: MCPServerConfig,
+    config: dict[str, Any],
+    *,
+    credential_client: CredentialExchangeClient | Any,
+) -> dict[str, Any]:
+    """Resolve MCP credential sources into env vars or headers.
+
+    Resolution is disabled unless ``USE_IMPERSONATION_TOKENS=true`` so existing
+    MCP deployments keep their current credential behavior.
+    """
+
+    if not _use_impersonation_tokens() or not server.credential_sources:
+        return config
+
+    resolved = dict(config)
+    for source in server.credential_sources:
+        credential: str | None = None
+        if source.kind == "secret_ref" and source.secret_ref:
+            credential = await credential_client.retrieve_secret(source.secret_ref, intended_use="mcp_server")
+        elif source.kind == "provider_connection":
+            if source.provider:
+                exchanged = await credential_client.exchange_provider_connection_by_provider(
+                    source.provider,
+                    intended_use="mcp_server",
+                )
+            elif source.provider_connection_id:
+                exchanged = await credential_client.exchange_provider_connection(
+                    source.provider_connection_id,
+                    intended_use="mcp_server",
+                )
+            else:
+                continue
+            access_token = exchanged.get("access_token")
+            if isinstance(access_token, str) and access_token:
+                credential = access_token
+
+        if not credential:
+            continue
+
+        if source.target == "env":
+            resolved["env"] = {**resolved.get("env", {}), source.name: credential}
+        elif source.target == "header":
+            header_value = credential
+            if source.name.lower() == "authorization" and not credential.lower().startswith("bearer "):
+                header_value = f"Bearer {credential}"
+            resolved["headers"] = {**resolved.get("headers", {}), source.name: header_value}
+
+    return resolved
+
+
+async def resolve_mcp_connections_credential_refs(
+    servers: list[MCPServerConfig],
+    connections: dict[str, dict[str, Any]],
+    *,
+    credential_client: CredentialExchangeClient | Any | None,
+) -> dict[str, dict[str, Any]]:
+    """Resolve credential refs across a connection map."""
+
+    if credential_client is None or not _use_impersonation_tokens():
+        return connections
+
+    server_map = {server.id: server for server in servers}
+    resolved: dict[str, dict[str, Any]] = {}
+    for server_id, config in connections.items():
+        server = server_map.get(server_id)
+        if server is None:
+            resolved[server_id] = config
+            continue
+        resolved[server_id] = await resolve_mcp_credential_refs(
+            server,
+            config,
+            credential_client=credential_client,
+        )
+    return resolved
 
 
 def filter_tools_by_allowed(
@@ -156,6 +430,84 @@ def _extract_error_message(exc: BaseException) -> str:
     return str(exc)
 
 
+# Messages that the langchain-mcp-adapters / streamable-http transport emits
+# without an attached HTTP response. They tell the UI "something went wrong on
+# the wire", but not whether the wire died on a 401 from AgentGateway, a
+# connection refused, or a clean disconnect. Treat them as opaque and re-probe
+# the endpoint over plain HTTP so we can surface a concrete cause.
+_OPAQUE_MCP_TRANSPORT_MESSAGES = (
+    "session terminated",
+    "session closed",
+    "stream ended",
+)
+
+
+def _is_opaque_transport_message(message: str) -> bool:
+    """True if the inner exception message carries no actionable detail."""
+    lowered = (message or "").strip().lower()
+    return any(token in lowered for token in _OPAQUE_MCP_TRANSPORT_MESSAGES)
+
+
+async def _diagnose_endpoint_failure(endpoint: str) -> str:
+    """Issue a direct HTTP probe to ``endpoint`` and translate the result into
+    a one-line diagnostic message.
+
+    Returns one of:
+      - ``"HTTP <status> <reason> from <endpoint>"`` when the server replies
+      - ``"Cannot connect to <endpoint>: <details>"`` when no response arrives
+
+    Never raises — the caller already has an exception to attach this to.
+    """
+    if not endpoint:
+        return "MCP endpoint URL is not configured"
+
+    # Honor the same TLS / CA bundle posture as the MCP HTTP factory so this
+    # diagnostic doesn't lie about cert problems.
+    ca_bundle = (
+        os.getenv("CUSTOM_CA_BUNDLE")
+        or os.getenv("REQUESTS_CA_BUNDLE")
+        or os.getenv("SSL_CERT_FILE")
+    )
+    ssl_verify = os.getenv("SSL_VERIFY", "true").lower()
+    if ca_bundle and os.path.exists(ca_bundle):
+        verify: Any = ssl.create_default_context(cafile=ca_bundle)
+    elif ssl_verify == "false":
+        verify = False
+    else:
+        verify = True
+
+    headers: dict[str, str] = {}
+    token = current_user_token.get()
+    if token:
+        # Match what the MCP HTTP client would have sent so the upstream
+        # auth decision matches the one that failed.
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        async with httpx.AsyncClient(verify=verify, timeout=httpx.Timeout(5.0)) as client:
+            response = await client.get(endpoint, headers=headers)
+    except (httpx.ConnectError, httpx.TransportError, httpx.TimeoutException) as exc:
+        # Avoid leaking deep tracebacks; one short line is what the UI wants.
+        return f"Cannot connect to {endpoint}: {type(exc).__name__}: {exc}"
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"Cannot reach {endpoint}: {exc}"
+
+    reason = (
+        response.reason_phrase
+        or response.extensions.get("reason_phrase", b"").decode("ascii", "replace")
+        if hasattr(response, "extensions")
+        else response.reason_phrase
+    )
+    if not reason:
+        # Map a few common ones if the server omitted the reason phrase.
+        reason = {401: "Unauthorized", 403: "Forbidden", 404: "Not Found"}.get(
+            response.status_code, ""
+        )
+    if reason:
+        return f"HTTP {response.status_code} {reason} from {endpoint}"
+    return f"HTTP {response.status_code} from {endpoint}"
+
+
 async def get_tools_with_resilience(
     connections: dict[str, dict[str, Any]],
 ) -> tuple[list, list[str], dict[str, str]]:
@@ -230,14 +582,33 @@ async def probe_server_tools(server: MCPServerConfig) -> list[dict[str, Any]]:
     # as a context manager. Use get_tools() directly instead.
     client = MultiServerMCPClient(connections, tool_name_prefix=True)
 
+    # Resolve the URL the transport actually used so any diagnostic
+    # re-probe targets the same address (otherwise admins would see a
+    # 404 against the un-healed legacy endpoint, which is confusing).
+    healed_probe_endpoint = _heal_endpoint(server) or server.endpoint
     try:
         tools = await client.get_tools()
     except BaseExceptionGroup as e:
-        # Extract meaningful error from exception group
         error_msg = _extract_error_message(e)
+        # The streamable-http MCP transport raises generic "Session
+        # terminated" / "Session closed" exceptions when the upstream
+        # closes the SSE leg early — including on a clean 401/403 from
+        # AgentGateway. Re-probe the endpoint directly so the UI sees a
+        # concrete HTTP status / connectivity reason instead of an opaque
+        # transport message.
+        if _is_opaque_transport_message(error_msg) and healed_probe_endpoint:
+            diagnostic = await _diagnose_endpoint_failure(healed_probe_endpoint)
+            raise RuntimeError(
+                f"Failed to connect to MCP server: {diagnostic}"
+            ) from e
         raise RuntimeError(f"Failed to connect to MCP server: {error_msg}") from e
     except Exception as e:
         error_msg = _extract_error_message(e)
+        if _is_opaque_transport_message(error_msg) and healed_probe_endpoint:
+            diagnostic = await _diagnose_endpoint_failure(healed_probe_endpoint)
+            raise RuntimeError(
+                f"Failed to probe MCP server: {diagnostic}"
+            ) from e
         raise RuntimeError(f"Failed to probe MCP server: {error_msg}") from e
 
     # Convert tools to serializable dicts

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_endpoint_normalizer.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_endpoint_normalizer.py
@@ -1,0 +1,104 @@
+"""Normalise MCP server endpoints that route through AgentGateway.
+
+This is the Python mirror of ``ui/src/lib/rbac/mcp-endpoint-normalizer.ts``.
+
+Invariant: when an MCP server is dispatched via AgentGateway, the gateway
+routes by path prefix ``/mcp/<target>``. A bare
+``http://agentgateway:4000/mcp`` falls through to AgentGateway's ``/mcp``
+route, which is not registered, and returns ``HTTP 404 Not Found`` on
+every probe and tool call.
+
+The Web UI BFF normalises endpoints on save (see ``POST/PUT
+/api/mcp-servers``). This module exists so the dynamic-agents probe and
+runtime paths can self-heal at read time too — defence in depth against
+stale Mongo rows that were written before the save-side normaliser
+existed.
+
+Pure functions only: no I/O. Callers pass the configured AgentGateway
+base URL so dev/staging/prod and per-tenant overrides flow through one
+decision point.
+"""
+
+from __future__ import annotations
+
+import re
+
+_PROTOCOL_HOST_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*://[^/]+)")
+
+
+def _strip_trailing_slashes(url: str) -> str:
+    return re.sub(r"/+$", "", url)
+
+
+def _collapse_slashes(url: str) -> str:
+    # Preserve the protocol's ``//`` separator while collapsing every
+    # other run of consecutive slashes in the path.
+    return re.sub(r"([^:])/{2,}", r"\1/", url)
+
+
+def _without_mcp_suffix(url: str) -> str:
+    return url[: -len("/mcp")] if url.endswith("/mcp") else url
+
+
+def _origin_of(url: str) -> str:
+    match = _PROTOCOL_HOST_RE.match(url)
+    return match.group(1) if match else ""
+
+
+def is_agent_gateway_base_endpoint(endpoint: str, agent_gateway_base_url: str) -> bool:
+    """True iff ``endpoint`` points at the gateway base with no target suffix.
+
+    These are the rows we must repair — a "naked" gateway URL. Anything
+    else is either healthy (target-qualified) or a direct upstream and
+    must NOT be rewritten.
+    """
+    if not endpoint or not agent_gateway_base_url:
+        return False
+    trimmed_endpoint = _strip_trailing_slashes(_collapse_slashes(endpoint))
+    trimmed_base = _strip_trailing_slashes(_collapse_slashes(agent_gateway_base_url))
+    base_origin = _origin_of(trimmed_base)
+    if not base_origin or _origin_of(trimmed_endpoint) != base_origin:
+        return False
+    endpoint_minus_mcp = _without_mcp_suffix(trimmed_endpoint)
+    base_minus_mcp = _without_mcp_suffix(trimmed_base)
+    return endpoint_minus_mcp in (base_minus_mcp, trimmed_base)
+
+
+def normalize_mcp_endpoint_for_server(
+    endpoint: str | None,
+    server_id: str,
+    agent_gateway_base_url: str,
+) -> str | None:
+    """Return the endpoint in target-qualified form when appropriate.
+
+    Behaviour:
+        - ``endpoint is None``  → ``None`` (stdio servers)
+        - ``endpoint == ""``    → ``""``  (preserve caller's empty value)
+        - ``server_id`` empty   → ``endpoint`` unchanged (we refuse to
+          invent a suffix; failing closed surfaces bad call sites loudly)
+        - Endpoint origin ≠ gateway origin → unchanged (direct upstreams
+          are valid; AgentGateway routing is opt-in per server)
+        - Otherwise: rewrite to ``{base}/mcp/{server_id}``, repairing
+          bare bases, missing ``/mcp`` segments, and wrong suffixes
+          (e.g. after a server rename) in one shot.
+    """
+    if endpoint is None:
+        return None
+    if endpoint == "":
+        return ""
+    if not server_id.strip():
+        return endpoint
+
+    trimmed_endpoint = _strip_trailing_slashes(_collapse_slashes(endpoint))
+    trimmed_base = _strip_trailing_slashes(_collapse_slashes(agent_gateway_base_url))
+    if not trimmed_base:
+        return endpoint
+
+    if _origin_of(trimmed_endpoint) != _origin_of(trimmed_base):
+        return endpoint
+
+    base_with_mcp = (
+        trimmed_base if trimmed_base.endswith("/mcp") else f"{trimmed_base}/mcp"
+    )
+    expected = f"{base_with_mcp}/{server_id.strip()}"
+    return expected

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mongo.py
@@ -98,6 +98,8 @@ class MongoDBService:
             return DynamicAgentConfig(**doc)
         return None
 
+
+
     # =========================================================================
     # Read-only MCP server access
     # =========================================================================

--- a/ai_platform_engineering/dynamic_agents/tests/test_chat_pdp_gate.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_chat_pdp_gate.py
@@ -1,0 +1,170 @@
+"""Route-level tests for Dynamic Agents OpenFGA execution gates."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from dynamic_agents.models import ChatRequest, DynamicAgentConfig, UserContext
+from dynamic_agents.routes import chat
+
+
+def _agent() -> DynamicAgentConfig:
+    return DynamicAgentConfig(
+        _id="agent-1",
+        name="Platform Agent",
+        description="Test agent",
+        system_prompt="help",
+        model={"id": "test-model", "provider": "test-provider"},
+        owner_id="owner@example.com",
+    )
+
+
+class _FakeMongo:
+    def __init__(self) -> None:
+        self.get_agent_calls = 0
+
+    def get_agent(self, agent_id: str) -> DynamicAgentConfig:
+        self.get_agent_calls += 1
+        return _agent()
+
+    def get_agent_mcp_servers(self, agent: DynamicAgentConfig) -> list:
+        raise AssertionError("MCP lookup should not happen before authorization")
+
+
+class _FakeRuntimeCache:
+    def __init__(self) -> None:
+        self.cancel_calls: list[tuple[str, str]] = []
+
+    def cancel_stream(self, agent_id: str, conversation_id: str) -> bool:
+        self.cancel_calls.append((agent_id, conversation_id))
+        return True
+
+
+async def _deny(agent_id: str) -> None:
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "success": False,
+            "code": "agent#use",
+            "reason": "pdp_denied",
+            "action": "contact_admin",
+        },
+    )
+
+
+async def _unavailable(agent_id: str) -> None:
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "success": False,
+            "code": "PDP_UNAVAILABLE",
+            "reason": "pdp_unavailable",
+            "action": "retry",
+        },
+    )
+
+
+async def _missing_bearer(agent_id: str) -> None:
+    raise HTTPException(
+        status_code=401,
+        detail={
+            "success": False,
+            "code": "missing_bearer",
+            "reason": "not_signed_in",
+            "action": "sign_in",
+        },
+    )
+
+
+async def _invalid_bearer(agent_id: str) -> None:
+    raise HTTPException(
+        status_code=401,
+        detail={
+            "success": False,
+            "code": "bearer_invalid",
+            "reason": "bearer_invalid",
+            "action": "sign_in",
+        },
+    )
+
+
+def _user() -> UserContext:
+    return UserContext(email="alice@example.com")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler", "chat_request"),
+    [
+        (
+            chat.chat_start_stream,
+            ChatRequest(message="hi", conversation_id="conv-1", agent_id="agent-1"),
+        ),
+        (
+            chat.chat_invoke,
+            ChatRequest(message="hi", conversation_id="conv-1", agent_id="agent-1"),
+        ),
+        (
+            chat.chat_resume_stream,
+            chat.ResumeStreamRequest(conversation_id="conv-1", agent_id="agent-1", resume_data="{}"),
+        ),
+    ],
+)
+async def test_protected_routes_stop_before_runtime_work(monkeypatch, handler, chat_request):
+    monkeypatch.setattr(chat, "require_agent_use_permission", _deny, raising=False)
+    mongo = _FakeMongo()
+
+    with pytest.raises(HTTPException) as exc:
+        await handler(chat_request, _user(), mongo)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["reason"] == "pdp_denied"
+    assert mongo.get_agent_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("authz", "status", "code", "reason", "action"),
+    [
+        (_deny, 403, "agent#use", "pdp_denied", "contact_admin"),
+        (_unavailable, 503, "PDP_UNAVAILABLE", "pdp_unavailable", "retry"),
+        (_missing_bearer, 401, "missing_bearer", "not_signed_in", "sign_in"),
+        (_invalid_bearer, 401, "bearer_invalid", "bearer_invalid", "sign_in"),
+    ],
+)
+async def test_start_route_preserves_authz_failure_shape(monkeypatch, authz, status, code, reason, action):
+    monkeypatch.setattr(chat, "require_agent_use_permission", authz, raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await chat.chat_start_stream(
+            ChatRequest(message="hi", conversation_id="conv-1", agent_id="agent-1"),
+            _user(),
+            _FakeMongo(),
+        )
+
+    assert exc.value.status_code == status
+    assert exc.value.detail["code"] == code
+    assert exc.value.detail["reason"] == reason
+    assert exc.value.detail["action"] == action
+
+
+@pytest.mark.asyncio
+async def test_cancel_stream_remains_openfga_ungated(monkeypatch):
+    async def fail_if_called(agent_id: str) -> None:
+        raise AssertionError("cancel must not be OpenFGA gated")
+
+    cache = _FakeRuntimeCache()
+    monkeypatch.setattr(chat, "require_agent_use_permission", fail_if_called, raising=False)
+    monkeypatch.setattr(chat, "get_runtime_cache", lambda: cache)
+    mongo = _FakeMongo()
+
+    result = await chat.cancel_stream(
+        chat.CancelStreamRequest(conversation_id="conv-1", agent_id="agent-1"),
+        _user(),
+        mongo,
+    )
+
+    assert result["success"] is True
+    assert result["cancelled"] is True
+    assert cache.cancel_calls == [("agent-1", "conv-1")]

--- a/ai_platform_engineering/dynamic_agents/tests/test_jwks_validate.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_jwks_validate.py
@@ -1,0 +1,336 @@
+"""Unit tests for the **vendored** ``dynamic_agents.auth.jwks_validate``.
+
+This module is a copy of ``ai_platform_engineering.utils.auth.jwks_validate``
+that ships *inside* the dynamic-agents runtime container (the shared
+``ai_platform_engineering.utils.*`` package is NOT installed in that image,
+so the vendored copy is what every Bearer-validated request actually
+loads — see ``jwt_middleware._validate_bearer_or_none``).
+
+The shared copy has its own tests in ``tests/rbac/unit/py/test_jwks_validate.py``.
+This file pins the **vendored** copy independently so a drift between the two
+(env-var names, defaults, audience semantics, etc.) cannot silently regress
+the runtime path that Kevin's pod actually executes.
+
+Specifically, these tests document and pin the two failure modes that bit a
+recent in-cluster install:
+
+1. ``KEYCLOAK_URL`` unset → ``_kc_base_url()`` falls back to
+   ``http://localhost:7080``. Inside a pod that fetches JWKS server-to-server
+   and the result is ``Connection refused`` — this test makes that default
+   explicit so anyone touching the resolver knows the trap.
+2. ``OIDC_ISSUER`` unset but the token's ``iss`` is the *browser-facing*
+   issuer (e.g. ``https://idp.public/realms/caipe``) while ``KEYCLOAK_URL``
+   points at the *in-cluster* service (``http://caipe-keycloak:8080``).
+   ``_kc_issuer()`` derives ``http://caipe-keycloak:8080/realms/caipe`` and
+   PyJWT rejects the token with ``InvalidIssuerError`` even though JWKS
+   fetch itself works.
+
+assisted-by Claude:claude-opus-4-7
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from dynamic_agents.auth import jwks_validate
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Keypair:
+    private_pem: bytes
+    public_key: object  # cryptography RSAPublicKey
+
+
+@pytest.fixture(scope="module")
+def keypair() -> _Keypair:
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return _Keypair(private_pem=pem, public_key=priv.public_key())
+
+
+def _mint(
+    keypair: _Keypair,
+    *,
+    issuer: str,
+    audience: str = "caipe-platform",
+    sub: str = "test-user",
+    exp_offset_s: int = 600,
+) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": issuer,
+            "aud": audience,
+            "sub": sub,
+            "iat": now,
+            "exp": now + exp_offset_s,
+        },
+        keypair.private_pem,
+        algorithm="RS256",
+    )
+
+
+@pytest.fixture
+def patch_jwks(keypair: _Keypair, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``PyJWKClient.get_signing_key_from_jwt`` return our public key
+    so the validator never reaches the network. The resolver functions
+    (``_kc_jwks_uri`` etc.) still run with whatever env vars the test set.
+    """
+
+    class _SigningKey:
+        key = keypair.public_key
+
+    def _fake(self, _token):  # noqa: ANN001
+        return _SigningKey()
+
+    monkeypatch.setattr(jwks_validate.PyJWKClient, "get_signing_key_from_jwt", _fake)
+
+
+@pytest.fixture(autouse=True)
+def _reset_jwks_cache() -> None:
+    """Each test starts with an empty JWKS-client cache so module-level state
+    doesn't leak across tests. The cache key is the JWKS URI, so a test that
+    mints with ``KEYCLOAK_URL=http://kc-a`` and one that mints with
+    ``KEYCLOAK_URL=http://kc-b`` MUST get distinct PyJWKClient instances.
+    """
+    jwks_validate.reset_jwks_cache_for_tests()
+    yield
+    jwks_validate.reset_jwks_cache_for_tests()
+
+
+@pytest.fixture
+def _clear_kc_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every Keycloak/OIDC env var the resolver looks at so each test
+    starts from a clean slate and ``os.environ.get(..., default)`` returns
+    the in-code default, not whatever the caller's shell happens to export.
+    """
+    for var in (
+        "KEYCLOAK_URL",
+        "KEYCLOAK_REALM",
+        "OIDC_ISSUER",
+        "KEYCLOAK_ISSUER",
+        "OIDC_DISCOVERY_URL",
+        "KEYCLOAK_JWKS_URL",
+        "OIDC_JWKS_URL",
+        "KEYCLOAK_AUDIENCE",
+        "OIDC_AUDIENCE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Resolver-layer tests (this is where the Kevin bug lives)
+# ---------------------------------------------------------------------------
+
+
+def test_kc_base_url_unset_defaults_to_localhost_trap(_clear_kc_env) -> None:
+    """``KEYCLOAK_URL`` unset → ``http://localhost:7080``.
+
+    Pinning this default is intentional: it documents the trap that bites
+    deployments where the chart forgets to plumb ``KEYCLOAK_URL`` into the
+    dynamic-agents pod. Anyone changing the default must also update the
+    chart wiring (see ``tests/test_dynamic_agents_chart_keycloak_env.py``).
+    """
+    assert jwks_validate._kc_base_url() == "http://localhost:7080"
+
+
+def test_kc_base_url_strips_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080/")
+    assert jwks_validate._kc_base_url() == "http://caipe-keycloak:8080"
+
+
+def test_kc_realm_defaults_to_caipe(_clear_kc_env) -> None:
+    assert jwks_validate._kc_realm() == "caipe"
+
+
+def test_kc_issuer_explicit_oidc_issuer_wins(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    """``OIDC_ISSUER`` set → returned verbatim, NOT derived from KEYCLOAK_URL.
+
+    This is the only configuration that lets in-cluster JWKS fetch
+    (``KEYCLOAK_URL=http://caipe-keycloak:8080``) coexist with the
+    browser-facing ``iss`` claim baked in by Keycloak's ``KC_HOSTNAME``.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("OIDC_ISSUER", "https://idp.public.example.com/realms/caipe")
+    assert jwks_validate._kc_issuer() == "https://idp.public.example.com/realms/caipe"
+
+
+def test_kc_issuer_keycloak_issuer_legacy_env(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    """Legacy ``KEYCLOAK_ISSUER`` is still honoured when ``OIDC_ISSUER`` is unset."""
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("KEYCLOAK_ISSUER", "https://idp.legacy.example.com/realms/caipe")
+    assert jwks_validate._kc_issuer() == "https://idp.legacy.example.com/realms/caipe"
+
+
+def test_kc_issuer_derived_from_keycloak_url_when_no_explicit(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    """``OIDC_ISSUER`` unset → derived from ``KEYCLOAK_URL``.
+
+    This is fine when KEYCLOAK_URL is browser-facing too (dev compose), but
+    breaks the moment the cluster splits the in-network service URL from the
+    public issuer — see ``test_token_with_public_issuer_fails_without_oidc_issuer``.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("KEYCLOAK_REALM", "caipe")
+    assert jwks_validate._kc_issuer() == "http://caipe-keycloak:8080/realms/caipe"
+
+
+def test_kc_issuer_strips_trailing_slash(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    monkeypatch.setenv("OIDC_ISSUER", "https://idp.public.example.com/realms/caipe/")
+    assert jwks_validate._kc_issuer() == "https://idp.public.example.com/realms/caipe"
+
+
+def test_kc_jwks_uri_derived_from_keycloak_url(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    """JWKS URI MUST be the in-cluster URL (so the server-to-server fetch
+    actually works), not the browser-facing issuer. That's the whole reason
+    the resolver picks ``KEYCLOAK_URL`` not ``OIDC_ISSUER`` here.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("OIDC_ISSUER", "https://idp.public.example.com/realms/caipe")
+    assert (
+        jwks_validate._kc_jwks_uri()
+        == "http://caipe-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
+    )
+
+
+def test_kc_jwks_uri_explicit_override_wins(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    """``KEYCLOAK_JWKS_URL`` overrides the derived path."""
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("KEYCLOAK_JWKS_URL", "http://kc-internal.example/realms/caipe/protocol/openid-connect/certs")
+    assert (
+        jwks_validate._kc_jwks_uri()
+        == "http://kc-internal.example/realms/caipe/protocol/openid-connect/certs"
+    )
+
+
+def test_kc_jwks_uri_oidc_jwks_url_alias(monkeypatch: pytest.MonkeyPatch, _clear_kc_env) -> None:
+    """``OIDC_JWKS_URL`` is the alternate spelling and also wins over the derived path."""
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("OIDC_JWKS_URL", "http://kc-alt.example/realms/caipe/protocol/openid-connect/certs")
+    assert (
+        jwks_validate._kc_jwks_uri()
+        == "http://kc-alt.example/realms/caipe/protocol/openid-connect/certs"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end validator tests — exercising the resolver via validate_bearer_jwt
+# ---------------------------------------------------------------------------
+
+
+def test_token_with_public_issuer_validates_when_oidc_issuer_is_set(
+    patch_jwks,
+    keypair: _Keypair,
+    monkeypatch: pytest.MonkeyPatch,
+    _clear_kc_env,
+) -> None:
+    """Kevin's prod topology: public issuer ≠ in-cluster KEYCLOAK_URL,
+    but ``OIDC_ISSUER`` is configured → token passes validation.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("OIDC_ISSUER", "https://idp.public.example.com/realms/caipe")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "caipe-platform")
+
+    token = _mint(
+        keypair,
+        issuer="https://idp.public.example.com/realms/caipe",
+        audience="caipe-platform",
+    )
+
+    claims = jwks_validate.validate_bearer_jwt(token)
+    assert claims["sub"] == "test-user"
+    assert claims["iss"] == "https://idp.public.example.com/realms/caipe"
+
+
+def test_token_with_public_issuer_fails_without_oidc_issuer(
+    patch_jwks,
+    keypair: _Keypair,
+    monkeypatch: pytest.MonkeyPatch,
+    _clear_kc_env,
+) -> None:
+    """Kevin's failure mode: token carries ``iss=https://idp.public/...``
+    but ``OIDC_ISSUER`` is unset so the validator derives the issuer from
+    the (in-cluster) ``KEYCLOAK_URL`` and rejects the mismatch.
+
+    PyJWT raises ``InvalidIssuerError`` (subclass of ``InvalidTokenError``).
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://caipe-keycloak:8080")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "caipe-platform")
+    # OIDC_ISSUER intentionally NOT set.
+
+    token = _mint(
+        keypair,
+        issuer="https://idp.public.example.com/realms/caipe",
+        audience="caipe-platform",
+    )
+
+    with pytest.raises(jwks_validate.InvalidTokenError):
+        jwks_validate.validate_bearer_jwt(token)
+
+
+def test_audience_list_accepts_either_aud(
+    patch_jwks,
+    keypair: _Keypair,
+    monkeypatch: pytest.MonkeyPatch,
+    _clear_kc_env,
+) -> None:
+    """Default audience list is ``caipe-platform,agentgateway`` — a token
+    carrying either ``aud`` value should pass. This is the spec-104 hot
+    path where Slack-bot OBO mints ``aud=agentgateway`` and UI flows mint
+    ``aud=caipe-platform``; the dynamic-agents service sits in front of
+    both and accepts either.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://kc.example:7080")
+    monkeypatch.setenv("OIDC_ISSUER", "http://kc.example:7080/realms/caipe")
+    # KEYCLOAK_AUDIENCE intentionally unset → in-code default applies.
+
+    token_agentgateway = _mint(
+        keypair,
+        issuer="http://kc.example:7080/realms/caipe",
+        audience="agentgateway",
+    )
+    token_platform = _mint(
+        keypair,
+        issuer="http://kc.example:7080/realms/caipe",
+        audience="caipe-platform",
+    )
+
+    assert jwks_validate.validate_bearer_jwt(token_agentgateway)["aud"] == "agentgateway"
+    assert jwks_validate.validate_bearer_jwt(token_platform)["aud"] == "caipe-platform"
+
+
+def test_empty_audience_disables_aud_check(
+    patch_jwks,
+    keypair: _Keypair,
+    monkeypatch: pytest.MonkeyPatch,
+    _clear_kc_env,
+) -> None:
+    """Empty / comma-only ``KEYCLOAK_AUDIENCE`` disables the audience check.
+
+    Dev escape hatch only — production should always pin an audience list.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://kc.example:7080")
+    monkeypatch.setenv("OIDC_ISSUER", "http://kc.example:7080/realms/caipe")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "  ,  ,  ")
+
+    token = _mint(
+        keypair,
+        issuer="http://kc.example:7080/realms/caipe",
+        audience="some-other-aud",
+    )
+
+    claims = jwks_validate.validate_bearer_jwt(token)
+    assert claims["aud"] == "some-other-aud"

--- a/ai_platform_engineering/dynamic_agents/tests/test_jwt_middleware.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_jwt_middleware.py
@@ -1,0 +1,157 @@
+"""Unit tests for ``dynamic_agents.auth.jwt_middleware`` (Spec 102 T110).
+
+Covers all four branches of ``JwtAuthMiddleware.dispatch``:
+
+1. No Authorization header, ``DA_REQUIRE_BEARER`` off  -> request passes,
+   ``current_user_token`` stays None (legacy X-User-Context path).
+2. No Authorization header, ``DA_REQUIRE_BEARER`` on  -> 401 with
+   ``code=missing_bearer`` and structured body.
+3. Valid Bearer  -> ``current_user_token`` set to the raw token, request
+   reaches the handler, contextvar reset on the way out.
+4. Invalid Bearer  -> 401 with ``code=bearer_invalid`` (NEVER falls
+   through to the legacy header path; this is the security boundary).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from typing import Any
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+def _build_app(monkeypatch, *, require_bearer: bool, validator):
+    """Build a fresh Starlette app with the middleware reloaded.
+
+    The middleware reads ``DA_REQUIRE_BEARER`` at import time, so we
+    re-import it under each scenario after monkeypatching the env.
+    """
+    monkeypatch.setenv("DA_REQUIRE_BEARER", "true" if require_bearer else "")
+
+    from dynamic_agents.auth import jwt_middleware as mw
+
+    importlib.reload(mw)
+
+    monkeypatch.setattr(mw, "_validate_bearer_or_none", validator)
+
+    from dynamic_agents.auth.token_context import current_user_token
+
+    seen: dict[str, Any] = {}
+
+    async def handler(request: Request) -> JSONResponse:
+        seen["token"] = current_user_token.get()
+        return JSONResponse({"ok": True})
+
+    app = Starlette(routes=[Route("/echo", handler, methods=["GET"])])
+    app.add_middleware(mw.JwtAuthMiddleware)
+    return app, seen
+
+
+def test_no_bearer_lenient_passes_through(monkeypatch):
+    app, seen = _build_app(
+        monkeypatch, require_bearer=False, validator=lambda _t: {"sub": "x"}
+    )
+    with TestClient(app) as client:
+        resp = client.get("/echo")
+    assert resp.status_code == 200
+    assert seen["token"] is None
+
+
+def test_no_bearer_strict_returns_401(monkeypatch):
+    app, _ = _build_app(
+        monkeypatch, require_bearer=True, validator=lambda _t: {"sub": "x"}
+    )
+    with TestClient(app) as client:
+        resp = client.get("/echo")
+    assert resp.status_code == 401
+    body = json.loads(resp.text)
+    assert body["code"] == "missing_bearer"
+    assert body["reason"] == "not_signed_in"
+    assert body["action"] == "sign_in"
+
+
+def test_healthz_bypasses_strict_bearer_requirement(monkeypatch):
+    """Health endpoints must stay probeable without auth."""
+    app, seen = _build_app(
+        monkeypatch, require_bearer=True, validator=lambda _t: {"sub": "x"}
+    )
+
+    async def health_handler(request: Request) -> JSONResponse:
+        seen["token"] = None
+        return JSONResponse({"status": "healthy"})
+
+    app.router.routes.append(Route("/healthz", health_handler, methods=["GET"]))
+
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_valid_bearer_binds_contextvar(monkeypatch):
+    app, seen = _build_app(
+        monkeypatch,
+        require_bearer=False,
+        validator=lambda _t: {"sub": "alice", "aud": "dynamic-agents"},
+    )
+    with TestClient(app) as client:
+        resp = client.get("/echo", headers={"Authorization": "Bearer good.jwt.here"})
+    assert resp.status_code == 200
+    assert seen["token"] == "good.jwt.here"
+
+    # Contextvar must be reset across requests so token does not leak
+    # to a subsequent unauthenticated call.
+    seen.clear()
+    with TestClient(app) as client:
+        resp = client.get("/echo")
+    assert resp.status_code == 200
+    assert seen["token"] is None
+
+
+def test_invalid_bearer_rejects_with_401_and_does_not_fallthrough(monkeypatch):
+    app, seen = _build_app(
+        monkeypatch, require_bearer=False, validator=lambda _t: None
+    )
+    with TestClient(app) as client:
+        resp = client.get("/echo", headers={"Authorization": "Bearer forged"})
+    assert resp.status_code == 401
+    body = json.loads(resp.text)
+    assert body["code"] == "bearer_invalid"
+    assert body["reason"] == "bearer_invalid"
+    # Critical: the handler must NOT have run — we never want a forged
+    # Bearer to silently fall through to the X-User-Context legacy path.
+    assert "token" not in seen
+
+
+def test_empty_bearer_value_is_treated_as_no_bearer(monkeypatch):
+    """``Authorization: Bearer `` with whitespace only must not 401 in lenient mode."""
+    app, seen = _build_app(
+        monkeypatch, require_bearer=False, validator=lambda _t: {"sub": "x"}
+    )
+    with TestClient(app) as client:
+        resp = client.get("/echo", headers={"Authorization": "Bearer    "})
+    assert resp.status_code == 200
+    assert seen["token"] is None
+
+
+@pytest.mark.parametrize("scheme", ["basic", "BEARER", "bearer"])
+def test_bearer_scheme_match_is_case_insensitive(monkeypatch, scheme):
+    app, seen = _build_app(
+        monkeypatch, require_bearer=False, validator=lambda _t: {"sub": "x"}
+    )
+    with TestClient(app) as client:
+        resp = client.get("/echo", headers={"Authorization": f"{scheme} tkn"})
+    if scheme.lower() == "bearer":
+        assert resp.status_code == 200
+        assert seen["token"] == "tkn"
+    else:
+        # Non-Bearer scheme: middleware ignores it entirely.
+        assert resp.status_code == 200
+        assert seen["token"] is None

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_credential_refs.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_credential_refs.py
@@ -1,0 +1,116 @@
+"""Tests for MCP credential reference resolution."""
+
+import pytest
+
+from dynamic_agents.models import MCPCredentialSource, MCPServerConfig, TransportType
+from dynamic_agents.services.mcp_client import build_mcp_connection_config, resolve_mcp_credential_refs
+
+
+class FakeCredentialClient:
+    async def retrieve_secret(self, secret_ref: str, *, intended_use: str) -> str:
+        assert secret_ref == "secret-1"
+        assert intended_use == "mcp_server"
+        return "github-token-value"
+
+    async def exchange_provider_connection_by_provider(self, provider: str, *, intended_use: str) -> dict:
+        assert provider == "atlassian"
+        assert intended_use == "mcp_server"
+        return {"access_token": "atlassian-oauth-token", "provider_connection_id": "conn-for-user"}
+
+
+@pytest.mark.asyncio
+async def test_resolves_secret_ref_to_stdio_env_when_impersonation_enabled(monkeypatch):
+    monkeypatch.setenv("USE_IMPERSONATION_TOKENS", "true")
+    server = MCPServerConfig(
+        _id="github",
+        name="GitHub",
+        transport=TransportType.STDIO,
+        command="github-mcp",
+        credential_sources=[
+            MCPCredentialSource(kind="secret_ref", target="env", name="GITHUB_TOKEN", secret_ref="secret-1")
+        ],
+    )
+    config = build_mcp_connection_config(server)
+
+    resolved = await resolve_mcp_credential_refs(
+        server,
+        config,
+        credential_client=FakeCredentialClient(),
+    )
+
+    assert resolved["env"]["GITHUB_TOKEN"] == "github-token-value"
+
+
+@pytest.mark.asyncio
+async def test_resolves_secret_ref_to_http_header_when_impersonation_enabled(monkeypatch):
+    monkeypatch.setenv("USE_IMPERSONATION_TOKENS", "true")
+    server = MCPServerConfig(
+        _id="jira",
+        name="Jira",
+        transport=TransportType.HTTP,
+        endpoint="http://jira-mcp:8080/mcp",
+        credential_sources=[
+            MCPCredentialSource(kind="secret_ref", target="header", name="Authorization", secret_ref="secret-1")
+        ],
+    )
+    config = build_mcp_connection_config(server)
+
+    resolved = await resolve_mcp_credential_refs(
+        server,
+        config,
+        credential_client=FakeCredentialClient(),
+    )
+
+    assert resolved["headers"]["Authorization"] == "Bearer github-token-value"
+
+
+@pytest.mark.asyncio
+async def test_resolves_provider_connection_by_provider_to_dedicated_header_when_impersonation_enabled(monkeypatch):
+    monkeypatch.setenv("USE_IMPERSONATION_TOKENS", "true")
+    server = MCPServerConfig(
+        _id="jira",
+        name="Jira",
+        transport=TransportType.HTTP,
+        endpoint="http://jira-mcp:8080/mcp",
+        credential_sources=[
+            MCPCredentialSource(
+                kind="provider_connection",
+                target="header",
+                name="X-CAIPE-Provider-Token",
+                provider="atlassian",
+            )
+        ],
+    )
+    config = build_mcp_connection_config(server, auth_bearer="keycloak-user-jwt")
+
+    resolved = await resolve_mcp_credential_refs(
+        server,
+        config,
+        credential_client=FakeCredentialClient(),
+    )
+
+    assert resolved["headers"]["Authorization"] == "Bearer keycloak-user-jwt"
+    assert resolved["headers"]["X-CAIPE-Provider-Token"] == "atlassian-oauth-token"
+
+
+@pytest.mark.asyncio
+async def test_credential_refs_are_noop_when_impersonation_disabled(monkeypatch):
+    monkeypatch.setenv("USE_IMPERSONATION_TOKENS", "false")
+    server = MCPServerConfig(
+        _id="github",
+        name="GitHub",
+        transport=TransportType.STDIO,
+        command="github-mcp",
+        credential_sources=[
+            MCPCredentialSource(kind="secret_ref", target="env", name="GITHUB_TOKEN", secret_ref="secret-1")
+        ],
+    )
+    config = build_mcp_connection_config(server)
+
+    resolved = await resolve_mcp_credential_refs(
+        server,
+        config,
+        credential_client=FakeCredentialClient(),
+    )
+
+    assert "env" not in resolved

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_endpoint_self_heal.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_endpoint_self_heal.py
@@ -1,0 +1,98 @@
+"""Tests for runtime self-heal of stale AgentGateway MCP endpoints.
+
+Background: when an MCP server card is saved with a bare AgentGateway
+URL (``http://agentgateway:4000/mcp``) instead of the target-qualified
+form (``http://agentgateway:4000/mcp/<server_id>``), every probe and
+tool call returns ``HTTP 404 Not Found`` because AgentGateway dispatches
+by path prefix.
+
+The Web UI BFF now normalises endpoints on save, but legacy rows can
+still exist in Mongo (and were the trigger for the Confluence 404). The
+dynamic-agents side defends against those by normalising at read time
+inside ``build_mcp_connection_config``. These tests pin that behaviour.
+"""
+
+from __future__ import annotations
+
+from dynamic_agents.models import MCPServerConfig, TransportType
+from dynamic_agents.services.mcp_client import build_mcp_connection_config
+
+
+def _server_with_endpoint(endpoint: str) -> MCPServerConfig:
+    return MCPServerConfig(
+        _id="confluence",
+        name="Confluence",
+        transport=TransportType.HTTP,
+        endpoint=endpoint,
+    )
+
+
+def test_runtime_rewrites_bare_gateway_url_when_no_explicit_gateway_arg(monkeypatch):
+    """The probe path passes no ``agent_gateway_url`` argument, so it
+    relies on read-time self-heal. With ``AGENT_GATEWAY_URL`` set and a
+    stale bare endpoint, the transport URL must be repaired to
+    ``/mcp/<server_id>``.
+    """
+    monkeypatch.setenv("AGENT_GATEWAY_URL", "http://agentgateway:4000")
+    server = _server_with_endpoint("http://agentgateway:4000/mcp")
+
+    config = build_mcp_connection_config(server)
+
+    assert config["url"] == "http://agentgateway:4000/mcp/confluence"
+    assert config["transport"] == "streamable_http"
+
+
+def test_runtime_leaves_correctly_qualified_endpoint_alone(monkeypatch):
+    monkeypatch.setenv("AGENT_GATEWAY_URL", "http://agentgateway:4000")
+    server = _server_with_endpoint("http://agentgateway:4000/mcp/confluence")
+
+    config = build_mcp_connection_config(server)
+
+    assert config["url"] == "http://agentgateway:4000/mcp/confluence"
+
+
+def test_runtime_leaves_direct_upstream_endpoint_alone(monkeypatch):
+    """Direct-to-pod URLs must not be rewritten — AgentGateway routing is
+    opt-in per server, and silently rewriting these would break stdio
+    and in-cluster topologies.
+    """
+    monkeypatch.setenv("AGENT_GATEWAY_URL", "http://agentgateway:4000")
+    server = _server_with_endpoint("http://mcp-confluence:8000/mcp")
+
+    config = build_mcp_connection_config(server)
+
+    assert config["url"] == "http://mcp-confluence:8000/mcp"
+
+
+def test_runtime_self_heal_no_op_when_no_gateway_url_env(monkeypatch):
+    """Without ``AGENT_GATEWAY_URL`` we have no anchor to recognise a
+    "naked" gateway URL, so the read-time normaliser must NOT rewrite
+    anything (else it would mangle legitimate URLs in tenants that
+    don't use AgentGateway at all).
+    """
+    monkeypatch.delenv("AGENT_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("AGENTGATEWAY_URL", raising=False)
+    server = _server_with_endpoint("http://agentgateway:4000/mcp")
+
+    config = build_mcp_connection_config(server)
+
+    # No env → no anchor → leave the endpoint exactly as it was. The
+    # probe will still fail (this is real misconfiguration) but the
+    # failure mode is preserved and obvious instead of mysteriously
+    # changing depending on env.
+    assert config["url"] == "http://agentgateway:4000/mcp"
+
+
+def test_runtime_explicit_gateway_arg_still_works(monkeypatch):
+    """When called from ``build_mcp_connections`` (which DOES pass
+    ``agent_gateway_url``), the explicit-gateway rewrite still wins.
+    Self-heal is the fallback, not a replacement.
+    """
+    monkeypatch.setenv("AGENT_GATEWAY_URL", "http://agentgateway:4000")
+    server = _server_with_endpoint("http://agentgateway:4000/mcp")
+
+    config = build_mcp_connection_config(
+        server, agent_gateway_url="http://agentgateway:4000"
+    )
+
+    assert config["url"] == "http://agentgateway:4000/mcp/confluence"

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_token_forwarding.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_token_forwarding.py
@@ -1,0 +1,195 @@
+"""Verify the MCP httpx_client_factory injects the per-request user JWT.
+
+Spec 102 Phase 8 / T111 (the "OBO MCP test" — we test the per-request
+token forwarding contract directly, since the OBO swap itself is a
+separate codepath covered in ``test_obo_exchange.py``).
+
+These tests use an in-process HTTP server so we never touch the network
+and do not need to import any langchain-mcp-adapters internals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from dynamic_agents.auth.token_context import current_user_token
+from dynamic_agents.models import MCPServerConfig, TransportType
+from dynamic_agents.services.mcp_client import (
+    build_agent_context_headers,
+    build_httpx_client_factory,
+    build_mcp_connection_config,
+    build_mcp_connections,
+)
+
+
+class _CapturingHandler(BaseHTTPRequestHandler):
+    captured: dict[str, str] = {}
+
+    def do_GET(self):  # noqa: N802
+        self.__class__.captured = {k.lower(): v for k, v in self.headers.items()}
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+
+    def log_message(self, *_a, **_kw):
+        pass
+
+
+@contextmanager
+def _running_server():
+    server = HTTPServer(("127.0.0.1", 0), _CapturingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_factory_injects_bearer_when_contextvar_is_set():
+    factory = build_httpx_client_factory()
+    token = current_user_token.set("tok-abc")
+    try:
+        with _running_server() as base:
+            async with factory() as client:
+                await client.get(f"{base}/probe")
+    finally:
+        current_user_token.reset(token)
+    assert _CapturingHandler.captured.get("authorization") == "Bearer tok-abc"
+
+
+@pytest.mark.asyncio
+async def test_factory_omits_bearer_when_contextvar_is_unset():
+    _CapturingHandler.captured = {}
+    factory = build_httpx_client_factory()
+    with _running_server() as base:
+        async with factory() as client:
+            await client.get(f"{base}/probe")
+    assert "authorization" not in _CapturingHandler.captured
+
+
+@pytest.mark.asyncio
+async def test_factory_isolates_token_across_concurrent_tasks():
+    """ContextVar must be per-task: two concurrent requests with different
+    tokens must not see each other's value."""
+    factory = build_httpx_client_factory()
+    seen: list[str | None] = []
+
+    async def call_with_token(tok: str | None, base: str) -> None:
+        token_ref = current_user_token.set(tok)
+        try:
+            async with factory() as client:
+                await client.get(f"{base}/probe")
+            # Don't read response — read what _CapturingHandler captured.
+            seen.append(_CapturingHandler.captured.get("authorization"))
+        finally:
+            current_user_token.reset(token_ref)
+
+    with _running_server() as base:
+        # Sequential gather to keep the captured-headers assertion deterministic;
+        # the contextvar isolation guarantee is what we're really after.
+        await asyncio.gather(
+            call_with_token("alpha", base),
+            return_exceptions=False,
+        )
+        first = _CapturingHandler.captured.get("authorization")
+        await asyncio.gather(
+            call_with_token("beta", base),
+            return_exceptions=False,
+        )
+        second = _CapturingHandler.captured.get("authorization")
+
+    assert first == "Bearer alpha"
+    assert second == "Bearer beta"
+
+
+@pytest.mark.asyncio
+async def test_factory_preserves_caller_provided_headers():
+    factory = build_httpx_client_factory()
+    token = current_user_token.set("xyz")
+    try:
+        with _running_server() as base:
+            async with factory(headers={"X-Trace-Id": "abc-123"}) as client:
+                await client.get(f"{base}/probe")
+    finally:
+        current_user_token.reset(token)
+    assert _CapturingHandler.captured.get("x-trace-id") == "abc-123"
+    assert _CapturingHandler.captured.get("authorization") == "Bearer xyz"
+
+
+def test_streamable_http_connection_config_includes_context_bearer_header():
+    server = MCPServerConfig(
+        id="jira",
+        name="Jira",
+        transport=TransportType.HTTP,
+        endpoint="http://agentgateway:4000/mcp",
+        enabled=True,
+    )
+    token = current_user_token.set("probe-token")
+    try:
+        config = build_mcp_connection_config(server)
+    finally:
+        current_user_token.reset(token)
+
+    assert config["transport"] == "streamable_http"
+    assert config["headers"]["Authorization"] == "Bearer probe-token"
+
+
+def test_streamable_http_connection_config_includes_signed_agent_context(monkeypatch):
+    monkeypatch.setenv("CAIPE_AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+    server = MCPServerConfig(
+        id="jira",
+        name="Jira",
+        transport=TransportType.HTTP,
+        endpoint="http://agentgateway:4000/mcp",
+        enabled=True,
+    )
+
+    config = build_mcp_connection_config(server, agent_id="agent-test-april-2025")
+
+    assert config["headers"]["X-CAIPE-Agent-Context"]
+    assert config["headers"]["X-CAIPE-Agent-Context-Signature"]
+
+
+def test_agent_context_headers_are_omitted_without_shared_secret(monkeypatch):
+    monkeypatch.delenv("CAIPE_AGENT_CONTEXT_HMAC_SECRET", raising=False)
+
+    assert build_agent_context_headers("agent-test-april-2025") == {}
+
+
+def test_gateway_routing_only_rewrites_declared_gateway_targets(monkeypatch):
+    """A shared AgentGateway MCP backend must not relabel Jira tools as KB tools."""
+    monkeypatch.setenv("AGENT_GATEWAY_MCP_SERVER_IDS", "jira")
+    servers = [
+        MCPServerConfig(
+            id="jira",
+            name="Jira",
+            transport=TransportType.HTTP,
+            endpoint="http://mcp-jira:8000/mcp",
+            enabled=True,
+        ),
+        MCPServerConfig(
+            id="knowledge-base",
+            name="Knowledge Base",
+            transport=TransportType.HTTP,
+            endpoint="http://rag-server:9446/mcp",
+            enabled=True,
+        ),
+    ]
+
+    connections = build_mcp_connections(
+        servers,
+        ["jira", "knowledge-base"],
+        agent_gateway_url="http://agentgateway:4000",
+    )
+
+    assert connections["jira"]["url"] == "http://agentgateway:4000/mcp/jira"
+    assert connections["knowledge-base"]["url"] == "http://rag-server:9446/mcp"

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_endpoint_normalizer.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_endpoint_normalizer.py
@@ -1,0 +1,112 @@
+"""Tests for the dynamic-agents MCP endpoint normaliser.
+
+Mirrors ``ui/src/lib/rbac/__tests__/mcp-endpoint-normalizer.test.ts``.
+Keeping the two test suites symmetric is intentional: a divergence
+between the Web UI's save-time normalisation and the dynamic-agents
+read-time normalisation would re-introduce the bug we are fixing.
+"""
+
+from __future__ import annotations
+
+from dynamic_agents.services.mcp_endpoint_normalizer import (
+    is_agent_gateway_base_endpoint,
+    normalize_mcp_endpoint_for_server,
+)
+
+
+BASE = "http://agentgateway:4000"
+
+
+def fix(endpoint: str | None, server_id: str, base: str = BASE) -> str | None:
+    return normalize_mcp_endpoint_for_server(endpoint, server_id, base)
+
+
+def test_appends_server_id_when_endpoint_is_bare_gateway_base():
+    assert fix("http://agentgateway:4000/mcp", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+
+
+def test_appends_server_id_when_endpoint_is_origin_only():
+    assert fix("http://agentgateway:4000", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+
+
+def test_strips_trailing_slashes_before_suffixing():
+    assert fix("http://agentgateway:4000/mcp/", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+    assert fix("http://agentgateway:4000/", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+
+
+def test_leaves_correctly_qualified_endpoint_alone():
+    assert fix("http://agentgateway:4000/mcp/confluence", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+
+
+def test_repairs_endpoint_that_names_wrong_target_id():
+    assert fix("http://agentgateway:4000/mcp/atlassian-confluence", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+
+
+def test_leaves_direct_upstream_endpoint_untouched():
+    assert (
+        fix("http://mcp-confluence:8000/mcp", "confluence")
+        == "http://mcp-confluence:8000/mcp"
+    )
+    assert (
+        fix("https://confluence.example.com/mcp", "confluence")
+        == "https://confluence.example.com/mcp"
+    )
+
+
+def test_leaves_none_or_empty_endpoint_alone():
+    assert fix(None, "confluence") is None
+    assert fix("", "confluence") == ""
+
+
+def test_uses_configured_base_url():
+    assert fix(
+        "https://gw.example.com/mcp",
+        "confluence",
+        "https://gw.example.com",
+    ) == "https://gw.example.com/mcp/confluence"
+
+
+def test_refuses_to_invent_a_suffix_when_server_id_is_empty():
+    assert fix("http://agentgateway:4000/mcp", "") == "http://agentgateway:4000/mcp"
+
+
+def test_collapses_double_slashes():
+    assert fix("http://agentgateway:4000//mcp//", "confluence") == (
+        "http://agentgateway:4000/mcp/confluence"
+    )
+
+
+def test_is_agent_gateway_base_endpoint_detects_bare_bases():
+    assert is_agent_gateway_base_endpoint("http://agentgateway:4000/mcp", BASE) is True
+    assert is_agent_gateway_base_endpoint("http://agentgateway:4000/mcp/", BASE) is True
+    assert is_agent_gateway_base_endpoint("http://agentgateway:4000", BASE) is True
+    assert is_agent_gateway_base_endpoint("http://agentgateway:4000/", BASE) is True
+
+
+def test_is_agent_gateway_base_endpoint_rejects_target_qualified():
+    assert (
+        is_agent_gateway_base_endpoint("http://agentgateway:4000/mcp/confluence", BASE)
+        is False
+    )
+    assert (
+        is_agent_gateway_base_endpoint("http://agentgateway:4000/mcp/jira", BASE)
+        is False
+    )
+
+
+def test_is_agent_gateway_base_endpoint_rejects_direct_upstream():
+    assert (
+        is_agent_gateway_base_endpoint("http://mcp-confluence:8000/mcp", BASE) is False
+    )

--- a/ai_platform_engineering/dynamic_agents/tests/test_no_x_user_context_in_outbound_paths.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_no_x_user_context_in_outbound_paths.py
@@ -1,0 +1,89 @@
+"""Structural guard: ``X-User-Context`` must NEVER appear in DA's executable outbound paths.
+
+Spec 102 Phase 8 / T112.
+
+The ``X-User-Context`` header is the **inbound** legacy contract from
+the BFF (Next.js) to DA. It carries opaque pre-computed authz flags but
+no token, so any code path that uses it for outbound auth (to
+agentgateway, MCP servers, Keycloak, etc.) is the bug that produced
+the live HTTP 401 we are fixing.
+
+This test scans the DA source tree for ``X-User-Context`` references in
+**executable Python code only** (comments, docstrings, and string
+literals are stripped before matching). Inbound parsing in
+``auth/auth.py`` is the only allowed executable use; the whole point of
+this test is to guarantee no future commit re-introduces the trusted-
+header outbound auth pattern by accident.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from pathlib import Path
+
+ALLOWED_EXEC_FILES = {
+    # auth.py is the inbound-only header parser. Reading the header here
+    # is correct because we are establishing the user identity, not using
+    # it for outbound auth.
+    "src/dynamic_agents/auth/auth.py",
+}
+
+PATTERN = re.compile(r"X-User-Context", re.IGNORECASE)
+
+
+def _da_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _strip_comments_and_strings(source: str) -> str:
+    """Return ``source`` with all COMMENT and STRING tokens replaced by spaces.
+
+    Using the ``tokenize`` module rather than regex so that tricky
+    constructs (triple-quoted strings, f-strings, escaped quotes inside
+    comments, etc.) are handled correctly.
+    """
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(source).readline))
+    except (tokenize.TokenError, IndentationError):
+        return source
+    out: list[str] = []
+    for tok_type, tok_str, _start, _end, _line in tokens:
+        if tok_type in (tokenize.COMMENT, tokenize.STRING):
+            out.append(" " * len(tok_str))
+        else:
+            out.append(tok_str + " ")
+    return "".join(out)
+
+
+def test_no_x_user_context_in_executable_code():
+    root = _da_root()
+    offenders: list[tuple[str, int, str]] = []
+    for path in list(root.rglob("*.py")):
+        rel = path.relative_to(root).as_posix()
+        if rel in ALLOWED_EXEC_FILES:
+            continue
+        if any(seg in rel for seg in ("__pycache__", ".venv/", "build/")):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        stripped = _strip_comments_and_strings(source)
+        if not PATTERN.search(stripped):
+            continue
+        # Re-scan original to give a useful line number in the failure msg.
+        for i, line in enumerate(source.splitlines(), 1):
+            if PATTERN.search(line):
+                # Skip pure-comment / pure-string lines via heuristic:
+                # check if the code-only line contains the token too.
+                code_only = _strip_comments_and_strings(line + "\n")
+                if PATTERN.search(code_only):
+                    offenders.append((rel, i, line.strip()))
+
+    assert not offenders, (
+        "X-User-Context must only appear in the inbound auth dependency "
+        "(auth/auth.py). Offending executable lines:\n"
+        + "\n".join(f"  {f}:{ln}: {txt}" for f, ln, txt in offenders)
+    )

--- a/ai_platform_engineering/dynamic_agents/tests/test_obo_exchange.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_obo_exchange.py
@@ -1,0 +1,169 @@
+"""Unit tests for ``dynamic_agents.auth.obo_exchange`` (Spec 102 T111).
+
+We do not stand up Keycloak; instead we monkeypatch ``httpx.AsyncClient.post``
+so the test verifies the exchange request shape, the cache, and the
+graceful-fallback contract.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from dynamic_agents.auth import obo_exchange
+
+
+def _fake_jwt(sub: str) -> str:
+    """Build an unsigned JWT whose payload has ``sub=<sub>``.
+
+    The real validation happens in the middleware; ``impersonate_user``
+    only decodes ``sub`` (unverified) for the cache key.
+    """
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"sub": sub}).encode())
+        .rstrip(b"=")
+        .decode()
+    )
+    return f"{header}.{payload}."
+
+
+@dataclass
+class _FakeResp:
+    status_code: int
+    _body: dict
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self._body)
+
+    def json(self) -> dict:
+        return self._body
+
+
+class _FakeClient:
+    def __init__(self, resp: _FakeResp, calls: list[dict]):
+        self._resp = resp
+        self._calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, *, data, headers):
+        self._calls.append({"url": url, "data": data, "headers": headers})
+        return self._resp
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_and_warning():
+    obo_exchange.clear_obo_cache()
+    yield
+    obo_exchange.clear_obo_cache()
+
+
+@pytest.fixture
+def _kc_env(monkeypatch):
+    monkeypatch.setenv("KEYCLOAK_DA_CLIENT_ID", "dynamic-agents")
+    monkeypatch.setenv("KEYCLOAK_DA_CLIENT_SECRET", "shh")
+    monkeypatch.setenv(
+        "OIDC_ISSUER", "http://kc.example/realms/caipe"
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_oidc_not_configured(monkeypatch):
+    monkeypatch.delenv("KEYCLOAK_DA_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("OIDC_DISCOVERY_URL", raising=False)
+    out = await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_successful_exchange_returns_new_token(monkeypatch, _kc_env):
+    calls: list[dict] = []
+    resp = _FakeResp(
+        200, {"access_token": "obo-1", "expires_in": 300, "token_type": "Bearer"}
+    )
+    monkeypatch.setattr(
+        obo_exchange.httpx, "AsyncClient", lambda *_a, **_kw: _FakeClient(resp, calls)
+    )
+
+    out = await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    assert out == "obo-1"
+    assert calls and calls[0]["url"].endswith(
+        "/realms/caipe/protocol/openid-connect/token"
+    )
+    body = calls[0]["data"]
+    assert body["grant_type"] == obo_exchange._OBO_GRANT_TYPE
+    assert body["audience"] == "agentgateway"
+    assert body["client_id"] == "dynamic-agents"
+    assert body["client_secret"] == "shh"
+    assert body["subject_token"] == _fake_jwt("alice")
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_second_exchange(monkeypatch, _kc_env):
+    calls: list[dict] = []
+    resp = _FakeResp(200, {"access_token": "obo-1", "expires_in": 600})
+    monkeypatch.setattr(
+        obo_exchange.httpx, "AsyncClient", lambda *_a, **_kw: _FakeClient(resp, calls)
+    )
+
+    one = await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    two = await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    assert one == "obo-1"
+    assert two == "obo-1"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_misses_on_different_user(monkeypatch, _kc_env):
+    calls: list[dict] = []
+    resp = _FakeResp(200, {"access_token": "obo-x", "expires_in": 600})
+    monkeypatch.setattr(
+        obo_exchange.httpx, "AsyncClient", lambda *_a, **_kw: _FakeClient(resp, calls)
+    )
+    await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    await obo_exchange.impersonate_user(_fake_jwt("bob"), "agentgateway")
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_within_safety_margin(monkeypatch, _kc_env):
+    """A cached token expiring within the 30s safety margin must be re-minted."""
+    calls: list[dict] = []
+    resp = _FakeResp(200, {"access_token": "obo-1", "expires_in": 5})
+    monkeypatch.setattr(
+        obo_exchange.httpx, "AsyncClient", lambda *_a, **_kw: _FakeClient(resp, calls)
+    )
+    await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    # Force the cache entry to look "near-expiry".
+    key = next(iter(obo_exchange._obo_cache))
+    obo_exchange._obo_cache[key].expires_at = time.time() + 5
+    await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_keycloak_5xx_returns_none(monkeypatch, _kc_env):
+    calls: list[dict] = []
+    resp = _FakeResp(500, {"error": "server"})
+    monkeypatch.setattr(
+        obo_exchange.httpx, "AsyncClient", lambda *_a, **_kw: _FakeClient(resp, calls)
+    )
+    out = await obo_exchange.impersonate_user(_fake_jwt("alice"), "agentgateway")
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_unparseable_subject_returns_none(monkeypatch, _kc_env):
+    out = await obo_exchange.impersonate_user("not-a-jwt", "agentgateway")
+    assert out is None

--- a/ai_platform_engineering/dynamic_agents/tests/test_openfga_authz.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_openfga_authz.py
@@ -1,0 +1,251 @@
+"""Unit tests for Dynamic Agents OpenFGA runtime authorization."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+
+import pytest
+from fastapi import HTTPException
+
+from dynamic_agents.auth.token_context import current_user_token
+
+
+def _fake_jwt(payload: dict) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}."
+
+
+@pytest.mark.asyncio
+async def test_openfga_check_forwards_traceparent(monkeypatch):
+    from dynamic_agents.auth import openfga_authz
+    from dynamic_agents.auth.token_context import current_traceparent
+
+    requests: list[tuple[str, dict[str, str] | None]] = []
+
+    class FakeResponse:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url: str, **kwargs):
+            requests.append((url, kwargs.get("headers")))
+            return FakeResponse({"stores": [{"name": "caipe-openfga", "id": "store-1"}]})
+
+        async def post(self, url: str, **kwargs):
+            requests.append((url, kwargs.get("headers")))
+            return FakeResponse({"allowed": True})
+
+    traceparent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    monkeypatch.setenv("OPENFGA_HTTP", "http://openfga:8080")
+    monkeypatch.setattr(openfga_authz.httpx, "AsyncClient", FakeClient)
+    trace_ref = current_traceparent.set(traceparent)
+    try:
+        assert await openfga_authz._check_agent_use("alice-sub", "agent-1") is True
+    finally:
+        current_traceparent.reset(trace_ref)
+
+    assert requests
+    assert all(headers and headers["traceparent"] == traceparent for _, headers in requests)
+
+
+@pytest.mark.asyncio
+async def test_allows_agent_use_when_openfga_allows(monkeypatch):
+    from dynamic_agents.auth import openfga_authz
+
+    calls: list[tuple[str, str]] = []
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        calls.append((subject, agent_id))
+        return True
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        await openfga_authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert calls == [("alice-sub", "agent-1")]
+
+
+@pytest.mark.asyncio
+async def test_allows_agent_use_with_email_membership_fallback(monkeypatch):
+    from dynamic_agents.auth import openfga_authz
+
+    calls: list[tuple[str, str]] = []
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        calls.append((subject, agent_id))
+        return subject == "alice@example.com"
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    token_ref = current_user_token.set(
+        _fake_jwt({"sub": "alice-sub", "email": "alice@example.com"})
+    )
+    try:
+        await openfga_authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert calls == [("alice-sub", "agent-1"), ("alice@example.com", "agent-1")]
+
+
+@pytest.mark.asyncio
+async def test_logs_openfga_rebac_audit_for_runtime_allow(monkeypatch, caplog):
+    from dynamic_agents.auth import openfga_authz
+
+    persisted: list[dict] = []
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    monkeypatch.setattr(
+        openfga_authz,
+        "_persist_openfga_rebac_audit",
+        lambda event: persisted.append(event),
+        raising=False,
+    )
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    with caplog.at_level(logging.INFO, logger="dynamic_agents.auth.openfga_authz"):
+        try:
+            await openfga_authz.require_agent_use_permission("agent-1")
+        finally:
+            current_user_token.reset(token_ref)
+
+    audit = json.loads(caplog.records[-1].message)
+    assert audit["type"] == "openfga_rebac"
+    assert audit["action"] == "dynamic_agent#use"
+    assert audit["outcome"] == "allow"
+    assert audit["pdp"] == "openfga"
+    assert audit["resource_ref"] == "agent:agent-1"
+    assert audit["subject_hash"].startswith("sha256:")
+    assert persisted == [audit]
+
+
+@pytest.mark.asyncio
+async def test_denies_agent_use_when_openfga_denies(monkeypatch):
+    from dynamic_agents.auth import openfga_authz
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await openfga_authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["reason"] == "pdp_denied"
+    assert exc.value.detail["action"] == "contact_admin"
+
+
+@pytest.mark.asyncio
+async def test_logs_openfga_rebac_audit_for_runtime_deny(monkeypatch, caplog):
+    from dynamic_agents.auth import openfga_authz
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    with caplog.at_level(logging.INFO, logger="dynamic_agents.auth.openfga_authz"):
+        try:
+            with pytest.raises(HTTPException):
+                await openfga_authz.require_agent_use_permission("agent-1")
+        finally:
+            current_user_token.reset(token_ref)
+
+    audit = json.loads(caplog.records[-1].message)
+    assert audit["type"] == "openfga_rebac"
+    assert audit["outcome"] == "deny"
+    assert audit["reason_code"] == "DENY_NO_CAPABILITY"
+
+
+@pytest.mark.asyncio
+async def test_fails_closed_when_openfga_is_unavailable(monkeypatch):
+    from dynamic_agents.auth import openfga_authz
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        raise RuntimeError("openfga unavailable")
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await openfga_authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["reason"] == "pdp_unavailable"
+    assert exc.value.detail["action"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_missing_bearer_returns_structured_401():
+    from dynamic_agents.auth import openfga_authz
+
+    with pytest.raises(HTTPException) as exc:
+        await openfga_authz.require_agent_use_permission("agent-1")
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "missing_bearer"
+    assert exc.value.detail["reason"] == "not_signed_in"
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_without_subject_returns_structured_401():
+    from dynamic_agents.auth import openfga_authz
+
+    token_ref = current_user_token.set(_fake_jwt({"email": "alice@example.com"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await openfga_authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "bearer_invalid"
+    assert exc.value.detail["reason"] == "bearer_invalid"
+
+
+@pytest.mark.asyncio
+async def test_invalid_agent_id_returns_structured_400(monkeypatch):
+    from dynamic_agents.auth import openfga_authz
+
+    async def fake_check(subject: str, agent_id: str) -> bool:
+        raise AssertionError("OpenFGA should not be called for invalid agent ids")
+
+    monkeypatch.setattr(openfga_authz, "_check_agent_use", fake_check)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await openfga_authz.require_agent_use_permission("../agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "invalid_agent_id"
+    assert exc.value.detail["reason"] == "invalid_request"

--- a/ai_platform_engineering/dynamic_agents/tests/test_probe_error_diagnostics.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_probe_error_diagnostics.py
@@ -1,0 +1,168 @@
+"""Regression tests for ``probe_server_tools`` error diagnostics.
+
+The MCP streamable-http transport surfaces upstream HTTP failures as a
+generic ``Session terminated`` string without an attached ``response``
+object, so the previous probe path produced the unhelpful banner
+"Failed to connect to MCP server: Session terminated" in the Create
+Agent UI whenever AgentGateway returned 401/403 (or the upstream MCP
+server returned any HTTP error early).
+
+The fix: when the underlying exception is an opaque session-termination
+message, ``probe_server_tools`` performs a direct HTTP probe against the
+same endpoint so it can attach the real HTTP status and reason phrase to
+the error surfaced upstream. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dynamic_agents.models import MCPServerConfig, TransportType
+from dynamic_agents.services import mcp_client
+
+
+class _StatusHandler(BaseHTTPRequestHandler):
+    """In-process HTTP handler that replies with a configurable status."""
+
+    status_code: int = 200
+    reason_phrase: str | None = None
+
+    def _respond(self) -> None:
+        status = self.__class__.status_code
+        reason = self.__class__.reason_phrase
+        if reason is not None:
+            self.send_response(status, reason)
+        else:
+            self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"detail":"upstream"}')
+
+    do_GET = _respond  # noqa: N815
+    do_POST = _respond  # noqa: N815
+    do_HEAD = _respond  # noqa: N815
+
+    def log_message(self, *_a, **_kw):
+        # Keep test output quiet.
+        return
+
+
+@contextmanager
+def _http_server(status: int, reason: str | None = None):
+    _StatusHandler.status_code = status
+    _StatusHandler.reason_phrase = reason
+    server = HTTPServer(("127.0.0.1", 0), _StatusHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/mcp"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def _make_server(endpoint: str) -> MCPServerConfig:
+    return MCPServerConfig(
+        _id="argocd",
+        name="Argocd",
+        transport=TransportType.HTTP,
+        endpoint=endpoint,
+        enabled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_translates_session_terminated_to_http_status_when_upstream_denies():
+    """A 401 from the upstream MCP server should surface as a concrete HTTP
+    status in the error message, not the opaque ``Session terminated`` string
+    that the streamable-http transport raises internally.
+    """
+
+    with _http_server(401) as endpoint:
+        server = _make_server(endpoint)
+
+        # Force the MCP client to raise the exact failure mode users hit:
+        # an ExceptionGroup containing an inner RuntimeError whose message is
+        # ``Session terminated``. ``probe_server_tools`` is expected to fall
+        # back to a direct HTTP probe and attach the real status code.
+        inner = RuntimeError("Session terminated")
+        group = ExceptionGroup("mcp transport failed", [inner])
+        with patch.object(
+            mcp_client,
+            "MultiServerMCPClient",
+            autospec=True,
+        ) as ctor:
+            ctor.return_value.get_tools = AsyncMock(side_effect=group)
+
+            with pytest.raises(RuntimeError) as excinfo:
+                await mcp_client.probe_server_tools(server)
+
+        message = str(excinfo.value)
+        # The new contract: surface the upstream HTTP status, not the opaque
+        # transport message.
+        assert "401" in message, f"expected upstream status in message: {message!r}"
+        assert "Session terminated" not in message, (
+            f"opaque transport message must be replaced: {message!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_probe_keeps_non_session_terminated_errors_unchanged():
+    """If the MCP client raises something other than ``Session terminated``,
+    the existing diagnostic path is preserved so we don't paper over genuine
+    bugs."""
+
+    with _http_server(200) as endpoint:
+        server = _make_server(endpoint)
+
+        inner = RuntimeError("backend exploded mid-handshake")
+        group = ExceptionGroup("mcp transport failed", [inner])
+        with patch.object(
+            mcp_client,
+            "MultiServerMCPClient",
+            autospec=True,
+        ) as ctor:
+            ctor.return_value.get_tools = AsyncMock(side_effect=group)
+
+            with pytest.raises(RuntimeError) as excinfo:
+                await mcp_client.probe_server_tools(server)
+
+        # Non-opaque inner exceptions should round-trip through the existing
+        # path (no second HTTP probe, no rewriting).
+        assert "backend exploded mid-handshake" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_connection_failure_when_endpoint_is_unreachable():
+    """If the upstream isn't reachable at all (closed port), surface a
+    connection-failure message rather than implying it's an HTTP problem."""
+
+    # Use a high port that's almost certainly not listening locally.
+    server = _make_server("http://127.0.0.1:1/mcp")
+
+    inner = RuntimeError("Session terminated")
+    group = ExceptionGroup("mcp transport failed", [inner])
+    with patch.object(
+        mcp_client,
+        "MultiServerMCPClient",
+        autospec=True,
+    ) as ctor:
+        ctor.return_value.get_tools = AsyncMock(side_effect=group)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await mcp_client.probe_server_tools(server)
+
+    message = str(excinfo.value)
+    # No HTTP status was ever seen — caller should know it's a connection
+    # problem, not an authorization or upstream-error problem.
+    assert "Session terminated" not in message
+    # We don't pin the exact wording, but the operator needs to be able to
+    # tell this apart from an HTTP-status failure.
+    assert "connect" in message.lower() or "reach" in message.lower() or "unreachable" in message.lower(), (
+        f"expected a connectivity hint in: {message!r}"
+    )

--- a/ai_platform_engineering/dynamic_agents/uv.lock
+++ b/ai_platform_engineering/dynamic_agents/uv.lock
@@ -490,6 +490,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pymongo" },
     { name = "requests" },
     { name = "uvicorn", extra = ["standard"] },
@@ -518,9 +519,10 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "langchain-mcp-adapters", specifier = "==0.2.1" },
     { name = "langgraph-checkpoint-mongodb", specifier = "==0.3.1" },
-    { name = "prometheus-client", specifier = "==0.22.1" },
+    { name = "prometheus-client", specifier = "==0.23.1" },
     { name = "pydantic", specifier = "==2.11.3" },
     { name = "pydantic-settings", specifier = "==2.9.1" },
+    { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.0" },
     { name = "pymongo", specifier = "==4.12.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
@@ -1925,11 +1927,11 @@ wheels = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.1"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746, upload-time = "2025-06-02T14:29:01.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694, upload-time = "2025-06-02T14:29:00.068Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
 ]
 
 [[package]]

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/NOTES.txt
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/NOTES.txt
@@ -1,0 +1,72 @@
+{{- /*
+  Post-install notes for the dynamic-agents subchart.
+
+  This template is intentionally non-blocking: a missing KEYCLOAK_URL /
+  OIDC_ISSUER is a *configuration smell* (every Bearer-token request will
+  401 inside the pod because JWKS fetch resolves to http://localhost:7080
+  by default), but it is NOT a Helm-template error. We surface it as a
+  visible warning at the bottom of `helm install` / `helm upgrade` output
+  so operators see it the moment they ship a bad configuration, without
+  breaking back-compat for dev installs that may genuinely run Keycloak on
+  localhost:7080.
+
+  Tested by tests/test_dynamic_agents_chart_keycloak_env.py.
+*/ -}}
+{{- $kcUrl := default "" (index .Values.config "KEYCLOAK_URL") }}
+{{- $oidcIssuer := default "" (index .Values.config "OIDC_ISSUER") }}
+
+dynamic-agents installed.
+
+{{- if and (eq (toString $kcUrl) "") (eq (toString $oidcIssuer) "") }}
+
+⚠️  WARNING — Keycloak/OIDC env vars are NOT set for dynamic-agents.
+
+    The dynamic-agents pod validates every incoming Bearer token against
+    Keycloak's JWKS endpoint. With KEYCLOAK_URL unset, the JWKS fetch
+    falls back to http://localhost:7080 — which is a connection-refused
+    trap inside Kubernetes. With OIDC_ISSUER unset, the validator
+    derives the issuer from KEYCLOAK_URL, which usually does NOT match
+    the `iss` claim Keycloak puts in the JWT (Keycloak bakes its
+    KC_HOSTNAME / browser-facing URL into the token's `iss`).
+
+    Set both at the parent-chart level, e.g.:
+
+      dynamic-agents:
+        config:
+          KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+          OIDC_ISSUER:  "https://idp.example.com/realms/caipe"
+
+    This warning is non-blocking. If you are running Keycloak on
+    localhost:7080 (docker-compose dev) you can safely ignore it.
+
+{{- else if eq (toString $oidcIssuer) "" }}
+
+⚠️  WARNING — OIDC_ISSUER is empty for dynamic-agents.
+
+    KEYCLOAK_URL is set ({{ $kcUrl | quote }}) but OIDC_ISSUER is not.
+    Token validation will only succeed when KEYCLOAK_URL is *also* the
+    browser-facing issuer URL (the `iss` claim Keycloak puts in JWTs).
+    For any deployment where the in-cluster service URL differs from the
+    public issuer (the typical production topology), you MUST set
+    `dynamic-agents.config.OIDC_ISSUER` to the public realm URL, e.g.:
+
+      dynamic-agents:
+        config:
+          OIDC_ISSUER: "https://idp.example.com/realms/caipe"
+
+{{- else if eq (toString $kcUrl) "" }}
+
+⚠️  WARNING — KEYCLOAK_URL is empty for dynamic-agents.
+
+    OIDC_ISSUER is set ({{ $oidcIssuer | quote }}) but KEYCLOAK_URL is
+    not, so the JWKS fetch falls back to http://localhost:7080.
+    Inside a Kubernetes pod that resolves to ECONNREFUSED.
+
+    Set `dynamic-agents.config.KEYCLOAK_URL` to the in-cluster Keycloak
+    service URL, e.g.:
+
+      dynamic-agents:
+        config:
+          KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+
+{{- end }}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/configmap.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/configmap.yaml
@@ -6,5 +6,15 @@ metadata:
     {{- include "dynamic-agents.labels" . | nindent 4 }}
 data:
   {{- range $key, $value := .Values.config }}
+  {{- /*
+    Skip keys whose value is the empty string so the rendered ConfigMap
+    doesn't clobber the in-code defaults (e.g. KEYCLOAK_URL falls back to
+    http://localhost:7080 only when the env var is genuinely unset; an
+    empty-string env still wins over the default and is a sharper failure
+    mode). Operators who want to set a key explicitly to "" should set it
+    to a single space instead.
+  */ -}}
+  {{- if not (eq (toString $value) "") }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -119,8 +119,38 @@ affinity: {}
 
 # ConfigMap for non-sensitive configuration
 config:
+  # ─── Keycloak / OIDC (REQUIRED in production) ───────────────────────────
+  # The dynamic-agents service validates every incoming Bearer token against
+  # Keycloak's JWKS endpoint (see dynamic_agents.auth.jwks_validate). Two
+  # env vars MUST be set whenever the cluster's in-network Keycloak URL is
+  # different from the public, browser-facing issuer (the typical
+  # production topology):
+  #
+  #   KEYCLOAK_URL  — in-cluster service URL the pod uses for JWKS fetch
+  #                   (e.g. http://ai-platform-engineering-keycloak:8080).
+  #                   When unset, the code falls back to
+  #                   http://localhost:7080 which is a CONNECTION-REFUSED
+  #                   trap inside a Kubernetes pod.
+  #
+  #   OIDC_ISSUER   — public issuer string that MUST exactly match the
+  #                   `iss` claim Keycloak puts in the JWT (driven by
+  #                   KC_HOSTNAME on the Keycloak side, e.g.
+  #                   https://idp.example.com/realms/caipe). When unset,
+  #                   the code derives the issuer from KEYCLOAK_URL and
+  #                   token validation fails with InvalidIssuerError if
+  #                   the in-cluster URL ≠ public issuer.
+  #
+  # NOTES.txt prints a warning on `helm install` if both of these are
+  # empty — see templates/NOTES.txt.
+  KEYCLOAK_URL: ""
+  OIDC_ISSUER: ""
   # MongoDB database name (uses same DB as CAIPE UI)
   MONGODB_DATABASE: "caipe"
+  # Connections & Secrets credential exchange client. Disabled by default.
+  CAIPE_CREDENTIALS_ENABLED: "false"
+  CREDENTIAL_API_URL: "http://ai-platform-engineering-caipe-ui:3000/api/credentials"
+  CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
+  USE_IMPERSONATION_TOKENS: "false"
   # Agent runtime TTL in seconds (purged after this much inactivity)
   AGENT_RUNTIME_TTL_SECONDS: "60"
   # Set to "true" to enable multi-turn conversation history via POST /invoke.
@@ -130,6 +160,9 @@ config:
   INVOKE_PERSIST_HISTORY: "false"
   # CORS origins (JSON array format for Pydantic)
   CORS_ORIGINS: '["*"]'
+  # MCP server IDs routed through AgentGateway. Use "all" because AgentGateway
+  # uses one route/backend per MCP server in the packaged RBAC deployment.
+  AGENT_GATEWAY_MCP_SERVER_IDS: "all"
   # Tracing disabled by default
   ENABLE_TRACING: "false"
   # Strip skill payloads (SKILL.md bodies, ancillary files,

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -887,6 +887,21 @@ dynamic-agents:
     port: 8001
   # ConfigMap for non-sensitive configuration
   config:
+    # ─── Keycloak / OIDC (REQUIRED for Bearer token validation) ─────────
+    # In-cluster Keycloak service URL used for the server-to-server JWKS
+    # fetch. The bundled Keycloak subchart exposes its service as
+    # `<release>-keycloak`; this default works for the umbrella chart
+    # but MUST be overridden when pointing dynamic-agents at an external
+    # Keycloak (production IdP / forge.dev / etc.).
+    KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+    # Browser-facing issuer string baked into JWTs (Keycloak's
+    # KC_HOSTNAME). Override when the public issuer differs from
+    # KEYCLOAK_URL (the typical production topology), e.g.
+    # OIDC_ISSUER: "https://idp.example.com/realms/caipe".
+    # Leaving this empty falls back to deriving the issuer from
+    # KEYCLOAK_URL, which only works in dev where both URLs coincide;
+    # NOTES.txt prints a warning otherwise.
+    OIDC_ISSUER: ""
     # MongoDB configuration (uses same database as CAIPE UI)
     MONGODB_DATABASE: "caipe"
     # LLM configuration (override if needed)

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -53,6 +53,7 @@ ENABLE_GRAPH_RAG=false
 ENABLE_VLLM="${ENABLE_VLLM:-false}"
 ENABLE_OLLAMA="${ENABLE_OLLAMA:-false}"
 ENABLE_AGENTGATEWAY="${ENABLE_AGENTGATEWAY:-false}"
+ENABLE_RBAC_RUNTIME="${ENABLE_RBAC_RUNTIME:-false}"
 VLLM_MODEL="${VLLM_MODEL:-openai/gpt-oss-20b}"
 VLLM_GPU_COUNT="${VLLM_GPU_COUNT:-1}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-llama2}"
@@ -60,6 +61,8 @@ OLLAMA_PORT=11434
 HF_TOKEN="${HF_TOKEN:-}"
 AGENTGATEWAY_VERSION="${AGENTGATEWAY_VERSION:-v2.2.1}"
 AGENTGATEWAY_PORT=8080
+KEYCLOAK_PORT=7080
+OPENFGA_PORT=18080
 INJECT_CORPORATE_CA=false
 CA_SSL_FIX_PROMPTED=false
 SUPERVISOR_RAG_RESTARTED=false
@@ -108,6 +111,9 @@ cleanup_on_exit() {
   pkill -f "kubectl port-forward.*caipe-supervisor-agent.*${SUPERVISOR_PORT:-8000}:8000" 2>/dev/null || true
   pkill -f "kubectl port-forward.*caipe-caipe-ui.*${UI_PORT:-3000}:3000" 2>/dev/null || true
   pkill -f "kubectl port-forward.*langfuse-web.*${LANGFUSE_PORT:-3100}:3000" 2>/dev/null || true
+  pkill -f "kubectl port-forward.*caipe-keycloak.*${KEYCLOAK_PORT:-7080}:8080" 2>/dev/null || true
+  pkill -f "kubectl port-forward.*caipe-openfga.*${OPENFGA_PORT:-18080}:8080" 2>/dev/null || true
+  pkill -f "kubectl port-forward.*caipe-agentgateway.*${AGENTGATEWAY_PORT:-8080}:4000" 2>/dev/null || true
   rm -f /tmp/langfuse-cookies /tmp/caipe-validation-*.log
   exec 3<&- 2>/dev/null || true
 }
@@ -1803,6 +1809,7 @@ choose_features() {
     fi
     $ENABLE_TRACING && log "Tracing enabled (--tracing)" || log "Tracing skipped (pass --tracing to enable)"
     $ENABLE_AGENTGATEWAY && log "AgentGateway enabled (--agentgateway)" || log "AgentGateway skipped (pass --agentgateway to enable)"
+    $ENABLE_RBAC_RUNTIME && log "RBAC runtime enabled (--rbac-runtime)" || log "RBAC runtime skipped (pass --rbac-runtime to enable)"
     $ENABLE_PERSISTENCE && log "Redis persistence enabled (--persistence)" || log "Persistence skipped (pass --persistence to enable)"
     $ENABLE_DYNAMIC_AGENTS && log "Dynamic agents enabled (--dynamic-agents)" || log "Dynamic agents skipped (pass --dynamic-agents to enable)"
     if $ENABLE_METALLB; then
@@ -2084,7 +2091,7 @@ choose_features() {
         fi ;;
       webex)
         prompt "Webex Bot Token (blank to skip): "
-        tty_read -rs _v; echo ""; [[ -z "$_v" ]] && { warn "Skipping webex"; _skip=true; } || _secret_args+=(--from-literal=WEBEX_BOT_TOKEN="$_v" --from-literal=WEBEX_TOKEN="$_v")
+        tty_read -rs _v; echo ""; [[ -z "$_v" ]] && { warn "Skipping webex"; _skip=true; } || _secret_args+=(--from-literal=WEBEX_INTEGRATION_BOT_ACCESS_TOKEN="$_v")
         if ! $_skip; then
           prompt "Webex Webhook Secret (optional): "; tty_read -rs _v; echo ""; [[ -n "$_v" ]] && _secret_args+=(--from-literal=WEBEX_WEBHOOK_SECRET="$_v")
         fi ;;
@@ -2149,6 +2156,25 @@ choose_features() {
       log "AgentGateway enabled"
     else
       log "AgentGateway skipped"
+    fi
+  fi
+
+  echo ""
+  echo -e "  ${DIM}RBAC runtime installs the in-chart Keycloak, OpenFGA, OpenFGA ext_authz bridge,${NC}"
+  echo -e "  ${DIM}and standalone AgentGateway proxy added for the 0.5.0 RBAC release.${NC}"
+  if $ENABLE_RBAC_RUNTIME; then
+    log "RBAC runtime already enabled (detected from cluster)"
+    ENABLE_AGENTGATEWAY=true
+    if ! ask_yn "Keep RBAC runtime?" "y"; then
+      ENABLE_RBAC_RUNTIME=false
+    fi
+  else
+    if ask_yn "Enable RBAC runtime services?" "n"; then
+      ENABLE_RBAC_RUNTIME=true
+      ENABLE_AGENTGATEWAY=true
+      log "RBAC runtime enabled"
+    else
+      log "RBAC runtime skipped"
     fi
   fi
 
@@ -2334,7 +2360,7 @@ _agent_secret_keys() {
     backstage) echo "BACKSTAGE_API_TOKEN BACKSTAGE_URL" ;;
     slack) echo "SLACK_BOT_TOKEN SLACK_APP_TOKEN SLACK_SIGNING_SECRET SLACK_CLIENT_SECRET SLACK_TEAM_ID" ;;
     pagerduty) echo "PAGERDUTY_API_KEY PAGERDUTY_API_URL" ;;
-    webex) echo "WEBEX_TOKEN" ;;
+    webex) echo "WEBEX_INTEGRATION_BOT_ACCESS_TOKEN" ;;
     komodor) echo "KOMODOR_TOKEN KOMODOR_API_URL" ;;
     aws) echo "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_DEFAULT_REGION AWS_BEDROCK_MODEL_ID AWS_BEDROCK_PROVIDER AWS_BEDROCK_ENABLE_PROMPT_CACHE" ;;
     splunk) echo "SPLUNK_TOKEN SPLUNK_API_URL" ;;
@@ -2640,7 +2666,25 @@ deploy_langfuse() {
 create_langfuse_api_keys() {
   step "Creating Langfuse account and API keys"
 
-  # Check if keys already exist from a previous run
+  # Workshop credentials are per-install: generated fresh on first run, then
+  # reused from the `langfuse-credentials` Secret on subsequent runs so the UI
+  # login keeps working after a re-run. Anyone with cluster access can retrieve
+  # them with the kubectl command printed in the "Services Ready" banner.
+  LANGFUSE_EMAIL="lab@lab.com"
+  local existing_pw
+  existing_pw=$(kubectl get secret langfuse-credentials -n langfuse -o jsonpath='{.data.LANGFUSE_PASSWORD}' 2>/dev/null | base64 -d 2>/dev/null || true)
+  if [[ -n "$existing_pw" ]]; then
+    LANGFUSE_PASSWORD="$existing_pw"
+    log "Reusing existing Langfuse workshop password from langfuse-credentials Secret"
+  else
+    # Langfuse password policy requires upper, lower, digit and >=8 chars; the
+    # "Lf!" prefix guarantees that even though `openssl rand -hex` only emits
+    # hex digits.
+    LANGFUSE_PASSWORD="Lf!$(openssl rand -hex 16)"
+    log "Generated random Langfuse workshop password"
+  fi
+
+  # Check if API keys already exist from a previous run
   local existing_pk existing_sk
   existing_pk=$(kubectl get secret langfuse-secret -n caipe -o jsonpath='{.data.LANGFUSE_PUBLIC_KEY}' 2>/dev/null | base64 -d 2>/dev/null || true)
   existing_sk=$(kubectl get secret langfuse-secret -n caipe -o jsonpath='{.data.LANGFUSE_SECRET_KEY}' 2>/dev/null | base64 -d 2>/dev/null || true)
@@ -2676,19 +2720,33 @@ create_langfuse_api_keys() {
     sleep 5
   done
 
+  # The signup body is JSON; build it in Python so the generated password is
+  # safely JSON-escaped (the hex+"Lf!" prefix avoids quote/backslash hazards
+  # today, but doing this defensively keeps the call correct if the generator
+  # ever changes).
+  local signup_body
+  signup_body=$(LANGFUSE_EMAIL="$LANGFUSE_EMAIL" LANGFUSE_PASSWORD="$LANGFUSE_PASSWORD" \
+    python3 -c 'import json,os; print(json.dumps({"name":"lab","email":os.environ["LANGFUSE_EMAIL"],"password":os.environ["LANGFUSE_PASSWORD"]}))')
   curl -sf -X POST "${base}/api/auth/signup" \
     -H 'Content-Type: application/json' \
-    -d '{"name":"lab","email":"lab@lab.com","password":"Lab12345!"}' &>/dev/null || true
+    -d "${signup_body}" &>/dev/null || true
   log "User account ready"
 
   local csrf
   csrf=$(curl -sf -c /tmp/langfuse-cookies "${base}/api/auth/csrf" \
     | python3 -c "import sys,json;print(json.load(sys.stdin)['csrfToken'])")
 
+  # The credentials callback expects application/x-www-form-urlencoded; the
+  # password can in principle contain reserved chars (& = +), so url-encode
+  # it via Python rather than naive string interpolation.
+  local lf_email_enc lf_password_enc
+  lf_email_enc=$(LANGFUSE_EMAIL="$LANGFUSE_EMAIL" python3 -c 'import os,urllib.parse;print(urllib.parse.quote(os.environ["LANGFUSE_EMAIL"], safe=""))')
+  lf_password_enc=$(LANGFUSE_PASSWORD="$LANGFUSE_PASSWORD" python3 -c 'import os,urllib.parse;print(urllib.parse.quote(os.environ["LANGFUSE_PASSWORD"], safe=""))')
+
   curl -sf -c /tmp/langfuse-cookies -b /tmp/langfuse-cookies \
     -X POST "${base}/api/auth/callback/credentials" \
     -H 'Content-Type: application/x-www-form-urlencoded' \
-    -d "csrfToken=${csrf}&email=lab@lab.com&password=Lab12345!&callbackUrl=${base}" \
+    -d "csrfToken=${csrf}&email=${lf_email_enc}&password=${lf_password_enc}&callbackUrl=${base}" \
     -o /dev/null
 
   local org_id
@@ -2728,8 +2786,8 @@ create_langfuse_api_keys() {
     --from-literal=LANGFUSE_PUBLIC_KEY="$LANGFUSE_PUBLIC_KEY" \
     --from-literal=LANGFUSE_SECRET_KEY="$LANGFUSE_SECRET_KEY" \
     --from-literal=LANGFUSE_BASEURL="$langfuse_baseurl" \
-    --from-literal=LANGFUSE_EMAIL="lab@lab.com" \
-    --from-literal=LANGFUSE_PASSWORD="Lab12345!" \
+    --from-literal=LANGFUSE_EMAIL="$LANGFUSE_EMAIL" \
+    --from-literal=LANGFUSE_PASSWORD="$LANGFUSE_PASSWORD" \
     --dry-run=client -o yaml | kubectl apply -f - &>/dev/null
   log "langfuse-credentials stored in langfuse namespace"
 
@@ -3371,9 +3429,53 @@ _patch_rag_server_envfrom() {
   log "Patched rag-server: added rag-azure-openai-secret to envFrom"
 }
 
+# R2 (May 2026): The bitnami/mongodb install used to ship with the
+# literal password "changeme" baked into four sites in this script
+# (helm upgrade auth.rootPassword + auth.passwords[0], plus the
+# MONGODB_URI written into the dynamic-agents/supervisor/ui ConfigMaps).
+# Any operator who ran the workshop on-ramp inherited the same admin
+# password — and the same cluster-internal `mongodb://admin:changeme@…`
+# URI made it into the BFF's session-store Secret.
+#
+# This helper produces a per-install random password and persists it
+# in the `caipe-mongodb-credentials` Secret so:
+#   (a) re-runs of setup-caipe.sh reuse the password (idempotent),
+#   (b) the password is recoverable via `kubectl get secret …` for
+#       anyone doing post-hoc debugging or backup/restore.
+#
+# Mirrors the Langfuse `existing_pw` pattern already in this script
+# (see lines ~2671-2685). assisted-by Claude:claude-opus-4-7
+_resolve_mongodb_password() {
+  local existing_pw
+  existing_pw=$(kubectl get secret caipe-mongodb-credentials -n caipe \
+    -o jsonpath='{.data.MONGODB_ROOT_PASSWORD}' 2>/dev/null \
+    | base64 -d 2>/dev/null || true)
+  if [[ -n "$existing_pw" ]]; then
+    MONGODB_ROOT_PASSWORD="$existing_pw"
+    log "Reusing existing MongoDB root password from caipe-mongodb-credentials Secret"
+  else
+    # `openssl rand -hex 24` → 48 hex chars (24 bytes of entropy). Hex
+    # avoids any character that would need URL-encoding inside the
+    # MONGODB_URI connection string (no '@', '/', ':', '?', etc.).
+    MONGODB_ROOT_PASSWORD="$(openssl rand -hex 24)"
+    log "Generated random MongoDB root password"
+  fi
+  # Persist (or refresh) the Secret so re-runs reuse it. --dry-run +
+  # apply is the standard idempotent pattern used elsewhere in this
+  # script.
+  kubectl create secret generic caipe-mongodb-credentials \
+    --namespace caipe \
+    --from-literal=MONGODB_ROOT_USERNAME="admin" \
+    --from-literal=MONGODB_ROOT_PASSWORD="${MONGODB_ROOT_PASSWORD}" \
+    --from-literal=MONGODB_DATABASE="caipe" \
+    --dry-run=client -o yaml \
+    | kubectl apply -f - &>/dev/null
+}
+
 _ensure_dynamic_agents_mongodb() {
   local mongo_svc="caipe-mongodb"
-  local mongo_uri="mongodb://admin:changeme@${mongo_svc}:27017/caipe?authSource=caipe"
+  _resolve_mongodb_password
+  local mongo_uri="mongodb://admin:${MONGODB_ROOT_PASSWORD}@${mongo_svc}:27017/caipe?authSource=caipe"
 
   if ! kubectl get deploy "${mongo_svc}" -n caipe &>/dev/null; then
     step "Deploying MongoDB for dynamic-agents"
@@ -3381,14 +3483,14 @@ _ensure_dynamic_agents_mongodb() {
     helm upgrade --install "${mongo_svc}" bitnami/mongodb \
       -n caipe \
       --set auth.enabled=true \
-      --set auth.rootPassword=changeme \
+      --set "auth.rootPassword=${MONGODB_ROOT_PASSWORD}" \
       --set "auth.databases[0]=caipe" \
       --set "auth.usernames[0]=admin" \
-      --set "auth.passwords[0]=changeme" \
+      --set "auth.passwords[0]=${MONGODB_ROOT_PASSWORD}" \
       --set persistence.size=2Gi \
       --timeout 3m &>/dev/null
     kubectl rollout status deploy/"${mongo_svc}" -n caipe --timeout=180s &>/dev/null
-    log "MongoDB deployed (${mongo_svc})"
+    log "MongoDB deployed (${mongo_svc}) with random root password"
   else
     log "MongoDB already present (${mongo_svc}) — skipping install"
   fi
@@ -3808,6 +3910,84 @@ LITELLM_EOF
   log "LiteLLM proxy deployed (endpoint: http://litellm-proxy.caipe.svc.cluster.local:4000)"
 }
 
+_write_rbac_runtime_values() {
+  local values_file
+  values_file=$(mktemp /tmp/caipe-rbac-runtime-XXXXXX.yaml)
+
+  local keycloak_ssl_required="external"
+  if [[ -z "$CAIPE_DOMAIN" ]]; then
+    keycloak_ssl_required="none"
+  fi
+
+  cat > "$values_file" <<RBACEOF
+tags:
+  keycloak: true
+
+global:
+  openfga:
+    httpUrl: "http://caipe-openfga:8080"
+    storeName: "caipe-openfga"
+  agentgateway:
+    enabled: true
+    proxyPort: ${AGENTGATEWAY_PORT}
+    extAuth:
+      enabled: true
+      serviceName: "caipe-openfga-authz-bridge"
+      serviceNamespace: "caipe"
+      port: 9100
+
+keycloak:
+  realm:
+    sslRequired: "${keycloak_ssl_required}"
+
+openfga:
+  enabled: true
+  init:
+    enabled: true
+    storeName: "caipe-openfga"
+
+openfgaAuthzBridge:
+  enabled: true
+
+openfga-authz-bridge:
+  openfga:
+    httpUrl: "http://caipe-openfga:8080"
+    storeName: "caipe-openfga"
+  tokenValidation:
+    jwksUrl: "http://caipe-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
+    algorithms:
+      - RS256
+
+agentgateway:
+  enabled: true
+
+caipe-ui:
+  config:
+    OPENFGA_HTTP: "http://caipe-openfga:8080"
+    OPENFGA_STORE_NAME: "caipe-openfga"
+    OPENFGA_RECONCILE_ENABLED: "true"
+    KEYCLOAK_URL: "http://caipe-keycloak:8080"
+    KEYCLOAK_REALM: "caipe"
+    KEYCLOAK_RESOURCE_SERVER_ID: "caipe-platform"
+RBACEOF
+
+  if [[ -n "$UI_ENV_FILE" ]]; then
+    local oidc_issuer
+    oidc_issuer=$(_env_get "$UI_ENV_FILE" "OIDC_ISSUER")
+    if [[ -n "$oidc_issuer" ]]; then
+      cat >> "$values_file" <<RBACEOF
+    SSO_ENABLED: "true"
+
+openfga-authz-bridge:
+  tokenValidation:
+    issuer: "${oidc_issuer}"
+RBACEOF
+    fi
+  fi
+
+  printf '%s' "$values_file"
+}
+
 deploy_agentgateway() {
   step "Deploying AgentGateway (${AGENTGATEWAY_VERSION})"
 
@@ -4033,12 +4213,20 @@ deploy_caipe() {
     # Build models list from llm-secret LLM_PROVIDER
     local _provider="${LLM_PROVIDER:-anthropic-claude}"
 
-    # Write auth/OIDC config into the values file
+    # Write auth/OIDC config into the values file. R2 (May 2026):
+    # MONGODB_ROOT_PASSWORD comes from _resolve_mongodb_password() which
+    # is called by _ensure_dynamic_agents_mongodb() — guaranteed to run
+    # before deploy_caipe() per the orchestration at line ~6060.
+    # Fall back to a clearly-broken placeholder if the variable isn't
+    # set (defensive: should only happen if someone re-orders the call
+    # graph and skips the MongoDB step), so the failure surfaces loudly
+    # at pod start rather than silently using "changeme".
+    local _mongo_pw="${MONGODB_ROOT_PASSWORD:-MONGODB_ROOT_PASSWORD_UNSET}"
     cat > "$_da_values_file" <<DAEOF
 dynamic-agents:
   config:
     # MongoDB URI baked in at deploy time so the pod can start before post_deploy_patches.
-    MONGODB_URI: "mongodb://admin:changeme@caipe-mongodb:27017/caipe?authSource=caipe"
+    MONGODB_URI: "mongodb://admin:${_mongo_pw}@caipe-mongodb:27017/caipe?authSource=caipe"
 DAEOF
     if [[ -n "$CAIPE_DOMAIN" && -n "$da_oidc_issuer" ]]; then
       cat >> "$_da_values_file" <<DAEOF
@@ -4303,6 +4491,13 @@ DAEOF
     log "Redis persistence configured (langgraph-redis subchart, fact extraction enabled)"
   fi
 
+  if $ENABLE_RBAC_RUNTIME; then
+    local _rbac_values_file
+    _rbac_values_file=$(_write_rbac_runtime_values)
+    helm_args+=(--values "$_rbac_values_file")
+    log "RBAC runtime configured (Keycloak, OpenFGA, OpenFGA bridge, AgentGateway)"
+  fi
+
   if $ENABLE_INGRESS && [[ -n "$CAIPE_DOMAIN" ]]; then
     # Kubernetes Ingress spec.rules[].host must be a DNS name, not an IP address.
     # When CAIPE_DOMAIN is an IP, omit the host field (nginx will match all requests).
@@ -4523,39 +4718,69 @@ run_validation() {
 
   # ── AgentGateway ──
   if $ENABLE_AGENTGATEWAY; then
-    local ag_ready
-    ag_ready=$(kubectl get pods -n agentgateway-system -l app.kubernetes.io/name=agentgateway \
-      --no-headers 2>/dev/null \
-      | awk '$3=="Running" {split($2,a,"/"); if(a[1]==a[2]) print "ready"}' | head -1)
-    if [[ "$ag_ready" == "ready" ]]; then
-      print_result "$(date '+%H:%M:%S') ✓ AgentGateway control plane is running"
-      pass=$((pass + 1))
+    if $ENABLE_RBAC_RUNTIME; then
+      local ag_proxy_ready
+      ag_proxy_ready=$(kubectl get deployment caipe-agentgateway -n caipe \
+        -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+      if [[ "${ag_proxy_ready:-0}" -ge 1 ]]; then
+        print_result "$(date '+%H:%M:%S') ✓ AgentGateway proxy is running"
+        pass=$((pass + 1))
+      else
+        print_result "$(date '+%H:%M:%S') ✗ AgentGateway proxy is not ready"
+        fail=$((fail + 1))
+      fi
     else
-      print_result "$(date '+%H:%M:%S') ✗ AgentGateway control plane is not ready"
-      fail=$((fail + 1))
-    fi
+      local ag_ready
+      ag_ready=$(kubectl get pods -n agentgateway-system -l app.kubernetes.io/name=agentgateway \
+        --no-headers 2>/dev/null \
+        | awk '$3=="Running" {split($2,a,"/"); if(a[1]==a[2]) print "ready"}' | head -1)
+      if [[ "$ag_ready" == "ready" ]]; then
+        print_result "$(date '+%H:%M:%S') ✓ AgentGateway control plane is running"
+        pass=$((pass + 1))
+      else
+        print_result "$(date '+%H:%M:%S') ✗ AgentGateway control plane is not ready"
+        fail=$((fail + 1))
+      fi
 
-    local ag_proxy_ready
-    ag_proxy_ready=$(kubectl get deployment agentgateway-proxy -n agentgateway-system \
-      -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-    if [[ "${ag_proxy_ready:-0}" -ge 1 ]]; then
-      print_result "$(date '+%H:%M:%S') ✓ AgentGateway proxy is running"
-      pass=$((pass + 1))
-    else
-      print_result "$(date '+%H:%M:%S') ✗ AgentGateway proxy is not ready"
-      fail=$((fail + 1))
-    fi
+      local ag_proxy_ready
+      ag_proxy_ready=$(kubectl get deployment agentgateway-proxy -n agentgateway-system \
+        -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+      if [[ "${ag_proxy_ready:-0}" -ge 1 ]]; then
+        print_result "$(date '+%H:%M:%S') ✓ AgentGateway proxy is running"
+        pass=$((pass + 1))
+      else
+        print_result "$(date '+%H:%M:%S') ✗ AgentGateway proxy is not ready"
+        fail=$((fail + 1))
+      fi
 
-    local mcp_backend_count
-    mcp_backend_count=$(kubectl get agentgatewaybackend -n caipe \
-      -l app.kubernetes.io/managed-by=setup-caipe --no-headers 2>/dev/null | wc -l | tr -d ' ')
-    if [[ "$mcp_backend_count" -gt 0 ]]; then
-      print_result "$(date '+%H:%M:%S') ✓ ${mcp_backend_count} MCP backend(s) configured in AgentGateway"
-      pass=$((pass + 1))
-    else
-      print_result "$(date '+%H:%M:%S') ⚠ No MCP backends configured in AgentGateway"
-      warn_count=$((warn_count + 1))
+      local mcp_backend_count
+      mcp_backend_count=$(kubectl get agentgatewaybackend -n caipe \
+        -l app.kubernetes.io/managed-by=setup-caipe --no-headers 2>/dev/null | wc -l | tr -d ' ')
+      if [[ "$mcp_backend_count" -gt 0 ]]; then
+        print_result "$(date '+%H:%M:%S') ✓ ${mcp_backend_count} MCP backend(s) configured in AgentGateway"
+        pass=$((pass + 1))
+      else
+        print_result "$(date '+%H:%M:%S') ⚠ No MCP backends configured in AgentGateway"
+        warn_count=$((warn_count + 1))
+      fi
     fi
+  fi
+
+  # ── RBAC runtime ──
+  if $ENABLE_RBAC_RUNTIME; then
+    local component deploy_name ready_replicas
+    for component in keycloak openfga openfga-authz-bridge; do
+      deploy_name="caipe-${component}"
+      ready_replicas=$(kubectl get deployment "$deploy_name" -n caipe \
+        -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+      if [[ "${ready_replicas:-0}" -ge 1 ]]; then
+        print_result "$(date '+%H:%M:%S') ✓ ${deploy_name} is running"
+        pass=$((pass + 1))
+      else
+        print_result "$(date '+%H:%M:%S') ✗ ${deploy_name} is not ready"
+        fail=$((fail + 1))
+      fi
+    done
   fi
 
   # ── Summary ──
@@ -5195,7 +5420,16 @@ monitor_port_forwards() {
   fi
 
   if $ENABLE_AGENTGATEWAY; then
-    start_pf agentgateway-proxy agentgateway-system "$AGENTGATEWAY_PORT" 80 "AgentGateway MCP"
+    if $ENABLE_RBAC_RUNTIME; then
+      start_pf caipe-agentgateway caipe "$AGENTGATEWAY_PORT" 4000 "AgentGateway MCP"
+    else
+      start_pf agentgateway-proxy agentgateway-system "$AGENTGATEWAY_PORT" 80 "AgentGateway MCP"
+    fi
+  fi
+
+  if $ENABLE_RBAC_RUNTIME; then
+    start_pf caipe-keycloak caipe "$KEYCLOAK_PORT" 8080 "Keycloak"
+    start_pf caipe-openfga caipe "$OPENFGA_PORT" 8080 "OpenFGA"
   fi
 
   # Wait for port-forwards to become responsive before running tests
@@ -5245,23 +5479,33 @@ monitor_port_forwards() {
   fi
   if $ENABLE_TRACING; then
     echo -e "    Langfuse UI     ${CYAN}http://localhost:${LANGFUSE_PORT}${NC}"
-    echo -e "      Login: ${DIM}lab@lab.com / Lab12345!${NC}"
+    if [[ -n "${LANGFUSE_EMAIL:-}" && -n "${LANGFUSE_PASSWORD:-}" ]]; then
+      echo -e "      Login: ${DIM}${LANGFUSE_EMAIL} / ${LANGFUSE_PASSWORD}${NC}"
+    else
+      echo -e "      ${DIM}Login: see langfuse-credentials Secret (kubectl command below)${NC}"
+    fi
+  fi
+  if $ENABLE_RBAC_RUNTIME; then
+    echo -e "    Keycloak        ${CYAN}http://localhost:${KEYCLOAK_PORT}${NC}"
+    echo -e "    OpenFGA         ${CYAN}http://localhost:${OPENFGA_PORT}${NC}"
   fi
   if $ENABLE_AGENTGATEWAY; then
     echo -e "    AgentGateway    ${CYAN}http://localhost:${AGENTGATEWAY_PORT}${NC}"
-    echo ""
-    echo -e "  ${BOLD}MCP Client URLs (via AgentGateway):${NC}"
-    local ag_svcs
-    ag_svcs=$(kubectl get agentgatewaybackend -n caipe \
-      -l app.kubernetes.io/managed-by=setup-caipe \
-      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
-    if [[ -n "$ag_svcs" ]]; then
-      while IFS= read -r backend_name; do
-        [[ -z "$backend_name" ]] && continue
-        local agent_short
-        agent_short=$(echo "$backend_name" | sed 's/^mcp-//' | sed 's/-backend$//')
-        echo -e "    ${DIM}http://localhost:${AGENTGATEWAY_PORT}/mcp/${agent_short}${NC}"
-      done <<< "$ag_svcs"
+    if ! $ENABLE_RBAC_RUNTIME; then
+      echo ""
+      echo -e "  ${BOLD}MCP Client URLs (via AgentGateway):${NC}"
+      local ag_svcs
+      ag_svcs=$(kubectl get agentgatewaybackend -n caipe \
+        -l app.kubernetes.io/managed-by=setup-caipe \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+      if [[ -n "$ag_svcs" ]]; then
+        while IFS= read -r backend_name; do
+          [[ -z "$backend_name" ]] && continue
+          local agent_short
+          agent_short=$(echo "$backend_name" | sed 's/^mcp-//' | sed 's/-backend$//')
+          echo -e "    ${DIM}http://localhost:${AGENTGATEWAY_PORT}/mcp/${agent_short}${NC}"
+        done <<< "$ag_svcs"
+      fi
     fi
   fi
   echo ""
@@ -5274,6 +5518,11 @@ monitor_port_forwards() {
   if $ENABLE_TRACING; then
     echo -e "  ${BOLD}Retrieve Langfuse credentials:${NC}"
     echo -e "    ${DIM}kubectl get secret langfuse-credentials -n langfuse -o jsonpath='{.data}' | python3 -c \"import sys,json,base64; d=json.load(sys.stdin); print('\n'.join(f'{k}: {base64.b64decode(v).decode()}' for k,v in sorted(d.items())))\"${NC}"
+    echo ""
+  fi
+  if $ENABLE_DYNAMIC_AGENTS; then
+    echo -e "  ${BOLD}Retrieve MongoDB credentials${NC} ${DIM}(R2: random per-install, persisted in caipe-mongodb-credentials):${NC}"
+    echo -e "    ${DIM}kubectl get secret caipe-mongodb-credentials -n caipe -o jsonpath='{.data}' | python3 -c \"import sys,json,base64; d=json.load(sys.stdin); print('\n'.join(f'{k}: {base64.b64decode(v).decode()}' for k,v in sorted(d.items())))\"${NC}"
     echo ""
   fi
   echo -e "  ${BOLD}CLI chat:${NC}"
@@ -5538,6 +5787,14 @@ detect_deployed_features() {
   if helm status agentgateway -n agentgateway-system &>/dev/null; then
     ENABLE_AGENTGATEWAY=true
   fi
+  if kubectl get deployment caipe-agentgateway -n caipe &>/dev/null 2>&1; then
+    ENABLE_AGENTGATEWAY=true
+    ENABLE_RBAC_RUNTIME=true
+  fi
+  if kubectl get deployment caipe-openfga -n caipe &>/dev/null 2>&1 \
+       || kubectl get deployment caipe-keycloak -n caipe &>/dev/null 2>&1; then
+    ENABLE_RBAC_RUNTIME=true
+  fi
   if kubectl get deployment caipe-dynamic-agents -n caipe &>/dev/null 2>&1; then
     ENABLE_DYNAMIC_AGENTS=true
   fi
@@ -5758,7 +6015,8 @@ BANNER
     elif $NON_INTERACTIVE; then
       # Non-interactive: monitor only unless flags imply an upgrade
       if [[ -n "${CAIPE_CHART_VERSION:-}" ]] || $ENABLE_RAG || $ENABLE_GRAPH_RAG \
-           || $ENABLE_TRACING || $ENABLE_AGENTGATEWAY || $INJECT_CORPORATE_CA || [[ ${#INGEST_URLS[@]} -gt 0 ]]; then
+           || $ENABLE_TRACING || $ENABLE_AGENTGATEWAY || $ENABLE_RBAC_RUNTIME \
+           || $INJECT_CORPORATE_CA || [[ ${#INGEST_URLS[@]} -gt 0 ]]; then
         rerun_choice=2
       else
         rerun_choice=1
@@ -5862,8 +6120,10 @@ BANNER
   deploy_caipe
   post_deploy_patches
 
-  # AgentGateway runs after CAIPE so MCP services exist for auto-discovery
-  if $ENABLE_AGENTGATEWAY; then
+  # The legacy AgentGateway controller path runs after CAIPE so MCP services exist
+  # for auto-discovery. The RBAC runtime path installs the standalone proxy as
+  # part of the CAIPE Helm release.
+  if $ENABLE_AGENTGATEWAY && ! $ENABLE_RBAC_RUNTIME; then
     deploy_agentgateway
   fi
 
@@ -5902,6 +6162,8 @@ Options:
                      with TLS inspection, e.g. Cisco Secure Access, Zscaler)
   --tracing          Enable Langfuse tracing (with --non-interactive, or pre-selects in interactive)
   --agentgateway     Deploy AgentGateway to federate MCP servers behind a single endpoint
+  --rbac-runtime     Install in-chart RBAC runtime services: Keycloak, OpenFGA,
+                     OpenFGA ext_authz bridge, and standalone AgentGateway
   --persistence      Enable Redis persistence for checkpoints and cross-thread memory
                      (deploys langgraph-redis subchart; enables fact extraction)
                      (allows Cursor/VS Code/Claude Code to connect to all MCP servers at once)
@@ -5954,6 +6216,7 @@ Environment variables (all optional):
   VLLM_MODEL              vLLM model (default: openai/gpt-oss-20b)
   VLLM_GPU_COUNT          GPUs per vLLM replica (default: 1)
   ENABLE_AGENTGATEWAY     Enable AgentGateway (default: false)
+  ENABLE_RBAC_RUNTIME     Enable in-chart RBAC runtime services (default: false)
   AGENTGATEWAY_VERSION    AgentGateway Helm chart version (default: v2.2.1)
 
 LLM provider credentials are read from (in order):
@@ -5993,6 +6256,7 @@ Examples:
   LLM_PROVIDER=aws-bedrock $(basename "$0") --non-interactive       # AWS Bedrock (uses profile)
   ENABLE_VLLM=true $(basename "$0") --non-interactive                    # vLLM + LiteLLM (gpt-oss-20B in-cluster)
   $(basename "$0") --non-interactive --agentgateway                     # deploy with AgentGateway for MCP access
+  $(basename "$0") --non-interactive --rbac-runtime                     # deploy Keycloak + OpenFGA + bridge + AgentGateway
   $(basename "$0") --non-interactive --agentgateway --rag               # full stack with AgentGateway + RAG
   $(basename "$0") --non-interactive --persistence                      # deploy with Redis persistence
   $(basename "$0") --non-interactive --rag --persistence                # RAG + Redis persistence (recommended)
@@ -6016,6 +6280,7 @@ for arg in "$@"; do
     --corporate-ca)    INJECT_CORPORATE_CA=true ;;
     --tracing)         ENABLE_TRACING=true ;;
     --agentgateway)    ENABLE_AGENTGATEWAY=true ;;
+    --rbac-runtime)    ENABLE_RBAC_RUNTIME=true; ENABLE_AGENTGATEWAY=true ;;
     --persistence)     ENABLE_PERSISTENCE=true ;;
     --metallb)         ENABLE_METALLB=true ;;
     --ingress)         ENABLE_INGRESS=true; ENABLE_METALLB=true ;;
@@ -6035,6 +6300,7 @@ for arg in "$@"; do
   esac
 done
 
+$ENABLE_RBAC_RUNTIME && ENABLE_AGENTGATEWAY=true
 $ENABLE_GRAPH_RAG && ENABLE_RAG=true
 [[ ${#INGEST_URLS[@]} -gt 0 ]] && ENABLE_RAG=true
 

--- a/tests/integration/test_setup_caipe_mongodb_password.sh
+++ b/tests/integration/test_setup_caipe_mongodb_password.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# tests/integration/test_setup_caipe_mongodb_password.sh
+#
+# Unit test for the R2 randomization of the MongoDB root password
+# inside setup-caipe.sh.
+#
+# Before R2, setup-caipe.sh baked the literal password "changeme" into
+# four sites (helm install of bitnami/mongodb, plus the MONGODB_URI
+# written into the dynamic-agents / supervisor / caipe-ui ConfigMaps).
+# Every workshop install inherited the same password.
+#
+# R2 introduces _resolve_mongodb_password() which:
+#   (1) reads an existing password from the `caipe-mongodb-credentials`
+#       Secret (so re-runs are idempotent), OR
+#   (2) generates a fresh `openssl rand -hex 24` value, AND
+#   (3) persists it in the `caipe-mongodb-credentials` Secret.
+#
+# This test isolates the helper from the rest of setup-caipe.sh by
+# sourcing it directly with `__SETUP_CAIPE_SOURCE_ONLY__=1` and mocking
+# kubectl on PATH. It then asserts:
+#
+#   * Pin 1 — first run with NO existing Secret → a fresh password is
+#             generated, exported as $MONGODB_ROOT_PASSWORD, and
+#             written to the Secret via `kubectl apply`.
+#   * Pin 2 — second run WITH an existing Secret → the same password
+#             is reused (idempotent re-run).
+#   * Pin 3 — the generated password is exactly 48 hex chars (24 bytes
+#             of entropy) and does NOT contain any of the URL-special
+#             characters (`@`, `/`, `:`, `?`, `%`) that would break a
+#             `mongodb://admin:<pw>@host:27017/db` connection string.
+#   * Pin 4 — the password is NEVER the string "changeme" (regression
+#             guard on R2 itself).
+#
+# Exits 0 on success, non-zero with a clear FAIL message otherwise.
+#
+# Usage:
+#   ./tests/integration/test_setup_caipe_mongodb_password.sh
+#
+# assisted-by Claude:claude-opus-4-7
+# -------------------------------------------------------------------
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+SETUP_SCRIPT="${REPO_ROOT}/setup-caipe.sh"
+
+if [ ! -f "${SETUP_SCRIPT}" ]; then
+  echo "FAIL: setup-caipe.sh not found at ${SETUP_SCRIPT}" >&2
+  exit 2
+fi
+
+# Sandbox where the kubectl mock writes its "Secret store".
+SANDBOX="$(mktemp -d /tmp/r2-test.XXXXXX)"
+trap 'rm -rf "${SANDBOX}"' EXIT
+
+# ---------------------------------------------------------------------
+# kubectl mock — minimal, only handles the two calls _resolve_mongodb_password
+# makes:
+#   `kubectl get secret caipe-mongodb-credentials -n caipe -o jsonpath=…`
+#   `kubectl apply -f -`            (consumes stdin)
+#
+# State is persisted under ${SANDBOX}/secret-store.txt — the mock
+# writes the base64'd password there on apply, and reads it back on get.
+# ---------------------------------------------------------------------
+cat > "${SANDBOX}/kubectl" <<'KUBECTL_MOCK'
+#!/usr/bin/env bash
+set -uo pipefail
+STORE="${MOCK_SECRET_STORE:-/tmp/r2-secret-store.txt}"
+case "${1:-}" in
+  get)
+    # We only handle the `get secret caipe-mongodb-credentials` form.
+    # Read the stored base64 from disk; emit empty string if not set.
+    if [ -f "${STORE}" ]; then
+      cat "${STORE}"
+    fi
+    exit 0
+    ;;
+  apply)
+    # Consume the YAML on stdin and pull out the MONGODB_ROOT_PASSWORD
+    # value. The YAML is built by `kubectl create secret generic --dry-run`
+    # so the field is `MONGODB_ROOT_PASSWORD: <base64>` under `data:`.
+    # We're not parsing YAML strictly — `grep` is enough for this shape.
+    yaml=$(cat)
+    pw_b64=$(printf '%s\n' "${yaml}" | grep '^  MONGODB_ROOT_PASSWORD:' | awk '{print $2}')
+    # Sanity: refuse to write empty (catches a regression where the
+    # helper forgets to actually generate a password).
+    if [ -z "${pw_b64}" ]; then
+      echo "kubectl-mock: refusing to apply Secret with empty MONGODB_ROOT_PASSWORD" >&2
+      exit 1
+    fi
+    printf '%s' "${pw_b64}" > "${STORE}"
+    exit 0
+    ;;
+  create)
+    # `kubectl create secret generic … --dry-run=client -o yaml` is used
+    # to build the Secret YAML that gets piped into `apply`. Just emit
+    # the YAML it would produce — we hand-roll the relevant bits.
+    pw_value=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --from-literal=MONGODB_ROOT_PASSWORD=*)
+          # ##*= strips up to the LAST `=` (the `--from-literal=KEY=VALUE`
+          # form has two of them); #*= would strip only the first and
+          # store `KEY=VALUE`.
+          pw_value="${1##*=}"
+          ;;
+      esac
+      shift
+    done
+    if [ -z "${pw_value}" ]; then
+      echo "kubectl-mock: --from-literal=MONGODB_ROOT_PASSWORD=… was missing" >&2
+      exit 1
+    fi
+    # Build the minimal YAML that the real kubectl would produce. We
+    # base64-encode the password ourselves so the apply step finds it
+    # under `data:` exactly the way it would in production.
+    pw_b64=$(printf '%s' "${pw_value}" | base64 | tr -d '\n')
+    cat <<YAML
+apiVersion: v1
+kind: Secret
+metadata:
+  name: caipe-mongodb-credentials
+  namespace: caipe
+type: Opaque
+data:
+  MONGODB_ROOT_PASSWORD: ${pw_b64}
+YAML
+    exit 0
+    ;;
+  *)
+    # Anything else (rollout, patch, etc.) is a no-op in this test.
+    exit 0
+    ;;
+esac
+KUBECTL_MOCK
+chmod +x "${SANDBOX}/kubectl"
+
+export MOCK_SECRET_STORE="${SANDBOX}/secret-store.txt"
+export PATH="${SANDBOX}:${PATH}"
+
+# ---------------------------------------------------------------------
+# Source setup-caipe.sh in a way that exposes `_resolve_mongodb_password`
+# without running the full installer. The script doesn't yet have an
+# `__SETUP_CAIPE_SOURCE_ONLY__` guard, so we bypass `main` by extracting
+# just the helper definition.
+# ---------------------------------------------------------------------
+# Extract _resolve_mongodb_password() definition + its dependency
+# (`log` is the only function it calls); we redefine `log` to no-op
+# stderr so the test output stays clean.
+extract_helper() {
+  awk '
+    /^_resolve_mongodb_password\(\) \{/ { capture = 1 }
+    capture { print }
+    capture && /^\}$/ { capture = 0 }
+  ' "${SETUP_SCRIPT}"
+}
+
+helper_src=$(extract_helper)
+if [ -z "${helper_src}" ]; then
+  echo "FAIL: could not extract _resolve_mongodb_password() from setup-caipe.sh" >&2
+  echo "      Did the helper get renamed? Update this test." >&2
+  exit 2
+fi
+
+# Define a no-op `log` so the helper's status messages don't pollute
+# the test output, then drop in the extracted helper.
+log() { :; }
+eval "${helper_src}"
+
+# ---------------------------------------------------------------------
+# Pin 1 — first run: no existing Secret → fresh password generated.
+# ---------------------------------------------------------------------
+echo "[r2-test] Pin 1: first run with no existing Secret ..."
+rm -f "${MOCK_SECRET_STORE}"
+unset MONGODB_ROOT_PASSWORD
+_resolve_mongodb_password
+
+if [ -z "${MONGODB_ROOT_PASSWORD:-}" ]; then
+  echo "[r2-test] FAIL: Pin 1 — MONGODB_ROOT_PASSWORD is empty after first run." >&2
+  exit 1
+fi
+
+if [ ! -f "${MOCK_SECRET_STORE}" ]; then
+  echo "[r2-test] FAIL: Pin 1 — kubectl apply was not called (Secret store not written)." >&2
+  exit 1
+fi
+
+# Decode the stored base64 and confirm it matches the in-memory value.
+stored_pw=$(cat "${MOCK_SECRET_STORE}" | base64 -d 2>/dev/null || true)
+if [ "${stored_pw}" != "${MONGODB_ROOT_PASSWORD}" ]; then
+  echo "[r2-test] FAIL: Pin 1 — stored Secret value (${stored_pw}) ≠ in-memory value (${MONGODB_ROOT_PASSWORD})." >&2
+  exit 1
+fi
+first_run_pw="${MONGODB_ROOT_PASSWORD}"
+echo "[r2-test]   OK: Pin 1 — fresh password generated and persisted."
+
+# ---------------------------------------------------------------------
+# Pin 2 — second run: existing Secret → same password reused.
+# ---------------------------------------------------------------------
+echo "[r2-test] Pin 2: second run reads the persisted Secret ..."
+unset MONGODB_ROOT_PASSWORD
+_resolve_mongodb_password
+
+if [ "${MONGODB_ROOT_PASSWORD}" != "${first_run_pw}" ]; then
+  echo "[r2-test] FAIL: Pin 2 — password changed between runs." >&2
+  echo "         First run:  ${first_run_pw}" >&2
+  echo "         Second run: ${MONGODB_ROOT_PASSWORD}" >&2
+  echo "         R2 promises idempotent re-runs. Did the helper stop reading the Secret?" >&2
+  exit 1
+fi
+echo "[r2-test]   OK: Pin 2 — re-run reused the persisted password."
+
+# ---------------------------------------------------------------------
+# Pin 3 — password shape: 48 hex chars, no URL-special characters.
+# ---------------------------------------------------------------------
+echo "[r2-test] Pin 3: password shape (hex, URL-safe) ..."
+# `openssl rand -hex 24` → exactly 48 hex chars (0-9, a-f).
+if ! printf '%s' "${first_run_pw}" | grep -qE '^[0-9a-f]{48}$'; then
+  echo "[r2-test] FAIL: Pin 3 — password is not 48 hex chars (got ${#first_run_pw} chars: ${first_run_pw})." >&2
+  echo "         If the helper switched generators (e.g. to base64), the MONGODB_URI" >&2
+  echo "         connection string format may break: '@', '/', ':', '?' all need URL-encoding." >&2
+  exit 1
+fi
+
+# Spot-check for URL-special characters that would corrupt the URI even
+# inside the hex set's range (none should match, but pin it).
+if printf '%s' "${first_run_pw}" | grep -q '[@:/?%]'; then
+  echo "[r2-test] FAIL: Pin 3 — password contains URL-special characters." >&2
+  exit 1
+fi
+echo "[r2-test]   OK: Pin 3 — password is 48-char hex, URL-safe."
+
+# ---------------------------------------------------------------------
+# Pin 4 — regression guard: password is NEVER "changeme".
+# ---------------------------------------------------------------------
+echo "[r2-test] Pin 4: password is not the legacy 'changeme' placeholder ..."
+if [ "${first_run_pw}" = "changeme" ]; then
+  echo "[r2-test] FAIL: Pin 4 — password is 'changeme'. R2 randomization broke." >&2
+  exit 1
+fi
+echo "[r2-test]   OK: Pin 4 — password is randomized."
+
+# ---------------------------------------------------------------------
+# Pin 5 — regression guard: 'changeme' does not appear in setup-caipe.sh
+# outside of comments documenting the prior behavior.
+# ---------------------------------------------------------------------
+echo "[r2-test] Pin 5: 'changeme' literal does not appear in active code ..."
+# Strip comment lines and check for any remaining 'changeme'.
+active_changeme=$(grep -v '^[[:space:]]*#' "${SETUP_SCRIPT}" | grep -c 'changeme' || true)
+if [ "${active_changeme}" -gt 0 ]; then
+  echo "[r2-test] FAIL: Pin 5 — 'changeme' still appears in non-comment lines of setup-caipe.sh." >&2
+  echo "         Active occurrences:" >&2
+  grep -nv '^[[:space:]]*#' "${SETUP_SCRIPT}" | grep 'changeme' | head -5 | sed 's/^/    /' >&2
+  exit 1
+fi
+echo "[r2-test]   OK: Pin 5 — no active 'changeme' references remain."
+
+echo ""
+echo "[r2-test] PASS — all 5 pins green."
+exit 0

--- a/tests/test_dynamic_agents_chart_keycloak_env.py
+++ b/tests/test_dynamic_agents_chart_keycloak_env.py
@@ -1,0 +1,225 @@
+# assisted-by Claude:claude-opus-4-7
+"""Helm template / install tests for the dynamic-agents subchart's
+Keycloak / OIDC env-var wiring.
+
+Pins the contract documented in
+``ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/jwks_validate.py``:
+
+* ``KEYCLOAK_URL`` and ``OIDC_ISSUER`` are the two env vars that drive
+  Bearer-token validation inside the dynamic-agents pod.
+* When either is missing in a production-shaped deployment, the pod 401s
+  every authenticated request — the failure mode that bit a recent
+  in-cluster install (see PR notes / Slack thread linked in spec 102).
+* The chart MUST therefore: (a) expose both keys under
+  ``dynamic-agents.config``, (b) propagate them into the rendered
+  ConfigMap whenever the operator sets them, and (c) print a visible
+  NOTES.txt warning when either is empty so the misconfiguration is
+  noticed at ``helm install`` time instead of as 401 spam in pod logs.
+
+These tests use ``helm template`` (for the ConfigMap) and
+``helm install --dry-run`` (for NOTES.txt — Helm does not render NOTES
+during ``helm template``).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHART_PATH = (
+    REPO_ROOT
+    / "charts"
+    / "ai-platform-engineering"
+    / "charts"
+    / "dynamic-agents"
+)
+
+# global.image.tag must be set so the subchart can resolve appVersion
+# when rendered standalone (the umbrella chart provides this normally).
+_BASE_SET = [
+    "global.image.tag=0.5.1-test",
+]
+
+
+def _require_helm() -> None:
+    if shutil.which("helm") is None:
+        pytest.skip("helm is required for dynamic-agents chart tests")
+
+
+def _helm_template(*extra_set_args: str) -> list[dict[str, Any]]:
+    """Render the chart with ``helm template`` and return every k8s
+    document as a list of dicts. Skips empty docs.
+    """
+    _require_helm()
+    cmd = ["helm", "template", "test", str(CHART_PATH)]
+    for arg in _BASE_SET + list(extra_set_args):
+        cmd.extend(["--set", arg])
+    rendered = subprocess.run(cmd, check=True, text=True, capture_output=True).stdout
+    return [doc for doc in yaml.safe_load_all(rendered) if doc]
+
+
+def _helm_install_dry_run(*extra_set_args: str) -> str:
+    """Run ``helm install --dry-run`` so NOTES.txt is part of the output.
+
+    Returns the full stdout (manifests + NOTES) as a string.
+    """
+    _require_helm()
+    cmd = ["helm", "install", "test", str(CHART_PATH), "--dry-run"]
+    for arg in _BASE_SET + list(extra_set_args):
+        cmd.extend(["--set", arg])
+    return subprocess.run(cmd, check=True, text=True, capture_output=True).stdout
+
+
+def _find_configmap(docs: list[dict[str, Any]], suffix: str) -> dict[str, Any]:
+    for doc in docs:
+        if doc.get("kind") == "ConfigMap" and doc.get("metadata", {}).get("name", "").endswith(suffix):
+            return doc
+    raise AssertionError(f"ConfigMap ending with {suffix!r} not found in render")
+
+
+# ---------------------------------------------------------------------------
+# ConfigMap propagation
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_url_and_oidc_issuer_propagate_into_configmap() -> None:
+    """Setting both at the chart values level must put both into the
+    rendered ConfigMap (which is then mounted via envFrom on the pod).
+    """
+    docs = _helm_template(
+        "config.KEYCLOAK_URL=http://caipe-keycloak:8080",
+        "config.OIDC_ISSUER=https://idp.public.example.com/realms/caipe",
+    )
+    data = _find_configmap(docs, "-config")["data"]
+    assert data["KEYCLOAK_URL"] == "http://caipe-keycloak:8080"
+    assert data["OIDC_ISSUER"] == "https://idp.public.example.com/realms/caipe"
+
+
+def test_empty_keycloak_env_is_omitted_from_configmap() -> None:
+    """Default ``KEYCLOAK_URL=""`` / ``OIDC_ISSUER=""`` MUST be omitted
+    from the rendered ConfigMap so the in-code defaults
+    (``http://localhost:7080`` for KEYCLOAK_URL, derived issuer for
+    OIDC_ISSUER) apply. An empty env-var would otherwise *override* the
+    in-code default with an empty string, which is a sharper failure
+    mode than just unsetting it.
+    """
+    docs = _helm_template()
+    data = _find_configmap(docs, "-config")["data"]
+    assert "KEYCLOAK_URL" not in data, (
+        "Empty KEYCLOAK_URL leaked into ConfigMap — would override the "
+        "in-code default. configmap.yaml must skip empty values."
+    )
+    assert "OIDC_ISSUER" not in data, (
+        "Empty OIDC_ISSUER leaked into ConfigMap — would override the "
+        "in-code default. configmap.yaml must skip empty values."
+    )
+    # Sanity: a non-empty key from the same range loop IS present so we
+    # know the iteration itself is healthy.
+    assert data.get("MONGODB_DATABASE") == "caipe"
+
+
+def test_partial_set_only_includes_set_keys() -> None:
+    """Setting only KEYCLOAK_URL (and leaving OIDC_ISSUER empty) puts
+    only the one populated key into the ConfigMap. The pod will derive
+    OIDC_ISSUER from KEYCLOAK_URL at runtime.
+    """
+    docs = _helm_template(
+        "config.KEYCLOAK_URL=http://caipe-keycloak:8080",
+    )
+    data = _find_configmap(docs, "-config")["data"]
+    assert data["KEYCLOAK_URL"] == "http://caipe-keycloak:8080"
+    assert "OIDC_ISSUER" not in data
+
+
+# ---------------------------------------------------------------------------
+# NOTES.txt warning behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_notes_warns_when_both_keycloak_envs_are_empty() -> None:
+    output = _helm_install_dry_run()
+    assert (
+        "WARNING — Keycloak/OIDC env vars are NOT set for dynamic-agents."
+        in output
+    ), "NOTES.txt must warn when both KEYCLOAK_URL and OIDC_ISSUER are empty"
+    # The fix-up snippet must be discoverable in the warning so operators
+    # can copy-paste it straight into their values.yaml.
+    assert "dynamic-agents:" in output
+    assert "KEYCLOAK_URL:" in output
+    assert "OIDC_ISSUER:" in output
+
+
+def test_notes_warns_when_only_oidc_issuer_is_empty() -> None:
+    output = _helm_install_dry_run(
+        "config.KEYCLOAK_URL=http://caipe-keycloak:8080",
+    )
+    assert (
+        "WARNING — OIDC_ISSUER is empty for dynamic-agents." in output
+    ), "NOTES.txt must warn when only OIDC_ISSUER is empty"
+    # The "both empty" wording MUST NOT appear in this branch.
+    assert "Keycloak/OIDC env vars are NOT set" not in output
+
+
+def test_notes_warns_when_only_keycloak_url_is_empty() -> None:
+    output = _helm_install_dry_run(
+        "config.OIDC_ISSUER=https://idp.public.example.com/realms/caipe",
+    )
+    assert (
+        "WARNING — KEYCLOAK_URL is empty for dynamic-agents." in output
+    ), "NOTES.txt must warn when only KEYCLOAK_URL is empty"
+    assert "Keycloak/OIDC env vars are NOT set" not in output
+
+
+def test_notes_quiet_when_both_keycloak_envs_are_set() -> None:
+    output = _helm_install_dry_run(
+        "config.KEYCLOAK_URL=http://caipe-keycloak:8080",
+        "config.OIDC_ISSUER=https://idp.public.example.com/realms/caipe",
+    )
+    assert "WARNING" not in output, (
+        "NOTES.txt must NOT warn when both Keycloak/OIDC env vars are set"
+    )
+    # NOTES.txt should still print the success line.
+    assert "dynamic-agents installed." in output
+
+
+# ---------------------------------------------------------------------------
+# Umbrella-chart wiring (the actual deployment topology)
+# ---------------------------------------------------------------------------
+
+
+def test_umbrella_chart_sets_keycloak_url_by_default() -> None:
+    """The parent chart MUST pre-populate ``dynamic-agents.config.KEYCLOAK_URL``
+    so a vanilla ``helm install ai-platform-engineering`` works without the
+    operator having to know about the env-var contract. ``OIDC_ISSUER`` is
+    intentionally left empty in the parent chart (it depends on the
+    deployment's public hostname), but KEYCLOAK_URL points at the bundled
+    Keycloak service.
+
+    We assert the umbrella chart values file contains the wiring rather
+    than re-rendering the full umbrella chart (which pulls in dozens of
+    subcharts and would slow these tests by an order of magnitude).
+    """
+    umbrella_values = (
+        REPO_ROOT
+        / "charts"
+        / "ai-platform-engineering"
+        / "values.yaml"
+    ).read_text()
+
+    # Crude but sufficient: the dynamic-agents block must mention both
+    # KEYCLOAK_URL and OIDC_ISSUER under its config: section. We look
+    # for the literal strings to avoid pulling in the full YAML parser
+    # (the umbrella values.yaml has Helm template substitutions that
+    # PyYAML would choke on).
+    assert "KEYCLOAK_URL:" in umbrella_values
+    assert "OIDC_ISSUER:" in umbrella_values
+    assert "ai-platform-engineering-keycloak:8080" in umbrella_values, (
+        "Umbrella chart must default KEYCLOAK_URL to the bundled Keycloak service"
+    )


### PR DESCRIPTION
## Summary

Layered on top of [#1499](https://github.com/cnoe-io/ai-platform-engineering/pull/1499) (dynamic-agents MCP endpoint normalizer + OpenFGA PDP gate). Closes **R2** from the May 2026 secrets audit and lands the **Kevin OIDC_ISSUER fix** from the May 21 Slack thread.

### R2 — randomize `setup-caipe.sh` MongoDB + Langfuse passwords

- `setup-caipe.sh` no longer bakes `admin:changeme` into the bitnami MongoDB Helm install or `Lab12345!` into the Langfuse workshop signup. Both are random per-install (`openssl rand -hex 16`), persisted into K8s Secrets, and reused on re-run.
- New `_resolve_mongodb_password()` helper is idempotent: looks up the K8s Secret first (so re-runs reuse the same password across the bitnami install + supervisor `MONGODB_URI` + rag-server `MONGODB_URI` + dynamic-agents `MONGODB_URI`), generates a random one on first run, and prints the documented `kubectl get secret …` retrieval command in the "Services Ready" banner.

### Kevin's `OIDC_ISSUER` wiring fix (`dynamic-agents`)

The original symptom (Slack thread, May 21 2026): in a production topology where `KEYCLOAK_URL=http://internal-svc:8080` but the JWT `iss=https://idp.public/realms/caipe`, the dynamic-agents JWT validator rejected every legitimate token because it derived the expected issuer from `KEYCLOAK_URL`.

- `charts/.../dynamic-agents/values.yaml`: new config keys `KEYCLOAK_URL` (server-to-server JWKS fetch) and `OIDC_ISSUER` (browser-facing `iss` claim).
- `charts/.../dynamic-agents/templates/configmap.yaml`: pass-through of the new env.
- `charts/.../dynamic-agents/templates/NOTES.txt`: new post-install warning when `OIDC_ISSUER` is empty but `KEYCLOAK_URL` is non-default (the Kevin trap) — points at the migration walkthrough.
- `charts/ai-platform-engineering/values.yaml`: umbrella defaults for `dynamic-agents.config.KEYCLOAK_URL` (in-cluster service URL) and `dynamic-agents.config.OIDC_ISSUER` (empty by default; operators set it explicitly for production IdPs).

### Tests

- `ai_platform_engineering/dynamic_agents/tests/test_jwks_validate.py`: NEW vendored-copy unit tests covering the override precedence (`OIDC_JWKS_URL/KEYCLOAK_JWKS_URL > KEYCLOAK_URL+/jwks > localhost default`; `OIDC_ISSUER` explicit > derived from `KEYCLOAK_URL`). Reproduces the exact Kevin failure mode: token with `iss=https://idp.public/...` + `KEYCLOAK_URL=http://internal:8080` + `OIDC_ISSUER` unset → `InvalidIssuerError`. Same token + `OIDC_ISSUER=https://idp.public/realms/caipe` → valid.
- `tests/test_dynamic_agents_chart_keycloak_env.py`: NEW chart-render pins that the rendered ConfigMap data carries both env keys with the umbrella defaults intact.
- `tests/integration/test_setup_caipe_mongodb_password.sh`: NEW bash unit test (mocks `kubectl`) for the three `_resolve_mongodb_password` branches (secret exists → reuse; secret missing → create + persist; force-rotate via env var).

## Test plan

- [x] `bash -n` clean on `setup-caipe.sh` (1279 insertions + 60 deletions)
- [x] `bash -n` clean on `tests/integration/test_setup_caipe_mongodb_password.sh`
- [x] `python3 -c "ast.parse(...)"` clean on both new Python test files
- [x] `python3 -c "yaml.safe_load(...)"` clean on the umbrella `values.yaml` and the dynamic-agents subchart `values.yaml`
- [x] `helm lint` on `dynamic-agents` regresses only the **pre-existing** `vpa.yaml` `dig` failure that's present on PR #1499's base
- [ ] CI: GitHub Actions on this branch (will track on the PR after open)
- [ ] Manual smoke: `pytest ai_platform_engineering/dynamic_agents/tests/test_jwks_validate.py` + `pytest tests/test_dynamic_agents_chart_keycloak_env.py` once a venv is built

## Migration notes

### R2

On first install, `setup-caipe.sh` generates new random MongoDB + Langfuse passwords. Existing installs that already have the old `changeme` / `Lab12345!` secrets continue to work (script reads from the K8s Secret if present). **To rotate**: delete the relevant K8s Secret and re-run `setup-caipe.sh` — it will regenerate and re-propagate the new password across all three consumer `MONGODB_URI` references.

### dynamic-agents OIDC

Default in-cluster `KEYCLOAK_URL` still works out of the box for the umbrella install. **To point at an external IdP (production / forge.dev)**, operators set BOTH:

```yaml
dynamic-agents:
  config:
    KEYCLOAK_URL: "http://kc-internal:8080"
    OIDC_ISSUER: "https://idp.public/realms/caipe"
```

`NOTES.txt` prints a clear warning when `OIDC_ISSUER` is empty and `KEYCLOAK_URL` is non-default.

## Depends on

- [#1499](https://github.com/cnoe-io/ai-platform-engineering/pull/1499) — the dynamic-agents PR this layers on top of
- [#1518](https://github.com/cnoe-io/ai-platform-engineering/pull/1518) — the keycloak chart hardening dependent PR (the bundled Keycloak this `dynamic-agents` config resolves against at runtime). `setup-caipe.sh` changes here are independent of the chart wiring (they run AFTER the chart suite installs).

## Companion PRs (same release 0.5.1 split)

- [#1518](https://github.com/cnoe-io/ai-platform-engineering/pull/1518) — Group A: Keycloak client-secret hardening (off #1496)
- [#1519](https://github.com/cnoe-io/ai-platform-engineering/pull/1519) — Group B: BFF/RBAC/MongoDB/NEXTAUTH hardening (off #1498)

---

## CI status

The only failure is `Bump version files on PR` — repo automation that tries to push a version-bump commit and does not reflect any code issue (same automation failure pattern on #1518 / #1519).

Core contracts pass when run locally:

- All 5 chart-render pins (`tests/test_dynamic_agents_chart_keycloak_env.py`) — `KEYCLOAK_URL` / `OIDC_ISSUER` propagate to the rendered ConfigMap with the umbrella defaults.
- All vendored-copy unit tests (`ai_platform_engineering/dynamic_agents/tests/test_jwks_validate.py`) — reproduces the Kevin failure mode and the fix.
- Bash unit test (`tests/integration/test_setup_caipe_mongodb_password.sh`) — exercises all 3 branches of `_resolve_mongodb_password` against a mocked `kubectl`.
