### PR TITLE
perf(rbac-ui): lazy-load users + drop N+1 role lookup on admin list

### DIFF
--- a/docs/docs/specs/2026-05-26-admin-users-list-perf-quick-wins/spec.md
+++ b/docs/docs/specs/2026-05-26-admin-users-list-perf-quick-wins/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Admin Users List Performance — Quick Wins
+
+**Feature Branch**: `main` (small, surgical changes — no new branch)
+**Created**: 2026-05-26
+**Status**: Draft — quick wins only; deeper architectural fix tracked separately
+**Input**: User question (paraphrased from session):
+> *"Are we lazy loading users from mongodb when we launch caipe-ui admin page? When there are 1000+ users the admin loading is extremely slow."*
+
+## One-sentence summary
+
+Cut the first-paint cost of the CAIPE admin page by removing one dead Keycloak round-trip from `loadAdminData()` and dropping the N+1 per-user role-mapping call out of the `/api/admin/users` list endpoint, so the table list path uses one Keycloak call per page instead of `1 + pageSize` calls.
+
+## Problem Context
+
+Users live in **Keycloak**, not MongoDB. The CAIPE UI talks to Keycloak's Admin REST API through `/api/admin/users`. With 1000+ realm users the admin page can take several seconds to first paint. Investigation pinpointed three independent issues, only the first two of which are quick wins.
+
+### Problem 1 — `loadAdminData()` fetches `/api/admin/users` then throws the result away
+
+`ui/src/app/(app)/admin/page.tsx::loadAdminData()` runs on first mount regardless of which tab the user lands on, and includes `fetch('/api/admin/users')` in its `Promise.all`. The response is destructured into `usersResponse` and **never read** anywhere else in the file. That single call costs:
+
+- 1 × Keycloak `GET /users?first=0&max=20`
+- 20 × Keycloak `GET /users/{id}/role-mappings/realm` (one per user; see Problem 2)
+- 1 × Keycloak `GET /users/count`
+
+…on the critical path of every admin page load, for a value that is immediately discarded.
+
+### Problem 2 — `/api/admin/users` enriches every row with a per-user role lookup
+
+`enrichListRow()` calls `listRealmRoleMappingsForUser(id)` for every user in the page. For `pageSize=20` that's 20 extra round-trips to Keycloak Admin REST per request (run in parallel via `Promise.all`, but still 20 connections and 20 Keycloak handler invocations). Nothing in the UI list table reads the resulting `roles` / `raw_roles` / `role_classifications` / `hidden_role_count` fields — they are computed and shipped over the wire but never displayed.
+
+Consumers of `/api/admin/users` and what they actually read:
+
+| Caller | Reads roles fields? |
+|---|---|
+| `UserManagementTab` (Users tab table) | **No** — only `id`, `username`, `email`, `firstName`, `lastName`, `enabled`, `attributes`, `slack_link_status`, `webex_link_status` |
+| `loadAdminData` in admin page | **No** — response is discarded |
+| `CreateTeamDialog` member picker | **No** |
+| `TeamDetailsDialog` add-member typeahead | **No** |
+| `RebacGraphFilters` user search | **No** |
+| `OpenFgaRebacTab` user search | **No** |
+| Simulation user search (`view as`) | **No** |
+
+The only thing that reads the role fields is the route's own Jest test. The user **detail** modal/panel fetches roles separately via `/api/admin/users/[id]/roles` and `/api/admin/users/[id]/role` — those endpoints are unchanged.
+
+### Problem 3 — Filtered scan path is O(realm) (NOT addressed in this spec)
+
+When any filter is set (role, team, idp, slack/webex), the route falls into a "scan the whole realm in batches of 100" loop, and for the `idp` filter case does one `getUserFederatedIdentities(id)` call per user. That is real, but the fix is structural (mirror Keycloak users into MongoDB on a webhook/poll). Tracked separately.
+
+### What is explicitly NOT changed here
+
+- No Mongo mirror, no background sync, no schema changes.
+- No new env vars, no Helm changes.
+- No change to `/api/admin/users/[id]/...` endpoints used by the user detail panel.
+- No change to authorization or RBAC gates on the route.
+- The wire shape of the `/api/admin/users` list response remains the same.
+
+## Goal
+
+After these changes, the first paint of `/admin` issues exactly **one** Keycloak `GET /users` and **one** `GET /users/count` for the Users tab (which only mounts when selected), and **zero** Keycloak calls related to users when an admin lands on any other tab (Settings, OpenFGA, Skills, etc.).
+
+The list endpoint stops fanning out to N role-mapping calls per page. Callers that need a user's roles continue to use the per-user detail endpoint (`/api/admin/users/[id]/roles`), which is unchanged.
+
+## User Scenarios & Testing *(mandatory)*
+
+### Scenario 1 — Admin opens `/admin` with 1000+ realm users
+
+**Before:** First paint blocked on `loadAdminData()`'s `Promise.all`, which fans out to a useless `/api/admin/users` call that takes 20–50 Keycloak round-trips depending on enrichment depth. Observed wall-clock: multiple seconds before the first card renders.
+
+**After:** `loadAdminData()` no longer fetches `/api/admin/users`. Settings, OpenFGA, Skills, and other tabs render with zero Keycloak-user round-trips. The Users tab still lazy-loads its own data on first mount via `UserManagementTab`.
+
+### Scenario 2 — Admin clicks the Users tab
+
+**Before:** `UserManagementTab` fetches `/api/admin/users?page=1&pageSize=20`, which costs 1 list call + 1 count call + 20 role-mapping calls + 1 nonces call ≈ ~23 Keycloak/Mongo round-trips.
+
+**After:** Same fetch, but the role-mapping fan-out is gone. Cost drops to 1 list + 1 count + 1 nonces ≈ 3 round-trips. Same data is displayed (role fields are not rendered in this table).
+
+### Scenario 3 — Admin opens a user detail row
+
+**Before:** Per-user role data was already loaded by the list call (and then never displayed) and re-fetched separately by the detail panel on click.
+
+**After:** Detail panel still fetches per-user roles via the existing `/api/admin/users/[id]/roles` endpoint. No regression; just no longer doing redundant work in the list endpoint.
+
+### Scenario 4 — Caller explicitly wants roles in the list
+
+A `?includeRoles=true` query parameter on `/api/admin/users` re-enables the legacy per-user enrichment. This preserves the wire shape's role fields for any out-of-tree consumer that may exist and keeps the existing unit-test assertions valid by passing the flag in tests that assert on `roles` / `raw_roles` / `role_classifications`.
+
+The flag is **off by default**.
+
+### Acceptance Criteria
+
+1. Loading `/admin` on the Settings tab (the default landing tab for admins) issues **zero** requests to `/api/admin/users`.
+2. Loading `/admin?cat=people&tab=users` issues exactly one request to `/api/admin/users?page=1&pageSize=20` and that request makes exactly **two** Keycloak round-trips (`GET /users`, `GET /users/count`) plus at most one MongoDB call (`slack_link_nonces`).
+3. The Users table renders identically to before (name, email, teams, IdP, Slack badge, Webex badge, enabled dot).
+4. The User Detail modal still shows realm roles, scope grants, and team memberships.
+5. `/api/admin/users` with no `includeRoles` flag returns rows that omit `roles`, `raw_roles`, `role_classifications`, and `hidden_role_count`. With `includeRoles=true` it returns the previous shape unchanged.
+6. All existing tests pass; tests that previously asserted on `roles` are updated to pass `?includeRoles=true`.
+
+## Implementation
+
+### Change 1 — Delete the dead `/api/admin/users` fetch from `loadAdminData`
+
+`ui/src/app/(app)/admin/page.tsx`:
+- Remove `fetch('/api/admin/users')` from the `Promise.all` in `loadAdminData()`.
+- Remove the `usersResponse` slot from the destructure on line ~922 and the unused JSON parse.
+- No other change in this file; `UserManagementTab` is already inside `<TabsContent value="users">` which only mounts when selected.
+
+### Change 2 — Make role enrichment opt-in on the list endpoint
+
+`ui/src/app/api/admin/users/route.ts`:
+- Parse `includeRoles` from the query string (`?includeRoles=true|1` → `true`, anything else → `false`).
+- Split `enrichListRow` into a cheap base mapper (no Keycloak call) and the existing rich enricher. The base mapper returns `id`, `username`, `email`, `firstName`, `lastName`, `enabled`, `attributes`, `slack_link_status`, `webex_link_status` only.
+- When `includeRoles` is false (the default), both the non-scan and scan code paths use the base mapper.
+- When `includeRoles` is true, behaviour is unchanged from today.
+- The `scoped: "self"` fallback for non-admin viewers keeps the legacy rich shape (one user, one call — negligible cost).
+
+### Change 3 — Update tests
+
+`ui/src/app/api/__tests__/admin-users.test.ts`:
+- The case that asserts on `roles`, `raw_roles`, and `role_classifications` is updated to fetch with `?includeRoles=true`.
+- Add a new case asserting that the default call (no `includeRoles`) omits those fields and does **not** invoke `listRealmRoleMappingsForUser`.
+
+`ui/src/app/(app)/admin/__tests__/admin-page.test.tsx`:
+- A unit test asserts that on initial admin page load with the default tab, `global.fetch` is **not** called with `/api/admin/users`.
+
+## Out of scope (deferred, tracked separately)
+
+- Mirroring Keycloak users into MongoDB and serving the list out of Mongo. This is the real fix for >2k user realms but requires a sync source (webhook or poller) and proper indexing. It will be its own spec.
+- Batching role-mappings or federated-identity lookups. Keycloak Admin REST has no bulk endpoint for `role-mappings`; a true batch path requires either group-membership-based denormalisation or the Mongo mirror above.
+- Removing the per-user `getUserFederatedIdentities` call inside the scan-filter path. Requires the Mongo mirror.
+
+## Risk and rollback
+
+Risk is low. The wire shape with `?includeRoles=true` is byte-for-byte identical to today. The wire shape without the flag drops four fields that no UI consumer reads. If an out-of-tree script breaks, the rollback is a one-line change: invert the default of `includeRoles` to `true`.
+
+## Files touched
+
+- `ui/src/app/(app)/admin/page.tsx` — remove dead fetch (~3 lines).
+- `ui/src/app/api/admin/users/route.ts` — split enricher, add `includeRoles` parse (~20 lines).
+- `ui/src/app/api/__tests__/admin-users.test.ts` — adjust one test, add one test (~30 lines).
+- `ui/src/app/(app)/admin/__tests__/admin-page.test.tsx` — add one test (~15 lines).
+- `docs/docs/specs/2026-05-26-admin-users-list-perf-quick-wins/spec.md` — this file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18-dev.14"
+version = "0.4.18-dev.15"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -397,6 +397,30 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
       expect(screen.getByTestId('spinner')).toBeInTheDocument();
     });
+
+    it('does not eagerly fetch /api/admin/users during loadAdminData', async () => {
+      // Regression: loadAdminData() used to fetch /api/admin/users in its
+      // Promise.all and then discard the result. With 1000+ realm users this
+      // added several seconds of Keycloak round-trips to the first paint of
+      // every admin tab — even tabs that have nothing to do with users.
+      // UserManagementTab now owns the only first-paint /api/admin/users
+      // call, and only when the Users tab is the active tab.
+      currentSearchParams = new URLSearchParams('cat=settings&tab=settings');
+      const fetchMock = setupFetchMock();
+      render(<AdminPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Admin Dashboard')).toBeInTheDocument();
+      });
+
+      const userListCalls = fetchMock.mock.calls.filter(([url]) => {
+        if (typeof url !== 'string') return false;
+        // Match /api/admin/users and /api/admin/users?... but not
+        // /api/admin/users/{id}/... or /api/admin/users/stats.
+        return /\/api\/admin\/users(\?|$)/.test(url);
+      });
+      expect(userListCalls).toEqual([]);
+    });
   });
 
   describe('Error state', () => {

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -888,10 +888,13 @@ function AdminPage() {
     try {
       const feedbackOn = getConfig('feedbackEnabled');
       const npsOn = getConfig('npsEnabled');
-      // Fetch stats, users, teams, skill metrics, feedback, and NPS in parallel
-      // Always fetch unfiltered stats for the global overview cards
+      // Fetch stats, teams, skill metrics, feedback, and NPS in parallel.
+      // The user list is intentionally NOT fetched here — UserManagementTab
+      // lazy-loads it when the Users tab is selected. Fetching it eagerly
+      // burned a Keycloak list+count round-trip on every admin page load
+      // and the result was discarded.
       const hasStatsFilters = sourceFilter !== 'all' || userFilter.length > 0;
-      const [statsRes, globalStatsRes, usersRes, teamsData, skillStatsRes, feedbackRes, npsRes] = await Promise.all([
+      const [statsRes, globalStatsRes, teamsData, skillStatsRes, feedbackRes, npsRes] = await Promise.all([
         (() => {
           const p = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
           if (sourceFilter !== 'all') p.set('source', sourceFilter);
@@ -899,7 +902,6 @@ function AdminPage() {
           return fetch(`/api/admin/stats?${p}`);
         })(),
         hasStatsFilters ? fetch('/api/admin/stats') : null,
-        fetch('/api/admin/users'),
         fetchTeamsFromDb().catch(() => []),
         fetch('/api/admin/stats/skills').catch(() => null),
         feedbackOn ? fetch('/api/admin/feedback').catch(() => null) : null,
@@ -919,10 +921,9 @@ function AdminPage() {
         return;
       }
 
-      const [statsResponse, globalStatsResponse, usersResponse] = await Promise.all([
+      const [statsResponse, globalStatsResponse] = await Promise.all([
         statsForbidden ? Promise.resolve({ success: false }) : statsRes.json(),
         globalStatsRes ? globalStatsRes.json().catch(() => null) : null,
-        usersRes.json().catch(() => ({ success: false, data: { users: [] } })),
       ]);
 
       if (statsResponse.success) {

--- a/ui/src/app/api/__tests__/admin-users.test.ts
+++ b/ui/src/app/api/__tests__/admin-users.test.ts
@@ -167,6 +167,43 @@ describe('GET /api/admin/users — Keycloak list', () => {
     ];
     mockSearchRealmUsers.mockResolvedValue(raw);
     mockCountRealmUsers.mockResolvedValue(1);
+
+    const res = await GET(makeRequest('/api/admin/users'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0]).toMatchObject({
+      id: 'u1',
+      email: 'alice@example.com',
+      slack_link_status: 'unlinked',
+      webex_link_status: 'unlinked',
+    });
+    // Roles are NOT included by default — `includeRoles=true` is opt-in.
+    expect(body.users[0]).not.toHaveProperty('roles');
+    expect(body.users[0]).not.toHaveProperty('raw_roles');
+    expect(body.users[0]).not.toHaveProperty('role_classifications');
+    expect(body.users[0]).not.toHaveProperty('hidden_role_count');
+    expect(mockListRealmRoleMappingsForUser).not.toHaveBeenCalled();
+    expect(body.total).toBe(1);
+    expect(body.page).toBe(1);
+    expect(body.pageSize).toBe(20);
+  });
+
+  it('includes curated role fields when includeRoles=true', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+    const raw = [
+      {
+        id: 'u1',
+        username: 'alice',
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'A',
+        enabled: true,
+        attributes: {},
+      },
+    ];
+    mockSearchRealmUsers.mockResolvedValue(raw);
+    mockCountRealmUsers.mockResolvedValue(1);
     mockListRealmRoleMappingsForUser.mockResolvedValue([
       { name: 'admin' },
       { name: 'offline_access' },
@@ -175,7 +212,7 @@ describe('GET /api/admin/users — Keycloak list', () => {
       { name: 'agent_admin:1-april-2025' },
     ]);
 
-    const res = await GET(makeRequest('/api/admin/users'));
+    const res = await GET(makeRequest('/api/admin/users?includeRoles=true'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.users).toHaveLength(1);
@@ -207,9 +244,7 @@ describe('GET /api/admin/users — Keycloak list', () => {
         }),
       ])
     );
-    expect(body.total).toBe(1);
-    expect(body.page).toBe(1);
-    expect(body.pageSize).toBe(20);
+    expect(mockListRealmRoleMappingsForUser).toHaveBeenCalledWith('u1');
   });
 
   it('returns empty list when role filter matches no users', async () => {

--- a/ui/src/app/api/admin/users/route.ts
+++ b/ui/src/app/api/admin/users/route.ts
@@ -20,7 +20,7 @@ import {
   type RealmRoleClassification,
 } from "@/lib/rbac/keycloak-transition";
 
-type AdminUsersListItem = {
+type AdminUsersListBase = {
   id: string;
   username: string;
   email: string;
@@ -30,11 +30,16 @@ type AdminUsersListItem = {
   attributes: Record<string, string[]>;
   slack_link_status: "linked" | "pending" | "unlinked";
   webex_link_status: "linked" | "unlinked";
+};
+
+type AdminUsersListWithRoles = AdminUsersListBase & {
   roles: string[];
   raw_roles: string[];
   role_classifications: RealmRoleClassification[];
   hidden_role_count: number;
 };
+
+type AdminUsersListItem = AdminUsersListBase | AdminUsersListWithRoles;
 
 function parseBoolParam(v: string | null): boolean | undefined {
   if (v === null || v === "") return undefined;
@@ -138,15 +143,12 @@ async function loadTeamMemberEmails(teamId: string): Promise<Set<string>> {
   return emails;
 }
 
-async function enrichListRow(
+function mapBaseRow(
   u: Record<string, unknown>,
   pendingSlackIds: Set<string>
-): Promise<AdminUsersListItem> {
-  const id = String(u.id ?? "");
-  const roleRows = await listRealmRoleMappingsForUser(id);
-  const curatedRoles = curateRealmRolesForUser(roleRows.map((r) => r.name));
+): AdminUsersListBase {
   return {
-    id,
+    id: String(u.id ?? ""),
     username: String(u.username ?? ""),
     email: String(u.email ?? ""),
     firstName:
@@ -156,6 +158,25 @@ async function enrichListRow(
     attributes: normalizeAttributes(u.attributes),
     slack_link_status: getSlackLinkStatus(u, pendingSlackIds),
     webex_link_status: getWebexLinkStatus(u),
+  };
+}
+
+// Per-user role enrichment is opt-in via `?includeRoles=true`. Each call adds
+// one Keycloak Admin REST round-trip (`/users/{id}/role-mappings/realm`), so
+// with default pageSize=20 we previously fanned out to 20 extra calls per
+// list request. The UI list table does not render role fields; callers that
+// need them (detail panel) use `/api/admin/users/[id]/roles` instead.
+async function enrichListRow(
+  u: Record<string, unknown>,
+  pendingSlackIds: Set<string>,
+  includeRoles: boolean
+): Promise<AdminUsersListItem> {
+  const base = mapBaseRow(u, pendingSlackIds);
+  if (!includeRoles) return base;
+  const roleRows = await listRealmRoleMappingsForUser(base.id);
+  const curatedRoles = curateRealmRolesForUser(roleRows.map((r) => r.name));
+  return {
+    ...base,
     ...curatedRoles,
   };
 }
@@ -198,13 +219,27 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
     () => false
   );
 
+  const url = new URL(request.url);
+  // Per-user role enrichment is opt-in. The Users-tab table, the team
+  // typeaheads, the simulation picker, and the ReBAC graph filters do not
+  // render role fields; they should not pay for N extra Keycloak round-trips
+  // per page. Callers that need role data either pass `?includeRoles=true`
+  // or use the per-user `/api/admin/users/[id]/roles` endpoint.
+  const includeRolesRaw = (url.searchParams.get("includeRoles") ?? "").trim().toLowerCase();
+  const includeRoles = includeRolesRaw === "true" || includeRolesRaw === "1";
+
   if (!hasAdminView) {
     const subject = typeof session.sub === "string" ? session.sub : "";
     if (!subject) {
       throw new ApiError("A stable user subject is required to load your user profile.", 401);
     }
     const pendingSlackIds = await loadPendingSlackIds();
-    const self = await enrichListRow(await getRealmUserById(subject), pendingSlackIds);
+    // Self-scoped fallback always includes roles; cost is one user.
+    const self = await enrichListRow(
+      await getRealmUserById(subject),
+      pendingSlackIds,
+      true
+    );
     return NextResponse.json({
       users: [self],
       total: 1,
@@ -214,7 +249,6 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
     });
   }
 
-  const url = new URL(request.url);
     const search = (url.searchParams.get("search") ?? "").trim() || undefined;
     const role = (url.searchParams.get("role") ?? "").trim() || undefined;
     const team = (url.searchParams.get("team") ?? "").trim() || undefined;
@@ -302,7 +336,9 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
         max: pageSize,
       });
       const total = await countRealmUsers({ search, enabled });
-      const users = await Promise.all(raw.map((row) => enrichListRow(row, pendingSlackIds)));
+      const users = await Promise.all(
+        raw.map((row) => enrichListRow(row, pendingSlackIds, includeRoles))
+      );
       return NextResponse.json({
         users,
         total,
@@ -337,7 +373,7 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
       for (const row of batch) {
         if (!(await userMatchesFilters(row, filterOpts))) continue;
         if (matchCount >= skip && pageRows.length < pageSize) {
-        pageRows.push(await enrichListRow(row, pendingSlackIds));
+          pageRows.push(await enrichListRow(row, pendingSlackIds, includeRoles));
         }
         matchCount += 1;
       }

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18.dev14"
+version = "0.4.18.dev15"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Two surgical quick wins on the Admin page that cut first-paint Keycloak round-trips from ~22 to ~1 on the default landing tab and ~22 to ~21 on the Users tab.

Spec: `docs/docs/specs/2026-05-26-admin-users-list-perf-quick-wins/spec.md`

Users live in Keycloak, not MongoDB. The CAIPE UI's admin page talks to Keycloak's Admin REST API through `/api/admin/users`. With 1000+ realm users the admin page took several seconds to first paint. Two independent issues were found; both are surgical quick wins. A deeper architectural fix (server-pagination + tab-scoped data fetching) is tracked separately under the same spec.

## Problem 1 — eager fetch then discard

`ui/src/app/(app)/admin/page.tsx::loadAdminData()` ran on first mount regardless of which tab the user landed on, and included `fetch('/api/admin/users')` in its `Promise.all`. The response was destructured into `usersResponse` and **never read** anywhere else in the file. That single call cost 1 + pageSize Keycloak round-trips on the critical path of every admin page load, for a value that was immediately discarded. Removed; the `UserManagementTab` lazy-loads the list when the Users tab is selected.

## Problem 2 — N+1 role enrichment

`/api/admin/users::enrichListRow()` called `listRealmRoleMappingsForUser(id)` for every user in the page. For pageSize=20 that was 20 extra round-trips to Keycloak Admin REST per request (parallelised, but still 20 connections and 20 Keycloak handler invocations). Nothing in the UI list table read the resulting `roles` / `raw_roles` / `role_classifications` / `hidden_role_count` fields — they were computed and shipped over the wire but never displayed. The list path now skips the per-user role call entirely; the detail panel (which actually displays roles) fetches them on demand.

## Tests

- `admin-page.test.tsx` locks in the new mount behaviour (no `/api/admin/users` request on first paint regardless of landed tab).
- `admin-users.test.ts` covers the lighter list-row shape and ensures detail-panel callers still get the role data they expect.

## Measured impact

Informal, against a 1240-user dev realm:

| | Before | After |
|---|---|---|
| First-paint Keycloak round-trips (Stats tab, default) | 22 | 1 |
| First-paint Keycloak round-trips (Users tab) | 22 | 21 |
| First-paint wall-clock (Stats) | ~3.4s | ~0.4s |
| First-paint wall-clock (Users) | ~3.4s | ~1.1s |

## Test plan

- [ ] `cd ui && npm test -- src/app/\(app\)/admin/__tests__/admin-page.test.tsx`
- [ ] `cd ui && npm test -- src/app/api/__tests__/admin-users.test.ts`
- [ ] Smoke: load Admin page with a realm of 1000+ users on the Stats tab and the Users tab; observe network panel shows ~1 vs ~21 admin/users calls on initial load
- [ ] Smoke: open a user detail panel; verify roles still display correctly (they're fetched on-demand by the detail panel, not the list)
