### PR TITLE
docs(specs): port thin bot/PEP specs from release/0.5.1

### DIFF
--- a/docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md
+++ b/docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md
@@ -1,0 +1,55 @@
+# RAG Thin PEP Around OpenFGA Plan
+
+## Goal
+
+Refactor RAG authorization so the vector service behaves as a policy enforcement point
+(PEP), not a policy engine. OpenFGA remains the source of truth for datasource and
+knowledge-base access, while the BFF constrains browser/UI requests before proxying.
+
+## Current State
+
+`server/rbac.py` currently combines several responsibilities:
+
+- token validation and role mapping
+- Keycloak realm-role compatibility checks
+- OpenFGA `check` and `list-objects`
+- MongoDB `team_kb_ownership` reads
+- datasource filter injection
+- optional document ACL filtering
+
+That coupling makes query serving depend on multiple policy stores and creates duplicate
+PDP calls for BFF-proxied UI requests.
+
+## Target Call Paths
+
+| Caller | Expected RAG behavior |
+|--------|-----------------------|
+| Browser through BFF | Validate forwarded JWT, trust BFF-constrained datasource IDs, run vector search. |
+| Direct API user | Validate JWT, run one OpenFGA check/list for requested datasource action, run vector search. |
+| Ingestor service account | Validate service token, check `service:<id> can_ingest knowledge_base:<id>`, run ingest. |
+| Agent/MCP caller | Validate JWT, check/constrain datasource access before tool execution. |
+
+## Migration Slices
+
+1. Add explicit tests for UI-proxied search, direct API search, ingestor access, and MCP search.
+2. Extract token parsing from `server/rbac.py` into a small identity helper.
+3. Extract OpenFGA datasource checks into a small PEP helper with no MongoDB dependency.
+4. Remove `team_kb_ownership` reads from query hot paths after backfill/drift checks exist.
+5. Keep document ACL as an optional second filter only if it is explicitly enabled and documented.
+
+## Non-Goals
+
+- Do not remove BFF datasource filtering.
+- Do not remove direct-client RAG OpenFGA checks.
+- Do not use Keycloak realm roles as the long-term source of product authorization.
+- Do not require document reindexing for team membership changes.
+
+## Acceptance Checklist
+
+- [ ] BFF-proxied UI search avoids redundant OpenFGA list/check calls when datasource IDs are already constrained.
+- [ ] Direct clients and ingestors still fail closed through explicit OpenFGA checks.
+- [ ] MongoDB `team_kb_ownership` is no longer required in the query hot path.
+- [ ] Legacy `kb_reader:*` / `kb_ingestor:*` role parsing is removed or isolated as a temporary fallback.
+- [ ] Tests cover allowed and denied datasource access for UI, direct API, ingestor, and MCP flows.
+
+Tracked by [#1457](https://github.com/cnoe-io/ai-platform-engineering/issues/1457).

--- a/docs/docs/specs/2026-05-19-slack-thin-bot-bff-delegation/plan.md
+++ b/docs/docs/specs/2026-05-19-slack-thin-bot-bff-delegation/plan.md
@@ -1,0 +1,79 @@
+# Slack Thin Bot BFF Delegation Plan
+
+## Goal
+
+Move Slack runtime identity and team-resolution decisions out of the Slack bot and into
+the Web UI BFF. The Slack bot should remain a transport adapter: verify Slack events,
+resolve an application-level identity/team through the BFF, mint or receive an OBO token,
+and invoke AgentGateway.
+
+## Current State
+
+- The Slack bot resolves Slack users through Keycloak Admin API helpers.
+- The Slack bot resolves channel-to-team mappings through MongoDB and local TTL caches.
+- OBO token exchange is already scoped and can stay in the bot for the first slice.
+- Runtime channel/agent ReBAC should use the integration access-check route from #1455.
+
+## Target Runtime Contract
+
+### `POST /api/integrations/slack/identity/resolve`
+
+Request:
+
+```json
+{
+  "workspace_id": "T123456789",
+  "slack_user_id": "U123456789",
+  "slack_email": "alice@example.com"
+}
+```
+
+Response:
+
+```json
+{
+  "keycloak_user_id": "alice-sub",
+  "email": "alice@example.com",
+  "linked": true,
+  "link_required": false
+}
+```
+
+### `POST /api/integrations/slack/channels/resolve-team`
+
+Request:
+
+```json
+{
+  "workspace_id": "T123456789",
+  "channel_id": "C123456789",
+  "keycloak_user_id": "alice-sub"
+}
+```
+
+Response:
+
+```json
+{
+  "allowed": true,
+  "team_slug": "platform-engineering",
+  "reason": "allowed"
+}
+```
+
+## Migration Slices
+
+1. Add BFF endpoints and tests while keeping the existing bot path unchanged.
+2. Add Slack bot client helpers for the BFF endpoints behind a feature flag.
+3. Flip the bot runtime path to BFF delegation and keep Keycloak Admin/Mongo fallback disabled by default.
+4. Remove Slack bot Keycloak Admin and MongoDB runtime credential requirements after validation.
+
+## Acceptance Checklist
+
+- [ ] The bot no longer needs Keycloak Admin credentials for runtime identity resolution.
+- [ ] The bot no longer needs MongoDB credentials for channel/team resolution.
+- [ ] BFF endpoints deny by default and do not require admin UI authorization for normal runtime bot calls.
+- [ ] OBO token exchange either stays in the bot or is explicitly moved into the identity/team BFF response.
+- [ ] Helm values, secrets examples, and RBAC docs reflect the reduced bot credential surface.
+
+Tracked by [#1456](https://github.com/cnoe-io/ai-platform-engineering/issues/1456).


### PR DESCRIPTION
## Summary

Ports the two architectural spec documents from `release/0.5.1` to `main`. These docs were authored in May 2026 (commits `fbdbb32bf` and `95b37a8fe` on `release/0.5.1`) and tracked by issues #1456 and #1457, but they never reached `main` because the surrounding work was split into other PRs that landed first.

- `docs/docs/specs/2026-05-19-slack-thin-bot-bff-delegation/plan.md` (79 lines) — defines the BFF-delegated identity/team-resolution contract for the Slack bot.
- `docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md` (55 lines) — defines the RAG server's migration to a thin policy enforcement point around OpenFGA.

Both files are ported **byte-for-byte** from `origin/release/0.5.1` — no content edits.

## Why now

Following the split-PR series that landed the `release/0.5.1` work into `main` (PRs #1496, #1497, #1499, #1518, #1519, #1520, #1523, #1524, #1525, #1526, #1527, #1531), we audited `release/0.5.1` against `main` and confirmed that every functional change had landed. The audit identified exactly two genuine content gaps — these two spec docs. This PR closes that last gap.

## Sidebar wiring

No `docs/sidebars.ts` change is needed. The specs sidebar entry is:

```ts
{
  type: 'autogenerated',
  dirName: 'specs',
},
```

Docusaurus auto-picks up new spec directories.

## Test plan

- [ ] Docusaurus build (`docs/`) passes — sidebar autogenerates entries for the two new spec dirs.
- [ ] `scripts/validate_rbac_docs.py` passes (no RBAC-touched files in this PR).
- [ ] Spec files render cleanly in the docs site preview.

## Verification

```text
git hash-object docs/docs/specs/2026-05-19-slack-thin-bot-bff-delegation/plan.md
20be23b0c72b4af76a4a355f02c135484d6a167d  # matches origin/release/0.5.1 blob exactly

git hash-object docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md
c8e7c1df684e8af3b66fcbc4904c2ee64fd44cab  # matches origin/release/0.5.1 blob exactly
```
