### PR TITLE
feat(rbac): openfga admin-implies-member + auto-provision Super Admins team

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga/authorization-model.json
+++ b/charts/ai-platform-engineering/charts/openfga/authorization-model.json
@@ -128,7 +128,18 @@
       "type": "team",
       "relations": {
         "member": {
-          "this": {}
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "relation": "admin"
+                }
+              }
+            ]
+          }
         },
         "admin": {
           "this": {}

--- a/deploy/openfga-experiment/init/authorization-model.json
+++ b/deploy/openfga-experiment/init/authorization-model.json
@@ -128,7 +128,18 @@
       "type": "team",
       "relations": {
         "member": {
-          "this": {}
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "relation": "admin"
+                }
+              }
+            ]
+          }
         },
         "admin": {
           "this": {}

--- a/deploy/openfga-experiment/model.fga
+++ b/deploy/openfga-experiment/model.fga
@@ -11,6 +11,16 @@
 #   slack_channel:<workspace_id>--<channel_id> can_call tool:<tool_prefix>
 #   webex_space:<workspace_id>--<space_id> can_call tool:<tool_prefix>
 #   team:<slug>#member can_read knowledge_base:<kb_id>
+#
+# Team relation semantics:
+#   - `admin` is a raw relation written when a user is granted team admin.
+#   - `member` is `[direct member tuples] or admin`, so admins automatically
+#     satisfy any `team#member` check or subject reference. Consumers can
+#     therefore ask `check(user, "member", team:<slug>)` without also
+#     checking `admin` — admins always qualify.
+#   - The legacy convention of listing `team#member, team#admin` as a pair
+#     in other types' subject sets is now redundant but harmless; it stays
+#     for explicitness during this transition.
 
 model
   schema 1.1
@@ -34,7 +44,12 @@ type external_group
 
 type team
   relations
-    define member: [user, external_group#member]
+    # `member` is the union of explicit member tuples AND anyone with the
+    # `admin` relation on this team. That way a check for `team#member`
+    # returns true for both straight members and admins — matching the
+    # mental model "an admin is also a member of the team".
+    # assisted-by Cursor claude-opus-4-7
+    define member: [user, external_group#member] or admin
     define admin: [user, external_group#member]
     define can_read: member or admin
     define can_use: member or admin

--- a/deploy/openfga/init/authorization-model.json
+++ b/deploy/openfga/init/authorization-model.json
@@ -128,7 +128,18 @@
       "type": "team",
       "relations": {
         "member": {
-          "this": {}
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "relation": "admin"
+                }
+              }
+            ]
+          }
         },
         "admin": {
           "this": {}

--- a/deploy/openfga/model.fga
+++ b/deploy/openfga/model.fga
@@ -11,6 +11,16 @@
 #   slack_channel:<workspace_id>--<channel_id> can_call tool:<tool_prefix>
 #   webex_space:<workspace_id>--<space_id> can_call tool:<tool_prefix>
 #   team:<slug>#member can_read knowledge_base:<kb_id>
+#
+# Team relation semantics:
+#   - `admin` is a raw relation written when a user is granted team admin.
+#   - `member` is `[direct member tuples] or admin`, so admins automatically
+#     satisfy any `team#member` check or subject reference. Consumers can
+#     therefore ask `check(user, "member", team:<slug>)` without also
+#     checking `admin` — admins always qualify.
+#   - The legacy convention of listing `team#member, team#admin` as a pair
+#     in other types' subject sets is now redundant but harmless; it stays
+#     for explicitness during this transition.
 
 model
   schema 1.1
@@ -34,7 +44,12 @@ type external_group
 
 type team
   relations
-    define member: [user, external_group#member]
+    # `member` is the union of explicit member tuples AND anyone with the
+    # `admin` relation on this team. That way a check for `team#member`
+    # returns true for both straight members and admins — matching the
+    # mental model "an admin is also a member of the team".
+    # assisted-by Cursor claude-opus-4-7
+    define member: [user, external_group#member] or admin
     define admin: [user, external_group#member]
     define can_read: member or admin
     define can_use: member or admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
     "a2a-sdk==0.3.0",
     "ag-ui-protocol==0.1.15",
     "agntcy-app-sdk==0.4.0",
+    # `cachetools.TTLCache` backs the Keycloak JWKS / userinfo cache and the
+    # PDP decision cache used by `utils/auth/keycloak_authz.py`. Pinned to
+    # match the version already locked across every agent sub-package in
+    # `ai_platform_engineering/agents/*/uv.lock` so the supervisor image
+    # cannot drift from sub-agents.
+    "cachetools==6.2.2",
     "cnoe-agent-utils==0.4.0",
     "config==0.5.1",
     "cryptography==46.0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18-dev.12"
+version = "0.4.18-dev.13"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/__tests__/admin-audit-access.test.ts
+++ b/ui/src/app/api/__tests__/admin-audit-access.test.ts
@@ -27,6 +27,13 @@ jest.mock('@/lib/mongodb', () => ({
   getCollection: (...args: any[]) => mockGetCollection(...args),
   isMongoDBConfigured: true,
 }));
+
+// 098-enterprise-rbac introduced an OpenFGA PDP gate on the chat read
+// route via `requireConversationResourcePermission`. Mock it so admin
+// auditors can access non-owned conversations without a live OpenFGA.
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
 jest.spyOn(console, 'error').mockImplementation(() => {});
 jest.spyOn(console, 'log').mockImplementation(() => {});
 jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -310,6 +317,8 @@ describe('GET /api/chat/conversations/[id] — access_level in response', () => 
     mockGetServerSession.mockResolvedValue({
       user: { email: 'admin@example.com', name: 'Admin' },
       role: 'admin',
+      // 098-enterprise-rbac: OpenFGA gates require a stable subject id.
+      sub: 'admin-sub',
     });
 
     const convsCol = createMockCollection();

--- a/ui/src/app/api/__tests__/admin-scan-override-hub.test.ts
+++ b/ui/src/app/api/__tests__/admin-scan-override-hub.test.ts
@@ -79,6 +79,34 @@ jest.mock("@/lib/rbac/keycloak-authz", () => ({
   checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
 }));
 
+// See admin-scan-override.test.ts for rationale: the route added a
+// `requireResourcePermission` gate that rejects sessions without `sub`.
+// Stub it to defer to the same `role === 'admin'` shortcut the
+// surrounding `requireRbacPermission` mock uses.
+jest.mock("@/lib/rbac/resource-authz", () => {
+  const actual =
+    jest.requireActual<typeof import("@/lib/rbac/resource-authz")>(
+      "@/lib/rbac/resource-authz",
+    );
+  return {
+    ...actual,
+    requireResourcePermission: jest.fn(async (session: { role?: string }) => {
+      if (session.role !== "admin") {
+        const { ApiError } = jest.requireActual<typeof import("@/lib/api-error")>(
+          "@/lib/api-error",
+        );
+        throw new ApiError(
+          "You do not have permission to access this resource.",
+          403,
+          "skill#admin",
+          "pdp_denied",
+          "contact_admin",
+        );
+      }
+    }),
+  };
+});
+
 let mockIsMongoDBConfigured = true;
 const mockCollections: Record<string, ReturnType<typeof createMockCollection>> = {};
 const mockGetCollection = jest.fn((name: string) => {

--- a/ui/src/app/api/__tests__/admin-scan-override.test.ts
+++ b/ui/src/app/api/__tests__/admin-scan-override.test.ts
@@ -79,6 +79,37 @@ jest.mock("@/lib/rbac/keycloak-authz", () => ({
   checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
 }));
 
+// `requireResourcePermission` (the third gate the route runs after
+// `requireRbacPermission`) was added with the 098-enterprise-rbac PR and
+// rejects any session whose `sub` is missing or whose OpenFGA check fails.
+// Stub it to defer to the `role === 'admin'` shortcut the surrounding
+// `requireRbacPermission` mock already uses, so this suite keeps testing
+// the route's *body validation / scan-override invariants* and does not
+// double-up on PDP plumbing.
+jest.mock("@/lib/rbac/resource-authz", () => {
+  const actual =
+    jest.requireActual<typeof import("@/lib/rbac/resource-authz")>(
+      "@/lib/rbac/resource-authz",
+    );
+  return {
+    ...actual,
+    requireResourcePermission: jest.fn(async (session: { role?: string }) => {
+      if (session.role !== "admin") {
+        const { ApiError } = jest.requireActual<typeof import("@/lib/api-error")>(
+          "@/lib/api-error",
+        );
+        throw new ApiError(
+          "You do not have permission to access this resource.",
+          403,
+          "skill#admin",
+          "pdp_denied",
+          "contact_admin",
+        );
+      }
+    }),
+  };
+});
+
 let mockIsMongoDBConfigured = true;
 const mockCollections: Record<string, ReturnType<typeof createMockCollection>> = {};
 const mockGetCollection = jest.fn((name: string) => {

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -49,6 +49,16 @@ jest.mock('@/lib/rbac/audit', () => ({
   logAuthzDecision: jest.fn(),
 }));
 
+// Admin route handlers were retrofitted with the OpenFGA-backed
+// `requireAdminSurfaceManage`/`requireBaselineAdminSurfaceRead` gates from
+// `@/lib/rbac/require-openfga`, which calls `checkOpenFgaTuple` and rejects
+// any session without `sub`. Mock it so tests can drive allow/deny per
+// `tuple.user`.
+const mockCheckOpenFgaTuple = jest.fn();
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
 const mockCheckPermission = jest.requireMock<{ checkPermission: jest.Mock }>(
   '@/lib/rbac/keycloak-authz'
 ).checkPermission;
@@ -121,6 +131,7 @@ function adminSession() {
   return {
     user: { email: 'admin@example.com', name: 'Admin User' },
     role: 'admin',
+    sub: 'admin-user-sub',
     accessToken: accessTokenWithRoles(['admin']),
   };
 }
@@ -133,6 +144,7 @@ function userSession() {
   return {
     user: { email: 'user@example.com', name: 'Regular User' },
     role: 'user',
+    sub: 'regular-user-sub',
     accessToken: accessTokenWithRoles(['chat_user']),
   };
 }
@@ -146,6 +158,12 @@ function resetMocks() {
     allowed: false,
     reason: 'DENY_NO_CAPABILITY',
   });
+  // Default: only `user:admin-user-sub` passes the OpenFGA ReBAC gate.
+  // Tests can override per-case with `mockCheckOpenFgaTuple.mockResolvedValueOnce(...)`.
+  mockCheckOpenFgaTuple.mockReset();
+  mockCheckOpenFgaTuple.mockImplementation(async (tuple: { user?: string }) => ({
+    allowed: tuple.user === 'user:admin-user-sub',
+  }));
   Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
 }
 
@@ -213,7 +231,7 @@ describe('GET /api/admin/stats — Authentication & Authorization', () => {
     const res = await GET(req);
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission to perform this action');
+    expect(body.error).toContain('You do not have permission');
   });
 
   // ────────────────────────────────────────────────────────────────────────
@@ -246,7 +264,7 @@ describe('GET /api/admin/stats — Authentication & Authorization', () => {
     const res = await GET(req);
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission to perform this action');
+    expect(body.error).toContain('You do not have permission');
   });
 
   it('returns 403 when MongoDB has admin role but realm_access does not (Mongo fallback NOT honored by RBAC)', async () => {
@@ -266,7 +284,7 @@ describe('GET /api/admin/stats — Authentication & Authorization', () => {
     const res = await GET(req);
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission to perform this action');
+    expect(body.error).toContain('You do not have permission');
   });
 
   it('returns 503 when MongoDB is not configured', async () => {

--- a/ui/src/app/api/__tests__/admin-teams.test.ts
+++ b/ui/src/app/api/__tests__/admin-teams.test.ts
@@ -105,6 +105,14 @@ function createMockCollection() {
     updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
     updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
     deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    // `team-membership-source-store.upsertTeamMembershipSource()` now
+    // calls `deleteMany` after `updateOne` to collapse stale
+    // `status:"removed"` orphan rows (introduced together with the
+    // OpenFGA admin-implies-member model change). Routes that create
+    // teams hit that path indirectly through membership-source writes,
+    // so the shared mock collection has to advertise `deleteMany` too
+    // or the POST route fails with HTTP 500.
+    deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
     countDocuments: jest.fn().mockResolvedValue(0),
   };
 }

--- a/ui/src/app/api/__tests__/admin-users-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-users-stats.test.ts
@@ -58,6 +58,14 @@ jest.mock('@/lib/rbac/audit', () => ({
   logAuthzDecision: jest.fn(),
 }));
 
+// OpenFGA-backed `requireAdminSurfaceManage` / `requireBaselineAdminSurfaceRead`
+// (added with 098-enterprise-rbac) calls `checkOpenFgaTuple`. Default
+// allow-for-admin-sub matches `admin-teams.test.ts`.
+const mockCheckOpenFgaTuple = jest.fn();
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
 const mockCheckPermission = jest.requireMock<{ checkPermission: jest.Mock }>(
   '@/lib/rbac/keycloak-authz'
 ).checkPermission;
@@ -161,6 +169,11 @@ function resetMocks() {
     allowed: false,
     reason: 'DENY_NO_CAPABILITY',
   });
+  // OpenFGA: only `user:admin-sub` passes by default.
+  mockCheckOpenFgaTuple.mockReset();
+  mockCheckOpenFgaTuple.mockImplementation(async (tuple: { user?: string }) => ({
+    allowed: tuple.user === 'user:admin-sub',
+  }));
   Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
 }
 
@@ -237,12 +250,15 @@ describe('GET /api/admin/users/stats — Auth (Keycloak-only)', () => {
     const res = await GET(req);
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission to perform this action');
+    expect(body.error).toContain('You do not have permission');
   });
 
-  it('returns 200 when Keycloak Authorization Services grants admin_ui#view', async () => {
-    // PDP allows the call regardless of realm roles.
+  it('returns 200 when the OpenFGA PDP grants admin_surface:users#can_read', async () => {
+    // 098-enterprise-rbac moved baseline admin surface reads to OpenFGA.
+    // A regular user session is granted access once the PDP allows the
+    // derived tuple `user:user-sub#can_read@admin_surface:users`.
     mockCheckPermission.mockResolvedValue({ allowed: true });
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
     mockGetServerSession.mockResolvedValue(userSession());
 
     setupUsersCol([]);
@@ -282,7 +298,7 @@ describe('GET /api/admin/users/stats — Auth (Keycloak-only)', () => {
     const res = await GET(req);
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission to perform this action');
+    expect(body.error).toContain('You do not have permission');
   });
 
   it('returns 403 for legacy MongoDB metadata.role=admin signal (Keycloak-only contract)', async () => {
@@ -298,7 +314,7 @@ describe('GET /api/admin/users/stats — Auth (Keycloak-only)', () => {
     const res = await GET(req);
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission to perform this action');
+    expect(body.error).toContain('You do not have permission');
   });
 
   it('returns 503 when MongoDB is not configured', async () => {

--- a/ui/src/app/api/__tests__/admin-write-routes.test.ts
+++ b/ui/src/app/api/__tests__/admin-write-routes.test.ts
@@ -350,6 +350,14 @@ describe('POST /api/admin/teams/[id]/members', () => {
 
   it('returns 403 when not admin', async () => {
     mockGetServerSession.mockResolvedValue(userSession());
+    // Spec 098 reordered the route: the team is loaded before the permission
+    // gate so we can pass the resolved team into
+    // `requireTeamMembershipManagementPermission`. Seed the team so the test
+    // reaches the auth gate (instead of stopping at the 404).
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue(TEST_TEAM);
+    mockCollections['teams'] = teamsCol;
+
     const req = makeRequest(`/api/admin/teams/${TEST_TEAM_ID}/members`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -481,6 +489,13 @@ describe('DELETE /api/admin/teams/[id]/members', () => {
 
   it('returns 403 when not admin', async () => {
     mockGetServerSession.mockResolvedValue(userSession());
+    // See POST 403 test above — spec 098 reordered the route so the team is
+    // resolved before the auth gate. Seed the team so the test reaches the
+    // permission check instead of short-circuiting to 404.
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue(TEST_TEAM);
+    mockCollections['teams'] = teamsCol;
+
     const req = makeRequest(`/api/admin/teams/${TEST_TEAM_ID}/members?user_id=member@example.com`, {
       method: 'DELETE',
     });

--- a/ui/src/app/api/__tests__/agent-skill-visibility.test.ts
+++ b/ui/src/app/api/__tests__/agent-skill-visibility.test.ts
@@ -38,6 +38,20 @@ jest.mock("@/lib/mongodb", () => ({
   isMongoDBConfigured: true,
 }));
 
+// `requireResourcePermission` (added by 098-enterprise-rbac for skill
+// visibility / share gates) calls `checkOpenFgaTuple`. Default-allow so
+// these tests just exercise the route's own visibility validation.
+// `writeOpenFgaTupleDiff` is invoked by `grantSkillsToTeams` for team
+// visibility creates; stub it out so the tests don't touch the real PDP.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+  writeOpenFgaTupleDiff: jest
+    .fn()
+    .mockResolvedValue({ writes: 0, deletes: 0, enabled: false }),
+  writeOpenFgaTuples: jest.fn().mockResolvedValue(undefined),
+  deleteOpenFgaTuples: jest.fn().mockResolvedValue(undefined),
+}));
+
 function createMockCollection() {
   const findReturnValue = {
     project: jest.fn().mockReturnValue({
@@ -67,6 +81,7 @@ function userSession(email = "user@example.com") {
   return {
     user: { email, name: "Test User" },
     role: "user",
+    sub: "user-sub",
   };
 }
 
@@ -74,6 +89,7 @@ function adminSession() {
   return {
     user: { email: "admin@example.com", name: "Admin" },
     role: "admin",
+    sub: "admin-sub",
   };
 }
 

--- a/ui/src/app/api/__tests__/chat-messages.test.ts
+++ b/ui/src/app/api/__tests__/chat-messages.test.ts
@@ -56,6 +56,16 @@ jest.mock('@/lib/rbac/keycloak-authz', () => ({
   checkPermission: jest.fn().mockResolvedValue({ allowed: true }),
 }));
 
+// `requireConversationResourcePermission` (used by the messages route)
+// delegates to `requireResourcePermission` which calls `checkOpenFgaTuple`.
+// Without this mock the test hits the real OpenFGA client and errors with
+// `OPENFGA_HTTP is not set`. Default to allow so most tests just exercise
+// route-level logic.
+const mockCheckOpenFgaTuple = jest.fn().mockResolvedValue({ allowed: true });
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -1448,6 +1458,7 @@ describe('POST /api/chat/conversations/[id]/messages — admin audit write block
     mockGetServerSession.mockResolvedValue({
       user: { email: 'admin@example.com', name: 'Admin' },
       role: 'admin',
+      sub: 'admin-sub',
     });
 
     setupConversationMocks('owner@example.com');

--- a/ui/src/app/api/__tests__/chat-sharing-public.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-public.test.ts
@@ -51,6 +51,14 @@ jest.mock('uuid', () => ({
   v4: () => '550e8400-e29b-41d4-a716-446655440000',
 }));
 
+// 098-enterprise-rbac introduced an OpenFGA PDP gate in
+// `requireConversationResourcePermission`. Mock the OpenFGA helper so the
+// fallback ownership check decides 403 vs allow (implicit owner short-circuits
+// before this is consulted). For non-owners, deny so the route returns 403.
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: false }),
+}));
+
 jest.spyOn(console, 'error').mockImplementation(() => {});
 jest.spyOn(console, 'log').mockImplementation(() => {});
 jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -93,6 +101,9 @@ function userSession(email = 'user@example.com') {
   return {
     user: { email, name: 'Test User' },
     role: 'user',
+    // OpenFGA gates need a stable subject id, otherwise session-bound checks
+    // throw NO_SUBJECT and return 401 before the ownership/PDP decision.
+    sub: `sub-${email}`,
   };
 }
 
@@ -515,7 +526,12 @@ describe('GET /api/chat/conversations — public conversations', () => {
     GET = mod.GET;
   });
 
-  it('includes is_public condition in query', async () => {
+  // Spec 098-enterprise-rbac removed the per-user `$or` (owner_id /
+  // sharing.shared_with / sharing.is_public) from
+  // `/api/chat/conversations`. Visibility is now decided by the ReBAC
+  // post-filter (`filterConversationsByImplicitOrExplicitPermission`),
+  // so the Mongo query no longer references legacy sharing fields.
+  it('does NOT include legacy is_public/sharing predicates in the Mongo query', async () => {
     mockGetServerSession.mockResolvedValue(userSession(VIEWER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -534,12 +550,12 @@ describe('GET /api/chat/conversations — public conversations', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    const orConditions = findCall.$or;
-
-    expect(orConditions).toContainEqual({ 'sharing.is_public': true });
+    const serialized = JSON.stringify(findCall);
+    expect(serialized).not.toContain('sharing.is_public');
+    expect(serialized).not.toContain('sharing.shared_with');
   });
 
-  it('includes is_public alongside owner and shared_with conditions', async () => {
+  it('keeps a stable $and query regardless of caller identity', async () => {
     mockGetServerSession.mockResolvedValue(userSession(VIEWER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -558,11 +574,8 @@ describe('GET /api/chat/conversations — public conversations', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    const orConditions = findCall.$or;
-
-    expect(orConditions).toContainEqual({ owner_id: VIEWER_EMAIL });
-    expect(orConditions).toContainEqual({ 'sharing.shared_with': VIEWER_EMAIL });
-    expect(orConditions).toContainEqual({ 'sharing.is_public': true });
+    expect(findCall.$and).toBeDefined();
+    expect(JSON.stringify(findCall)).not.toContain('sharing.is_public');
   });
 });
 
@@ -579,7 +592,9 @@ describe('GET /api/chat/shared — public conversations', () => {
     GET = mod.GET;
   });
 
-  it('includes is_public condition in shared query', async () => {
+  // Spec 098-enterprise-rbac: `/api/chat/shared` now relies on the ReBAC
+  // post-filter and the Mongo query is just `{ owner_id: { $ne: caller } }`.
+  it('queries only owner_id !== caller and delegates is_public visibility to the ReBAC filter', async () => {
     mockGetServerSession.mockResolvedValue(userSession(VIEWER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -598,8 +613,8 @@ describe('GET /api/chat/shared — public conversations', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    expect(findCall.$or).toContainEqual({ 'sharing.is_public': true });
     expect(findCall.owner_id).toEqual({ $ne: VIEWER_EMAIL });
+    expect(JSON.stringify(findCall)).not.toContain('sharing.');
   });
 
   it('excludes own public conversations from shared listing', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
@@ -52,6 +52,21 @@ jest.mock('@/lib/rbac/keycloak-authz', () => ({
   checkPermission: jest.fn().mockResolvedValue({ allowed: true }),
 }));
 
+// `requireConversationResourcePermission` falls through to OpenFGA only
+// when the session is NOT the implicit conversation owner. In this suite
+// we want the route's own `access_level === 'shared_readonly'` check and
+// owner-only branches in `share/route.ts` to drive the outcome, not the
+// PDP. Default to allow non-privileged actions (`can_read`/`can_discover`/
+// `can_write`) so the route reaches its own logic; deny `can_share` /
+// `can_manage` / `can_delete` so non-owner privileged actions return 403.
+const mockCheckOpenFgaTuple = jest.fn().mockImplementation(async (tuple: { relation?: string }) => {
+  const allowed = new Set(['can_read', 'can_discover', 'can_write', 'can_use']);
+  return { allowed: allowed.has(tuple?.relation ?? '') };
+});
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
 jest.mock('uuid', () => ({
   v4: () => 'mock-uuid-1234',
 }));
@@ -468,6 +483,7 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
     });
 
     const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
@@ -504,6 +520,7 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
     });
 
     const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
@@ -526,6 +543,7 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
   it('rejects PATCH with invalid permission value', async () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
     });
 
     const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
@@ -552,6 +570,7 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
 
     mockGetServerSession.mockResolvedValue({
       user: { email: VIEWER_EMAIL, name: 'Viewer' },
+      sub: 'viewer-sub',
     });
 
     const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
@@ -585,6 +604,7 @@ describe('POST /api/chat/conversations/[id]/share — permission storage', () =>
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
     });
 
     const { POST } = await import('@/app/api/chat/conversations/[id]/share/route');
@@ -627,6 +647,7 @@ describe('POST /api/chat/conversations/[id]/share — permission storage', () =>
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
     });
 
     const { POST } = await import('@/app/api/chat/conversations/[id]/share/route');

--- a/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
@@ -433,10 +433,16 @@ describe('GET /api/chat/conversations — team sharing', () => {
     GET = mod.GET;
   });
 
-  it('includes shared_with_teams condition when user belongs to teams', async () => {
+  // Spec 098-enterprise-rbac moved team-share visibility out of the Mongo
+  // query and into a ReBAC post-filter. The route now fetches non-deleted
+  // candidates and lets `filterConversationsByImplicitOrExplicitPermission`
+  // decide visibility, so the legacy `$or` over `sharing.shared_with_*` is
+  // intentionally gone. These tests now assert the new contract: the query
+  // no longer leaks legacy sharing predicates regardless of the caller's
+  // team memberships.
+  it('does NOT include legacy shared_with_teams predicates in the Mongo query', async () => {
     mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
 
-    // User belongs to TEAM_ID_1
     const teamsCol = createMockCollection();
     teamsCol.find.mockReturnValue({
       project: jest.fn().mockReturnValue({
@@ -453,19 +459,14 @@ describe('GET /api/chat/conversations — team sharing', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    const orConditions = findCall.$or;
-
-    expect(orConditions).toContainEqual({ owner_id: MEMBER_EMAIL });
-    expect(orConditions).toContainEqual({ 'sharing.shared_with': MEMBER_EMAIL });
-    expect(orConditions).toContainEqual({
-      'sharing.shared_with_teams': { $in: [TEAM_ID_1.toString()] },
-    });
+    const serialized = JSON.stringify(findCall);
+    expect(serialized).not.toContain('shared_with_teams');
+    expect(serialized).not.toContain('shared_with');
   });
 
-  it('does NOT include shared_with_teams condition when user has no teams', async () => {
+  it('does NOT include legacy shared_with predicates when user has no teams', async () => {
     mockGetServerSession.mockResolvedValue(userSession(NON_MEMBER_EMAIL));
 
-    // No teams
     const teamsCol = createMockCollection();
     teamsCol.find.mockReturnValue({
       project: jest.fn().mockReturnValue({
@@ -482,19 +483,10 @@ describe('GET /api/chat/conversations — team sharing', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    const orConditions = findCall.$or;
-
-    expect(orConditions).toHaveLength(3);
-    expect(orConditions).toContainEqual({ owner_id: NON_MEMBER_EMAIL });
-    expect(orConditions).toContainEqual({ 'sharing.shared_with': NON_MEMBER_EMAIL });
-    expect(orConditions).toContainEqual({ 'sharing.is_public': true });
-    const teamCondition = orConditions.find(
-      (c: any) => c['sharing.shared_with_teams']
-    );
-    expect(teamCondition).toBeUndefined();
+    expect(JSON.stringify(findCall)).not.toContain('shared_with');
   });
 
-  it('includes multiple team IDs when user belongs to multiple teams', async () => {
+  it('does not branch query shape on the number of teams (ReBAC does the filtering)', async () => {
     mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -516,16 +508,7 @@ describe('GET /api/chat/conversations — team sharing', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    const orConditions = findCall.$or;
-    const teamCondition = orConditions.find(
-      (c: any) => c['sharing.shared_with_teams']
-    );
-
-    expect(teamCondition).toBeDefined();
-    expect(teamCondition['sharing.shared_with_teams'].$in).toEqual([
-      TEAM_ID_1.toString(),
-      TEAM_ID_2.toString(),
-    ]);
+    expect(JSON.stringify(findCall)).not.toContain('shared_with_teams');
   });
 
   it('still excludes soft-deleted conversations', async () => {
@@ -580,7 +563,12 @@ describe('GET /api/chat/shared — team sharing', () => {
     GET = mod.GET;
   });
 
-  it('includes shared_with_teams condition when user belongs to teams', async () => {
+  // Spec 098-enterprise-rbac: `/api/chat/shared` now does
+  //   find({ owner_id: { $ne: user.email } })
+  // and then post-filters with
+  // `filterConversationsByImplicitOrExplicitPermission`. The legacy
+  // `$or` over `sharing.shared_with*` is gone.
+  it('queries only owner_id !== caller and delegates visibility to the ReBAC filter', async () => {
     mockGetServerSession.mockResolvedValue(userSession(MEMBER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -600,18 +588,11 @@ describe('GET /api/chat/shared — team sharing', () => {
 
     const findCall = convsCol.find.mock.calls[0][0];
 
-    // Should exclude owner's own conversations
     expect(findCall.owner_id).toEqual({ $ne: MEMBER_EMAIL });
-
-    // Should have $or with direct and team sharing
-    expect(findCall.$or).toBeDefined();
-    expect(findCall.$or).toContainEqual({ 'sharing.shared_with': MEMBER_EMAIL });
-    expect(findCall.$or).toContainEqual({
-      'sharing.shared_with_teams': { $in: [TEAM_ID_1.toString()] },
-    });
+    expect(JSON.stringify(findCall)).not.toContain('shared_with');
   });
 
-  it('only includes direct sharing when user has no teams', async () => {
+  it('keeps the same query shape regardless of team membership', async () => {
     mockGetServerSession.mockResolvedValue(userSession(NON_MEMBER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -630,9 +611,8 @@ describe('GET /api/chat/shared — team sharing', () => {
     await GET(req);
 
     const findCall = convsCol.find.mock.calls[0][0];
-    expect(findCall.$or).toHaveLength(2);
-    expect(findCall.$or).toContainEqual({ 'sharing.shared_with': NON_MEMBER_EMAIL });
-    expect(findCall.$or).toContainEqual({ 'sharing.is_public': true });
+    expect(findCall.owner_id).toEqual({ $ne: NON_MEMBER_EMAIL });
+    expect(JSON.stringify(findCall)).not.toContain('shared_with');
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/ui/src/app/api/__tests__/recycle-bin.test.ts
+++ b/ui/src/app/api/__tests__/recycle-bin.test.ts
@@ -96,6 +96,7 @@ function authenticatedSession(email = 'user@example.com') {
   return {
     user: { email, name: 'Test User' },
     role: 'user',
+    sub: 'user-sub',
   };
 }
 

--- a/ui/src/app/api/__tests__/skill-export.test.ts
+++ b/ui/src/app/api/__tests__/skill-export.test.ts
@@ -47,6 +47,13 @@ jest.mock("@/lib/agent-skill-visibility", () => ({
   userCanModifyAgentSkill: jest.fn().mockReturnValue(true),
 }));
 
+// 098-enterprise-rbac introduced an OpenFGA PDP gate on the export route via
+// `requireResourcePermission`. Mock it so tests don't need a live OpenFGA;
+// the underlying visibility helper is what actually controls 404 vs 200 here.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
 function makeRequest(): NextRequest {
   return new NextRequest(
     new URL("/api/skills/configs/skill-1/export", "http://localhost:3000"),
@@ -57,6 +64,9 @@ function userSession(email = "user@example.com") {
   return {
     user: { email, name: "Test User" },
     role: "user",
+    // OpenFGA gates require a stable subject id; populate it so the
+    // 098-enterprise-rbac PDP gates don't 401 with NO_SUBJECT.
+    sub: "user-sub",
   };
 }
 

--- a/ui/src/app/api/admin/rebac/__tests__/catalog-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/catalog-route.test.ts
@@ -74,6 +74,19 @@ beforeEach(() => {
   mockCollections.dynamic_agents = createMockCollection([
     { _id: "agent-1", name: "Incident Agent", enabled: true },
   ]);
+  // Spec 098 added `user` + `user_profile` to the universal resource model,
+  // sourced from the `users` collection. Without a seed there's no `user`
+  // resource in the catalog and the "every type is represented" assertion
+  // fails. Seed one user so both `user` and `user_profile` resources are
+  // emitted.
+  mockCollections.users = createMockCollection([
+    {
+      _id: "user-1",
+      email: "user@example.com",
+      name: "Test User",
+      keycloak_sub: "user-sub",
+    },
+  ]);
 });
 
 describe("GET /api/admin/rebac/catalog", () => {

--- a/ui/src/app/api/skill-hubs/[id]/refresh/__tests__/route.test.ts
+++ b/ui/src/app/api/skill-hubs/[id]/refresh/__tests__/route.test.ts
@@ -51,6 +51,15 @@ jest.mock("@/lib/rbac/skill-team-grants", () => ({
   grantSkillsToTeams: (...args: unknown[]) => mockGrantSkillsToTeams(...args),
 }));
 
+// 098-enterprise-rbac added a `requireAdminSurfaceManage` PDP gate via
+// `requireDerivedTuple → checkOpenFgaTuple`. Without OpenFGA configured the
+// gate throws ApiError(503 PDP_UNAVAILABLE), which the test sees as
+// `status: 503`. Mock OpenFGA permissively so the test focuses on the
+// team-grant behaviour.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
 function makeRequest(): Request {
   return new Request("http://localhost/api/skill-hubs/hub-1/refresh", {
     method: "POST",

--- a/ui/src/app/api/skills/configs/[id]/revisions/__tests__/route.test.ts
+++ b/ui/src/app/api/skills/configs/[id]/revisions/__tests__/route.test.ts
@@ -52,12 +52,24 @@ jest.mock("@/lib/skill-scan-history", () => ({
   recordScanEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
+// 098-enterprise-rbac added a `requireResourcePermission` gate that needs
+// `session.sub` and calls `checkOpenFgaTuple`. Allow it by default so
+// these tests focus on the visibility / revisions surface they were
+// originally written to pin.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
 function makeRequest(url: string, options: RequestInit = {}): NextRequest {
   return new NextRequest(new URL(url, "http://localhost:3000"), options);
 }
 
 function userSession(email = "user@example.com") {
-  return { user: { email, name: "Test User" }, role: "user" };
+  return {
+    user: { email, name: "Test User" },
+    role: "user",
+    sub: "user-sub",
+  };
 }
 
 beforeEach(() => {
@@ -195,13 +207,17 @@ describe("POST .../revisions/[revisionId]/restore", () => {
     updateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
     // Override the Mongo mock for this describe block — restore
     // writes the live agent_skills row directly so we need a real
-    // collection-shaped mock.
+    // collection-shaped mock. Distinguish the `users` collection
+    // (touched by `persistKeycloakSubMapping` whenever a session
+    // carries `sub`) so its writes don't pollute the `updateOne`
+    // counter we're asserting on for `agent_skills`.
+    const usersUpdateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });
     const mongo = jest.requireMock("@/lib/mongodb") as {
       getCollection: jest.Mock;
     };
-    mongo.getCollection.mockResolvedValue({
-      updateOne,
-    });
+    mongo.getCollection.mockImplementation(async (name: string) =>
+      name === "users" ? { updateOne: usersUpdateOne } : { updateOne },
+    );
     mockRunSkillScan.mockResolvedValue({
       scan_status: "passed",
       scan_summary: "ok",

--- a/ui/src/app/api/skills/configs/[id]/scan/__tests__/route.override-revert.test.ts
+++ b/ui/src/app/api/skills/configs/[id]/scan/__tests__/route.override-revert.test.ts
@@ -85,6 +85,13 @@ jest.mock("@/lib/skill-scan-override-history", () => ({
     mockRecordOverrideEvent(event),
 }));
 
+// 098-enterprise-rbac introduced an OpenFGA PDP gate on the scan route
+// via `requireResourcePermission`. Mock it permissively so the suite
+// focuses on the override-vs-rescan invariant under test.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
 jest.spyOn(console, "warn").mockImplementation(() => {});
 jest.spyOn(console, "error").mockImplementation(() => {});
 
@@ -101,6 +108,8 @@ function adminSession() {
   return {
     user: { email: "admin@example.com", name: "Admin" },
     role: "admin",
+    // OpenFGA gates need a stable subject id.
+    sub: "admin-sub",
   };
 }
 

--- a/ui/src/app/api/skills/hub/[hubId]/[skillId]/scan/__tests__/route.override-revert.test.ts
+++ b/ui/src/app/api/skills/hub/[hubId]/[skillId]/scan/__tests__/route.override-revert.test.ts
@@ -68,6 +68,13 @@ jest.mock("@/lib/skill-scan-override-history", () => ({
     mockRecordOverrideEvent(event),
 }));
 
+// 098-enterprise-rbac introduced an OpenFGA PDP gate on the scan route
+// via `requireResourcePermission`. Mock it permissively so the suite
+// focuses on the override-vs-rescan invariant under test.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
+
 jest.spyOn(console, "warn").mockImplementation(() => {});
 jest.spyOn(console, "error").mockImplementation(() => {});
 
@@ -84,6 +91,8 @@ function adminSession() {
   return {
     user: { email: "admin@example.com", name: "Admin" },
     role: "admin",
+    // OpenFGA gates need a stable subject id.
+    sub: "admin-sub",
   };
 }
 

--- a/ui/src/app/api/skills/scan-all/__tests__/route.test.ts
+++ b/ui/src/app/api/skills/scan-all/__tests__/route.test.ts
@@ -43,10 +43,19 @@ jest.mock("@/lib/api-middleware", () => {
   return {
     ...actual,
     withAuth: jest.fn(async (_req: any, handler: any) =>
-      handler(_req, mockUser, { accessToken: "tok" }),
+      // `sub` is now required by the new `requireResourcePermission`
+      // gate that runs after the role check. Forge a stable admin subject.
+      handler(_req, mockUser, { accessToken: "tok", sub: "admin-sub" }),
     ),
   };
 });
+
+// `requireResourcePermission` (admin_surface:skills-scan-all#admin) calls
+// `checkOpenFgaTuple` after the role check. Allow it by default; tests
+// asserting on PDP deny can override with `.mockResolvedValueOnce(...)`.
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn().mockResolvedValue({ allowed: true }),
+}));
 
 // Mongo: stub two collections we touch.
 const agentSkillsDocs: any[] = [];

--- a/ui/src/components/admin/TeamDetailsDialog.tsx
+++ b/ui/src/components/admin/TeamDetailsDialog.tsx
@@ -1631,7 +1631,13 @@ export function TeamDetailsDialog({
                   </p>
                 ) : (
                   sortedMembers.map((member) => {
-                    const memberSources = sourcesByMember[member.user_id.toLowerCase()] ?? [];
+                    // Only surface currently-active provenance to operators. Non-active
+                    // rows (status="removed") are an audit-trail artefact: when a user is
+                    // removed and later re-added they otherwise show up next to the active
+                    // badge as a confusing "Manual: Removed" pill alongside "Manual".
+                    // See team-membership-source-store.markTeamMembershipSourceRemoved.
+                    const memberSources = (sourcesByMember[member.user_id.toLowerCase()] ?? [])
+                      .filter((source) => source.status === "active");
                     const syncEntry = syncByMember[member.user_id.toLowerCase()];
                     const syncBadge = syncEntry
                       ? syncBadgeAppearance(syncEntry.status)

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -85,7 +85,11 @@ describe("MCPServersTab AgentGateway sync", () => {
       );
     });
 
-    expect(await screen.findByText(/Added 1 MCP server/i)).toBeInTheDocument();
+    // Message format changed to break down counts:
+    //   "Added 1, migrated 0, and refreshed 0 MCP server from AgentGateway."
+    expect(
+      await screen.findByText(/Added 1, migrated 0, and refreshed 0 MCP server/i),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/1 legacy MCP server conflicts with AgentGateway targets/i),
     ).toBeInTheDocument();

--- a/ui/src/lib/__tests__/agent-skill-visibility.test.ts
+++ b/ui/src/lib/__tests__/agent-skill-visibility.test.ts
@@ -81,12 +81,20 @@ describe("userCanModifyAgentSkill — built-in lock integration", () => {
     ).toBe(true);
   });
 
-  it("blocks non-owners on user-owned rows", async () => {
+  // After 098-enterprise-rbac (commit 6cc3e7324) per-user ownership of
+  // non-system rows is enforced by OpenFGA at the route layer
+  // (`requireResourcePermission(... type: 'skill', action: 'write')`),
+  // not by this helper. `userCanModifyAgentSkill` now only guards the
+  // built-in `is_system: true` rows — any other user-owned skill returns
+  // `true` here and the gate decides ownership upstream. This test pins
+  // that new contract so a future drift back to in-helper ownership
+  // doesn't go unnoticed.
+  it("delegates non-system ownership checks to the upstream OpenFGA gate", async () => {
     delete process.env.ALLOW_BUILTIN_SKILL_MUTATION;
     const { userCanModifyAgentSkill } = await reload();
     const skill = baseSkill({ is_system: false, owner_id: "alice@example.com" });
     expect(
       userCanModifyAgentSkill(skill, { email: "bob@example.com" }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/stores.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/stores.test.ts
@@ -26,7 +26,8 @@ describe("identity group sync stores", () => {
 
   it("upserts membership sources by source identity", async () => {
     const updateOne = jest.fn().mockResolvedValue({ upsertedCount: 1 });
-    getRbacCollection.mockResolvedValue({ updateOne });
+    const deleteMany = jest.fn().mockResolvedValue({ deletedCount: 0 });
+    getRbacCollection.mockResolvedValue({ updateOne, deleteMany });
 
     const { upsertTeamMembershipSource } = await import("../../team-membership-source-store");
     await upsertTeamMembershipSource({
@@ -56,6 +57,19 @@ describe("identity group sync stores", () => {
       },
       expect.objectContaining({ $set: expect.objectContaining({ status: "active" }) }),
       { upsert: true }
+    );
+    // The new orphan-collapse path in #1555 also calls `deleteMany` to drop
+    // stale `status:"removed"` rows when a user re-appears under a different
+    // relationship. We assert that the mock is invoked with the same logical
+    // identity but a different status filter so it cannot collide with active
+    // rows.
+    expect(deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        team_slug: "platform",
+        user_subject: "user-sub",
+        source_type: "oidc_claim",
+        status: "removed",
+      })
     );
   });
 });

--- a/ui/src/lib/rbac/__tests__/team-membership-source-store.test.ts
+++ b/ui/src/lib/rbac/__tests__/team-membership-source-store.test.ts
@@ -13,14 +13,21 @@
 import type { TeamMembershipSource } from "@/types/identity-group-sync";
 
 const updateManyMock = jest.fn();
+const updateOneMock = jest.fn();
+const deleteManyMock = jest.fn();
 
 jest.mock("../mongo-collections", () => ({
   getRbacCollection: jest.fn(async () => ({
     updateMany: updateManyMock,
+    updateOne: updateOneMock,
+    deleteMany: deleteManyMock,
   })),
 }));
 
-import { markTeamMembershipSourceRemoved } from "../team-membership-source-store";
+import {
+  markTeamMembershipSourceRemoved,
+  upsertTeamMembershipSource,
+} from "../team-membership-source-store";
 
 function baseSource(overrides: Partial<TeamMembershipSource> = {}): TeamMembershipSource {
   return {
@@ -44,6 +51,10 @@ function baseSource(overrides: Partial<TeamMembershipSource> = {}): TeamMembersh
 beforeEach(() => {
   updateManyMock.mockReset();
   updateManyMock.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+  updateOneMock.mockReset();
+  updateOneMock.mockResolvedValue({ matchedCount: 1, modifiedCount: 1, upsertedCount: 0 });
+  deleteManyMock.mockReset();
+  deleteManyMock.mockResolvedValue({ deletedCount: 0 });
 });
 
 describe("markTeamMembershipSourceRemoved", () => {
@@ -139,5 +150,113 @@ describe("markTeamMembershipSourceRemoved", () => {
     );
 
     expect(result).toEqual({ matchedCount: 2, modifiedCount: 2 });
+  });
+});
+
+describe("upsertTeamMembershipSource", () => {
+  /**
+   * Regression guard for the "Manual: Removed" badge bug. A user removed
+   * as `member` then re-added as `admin` was leaving a stale row with
+   * `status: "removed"` next to the new active row, because the upsert
+   * filter keys on `relationship`. We now sweep orphan removed rows for
+   * the same (team, user, source_type, provider, group) tuple regardless
+   * of relationship.
+   */
+
+  it("upserts the new source row keyed on relationship", async () => {
+    await upsertTeamMembershipSource(
+      baseSource({
+        user_subject: "kc-eti",
+        user_email: "eti@example.com",
+        relationship: "admin",
+      }),
+    );
+
+    expect(updateOneMock).toHaveBeenCalledTimes(1);
+    const [filter] = updateOneMock.mock.calls[0];
+    expect(filter).toMatchObject({
+      team_slug: "platform",
+      user_subject: "kc-eti",
+      relationship: "admin",
+      source_type: "manual",
+    });
+  });
+
+  it("deletes orphan 'removed' rows for the same user regardless of relationship", async () => {
+    deleteManyMock.mockResolvedValueOnce({ deletedCount: 1 });
+
+    await upsertTeamMembershipSource(
+      baseSource({
+        user_subject: "kc-eti",
+        user_email: "eti@example.com",
+        relationship: "admin",
+      }),
+    );
+
+    expect(deleteManyMock).toHaveBeenCalledTimes(1);
+    const [filter] = deleteManyMock.mock.calls[0];
+    expect(filter).toMatchObject({
+      team_slug: "platform",
+      user_subject: "kc-eti",
+      source_type: "manual",
+      status: "removed",
+    });
+    // The whole point: must NOT pin relationship.
+    expect(Object.keys(filter)).not.toContain("relationship");
+    // Provenance fields are still tied to "absent-or-null" so we never
+    // collapse rows that came from a different provider / sync rule.
+    expect(filter.provider_id).toEqual({ $in: [null, undefined] });
+    expect(filter.external_group_id).toEqual({ $in: [null, undefined] });
+    expect(filter.sync_rule_id).toEqual({ $in: [null, undefined] });
+  });
+
+  it("falls back to user_email when user_subject is missing", async () => {
+    await upsertTeamMembershipSource(
+      baseSource({
+        user_subject: undefined,
+        user_email: "synced@example.com",
+        relationship: "admin",
+      }),
+    );
+
+    const [filter] = deleteManyMock.mock.calls[0];
+    expect(filter.user_email).toBe("synced@example.com");
+    expect(Object.keys(filter)).not.toContain("user_subject");
+  });
+
+  it("skips the orphan sweep when no identity anchor is available", async () => {
+    await upsertTeamMembershipSource(
+      baseSource({
+        user_subject: undefined,
+        user_email: undefined,
+        relationship: "admin",
+      }),
+    );
+
+    // Upsert still runs (its filter is built independently); orphan
+    // sweep is correctly skipped to avoid mass-deleting rows.
+    expect(updateOneMock).toHaveBeenCalledTimes(1);
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("pins provenance fields when set so cross-provider rows survive", async () => {
+    await upsertTeamMembershipSource(
+      baseSource({
+        user_subject: "kc-eti",
+        relationship: "admin",
+        source_type: "okta",
+        managed: true,
+        provider_id: "okta-main",
+        external_group_id: "00g-platform",
+        sync_rule_id: "rule-1",
+      }),
+    );
+
+    const [filter] = deleteManyMock.mock.calls[0];
+    expect(filter).toMatchObject({
+      provider_id: "okta-main",
+      external_group_id: "00g-platform",
+      sync_rule_id: "rule-1",
+    });
   });
 });

--- a/ui/src/lib/rbac/keycloak-rbac-reconciliation.ts
+++ b/ui/src/lib/rbac/keycloak-rbac-reconciliation.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/rbac/keycloak-admin";
 import { reconcileBootstrapAdmins } from "@/lib/rbac/keycloak-bootstrap-admins";
 import type { BootstrapAdminReconciliationResult } from "@/lib/rbac/keycloak-bootstrap-admins";
+import { ensureSuperAdminsTeam } from "@/lib/rbac/super-admins-team";
 import type { MigrationApplyResult, MigrationDefinition, MigrationPlanResult } from "@/lib/rbac/migrations/types";
 
 export const KEYCLOAK_RBAC_RECONCILIATION_MIGRATION_ID = "keycloak_rbac_mapping_reconciliation_v1";
@@ -340,6 +341,32 @@ export async function runKeycloakRbacStartupMigration(input: {
     warnings.push(...bootstrapAdmins.warnings);
     if (bootstrapAdmins.failed_count > 0) {
       throw new Error(`Bootstrap admin reconciliation failed for ${bootstrapAdmins.failed_count} email(s)`);
+    }
+
+    // Idempotently materialise the "Super Admins" team that backs the
+    // platform default-team selector. We feed it the *resolved* user
+    // subjects from the bootstrap-admin step so OpenFGA tuples are written
+    // with the canonical Keycloak `sub`, not the email.
+    try {
+      const superAdmins = await ensureSuperAdminsTeam({
+        actor,
+        members: bootstrapAdmins.outcomes
+          .filter((outcome) => outcome.status !== "failed" && outcome.user_id)
+          .map((outcome) => ({ email: outcome.email, userSubject: outcome.user_id })),
+      });
+      counts.super_admins_team_status =
+        superAdmins.status === "created"
+          ? 2
+          : superAdmins.status === "updated"
+            ? 1
+            : 0;
+      counts.super_admins_members_added = superAdmins.members_added;
+      counts.super_admins_members_already_present = superAdmins.members_already_present;
+      counts.super_admins_members_unresolved = superAdmins.members_unresolved;
+      warnings.push(...superAdmins.warnings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warnings.push(`super-admins team bootstrap failed: ${message}`);
     }
 
     await recordCompleted({ actor, now, counts, warnings, bootstrapAdmins });

--- a/ui/src/lib/rbac/super-admins-team.ts
+++ b/ui/src/lib/rbac/super-admins-team.ts
@@ -1,0 +1,316 @@
+// Idempotently bootstrap the "Super Admins" team that backs the platform
+// default-team selector.
+//
+// On UI startup (after `reconcileBootstrapAdmins` resolves the bootstrap
+// admin emails to Keycloak user subjects) we materialise a team called
+// "Super Admins" with slug `super-admins` whose membership mirrors
+// `RBAC_BOOTSTRAP_ADMIN_EMAILS`/`BOOTSTRAP_ADMIN_EMAILS`:
+//
+//   - First listed email -> Mongo role=owner, OpenFGA `team:super-admins#admin`
+//   - All others         -> Mongo role=admin, OpenFGA `team:super-admins#admin`
+//
+// The model already implies `member` from `admin` (Option C fix), so we
+// only need to write the admin tuple.
+//
+// The team is marked `source: "system"` and `is_system_managed: true` so the
+// generic team APIs (PATCH/DELETE) can refuse rename/delete and the UI can
+// show a "managed by platform" badge.
+//
+// assisted-by Cursor claude-opus-4-7
+
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
+import {
+  resolveKeycloakUserSubject,
+  writeTeamMembershipTuples,
+  mongoRoleToOpenFgaRelations,
+} from "@/lib/rbac/team-membership-sync";
+import { upsertTeamMembershipSource } from "@/lib/rbac/team-membership-source-store";
+import type { TeamMembershipSource } from "@/types/identity-group-sync";
+
+export const SUPER_ADMINS_TEAM_SLUG = "super-admins";
+export const SUPER_ADMINS_TEAM_NAME = "Super Admins";
+
+export interface SuperAdminsBootstrapMember {
+  email: string;
+  /** Resolved Keycloak `sub`. Undefined when the user hasn't been provisioned yet. */
+  userSubject?: string;
+}
+
+export interface SuperAdminsBootstrapInput {
+  /** Normalised, lowercase, deduped bootstrap admin emails, in priority order. */
+  members: SuperAdminsBootstrapMember[];
+  /** Who is initiating the bootstrap (e.g. `keycloak-rbac-startup`). */
+  actor: string;
+  /** Override the current time, useful for tests. */
+  now?: Date;
+}
+
+export type SuperAdminsBootstrapStatus =
+  | "created"
+  | "updated"
+  | "noop"
+  | "skipped";
+
+export interface SuperAdminsBootstrapResult {
+  status: SuperAdminsBootstrapStatus;
+  team_slug: string;
+  members_added: number;
+  members_already_present: number;
+  members_unresolved: number;
+  warnings: string[];
+}
+
+interface TeamMemberDoc {
+  user_id: string;
+  role: "owner" | "admin" | "member";
+  added_at: Date;
+  added_by: string;
+}
+
+interface TeamDoc {
+  _id?: unknown;
+  name: string;
+  slug: string;
+  description?: string;
+  source?: string;
+  is_system_managed?: boolean;
+  status?: string;
+  owner_id?: string;
+  created_by?: string;
+  updated_by?: string;
+  created_at?: Date;
+  updated_at?: Date;
+  members?: TeamMemberDoc[];
+}
+
+function emptySkipped(reason: string): SuperAdminsBootstrapResult {
+  return {
+    status: "skipped",
+    team_slug: SUPER_ADMINS_TEAM_SLUG,
+    members_added: 0,
+    members_already_present: 0,
+    members_unresolved: 0,
+    warnings: [reason],
+  };
+}
+
+/**
+ * Idempotently ensure the Super Admins team exists with the supplied members.
+ *
+ * - If no bootstrap admins are configured, returns `skipped` and does nothing.
+ * - If the team is missing, creates it and writes membership tuples.
+ * - If the team exists but is missing one or more bootstrap admins, adds the
+ *   missing rows in both Mongo and OpenFGA. Never demotes or removes anyone.
+ * - Never throws: per-member failures are captured in `warnings` so the
+ *   surrounding startup migration can finish.
+ */
+export async function ensureSuperAdminsTeam(
+  input: SuperAdminsBootstrapInput,
+): Promise<SuperAdminsBootstrapResult> {
+  if (!isMongoDBConfigured) {
+    return emptySkipped("MongoDB not configured; super-admins bootstrap skipped");
+  }
+  if (input.members.length === 0) {
+    return emptySkipped("No bootstrap admins configured; super-admins bootstrap skipped");
+  }
+
+  const now = input.now ?? new Date();
+  const actor = input.actor.trim() || "system";
+  const warnings: string[] = [];
+  const teams = await getCollection<TeamDoc>("teams");
+
+  // Resolve missing Keycloak subjects on the fly so the helper is callable
+  // outside of `reconcileBootstrapAdmins` too (e.g. from a test or admin
+  // tool). When `userSubject` is already populated we trust it.
+  const resolvedMembers = await Promise.all(
+    input.members.map(async (member) => {
+      const email = member.email.trim().toLowerCase();
+      let userSubject = member.userSubject;
+      if (!userSubject) {
+        try {
+          userSubject = await resolveKeycloakUserSubject(email, SUPER_ADMINS_TEAM_SLUG);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          warnings.push(`${email}: ${message}`);
+        }
+      }
+      return { email, userSubject };
+    }),
+  );
+
+  let membersAdded = 0;
+  let membersAlreadyPresent = 0;
+  let membersUnresolved = 0;
+
+  const existing = await teams.findOne({ slug: SUPER_ADMINS_TEAM_SLUG });
+
+  if (!existing) {
+    const memberDocs: TeamMemberDoc[] = resolvedMembers.map((member, index) => ({
+      user_id: member.email,
+      role: index === 0 ? "owner" : "admin",
+      added_at: now,
+      added_by: actor,
+    }));
+    const team: TeamDoc = {
+      name: SUPER_ADMINS_TEAM_NAME,
+      slug: SUPER_ADMINS_TEAM_SLUG,
+      description:
+        "Platform-managed team seeded from RBAC_BOOTSTRAP_ADMIN_EMAILS. " +
+        "Used as the default onboarding team for Slack/Webex channels until an admin picks one explicitly.",
+      source: "system",
+      is_system_managed: true,
+      status: "active",
+      owner_id: resolvedMembers[0]?.email ?? actor,
+      created_by: actor,
+      updated_by: actor,
+      created_at: now,
+      updated_at: now,
+      members: memberDocs,
+    };
+    const insertResult = await teams.insertOne(team);
+    const teamId = String(insertResult.insertedId);
+    const createdAt = now.toISOString();
+    const sourceBase = {
+      team_id: teamId,
+      team_slug: SUPER_ADMINS_TEAM_SLUG,
+      source_type: "manual" as const,
+      managed: true,
+      status: "active" as const,
+      created_by: actor,
+      created_at: createdAt,
+      first_seen_at: createdAt,
+      last_seen_at: createdAt,
+      last_applied_at: createdAt,
+    };
+    for (let i = 0; i < resolvedMembers.length; i += 1) {
+      const member = resolvedMembers[i];
+      const role: TeamMemberDoc["role"] = i === 0 ? "owner" : "admin";
+      if (!member.userSubject) {
+        membersUnresolved += 1;
+        warnings.push(
+          `${member.email}: no Keycloak subject; persisted membership source for later repair`,
+        );
+      } else {
+        try {
+          await writeTeamMembershipTuples(
+            member.userSubject,
+            SUPER_ADMINS_TEAM_SLUG,
+            mongoRoleToOpenFgaRelations(role),
+            "assign",
+          );
+          membersAdded += 1;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          warnings.push(`${member.email}: failed to write OpenFGA tuple: ${message}`);
+        }
+      }
+      const source: TeamMembershipSource = {
+        ...sourceBase,
+        user_email: member.email,
+        user_subject: member.userSubject,
+        relationship: role === "owner" ? "admin" : role,
+      };
+      try {
+        await upsertTeamMembershipSource(source);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        warnings.push(`${member.email}: failed to record membership source: ${message}`);
+      }
+    }
+    return {
+      status: "created",
+      team_slug: SUPER_ADMINS_TEAM_SLUG,
+      members_added: membersAdded,
+      members_already_present: 0,
+      members_unresolved: membersUnresolved,
+      warnings,
+    };
+  }
+
+  // Team already exists. Top up missing bootstrap admins; never demote or
+  // remove anyone -- this preserves manual edits an admin may have made.
+  const existingMemberEmails = new Set(
+    (existing.members ?? []).map((member) => member.user_id.toLowerCase()),
+  );
+  const teamId = existing._id ? String(existing._id) : SUPER_ADMINS_TEAM_SLUG;
+  const createdAt = (existing.created_at ?? now).toISOString();
+  const sourceBase = {
+    team_id: teamId,
+    team_slug: SUPER_ADMINS_TEAM_SLUG,
+    source_type: "manual" as const,
+    managed: true,
+    status: "active" as const,
+    created_by: existing.created_by ?? actor,
+    created_at: createdAt,
+    first_seen_at: createdAt,
+    last_seen_at: now.toISOString(),
+    last_applied_at: now.toISOString(),
+  };
+  const newMemberDocs: TeamMemberDoc[] = [];
+  for (const member of resolvedMembers) {
+    if (existingMemberEmails.has(member.email)) {
+      membersAlreadyPresent += 1;
+      continue;
+    }
+    newMemberDocs.push({
+      user_id: member.email,
+      role: "admin",
+      added_at: now,
+      added_by: actor,
+    });
+    if (!member.userSubject) {
+      membersUnresolved += 1;
+      warnings.push(
+        `${member.email}: no Keycloak subject; persisted membership source for later repair`,
+      );
+    } else {
+      try {
+        await writeTeamMembershipTuples(
+          member.userSubject,
+          SUPER_ADMINS_TEAM_SLUG,
+          mongoRoleToOpenFgaRelations("admin"),
+          "assign",
+        );
+        membersAdded += 1;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        warnings.push(`${member.email}: failed to write OpenFGA tuple: ${message}`);
+      }
+    }
+    const source: TeamMembershipSource = {
+      ...sourceBase,
+      user_email: member.email,
+      user_subject: member.userSubject,
+      relationship: "admin",
+    };
+    try {
+      await upsertTeamMembershipSource(source);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warnings.push(`${member.email}: failed to record membership source: ${message}`);
+    }
+  }
+
+  // Always make sure the system-managed marker is set on the team doc --
+  // upgrades from a hand-created `super-admins` team should inherit it.
+  const setOps: Record<string, unknown> = {
+    is_system_managed: true,
+    source: existing.source ?? "system",
+    updated_at: now,
+    updated_by: actor,
+  };
+  const updateDoc: Record<string, unknown> = { $set: setOps };
+  if (newMemberDocs.length > 0) {
+    updateDoc.$push = { members: { $each: newMemberDocs } };
+  }
+  await teams.updateOne({ slug: SUPER_ADMINS_TEAM_SLUG }, updateDoc);
+
+  return {
+    status: newMemberDocs.length > 0 ? "updated" : "noop",
+    team_slug: SUPER_ADMINS_TEAM_SLUG,
+    members_added: membersAdded,
+    members_already_present: membersAlreadyPresent,
+    members_unresolved: membersUnresolved,
+    warnings,
+  };
+}

--- a/ui/src/lib/rbac/super-admins-team.ts
+++ b/ui/src/lib/rbac/super-admins-team.ts
@@ -67,8 +67,11 @@ interface TeamMemberDoc {
   added_by: string;
 }
 
+// `_id` is intentionally omitted here so the doc is a valid
+// `OptionalId<TeamDoc>` for `teams.insertOne(team)`. `findOne` results are
+// automatically widened to `WithId<TeamDoc>` by the MongoDB driver, which
+// supplies `_id: ObjectId` when we read `existing._id` below.
 interface TeamDoc {
-  _id?: unknown;
   name: string;
   slug: string;
   description?: string;

--- a/ui/src/lib/rbac/team-membership-source-store.ts
+++ b/ui/src/lib/rbac/team-membership-source-store.ts
@@ -155,6 +155,52 @@ export async function upsertTeamMembershipSource(source: TeamMembershipSource): 
     "teamMembershipSources"
   );
   await collection.updateOne(membershipSourceFilter(source), { $set: source }, { upsert: true });
+
+  // Collapse stale orphans: when a user is removed and later re-added with a
+  // different `relationship` (e.g. removed as member, re-added as admin), the
+  // `relationship`-keyed upsert above does not match the previous row, so the
+  // `status:"removed"` record is left behind. The UI then renders both a
+  // "Manual" and "Manual: Removed" badge next to the same user, which is
+  // confusing. Removed rows have no operational consumer (only the UI badge
+  // renderer reads them, and we now filter them out there) so we drop them
+  // here to keep the collection clean. Provenance fields are still matched
+  // exactly so we never collapse rows that came from different providers /
+  // sync rules.
+  const orphanFilter = orphanRemovedMatchFilter(source);
+  if (orphanFilter) {
+    await collection.deleteMany({ ...orphanFilter, status: "removed" });
+  }
+}
+
+/**
+ * Filter for the same logical user+team+source combination as
+ * `membershipSourceMatchFilter`, but intentionally agnostic to
+ * `relationship` so we can find rows that differ only in member-vs-admin.
+ * Returns `null` when the input has no usable identity anchor.
+ */
+function orphanRemovedMatchFilter(
+  source: TeamMembershipSource,
+): Record<string, unknown> | null {
+  const filter: Record<string, unknown> = {
+    team_slug: source.team_slug,
+    source_type: source.source_type,
+  };
+  if (source.user_subject) {
+    filter.user_subject = source.user_subject;
+  } else if (source.user_email) {
+    filter.user_email = source.user_email;
+  } else {
+    return null;
+  }
+  filter.provider_id =
+    source.provider_id !== undefined ? source.provider_id : { $in: [null, undefined] };
+  filter.external_group_id =
+    source.external_group_id !== undefined
+      ? source.external_group_id
+      : { $in: [null, undefined] };
+  filter.sync_rule_id =
+    source.sync_rule_id !== undefined ? source.sync_rule_id : { $in: [null, undefined] };
+  return filter;
 }
 
 export async function markTeamMembershipSourceRemoved(

--- a/ui/src/lib/streaming/__tests__/custom-adapter.test.ts
+++ b/ui/src/lib/streaming/__tests__/custom-adapter.test.ts
@@ -2,7 +2,11 @@
  * @jest-environment node
  */
 
-import { CustomStreamAdapter } from "../custom-adapter";
+// 098/streaming refactor moved the adapters under `clients/` and the
+// public entry point became `createStreamAdapter({ protocol: "custom" })`.
+// We still want to exercise the legacy class directly to keep the
+// protocol-level assertions tight; import from the new location.
+import { CustomStreamAdapter } from "../clients/browser-custom-consumer";
 import type { StreamCallbacks } from "../callbacks";
 
 const mockFetch = jest.fn();
@@ -179,12 +183,15 @@ describe("CustomStreamAdapter", () => {
       cb,
     );
 
+    // 098 added a 6th `toolApprovals` parameter (batched gated tool calls).
+    // The custom protocol doesn't emit it, so it's expected to be undefined.
     expect(cb.onToolApprovalRequired).toHaveBeenCalledWith(
       "approval-1",
       "delete_file",
       { path: "/tmp/a" },
       ["approve", "reject"],
       "helper",
+      undefined,
     );
     expect(cb.onInputRequired).not.toHaveBeenCalled();
   });

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,7 @@ dependencies = [
     { name = "a2a-sdk" },
     { name = "ag-ui-protocol" },
     { name = "agntcy-app-sdk" },
+    { name = "cachetools" },
     { name = "clorm" },
     { name = "cnoe-agent-utils" },
     { name = "config" },
@@ -120,6 +121,7 @@ requires-dist = [
     { name = "a2a-sdk", specifier = "==0.3.0" },
     { name = "ag-ui-protocol", specifier = "==0.1.15" },
     { name = "agntcy-app-sdk", specifier = "==0.4.0" },
+    { name = "cachetools", specifier = "==6.2.2" },
     { name = "clorm", specifier = "==1.6.1" },
     { name = "cnoe-agent-utils", specifier = "==0.4.0" },
     { name = "config", specifier = "==0.5.1" },
@@ -478,6 +480,15 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18.dev12"
+version = "0.4.18.dev13"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Two coupled RBAC changes that together enable the "platform default team" selector backing future admin UI work, without requiring operators to dual-write `team#member` + `team#admin` tuples for every admin.

## Part 1 — OpenFGA model: `admin` implies `member`

Bumps the model so `member` is `[user, external_group#member] or admin`. Anyone with the `admin` relation on a team automatically satisfies any `team#member` check or subject reference. The legacy convention of listing `team#member, team#admin` as a pair in other types' subject sets is now redundant but harmless and stays for explicitness during the transition.

Files:
- `deploy/openfga/model.fga` (+ matching JSON)
- `deploy/openfga/init/authorization-model.json`
- `charts/ai-platform-engineering/charts/openfga/authorization-model.json`
- `deploy/openfga-experiment/model.fga` + JSON

An inline comment in the .fga file documents the new semantics so future readers don't have to dig through commit history to understand why `admin` doesn't need its own `can_*` rules.

## Part 2 — Auto-provision a "Super Admins" team

`ui/src/lib/rbac/super-admins-team.ts` (new) idempotently materialises a team called "Super Admins" with slug `super-admins` whose membership mirrors `RBAC_BOOTSTRAP_ADMIN_EMAILS` / `BOOTSTRAP_ADMIN_EMAILS`: first listed email is owner, remainder are admins. Because the model now implies `member` from `admin`, only the admin tuple is written.

- The team is marked `source: "system"` and `is_system_managed: true` so the generic team APIs can refuse rename/delete and the UI can show a "managed by platform" badge.
- `keycloak-rbac-reconciliation.ts` calls `ensureSuperAdminsTeam()` on startup, after `reconcileBootstrapAdmins` resolves emails to Keycloak user subjects. Failures don't abort startup — they get appended to the migration warnings array so the admin UI surface displays them for manual fix.

## Part 3 — Orphan-source row collapse (UI hygiene)

`team-membership-source-store.upsertTeamMembershipSource()` now deletes stale `status:"removed"` rows that share the same user+team+source provenance but a different `relationship`. Without this, a user removed-as-member-then-re-added-as-admin would render twice in `TeamDetailsDialog` ("Manual" badge + "Manual: Removed" badge) and confuse operators. Provenance fields are still matched exactly so rows from different providers / sync rules never collapse.

`TeamDetailsDialog` filters out non-active provenance from the per-member badge stack defensively, so an admin who upgrades a UI worker before the DB collapse runs still sees a clean view.

## Operational notes

- The OpenFGA model bump is a write-once change; once the new model is in the store, existing tuples continue to work and the `admin → member` union takes effect on the next check. **No tuple migration needed.**
- `ensureSuperAdminsTeam` is safe to run repeatedly — it short-circuits when Mongo isn't configured and is idempotent on the team document.

## Test plan

- [ ] Existing unit tests pass: `cd ui && npm test -- src/lib/rbac/__tests__/team-membership-source-store.test.ts`
- [ ] Apply new OpenFGA model to a dev cluster: `openfga store import --model deploy/openfga/init/authorization-model.json`
- [ ] Verify with the existing model the check `check(user:<admin>, member, team:<slug>)` returns `allowed: true` even without an explicit `member` tuple, given only an `admin` tuple
- [ ] Start a fresh dev stack with `BOOTSTRAP_ADMIN_EMAILS=alice@example.com,bob@example.com`; verify the Super Admins team appears in Admin → Teams with Alice as owner, Bob as admin, no rename/delete
- [ ] Verify `TeamDetailsDialog` shows only one provenance badge per member after removing-then-re-adding a user
