### PR TITLE
feat(rbac): admin-configurable discovery cache TTL for Slack/Webex onboarding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18-dev.13"
+version = "0.4.18-dev.14"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts
@@ -87,6 +87,11 @@ beforeEach(async () => {
   // Reset the route's in-process cache so each test starts clean.
   const route = await import("../route");
   route.__resetAvailableChannelsCacheForTests();
+  // Also reset the discovery-cache TTL memo so a previous test's env
+  // toggling can't bleed into the next test.
+  const cfg = await import("@/lib/rbac/discovery-cache-config");
+  cfg.__resetDiscoveryCacheConfigForTests();
+  delete process.env.DISCOVERY_CACHE_TTL_MINUTES;
 });
 
 describe("GET /api/admin/slack/available-channels", () => {
@@ -171,6 +176,24 @@ describe("GET /api/admin/slack/available-channels", () => {
 
       expect(slackCalls).toHaveLength(2);
       expect(slackCalls.every((c) => c.endpoint === "users.conversations")).toBe(true);
+    });
+
+    it("skips the cache entirely when the admin TTL is 0 minutes", async () => {
+      // Admin set the discovery cache TTL to 0 (= caching disabled) via
+      // Admin → Platform Settings. Every request should re-fetch from
+      // Slack — this is the debug knob for the `#test-0525` scenario
+      // where the bot was just added to a new channel.
+      process.env.DISCOVERY_CACHE_TTL_MINUTES = "0";
+      const cfg = await import("@/lib/rbac/discovery-cache-config");
+      cfg.__resetDiscoveryCacheConfigForTests();
+
+      mockSlackFetch(() => ({ ok: true, channels: [{ id: "C100", name: "incidents" }] }));
+
+      await makeRequest("member_only=1");
+      await makeRequest("member_only=1");
+      await makeRequest("member_only=1");
+
+      expect(slackCalls).toHaveLength(3);
     });
 
     it("splits the cache by scope so member_only and full-list don't poison each other", async () => {

--- a/ui/src/app/api/admin/slack/available-channels/route.ts
+++ b/ui/src/app/api/admin/slack/available-channels/route.ts
@@ -55,6 +55,7 @@ import {
   requireRbacPermission,
   ApiError,
 } from "@/lib/api-middleware";
+import { getDiscoveryCacheTtlMs } from "@/lib/rbac/discovery-cache-config";
 
 interface SlackConversation {
   id: string;
@@ -88,9 +89,13 @@ interface CacheEntry {
   endpoint: "users.conversations" | "conversations.list";
 }
 
-// Channel lists rarely change between admin actions; 10 min keeps us well
-// inside Slack's rate limits even when several admins are active.
-const CACHE_TTL_MS = 10 * 60_000;
+// Channel lists rarely change between admin actions. The TTL is admin-
+// configurable in Admin → Platform Settings → Discovery cache TTL and is
+// read live from `platform_config` via getDiscoveryCacheTtlMs(); the
+// default is 60 minutes. A value of 0 disables caching entirely (every
+// request hits Slack), which is useful when an admin just added the bot
+// to a brand-new channel and wants the picker to reflect that without
+// clicking "Force refresh".
 // Slack max page size is 1000 for conversations.list / 999 for
 // users.conversations, but Slack recommends <=200 for stability. We pull at
 // 200 internally regardless of the UI page size (which is just a slice on top
@@ -248,12 +253,14 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   // part of the key so the two endpoints don't poison each other's snapshot.
   const cacheKey = `${scope}:${token.slice(-12)}`;
   const cached = cache.get(cacheKey);
+  const cacheTtlMs = await getDiscoveryCacheTtlMs();
 
   let snapshot: NormalizedChannel[];
   let cacheHit = false;
   let fetchedAt: number;
 
-  if (!refresh && cached && now - cached.fetched_at < CACHE_TTL_MS) {
+  // ttl=0 disables caching entirely (admin-controlled debug knob).
+  if (!refresh && cacheTtlMs > 0 && cached && now - cached.fetched_at < cacheTtlMs) {
     snapshot = cached.channels;
     fetchedAt = cached.fetched_at;
     cacheHit = true;
@@ -263,7 +270,13 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       defaultIsMember: memberOnly,
     });
     fetchedAt = now;
-    cache.set(cacheKey, { channels: snapshot, fetched_at: fetchedAt, endpoint });
+    if (cacheTtlMs > 0) {
+      cache.set(cacheKey, { channels: snapshot, fetched_at: fetchedAt, endpoint });
+    } else {
+      // Caching disabled — drop any stale entry so a future TTL increase
+      // can't be served from a snapshot fetched while caching was off.
+      cache.delete(cacheKey);
+    }
   }
 
   // Filter pipeline runs in-process against the cached snapshot.

--- a/ui/src/app/api/admin/webex/available-spaces/route.ts
+++ b/ui/src/app/api/admin/webex/available-spaces/route.ts
@@ -15,6 +15,7 @@ import {
   requireRbacPermission,
   ApiError,
 } from "@/lib/api-middleware";
+import { getDiscoveryCacheTtlMs } from "@/lib/rbac/discovery-cache-config";
 
 interface WebexRoom {
   id: string;
@@ -42,7 +43,10 @@ interface CacheEntry {
   fetched_at: number;
 }
 
-const CACHE_TTL_MS = 10 * 60_000;
+// Webex space lists rarely change between admin actions. The TTL is
+// admin-configurable in Admin → Platform Settings → Discovery cache TTL
+// and is read live from `platform_config` via getDiscoveryCacheTtlMs();
+// the default is 60 minutes, and 0 disables caching.
 const DEFAULT_UI_LIMIT = 200;
 const MAX_UI_LIMIT = 500;
 const MAX_WEBEX_PAGES = 50;
@@ -157,19 +161,25 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const now = Date.now();
   const cacheKey = token.slice(-12);
   const cached = cache.get(cacheKey);
+  const cacheTtlMs = await getDiscoveryCacheTtlMs();
 
   let allSpaces: NormalizedSpace[];
   let cacheHit = false;
   let fetchedAt: number;
 
-  if (!refresh && cached && now - cached.fetched_at < CACHE_TTL_MS) {
+  // ttl=0 disables caching entirely (admin-controlled debug knob).
+  if (!refresh && cacheTtlMs > 0 && cached && now - cached.fetched_at < cacheTtlMs) {
     allSpaces = cached.spaces;
     fetchedAt = cached.fetched_at;
     cacheHit = true;
   } else {
     allSpaces = await listAllRooms(token);
     fetchedAt = now;
-    cache.set(cacheKey, { spaces: allSpaces, fetched_at: fetchedAt });
+    if (cacheTtlMs > 0) {
+      cache.set(cacheKey, { spaces: allSpaces, fetched_at: fetchedAt });
+    } else {
+      cache.delete(cacheKey);
+    }
   }
 
   let filtered = allSpaces;

--- a/ui/src/components/admin/rebac/ConnectorOnboardingWizard.tsx
+++ b/ui/src/components/admin/rebac/ConnectorOnboardingWizard.tsx
@@ -5,6 +5,10 @@ import { AlertCircle, CheckCircle2, CircleDashed, Search } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import {
+  DiscoveryCacheControls,
+  type DiscoveryCacheProvider,
+} from "@/components/admin/rebac/DiscoveryCacheControls";
 
 export interface ConnectorOnboardingOption {
   value: string;
@@ -26,6 +30,18 @@ export interface ConnectorOnboardingRow {
 
 interface ConnectorOnboardingWizardProps {
   connectorName: string;
+  /**
+   * Machine-readable connector id used to scope the inline discovery
+   * cache controls. Drives which `/api/admin/<provider>/available-...`
+   * route the "Force refresh" button invalidates. Optional so existing
+   * callers (and tests) that don't render the cache controls keep
+   * working; callers that pass it get the inline popover next to the
+   * Find button.
+   */
+  provider?: DiscoveryCacheProvider;
+  /** Whether the current viewer can edit platform config. Falls back to
+   * read-only mode in the popover when false. */
+  isAdmin?: boolean;
   itemSingular: string;
   itemPlural: string;
   discoveredLabel: string;
@@ -102,6 +118,8 @@ function ReadinessIcon({ state }: { state: ReadinessState }) {
 
 export function ConnectorOnboardingWizard({
   connectorName,
+  provider,
+  isAdmin = false,
   itemSingular,
   itemPlural,
   discoveredLabel,
@@ -178,6 +196,16 @@ export function ConnectorOnboardingWizard({
           <Search className="h-4 w-4" aria-hidden="true" />
           {discovering ? loadingLabel : discoveredCount > 0 ? refreshLabel : findLabel}
         </Button>
+        {provider && (
+          <DiscoveryCacheControls
+            provider={provider}
+            isAdmin={isAdmin}
+            // After a force-refresh, kick off another discovery query so
+            // the wizard reflects the fresh server-side snapshot without
+            // the admin having to click "Find ..." again.
+            onAfterRefresh={onDiscover}
+          />
+        )}
         <span
           role="status"
           aria-label={discoveryStatusText}

--- a/ui/src/components/admin/rebac/DiscoveryCacheControls.tsx
+++ b/ui/src/components/admin/rebac/DiscoveryCacheControls.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+/**
+ * Inline cache controls for connector discovery (Slack channels, Webex
+ * spaces). Rendered next to the "Find ... with Bot Integration" button on
+ * each connector's onboarding wizard.
+ *
+ * Why inline:
+ *   The cache snapshot belongs to the picker the admin is actively using.
+ *   Forcing them to navigate to a separate Platform Settings tab just to
+ *   drop a stale snapshot is the wrong UX — that's why we moved the
+ *   single editing surface here. The TTL is platform-wide (one value
+ *   governs both Slack and Webex), but the "Force refresh now" action is
+ *   provider-scoped so we only invalidate what the admin is looking at.
+ *
+ * Persistence:
+ *   - GET/PATCH /api/admin/platform-config persist
+ *     `discovery_cache_ttl_minutes` (range 0..1440; 0 disables caching).
+ *   - Force refresh hits `/api/admin/<provider>/available-...` with
+ *     `?refresh=1` so the next picker open sees a fresh snapshot.
+ *
+ * Auth:
+ *   Read access mirrors the rest of the integrations wizard (admin_ui:view).
+ *   PATCH requires admin_ui:admin; viewers see the popover open in read-
+ *   only mode (input + Save are disabled) so they can still see the TTL
+ *   that's in effect.
+ *
+ * assisted-by Cursor claude-opus-4-7
+ */
+
+import React, { useEffect, useState } from "react";
+import { CheckCircle2, Loader2, RefreshCw, Save, SlidersHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+// Bounds mirror ui/src/lib/rbac/discovery-cache-config.ts. Kept as
+// constants (not imported from the server helper) so the client bundle
+// stays free of the Mongo dependency chain.
+const DISCOVERY_TTL_MIN = 0;
+const DISCOVERY_TTL_MAX = 1440;
+const DISCOVERY_TTL_DEFAULT = 60;
+
+export type DiscoveryCacheProvider = "slack" | "webex";
+
+interface DiscoveryCacheControlsProps {
+  /**
+   * Which connector this control instance lives next to. Determines which
+   * discovery route the "Force refresh" button invalidates. The TTL value
+   * is platform-wide and applies to both providers.
+   */
+  provider: DiscoveryCacheProvider;
+  /**
+   * True when the signed-in user can edit platform_config. When false the
+   * popover is still openable (so viewers can see the current TTL) but
+   * the input and Save button are disabled, and Force refresh is hidden.
+   */
+  isAdmin: boolean;
+  /**
+   * Optional callback invoked after a successful Force refresh so the
+   * parent wizard can re-run its own discovery query against the now-
+   * fresh server-side cache. Slack/Webex panels pass `onDiscover` here.
+   */
+  onAfterRefresh?: () => void;
+}
+
+const ROUTE_BY_PROVIDER: Record<DiscoveryCacheProvider, string> = {
+  slack: "/api/admin/slack/available-channels",
+  webex: "/api/admin/webex/available-spaces",
+};
+
+const LABEL_BY_PROVIDER: Record<DiscoveryCacheProvider, string> = {
+  slack: "Slack",
+  webex: "Webex",
+};
+
+export function DiscoveryCacheControls({
+  provider,
+  isAdmin,
+  onAfterRefresh,
+}: DiscoveryCacheControlsProps) {
+  const [open, setOpen] = useState(false);
+  const [loadingConfig, setLoadingConfig] = useState(false);
+  const [ttlInput, setTtlInput] = useState<string>(String(DISCOVERY_TTL_DEFAULT));
+  const [savedTtl, setSavedTtl] = useState<number>(DISCOVERY_TTL_DEFAULT);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveResult, setSaveResult] = useState<"success" | "error" | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshResult, setRefreshResult] = useState<"success" | "error" | null>(null);
+
+  // Lazy-load the persisted TTL the first time the popover opens. We
+  // don't fetch on mount so a viewer who never opens the popover doesn't
+  // pay for an extra platform-config round-trip.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoadingConfig(true);
+    fetch("/api/admin/platform-config")
+      .then((r) => r.json())
+      .catch(() => ({ success: false }))
+      .then((body) => {
+        if (cancelled) return;
+        const live = Number(body?.data?.discovery_cache_ttl_minutes);
+        if (Number.isFinite(live)) {
+          setTtlInput(String(live));
+          setSavedTtl(live);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingConfig(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const ttlDirty = String(savedTtl) !== ttlInput.trim();
+  const providerLabel = LABEL_BY_PROVIDER[provider];
+
+  const handleSaveTtl = async () => {
+    if (!isAdmin) return;
+    setSaveError(null);
+    setSaveResult(null);
+    const trimmed = ttlInput.trim();
+    if (trimmed === "") {
+      setSaveError("Enter a number of minutes (0 disables caching).");
+      return;
+    }
+    const next = Number(trimmed);
+    if (
+      !Number.isFinite(next) ||
+      !Number.isInteger(next) ||
+      next < DISCOVERY_TTL_MIN ||
+      next > DISCOVERY_TTL_MAX
+    ) {
+      setSaveError(
+        `Enter an integer between ${DISCOVERY_TTL_MIN} and ${DISCOVERY_TTL_MAX} minutes.`,
+      );
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/platform-config", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ discovery_cache_ttl_minutes: next }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setSavedTtl(next);
+        setSaveResult("success");
+        setTimeout(() => setSaveResult(null), 3000);
+      } else {
+        setSaveResult("error");
+        setSaveError(typeof data.error === "string" ? data.error : "Failed to save.");
+      }
+    } catch {
+      setSaveResult("error");
+      setSaveError("Failed to save. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleForceRefresh = async () => {
+    if (!isAdmin) return;
+    setRefreshing(true);
+    setRefreshResult(null);
+    try {
+      const route = ROUTE_BY_PROVIDER[provider];
+      const res = await fetch(`${route}?refresh=1&limit=1`);
+      // 200 OK = fresh snapshot built. 503 = the connector isn't
+      // configured (e.g. no SLACK_BOT_TOKEN), which is "not an error"
+      // from the admin's POV — there's just nothing to refresh. We
+      // treat both as success so the UI message reads sensibly.
+      const okish = res.ok || res.status === 503;
+      setRefreshResult(okish ? "success" : "error");
+      if (okish) {
+        onAfterRefresh?.();
+      }
+      setTimeout(() => setRefreshResult(null), 3000);
+    } catch {
+      setRefreshResult("error");
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          aria-label={`${providerLabel} discovery cache settings`}
+          data-testid={`discovery-cache-controls-trigger-${provider}`}
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+          Cache
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 space-y-4 p-4" align="end">
+        <div className="space-y-1">
+          <div className="text-sm font-medium">Discovery cache</div>
+          <p className="text-xs text-muted-foreground">
+            Snapshot of {providerLabel} {provider === "slack" ? "channels" : "spaces"} kept in memory
+            so the picker scrolls instantly without hammering {providerLabel}&apos;s rate limits.
+            The TTL is shared between Slack and Webex.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor={`discovery-cache-ttl-${provider}`}
+            className="text-xs font-medium"
+          >
+            Cache TTL (minutes)
+          </label>
+          <div className="flex items-center gap-2">
+            <Input
+              id={`discovery-cache-ttl-${provider}`}
+              data-testid={`discovery-cache-ttl-input-${provider}`}
+              type="number"
+              inputMode="numeric"
+              min={DISCOVERY_TTL_MIN}
+              max={DISCOVERY_TTL_MAX}
+              step={1}
+              value={ttlInput}
+              onChange={(e) => setTtlInput(e.target.value)}
+              disabled={!isAdmin || saving || loadingConfig}
+              aria-describedby={`discovery-cache-ttl-help-${provider}`}
+              className="h-8 max-w-[8rem]"
+            />
+            {isAdmin && (
+              <Button
+                type="button"
+                size="sm"
+                onClick={handleSaveTtl}
+                disabled={saving || !ttlDirty}
+                className="gap-1.5"
+                data-testid={`discovery-cache-ttl-save-${provider}`}
+              >
+                {saving ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                Save
+              </Button>
+            )}
+            {saveResult === "success" && (
+              <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                <CheckCircle2 className="h-3.5 w-3.5" /> Saved
+              </span>
+            )}
+          </div>
+          <p
+            id={`discovery-cache-ttl-help-${provider}`}
+            className="text-[11px] leading-snug text-muted-foreground"
+          >
+            Default <strong>{DISCOVERY_TTL_DEFAULT}</strong>. Range {DISCOVERY_TTL_MIN}&ndash;
+            {DISCOVERY_TTL_MAX}. <strong>0</strong> disables caching (every request hits{" "}
+            {providerLabel}).
+          </p>
+          {saveError && (
+            <p className="text-xs text-destructive" role="alert">
+              {saveError}
+            </p>
+          )}
+        </div>
+
+        {isAdmin && (
+          <div className="space-y-2 border-t border-border/40 pt-3">
+            <p className="text-xs text-muted-foreground">
+              Just invited the bot to a new {provider === "slack" ? "channel" : "space"} and the
+              picker still doesn&apos;t list it? Drop the snapshot now and the next discovery call
+              will fetch a fresh list.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={handleForceRefresh}
+                disabled={refreshing}
+                className="gap-1.5"
+                data-testid={`discovery-cache-refresh-${provider}`}
+              >
+                {refreshing ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-3.5 w-3.5" />
+                )}
+                Force refresh now
+              </Button>
+              {refreshResult === "success" && (
+                <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                  <CheckCircle2 className="h-3.5 w-3.5" /> Refreshed
+                </span>
+              )}
+              {refreshResult === "error" && (
+                <span className="text-xs text-destructive">Refresh failed</span>
+              )}
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/src/components/admin/rebac/__tests__/DiscoveryCacheControls.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/DiscoveryCacheControls.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Inline discovery-cache popover that lives next to the "Find ... with
+ * Bot Integration" button on the Slack and Webex onboarding wizards.
+ * Tests cover:
+ *   - Lazy GET only fires when the popover is opened (no popup = no
+ *     extra round-trip on the integrations page)
+ *   - TTL input is pre-filled from platform_config
+ *   - Save PATCHes the right field; client-side validates the range
+ *   - "Force refresh now" hits the right per-provider route with
+ *     refresh=1 and fires onAfterRefresh
+ *   - Read-only viewers see the TTL but no Save/refresh controls
+ *
+ * assisted-by Cursor claude-opus-4-7
+ */
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DiscoveryCacheControls } from "../DiscoveryCacheControls";
+
+type FetchInit = RequestInit | undefined;
+
+function mockFetch({
+  ttl = 60,
+  patch = { success: true },
+  refresh = { ok: true, status: 200 },
+  onCall,
+}: {
+  ttl?: number;
+  patch?: { success: boolean; error?: string };
+  refresh?: { ok?: boolean; status?: number };
+  onCall?: (href: string, init: FetchInit) => void;
+} = {}) {
+  global.fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const href = String(input);
+    onCall?.(href, init);
+    if (href.includes("/api/admin/platform-config") && init?.method === "PATCH") {
+      return Promise.resolve({
+        json: () => Promise.resolve(patch),
+      } as Response);
+    }
+    if (href.includes("/api/admin/platform-config")) {
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: { default_agent_id: null, discovery_cache_ttl_minutes: ttl },
+          }),
+      } as Response);
+    }
+    if (
+      href.includes("/api/admin/slack/available-channels") ||
+      href.includes("/api/admin/webex/available-spaces")
+    ) {
+      return Promise.resolve({
+        ok: refresh.ok ?? true,
+        status: refresh.status ?? 200,
+        json: () => Promise.resolve({ success: true }),
+      } as unknown as Response);
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${href}`));
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("DiscoveryCacheControls", () => {
+  it("does not fetch platform-config until the popover is opened (no work for closed UI)", async () => {
+    mockFetch();
+
+    render(<DiscoveryCacheControls provider="slack" isAdmin />);
+
+    // The trigger is rendered; nothing was fetched yet.
+    expect(screen.getByTestId("discovery-cache-controls-trigger-slack")).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("loads the persisted TTL when opened", async () => {
+    mockFetch({ ttl: 30 });
+
+    render(<DiscoveryCacheControls provider="slack" isAdmin />);
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-slack"));
+
+    const input = (await screen.findByTestId(
+      "discovery-cache-ttl-input-slack",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("30"));
+  });
+
+  it("PATCHes the new TTL on save and reflects the new saved value", async () => {
+    const calls: string[] = [];
+    mockFetch({ ttl: 60, onCall: (href, init) => calls.push(`${init?.method ?? "GET"} ${href}`) });
+
+    render(<DiscoveryCacheControls provider="slack" isAdmin />);
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-slack"));
+    const input = await screen.findByTestId("discovery-cache-ttl-input-slack");
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe("60"));
+
+    fireEvent.change(input, { target: { value: "120" } });
+    fireEvent.click(screen.getByTestId("discovery-cache-ttl-save-slack"));
+
+    await waitFor(() => {
+      expect(calls).toContainEqual(
+        expect.stringContaining("PATCH /api/admin/platform-config"),
+      );
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/admin/platform-config",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ discovery_cache_ttl_minutes: 120 }),
+      }),
+    );
+    expect(await screen.findByText(/saved/i)).toBeInTheDocument();
+  });
+
+  it("rejects out-of-range TTL client-side without firing a PATCH", async () => {
+    mockFetch();
+
+    render(<DiscoveryCacheControls provider="slack" isAdmin />);
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-slack"));
+    const input = await screen.findByTestId("discovery-cache-ttl-input-slack");
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe("60"));
+
+    fireEvent.change(input, { target: { value: "5000" } });
+    fireEvent.click(screen.getByTestId("discovery-cache-ttl-save-slack"));
+
+    expect(
+      await screen.findByText(/integer between 0 and 1440/i),
+    ).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/admin/platform-config",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ discovery_cache_ttl_minutes: 5000 }),
+      }),
+    );
+  });
+
+  it("force refresh hits only the Slack route when provider=slack and fires onAfterRefresh", async () => {
+    const seen: string[] = [];
+    mockFetch({ onCall: (href) => seen.push(href) });
+    const onAfterRefresh = jest.fn();
+
+    render(
+      <DiscoveryCacheControls provider="slack" isAdmin onAfterRefresh={onAfterRefresh} />,
+    );
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-slack"));
+    await screen.findByTestId("discovery-cache-ttl-input-slack");
+
+    fireEvent.click(screen.getByTestId("discovery-cache-refresh-slack"));
+
+    await waitFor(() => {
+      expect(seen.some((h) => h.includes("/api/admin/slack/available-channels") && h.includes("refresh=1"))).toBe(true);
+    });
+    expect(seen.some((h) => h.includes("/api/admin/webex/available-spaces"))).toBe(false);
+    await waitFor(() => expect(onAfterRefresh).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/refreshed/i)).toBeInTheDocument();
+  });
+
+  it("force refresh hits only the Webex route when provider=webex", async () => {
+    const seen: string[] = [];
+    mockFetch({ onCall: (href) => seen.push(href) });
+
+    render(<DiscoveryCacheControls provider="webex" isAdmin />);
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-webex"));
+    await screen.findByTestId("discovery-cache-ttl-input-webex");
+
+    fireEvent.click(screen.getByTestId("discovery-cache-refresh-webex"));
+
+    await waitFor(() => {
+      expect(seen.some((h) => h.includes("/api/admin/webex/available-spaces") && h.includes("refresh=1"))).toBe(true);
+    });
+    expect(seen.some((h) => h.includes("/api/admin/slack/available-channels"))).toBe(false);
+  });
+
+  it("treats 503 from the discovery route as a no-op success (connector not configured)", async () => {
+    mockFetch({ refresh: { ok: false, status: 503 } });
+    const onAfterRefresh = jest.fn();
+
+    render(
+      <DiscoveryCacheControls provider="webex" isAdmin onAfterRefresh={onAfterRefresh} />,
+    );
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-webex"));
+    await screen.findByTestId("discovery-cache-ttl-input-webex");
+
+    fireEvent.click(screen.getByTestId("discovery-cache-refresh-webex"));
+
+    expect(await screen.findByText(/refreshed/i)).toBeInTheDocument();
+    expect(onAfterRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Save and Force-refresh for read-only viewers but keeps the TTL visible", async () => {
+    mockFetch({ ttl: 45 });
+
+    render(<DiscoveryCacheControls provider="slack" isAdmin={false} />);
+    fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-slack"));
+
+    const input = (await screen.findByTestId(
+      "discovery-cache-ttl-input-slack",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("45"));
+    expect(input).toBeDisabled();
+    expect(screen.queryByTestId("discovery-cache-ttl-save-slack")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("discovery-cache-refresh-slack")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/rbac/__tests__/discovery-cache-config.test.ts
+++ b/ui/src/lib/rbac/__tests__/discovery-cache-config.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the discovery cache TTL helper.
+ *
+ * Why this file:
+ *   - Hardcoded 10-minute TTL used to live in two route files. We moved
+ *     it into platform_config and exposed it in the admin UI. The helper
+ *     is the single source of truth for resolving the live value, so it
+ *     needs explicit coverage for fallback ordering and bound clamping.
+ *   - The helper short-circuits with an in-process memo. The test below
+ *     uses the test-only reset hook so cases don't bleed into each other.
+ *
+ * assisted-by Cursor claude-opus-4-7
+ */
+
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+import {
+  DEFAULT_DISCOVERY_CACHE_TTL_MINUTES,
+  MAX_DISCOVERY_CACHE_TTL_MINUTES,
+  __resetDiscoveryCacheConfigForTests,
+  getDiscoveryCacheTtlMs,
+  normalizeDiscoveryCacheTtlMinutes,
+} from "../discovery-cache-config";
+
+function mockMongoTtl(value: unknown): void {
+  mockGetCollection.mockResolvedValue({
+    findOne: jest.fn().mockResolvedValue({
+      _id: "platform_settings",
+      discovery_cache_ttl_minutes: value,
+    }),
+  });
+}
+
+describe("normalizeDiscoveryCacheTtlMinutes", () => {
+  it("returns null for null/undefined/empty so callers can fall back to defaults", () => {
+    expect(normalizeDiscoveryCacheTtlMinutes(null)).toBeNull();
+    expect(normalizeDiscoveryCacheTtlMinutes(undefined)).toBeNull();
+    expect(normalizeDiscoveryCacheTtlMinutes("")).toBeNull();
+  });
+
+  it("returns null for non-numeric input (admins shouldn't be able to wedge the helper)", () => {
+    expect(normalizeDiscoveryCacheTtlMinutes("nope")).toBeNull();
+    expect(normalizeDiscoveryCacheTtlMinutes({})).toBeNull();
+    expect(normalizeDiscoveryCacheTtlMinutes(Number.NaN)).toBeNull();
+  });
+
+  it("returns null for negative values (0 means 'no cache', negatives are nonsense)", () => {
+    expect(normalizeDiscoveryCacheTtlMinutes(-1)).toBeNull();
+    expect(normalizeDiscoveryCacheTtlMinutes("-5")).toBeNull();
+  });
+
+  it("accepts 0 to mean caching disabled", () => {
+    expect(normalizeDiscoveryCacheTtlMinutes(0)).toBe(0);
+    expect(normalizeDiscoveryCacheTtlMinutes("0")).toBe(0);
+  });
+
+  it("clamps values above the upper bound (defensive against a typo'd PATCH)", () => {
+    expect(normalizeDiscoveryCacheTtlMinutes(MAX_DISCOVERY_CACHE_TTL_MINUTES + 1)).toBe(
+      MAX_DISCOVERY_CACHE_TTL_MINUTES,
+    );
+    expect(normalizeDiscoveryCacheTtlMinutes(100_000)).toBe(MAX_DISCOVERY_CACHE_TTL_MINUTES);
+  });
+
+  it("floors fractional inputs so the cache window is always whole minutes", () => {
+    expect(normalizeDiscoveryCacheTtlMinutes(59.9)).toBe(59);
+    expect(normalizeDiscoveryCacheTtlMinutes("12.5")).toBe(12);
+  });
+});
+
+describe("getDiscoveryCacheTtlMs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.DISCOVERY_CACHE_TTL_MINUTES;
+    __resetDiscoveryCacheConfigForTests();
+  });
+
+  it("uses the Mongo-backed value when one is configured", async () => {
+    mockMongoTtl(30);
+    expect(await getDiscoveryCacheTtlMs()).toBe(30 * 60_000);
+  });
+
+  it("falls back to DISCOVERY_CACHE_TTL_MINUTES env var when Mongo is unset", async () => {
+    mockMongoTtl(undefined);
+    process.env.DISCOVERY_CACHE_TTL_MINUTES = "15";
+    expect(await getDiscoveryCacheTtlMs()).toBe(15 * 60_000);
+  });
+
+  it("falls back to the default 60 minutes when neither Mongo nor env is set", async () => {
+    mockMongoTtl(undefined);
+    expect(await getDiscoveryCacheTtlMs()).toBe(DEFAULT_DISCOVERY_CACHE_TTL_MINUTES * 60_000);
+  });
+
+  it("honours 0 from Mongo as 'caching disabled' (does NOT fall through to env)", async () => {
+    mockMongoTtl(0);
+    process.env.DISCOVERY_CACHE_TTL_MINUTES = "999";
+    expect(await getDiscoveryCacheTtlMs()).toBe(0);
+  });
+
+  it("clamps an out-of-range Mongo value rather than crashing the picker", async () => {
+    mockMongoTtl(99_999);
+    expect(await getDiscoveryCacheTtlMs()).toBe(MAX_DISCOVERY_CACHE_TTL_MINUTES * 60_000);
+  });
+
+  it("falls back to defaults when Mongo throws (so a Mongo outage doesn't break discovery)", async () => {
+    mockGetCollection.mockRejectedValue(new Error("mongo unreachable"));
+    process.env.DISCOVERY_CACHE_TTL_MINUTES = "20";
+    expect(await getDiscoveryCacheTtlMs()).toBe(20 * 60_000);
+  });
+
+  it("memoises the read so back-to-back calls in the same request hit Mongo only once", async () => {
+    mockMongoTtl(45);
+    await getDiscoveryCacheTtlMs();
+    await getDiscoveryCacheTtlMs();
+    await getDiscoveryCacheTtlMs();
+    // getCollection is the only mocked entry point; a single call covers all
+    // three TTL reads thanks to the in-process memo.
+    expect(mockGetCollection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/rbac/discovery-cache-config.ts
+++ b/ui/src/lib/rbac/discovery-cache-config.ts
@@ -1,0 +1,122 @@
+// Shared helper for reading the admin-configurable discovery cache TTL
+// applied to Slack channel discovery (`/api/admin/slack/available-channels`)
+// and Webex space discovery (`/api/admin/webex/available-spaces`).
+//
+// Background: both routes maintain an in-process snapshot of the
+// provider's room/channel list so admins can search/scroll without
+// hammering Slack/Webex API rate limits. The TTL used to be hard-coded
+// to 10 minutes, which was too short for stable workspaces and too long
+// for ad-hoc bot-membership changes (e.g. an admin just added the bot
+// to a brand-new private channel; that channel didn't appear in the
+// picker for up to 10 minutes).
+//
+// The TTL now lives in `platform_config.discovery_cache_ttl_minutes`:
+//   - default 60 minutes (good for typical admin workflows)
+//   - range 0..1440 — 0 disables the cache entirely (every request hits
+//     the upstream API; useful for debugging bot-membership rollouts)
+//   - admins force a fresh snapshot at any time with the route's
+//     existing `?refresh=1` query param, which both routes already honor
+//
+// This helper hot-caches the read for `MEMO_TTL_MS` so that a single
+// discovery request doesn't make two extra Mongo round trips per page
+// it walks (the routes call us once per Slack/Webex page). It is fine
+// for an admin TTL change to take a few seconds to propagate — much
+// faster than rolling the UI workers, but slower than per-call reads.
+//
+// assisted-by Cursor claude-opus-4-7
+
+import { getCollection } from "@/lib/mongodb";
+
+const CONFIG_ID = "platform_settings";
+
+/** Default if the admin hasn't configured one yet. Matches the docs. */
+export const DEFAULT_DISCOVERY_CACHE_TTL_MINUTES = 60;
+/** Upper bound (24 h). Past this we'd risk operators forgetting the cache exists. */
+export const MAX_DISCOVERY_CACHE_TTL_MINUTES = 1440;
+/** Lower bound. 0 means "no cache" — every request goes to Slack/Webex. */
+export const MIN_DISCOVERY_CACHE_TTL_MINUTES = 0;
+
+/**
+ * Hot-cache the platform_config read so a single discovery request that
+ * walks N upstream pages doesn't trigger N+1 reads of the same Mongo
+ * document. 30 s is short enough that an admin who tweaks the TTL sees
+ * it apply nearly immediately on their next click. The memo is keyed on
+ * Node process memory, so it auto-resets on UI worker restart.
+ */
+const MEMO_TTL_MS = 30_000;
+let memoizedAt = 0;
+let memoizedMs: number | null = null;
+
+interface PlatformConfigDoc {
+  _id?: string;
+  discovery_cache_ttl_minutes?: unknown;
+}
+
+/**
+ * Validates and clamps a raw value (from Mongo, the env, or a PATCH
+ * body) to a sane minute count. Returns null if the value isn't a
+ * positive integer-like number so callers can fall back to defaults.
+ */
+export function normalizeDiscoveryCacheTtlMinutes(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return null;
+  const floored = Math.floor(n);
+  if (floored < MIN_DISCOVERY_CACHE_TTL_MINUTES) return null;
+  if (floored > MAX_DISCOVERY_CACHE_TTL_MINUTES) return MAX_DISCOVERY_CACHE_TTL_MINUTES;
+  return floored;
+}
+
+/**
+ * Returns the configured TTL in milliseconds. 0 means "don't cache" and
+ * is honored by callers as a per-request live read.
+ *
+ * Resolution order:
+ *   1. `platform_config.discovery_cache_ttl_minutes` (admin-set)
+ *   2. `DISCOVERY_CACHE_TTL_MINUTES` env (for locked-down envs that
+ *      bake the value into Helm)
+ *   3. `DEFAULT_DISCOVERY_CACHE_TTL_MINUTES` (60 min)
+ *
+ * Any failure to reach Mongo falls back through (2) → (3) so a failed
+ * Mongo lookup doesn't break the discovery picker.
+ */
+export async function getDiscoveryCacheTtlMs(): Promise<number> {
+  const now = Date.now();
+  if (memoizedMs !== null && now - memoizedAt < MEMO_TTL_MS) {
+    return memoizedMs;
+  }
+  let minutes = await readMongoMinutes();
+  if (minutes === null) {
+    minutes = normalizeDiscoveryCacheTtlMinutes(process.env.DISCOVERY_CACHE_TTL_MINUTES);
+  }
+  if (minutes === null) {
+    minutes = DEFAULT_DISCOVERY_CACHE_TTL_MINUTES;
+  }
+  const ms = minutes * 60_000;
+  memoizedMs = ms;
+  memoizedAt = now;
+  return ms;
+}
+
+async function readMongoMinutes(): Promise<number | null> {
+  try {
+    const col = await getCollection<PlatformConfigDoc>("platform_config");
+    const doc = await col.findOne({ _id: CONFIG_ID } as never);
+    return normalizeDiscoveryCacheTtlMinutes(doc?.discovery_cache_ttl_minutes);
+  } catch {
+    // If Mongo is unreachable, fall through to env/default. Discovery
+    // pickers should keep working in that scenario; only the TTL itself
+    // is degraded.
+    return null;
+  }
+}
+
+/**
+ * Test-only escape hatch so jest specs can flush the memo between
+ * cases without restarting the Node process. Production callers should
+ * not import this.
+ */
+export function __resetDiscoveryCacheConfigForTests(): void {
+  memoizedAt = 0;
+  memoizedMs = null;
+}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18.dev13"
+version = "0.4.18.dev14"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Makes the Slack channel and Webex space discovery cache TTL admin-configurable instead of hard-coded to 10 minutes.

The Slack channel and Webex space discovery routes (`/api/admin/slack/available-channels`, `/api/admin/webex/available-spaces`) maintain an in-process snapshot of the provider's room/channel list so admins can search/scroll the onboarding picker without hammering Slack/Webex API rate limits.

The TTL used to be hard-coded to 10 minutes, which was empirically:
- **Too short for stable workspaces** — admins re-paged frequently and hit the rate limiter.
- **Too long for ad-hoc bot-membership changes** — an admin who'd just added the bot to a brand-new private channel had to wait up to 10 minutes for it to appear in the picker.

## Changes

- **`ui/src/lib/rbac/discovery-cache-config.ts`** (new) — shared helper that reads `platform_config.discovery_cache_ttl_minutes` (default **60 minutes**, range 0..1440, where `0` disables the cache entirely for debugging bot-membership rollouts). Hot-cached for 30s with `MEMO_TTL_MS` so a single discovery request that walks N upstream pages doesn't trigger N+1 reads of the same Mongo document.
- **`ui/src/lib/rbac/__tests__/discovery-cache-config.test.ts`** (new) — covers normalisation, clamping, the memoisation TTL, the env-var fallback path, and the "TTL=0 means no cache" guarantee.
- **`ui/src/components/admin/rebac/DiscoveryCacheControls.tsx`** (new) — inline popover next to the onboarding wizard's Find button. Shows current TTL, lets admins change it (admin-only PATCH, read-only render otherwise), and offers a **Force refresh** button that invalidates the in-process snapshot via the routes' existing `?refresh=1` query param. Optional render — wizard callers opt in by passing `provider`.
- **`ConnectorOnboardingWizard.tsx`** — accepts optional `provider` and `isAdmin` props and renders the new popover. **Existing callers** (and tests) that don't pass `provider` keep working unchanged.
- **Slack and Webex discovery routes** now read the TTL through the shared helper instead of hard-coding 10 minutes. The Slack route also picks up the corresponding test update.

## Migration

**No env-var migration needed.** Callers without a Mongo `platform_config` document fall through to the 60-minute default. Operators who already relied on the implicit 10-minute behaviour can restore it by:

- writing `{ discovery_cache_ttl_minutes: 10 }` into the platform_config doc, or
- leaving it unset and letting the new default take effect.

## Test plan

- [ ] `cd ui && npm test -- src/lib/rbac/__tests__/discovery-cache-config.test.ts` — new helper tests
- [ ] `cd ui && npm test -- src/components/admin/rebac/__tests__/DiscoveryCacheControls.test.tsx` — UI popover tests
- [ ] `cd ui && npm test -- src/app/api/admin/slack/available-channels/__tests__/route.test.ts` — route now consults helper
- [ ] Manual smoke: open `Admin → Integrations → Slack`, click *Find Slack Channels with Bot Integration*, verify the **Cache** popover renders next to the button, change TTL to 0, force refresh, observe fresh data
