### PR TITLE
fix: enable ContextEditingMiddleware by default for dynamic agents

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -123,7 +123,7 @@ MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
     "context_editing": MiddlewareSpec(
         cls=ContextEditingMiddleware,
         default_params={"trigger": 100_000, "keep": 3},
-        enabled_by_default=False,
+        enabled_by_default=True,
         allow_multiple=False,
         label="Context Editing",
         description="Clears older tool outputs when approaching token limits",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18+hotfix.2"
+version = "0.4.18+hotfix.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18+hotfix.2"
+version = "0.4.18+hotfix.3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Flip `enabled_by_default` from `False` to `True` for `context_editing` in `MIDDLEWARE_REGISTRY` (`middleware.py`)
- 1-line change — no new code, no new dependencies

## Why

Multi-turn conversations with RAG-heavy tool use accumulate `ToolMessage` results in LangGraph state across turns. By turn 3-4, the accumulated context exceeds the effective input ceiling (~136K tokens for Sonnet 4.5: 200K total minus 64K max output), causing:

```
ValidationException: Input is too long for requested model
```

`ContextEditingMiddleware` was already implemented, registered, and tested but gated behind `enabled_by_default=False`. It clears old `ToolMessage` content from the model's view (replacing with `[cleared]`) when accumulated input exceeds the trigger threshold, while keeping the `keep=3` most recent tool results intact. Persisted LangGraph state is not mutated.

## Validation

Tested in a multi-turn RAG session. With `context_editing` active, input token counts show the expected sawtooth pattern — rising as RAG results accumulate, dropping when the trigger fires, rising again:

```
model call 1:  9,740 tokens   (first turn, no history)
model call 2: 104,938 tokens  (after 10 RAG calls — trigger fires)
model call 3:  95,944 tokens  (cleared — dropped ~9K)
model call 4: 106,412 tokens  (new RAG results added)
```

No `ValidationException` errors across any turns. Previously, turn 4 would reliably fail with 136K+ tokens.

The `trigger=100_000` and `keep=3` defaults remain unchanged.

[GAI]