### PR TITLE
fix(ui/slack): drop stale env-provided Slack default agent/team and surface a warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18-dev.9"
+version = "0.4.18-dev.10"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -189,6 +189,8 @@ export function SlackChannelRebacPanel({
   const [routePendingDelete, setRoutePendingDelete] = useState<SlackChannelAgentRoute | null>(null);
   const [defaultTeamSlug, setDefaultTeamSlug] = useState("");
   const [defaultAgentId, setDefaultAgentId] = useState("");
+  const [invalidDefaultTeamSlug, setInvalidDefaultTeamSlug] = useState<string | null>(null);
+  const [invalidDefaultAgentId, setInvalidDefaultAgentId] = useState<string | null>(null);
   const [configuredDefaults, setConfiguredDefaults] = useState<SlackChannelAssociationDefaults | null>(null);
   const [useSlackbotConfigDefaults, setUseSlackbotConfigDefaults] = useState(true);
   const [slackRuntimeStatus, setSlackRuntimeStatus] = useState<SlackBotRuntimeStatus | null>(null);
@@ -231,6 +233,10 @@ export function SlackChannelRebacPanel({
   const dynamicAgentIds = useMemo(
     () => new Set(dynamicAgents.map((agent) => agent._id)),
     [dynamicAgents]
+  );
+  const teamSlugSet = useMemo(
+    () => new Set(teams.map((team) => team.slug).filter(Boolean) as string[]),
+    [teams]
   );
   const fallbackAgentId = useMemo(() => {
     if (defaultAgentId && dynamicAgentIds.has(defaultAgentId)) return defaultAgentId;
@@ -343,6 +349,40 @@ export function SlackChannelRebacPanel({
       setMessage(error instanceof Error ? error.message : "Failed to load Slack channel association defaults")
     );
   }, [loadAssociationDefaults, selfService]);
+
+  // Drop env-provided default Dynamic Agent / team if it no longer resolves to a
+  // real, enabled record. Otherwise the dropdown silently submits a stale id
+  // (e.g. SLACK_DEFAULT_AGENT_ID points at a deleted agent) and the API
+  // rejects with "Dynamic Agent <id> was not found or is disabled".
+  useEffect(() => {
+    if (selfService) return;
+    if (dynamicAgents.length === 0) return;
+    if (!defaultAgentId) {
+      if (invalidDefaultAgentId) setInvalidDefaultAgentId(null);
+      return;
+    }
+    if (!dynamicAgentIds.has(defaultAgentId)) {
+      setInvalidDefaultAgentId(defaultAgentId);
+      setDefaultAgentId("");
+    } else if (invalidDefaultAgentId) {
+      setInvalidDefaultAgentId(null);
+    }
+  }, [selfService, dynamicAgents.length, dynamicAgentIds, defaultAgentId, invalidDefaultAgentId]);
+
+  useEffect(() => {
+    if (selfService) return;
+    if (teams.length === 0) return;
+    if (!defaultTeamSlug) {
+      if (invalidDefaultTeamSlug) setInvalidDefaultTeamSlug(null);
+      return;
+    }
+    if (!teamSlugSet.has(defaultTeamSlug)) {
+      setInvalidDefaultTeamSlug(defaultTeamSlug);
+      setDefaultTeamSlug("");
+    } else if (invalidDefaultTeamSlug) {
+      setInvalidDefaultTeamSlug(null);
+    }
+  }, [selfService, teams.length, teamSlugSet, defaultTeamSlug, invalidDefaultTeamSlug]);
 
   useEffect(() => {
     if (selfService) return;
@@ -608,7 +648,15 @@ export function SlackChannelRebacPanel({
   };
 
   const confirmMigrationDefaults = async (channelImportRows: SlackChannelImportRow[] = []) => {
-    if (!defaultTeamSlug || !defaultAgentId) return;
+    if (!defaultTeamSlug || !defaultAgentId) {
+      const missing: string[] = [];
+      if (!defaultTeamSlug) missing.push("Preselected Team");
+      if (!defaultAgentId) missing.push("Preselected Dynamic Agent");
+      const reason = `Select ${missing.join(" and ")} in the Onboarding Default Selection section before running setup.`;
+      setMessage(reason);
+      toast(reason, "error");
+      return;
+    }
     setLoading(true);
     setMessage(null);
     try {
@@ -969,6 +1017,13 @@ export function SlackChannelRebacPanel({
                   </option>
                 ))}
               </select>
+              {invalidDefaultTeamSlug && (
+                <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
+                  The saved default team <code>team:{invalidDefaultTeamSlug}</code> doesn&apos;t match any
+                  current team. Pick one above. Update <code>SLACK_DEFAULT_TEAM_SLUG</code> in the
+                  environment to make the new choice the default for next time.
+                </p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="slack-default-agent">Preselected Dynamic Agent</Label>
@@ -988,6 +1043,13 @@ export function SlackChannelRebacPanel({
                   </option>
                 ))}
               </select>
+              {invalidDefaultAgentId && (
+                <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
+                  The saved default Dynamic Agent <code>agent:{invalidDefaultAgentId}</code> wasn&apos;t
+                  found (or is disabled). Pick one above. Update <code>SLACK_DEFAULT_AGENT_ID</code> in
+                  the environment to make the new choice the default for next time.
+                </p>
+              )}
             </div>
           </div>
           <label className="flex items-start gap-2 rounded-md border border-teal-500/15 bg-background/60 p-3 text-sm">

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -888,3 +888,113 @@ it("opens a runtime sync modal with preview progress and apply results", async (
   expect(screen.getByText("1 route upserted")).toBeInTheDocument();
   expect(screen.getByText("1 OpenFGA tuple written")).toBeInTheDocument();
 });
+
+function mockMinimalSlackPanel(defaults: { team_slug?: string; agent_id?: string }) {
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url === "/api/admin/slack/channels") {
+      return response({ data: { channels: [] } });
+    }
+    if (url === "/api/dynamic-agents?enabled_only=true") {
+      return response({
+        data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] },
+      });
+    }
+    if (url === "/api/admin/teams") {
+      return response({
+        data: {
+          teams: [{ _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" }],
+        },
+      });
+    }
+    if (url === "/api/admin/slack/channels/defaults") {
+      return response({ data: { defaults } });
+    }
+    if (url === "/api/admin/slack/runtime/status") {
+      return response({
+        data: {
+          route_mode: "db_prefer",
+          static_config: { channels: 0, routes: 0 },
+          route_cache: { ttl_seconds: 60, cache_size: 0, cached_channels: [] },
+          last_sync: null,
+        },
+      });
+    }
+    if (url === "/api/admin/slack/runtime/config-defaults") {
+      return response({
+        data: { workspace_id: "T123456789", channels_seen: 0, routes_seen: 0, channels: {} },
+      });
+    }
+    if (url.startsWith("/api/admin/slack/available-channels")) {
+      return response({
+        data: { channels: [], next_cursor: null, has_more: false },
+      });
+    }
+    if (url.endsWith("/resources")) {
+      return response({ data: { grants: [] } });
+    }
+    if (url.endsWith("/routes")) {
+      return response({ data: { routes: [] } });
+    }
+    if (url.endsWith("/diagnostics")) {
+      return response({
+        data: {
+          openfga: { reachable: true, tuple_count: 0 },
+          warnings: [],
+          routes: [],
+          last_runtime_error: null,
+        },
+      });
+    }
+    return response({});
+  });
+}
+
+// Regression for the silent-no-op stale-env-default bug: a SLACK_DEFAULT_AGENT_ID
+// or SLACK_DEFAULT_TEAM_SLUG that no longer matches a real, enabled record used
+// to be silently submitted by the apply button, causing the API to 404 with
+// "Default Dynamic Agent <id> was not found or is disabled". The fix drops the
+// stale value back to "" once dynamicAgents/teams load and shows a visible
+// amber warning telling the admin which env value was rejected.
+it("clears stale env-provided default Dynamic Agent and warns the admin", async () => {
+  mockMinimalSlackPanel({ team_slug: "platform-engineering", agent_id: "ghost-agent" });
+
+  render(<SlackChannelRebacPanel />);
+
+  const agentSelect = (await screen.findByRole("combobox", {
+    name: "Preselected Dynamic Agent",
+  })) as HTMLSelectElement;
+  await waitFor(() => expect(agentSelect.value).toBe(""));
+
+  await waitFor(() => {
+    const alerts = screen.queryAllByRole("alert");
+    const warning = alerts.find(
+      (alert) =>
+        (alert.textContent ?? "").includes("saved default Dynamic Agent") &&
+        (alert.textContent ?? "").includes("ghost-agent")
+    );
+    expect(warning).toBeDefined();
+    expect(warning!.textContent).toMatch(/SLACK_DEFAULT_AGENT_ID/);
+  });
+});
+
+it("clears stale env-provided default Team and warns the admin", async () => {
+  mockMinimalSlackPanel({ team_slug: "deleted-team", agent_id: "incident-agent" });
+
+  render(<SlackChannelRebacPanel />);
+
+  const teamSelect = (await screen.findByRole("combobox", {
+    name: "Preselected Team",
+  })) as HTMLSelectElement;
+  await waitFor(() => expect(teamSelect.value).toBe(""));
+
+  await waitFor(() => {
+    const alerts = screen.queryAllByRole("alert");
+    const warning = alerts.find(
+      (alert) =>
+        (alert.textContent ?? "").includes("saved default team") &&
+        (alert.textContent ?? "").includes("deleted-team")
+    );
+    expect(warning).toBeDefined();
+    expect(warning!.textContent).toMatch(/SLACK_DEFAULT_TEAM_SLUG/);
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18.dev9"
+version = "0.4.18.dev10"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

When `SLACK_DEFAULT_AGENT_ID` or `SLACK_DEFAULT_TEAM_SLUG` points at a Dynamic Agent or team that no longer exists in MongoDB (or is disabled), the BFF `GET /api/admin/slack/channels/defaults` still returns that env value as the saved default. `SlackChannelRebacPanel.tsx` hydrated it into the Preselected Dynamic Agent / Preselected Team dropdowns without checking that it actually resolved to a loaded record.

The dropdown then rendered the placeholder text but silently held the stale id, so clicking **"Set up selected Slack channels"** POSTed it and the API correctly rejected with:

```
404 Default Dynamic Agent "<id>" was not found or is disabled
```

This change adds two defense-in-depth layers:

1. **Validation effects** that drop the stale value back to `""` once `dynamicAgents` / `teams` resolve, capture the bad id, and render a visible amber `role="alert"` warning under the affected dropdown telling the admin which env var to update.
2. **`confirmMigrationDefaults` no longer silently `return`s** when defaults are unset — it surfaces an inline error message and toast explaining exactly which Preselected field is missing, so the click is never a no-op.

This is the off-topic `SlackChannelRebacPanel.tsx` item parked in the 0.5.1 release-split manifest; it ships as its own small PR off `main` because it is unrelated to the secrets-hardening theme of the release/0.5.1 splits (#1518, #1519, #1520, #1523-#1527) and has no shared dependencies.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Test plan

- [x] `cd ui && npm test -- --testPathPatterns='SlackChannelRebacPanel'` — **19/19 pass** (17 existing + 2 new regression tests for stale agent + stale team paths)
- [x] Lints clean
- [ ] Manual smoke: set `SLACK_DEFAULT_AGENT_ID=ghost-agent` in `.env`, load `/admin?tab=slack`, confirm dropdown shows "Select preselected Dynamic Agent" with an amber warning citing `ghost-agent` and `SLACK_DEFAULT_AGENT_ID`. Click "Set up selected Slack channels" without picking a real agent → red toast saying the Preselected Dynamic Agent must be selected (no silent no-op).

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (warning text in UI + inline code comment explaining the silent-no-op bug)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
