### PR TITLE
fix(setup-caipe): Disable ENABLE_METALLB/ENABLE_INGRESS when user declines

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -2742,9 +2742,12 @@ choose_features() {
         fi
       fi
     else
+      ENABLE_INGRESS=false
       log "Ingress skipped"
     fi
   else
+    ENABLE_METALLB=false
+    ENABLE_INGRESS=false
     log "MetalLB skipped"
   fi
 }


### PR DESCRIPTION
# Description

Both flags default to true but never to false on no. As a result, answering "No" to either the MetalLB or nginx-ingress prompt had no effect; the install phase always saw true and ran both.

Addressing the issue by adding two else-branches:
- ENABLE_INGRESS=false when user declines ingress (MetalLB-yes path)
- ENABLE_METALLB=false + ENABLE_INGRESS=false when user declines MetalLB

Fixes https://github.com/cnoe-io/ai-platform-engineering/issues/1585

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
