### PR TITLE
fix(ci): use github.token for GHCR login across all workflows

### DIFF
--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -216,7 +216,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -409,7 +409,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -226,7 +226,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -396,7 +396,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -331,7 +331,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -284,7 +284,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Login to GHCR
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
         run: |
-          echo "${{ steps.app-token.outputs.token }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ github.token }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Write local chart version normalizer
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -359,7 +359,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -213,7 +213,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -364,7 +364,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -184,7 +184,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -305,7 +305,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/ci-supervisor-agent.yml
+++ b/.github/workflows/ci-supervisor-agent.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta
@@ -296,7 +296,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -164,18 +164,9 @@ jobs:
         with:
           version: v3.14.0
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: 🔐 Login to GHCR
         run: |
-          echo "${{ steps.app-token.outputs.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: 🔍 Detect Changed Charts
         id: detect

--- a/.github/workflows/prebuild-a2a-rag.yml
+++ b/.github/workflows/prebuild-a2a-rag.yml
@@ -131,14 +131,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |
@@ -181,7 +173,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         id: compute_tag

--- a/.github/workflows/prebuild-a2a-sub-agent.yml
+++ b/.github/workflows/prebuild-a2a-sub-agent.yml
@@ -170,15 +170,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_A2A_APP_ID }}
-          private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -192,7 +183,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         id: compute_tag

--- a/.github/workflows/prebuild-caipe-ui.yml
+++ b/.github/workflows/prebuild-caipe-ui.yml
@@ -61,14 +61,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |
@@ -127,7 +119,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         if: steps.eligibility.outputs.should_build == 'true'

--- a/.github/workflows/prebuild-dynamic-agents.yml
+++ b/.github/workflows/prebuild-dynamic-agents.yml
@@ -61,14 +61,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -105,7 +97,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         if: steps.eligibility.outputs.should_build == 'true'

--- a/.github/workflows/prebuild-helm.yml
+++ b/.github/workflows/prebuild-helm.yml
@@ -50,15 +50,6 @@ jobs:
     if: ${{ !inputs.new_commit }}
 
     steps:
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: 📋 Set PR info from inputs
         id: bump-status
         run: |
@@ -201,7 +192,7 @@ jobs:
       - name: 🔐 Login to GHCR
         if: steps.version-check.outputs.skip != 'true'
         run: |
-          echo "${{ steps.app-token.outputs.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: 🔍 Detect Changed Charts
         if: steps.version-check.outputs.skip != 'true'

--- a/.github/workflows/prebuild-mcp-agent.yml
+++ b/.github/workflows/prebuild-mcp-agent.yml
@@ -157,15 +157,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_MCP_APP_ID }}
-          private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -179,7 +170,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         id: compute_tag

--- a/.github/workflows/prebuild-skill-scanner.yml
+++ b/.github/workflows/prebuild-skill-scanner.yml
@@ -76,14 +76,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Free disk space
         run: |
@@ -119,7 +111,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         id: compute_tag

--- a/.github/workflows/prebuild-slack-bot.yml
+++ b/.github/workflows/prebuild-slack-bot.yml
@@ -61,14 +61,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -83,7 +75,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         id: compute_tag

--- a/.github/workflows/prebuild-supervisor-agent.yml
+++ b/.github/workflows/prebuild-supervisor-agent.yml
@@ -64,14 +64,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -118,7 +110,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         if: steps.eligibility.outputs.should_build == 'true'


### PR DESCRIPTION
## Summary

- Fixes 403 Forbidden on GHCR pushes introduced by #1535
- Root cause: GitHub App tokens (`caipe-ci-build`, `caipe-ci-mcp`, `caipe-ci-a2a`) lack `packages:write`, so using them as the GHCR password fails with 403
- Fix: switch all GHCR login steps back to `github.token`, which carries `packages:write` from each workflow's `permissions:` block
- App tokens are **kept** for REST API calls (`GH_TOKEN`, `token:` in `github-script`) so the rate-limit distribution from #1535 is preserved

GHCR push/pull (Docker registry `/v2/` ops) don't consume from the GitHub REST API rate limit — these are separate quotas, so this change doesn't re-introduce the original rate limiting problem.

**19 files changed:**
- `ci-*` files (9): change `docker/login-action` password only; retain app-token step for GH API calls
- `prebuild-*` + `helm.yml` (10): remove dead app-token generation step entirely; login uses `github.token`
- `prebuild-mcp-agent` + `prebuild-a2a-sub-agent`: also remove orphaned second app-token step (`CI_MCP_APP_ID` / `CI_A2A_APP_ID`) that was generated but never referenced

## Test plan

- [ ] Open a PR that triggers image builds and verify no 403 on GHCR push
- [ ] Open a PR that triggers Helm chart publish and verify prebuild-helm passes
- [ ] Verify API-heavy workflows (ci-mcp-sub-agent, ci-a2a-sub-agent) still use App tokens for GH API calls and don't hit rate limits