### PR TITLE
fix(ui): use users.conversations for Slack channel discovery to dodge rate limits (#1506)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18-dev.9"
+version = "0.4.18-dev.10"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts
@@ -1,0 +1,275 @@
+/**
+ * @jest-environment node
+ *
+ * Regression coverage for GitHub issue #1506: Slack Integration channel
+ * discovery returning irrelevant results + no caching.
+ *
+ * Verifies that the `available-channels` route:
+ *   - Uses `users.conversations` (Tier 3) when member_only=1 (default), so
+ *     workspaces with thousands of channels don't trip Slack's Tier-2 rate
+ *     limit on `conversations.list`.
+ *   - Falls back to `conversations.list` when member_only=0.
+ *   - Caches results per (scope, token) and serves repeat requests from cache
+ *     without calling Slack again.
+ *   - Splits the cache key per scope so the two endpoints don't poison each
+ *     other's snapshot.
+ *   - Honors `refresh=1` to force a re-fetch.
+ *   - Defaults `is_member=true` for rows from `users.conversations` (which
+ *     omits the field per Slack's docs).
+ *
+ * assisted-by Claude Claude-opus-4-7
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockRequireRbacPermission = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  const actual = jest.requireActual("@/lib/api-middleware");
+  return {
+    ...actual,
+    getAuthFromBearerOrSession: (...args: unknown[]) =>
+      mockGetAuthFromBearerOrSession(...args),
+    requireRbacPermission: (...args: unknown[]) =>
+      mockRequireRbacPermission(...args),
+  };
+});
+
+interface SlackFetchCall {
+  endpoint: string;
+  cursor: string | null;
+  url: string;
+}
+
+const slackCalls: SlackFetchCall[] = [];
+
+function mockSlackFetch(handler: (call: SlackFetchCall) => unknown) {
+  (global.fetch as jest.Mock).mockImplementation(async (input: string) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const parsed = new URL(url);
+    const endpointName = parsed.pathname.split("/").pop() ?? "";
+    const cursor = parsed.searchParams.get("cursor");
+    const call: SlackFetchCall = { endpoint: endpointName, cursor, url };
+    slackCalls.push(call);
+    const body = handler(call);
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map<string, string>(),
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    };
+  });
+}
+
+async function makeRequest(query: string): Promise<unknown> {
+  const { GET } = await import("../route");
+  const response = await GET(
+    new NextRequest(
+      `http://localhost:3000/api/admin/slack/available-channels?${query}`,
+      { headers: { Authorization: "Bearer test-token" } }
+    )
+  );
+  return await response.json();
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  slackCalls.length = 0;
+  mockGetAuthFromBearerOrSession.mockResolvedValue({
+    user: { email: "admin@example.com" },
+    session: { sub: "admin-sub" },
+  });
+  mockRequireRbacPermission.mockResolvedValue(undefined);
+  process.env.SLACK_BOT_TOKEN = "xoxb-test-token-abcdefghijkl";
+
+  // Reset the route's in-process cache so each test starts clean.
+  const route = await import("../route");
+  route.__resetAvailableChannelsCacheForTests();
+});
+
+describe("GET /api/admin/slack/available-channels", () => {
+  describe("issue #1506 — endpoint selection", () => {
+    it("uses users.conversations when member_only=1 (default)", async () => {
+      mockSlackFetch(() => ({
+        ok: true,
+        channels: [
+          { id: "C100", name: "incidents", is_private: false, num_members: 5 },
+          { id: "C101", name: "alerts", is_private: true, num_members: 2 },
+        ],
+        response_metadata: { next_cursor: "" },
+      }));
+
+      const body = await makeRequest("member_only=1");
+
+      expect(slackCalls).toHaveLength(1);
+      expect(slackCalls[0].endpoint).toBe("users.conversations");
+      // Both channels should come back with is_member=true even though
+      // users.conversations omits the field.
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          scope: "member_only",
+          endpoint: "users.conversations",
+          channels: [
+            expect.objectContaining({ id: "C101", name: "alerts", is_member: true }),
+            expect.objectContaining({ id: "C100", name: "incidents", is_member: true }),
+          ],
+        },
+      });
+    });
+
+    it("uses users.conversations by default (no member_only param)", async () => {
+      mockSlackFetch(() => ({ ok: true, channels: [] }));
+      await makeRequest("");
+      expect(slackCalls[0].endpoint).toBe("users.conversations");
+    });
+
+    it("falls back to conversations.list when member_only=0", async () => {
+      mockSlackFetch(() => ({
+        ok: true,
+        channels: [
+          { id: "C200", name: "general", is_private: false, is_member: true, num_members: 100 },
+          { id: "C201", name: "random", is_private: false, is_member: false, num_members: 200 },
+        ],
+      }));
+
+      const body = await makeRequest("member_only=0");
+
+      expect(slackCalls).toHaveLength(1);
+      expect(slackCalls[0].endpoint).toBe("conversations.list");
+      expect(body).toMatchObject({
+        success: true,
+        data: { scope: "all", endpoint: "conversations.list" },
+      });
+    });
+  });
+
+  describe("issue #1506 — caching", () => {
+    it("serves repeat requests from cache without hitting Slack again", async () => {
+      mockSlackFetch(() => ({
+        ok: true,
+        channels: [
+          { id: "C100", name: "incidents", num_members: 5 },
+        ],
+      }));
+
+      const first = (await makeRequest("member_only=1")) as { data: { cached: boolean } };
+      const second = (await makeRequest("member_only=1")) as { data: { cached: boolean } };
+
+      expect(slackCalls).toHaveLength(1); // second call hit the cache
+      expect(first.data.cached).toBe(false);
+      expect(second.data.cached).toBe(true);
+    });
+
+    it("forces a re-fetch when refresh=1 is set", async () => {
+      mockSlackFetch(() => ({ ok: true, channels: [{ id: "C100", name: "incidents" }] }));
+
+      await makeRequest("member_only=1");
+      await makeRequest("member_only=1&refresh=1");
+
+      expect(slackCalls).toHaveLength(2);
+      expect(slackCalls.every((c) => c.endpoint === "users.conversations")).toBe(true);
+    });
+
+    it("splits the cache by scope so member_only and full-list don't poison each other", async () => {
+      mockSlackFetch((call) => {
+        if (call.endpoint === "users.conversations") {
+          return { ok: true, channels: [{ id: "C100", name: "members-only-channel" }] };
+        }
+        return {
+          ok: true,
+          channels: [
+            { id: "C100", name: "members-only-channel", is_member: true },
+            { id: "C999", name: "non-member-channel", is_member: false },
+          ],
+        };
+      });
+
+      const memberOnly = (await makeRequest("member_only=1")) as {
+        data: { channels: Array<{ id: string }> };
+      };
+      const all = (await makeRequest("member_only=0")) as {
+        data: { channels: Array<{ id: string }>; total_visible: number };
+      };
+
+      // Two distinct Slack calls (one per endpoint), each cached separately.
+      expect(slackCalls).toHaveLength(2);
+      expect(slackCalls.map((c) => c.endpoint).sort()).toEqual([
+        "conversations.list",
+        "users.conversations",
+      ]);
+      expect(memberOnly.data.channels.map((c) => c.id)).toEqual(["C100"]);
+      expect(all.data.channels.map((c) => c.id)).toEqual(["C100", "C999"]);
+
+      // And a second member_only request should still come from cache, not
+      // contaminated by the all-list fetch.
+      const repeat = (await makeRequest("member_only=1")) as {
+        data: { cached: boolean; channels: Array<{ id: string }> };
+      };
+      expect(slackCalls).toHaveLength(2);
+      expect(repeat.data.cached).toBe(true);
+      expect(repeat.data.channels.map((c) => c.id)).toEqual(["C100"]);
+    });
+  });
+
+  describe("pagination + filtering", () => {
+    it("walks Slack cursors and returns all pages", async () => {
+      mockSlackFetch((call) => {
+        if (!call.cursor) {
+          return {
+            ok: true,
+            channels: [{ id: "C001", name: "a-channel" }],
+            response_metadata: { next_cursor: "page2" },
+          };
+        }
+        return {
+          ok: true,
+          channels: [{ id: "C002", name: "b-channel" }],
+          response_metadata: { next_cursor: "" },
+        };
+      });
+
+      const body = (await makeRequest("member_only=1")) as {
+        data: { channels: Array<{ id: string }>; total_visible: number };
+      };
+
+      expect(slackCalls).toHaveLength(2);
+      expect(body.data.total_visible).toBe(2);
+      expect(body.data.channels.map((c) => c.id)).toEqual(["C001", "C002"]);
+    });
+
+    it("filters by q (case-insensitive substring) over the cached snapshot", async () => {
+      mockSlackFetch(() => ({
+        ok: true,
+        channels: [
+          { id: "C001", name: "incidents-prod" },
+          { id: "C002", name: "incidents-dev" },
+          { id: "C003", name: "random" },
+        ],
+      }));
+
+      const body = (await makeRequest("member_only=1&q=INCIDENTS")) as {
+        data: { channels: Array<{ id: string }>; total_matches: number };
+      };
+
+      expect(body.data.total_matches).toBe(2);
+      expect(body.data.channels.map((c) => c.id).sort()).toEqual(["C001", "C002"]);
+    });
+  });
+
+  describe("failure modes", () => {
+    it("returns 503 when SLACK_BOT_TOKEN is unset", async () => {
+      delete process.env.SLACK_BOT_TOKEN;
+      const { GET } = await import("../route");
+      const response = await GET(
+        new NextRequest(
+          "http://localhost:3000/api/admin/slack/available-channels?member_only=1",
+          { headers: { Authorization: "Bearer test-token" } }
+        )
+      );
+      expect(response.status).toBe(503);
+    });
+  });
+});

--- a/ui/src/app/api/admin/slack/available-channels/route.ts
+++ b/ui/src/app/api/admin/slack/available-channels/route.ts
@@ -18,18 +18,33 @@
  * Auth: requires `admin_ui:view`.
  *
  * Caching strategy:
- *   We always pull the FULL channel list from Slack once per token (Slack has
- *   no server-side name search for channels) and keep it in-process for
- *   `CACHE_TTL_MS`. Filtering, sorting, and paging happen here on the cached
- *   snapshot so the UI can search/scroll instantly without hammering Slack's
- *   Tier-2 rate limit (20 req/min). Admins can force a refresh via `?refresh=1`.
+ *   We pull a snapshot of channels from Slack once per (token, scope) and keep
+ *   it in-process for `CACHE_TTL_MS`. Filtering, sorting, and paging happen
+ *   here on the cached snapshot so the UI can search/scroll instantly without
+ *   hammering Slack's rate limits. Admins can force a refresh via `?refresh=1`.
  *
- *   The Slack walk handles HTTP 429 with the `Retry-After` header so a busy
+ *   Endpoint selection (fixes #1506):
+ *     - `member_only=1` (default)  → `users.conversations` (Tier 3, ~50 req/min).
+ *       Returns ONLY channels the bot is a member of. This is what the admin UI
+ *       almost always wants and is orders of magnitude smaller than the whole
+ *       workspace, which keeps us off Slack's Tier-2 rate limit in big tenants.
+ *     - `member_only=0`            → `conversations.list` (Tier 2, ~20 req/min).
+ *       Returns every public/private channel the token can see. Used only when
+ *       an admin explicitly opts in (e.g. assigning the bot to a brand new
+ *       channel). The cache softens the rate-limit blast radius.
+ *
+ *   The two scopes have separate cache entries because their result sets are
+ *   different — mixing them would either pollute member-only with non-member
+ *   channels or starve full-list mode.
+ *
+ *   Both walks handle HTTP 429 with the `Retry-After` header so a busy
  *   workspace doesn't break discovery.
  *
  * Failure modes:
  *   - SLACK_BOT_TOKEN unset → 503 (UI falls back to manual channel-ID entry).
  *   - Slack API error → 502 with upstream error code.
+ *
+ * assisted-by Claude Claude-opus-4-7
  */
 
 import { NextRequest } from "next/server";
@@ -65,21 +80,29 @@ interface NormalizedChannel {
   num_members: number;
 }
 
+type DiscoveryScope = "member_only" | "all";
+
 interface CacheEntry {
   channels: NormalizedChannel[];
   fetched_at: number;
+  endpoint: "users.conversations" | "conversations.list";
 }
 
 // Channel lists rarely change between admin actions; 10 min keeps us well
 // inside Slack's rate limits even when several admins are active.
 const CACHE_TTL_MS = 10 * 60_000;
-// Slack max page size for conversations.list is 1000, but they recommend
-// <=200 for stability. We pull at 200 internally regardless of the UI page
-// size (which is just a slice on top of the cache).
+// Slack max page size is 1000 for conversations.list / 999 for
+// users.conversations, but Slack recommends <=200 for stability. We pull at
+// 200 internally regardless of the UI page size (which is just a slice on top
+// of the cache).
 const SLACK_PAGE_SIZE = 200;
-// Hard ceiling on how many Slack pages we'll walk. 200 channels/page * 100
-// pages = 20k channels, more than any realistic workspace.
-const MAX_SLACK_PAGES = 100;
+// Hard ceiling on how many Slack pages we'll walk per scope.
+//   - member_only (users.conversations): 200 * 50 = 10k channels, far more than
+//     any sane bot membership.
+//   - all (conversations.list): 200 * 100 = 20k channels, more than any
+//     realistic workspace.
+const MAX_SLACK_PAGES_MEMBER = 50;
+const MAX_SLACK_PAGES_ALL = 100;
 // Defensive ceiling on how long we'll sleep waiting for Slack rate limits
 // before giving up and 502'ing. Prevents a single request from holding a
 // Next.js worker forever.
@@ -92,12 +115,33 @@ const cache = new Map<string, CacheEntry>();
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-async function listAllConversations(token: string): Promise<NormalizedChannel[]> {
+/**
+ * Test-only helper. Lets us reset the in-process cache between unit tests so
+ * one test's snapshot doesn't bleed into the next. Not exported in production
+ * code paths — it's a no-op for callers that don't import it.
+ */
+export function __resetAvailableChannelsCacheForTests(): void {
+  cache.clear();
+}
+
+/**
+ * Walk a Slack conversations endpoint and accumulate normalized channels.
+ *
+ * The two supported endpoints (`users.conversations` for member-only and
+ * `conversations.list` for full workspace) share the same response shape, so
+ * we parameterise endpoint, page cap, and is_member defaulting and reuse the
+ * pagination + rate-limit loop.
+ */
+async function walkSlackConversations(
+  token: string,
+  endpoint: "users.conversations" | "conversations.list",
+  options: { maxPages: number; defaultIsMember: boolean }
+): Promise<NormalizedChannel[]> {
   const out: NormalizedChannel[] = [];
   let cursor: string | undefined;
 
-  for (let page = 0; page < MAX_SLACK_PAGES; page++) {
-    const url = new URL("https://slack.com/api/conversations.list");
+  for (let page = 0; page < options.maxPages; page++) {
+    const url = new URL(`https://slack.com/api/${endpoint}`);
     url.searchParams.set("limit", String(SLACK_PAGE_SIZE));
     url.searchParams.set("exclude_archived", "true");
     // public + private; DMs/MPIMs are not assignable to teams.
@@ -109,14 +153,13 @@ async function listAllConversations(token: string): Promise<NormalizedChannel[]>
       cache: "no-store",
     });
 
-    // Honor Slack rate-limit responses. Tier-2 = 20 req/min so this is rare
-    // when we cache, but it can happen if multiple admins click Refresh
-    // simultaneously across UI replicas.
+    // Honor Slack rate-limit responses. Even on Tier 3 this can happen if
+    // multiple admins click Refresh simultaneously across UI replicas.
     if (res.status === 429) {
       const retryAfter = Number(res.headers.get("retry-after") ?? "1");
       const waitMs = Math.min(Math.max(retryAfter, 1) * 1000, MAX_RATE_LIMIT_WAIT_MS);
       console.warn(
-        `[Admin SlackChannels] rate-limited by Slack, sleeping ${waitMs}ms (page=${page})`
+        `[Admin SlackChannels] rate-limited by Slack ${endpoint}, sleeping ${waitMs}ms (page=${page})`
       );
       await sleep(waitMs);
       continue; // retry same cursor
@@ -137,7 +180,11 @@ async function listAllConversations(token: string): Promise<NormalizedChannel[]>
           id: c.id,
           name: c.name ?? c.id,
           is_private: Boolean(c.is_private),
-          is_member: Boolean(c.is_member),
+          // `users.conversations` omits `is_member` (per Slack docs) since by
+          // definition every row is one the bot is in. Default accordingly so
+          // downstream filters and the UI's `channel.is_member !== false`
+          // check both behave correctly.
+          is_member: c.is_member ?? options.defaultIsMember,
           num_members: c.num_members ?? 0,
         });
       }
@@ -171,71 +218,87 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const { user, session } = await getAuthFromBearerOrSession(request);
   await requireRbacPermission(session, "admin_ui", "view");
 
-    const token = process.env.SLACK_BOT_TOKEN?.trim();
-    if (!token) {
-      throw new ApiError(
-        "SLACK_BOT_TOKEN is not configured on the UI service. Channel discovery is unavailable; admins can still paste channel IDs manually.",
-        503
-      );
-    }
-
-    const params = request.nextUrl.searchParams;
-    const refresh = params.get("refresh") === "1";
-    const q = (params.get("q") ?? "").trim().toLowerCase();
-    const memberOnly = params.get("member_only") !== "0"; // default ON
-    const cursor = params.get("cursor") ?? undefined;
-    const requestedLimit = Number.parseInt(params.get("limit") ?? "", 10);
-    const limit =
-      Number.isFinite(requestedLimit) && requestedLimit > 0
-        ? Math.min(requestedLimit, MAX_UI_LIMIT)
-        : DEFAULT_UI_LIMIT;
-
-    const now = Date.now();
-    // last 12 chars uniquely identifies the token without logging it.
-    const cacheKey = token.slice(-12);
-    const cached = cache.get(cacheKey);
-
-    let allChannels: NormalizedChannel[];
-    let cacheHit = false;
-    let fetchedAt: number;
-
-    if (!refresh && cached && now - cached.fetched_at < CACHE_TTL_MS) {
-      allChannels = cached.channels;
-      fetchedAt = cached.fetched_at;
-      cacheHit = true;
-    } else {
-      allChannels = await listAllConversations(token);
-      fetchedAt = now;
-      cache.set(cacheKey, { channels: allChannels, fetched_at: fetchedAt });
-    }
-
-    // Filter pipeline runs in-process against the cached snapshot.
-    let filtered = allChannels;
-    if (memberOnly) {
-      filtered = filtered.filter((c) => c.is_member);
-    }
-    if (q) {
-      filtered = filtered.filter((c) => c.name.toLowerCase().includes(q));
-    }
-
-    const totalMatches = filtered.length;
-    const afterCursor = applyCursor(filtered, cursor);
-    const page = afterCursor.slice(0, limit);
-    const hasMore = afterCursor.length > limit;
-    const nextCursor = hasMore ? page[page.length - 1].name : null;
-
-    console.log(
-      `[Admin SlackChannels] discovery ok total=${allChannels.length} matches=${totalMatches} returned=${page.length} q="${q}" member_only=${memberOnly} cache=${cacheHit ? "hit" : "miss"} by=${user.email}`
+  const token = process.env.SLACK_BOT_TOKEN?.trim();
+  if (!token) {
+    throw new ApiError(
+      "SLACK_BOT_TOKEN is not configured on the UI service. Channel discovery is unavailable; admins can still paste channel IDs manually.",
+      503
     );
+  }
 
-    return successResponse({
-      channels: page,
-      total_matches: totalMatches,
-      total_visible: allChannels.length,
-      next_cursor: nextCursor,
-      has_more: hasMore,
-      cached: cacheHit,
-      fetched_at: fetchedAt,
-      query: { q, member_only: memberOnly, limit },
+  const params = request.nextUrl.searchParams;
+  const refresh = params.get("refresh") === "1";
+  const q = (params.get("q") ?? "").trim().toLowerCase();
+  const memberOnly = params.get("member_only") !== "0"; // default ON
+  const cursor = params.get("cursor") ?? undefined;
+  const requestedLimit = Number.parseInt(params.get("limit") ?? "", 10);
+  const limit =
+    Number.isFinite(requestedLimit) && requestedLimit > 0
+      ? Math.min(requestedLimit, MAX_UI_LIMIT)
+      : DEFAULT_UI_LIMIT;
+
+  const scope: DiscoveryScope = memberOnly ? "member_only" : "all";
+  const endpoint: "users.conversations" | "conversations.list" = memberOnly
+    ? "users.conversations"
+    : "conversations.list";
+  const maxPages = memberOnly ? MAX_SLACK_PAGES_MEMBER : MAX_SLACK_PAGES_ALL;
+
+  const now = Date.now();
+  // last 12 chars uniquely identifies the token without logging it. Scope is
+  // part of the key so the two endpoints don't poison each other's snapshot.
+  const cacheKey = `${scope}:${token.slice(-12)}`;
+  const cached = cache.get(cacheKey);
+
+  let snapshot: NormalizedChannel[];
+  let cacheHit = false;
+  let fetchedAt: number;
+
+  if (!refresh && cached && now - cached.fetched_at < CACHE_TTL_MS) {
+    snapshot = cached.channels;
+    fetchedAt = cached.fetched_at;
+    cacheHit = true;
+  } else {
+    snapshot = await walkSlackConversations(token, endpoint, {
+      maxPages,
+      defaultIsMember: memberOnly,
     });
+    fetchedAt = now;
+    cache.set(cacheKey, { channels: snapshot, fetched_at: fetchedAt, endpoint });
+  }
+
+  // Filter pipeline runs in-process against the cached snapshot.
+  // NOTE: when scope is "member_only" the snapshot is already members-only
+  // (users.conversations returns only those rows), so this filter is a no-op
+  // there. Keep it for defence-in-depth against a future provider that
+  // returns extras.
+  let filtered = snapshot;
+  if (memberOnly) {
+    filtered = filtered.filter((c) => c.is_member);
+  }
+  if (q) {
+    filtered = filtered.filter((c) => c.name.toLowerCase().includes(q));
+  }
+
+  const totalMatches = filtered.length;
+  const afterCursor = applyCursor(filtered, cursor);
+  const page = afterCursor.slice(0, limit);
+  const hasMore = afterCursor.length > limit;
+  const nextCursor = hasMore ? page[page.length - 1].name : null;
+
+  console.log(
+    `[Admin SlackChannels] discovery ok scope=${scope} endpoint=${endpoint} total=${snapshot.length} matches=${totalMatches} returned=${page.length} q="${q}" cache=${cacheHit ? "hit" : "miss"} by=${user.email}`
+  );
+
+  return successResponse({
+    channels: page,
+    total_matches: totalMatches,
+    total_visible: snapshot.length,
+    next_cursor: nextCursor,
+    has_more: hasMore,
+    cached: cacheHit,
+    fetched_at: fetchedAt,
+    scope,
+    endpoint,
+    query: { q, member_only: memberOnly, limit },
+  });
 });

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -518,15 +518,19 @@ export function SlackChannelRebacPanel({
   };
 
   const fetchBotMemberChannels = async (): Promise<DiscoveredSlackChannel[]> => {
+    // Issue #1506: previously this set `refresh=1` on the first page of every
+    // Discover click, which defeated the server-side cache entirely and
+    // tripped Slack's per-tenant rate limits on workspaces with thousands of
+    // channels. The cache TTL (10 min, server-side) is short enough for human
+    // admin workflows; a hard refresh button can be added separately if/when
+    // operators actually need it.
     const discovered: DiscoveredSlackChannel[] = [];
     let cursor: string | null | undefined;
-    let firstPage = true;
     do {
       const params = new URLSearchParams({
         member_only: "1",
         limit: "500",
       });
-      if (firstPage) params.set("refresh", "1");
       if (cursor) params.set("cursor", cursor);
       const response = await fetch(`/api/admin/slack/available-channels?${params.toString()}`, {
         cache: "no-store",
@@ -535,7 +539,6 @@ export function SlackChannelRebacPanel({
       const data = apiData<SlackChannelDiscoveryPayload>(await response.json());
       discovered.push(...(data.channels ?? []));
       cursor = data.has_more ? data.next_cursor : null;
-      firstPage = false;
     } while (cursor);
     return discovered.filter((channel) => channel.is_member !== false);
   };

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18.dev9"
+version = "0.4.18.dev10"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Fixes #1506 — Slack Integration channel discovery returning irrelevant results + no caching.

## Root cause

The admin UI's Slack channel picker (`/api/admin/slack/available-channels`) was always calling Slack's [`conversations.list`](https://docs.slack.dev/reference/methods/conversations.list/) endpoint and walking the **entire workspace** channel list — even when the caller only wanted channels the bot was a member of (which is what the UI almost always sends).

On tenants with thousands of channels this caused both halves of the bug report:

1. **Rate limiting.** `conversations.list` is Slack **Tier 2 (~20 req/min)**. Every cache miss pulled hundreds-to-thousands of channels across many paginated requests, easily blowing the per-tenant budget and returning HTTP 429.
2. **Irrelevant results.** The `is_member=true` filter ran **after** the full pagination walk in JS, so the page would briefly show non-member channels before the filter kicked in — and if Slack 429-ed mid-walk, the request returned a partial / nothing-shaped response.
3. **No effective caching.** The `SlackChannelRebacPanel` was sending `refresh=1` on the **first page of every Discover click**, bypassing the 10-min in-process cache entirely. So the rate-limit pain repeated on every interaction.

## Fix

1. **Switch endpoints by intent.** When `member_only=1` (the default and what the UI sends), call [`users.conversations`](https://docs.slack.dev/reference/methods/users.conversations/) instead. That endpoint is **Tier 3 (~50 req/min, ~2.5× more headroom)** and returns **only** channels the bot is a member of — usually tens-to-hundreds, not thousands. `conversations.list` is still used for the rare `member_only=0` ("show every channel even if the bot isn't in it") case.
2. **Split the cache by scope.** `member_only` and `all` now have separate cache entries keyed `${scope}:${token-tail}`, so the two endpoints can't poison each other's snapshot.
3. **Honor Slack's omission.** `users.conversations` omits the `is_member` field (because every row is, by definition, one the bot is in). The route now defaults `is_member=true` for that path so the UI's existing `channel.is_member !== false` guard doesn't drop everything.
4. **Surface diagnostics.** The response now includes `scope` and `endpoint`, so operators can confirm from the network tab which path served them.
5. **Stop fighting the cache.** Removed the unconditional `refresh=1` from `SlackChannelRebacPanel`'s `fetchBotMemberChannels`. The 10-min server-side TTL is short enough for human admin workflows; a hard refresh button can be added separately if/when operators ask for it.

## No new Slack scopes required

Both `users.conversations` and `conversations.list` require the **same** bot token scopes — `channels:read`, `groups:read`, `im:read`, `mpim:read` — which the CAIPE Slack bot already requests at install time. **This is a zero-config swap; no Slack app re-install or admin consent is needed to deploy this fix.**

## Why `conversations.list` is still retained (not removed)

`conversations.list` is **not deprecated** by Slack — the docs page (fetched 2026-05-23) shows no deprecation banner and the Slack changelog has no sunset entries for it. The `deprecated_endpoint` / `method_deprecated` strings that appear in its docs are part of the **generic error catalog** that every Slack method documents, not declarations that this specific method is deprecated.

It is intentionally kept in the route as the fallback for `member_only=0`, which is wired to an admin checkbox in the Team Details dialog ("Only channels the bot is a member of" — untick to see all workspace channels). That checkbox supports a real workflow: **adding the bot to a channel it isn't in yet.** `users.conversations` cannot satisfy that case because it is, by definition, scoped to channels the bot is already a member of.

If/when we want to retire `conversations.list` entirely, the migration path is clean: the `TeamDetailsDialog` Slack Channels panel already ships a "**Or add by ID**" manual paste UX (a Slack channel-ID input next to a display-name input + a `+` button — see `SlackChannelsPanel` around L2435–2462). Mirroring that into `SlackChannelRebacPanel` and removing the "show all" checkbox would let us drop `conversations.list` calls without regressing the bring-bot-to-new-channel flow. That's intentionally out of scope here so this PR stays a tight bugfix; happy to file a follow-up issue.

## Verification

- **9/9 new tests pass** in `ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts` — endpoint selection, cache hits + refresh, per-scope cache splitting, pagination, query filter, and the SLACK_BOT_TOKEN-missing failure mode.
- **47/47 tests** across `src/app/api/admin/slack/**`, `SlackChannelRebacPanel.test.tsx`, and `TeamDetailsDialog.webex.test.tsx` continue to pass — the response shape is a superset of the previous one, so existing callers are unaffected.
- ESLint clean on the changed files.
- `tsc --noEmit` reports zero TypeScript errors in the changed files. (Stale `.next/dev/types` errors for unrelated routes exist on `main` already and are not regressions.)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Unit tests for endpoint selection (members_only vs all) — `route.test.ts`
- [x] Unit tests for per-scope cache splitting and `refresh=1` behaviour
- [x] Existing rebac panel + team-details-dialog tests still pass
- [ ] **Manual:** in a large Slack workspace (the original repro), open the admin Integrations tab → Slack → Discover and confirm only bot-member channels appear with no 429s.
- [ ] **Manual:** click Discover twice quickly and confirm the second call is served from cache (server logs show `cache=hit`, no Slack call fired).

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (Closes #1506)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (route docstring + comments call out the issue and the rationale)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
