### PR TITLE
fix(ci): use org-scoped token for GHCR pushes

### DIFF
--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -174,6 +175,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Free disk space
         run: |
@@ -294,6 +296,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -451,6 +454,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -57,6 +57,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -176,6 +177,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |
@@ -297,6 +299,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -455,6 +458,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -212,6 +213,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -321,6 +323,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -463,6 +466,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -77,6 +77,7 @@ jobs:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -214,6 +215,7 @@ jobs:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -324,6 +326,7 @@ jobs:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -467,6 +470,7 @@ jobs:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Determine Tag
         id: version
@@ -144,6 +145,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Free disk space
         run: |
@@ -236,6 +238,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -369,6 +372,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -45,6 +45,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Determine Tag
         id: version
@@ -146,6 +147,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |
@@ -239,6 +241,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -373,6 +376,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Determine Tag
         id: version
@@ -142,6 +143,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -206,6 +208,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -315,6 +318,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -44,6 +44,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Determine Tag
         id: version
@@ -144,6 +145,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -209,6 +211,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -319,6 +322,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Login to GHCR
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
@@ -355,6 +356,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Notify release finalize
         env:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -134,6 +134,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Login to GHCR
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
@@ -357,6 +358,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Notify release finalize
         env:

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -204,6 +205,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -284,6 +286,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -400,6 +403,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -72,6 +72,7 @@ jobs:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -206,6 +207,7 @@ jobs:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -287,6 +289,7 @@ jobs:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -404,6 +407,7 @@ jobs:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -64,6 +64,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Determine Tag
         id: version
@@ -180,6 +181,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |
@@ -272,6 +274,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -407,6 +410,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Determine Tag
         id: version
@@ -178,6 +179,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Free disk space
         run: |
@@ -269,6 +271,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -403,6 +406,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Determine Tag
         id: version
@@ -170,6 +171,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -232,6 +234,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -334,6 +337,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -48,6 +48,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Determine Tag
         id: version
@@ -172,6 +173,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -235,6 +237,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -338,6 +341,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-supervisor-agent.yml
+++ b/.github/workflows/ci-supervisor-agent.yml
@@ -53,6 +53,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Determine Tag
         id: version
@@ -160,6 +161,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -224,6 +226,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📦 Install crane
         run: |
@@ -329,6 +332,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/ci-supervisor-agent.yml
+++ b/.github/workflows/ci-supervisor-agent.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Determine Tag
         id: version
@@ -158,6 +159,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -221,6 +223,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📦 Install crane
         run: |
@@ -325,6 +328,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔔 Notify release finalize
         env:

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_RELEASE_APP_ID }}
           private-key: ${{ secrets.CI_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -29,6 +29,7 @@ jobs:
           app-id: ${{ secrets.CI_RELEASE_APP_ID }}
           private-key: ${{ secrets.CI_RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -171,6 +171,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 🔐 Login to GHCR
         run: |

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -170,6 +170,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 🔐 Login to GHCR
         run: |

--- a/.github/workflows/prebuild-a2a-rag.yml
+++ b/.github/workflows/prebuild-a2a-rag.yml
@@ -138,6 +138,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/prebuild-a2a-rag.yml
+++ b/.github/workflows/prebuild-a2a-rag.yml
@@ -137,6 +137,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/prebuild-a2a-sub-agent.yml
+++ b/.github/workflows/prebuild-a2a-sub-agent.yml
@@ -177,6 +177,7 @@ jobs:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-a2a-sub-agent.yml
+++ b/.github/workflows/prebuild-a2a-sub-agent.yml
@@ -176,6 +176,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_A2A_APP_ID }}
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-caipe-ui.yml
+++ b/.github/workflows/prebuild-caipe-ui.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/prebuild-caipe-ui.yml
+++ b/.github/workflows/prebuild-caipe-ui.yml
@@ -68,6 +68,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/prebuild-dynamic-agents.yml
+++ b/.github/workflows/prebuild-dynamic-agents.yml
@@ -68,6 +68,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-dynamic-agents.yml
+++ b/.github/workflows/prebuild-dynamic-agents.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-helm.yml
+++ b/.github/workflows/prebuild-helm.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: 📋 Set PR info from inputs
         id: bump-status

--- a/.github/workflows/prebuild-helm.yml
+++ b/.github/workflows/prebuild-helm.yml
@@ -57,6 +57,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: 📋 Set PR info from inputs
         id: bump-status

--- a/.github/workflows/prebuild-mcp-agent.yml
+++ b/.github/workflows/prebuild-mcp-agent.yml
@@ -164,6 +164,7 @@ jobs:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-mcp-agent.yml
+++ b/.github/workflows/prebuild-mcp-agent.yml
@@ -163,6 +163,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_MCP_APP_ID }}
           private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-skill-scanner.yml
+++ b/.github/workflows/prebuild-skill-scanner.yml
@@ -83,6 +83,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/prebuild-skill-scanner.yml
+++ b/.github/workflows/prebuild-skill-scanner.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Free disk space
         run: |

--- a/.github/workflows/prebuild-slack-bot.yml
+++ b/.github/workflows/prebuild-slack-bot.yml
@@ -68,6 +68,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-slack-bot.yml
+++ b/.github/workflows/prebuild-slack-bot.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-supervisor-agent.yml
+++ b/.github/workflows/prebuild-supervisor-agent.yml
@@ -71,6 +71,7 @@ jobs:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prebuild-supervisor-agent.yml
+++ b/.github/workflows/prebuild-supervisor-agent.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Fixes `permission_denied: installation not allowed to Write organization package` on all tag-triggered image builds (introduced in #1535).

**Root cause:** `actions/create-github-app-token` generates repo-scoped tokens by default. Repo-scoped tokens can only write to packages linked to that specific repository, but `ghcr.io/cnoe-io/*` packages are org-owned.

**Fix:** Add `owner: ${{ github.repository_owner }}` to every `create-github-app-token` step in the 20 workflows that push to GHCR. This generates an org-scoped installation token which retains the same code-repo access restrictions but gains write access to org packages.

20 files patched: all CI and prebuild workflows that call `docker/build-push-action` or `crane tag`.

## Test plan

- [ ] `[CI][MCP]`, `[CI][A2A]`, `[CI] CAIPE UI`, `[CI] Slack Bot`, `[CI] Dynamic Agents`, `[CI][Helm]` all pass on next tag push
- [ ] `retag-unchanged` jobs retag without falling back to full build