### PR TITLE
fix(chart/caipe-ui): include workflow_configs in app-configmap

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/app-configmap.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/app-configmap.yaml
@@ -1,7 +1,8 @@
 {{- $hasModels := and .Values.appConfig.models (gt (len .Values.appConfig.models) 0) }}
 {{- $hasMcpServers := and .Values.appConfig.mcp_servers (gt (len .Values.appConfig.mcp_servers) 0) }}
 {{- $hasAgents := and .Values.appConfig.agents (gt (len .Values.appConfig.agents) 0) }}
-{{- if or $hasModels $hasMcpServers $hasAgents }}
+{{- $hasWorkflowConfigs := and .Values.appConfig.workflow_configs (gt (len .Values.appConfig.workflow_configs) 0) }}
+{{- if or $hasModels $hasMcpServers $hasAgents $hasWorkflowConfigs }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,5 +33,12 @@ data:
       {{- toYaml .Values.appConfig.agents | nindent 6 }}
     {{- else }}
     agents: []
+    {{- end }}
+
+    {{- if $hasWorkflowConfigs }}
+    workflow_configs:
+      {{- toYaml .Values.appConfig.workflow_configs | nindent 6 }}
+    {{- else }}
+    workflow_configs: []
     {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -531,3 +531,17 @@ appConfig:
   #   allowed_tools:
   #     github: []
   #   enabled: true
+
+  # Workflow configurations (multi-step automated pipelines)
+  workflow_configs: []
+  # Example:
+  # - id: "my-workflow"
+  #   name: "My Workflow"
+  #   description: "A multi-step workflow"
+  #   config_driven: true
+  #   steps:
+  #     - type: "step"
+  #       display_text: "Step description"
+  #       agent_id: "agent-sre"
+  #       prompt: "Do something"
+  #       on_error: "abort"


### PR DESCRIPTION
## Summary

- Add `workflow_configs` rendering to the caipe-ui ConfigMap template
- Add default `workflow_configs: []` to chart values.yaml with example

## Problem

The ConfigMap template (`app-configmap.yaml`) only rendered `models`, `mcp_servers`, and `agents` from `appConfig`. Any `workflow_configs` defined in values.yaml were silently dropped, causing the seed function to find 0 workflow configs on startup.

## Fix

Added the same pattern used for models/agents/mcp_servers: check if `appConfig.workflow_configs` has entries, render them into the ConfigMap YAML, otherwise emit an empty list.

Assisted-by: Claude:claude-opus-4-6