### PR TITLE
feat(agentgateway): add MCP route bridge for RBAC runtimes

### DIFF
--- a/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["--file", "/etc/agentgateway/config.yaml"]
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/ai-platform-engineering/charts/agentgateway/values.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/values.yaml
@@ -5,6 +5,22 @@ image:
   tag: v1.1.0
   pullPolicy: IfNotPresent
 
+extraEnv: []
+# - name: GITHUB_PERSONAL_ACCESS_TOKEN
+#   valueFrom:
+#     secretKeyRef:
+#       name: github-mcp-secret
+#       key: GITHUB_PERSONAL_ACCESS_TOKEN
+# - name: GITLAB_PERSONAL_ACCESS_TOKEN
+#   valueFrom:
+#     secretKeyRef:
+#       name: gitlab-mcp-secret
+#       key: GITLAB_PERSONAL_ACCESS_TOKEN
+
+extraEnvFrom: []
+# - secretRef:
+#     name: agentgateway-secrets
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/ai-platform-engineering/templates/agentgateway-mcp.yaml
+++ b/charts/ai-platform-engineering/templates/agentgateway-mcp.yaml
@@ -14,6 +14,8 @@ Prerequisites:
 {{- $gatewayName := printf "%s-agentgateway-proxy" .Release.Name }}
 {{- $gatewayPort := .Values.global.agentgateway.proxyPort | default 8080 }}
 {{- $hasAgentgatewayAgent := false }}
+{{- $extraMcpTargets := .Values.global.agentgateway.extraMcpTargets | default list }}
+{{- $knowledgeBaseTarget := .Values.global.agentgateway.knowledgeBaseTarget | default dict }}
 
 {{- /* Scan for any agent that has mcp.agentgateway.enabled */ -}}
 {{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
@@ -25,6 +27,14 @@ Prerequisites:
 {{- $hasAgentgatewayAgent = true }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- range $target := $extraMcpTargets }}
+{{- if or (not (hasKey $target "enabled")) $target.enabled }}
+{{- $hasAgentgatewayAgent = true }}
+{{- end }}
+{{- end }}
+{{- if or (not (hasKey $knowledgeBaseTarget "enabled")) $knowledgeBaseTarget.enabled }}
+{{- $hasAgentgatewayAgent = true }}
 {{- end }}
 
 {{- if $hasAgentgatewayAgent }}
@@ -105,6 +115,84 @@ spec:
           group: agentgateway.dev
           kind: AgentgatewayBackend
 {{- end }}
+{{- end }}
+{{- end }}
+{{- if or (not (hasKey $knowledgeBaseTarget "enabled")) $knowledgeBaseTarget.enabled }}
+{{- $kbHost := required "global.agentgateway.knowledgeBaseTarget.host is required" $knowledgeBaseTarget.host }}
+{{- $kbPort := required "global.agentgateway.knowledgeBaseTarget.port is required" $knowledgeBaseTarget.port }}
+{{- $kbProtocol := $knowledgeBaseTarget.protocol | default "StreamableHTTP" }}
+{{- $kbPathPrefix := $knowledgeBaseTarget.pathPrefix | default "/mcp/knowledge-base" }}
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: knowledge-base-extra-mcp-backend
+spec:
+  mcp:
+    targets:
+      - name: "knowledge-base"
+        static:
+          host: {{ tpl $kbHost $ | quote }}
+          port: {{ $kbPort }}
+          protocol: {{ $kbProtocol }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: knowledge-base-extra-mcp-route
+spec:
+  parentRefs:
+    - name: {{ $gatewayName }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $kbPathPrefix | quote }}
+      backendRefs:
+        - name: knowledge-base-extra-mcp-backend
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+{{- end }}
+{{- range $target := $extraMcpTargets }}
+{{- if or (not (hasKey $target "enabled")) $target.enabled }}
+{{- $id := required "global.agentgateway.extraMcpTargets[].id is required" $target.id }}
+{{- $safeId := regexReplaceAll "[^a-z0-9-]" (lower $id) "-" | trunc 45 | trimSuffix "-" }}
+{{- $host := required (printf "global.agentgateway.extraMcpTargets[%s].host is required" $id) $target.host }}
+{{- $port := required (printf "global.agentgateway.extraMcpTargets[%s].port is required" $id) $target.port }}
+{{- $protocol := $target.protocol | default "StreamableHTTP" }}
+{{- $pathPrefix := $target.pathPrefix | default (printf "/mcp/%s" $id) }}
+{{- $routeName := printf "%s-extra-mcp-route" $safeId }}
+{{- $backendName := printf "%s-extra-mcp-backend" $safeId }}
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: {{ $backendName }}
+spec:
+  mcp:
+    targets:
+      - name: {{ $id | quote }}
+        static:
+          host: {{ tpl $host $ | quote }}
+          port: {{ $port }}
+          protocol: {{ $protocol }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+spec:
+  parentRefs:
+    - name: {{ $gatewayName }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $pathPrefix | quote }}
+      backendRefs:
+        - name: {{ $backendName }}
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -132,6 +132,28 @@ global:
       serviceName: "ai-platform-engineering-openfga-authz-bridge"
       serviceNamespace: ""
       port: 9100
+    # Built-in Knowledge Base MCP route. This keeps the Dynamic Agents
+    # `knowledge-base` MCP server ID aligned with the RAG server MCP backend
+    # when AgentGateway is enabled in the umbrella chart.
+    knowledgeBaseTarget:
+      enabled: true
+      host: "rag-server.{{ .Release.Namespace }}.svc.cluster.local"
+      port: 9446
+      protocol: StreamableHTTP
+      pathPrefix: /mcp/knowledge-base
+    # Additional MCP routes that are not rendered from `agent-*` subcharts.
+    # Use this for platform MCP endpoints such as RAG/Knowledge Base.
+    # Each item renders one AgentgatewayBackend and one HTTPRoute:
+    #   /mcp/<id> -> static host:port using the requested MCP protocol.
+    #
+    # Example:
+    # extraMcpTargets:
+    #   - id: knowledge-base
+    #     host: "{{ .Release.Name }}-rag-server.{{ .Release.Namespace }}.svc.cluster.local"
+    #     port: 9446
+    #     protocol: StreamableHTTP
+    #     pathPrefix: /mcp/knowledge-base
+    extraMcpTargets: []
 
   # OpenFGA service discovery defaults for CAIPE components that perform
   # relationship-based authorization or reconciliation.
@@ -1056,9 +1078,9 @@ dynamic-agents:
     CREDENTIAL_API_URL: "http://ai-platform-engineering-caipe-ui:3000/api/credentials"
     CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
     USE_IMPERSONATION_TOKENS: "false"
-    # MCP server IDs routed through the shared AgentGateway backend.
-    # Other MCP servers keep direct endpoints so tool names reflect real upstreams.
-    AGENT_GATEWAY_MCP_SERVER_IDS: "jira"
+    # MCP server IDs routed through AgentGateway. "all" only applies to
+    # gateway-managed MCP rows; manual/direct MCP rows keep their stored endpoint.
+    AGENT_GATEWAY_MCP_SERVER_IDS: "all"
     # LLM configuration (override if needed)
     # LLM_PROVIDER: "openai"
     # LLM_MODEL: "gpt-4o"

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -167,6 +167,23 @@ agentgateway:
     repository: cr.agentgateway.dev/agentgateway
     tag: v1.1.0
     pullPolicy: IfNotPresent
+  # Secret-backed environment for backend auth placeholders used by the
+  # standalone AgentGateway config, for example:
+  #   backendAuth:
+  #     key: "$GITHUB_PERSONAL_ACCESS_TOKEN"
+  #     key: "$GITLAB_PERSONAL_ACCESS_TOKEN"
+  extraEnv: []
+  # - name: GITHUB_PERSONAL_ACCESS_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: github-mcp-secret
+  #       key: GITHUB_PERSONAL_ACCESS_TOKEN
+  # - name: GITLAB_PERSONAL_ACCESS_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: gitlab-mcp-secret
+  #       key: GITLAB_PERSONAL_ACCESS_TOKEN
+  extraEnvFrom: []
 
   # LangGraph Redis for checkpoint and cross-thread store persistence.
   # Two deployment options:

--- a/deploy/agentgateway/Dockerfile.config-bridge
+++ b/deploy/agentgateway/Dockerfile.config-bridge
@@ -1,0 +1,36 @@
+# assisted-by Codex Codex-sonnet-4-6
+
+FROM cgr.dev/chainguard/wolfi-base
+
+WORKDIR /app
+
+# Public Wolfi OS repo (no auth). Matches the other hardened runtime images.
+RUN echo "https://packages.wolfi.dev/os" > /etc/apk/repositories
+
+RUN for i in 1 2 3; do apk add --no-cache python-3.13 shadow && break; [ $i -lt 3 ] && sleep $((i * 10)); done && \
+    apk upgrade --no-cache
+
+# Use the official uv binary rather than apk uv to avoid stale packaged crates.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN mkdir -p /usr/local/bin \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python3.13 \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python
+
+RUN groupadd -r -g 1001 appuser && useradd -r -g appuser -u 1001 -m appuser
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv venv --python python3.13 /app/.venv \
+    && UV_HTTP_TIMEOUT=900 uv pip install --python /app/.venv/bin/python pymongo==4.15.5
+
+COPY --chown=appuser:appuser config_bridge.py /app/config_bridge.py
+RUN mkdir -p /generated && chown appuser:appuser /generated
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    UV_PROJECT_ENVIRONMENT="/app/.venv" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+USER 1001:1001
+
+CMD ["python", "/app/config_bridge.py"]

--- a/deploy/agentgateway/config.caipe-rbac.yaml
+++ b/deploy/agentgateway/config.caipe-rbac.yaml
@@ -96,6 +96,13 @@ binds:
           targets:
           - name: rag
             mcp: { host: http://rag-server:9446/mcp }
+    - matches: [{ path: { pathPrefix: /mcp/knowledge-base } }]
+      policies: *mcpAuthzPolicy
+      backends:
+      - mcp:
+          targets:
+          - name: knowledge-base
+            mcp: { host: http://rag-server:9446/mcp }
     - matches: [{ path: { pathPrefix: /mcp/slack } }]
       policies: *mcpAuthzPolicy
       backends:

--- a/deploy/agentgateway/config.caipe-rbac.yaml
+++ b/deploy/agentgateway/config.caipe-rbac.yaml
@@ -54,6 +54,9 @@ binds:
           targets:
           - name: github
             mcp: { host: http://github-mcp-server:8082/mcp }
+            policies:
+              backendAuth:
+                key: "$GITHUB_PERSONAL_ACCESS_TOKEN"
     - matches: [{ path: { pathPrefix: /mcp/gitlab } }]
       policies: *mcpAuthzPolicy
       backends:
@@ -61,6 +64,9 @@ binds:
           targets:
           - name: gitlab
             mcp: { host: http://mcp-gitlab:8000/mcp }
+            policies:
+              backendAuth:
+                key: "$GITLAB_PERSONAL_ACCESS_TOKEN"
     - matches: [{ path: { pathPrefix: /mcp/jira } }]
       policies: *mcpAuthzPolicy
       backends:

--- a/deploy/agentgateway/config.yaml
+++ b/deploy/agentgateway/config.yaml
@@ -65,6 +65,9 @@ binds:
           targets:
           - name: github
             mcp: { host: http://github-mcp-server:8082/mcp }
+            policies:
+              backendAuth:
+                key: "$GITHUB_PERSONAL_ACCESS_TOKEN"
     - matches: [{ path: { pathPrefix: /mcp/gitlab } }]
       policies: *mcpAuthzPolicy
       backends:
@@ -72,6 +75,9 @@ binds:
           targets:
           - name: gitlab
             mcp: { host: http://mcp-gitlab:8000/mcp }
+            policies:
+              backendAuth:
+                key: "$GITLAB_PERSONAL_ACCESS_TOKEN"
     - matches: [{ path: { pathPrefix: /mcp/jira } }]
       policies: *mcpAuthzPolicy
       backends:

--- a/deploy/agentgateway/config.yaml
+++ b/deploy/agentgateway/config.yaml
@@ -107,6 +107,13 @@ binds:
           targets:
           - name: rag
             mcp: { host: http://rag-server:9446/mcp }
+    - matches: [{ path: { pathPrefix: /mcp/knowledge-base } }]
+      policies: *mcpAuthzPolicy
+      backends:
+      - mcp:
+          targets:
+          - name: knowledge-base
+            mcp: { host: http://rag-server:9446/mcp }
     - matches: [{ path: { pathPrefix: /mcp/slack } }]
       policies: *mcpAuthzPolicy
       backends:

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -50,6 +50,19 @@ DEFAULT_MCP_ROUTE_POLICIES: dict[str, Any] = {
     },
 }
 
+DEFAULT_MCP_TARGET_POLICIES: dict[str, dict[str, Any]] = {
+    "github": {
+        "backendAuth": {
+            "key": "$GITHUB_PERSONAL_ACCESS_TOKEN",
+        },
+    },
+    "gitlab": {
+        "backendAuth": {
+            "key": "$GITLAB_PERSONAL_ACCESS_TOKEN",
+        },
+    },
+}
+
 
 @dataclass(frozen=True)
 class McpGatewayTarget:
@@ -150,19 +163,45 @@ def _route_path(route: dict[str, Any]) -> str | None:
     return None
 
 
-def _mcp_route(target: McpGatewayTarget, policies: dict[str, Any]) -> dict[str, Any]:
+def _target_policies(route: dict[str, Any]) -> dict[str, Any] | None:
+    backends = route.get("backends")
+    if not isinstance(backends, list) or not backends:
+        return None
+    backend = backends[0]
+    if not isinstance(backend, dict):
+        return None
+    mcp_backend = backend.get("mcp")
+    if not isinstance(mcp_backend, dict):
+        return None
+    targets = mcp_backend.get("targets")
+    if not isinstance(targets, list) or not targets:
+        return None
+    target = targets[0]
+    if not isinstance(target, dict):
+        return None
+    policies = target.get("policies")
+    return copy.deepcopy(policies) if isinstance(policies, dict) else None
+
+
+def _mcp_route(
+    target: McpGatewayTarget,
+    policies: dict[str, Any],
+    *,
+    target_policies: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    mcp_target = {
+        "name": target.id,
+        "mcp": {"host": target.upstream_url},
+    }
+    if target_policies:
+        mcp_target["policies"] = copy.deepcopy(target_policies)
     return {
         "matches": [{"path": {"pathPrefix": f"/mcp/{target.id}"}}],
         "policies": copy.deepcopy(policies),
         "backends": [
             {
                 "mcp": {
-                    "targets": [
-                        {
-                            "name": target.id,
-                            "mcp": {"host": target.upstream_url},
-                        },
-                    ],
+                    "targets": [mcp_target],
                 },
             },
         ],
@@ -186,13 +225,27 @@ def merge_agentgateway_mcp_routes(
 
     policies = route_policies or DEFAULT_MCP_ROUTE_POLICIES
     desired_by_path = {f"/mcp/{target.id}": target for target in targets}
+    target_policies_by_path = {
+        path: target_policies
+        for route in routes
+        if isinstance(route, dict)
+        for path in [_route_path(route)]
+        for target_policies in [_target_policies(route)]
+        if path in desired_by_path and target_policies
+    }
     retained_routes = [
         route
         for route in routes
         if not (isinstance(route, dict) and _route_path(route) in desired_by_path)
     ]
     retained_routes.extend(
-        _mcp_route(target, policies) for target in sorted(desired_by_path.values(), key=lambda t: t.id)
+        _mcp_route(
+            target,
+            policies,
+            target_policies=target_policies_by_path.get(f"/mcp/{target.id}")
+            or DEFAULT_MCP_TARGET_POLICIES.get(target.id),
+        )
+        for target in sorted(desired_by_path.values(), key=lambda t: t.id)
     )
     listener["routes"] = retained_routes
     return rendered
@@ -302,12 +355,18 @@ def _minimal_config() -> dict[str, Any]:
     }
 
 
-def load_baseline_config(admin_config_url: str) -> dict[str, Any]:
+def load_baseline_config(
+    admin_config_url: str,
+    *,
+    allow_minimal_fallback: bool = True,
+) -> dict[str, Any]:
     """Load live config, falling back to a minimal bootstrap config."""
 
     try:
         return fetch_agentgateway_config(admin_config_url)
     except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+        if not allow_minimal_fallback:
+            raise
         LOGGER.warning("Falling back to minimal AgentGateway config: %s", exc)
         return _minimal_config()
 
@@ -331,7 +390,10 @@ def reconcile_once(
     """Render and write one AgentGateway config generation."""
 
     targets = _load_targets_from_mongo()
-    baseline = load_baseline_config(admin_config_url)
+    baseline = load_baseline_config(
+        admin_config_url,
+        allow_minimal_fallback=not config_path.exists(),
+    )
     rendered = merge_agentgateway_mcp_routes(baseline, targets)
     changed = write_config_atomically(config_path, rendered)
     result = {

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -1,0 +1,377 @@
+# assisted-by Codex Codex-sonnet-4-6
+
+"""Reconcile Mongo MCP server records into standalone AgentGateway config.
+
+AgentGateway's Kubernetes mode should use native Gateway API resources
+(`HTTPRoute` + `AgentgatewayBackend`). Local Docker Compose runs standalone
+AgentGateway from a config file, and AgentGateway hot-reloads route/backend
+changes written to that file. This bridge keeps those local routes in sync
+with the `mcp_servers` collection so runtime-added MCP servers get a matching
+`/mcp/<server_id>` route.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import re
+import stat
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LOGGER = logging.getLogger("agentgateway-config-bridge")
+SAFE_TARGET_ID = re.compile(r"^[A-Za-z0-9._-]+$")
+PUBLISHED_CONFIG_MODE = 0o644
+
+DEFAULT_MCP_ROUTE_POLICIES: dict[str, Any] = {
+    "extAuthz": {
+        "host": "openfga-authz-bridge:9100",
+        "failureMode": {"denyWithStatus": 403},
+        "protocol": {
+            "grpc": {
+                "metadata": {
+                    "caipe.auth": '{"sub": jwt.sub}',
+                },
+            },
+        },
+    },
+    "authorization": {
+        "rules": [
+            {"allow": "true"},
+        ],
+    },
+}
+
+
+@dataclass(frozen=True)
+class McpGatewayTarget:
+    """AgentGateway MCP target rendered from an `mcp_servers` document."""
+
+    id: str
+    upstream_url: str
+
+
+def _as_bool(value: Any, *, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off"}
+    return bool(value)
+
+
+def _server_id(document: dict[str, Any]) -> str | None:
+    raw_id = document.get("_id") or document.get("id")
+    if not isinstance(raw_id, str):
+        return None
+    target_id = raw_id.strip()
+    return target_id if SAFE_TARGET_ID.fullmatch(target_id) else None
+
+
+def _upstream_url(document: dict[str, Any]) -> str | None:
+    raw_url = document.get("agentgateway_target_endpoint") or document.get(
+        "agentgateway_upstream_url"
+    )
+    if not isinstance(raw_url, str):
+        return None
+    upstream_url = raw_url.strip()
+    if not upstream_url.startswith(("http://", "https://")):
+        return None
+    return upstream_url
+
+
+def select_gateway_targets(documents: Iterable[dict[str, Any]]) -> list[McpGatewayTarget]:
+    """Select enabled AgentGateway-managed MCP targets from Mongo documents."""
+
+    targets: list[McpGatewayTarget] = []
+    seen: set[str] = set()
+    for document in documents:
+        if not _as_bool(document.get("enabled"), default=True):
+            continue
+        if document.get("source") != "agentgateway" and not document.get(
+            "agentgateway_discovered"
+        ):
+            continue
+        target_id = _server_id(document)
+        upstream_url = _upstream_url(document)
+        if target_id is None or upstream_url is None:
+            continue
+        if target_id in seen:
+            continue
+        targets.append(McpGatewayTarget(id=target_id, upstream_url=upstream_url))
+        seen.add(target_id)
+    return targets
+
+
+def _first_http_listener(config: dict[str, Any]) -> dict[str, Any]:
+    binds = config.setdefault("binds", [{"port": 4000, "listeners": [{}]}])
+    if not isinstance(binds, list) or not binds:
+        config["binds"] = [{"port": 4000, "listeners": [{}]}]
+        binds = config["binds"]
+    bind = binds[0]
+    if not isinstance(bind, dict):
+        bind = {"port": 4000, "listeners": [{}]}
+        binds[0] = bind
+    listeners = bind.setdefault("listeners", [{}])
+    if not isinstance(listeners, list) or not listeners:
+        bind["listeners"] = [{}]
+        listeners = bind["listeners"]
+    listener = listeners[0]
+    if not isinstance(listener, dict):
+        listener = {}
+        listeners[0] = listener
+    listener.setdefault("protocol", "HTTP")
+    listener.setdefault("routes", [])
+    return listener
+
+
+def _route_path(route: dict[str, Any]) -> str | None:
+    matches = route.get("matches")
+    if not isinstance(matches, list):
+        return None
+    for match in matches:
+        if not isinstance(match, dict):
+            continue
+        path = match.get("path")
+        if not isinstance(path, dict):
+            continue
+        value = path.get("pathPrefix") or path.get("value")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _mcp_route(target: McpGatewayTarget, policies: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "matches": [{"path": {"pathPrefix": f"/mcp/{target.id}"}}],
+        "policies": copy.deepcopy(policies),
+        "backends": [
+            {
+                "mcp": {
+                    "targets": [
+                        {
+                            "name": target.id,
+                            "mcp": {"host": target.upstream_url},
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def merge_agentgateway_mcp_routes(
+    baseline_config: dict[str, Any],
+    targets: Iterable[McpGatewayTarget],
+    *,
+    route_policies: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return AgentGateway config with one route per desired MCP target."""
+
+    rendered = copy.deepcopy(baseline_config)
+    listener = _first_http_listener(rendered)
+    routes = listener.setdefault("routes", [])
+    if not isinstance(routes, list):
+        routes = []
+        listener["routes"] = routes
+
+    policies = route_policies or DEFAULT_MCP_ROUTE_POLICIES
+    desired_by_path = {f"/mcp/{target.id}": target for target in targets}
+    retained_routes = [
+        route
+        for route in routes
+        if not (isinstance(route, dict) and _route_path(route) in desired_by_path)
+    ]
+    retained_routes.extend(
+        _mcp_route(target, policies) for target in sorted(desired_by_path.values(), key=lambda t: t.id)
+    )
+    listener["routes"] = retained_routes
+    return rendered
+
+
+def fetch_agentgateway_config(admin_config_url: str) -> dict[str, Any]:
+    """Fetch the current live AgentGateway config from the admin endpoint."""
+
+    with urllib.request.urlopen(admin_config_url, timeout=5) as response:
+        payload = response.read().decode("utf-8")
+    config = json.loads(payload)
+    if not isinstance(config, dict):
+        raise ValueError("AgentGateway admin config response was not an object")
+    return config
+
+
+def _ensure_published_config_mode(path: Path) -> bool:
+    """Ensure AgentGateway's non-root UID can read the generated config."""
+
+    current_mode = stat.S_IMODE(path.stat().st_mode)
+    if current_mode == PUBLISHED_CONFIG_MODE:
+        return False
+    path.chmod(PUBLISHED_CONFIG_MODE)
+    return True
+
+
+def write_config_atomically(path: Path, config: dict[str, Any]) -> bool:
+    """Write config as JSON/YAML-compatible content; return true when changed."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(config, indent=2, sort_keys=False) + "\n"
+    if path.exists() and path.read_text(encoding="utf-8") == rendered:
+        _ensure_published_config_mode(path)
+        return False
+
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        handle.write(rendered)
+        tmp_path = Path(handle.name)
+    tmp_path.chmod(PUBLISHED_CONFIG_MODE)
+    tmp_path.replace(path)
+    return True
+
+
+def seed_config_from_bootstrap(config_path: Path, bootstrap_path: Path | None) -> bool:
+    """Copy the static bootstrap config before AgentGateway is available."""
+
+    if config_path.exists() or bootstrap_path is None or not bootstrap_path.exists():
+        return False
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=config_path.parent,
+        delete=False,
+    ) as handle:
+        handle.write(bootstrap_path.read_text(encoding="utf-8"))
+        tmp_path = Path(handle.name)
+    tmp_path.chmod(PUBLISHED_CONFIG_MODE)
+    tmp_path.replace(config_path)
+    LOGGER.info("Seeded AgentGateway config from %s", bootstrap_path)
+    return True
+
+
+def _minimal_config() -> dict[str, Any]:
+    issuer = os.getenv("AGENTGATEWAY_JWT_ISSUER", "http://localhost:7080/realms/caipe")
+    jwks_url = os.getenv(
+        "AGENTGATEWAY_JWKS_URL",
+        "http://keycloak:7080/realms/caipe/protocol/openid-connect/certs",
+    )
+    audiences = [
+        audience.strip()
+        for audience in os.getenv(
+            "AGENTGATEWAY_JWT_AUDIENCES",
+            "caipe-platform,agentgateway",
+        ).split(",")
+        if audience.strip()
+    ]
+    return {
+        "binds": [
+            {
+                "port": int(os.getenv("AGENTGATEWAY_PORT", "4000")),
+                "listeners": [
+                    {
+                        "protocol": "HTTP",
+                        "policies": {
+                            "jwtAuth": {
+                                "mode": "strict",
+                                "issuer": issuer,
+                                "audiences": audiences,
+                                "jwks": {"url": jwks_url},
+                            },
+                        },
+                        "routes": [],
+                    },
+                ],
+            },
+        ],
+        "config": {
+            "adminAddr": os.getenv("AGENTGATEWAY_ADMIN_ADDR", "0.0.0.0:15000"),
+            "logging": {"level": os.getenv("LOG_LEVEL", "info"), "format": "json"},
+        },
+    }
+
+
+def load_baseline_config(admin_config_url: str) -> dict[str, Any]:
+    """Load live config, falling back to a minimal bootstrap config."""
+
+    try:
+        return fetch_agentgateway_config(admin_config_url)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+        LOGGER.warning("Falling back to minimal AgentGateway config: %s", exc)
+        return _minimal_config()
+
+
+def _load_targets_from_mongo() -> list[McpGatewayTarget]:
+    from pymongo import MongoClient
+
+    mongo_uri = os.environ["MONGODB_URI"]
+    database_name = os.getenv("MONGODB_DATABASE", "caipe")
+    collection_name = os.getenv("MCP_SERVERS_COLLECTION", "mcp_servers")
+    with MongoClient(mongo_uri) as client:
+        documents = list(client[database_name][collection_name].find({}))
+    return select_gateway_targets(documents)
+
+
+def reconcile_once(
+    *,
+    config_path: Path,
+    admin_config_url: str,
+) -> dict[str, Any]:
+    """Render and write one AgentGateway config generation."""
+
+    targets = _load_targets_from_mongo()
+    baseline = load_baseline_config(admin_config_url)
+    rendered = merge_agentgateway_mcp_routes(baseline, targets)
+    changed = write_config_atomically(config_path, rendered)
+    result = {
+        "targets": [target.id for target in targets],
+        "target_count": len(targets),
+        "changed": changed,
+        "config_path": str(config_path),
+    }
+    if changed:
+        LOGGER.info("AgentGateway MCP config reconciled: %s", result)
+    else:
+        LOGGER.debug("AgentGateway MCP config unchanged: %s", result)
+    return result
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    if not os.getenv("MONGODB_URI"):
+        raise RuntimeError("MONGODB_URI is required")
+
+    config_path = Path(os.getenv("AGENTGATEWAY_CONFIG_PATH", "/generated/config.yaml"))
+    bootstrap_config_path = os.getenv("AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH")
+    bootstrap_path = Path(bootstrap_config_path) if bootstrap_config_path else None
+    admin_config_url = os.getenv(
+        "AGENTGATEWAY_ADMIN_CONFIG_URL",
+        "http://agentgateway:15000/config",
+    )
+    poll_seconds = float(os.getenv("AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS", "5"))
+    seed_config_from_bootstrap(config_path, bootstrap_path)
+
+    while True:
+        try:
+            reconcile_once(config_path=config_path, admin_config_url=admin_config_url)
+        except Exception:
+            LOGGER.exception("AgentGateway MCP config reconciliation failed")
+        time.sleep(poll_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/agentgateway/tests/test_config_bridge.py
+++ b/deploy/agentgateway/tests/test_config_bridge.py
@@ -1,0 +1,226 @@
+# assisted-by Codex Codex-sonnet-4-6
+
+"""Tests for dynamic AgentGateway MCP config reconciliation."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import stat
+import sys
+from pathlib import Path
+
+
+BRIDGE_PATH = Path(__file__).resolve().parents[1] / "config_bridge.py"
+spec = importlib.util.spec_from_file_location("agentgateway_config_bridge", BRIDGE_PATH)
+assert spec is not None and spec.loader is not None
+bridge = importlib.util.module_from_spec(spec)
+sys.modules["agentgateway_config_bridge"] = bridge
+spec.loader.exec_module(bridge)
+
+
+def _baseline_config() -> dict:
+    return {
+        "binds": [
+            {
+                "port": 4000,
+                "listeners": [
+                    {
+                        "protocol": "HTTP",
+                        "policies": {
+                            "jwtAuth": {
+                                "mode": "strict",
+                                "issuer": "http://localhost:7080/realms/caipe",
+                                "audiences": ["caipe-platform", "agentgateway"],
+                                "jwks": {
+                                    "url": "http://keycloak:7080/realms/caipe/protocol/openid-connect/certs"
+                                },
+                            }
+                        },
+                        "routes": [
+                            {
+                                "matches": [{"path": {"pathPrefix": "/mcp/rag"}}],
+                                "policies": bridge.DEFAULT_MCP_ROUTE_POLICIES,
+                                "backends": [
+                                    {
+                                        "mcp": {
+                                            "targets": [
+                                                {
+                                                    "name": "rag",
+                                                    "mcp": {"host": "http://rag-server:9446/mcp"},
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "config": {
+            "adminAddr": "0.0.0.0:15000",
+            "logging": {"level": "debug", "format": "json"},
+        },
+    }
+
+
+def test_select_gateway_targets_uses_enabled_agentgateway_rows_only() -> None:
+    targets = bridge.select_gateway_targets(
+        [
+            {
+                "_id": "knowledge-base",
+                "enabled": True,
+                "source": "agentgateway",
+                "agentgateway_target_endpoint": "http://rag-server:9446/mcp",
+            },
+            {
+                "_id": "disabled-target",
+                "enabled": False,
+                "source": "agentgateway",
+                "agentgateway_target_endpoint": "http://disabled:8000/mcp",
+            },
+            {
+                "_id": "manual-target",
+                "enabled": True,
+                "source": "manual",
+                "endpoint": "http://mcp-manual:8000/mcp",
+            },
+            {
+                "_id": "bad target",
+                "enabled": True,
+                "source": "agentgateway",
+                "agentgateway_target_endpoint": "http://bad:8000/mcp",
+            },
+            {
+                "_id": "missing-upstream",
+                "enabled": True,
+                "source": "agentgateway",
+            },
+        ]
+    )
+
+    assert targets == [
+        bridge.McpGatewayTarget(
+            id="knowledge-base",
+            upstream_url="http://rag-server:9446/mcp",
+        )
+    ]
+
+
+def test_merge_agentgateway_mcp_routes_adds_missing_route_without_mutating_baseline() -> None:
+    baseline = _baseline_config()
+    original = copy.deepcopy(baseline)
+
+    rendered = bridge.merge_agentgateway_mcp_routes(
+        baseline,
+        [
+            bridge.McpGatewayTarget(
+                id="knowledge-base",
+                upstream_url="http://rag-server:9446/mcp",
+            )
+        ],
+    )
+
+    assert baseline == original
+    routes = rendered["binds"][0]["listeners"][0]["routes"]
+    route_paths = [route["matches"][0]["path"]["pathPrefix"] for route in routes]
+    assert route_paths == ["/mcp/rag", "/mcp/knowledge-base"]
+    assert routes[1]["backends"][0]["mcp"]["targets"][0] == {
+        "name": "knowledge-base",
+        "mcp": {"host": "http://rag-server:9446/mcp"},
+    }
+    assert routes[1]["policies"] == bridge.DEFAULT_MCP_ROUTE_POLICIES
+
+
+def test_merge_agentgateway_mcp_routes_replaces_stale_route_target() -> None:
+    baseline = _baseline_config()
+    baseline["binds"][0]["listeners"][0]["routes"].append(
+        {
+            "matches": [{"path": {"pathPrefix": "/mcp/knowledge-base"}}],
+            "policies": bridge.DEFAULT_MCP_ROUTE_POLICIES,
+            "backends": [
+                {
+                    "mcp": {
+                        "targets": [
+                            {
+                                "name": "knowledge-base",
+                                "mcp": {"host": "http://old-rag:9446/mcp"},
+                            }
+                        ]
+                    }
+                }
+            ],
+        }
+    )
+
+    rendered = bridge.merge_agentgateway_mcp_routes(
+        baseline,
+        [
+            bridge.McpGatewayTarget(
+                id="knowledge-base",
+                upstream_url="http://rag-server:9446/mcp",
+            )
+        ],
+    )
+
+    routes = rendered["binds"][0]["listeners"][0]["routes"]
+    matching_routes = [
+        route
+        for route in routes
+        if route["matches"][0]["path"]["pathPrefix"] == "/mcp/knowledge-base"
+    ]
+    assert len(matching_routes) == 1
+    assert matching_routes[0]["backends"][0]["mcp"]["targets"][0]["mcp"]["host"] == (
+        "http://rag-server:9446/mcp"
+    )
+
+
+def test_write_config_atomically_publishes_agentgateway_readable_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+
+    changed = bridge.write_config_atomically(config_path, _baseline_config())
+
+    mode = stat.S_IMODE(config_path.stat().st_mode)
+    assert changed is True
+    assert mode == 0o644
+
+
+def test_write_config_atomically_repairs_existing_unreadable_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    bridge.write_config_atomically(config_path, _baseline_config())
+    config_path.chmod(0o600)
+
+    changed = bridge.write_config_atomically(config_path, _baseline_config())
+
+    mode = stat.S_IMODE(config_path.stat().st_mode)
+    assert changed is False
+    assert mode == 0o644
+
+
+def test_ensure_published_config_mode_skips_existing_readable_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text('{"binds": []}\n', encoding="utf-8")
+    config_path.chmod(0o644)
+
+    def fail_chmod(_self: Path, _mode: int) -> None:
+        raise AssertionError("chmod should not run when mode is already correct")
+
+    monkeypatch.setattr(type(config_path), "chmod", fail_chmod)
+
+    assert bridge._ensure_published_config_mode(config_path) is False
+
+
+def test_seed_config_from_bootstrap_publishes_agentgateway_readable_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "generated" / "config.yaml"
+    bootstrap_path = tmp_path / "bootstrap.yaml"
+    bootstrap_path.write_text('{"binds": []}\n', encoding="utf-8")
+
+    changed = bridge.seed_config_from_bootstrap(config_path, bootstrap_path)
+
+    mode = stat.S_IMODE(config_path.stat().st_mode)
+    assert changed is True
+    assert mode == 0o644

--- a/deploy/agentgateway/tests/test_config_bridge.py
+++ b/deploy/agentgateway/tests/test_config_bridge.py
@@ -8,6 +8,7 @@ import copy
 import importlib.util
 import stat
 import sys
+import urllib.error
 from pathlib import Path
 
 
@@ -177,6 +178,74 @@ def test_merge_agentgateway_mcp_routes_replaces_stale_route_target() -> None:
     )
 
 
+def test_merge_agentgateway_mcp_routes_preserves_existing_target_policies() -> None:
+    baseline = _baseline_config()
+    baseline["binds"][0]["listeners"][0]["routes"].append(
+        {
+            "matches": [{"path": {"pathPrefix": "/mcp/github"}}],
+            "policies": bridge.DEFAULT_MCP_ROUTE_POLICIES,
+            "backends": [
+                {
+                    "mcp": {
+                        "targets": [
+                            {
+                                "name": "github",
+                                "mcp": {"host": "http://old-github:8082/mcp"},
+                                "policies": {
+                                    "backendAuth": {
+                                        "key": "$GITHUB_PERSONAL_ACCESS_TOKEN",
+                                    },
+                                },
+                            }
+                        ]
+                    }
+                }
+            ],
+        }
+    )
+
+    rendered = bridge.merge_agentgateway_mcp_routes(
+        baseline,
+        [
+            bridge.McpGatewayTarget(
+                id="github",
+                upstream_url="http://github-mcp-server:8082/mcp",
+            )
+        ],
+    )
+
+    route = next(
+        route
+        for route in rendered["binds"][0]["listeners"][0]["routes"]
+        if route["matches"][0]["path"]["pathPrefix"] == "/mcp/github"
+    )
+    target = route["backends"][0]["mcp"]["targets"][0]
+    assert target["mcp"]["host"] == "http://github-mcp-server:8082/mcp"
+    assert target["policies"]["backendAuth"]["key"] == "$GITHUB_PERSONAL_ACCESS_TOKEN"
+
+
+def test_merge_agentgateway_mcp_routes_applies_default_provider_target_policies() -> None:
+    baseline = _baseline_config()
+
+    rendered = bridge.merge_agentgateway_mcp_routes(
+        baseline,
+        [
+            bridge.McpGatewayTarget(
+                id="gitlab",
+                upstream_url="http://mcp-gitlab:8000/mcp",
+            )
+        ],
+    )
+
+    route = next(
+        route
+        for route in rendered["binds"][0]["listeners"][0]["routes"]
+        if route["matches"][0]["path"]["pathPrefix"] == "/mcp/gitlab"
+    )
+    target = route["backends"][0]["mcp"]["targets"][0]
+    assert target["policies"]["backendAuth"]["key"] == "$GITLAB_PERSONAL_ACCESS_TOKEN"
+
+
 def test_write_config_atomically_publishes_agentgateway_readable_file(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
 
@@ -224,3 +293,28 @@ def test_seed_config_from_bootstrap_publishes_agentgateway_readable_file(tmp_pat
     mode = stat.S_IMODE(config_path.stat().st_mode)
     assert changed is True
     assert mode == 0o644
+
+
+def test_reconcile_keeps_existing_config_when_admin_config_is_unavailable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_path = tmp_path / "generated" / "config.yaml"
+    config_path.parent.mkdir()
+    existing_config = '{"binds":[{"listeners":[{"routes":[{"matches":[{"path":{"pathPrefix":"/mcp/github"}}],"backends":[{"mcp":{"targets":[{"name":"github","policies":{"backendAuth":{"key":"$GITHUB_PERSONAL_ACCESS_TOKEN"}}}]}}]}]}]}]}\n'
+    config_path.write_text(existing_config, encoding="utf-8")
+
+    monkeypatch.setattr(bridge, "_load_targets_from_mongo", lambda: [])
+
+    def fail_fetch(_admin_config_url: str) -> dict:
+        raise urllib.error.URLError("agentgateway admin unavailable")
+
+    monkeypatch.setattr(bridge, "fetch_agentgateway_config", fail_fetch)
+
+    try:
+        bridge.reconcile_once(config_path=config_path, admin_config_url="http://agentgateway:15000/config")
+    except urllib.error.URLError:
+        pass
+    else:
+        raise AssertionError("reconcile should wait for the live config instead of overwriting")
+
+    assert config_path.read_text(encoding="utf-8") == existing_config

--- a/deploy/agentgateway/tests/test_static_config.py
+++ b/deploy/agentgateway/tests/test_static_config.py
@@ -1,0 +1,39 @@
+# assisted-by Codex Codex-sonnet-4-6
+
+"""Regression tests for the checked-in standalone AgentGateway config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+
+
+def _mcp_target(config: dict[str, Any], server_id: str) -> dict[str, Any]:
+    routes = config["binds"][0]["listeners"][0]["routes"]
+    route = next(
+        route
+        for route in routes
+        if route["matches"][0]["path"]["pathPrefix"] == f"/mcp/{server_id}"
+    )
+    return route["backends"][0]["mcp"]["targets"][0]
+
+
+def test_github_mcp_target_injects_backend_pat() -> None:
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    target = _mcp_target(config, "github")
+
+    assert target["policies"]["backendAuth"]["key"] == "$GITHUB_PERSONAL_ACCESS_TOKEN"
+
+
+def test_gitlab_mcp_target_injects_backend_pat() -> None:
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    target = _mcp_target(config, "gitlab")
+
+    assert target["policies"]["backendAuth"]["key"] == "$GITLAB_PERSONAL_ACCESS_TOKEN"

--- a/deploy/openfga/bridge/tests/test_helm_values.py
+++ b/deploy/openfga/bridge/tests/test_helm_values.py
@@ -63,6 +63,69 @@ def test_parent_chart_renders_bridge_token_validation_env() -> None:
     assert 'key: "MONGODB_URI"' in rendered
 
 
+def test_agentgateway_chart_can_mount_provider_backend_auth_secret_env() -> None:
+    if shutil.which("helm") is None:
+        pytest.skip("helm is required for chart render assertions")
+
+    chart = _repo_root() / "charts" / "ai-platform-engineering"
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "caipe",
+            str(chart),
+            "--namespace",
+            "caipe",
+            "--set",
+            "agentgateway.enabled=true",
+            "--set",
+            "agentgateway.extraEnv[0].name=GITHUB_PERSONAL_ACCESS_TOKEN",
+            "--set",
+            "agentgateway.extraEnv[0].valueFrom.secretKeyRef.name=github-mcp-secret",
+            "--set",
+            "agentgateway.extraEnv[0].valueFrom.secretKeyRef.key=GITHUB_PERSONAL_ACCESS_TOKEN",
+            "--set",
+            "agentgateway.extraEnv[1].name=GITLAB_PERSONAL_ACCESS_TOKEN",
+            "--set",
+            "agentgateway.extraEnv[1].valueFrom.secretKeyRef.name=gitlab-mcp-secret",
+            "--set",
+            "agentgateway.extraEnv[1].valueFrom.secretKeyRef.key=GITLAB_PERSONAL_ACCESS_TOKEN",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[0].matches[0].path.pathPrefix=/mcp/github",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[0].backends[0].mcp.targets[0].name=github",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[0].backends[0].mcp.targets[0].mcp.host=http://github-mcp-server:8082/mcp",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[0].backends[0].mcp.targets[0].policies.backendAuth.key=\\$GITHUB_PERSONAL_ACCESS_TOKEN",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[1].matches[0].path.pathPrefix=/mcp/gitlab",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[1].backends[0].mcp.targets[0].name=gitlab",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[1].backends[0].mcp.targets[0].mcp.host=http://mcp-gitlab:8000/mcp",
+            "--set",
+            "agentgateway.config.binds[0].listeners[0].routes[1].backends[0].mcp.targets[0].policies.backendAuth.key=\\$GITLAB_PERSONAL_ACCESS_TOKEN",
+        ],
+        check=True,
+        cwd=_repo_root(),
+        text=True,
+        capture_output=True,
+    )
+
+    rendered = result.stdout
+    assert "name: GITHUB_PERSONAL_ACCESS_TOKEN" in rendered
+    assert "secretKeyRef:" in rendered
+    assert "name: github-mcp-secret" in rendered
+    assert "key: GITHUB_PERSONAL_ACCESS_TOKEN" in rendered
+    assert "name: GITLAB_PERSONAL_ACCESS_TOKEN" in rendered
+    assert "name: gitlab-mcp-secret" in rendered
+    assert "key: GITLAB_PERSONAL_ACCESS_TOKEN" in rendered
+    assert "backendAuth:" in rendered
+    assert "key: $GITHUB_PERSONAL_ACCESS_TOKEN" in rendered
+    assert "key: $GITLAB_PERSONAL_ACCESS_TOKEN" in rendered
+
+
 def test_umbrella_values_define_webex_bot_section() -> None:
     root = _repo_root()
     values = yaml.safe_load((root / "charts/ai-platform-engineering/values.yaml").read_text())

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3042,6 +3042,9 @@ services:
     container_name: agentgateway
     restart: unless-stopped
     command: ["--file", "/etc/agentgateway/config.yaml"]
+    environment:
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN:-}
+      GITLAB_PERSONAL_ACCESS_TOKEN: ${GITLAB_PERSONAL_ACCESS_TOKEN:-${GITLAB_TOKEN:-}}
     read_only: true
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -19,6 +19,10 @@
 #     docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile <agent-profiles> up --build
 #     Set: DISTRIBUTED_AGENTS=argocd,github  (only listed agents are remote)
 #
+#   Single-node MCP-only — supervisor runs agents in-process and only external MCP
+#   server containers are started:
+#     DISTRIBUTED_AGENTS= docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile mcp-servers up --build
+#
 # Agent selection and configuration are controlled through environment variables
 # in the .env file—see documentation for full list and descriptions.
 # ============================================================================
@@ -454,6 +458,7 @@ services:
     profiles:
       - github
       - all-agents
+      - mcp-servers
 
   agent-github:
     build:
@@ -589,6 +594,7 @@ services:
       - USE_PIPELINE=true
       - GITLAB_API_URL=https://${GITLAB_HOST:-gitlab.com}/api/v4
       - GITLAB_PERSONAL_ACCESS_TOKEN=${GITLAB_PERSONAL_ACCESS_TOKEN:-${GITLAB_TOKEN}}
+      - REMOTE_AUTHORIZATION=${GITLAB_MCP_REMOTE_AUTHORIZATION:-true}
  
       # Option 1: Simple read-only mode (blocks all write operations)
       - GITLAB_READ_ONLY_MODE=${GITLAB_READ_ONLY_MODE:-true}
@@ -597,6 +603,7 @@ services:
     profiles:
       - gitlab
       - all-agents
+      - mcp-servers
 
   # Weather Agent
   agent-weather:
@@ -676,6 +683,7 @@ services:
     profiles:
       - backstage
       - all-agents
+      - mcp-servers
 
   # ArgoCD Agents
   agent-argocd:
@@ -730,6 +738,7 @@ services:
     profiles:
       - argocd
       - all-agents
+      - mcp-servers
 
   # Confluence Agents
   agent-confluence:
@@ -771,6 +780,7 @@ services:
     profiles:
       - confluence
       - all-agents
+      - mcp-servers
 
   # Jira Agent
   agent-jira:
@@ -841,6 +851,7 @@ services:
     profiles:
       - jira
       - all-agents
+      - mcp-servers
 
   # Komodor Agent
   agent-komodor:
@@ -892,6 +903,7 @@ services:
       start_period: 15s
     profiles:
       - komodor
+      - mcp-servers
 
   # PagerDuty Agent
   agent-pagerduty:
@@ -946,6 +958,7 @@ services:
     profiles:
       - pagerduty
       - all-agents
+      - mcp-servers
 
   # Slack Agent
   agent-slack:
@@ -1000,6 +1013,7 @@ services:
     profiles:
       - slack
       - all-agents
+      - mcp-servers
 
   # Splunk
   agent-splunk:
@@ -1054,6 +1068,7 @@ services:
     profiles:
       - splunk
       - all-agents
+      - mcp-servers
 
   # Webex
   agent-webex:
@@ -1108,6 +1123,7 @@ services:
     profiles:
       - webex
       - all-agents
+      - mcp-servers
 
   # VictorOps Agent
   agent-victorops:
@@ -1161,6 +1177,7 @@ services:
       start_period: 15s
     profiles:
       - victorops
+      - mcp-servers
 
   ####################################################################################################
   #                                      NETUTILS AGENT (NetUtils)                                    #
@@ -1219,6 +1236,7 @@ services:
       start_period: 15s
     profiles:
       - netutils-agent
+      - mcp-servers
 
   ####################################################################################################
   #                                      AGENT JARVIS A2A P2P                                        #
@@ -1834,13 +1852,6 @@ services:
       - OIDC_JWKS_URL=${OIDC_JWKS_URL:-http://keycloak:7080/realms/caipe/protocol/openid-connect/certs}
       - OIDC_DISCOVERY_URL=${OIDC_DISCOVERY_URL:-http://keycloak:7080/realms/caipe/.well-known/openid-configuration}
       - OIDC_GROUP_CLAIM=
-      - ALLOW_TRUSTED_NETWORK=false
-      - TRUSTED_NETWORK_CIDRS=
-      - TRUSTED_NETWORK_DEFAULT_ROLE=
-      - RBAC_ADMIN_GROUPS=
-      - RBAC_DEFAULT_AUTHENTICATED_ROLE=
-      - RBAC_READONLY_GROUPS=
-      - RBAC_INGESTONLY_GROUPS=
       # Ingestor OIDC configuration (for OAuth2 client credentials)
       - INGESTOR_OIDC_ISSUER=${INGESTOR_OIDC_ISSUER:-}
       - INGESTOR_OIDC_CLIENT_ID=${INGESTOR_OIDC_CLIENT_ID}
@@ -2946,8 +2957,8 @@ services:
       # Seed a dev allow tuple with a Keycloak user `sub`. If unset, OpenFGA
       # starts deny-by-default and you can write tuples later.
       OPENFGA_SEED_SUB: ${OPENFGA_SEED_SUB:-}
-      # Backward-compatible alias from the previous experiment overlay.
-      OPENFGA_EXPERIMENT_SUB: ${OPENFGA_EXPERIMENT_SUB:-}
+    volumes:
+      - ./charts/ai-platform-engineering/charts/openfga/authorization-model.json:/app/authorization-model.json:ro
     depends_on:
       openfga:
         condition: service_healthy
@@ -2987,6 +2998,45 @@ services:
       openfga:
         condition: service_healthy
 
+  agentgateway-config-bridge:
+    build:
+      context: ./deploy/agentgateway
+      dockerfile: Dockerfile.config-bridge
+    image: ghcr.io/cnoe-io/caipe-agentgateway-config-bridge:${IMAGE_TAG:-localtag}
+    container_name: agentgateway-config-bridge
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    profiles:
+      - rbac
+    environment:
+      MONGODB_URI: ${MONGODB_URI:-mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-mongodb:27017/${MONGODB_DATABASE:-caipe}?authSource=admin}
+      MONGODB_DATABASE: ${MONGODB_DATABASE:-caipe}
+      AGENTGATEWAY_CONFIG_PATH: /generated/config.yaml
+      AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH: /bootstrap/config.yaml
+      AGENTGATEWAY_ADMIN_CONFIG_URL: http://agentgateway:15000/config
+      AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS: ${AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS:-5}
+      LOG_LEVEL: ${AGENTGATEWAY_CONFIG_BRIDGE_LOG_LEVEL:-INFO}
+    volumes:
+      - agentgateway_config:/generated
+      - ./deploy/agentgateway/config.yaml:/bootstrap/config.yaml:ro
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "from pathlib import Path; import sys; sys.exit(0 if Path('/generated/config.yaml').is_file() and Path('/generated/config.yaml').stat().st_size > 0 else 1)"
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    depends_on:
+      caipe-mongodb:
+        condition: service_healthy
+
   agentgateway:
     image: ghcr.io/agentgateway/agentgateway:latest
     container_name: agentgateway
@@ -3016,11 +3066,13 @@ services:
         condition: service_completed_successfully
       openfga-authz-bridge:
         condition: service_healthy
+      agentgateway-config-bridge:
+        condition: service_healthy
     ports:
       - "4000:4000"
       - "127.0.0.1:15000:15000" # Admin UI (config.config.adminAddr)
     volumes:
-      - ./deploy/agentgateway/config.yaml:/etc/agentgateway/config.yaml:ro
+      - agentgateway_config:/etc/agentgateway:ro
     tmpfs:
       - /tmp
     healthcheck:
@@ -3195,6 +3247,8 @@ volumes:
   langgraph_mongodb_data:
     driver: local
   openfga_postgres_data:
+    driver: local
+  agentgateway_config:
     driver: local
   # Durable Keycloak state (users, role assignments, per-team client scopes,
   # `team_member:<slug>` realm roles, identity links, token-exchange grants).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.1-dev.5"
+version = "0.5.1-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/openfga/__tests__/baseline-diagnostics-route.test.ts
+++ b/ui/src/app/api/admin/openfga/__tests__/baseline-diagnostics-route.test.ts
@@ -60,6 +60,7 @@ describe("GET /api/admin/openfga/baseline-diagnostics", () => {
         tuple.object === "organization:grid" && tuple.relation === "can_use" ||
         tuple.object === "system_config:platform_settings" && tuple.relation === "can_read" ||
         tuple.object === "user_profile:bob-sub" && tuple.relation === "can_read" ||
+        tuple.object === "mcp_gateway:list" && tuple.relation === "caller" ||
         tuple.object.startsWith("admin_surface:") && tuple.relation === "can_read",
     }));
   });

--- a/ui/src/lib/rbac/__tests__/agentgateway-mcp-discovery.test.ts
+++ b/ui/src/lib/rbac/__tests__/agentgateway-mcp-discovery.test.ts
@@ -97,6 +97,7 @@ describe("AgentGateway MCP discovery", () => {
           "github",
           "gitlab",
           "jira",
+          "knowledge-base",
           "komodor",
           "netutils",
           "pagerduty",

--- a/ui/src/lib/rbac/__tests__/baseline-access.test.ts
+++ b/ui/src/lib/rbac/__tests__/baseline-access.test.ts
@@ -20,7 +20,7 @@ describe("baseline FGA profile bundles", () => {
         expect.objectContaining({
           id: "org-member",
           role: "member",
-          grants: expect.arrayContaining(["organization-member", "own-profile-owner"]),
+          grants: expect.arrayContaining(["organization-member", "own-profile-owner", "mcp-gateway-call"]),
         }),
         expect.objectContaining({
           id: "org-admin",

--- a/ui/src/lib/rbac/__tests__/keycloak-bootstrap-admins.test.ts
+++ b/ui/src/lib/rbac/__tests__/keycloak-bootstrap-admins.test.ts
@@ -53,7 +53,7 @@ describe("bootstrap admin reconciliation", () => {
     expect(result.configured_emails).toEqual(["admin@cisco.com", "second@cisco.com"]);
     expect(result.resolved_count).toBe(2);
     expect(result.created_count).toBe(1);
-    expect(result.tuple_write_count).toBe(60);
+    expect(result.tuple_write_count).toBe(62);
     expect(mockEnsureUserByEmail).toHaveBeenCalledWith("admin@cisco.com");
     expect(mockEnsureUserByEmail).toHaveBeenCalledWith("second@cisco.com");
     expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
@@ -67,6 +67,7 @@ describe("bootstrap admin reconciliation", () => {
         { user: "user:sub-admin", relation: "reader", object: "admin_surface:skills" },
         { user: "user:sub-admin", relation: "reader", object: "admin_surface:metrics" },
         { user: "user:sub-admin", relation: "reader", object: "admin_surface:health" },
+        { user: "user:sub-admin", relation: "reader", object: "admin_surface:credentials" },
         { user: "user:sub-admin", relation: "admin", object: "organization:grid" },
         { user: "user:sub-admin", relation: "manager", object: "system_config:platform_settings" },
         { user: "user:sub-admin", relation: "manager", object: "mcp_server:agentgateway" },
@@ -88,13 +89,13 @@ describe("bootstrap admin reconciliation", () => {
           email: "admin@cisco.com",
           user_id: "sub-admin",
           status: "existing",
-          tuple_write_count: 30,
+          tuple_write_count: 31,
         }),
         expect.objectContaining({
           email: "second@cisco.com",
           user_id: "sub-second",
           status: "created",
-          tuple_write_count: 30,
+          tuple_write_count: 31,
         }),
       ]),
     );

--- a/ui/src/lib/rbac/__tests__/keycloak-bootstrap-admins.test.ts
+++ b/ui/src/lib/rbac/__tests__/keycloak-bootstrap-admins.test.ts
@@ -61,6 +61,7 @@ describe("bootstrap admin reconciliation", () => {
         { user: "user:sub-admin", relation: "member", object: "organization:grid" },
         { user: "user:sub-admin", relation: "reader", object: "system_config:platform_settings" },
         { user: "user:sub-admin", relation: "owner", object: "user_profile:sub-admin" },
+        { user: "user:sub-admin", relation: "caller", object: "mcp_gateway:list" },
         { user: "user:sub-admin", relation: "reader", object: "admin_surface:users" },
         { user: "user:sub-admin", relation: "reader", object: "admin_surface:teams" },
         { user: "user:sub-admin", relation: "reader", object: "admin_surface:skills" },

--- a/ui/src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts
+++ b/ui/src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts
@@ -72,6 +72,7 @@ describe("login OpenFGA bootstrap", () => {
         { user: "user:sub-user", relation: "member", object: "organization:grid" },
         { user: "user:sub-user", relation: "reader", object: "system_config:platform_settings" },
         { user: "user:sub-user", relation: "owner", object: "user_profile:sub-user" },
+        { user: "user:sub-user", relation: "caller", object: "mcp_gateway:list" },
         { user: "user:sub-user", relation: "reader", object: "admin_surface:users" },
         { user: "user:sub-user", relation: "reader", object: "admin_surface:teams" },
         { user: "user:sub-user", relation: "reader", object: "admin_surface:skills" },

--- a/ui/src/lib/rbac/baseline-access.ts
+++ b/ui/src/lib/rbac/baseline-access.ts
@@ -132,6 +132,12 @@ export function memberBaselineGrantDefinitions(): BaselineFgaGrantDefinition[] {
       description: "Allows users to read and manage their own profile object.",
       tuple: (subject) => ({ user: `user:${subject}`, relation: "owner", object: userProfileObject(subject) }),
     },
+    {
+      id: "mcp-gateway-call",
+      label: "Call MCP gateway",
+      description: "Allows admitted users to pass AgentGateway's coarse MCP ext_authz gate.",
+      tuple: (subject) => ({ user: `user:${subject}`, relation: "caller", object: "mcp_gateway:list" }),
+    },
     ...BASELINE_ADMIN_SURFACES.map((surface) => ({
       id: `admin-surface:${surface}:read`,
       label: `Read ${surface.replaceAll("_", " ")} admin surface`,

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.1.dev5"
+version = "0.5.1.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Adds the AgentGateway config bridge for compose MCP route sync.\n- Renders Helm MCP route targets and updates local compose MCP-only/RBAC routing.

## Test plan

- [ ] Not run in this split pass; run config bridge tests and Helm/template checks before merge.

Made with [Cursor](https://cursor.com)