### PR TITLE
docs: fix broken relative links to source files outside docs tree

### DIFF
--- a/docs/docs/specs/008-platform-engineer-streaming-architecture/streaming-comparison.md
+++ b/docs/docs/specs/008-platform-engineer-streaming-architecture/streaming-comparison.md
@@ -6,8 +6,8 @@ title: "Streaming Comparison: v0.2.41 vs v0.3.0"
 
 # Streaming Comparison: v0.2.41 (Golden) vs v0.3.0
 
-> Captured 2026-04-13 using [`scripts/trace_a2a_streaming.py`](../../../../scripts/trace_a2a_streaming.py)
-> and [`scripts/capture_a2a_events.py`](../../../../scripts/capture_a2a_events.py).
+> Captured 2026-04-13 using [`scripts/trace_a2a_streaming.py`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/scripts/trace_a2a_streaming.py)
+> and [`scripts/capture_a2a_events.py`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/scripts/capture_a2a_events.py).
 >
 > See also: [Streaming Architecture Knowledge Base](./streaming-architecture-knowledge-base.md)
 > for the full architectural deep-dive, root-cause analysis, and fix documentation.
@@ -365,7 +365,7 @@ To restore v0.2.41's streaming UX in v0.3.0:
 
 | Script | Purpose | Usage |
 |--------|---------|-------|
-| [`scripts/trace_a2a_streaming.py`](../../../../scripts/trace_a2a_streaming.py) | Trace all SSE events with timestamps and summary stats | `python3 scripts/trace_a2a_streaming.py 8000 "what can you do?"` |
-| [`scripts/capture_a2a_events.py`](../../../../scripts/capture_a2a_events.py) | Capture raw A2A events to JSON for offline analysis | `python3 scripts/capture_a2a_events.py http://localhost:8000/ "query" /tmp/out.json` |
+| [`scripts/trace_a2a_streaming.py`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/scripts/trace_a2a_streaming.py) | Trace all SSE events with timestamps and summary stats | `python3 scripts/trace_a2a_streaming.py 8000 "what can you do?"` |
+| [`scripts/capture_a2a_events.py`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/scripts/capture_a2a_events.py) | Capture raw A2A events to JSON for offline analysis | `python3 scripts/capture_a2a_events.py http://localhost:8000/ "query" /tmp/out.json` |
 
 Both scripts use only the Python stdlib (`http.client`, `json`, `uuid`) -- no pip dependencies required.

--- a/docs/docs/specs/102-comprehensive-rbac-tests-and-completion/call-sequences.md
+++ b/docs/docs/specs/102-comprehensive-rbac-tests-and-completion/call-sequences.md
@@ -100,7 +100,7 @@ sequenceDiagram
 
 **Real code references**:
 
-- Route uses [`withAuth`](../../../../ui/src/lib/api-middleware.ts) — see `ui/src/lib/api-middleware.ts:139` (already exists)
+- Route uses [`withAuth`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/ui/src/lib/api-middleware.ts) — see `ui/src/lib/api-middleware.ts:139` (already exists)
 - `requireRbacPermission` body — `ui/src/lib/api-middleware.ts:345` (already exists)
 - `checkPermission` body — `ui/src/lib/rbac/keycloak-authz.ts:51` (already exists)
 - `logAuthzDecision` body — `ui/src/lib/rbac/audit.ts:107` (already exists)


### PR DESCRIPTION
## Summary

The `[Docs] Snapshot & Prune Versions` workflow has been failing on every release tag (most recently `0.5.0`) because Docusaurus is configured with `onBrokenLinks: 'throw'` and three Markdown links escaped the docs tree with `../../../../` paths.

Replace the broken relative paths with `https://github.com/cnoe-io/ai-platform-engineering/blob/main/...` URLs, matching the convention already used elsewhere in the docs site.

### Files changed

- `docs/docs/specs/102-comprehensive-rbac-tests-and-completion/call-sequences.md` — 1 link to `ui/src/lib/api-middleware.ts`
- `docs/docs/specs/008-platform-engineer-streaming-architecture/streaming-comparison.md` — 4 links to `scripts/trace_a2a_streaming.py` and `scripts/capture_a2a_events.py`

### Build error from the failed 0.5.0 release

```
Exhaustive list of all broken links found:
- Broken link on source page path = /ai-platform-engineering/docs/specs/comprehensive-rbac-tests-and-completion/call-sequences:
   -> linking to ../../../../ui/src/lib/api-middleware.ts (resolved as: /ui/src/lib/api-middleware.ts)
- Broken link on source page path = /ai-platform-engineering/docs/specs/platform-engineer-streaming-architecture/streaming-comparison:
   -> linking to ../../../../scripts/trace_a2a_streaming.py (resolved as: /scripts/trace_a2a_streaming.py)
   -> linking to ../../../../scripts/capture_a2a_events.py (resolved as: /scripts/capture_a2a_events.py)
```

## Test plan

- [x] Ran `npm run build` in `docs/` locally — exit code 0, no broken-link errors for these three targets
- [x] No relative `../../../../` paths into non-docs trees remain (grep verified)
- [ ] `[Docs] Snapshot & Prune Versions` workflow passes in CI
- [ ] `[Publish][Docs] GH Pages` workflow continues to pass on `main`

## Notes

- Visible link text was preserved exactly so the rendered prose reads identically.
- One unrelated `[WARNING] Docusaurus found broken anchors!` was observed in the local build for `roles-scopes-comparison` → `architecture#spec-104--active_team-jwt-claim-team-scope-refactor` — that's a separate stale-anchor issue and not in scope for this PR.
