### PR TITLE
fix(setup-caipe): use native Anthropic model ID for Claude Haiku 4.5

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -38,7 +38,7 @@ LITELLM_ENDPOINT="${LITELLM_ENDPOINT:-}"
 LITELLM_API_KEY="${LITELLM_API_KEY:-}"
 LITELLM_MODEL_NAME="${LITELLM_MODEL_NAME:-gpt-oss-20B}"
 ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
-ANTHROPIC_MODEL_NAME="claude-haiku-4-5-20251001-v1:0"
+ANTHROPIC_MODEL_NAME="claude-haiku-4-5-20251001"
 AWS_BEDROCK_MODEL_ID="${AWS_BEDROCK_MODEL_ID:-global.anthropic.claude-sonnet-4-6}"
 AWS_BEDROCK_PROVIDER="${AWS_BEDROCK_PROVIDER:-anthropic}"
 AWS_REGION="${AWS_REGION:-us-east-2}"
@@ -998,7 +998,7 @@ _collect_anthropic_credentials() {
     model_choice="${model_choice:-1}"
     if _is_back "$model_choice"; then ANTHROPIC_API_KEY=""; return 1; fi
     case "$model_choice" in
-      1) ANTHROPIC_MODEL_NAME="claude-haiku-4-5-20251001-v1:0" ;;
+      1) ANTHROPIC_MODEL_NAME="claude-haiku-4-5-20251001" ;;
       2) ANTHROPIC_MODEL_NAME="claude-sonnet-4-20250514" ;;
       3) ANTHROPIC_MODEL_NAME="claude-opus-4-20250514" ;;
       4)


### PR DESCRIPTION
# Description

The default Anthropic-native model ID was `claude-haiku-4-5-20251001-v1:0`, but the `-v1:0` suffix is an AWS Bedrock inference-profile convention.The native Anthropic API rejects it with "model not found", breaking chat for anyone who picks the default Haiku option under the Anthropic Claude provider.

Fixes #1516

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [X] I have read the [contributing guidelines](CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
