### PR TITLE
fix(setup-caipe): pull Ollama embedding model

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -2344,6 +2344,13 @@ choose_features() {
             warn "Ollama embeddings selected, but no Ollama LLM was configured."
             warn "  The RAG server will reach OLLAMA_BASE_URL=http://localhost:${OLLAMA_PORT}."
             warn "  You must run an Ollama server reachable from inside the cluster."
+          else
+            # Pull the embedding model. This is typically a different model from
+            # the LLM model (e.g. nomic-embed-text vs llama2), so it must be
+            # pulled separately even though _collect_ollama_config already pulled
+            # the LLM model.
+            log "Pulling Ollama embedding model: ${EMBEDDINGS_MODEL}"
+            ollama pull "${EMBEDDINGS_MODEL}" || warn "Failed to pull embedding model — run 'ollama pull ${EMBEDDINGS_MODEL}' manually"
           fi
           ;;
         custom-litellm)


### PR DESCRIPTION
# Description

- `setup-caipe.sh` was pulling the Ollama **LLM** model (`$OLLAMA_MODEL`) during `_collect_ollama_config()` but silently skipping the **embedding** model (`$EMBEDDINGS_MODEL`) when Ollama was selected as the RAG embeddings provider.
- Added an `else` branch to the Ollama embeddings credential block that calls `ollama pull "${EMBEDDINGS_MODEL}"` when `ENABLE_OLLAMA=true`, mirroring the pattern already used for the LLM model pull.

Closes #1551

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
