### PR TITLE
feat(admin): harden ReBAC assignment operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.1-dev.2"
+version = "0.5.1-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/audit-events/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/audit-events/__tests__/route.test.ts
@@ -52,6 +52,8 @@ interface TestAuditDoc {
   outcome: string;
   correlation_id: string;
   source: string;
+  agent_name?: string;
+  tool_name?: string;
 }
 
 const docs: TestAuditDoc[] = [
@@ -79,10 +81,43 @@ const docs: TestAuditDoc[] = [
     ts: new Date("2026-05-17T16:59:25.000Z"),
     type: "auth",
     tenant_id: "default",
-    subject_hash: "hash-supervisor",
-    action: "supervisor#invoke",
+    subject_hash: "hash-system-config",
+    action: "system_config#read",
     outcome: "allow",
-    correlation_id: "supervisor-correlation",
+    correlation_id: "system-config-correlation",
+    source: "webui_backend",
+  },
+  {
+    ts: new Date("2026-05-17T16:59:26.000Z"),
+    type: "tool_action",
+    tenant_id: "default",
+    subject_hash: "hash-tool",
+    action: "argocd_list_applications",
+    outcome: "success",
+    correlation_id: "tool-correlation",
+    source: "supervisor",
+    agent_name: "argocd",
+    tool_name: "argocd_list_applications",
+  },
+  {
+    ts: new Date("2026-05-17T16:59:27.000Z"),
+    type: "agent_delegation",
+    tenant_id: "default",
+    subject_hash: "hash-delegation",
+    action: "delegate_to_argocd",
+    outcome: "success",
+    correlation_id: "delegation-correlation",
+    source: "supervisor",
+    agent_name: "argocd",
+  },
+  {
+    ts: new Date("2026-05-17T16:59:28.000Z"),
+    type: "openfga_rebac",
+    tenant_id: "default",
+    subject_hash: "hash-openfga",
+    action: "agent#use",
+    outcome: "allow",
+    correlation_id: "openfga-correlation",
     source: "webui_backend",
   },
 ];
@@ -130,7 +165,7 @@ beforeEach(() => {
 });
 
 describe("GET /api/admin/audit-events", () => {
-  it("hides admin UI view authorization rows by default", async () => {
+  it("returns all audit event rows by default", async () => {
     const { GET } = await import("../route");
 
     const response = await GET(request("/api/admin/audit-events"));
@@ -138,7 +173,20 @@ describe("GET /api/admin/audit-events", () => {
 
     expect(response.status).toBe(200);
     expect(body.records.map((record: TestAuditDoc) => record.action)).toEqual([
-      "supervisor#invoke",
+      "admin_ui#view",
+      "admin_ui#audit.view",
+      "system_config#read",
+      "argocd_list_applications",
+      "delegate_to_argocd",
+      "agent#use",
+    ]);
+    expect(body.records.map((record: TestAuditDoc) => record.type)).toEqual([
+      "auth",
+      "auth",
+      "auth",
+      "tool_action",
+      "agent_delegation",
+      "openfga_rebac",
     ]);
   });
 
@@ -152,7 +200,7 @@ describe("GET /api/admin/audit-events", () => {
     expect(body.records.map((record: TestAuditDoc) => record.action)).toEqual([
       "admin_ui#view",
       "admin_ui#audit.view",
-      "supervisor#invoke",
+      "system_config#read",
     ]);
   });
 });

--- a/ui/src/app/api/admin/audit-events/route.ts
+++ b/ui/src/app/api/admin/audit-events/route.ts
@@ -10,7 +10,6 @@ import type {
 } from "@/lib/rbac/types";
 
 const COLLECTION = "audit_events";
-const DEFAULT_HIDDEN_ACTIONS = ["admin_ui#view", "admin_ui#audit.view"];
 
 const VALID_TYPES: AuditEventType[] = ["auth", "tool_action", "agent_delegation", "openfga_rebac"];
 const VALID_OUTCOMES: UnifiedAuditOutcome[] = ["allow", "deny", "success", "error"];
@@ -172,8 +171,6 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
   }
   if (typeParam) {
     filter.type = typeParam;
-  } else {
-    filter.action = { $nin: DEFAULT_HIDDEN_ACTIONS };
   }
   if (agentName) {
     filter.agent_name = agentName;

--- a/ui/src/app/api/admin/openfga/__tests__/tuples-route.test.ts
+++ b/ui/src/app/api/admin/openfga/__tests__/tuples-route.test.ts
@@ -71,6 +71,41 @@ describe("/api/admin/openfga/tuples", () => {
     );
   });
 
+  it("passes exact tuple filters through to OpenFGA instead of reading a broad page", async () => {
+    mockReadOpenFgaTuples.mockResolvedValue({
+      tuples: [
+        {
+          key: {
+            user: "team:platform#member",
+            relation: "user",
+            object: "agent:incident-agent",
+          },
+        },
+      ],
+      continuationToken: undefined,
+    });
+    const { GET } = await import("../tuples/route");
+
+    const response = await GET(
+      request(
+        "/api/admin/openfga/tuples?user=team%3Aplatform%23member&relation=user&object=agent%3Aincident-agent&limit=25",
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockReadOpenFgaTuples).toHaveBeenCalledWith({
+      tuple: {
+        user: "team:platform#member",
+        relation: "user",
+        object: "agent:incident-agent",
+      },
+      pageSize: 25,
+      continuationToken: undefined,
+    });
+    expect(body.data.tuples).toHaveLength(1);
+  });
+
   it("applies tuple inspector relation filters after a valid OpenFGA read", async () => {
     mockReadOpenFgaTuples.mockResolvedValue({
       tuples: [

--- a/ui/src/app/api/admin/openfga/tuples/route.ts
+++ b/ui/src/app/api/admin/openfga/tuples/route.ts
@@ -6,7 +6,7 @@ import {
   writeOpenFgaTuples,
   type OpenFgaTupleKey,
 } from "@/lib/rbac/openfga";
-import { validateTupleKey, withOpenFgaAdminAuth, withOpenFgaViewAuth } from "../_lib";
+import { ALLOWED_RELATIONS, validateTupleKey, withOpenFgaAdminAuth, withOpenFgaViewAuth } from "../_lib";
 
 function limitFromQuery(request: NextRequest): number {
   const raw = request.nextUrl.searchParams.get("limit");
@@ -20,16 +20,33 @@ function matchesFilter(value: string, filter: string | undefined): boolean {
   return value.toLowerCase().includes(filter.toLowerCase());
 }
 
+const EXACT_TUPLE_FIELD = /^[A-Za-z0-9._:@#*+=,/-]+$/;
+
+function exactTupleField(value: string | undefined): string | undefined {
+  if (!value || !EXACT_TUPLE_FIELD.test(value)) return undefined;
+  if (!value.includes(":") || value.endsWith(":")) return undefined;
+  return value;
+}
+
+function exactRelationFilter(value: string | undefined): string | undefined {
+  if (!value || !EXACT_TUPLE_FIELD.test(value)) return undefined;
+  return ALLOWED_RELATIONS.has(value) ? value : undefined;
+}
+
 export const GET = withErrorHandler(async (request: NextRequest) =>
   withOpenFgaViewAuth(request, async ({ user: actor, session }) => {
     const params = request.nextUrl.searchParams;
-    const tuple: Partial<OpenFgaTupleKey> = {};
     const user = params.get("user")?.trim();
     const relation = params.get("relation")?.trim();
     const object = params.get("object")?.trim();
+    const tuple: Partial<OpenFgaTupleKey> = {
+      ...(exactTupleField(user) ? { user: exactTupleField(user) } : {}),
+      ...(exactRelationFilter(relation) ? { relation: exactRelationFilter(relation) } : {}),
+      ...(exactTupleField(object) ? { object: exactTupleField(object) } : {}),
+    };
 
     const result = await readOpenFgaTuples({
-      tuple,
+      ...(Object.keys(tuple).length > 0 ? { tuple } : {}),
       pageSize: limitFromQuery(request),
       continuationToken: params.get("continuation_token") || undefined,
     });

--- a/ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/slack/available-channels/__tests__/route.test.ts
@@ -5,14 +5,12 @@
  * discovery returning irrelevant results + no caching.
  *
  * Verifies that the `available-channels` route:
- *   - Uses `users.conversations` (Tier 3) when member_only=1 (default), so
+ *   - Uses `users.conversations` (Tier 3) for every request, so
  *     workspaces with thousands of channels don't trip Slack's Tier-2 rate
  *     limit on `conversations.list`.
- *   - Falls back to `conversations.list` when member_only=0.
- *   - Caches results per (scope, token) and serves repeat requests from cache
+ *   - Ignores legacy `member_only=0` callers instead of using `conversations.list`.
+ *   - Caches results per bot token and serves repeat requests from cache
  *     without calling Slack again.
- *   - Splits the cache key per scope so the two endpoints don't poison each
- *     other's snapshot.
  *   - Honors `refresh=1` to force a re-fetch.
  *   - Defaults `is_member=true` for rows from `users.conversations` (which
  *     omits the field per Slack's docs).
@@ -131,22 +129,21 @@ describe("GET /api/admin/slack/available-channels", () => {
       expect(slackCalls[0].endpoint).toBe("users.conversations");
     });
 
-    it("falls back to conversations.list when member_only=0", async () => {
+    it("ignores legacy member_only=0 and still uses users.conversations", async () => {
       mockSlackFetch(() => ({
         ok: true,
         channels: [
-          { id: "C200", name: "general", is_private: false, is_member: true, num_members: 100 },
-          { id: "C201", name: "random", is_private: false, is_member: false, num_members: 200 },
+          { id: "C200", name: "general", is_private: false, num_members: 100 },
         ],
       }));
 
       const body = await makeRequest("member_only=0");
 
       expect(slackCalls).toHaveLength(1);
-      expect(slackCalls[0].endpoint).toBe("conversations.list");
+      expect(slackCalls[0].endpoint).toBe("users.conversations");
       expect(body).toMatchObject({
         success: true,
-        data: { scope: "all", endpoint: "conversations.list" },
+        data: { scope: "member_only", endpoint: "users.conversations" },
       });
     });
   });
@@ -196,44 +193,25 @@ describe("GET /api/admin/slack/available-channels", () => {
       expect(slackCalls).toHaveLength(3);
     });
 
-    it("splits the cache by scope so member_only and full-list don't poison each other", async () => {
-      mockSlackFetch((call) => {
-        if (call.endpoint === "users.conversations") {
-          return { ok: true, channels: [{ id: "C100", name: "members-only-channel" }] };
-        }
-        return {
-          ok: true,
-          channels: [
-            { id: "C100", name: "members-only-channel", is_member: true },
-            { id: "C999", name: "non-member-channel", is_member: false },
-          ],
-        };
-      });
+    it("uses one bot-member cache even for legacy member_only=0 callers", async () => {
+      mockSlackFetch(() => ({
+        ok: true,
+        channels: [{ id: "C100", name: "members-only-channel" }],
+      }));
 
       const memberOnly = (await makeRequest("member_only=1")) as {
-        data: { channels: Array<{ id: string }> };
+        data: { channels: Array<{ id: string }>; cached: boolean };
       };
-      const all = (await makeRequest("member_only=0")) as {
-        data: { channels: Array<{ id: string }>; total_visible: number };
+      const legacyAll = (await makeRequest("member_only=0")) as {
+        data: { channels: Array<{ id: string }>; cached: boolean };
       };
 
-      // Two distinct Slack calls (one per endpoint), each cached separately.
-      expect(slackCalls).toHaveLength(2);
-      expect(slackCalls.map((c) => c.endpoint).sort()).toEqual([
-        "conversations.list",
-        "users.conversations",
-      ]);
+      expect(slackCalls).toHaveLength(1);
+      expect(slackCalls[0].endpoint).toBe("users.conversations");
+      expect(memberOnly.data.cached).toBe(false);
+      expect(legacyAll.data.cached).toBe(true);
       expect(memberOnly.data.channels.map((c) => c.id)).toEqual(["C100"]);
-      expect(all.data.channels.map((c) => c.id)).toEqual(["C100", "C999"]);
-
-      // And a second member_only request should still come from cache, not
-      // contaminated by the all-list fetch.
-      const repeat = (await makeRequest("member_only=1")) as {
-        data: { cached: boolean; channels: Array<{ id: string }> };
-      };
-      expect(slackCalls).toHaveLength(2);
-      expect(repeat.data.cached).toBe(true);
-      expect(repeat.data.channels.map((c) => c.id)).toEqual(["C100"]);
+      expect(legacyAll.data.channels.map((c) => c.id)).toEqual(["C100"]);
     });
   });
 

--- a/ui/src/app/api/admin/slack/available-channels/route.ts
+++ b/ui/src/app/api/admin/slack/available-channels/route.ts
@@ -7,9 +7,8 @@
  *
  * Query params:
  *   - `q`            — case-insensitive substring filter on channel name.
- *   - `member_only`  — `1` (default) restricts to channels the bot is a
- *                      member of. `0` includes every public/private channel
- *                      the token can see.
+ *   - `member_only`  — legacy compatibility only; discovery is always
+ *                      restricted to channels the bot is a member of.
  *   - `limit`        — page size (default 200, max 500).
  *   - `cursor`       — opaque alphabetical cursor returned in the previous
  *                      response. Empty/absent ⇒ first page.
@@ -18,26 +17,17 @@
  * Auth: requires `admin_ui:view`.
  *
  * Caching strategy:
- *   We pull a snapshot of channels from Slack once per (token, scope) and keep
- *   it in-process for `CACHE_TTL_MS`. Filtering, sorting, and paging happen
+ *   We pull a snapshot of channels from Slack once per bot token and keep
+ *   it in-process for the configured TTL. Filtering, sorting, and paging happen
  *   here on the cached snapshot so the UI can search/scroll instantly without
  *   hammering Slack's rate limits. Admins can force a refresh via `?refresh=1`.
  *
- *   Endpoint selection (fixes #1506):
- *     - `member_only=1` (default)  → `users.conversations` (Tier 3, ~50 req/min).
- *       Returns ONLY channels the bot is a member of. This is what the admin UI
- *       almost always wants and is orders of magnitude smaller than the whole
- *       workspace, which keeps us off Slack's Tier-2 rate limit in big tenants.
- *     - `member_only=0`            → `conversations.list` (Tier 2, ~20 req/min).
- *       Returns every public/private channel the token can see. Used only when
- *       an admin explicitly opts in (e.g. assigning the bot to a brand new
- *       channel). The cache softens the rate-limit blast radius.
+ *   Endpoint selection (fixes #1506): we only use `users.conversations`
+ *   (Tier 3, ~50 req/min). It returns ONLY channels the bot is a member of,
+ *   which keeps the picker aligned with dispatch behavior and avoids listing
+ *   channels where the bot cannot actually operate.
  *
- *   The two scopes have separate cache entries because their result sets are
- *   different — mixing them would either pollute member-only with non-member
- *   channels or starve full-list mode.
- *
- *   Both walks handle HTTP 429 with the `Retry-After` header so a busy
+ *   The Slack walk handles HTTP 429 with the `Retry-After` header so a busy
  *   workspace doesn't break discovery.
  *
  * Failure modes:
@@ -81,12 +71,10 @@ interface NormalizedChannel {
   num_members: number;
 }
 
-type DiscoveryScope = "member_only" | "all";
-
 interface CacheEntry {
   channels: NormalizedChannel[];
   fetched_at: number;
-  endpoint: "users.conversations" | "conversations.list";
+  endpoint: "users.conversations";
 }
 
 // Channel lists rarely change between admin actions. The TTL is admin-
@@ -95,19 +83,14 @@ interface CacheEntry {
 // default is 60 minutes. A value of 0 disables caching entirely (every
 // request hits Slack), which is useful when an admin just added the bot
 // to a brand-new channel and wants the picker to reflect that without
-// clicking "Force refresh".
-// Slack max page size is 1000 for conversations.list / 999 for
-// users.conversations, but Slack recommends <=200 for stability. We pull at
-// 200 internally regardless of the UI page size (which is just a slice on top
-// of the cache).
+// clicking "Refresh from Slack now".
+// Slack max page size is 999 for users.conversations, but Slack recommends
+// <=200 for stability. We pull at 200 internally regardless of the UI page
+// size (which is just a slice on top of the cache).
 const SLACK_PAGE_SIZE = 200;
-// Hard ceiling on how many Slack pages we'll walk per scope.
-//   - member_only (users.conversations): 200 * 50 = 10k channels, far more than
-//     any sane bot membership.
-//   - all (conversations.list): 200 * 100 = 20k channels, more than any
-//     realistic workspace.
+// Hard ceiling on how many Slack pages we'll walk: 200 * 50 = 10k channels,
+// far more than any sane bot membership.
 const MAX_SLACK_PAGES_MEMBER = 50;
-const MAX_SLACK_PAGES_ALL = 100;
 // Defensive ceiling on how long we'll sleep waiting for Slack rate limits
 // before giving up and 502'ing. Prevents a single request from holding a
 // Next.js worker forever.
@@ -130,22 +113,14 @@ export function __resetAvailableChannelsCacheForTests(): void {
 }
 
 /**
- * Walk a Slack conversations endpoint and accumulate normalized channels.
- *
- * The two supported endpoints (`users.conversations` for member-only and
- * `conversations.list` for full workspace) share the same response shape, so
- * we parameterise endpoint, page cap, and is_member defaulting and reuse the
- * pagination + rate-limit loop.
+ * Walk Slack `users.conversations` and accumulate normalized bot-member channels.
  */
-async function walkSlackConversations(
-  token: string,
-  endpoint: "users.conversations" | "conversations.list",
-  options: { maxPages: number; defaultIsMember: boolean }
-): Promise<NormalizedChannel[]> {
+async function walkBotMemberSlackConversations(token: string): Promise<NormalizedChannel[]> {
   const out: NormalizedChannel[] = [];
   let cursor: string | undefined;
 
-  for (let page = 0; page < options.maxPages; page++) {
+  for (let page = 0; page < MAX_SLACK_PAGES_MEMBER; page++) {
+    const endpoint = "users.conversations";
     const url = new URL(`https://slack.com/api/${endpoint}`);
     url.searchParams.set("limit", String(SLACK_PAGE_SIZE));
     url.searchParams.set("exclude_archived", "true");
@@ -232,7 +207,7 @@ async function walkSlackConversations(
           // definition every row is one the bot is in. Default accordingly so
           // downstream filters and the UI's `channel.is_member !== false`
           // check both behave correctly.
-          is_member: c.is_member ?? options.defaultIsMember,
+          is_member: c.is_member ?? true,
           num_members: c.num_members ?? 0,
         });
       }
@@ -277,7 +252,6 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const params = request.nextUrl.searchParams;
   const refresh = params.get("refresh") === "1";
   const q = (params.get("q") ?? "").trim().toLowerCase();
-  const memberOnly = params.get("member_only") !== "0"; // default ON
   const cursor = params.get("cursor") ?? undefined;
   const requestedLimit = Number.parseInt(params.get("limit") ?? "", 10);
   const limit =
@@ -285,16 +259,12 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       ? Math.min(requestedLimit, MAX_UI_LIMIT)
       : DEFAULT_UI_LIMIT;
 
-  const scope: DiscoveryScope = memberOnly ? "member_only" : "all";
-  const endpoint: "users.conversations" | "conversations.list" = memberOnly
-    ? "users.conversations"
-    : "conversations.list";
-  const maxPages = memberOnly ? MAX_SLACK_PAGES_MEMBER : MAX_SLACK_PAGES_ALL;
+  const scope = "member_only";
+  const endpoint = "users.conversations";
 
   const now = Date.now();
-  // last 12 chars uniquely identifies the token without logging it. Scope is
-  // part of the key so the two endpoints don't poison each other's snapshot.
-  const cacheKey = `${scope}:${token.slice(-12)}`;
+  // last 12 chars uniquely identifies the token without logging it.
+  const cacheKey = token.slice(-12);
   const cached = cache.get(cacheKey);
   const cacheTtlMs = await getDiscoveryCacheTtlMs();
 
@@ -308,10 +278,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     fetchedAt = cached.fetched_at;
     cacheHit = true;
   } else {
-    snapshot = await walkSlackConversations(token, endpoint, {
-      maxPages,
-      defaultIsMember: memberOnly,
-    });
+    snapshot = await walkBotMemberSlackConversations(token);
     fetchedAt = now;
     if (cacheTtlMs > 0) {
       cache.set(cacheKey, { channels: snapshot, fetched_at: fetchedAt, endpoint });
@@ -322,15 +289,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
   }
 
-  // Filter pipeline runs in-process against the cached snapshot.
-  // NOTE: when scope is "member_only" the snapshot is already members-only
-  // (users.conversations returns only those rows), so this filter is a no-op
-  // there. Keep it for defence-in-depth against a future provider that
-  // returns extras.
-  let filtered = snapshot;
-  if (memberOnly) {
-    filtered = filtered.filter((c) => c.is_member);
-  }
+  // Filter pipeline runs in-process against the cached snapshot. The snapshot
+  // is already members-only (`users.conversations` returns only those rows);
+  // keep the membership filter as defense-in-depth against provider drift.
+  let filtered = snapshot.filter((c) => c.is_member);
   if (q) {
     filtered = filtered.filter((c) => c.name.toLowerCase().includes(q));
   }
@@ -355,6 +317,6 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     fetched_at: fetchedAt,
     scope,
     endpoint,
-    query: { q, member_only: memberOnly, limit },
+    query: { q, member_only: true, limit },
   });
 });

--- a/ui/src/app/api/admin/teams/[id]/kb-assignments/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/teams/[id]/kb-assignments/__tests__/route.test.ts
@@ -119,6 +119,32 @@ beforeEach(() => {
 });
 
 describe("/api/admin/teams/[id]/kb-assignments", () => {
+  it("falls back to legacy team resource KB assignments when ownership rows are missing", async () => {
+    mockCollections.teams = createMockCollection([
+      {
+        _id: teamId,
+        slug: "platform",
+        name: "Platform",
+        resources: {
+          knowledge_bases: ["legacy-ds"],
+        },
+      },
+    ]);
+    mockCollections.team_kb_ownership = createMockCollection([]);
+    const { GET } = await import("../route");
+
+    const response = await GET(
+      request(`/api/admin/teams/${teamId}/kb-assignments`),
+      { params: Promise.resolve({ id: String(teamId) }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.kb_ids).toEqual(["legacy-ds"]);
+    expect(body.data.kb_permissions).toEqual({ "legacy-ds": "read" });
+    expect(body.data.allowed_datasource_ids).toEqual(["legacy-ds"]);
+  });
+
   it("reconciles knowledge-base tuples before saving assignments", async () => {
     mockCollections.team_kb_ownership = createMockCollection([
       {
@@ -150,7 +176,7 @@ describe("/api/admin/teams/[id]/kb-assignments", () => {
       writes: [
         { user: "team:platform#member", relation: "reader", object: "knowledge_base:new-read-ds" },
         { user: "team:platform#member", relation: "ingestor", object: "knowledge_base:new-ingest-ds" },
-        { user: "team:platform#member", relation: "manager", object: "knowledge_base:new-admin-ds" },
+        { user: "team:platform#admin", relation: "manager", object: "knowledge_base:new-admin-ds" },
       ],
       deletes: [
         { user: "team:platform#member", relation: "reader", object: "knowledge_base:old-ds" },
@@ -263,7 +289,7 @@ describe("/api/admin/teams/[id]/kb-assignments", () => {
     expect(response.status).toBe(200);
     expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
       writes: [
-        { user: "team:platform#member", relation: "manager", object: "knowledge_base:team-ds" },
+        { user: "team:platform#admin", relation: "manager", object: "knowledge_base:team-ds" },
       ],
       deletes: [],
     });

--- a/ui/src/app/api/admin/teams/[id]/kb-assignments/route.ts
+++ b/ui/src/app/api/admin/teams/[id]/kb-assignments/route.ts
@@ -38,6 +38,9 @@ function validateTeamId(id: string): void {
 interface TeamDoc {
   _id: ObjectId;
   slug?: string;
+  resources?: {
+    knowledge_bases?: string[];
+  };
 }
 
 function normalizeEmail(value: unknown): string {
@@ -75,6 +78,12 @@ const KB_PERMISSION_TO_OPENFGA_RELATION: Record<KbPermission, string> = {
   admin: 'manager',
 };
 
+function teamUsersetForPermission(teamSlug: string, permission: KbPermission): string {
+  return permission === 'admin'
+    ? `team:${teamSlug}#admin`
+    : `team:${teamSlug}#member`;
+}
+
 function uniqueTupleKeys(tuples: OpenFgaTupleKey[]): OpenFgaTupleKey[] {
   const seen = new Set<string>();
   const unique: OpenFgaTupleKey[] = [];
@@ -89,7 +98,7 @@ function uniqueTupleKeys(tuples: OpenFgaTupleKey[]): OpenFgaTupleKey[] {
 
 function kbTuple(teamSlug: string, datasourceId: string, permission: KbPermission): OpenFgaTupleKey {
   return {
-    user: `team:${teamSlug}#member`,
+    user: teamUsersetForPermission(teamSlug, permission),
     relation: KB_PERMISSION_TO_OPENFGA_RELATION[permission],
     object: `knowledge_base:${datasourceId}`,
   };
@@ -146,6 +155,7 @@ export const GET = withErrorHandler(
 
       const params = await context.params;
       validateTeamId(params.id);
+      let team: TeamDoc | null = null;
 
       if (params.id === GLOBAL_PSEUDO_TEAM) {
         if (user.role !== 'admin') {
@@ -157,7 +167,7 @@ export const GET = withErrorHandler(
           () => false
         );
         const teams = await getCollection('teams');
-        const team = await teams.findOne({ _id: new ObjectId(params.id) }) as TeamDoc | null;
+        team = await teams.findOne({ _id: new ObjectId(params.id) }) as TeamDoc | null;
         if (!team) {
           throw new ApiError('Team not found', 404);
         }
@@ -168,12 +178,25 @@ export const GET = withErrorHandler(
 
       const ownership = await getCollection<TeamKbOwnership>('team_kb_ownership');
       const record = await ownership.findOne({ team_id: params.id });
+      const legacyKbIds =
+        !record && params.id !== GLOBAL_PSEUDO_TEAM && team?.resources?.knowledge_bases
+          ? Array.from(
+              new Set(
+                team.resources.knowledge_bases
+                  .map((id) => id.trim())
+                  .filter((id) => id.length > 0)
+              )
+            )
+          : [];
+      const legacyPermissions = Object.fromEntries(
+        legacyKbIds.map((id) => [id, 'read' as KbPermission])
+      );
 
       return successResponse({
         team_id: params.id,
-        kb_ids: record?.kb_ids ?? [],
-        kb_permissions: record?.kb_permissions ?? {},
-        allowed_datasource_ids: record?.allowed_datasource_ids ?? [],
+        kb_ids: record?.kb_ids ?? legacyKbIds,
+        kb_permissions: record?.kb_permissions ?? legacyPermissions,
+        allowed_datasource_ids: record?.allowed_datasource_ids ?? legacyKbIds,
         updated_at: record?.updated_at ?? null,
         updated_by: record?.updated_by ?? null,
       });

--- a/ui/src/components/admin/OpenFgaRebacTab.tsx
+++ b/ui/src/components/admin/OpenFgaRebacTab.tsx
@@ -521,6 +521,15 @@ function tupleKey(tuple: TupleKey): string {
   return `${tuple.user} ${tuple.relation} ${tuple.object}`;
 }
 
+function tupleFilterParams(filter: Partial<TupleKey>): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filter.user?.trim()) params.set("user", filter.user.trim());
+  if (filter.relation?.trim()) params.set("relation", filter.relation.trim());
+  if (filter.object?.trim()) params.set("object", filter.object.trim());
+  params.set("limit", "100");
+  return params;
+}
+
 function nodeKind(object: string): string {
   if (object.includes("#")) return "userset";
   const [type] = object.split(":");
@@ -720,17 +729,13 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
     setAccessResourceId((prev) => prev || accessResources(data, "agent")[0]?.id || "");
   }, []);
 
-  const loadTuples = useCallback(async () => {
-    const params = new URLSearchParams();
-    if (tupleFilter.user) params.set("user", tupleFilter.user);
-    if (tupleFilter.relation) params.set("relation", tupleFilter.relation);
-    if (tupleFilter.object) params.set("object", tupleFilter.object);
-    params.set("limit", "100");
+  const loadTuples = useCallback(async (filter: Partial<TupleKey> = {}) => {
+    const params = tupleFilterParams(filter);
     const res = await fetch(`/api/admin/openfga/tuples?${params.toString()}`);
     if (!res.ok) throw new Error(`Failed to load tuples: ${res.status}`);
     const payload = await res.json();
     setTuples(apiData<{ tuples: TupleRecord[] }>(payload).tuples ?? []);
-  }, [tupleFilter]);
+  }, []);
 
   const loadGraph = useCallback(async () => {
     const params = new URLSearchParams();
@@ -761,6 +766,15 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  const applyTupleFilters = useCallback(async () => {
+    setError(null);
+    try {
+      await loadTuples(tupleFilter);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load OpenFGA tuples");
+    }
+  }, [loadTuples, tupleFilter]);
 
   useEffect(() => {
     const nextSubjects = subjectOptions(catalog, accessSubjectType);
@@ -862,7 +876,7 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
       setMessage(
         `Granted ${selectedAccessRelationship.action} on ${selectedAccessRelationship.resource.type}:${selectedAccessRelationship.resource.id}`
       );
-      await Promise.all([loadTuples(), loadGraph()]);
+      await Promise.all([loadTuples(tupleFilter), loadGraph()]);
       await checkAccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Effective access grant failed");
@@ -888,7 +902,7 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
       setMessage(
         `Revoked ${selectedAccessRelationship.action} on ${selectedAccessRelationship.resource.type}:${selectedAccessRelationship.resource.id}`
       );
-      await Promise.all([loadTuples(), loadGraph()]);
+      await Promise.all([loadTuples(tupleFilter), loadGraph()]);
       await checkAccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Effective access revoke failed");
@@ -909,7 +923,7 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
     try {
       await applyChangeSet(`Revoke ${tuple.relation} ${tuple.object}`, [], [relationship]);
       setMessage(`Deleted ${tuple.user} ${tuple.relation} ${tuple.object}`);
-      await Promise.all([loadTuples(), loadGraph()]);
+      await Promise.all([loadTuples(tupleFilter), loadGraph()]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Tuple delete failed");
     } finally {
@@ -937,7 +951,7 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
       );
       setPendingGraphWrites([]);
       setPendingGraphDeletes([]);
-      await Promise.all([loadTuples(), loadGraph()]);
+      await Promise.all([loadTuples(tupleFilter), loadGraph()]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "OpenFGA graph save failed");
     } finally {
@@ -1250,7 +1264,7 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
                 <FilterInput label="User" value={tupleFilter.user ?? ""} onChange={(user) => setTupleFilter((prev) => ({ ...prev, user }))} />
                 <FilterInput label="Relation" value={tupleFilter.relation ?? ""} onChange={(relationValue) => setTupleFilter((prev) => ({ ...prev, relation: relationValue }))} />
                 <FilterInput label="Object" value={tupleFilter.object ?? ""} onChange={(object) => setTupleFilter((prev) => ({ ...prev, object }))} />
-                <Button variant="outline" className="self-end" onClick={loadTuples}>
+                <Button variant="outline" className="self-end" onClick={applyTupleFilters}>
                   Apply filters
                 </Button>
               </div>

--- a/ui/src/components/admin/TeamDetailsDialog.tsx
+++ b/ui/src/components/admin/TeamDetailsDialog.tsx
@@ -257,6 +257,34 @@ function syncBadgeAppearance(status: TeamMembershipSyncState): {
   }
 }
 
+function memberFromSource(source: TeamMembershipSource, fallbackDate: Date): TeamMember | null {
+  if (source.status !== "active") return null;
+  const userId = (source.user_email ?? source.user_subject ?? "").trim();
+  if (!userId) return null;
+
+  return {
+    user_id: userId,
+    role: source.relationship === "admin" ? "admin" : "member",
+    added_at: new Date(source.first_seen_at ?? source.created_at ?? source.last_seen_at ?? fallbackDate),
+    added_by: source.created_by ?? "identity-sync",
+  };
+}
+
+function membersFromSources(sources: TeamMembershipSource[], fallbackDate: Date): TeamMember[] {
+  const byUser = new Map<string, TeamMember>();
+  for (const source of sources) {
+    const member = memberFromSource(source, fallbackDate);
+    if (!member) continue;
+
+    const key = member.user_id.toLowerCase();
+    const existing = byUser.get(key);
+    if (!existing || existing.role === "member") {
+      byUser.set(key, member);
+    }
+  }
+  return Array.from(byUser.values());
+}
+
 export function TeamDetailsDialog({
   team,
   mode,
@@ -1185,7 +1213,11 @@ export function TeamDetailsDialog({
 
   if (!currentTeam) return null;
 
-  const members = currentTeam.members || [];
+  const canonicalMembers = membersFromSources(
+    membershipSources,
+    new Date(currentTeam.created_at),
+  );
+  const members = canonicalMembers.length > 0 ? canonicalMembers : currentTeam.members || [];
   const sourcesByMember = membershipSources.reduce<Record<string, TeamMembershipSource[]>>(
     (acc, source) => {
       const key = (source.user_email ?? source.user_subject ?? "").toLowerCase();
@@ -2167,9 +2199,9 @@ function ToolList({
  * Two-column layout:
  *   Left  — channels currently assigned to the team (editable: change bound
  *           agent, remove)
- *   Right — channel discovery (live Slack `conversations.list`) + manual
- *           channel-ID entry as fallback when SLACK_BOT_TOKEN is unset or
- *           the channel isn't visible to the bot yet
+ *   Right — bot-member channel discovery (live Slack `users.conversations`) +
+ *           manual channel-ID entry as fallback when SLACK_BOT_TOKEN is unset
+ *           or the channel isn't visible to the bot yet
  *
  * The bound-agent dropdown is intentionally limited to the team's
  * `resources.agents` so admins can't accidentally bind a channel to an
@@ -2315,17 +2347,17 @@ function SlackChannelsPanel({
             <Input
               value={discoverySearch}
               onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search bot-visible channels..."
+              placeholder="Search bot-member channels..."
               className="h-7 text-xs pl-6"
             />
           </div>
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
             {discovery ? (
               <span>
-                {totalBotVisibleChannels} bot-visible channels found. Showing {shownBotVisibleChannels}.
+                {totalBotVisibleChannels} bot-member channels found. Showing {shownBotVisibleChannels}.
               </span>
             ) : (
-              <span>Loading bot-visible channels...</span>
+              <span>Loading bot-member channels...</span>
             )}
             <label className="flex items-center gap-1.5 cursor-pointer select-none">
               <input

--- a/ui/src/components/admin/UnifiedAuditTab.tsx
+++ b/ui/src/components/admin/UnifiedAuditTab.tsx
@@ -35,7 +35,7 @@ interface PaginatedResult {
 }
 
 const TYPE_OPTIONS: { value: string; label: string }[] = [
-  { value: "", label: "Default view" },
+  { value: "", label: "All" },
   { value: "auth", label: "Authorization" },
   { value: "openfga_rebac", label: "OpenFGA ReBAC" },
   { value: "tool_action", label: "Tool Action" },
@@ -300,12 +300,6 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
             Search
           </Button>
         </div>
-        {!typeFilter && (
-          <p className="text-xs text-muted-foreground mb-3">
-            Default view hides routine admin page-view checks. Select Authorization to include them.
-          </p>
-        )}
-
         {/* Error */}
         {error && (
           <div className="text-sm text-destructive bg-destructive/10 rounded-md p-3 mb-4">

--- a/ui/src/components/admin/__tests__/OpenFgaRebacTab.test.tsx
+++ b/ui/src/components/admin/__tests__/OpenFgaRebacTab.test.tsx
@@ -377,6 +377,30 @@ it("keeps OpenFGA focused on tuples, graph, access management, and diagnostics",
   expect(screen.queryByRole("tab", { name: "Webex Spaces" })).not.toBeInTheDocument();
 });
 
+it("only reloads tuple filters when Apply filters is clicked", async () => {
+  const user = userEvent.setup();
+
+  render(<OpenFgaRebacTab isAdmin />);
+
+  expect(await screen.findByText("OpenFGA Tuple Store")).toBeInTheDocument();
+  await waitFor(() =>
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/admin/openfga/tuples"))).toHaveLength(1),
+  );
+
+  await user.type(screen.getByPlaceholderText("relation filter"), "can");
+
+  expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/admin/openfga/tuples"))).toHaveLength(1);
+
+  await user.click(screen.getByRole("button", { name: "Apply filters" }));
+
+  await waitFor(() =>
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/admin/openfga/tuples"))).toHaveLength(2),
+  );
+  expect(
+    fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/api/admin/openfga/tuples")).at(-1)?.[0],
+  ).toBe("/api/admin/openfga/tuples?relation=can&limit=100");
+});
+
 it("runs baseline diagnostics for an individual user", async () => {
   const user = userEvent.setup();
   currentSearchParams = new URLSearchParams("openfgaTab=diagnostics");

--- a/ui/src/components/admin/__tests__/TeamDetailsDialog.members.test.tsx
+++ b/ui/src/components/admin/__tests__/TeamDetailsDialog.members.test.tsx
@@ -40,6 +40,57 @@ beforeEach(() => {
   global.fetch = fetchMock as unknown as typeof fetch;
 });
 
+it("renders active canonical membership sources when embedded team members are empty", async () => {
+  const teamWithoutEmbeddedMembers: Team = {
+    ...baseTeam,
+    members: [],
+    membership_sources: [
+      {
+        team_id: "team-1",
+        team_slug: "platform",
+        user_email: "alice@example.com",
+        relationship: "member",
+        source_type: "active_directory",
+        managed: true,
+        status: "active",
+        created_at: "2026-01-02T00:00:00.000Z",
+      },
+    ],
+  };
+
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url === "/api/admin/identity-group-sync/teams/team-1/membership-sources") {
+      return jsonResponse({
+        success: true,
+        data: {
+          sources: teamWithoutEmbeddedMembers.membership_sources,
+        },
+      });
+    }
+    return jsonResponse({
+      success: true,
+      data: {
+        team: teamWithoutEmbeddedMembers,
+        membership_sources: teamWithoutEmbeddedMembers.membership_sources,
+      },
+    });
+  });
+
+  render(
+    <TeamDetailsDialog
+      team={teamWithoutEmbeddedMembers}
+      mode="members"
+      open
+      onOpenChange={jest.fn()}
+      onTeamUpdated={jest.fn()}
+    />,
+  );
+
+  expect(await screen.findByText("alice@example.com")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /Members \(1\)/i })).toBeInTheDocument();
+  expect(screen.queryByText("No members yet. Add members above.")).not.toBeInTheDocument();
+});
+
 it("calls onTeamMutated (not onTeamUpdated) when a member is added", async () => {
   const onTeamMutated = jest.fn();
   const onTeamUpdated = jest.fn();

--- a/ui/src/components/admin/__tests__/TeamDetailsDialog.webex.test.tsx
+++ b/ui/src/components/admin/__tests__/TeamDetailsDialog.webex.test.tsx
@@ -124,8 +124,8 @@ it("auto-loads bot-member Slack channels when the team Slack tab opens", async (
 
   expect(await screen.findByText("new-slack-channel")).toBeInTheDocument();
   expect(screen.getByText("C0B4GLC5EFQ")).toBeInTheDocument();
-  expect(screen.getByPlaceholderText("Search bot-visible channels...")).toBeInTheDocument();
-  expect(screen.getByText("184 bot-visible channels found. Showing 1.")).toBeInTheDocument();
+  expect(screen.getByPlaceholderText("Search bot-member channels...")).toBeInTheDocument();
+  expect(screen.getByText("184 bot-member channels found. Showing 1.")).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Refresh bot channels" })).toBeInTheDocument();
   expect(screen.queryByText(/Click Discover to list channels/i)).not.toBeInTheDocument();
   expect(fetchMock).toHaveBeenCalledWith(

--- a/ui/src/components/admin/__tests__/UnifiedAuditTab.test.tsx
+++ b/ui/src/components/admin/__tests__/UnifiedAuditTab.test.tsx
@@ -56,7 +56,8 @@ describe('UnifiedAuditTab', () => {
     });
 
     expect(await screen.findByText(/RBAC Audit Log/i)).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Default view/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /^All$/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Default view hides routine admin page-view checks/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /^All types$/i })).not.toBeInTheDocument();
     expect(screen.getByText(/admin_ui#view/i)).toBeInTheDocument();
     expect(screen.getByText(/webui_backend/i)).toBeInTheDocument();

--- a/ui/src/components/admin/identity-group-sync/DryRunPreview.tsx
+++ b/ui/src/components/admin/identity-group-sync/DryRunPreview.tsx
@@ -5,15 +5,16 @@ import { AlertCircle, CheckCircle2, Info, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import type { IdentityGroupSyncDryRunResult } from "@/types/identity-group-sync";
+import type { ExternalGroup, IdentityGroupSyncDryRunResult } from "@/types/identity-group-sync";
 
 interface DryRunPreviewProps {
   result: IdentityGroupSyncDryRunResult | null;
+  detectedGroups?: ExternalGroup[];
   applying: boolean;
   onApply: (options?: { acknowledgeRemovalRisks?: boolean }) => void;
 }
 
-export function DryRunPreview({ result, applying, onApply }: DryRunPreviewProps) {
+export function DryRunPreview({ result, detectedGroups = [], applying, onApply }: DryRunPreviewProps) {
   const [acknowledgedRemovalRisks, setAcknowledgedRemovalRisks] = useState(false);
 
   if (!result) {
@@ -36,8 +37,62 @@ export function DryRunPreview({ result, applying, onApply }: DryRunPreviewProps)
     result.membership_sources_to_remove.length +
     result.tuple_writes.length +
     result.tuple_deletes.length;
+  const detectedGroupRows = mergeDetectedGroups(detectedGroups, result.matched_groups, result.ignored_groups);
 
   if (changeCount === 0 && !hasConflicts && result.skipped_users.length === 0) {
+    if (detectedGroupRows.length > 0) {
+      const matchedIds = new Set(result.matched_groups.map((group) => group.external_group_id));
+      const ignoredIds = new Set(result.ignored_groups.map((group) => group.external_group_id));
+      const alreadyRepresentedCount = detectedGroupRows.filter((group) => matchedIds.has(group.external_group_id)).length;
+      const unmatchedCount = detectedGroupRows.filter((group) => ignoredIds.has(group.external_group_id)).length;
+
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CheckCircle2 className="h-5 w-5 text-green-500" />
+              Detected groups are already represented
+            </CardTitle>
+            <CardDescription>
+              {detectedGroupRows.length} group(s) were found in this preview. No team, membership, or tuple changes are
+              needed right now.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-3">
+              <Metric label="detected" value={detectedGroupRows.length} />
+              <Metric label="already represented" value={alreadyRepresentedCount} />
+              <Metric label="unmatched" value={unmatchedCount} />
+            </div>
+            <details className="rounded-md border bg-background/60 p-3">
+              <summary className="cursor-pointer text-sm font-medium">Detected groups</summary>
+              <div className="mt-3 grid gap-2">
+                {detectedGroupRows.map((group) => {
+                  const status = matchedIds.has(group.external_group_id)
+                    ? "Already represented"
+                    : ignoredIds.has(group.external_group_id)
+                      ? "No enabled sync rule matched"
+                      : "Detected";
+                  return (
+                    <div
+                      key={`${group.provider_id}:${group.external_group_id}`}
+                      className="flex flex-col gap-1 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div>
+                        <div className="font-medium">{group.display_name || group.external_group_id}</div>
+                        <div className="text-xs text-muted-foreground">{group.external_group_id}</div>
+                      </div>
+                      <span className="text-sm text-muted-foreground">{status}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </details>
+          </CardContent>
+        </Card>
+      );
+    }
+
     return (
       <Card>
         <CardHeader>
@@ -130,4 +185,16 @@ function Metric({ label, value }: { label: string; value: number }) {
       <div className="text-sm text-muted-foreground">{label}</div>
     </div>
   );
+}
+
+function mergeDetectedGroups(...groups: ExternalGroup[][]): ExternalGroup[] {
+  const seen = new Set<string>();
+  const merged: ExternalGroup[] = [];
+  for (const group of groups.flat()) {
+    const key = `${group.provider_id}:${group.external_group_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(group);
+  }
+  return merged;
 }

--- a/ui/src/components/admin/identity-group-sync/IdentityGroupSyncTab.tsx
+++ b/ui/src/components/admin/identity-group-sync/IdentityGroupSyncTab.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import type { IdentityGroupSyncDryRunResult } from "@/types/identity-group-sync";
+import type { ExternalGroup, IdentityGroupSyncDryRunResult } from "@/types/identity-group-sync";
 
 import { DryRunPreview } from "./DryRunPreview";
 import { MappingClusterEditor } from "./MappingClusterEditor";
@@ -33,6 +33,7 @@ export function IdentityGroupSyncTab({ isAdmin }: IdentityGroupSyncTabProps) {
   const [groupName, setGroupName] = useState("Engineering Platform Users");
   const [userEmail, setUserEmail] = useState("bob@example.test");
   const [dryRun, setDryRun] = useState<IdentityGroupSyncDryRunResult | null>(null);
+  const [detectedGroups, setDetectedGroups] = useState<ExternalGroup[]>([]);
   const [suggestions, setSuggestions] = useState<ClaimSuggestion[]>([]);
   const [suggestionFilter, setSuggestionFilter] = useState("");
   const [selectedSuggestionIds, setSelectedSuggestionIds] = useState<Set<string>>(new Set());
@@ -66,53 +67,34 @@ export function IdentityGroupSyncTab({ isAdmin }: IdentityGroupSyncTabProps) {
     setError(null);
     setSuggestionNotice(null);
     try {
+      const externalGroup: ExternalGroup & {
+        members: Array<{ subject?: string; email: string; display_name: string; active: boolean }>;
+      } = {
+        provider_id: "oidc-claims",
+        external_group_id: groupName.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+        display_name: groupName,
+        normalized_name: groupName.toLowerCase(),
+        status: "active",
+        members: [
+          {
+            subject: userEmail ? userEmail.replace(/[^a-z0-9]+/gi, "-").toLowerCase() : undefined,
+            email: userEmail,
+            display_name: userEmail,
+            active: true,
+          },
+        ],
+      };
       const res = await fetch("/api/admin/identity-group-sync/dry-run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          groups: [
-            {
-              provider_id: "oidc-claims",
-              external_group_id: groupName.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-              display_name: groupName,
-              normalized_name: groupName.toLowerCase(),
-              status: "active",
-              members: [
-                {
-                  subject: userEmail ? userEmail.replace(/[^a-z0-9]+/gi, "-").toLowerCase() : undefined,
-                  email: userEmail,
-                  display_name: userEmail,
-                  active: true,
-                },
-              ],
-            },
-          ],
-          rules: [
-            {
-              id: "preview-caipe-users",
-              provider_id: "oidc-claims",
-              name: "Preview platform users",
-              priority: 10,
-              enabled: true,
-              review_status: "enabled",
-              include_patterns: ["^Engineering (?<team>Platform) (?<role>Users)$"],
-              exclude_patterns: [],
-              team_name_template: "{{team}}",
-              team_slug_template: "{{team}}",
-              role_map: { Users: "member" },
-              auto_create_team: true,
-              created_by: "ui",
-              created_at: new Date().toISOString(),
-              updated_by: "ui",
-              updated_at: new Date().toISOString(),
-            },
-          ],
-          existing_teams: [],
-          existing_membership_sources: [],
+          provider_id: "oidc-claims",
+          groups: [externalGroup],
         }),
       });
       const json = await res.json();
       if (!json.success) throw new Error(json.error || "Dry-run failed");
+      setDetectedGroups([externalGroup]);
       setDryRun(json.data?.dry_run ?? null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Dry-run failed");
@@ -129,10 +111,12 @@ export function IdentityGroupSyncTab({ isAdmin }: IdentityGroupSyncTabProps) {
       const res = await fetch("/api/admin/identity-group-sync/claim-suggestions");
       const json = await res.json();
       if (!json.success) throw new Error(json.error || "Suggestion lookup failed");
+      setDetectedGroups((json.data?.groups as ExternalGroup[] | undefined) ?? []);
       setSuggestions((json.data?.suggestions as ClaimSuggestion[] | undefined) ?? []);
       setSelectedSuggestionIds(new Set());
       setDryRun((json.data?.dry_run as IdentityGroupSyncDryRunResult | null | undefined) ?? null);
       if (json.data?.reason === "missing_session_group_claims") {
+        setDetectedGroups([]);
         setSuggestionNotice("Sign out and sign back in to refresh cached OIDC claim groups before using suggestions.");
       }
     } catch (err) {
@@ -403,7 +387,7 @@ export function IdentityGroupSyncTab({ isAdmin }: IdentityGroupSyncTabProps) {
         />
       )}
 
-      <DryRunPreview result={dryRun} applying={applying} onApply={applyDryRun} />
+      <DryRunPreview result={dryRun} detectedGroups={detectedGroups} applying={applying} onApply={applyDryRun} />
     </div>
   );
 }

--- a/ui/src/components/admin/identity-group-sync/__tests__/DryRunPreview.test.tsx
+++ b/ui/src/components/admin/identity-group-sync/__tests__/DryRunPreview.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import { DryRunPreview } from "../DryRunPreview";
-import type { IdentityGroupSyncDryRunResult } from "@/types/identity-group-sync";
+import type { ExternalGroup, IdentityGroupSyncDryRunResult } from "@/types/identity-group-sync";
 
 const emptyResult: IdentityGroupSyncDryRunResult = {
   matched_groups: [],
@@ -24,6 +24,48 @@ describe("DryRunPreview", () => {
     expect(screen.getByText(/The detected groups did not produce team, membership, or tuple changes/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /apply reviewed sync/i })).not.toBeInTheDocument();
     expect(screen.queryByText("Teams to create")).not.toBeInTheDocument();
+  });
+
+  it("explains detected groups that are already represented or unmatched when no changes are needed", () => {
+    const detectedGroups: ExternalGroup[] = [
+      {
+        provider_id: "oidc-claims",
+        external_group_id: "backstage-access",
+        display_name: "backstage-access",
+        normalized_name: "backstage-access",
+        status: "active",
+      },
+      {
+        provider_id: "oidc-claims",
+        external_group_id: "foo-access",
+        display_name: "foo-access",
+        normalized_name: "foo-access",
+        status: "active",
+      },
+    ];
+
+    render(
+      <DryRunPreview
+        result={{
+          ...emptyResult,
+          matched_groups: [detectedGroups[0]],
+          ignored_groups: [detectedGroups[1]],
+        }}
+        detectedGroups={detectedGroups}
+        applying={false}
+        onApply={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Detected groups are already represented")).toBeInTheDocument();
+    expect(screen.getByText("detected")).toBeInTheDocument();
+    expect(screen.getByText("already represented")).toBeInTheDocument();
+    expect(screen.getByText("unmatched")).toBeInTheDocument();
+    expect(screen.getAllByText("backstage-access").length).toBeGreaterThan(0);
+    expect(screen.getByText("Already represented")).toBeInTheDocument();
+    expect(screen.getAllByText("foo-access").length).toBeGreaterThan(0);
+    expect(screen.getByText("No enabled sync rule matched")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /apply reviewed sync/i })).not.toBeInTheDocument();
   });
 
   it("requires acknowledgement before applying risky member removals", () => {

--- a/ui/src/components/admin/identity-group-sync/__tests__/IdentityGroupSyncTab.test.tsx
+++ b/ui/src/components/admin/identity-group-sync/__tests__/IdentityGroupSyncTab.test.tsx
@@ -17,6 +17,22 @@ describe("IdentityGroupSyncTab", () => {
           json: async () => ({
             success: true,
             data: {
+              groups: [
+                {
+                  provider_id: "oidc-claims",
+                  external_group_id: "caipe-users",
+                  display_name: "caipe-users",
+                  normalized_name: "caipe-users",
+                  status: "active",
+                },
+                {
+                  provider_id: "oidc-claims",
+                  external_group_id: "caipe-admins",
+                  display_name: "caipe-admins",
+                  normalized_name: "caipe-admins",
+                  status: "active",
+                },
+              ],
               suggestions: [
                 {
                   source_group_id: "caipe-users",
@@ -134,6 +150,52 @@ describe("IdentityGroupSyncTab", () => {
 
     expect(screen.getByLabelText(/resolved member email/i)).toBeInTheDocument();
     expect(screen.getByText(/test a specific upstream group/i)).toBeInTheDocument();
+  });
+
+  it("runs manual dry-run against backend-enabled rules instead of a hardcoded frontend preview rule", async () => {
+    render(<IdentityGroupSyncTab isAdmin />);
+
+    await screen.findByText("1 provider configured");
+    fireEvent.click(screen.getByRole("button", { name: /manual dry-run/i }));
+    fireEvent.change(screen.getByLabelText(/external group name/i), {
+      target: { value: "foo-access" },
+    });
+    fireEvent.change(screen.getByLabelText(/resolved member email/i), {
+      target: { value: "sraradhy@cisco.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /run dry-run/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/admin/identity-group-sync/dry-run",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"provider_id":"oidc-claims"'),
+        })
+      );
+    });
+
+    const dryRunCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === "/api/admin/identity-group-sync/dry-run"
+    );
+    const body = JSON.parse(dryRunCall[1].body);
+    expect(body.rules).toBeUndefined();
+    expect(body.existing_teams).toBeUndefined();
+    expect(body.existing_membership_sources).toBeUndefined();
+    expect(body.groups[0]).toEqual(
+      expect.objectContaining({
+        external_group_id: "foo-access",
+        display_name: "foo-access",
+        normalized_name: "foo-access",
+      })
+    );
+    expect(body.groups[0].members).toEqual([
+      expect.objectContaining({
+        email: "sraradhy@cisco.com",
+        display_name: "sraradhy@cisco.com",
+        active: true,
+      }),
+    ]);
   });
 
   it("shows a re-auth notice when session claim groups are not cached", async () => {

--- a/ui/src/components/admin/rebac/DiscoveryCacheControls.tsx
+++ b/ui/src/components/admin/rebac/DiscoveryCacheControls.tsx
@@ -10,7 +10,7 @@
  *   Forcing them to navigate to a separate Platform Settings tab just to
  *   drop a stale snapshot is the wrong UX — that's why we moved the
  *   single editing surface here. The TTL is platform-wide (one value
- *   governs both Slack and Webex), but the "Force refresh now" action is
+ *   governs both Slack and Webex), but the "Refresh from <provider> now" action is
  *   provider-scoped so we only invalidate what the admin is looking at.
  *
  * Persistence:
@@ -200,16 +200,16 @@ export function DiscoveryCacheControls({
           data-testid={`discovery-cache-controls-trigger-${provider}`}
         >
           <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
-          Cache
+          Discovery cache
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 space-y-4 p-4" align="end">
         <div className="space-y-1">
           <div className="text-sm font-medium">Discovery cache</div>
           <p className="text-xs text-muted-foreground">
-            Snapshot of {providerLabel} {provider === "slack" ? "channels" : "spaces"} kept in memory
-            so the picker scrolls instantly without hammering {providerLabel}&apos;s rate limits.
-            The TTL is shared between Slack and Webex.
+            Snapshot of {providerLabel} {provider === "slack" ? "bot-member channels" : "spaces"} kept
+            in memory so the picker scrolls instantly without hammering {providerLabel}&apos;s rate
+            limits. The TTL is shared between Slack and Webex.
           </p>
         </div>
 
@@ -277,8 +277,8 @@ export function DiscoveryCacheControls({
           <div className="space-y-2 border-t border-border/40 pt-3">
             <p className="text-xs text-muted-foreground">
               Just invited the bot to a new {provider === "slack" ? "channel" : "space"} and the
-              picker still doesn&apos;t list it? Drop the snapshot now and the next discovery call
-              will fetch a fresh list.
+              picker still doesn&apos;t list it? Refresh from {providerLabel} now to ignore CAIPE&apos;s
+              cached snapshot and fetch a fresh list.
             </p>
             <div className="flex items-center gap-2">
               <Button
@@ -295,7 +295,7 @@ export function DiscoveryCacheControls({
                 ) : (
                   <RefreshCw className="h-3.5 w-3.5" />
                 )}
-                Force refresh now
+                Refresh from {providerLabel} now
               </Button>
               {refreshResult === "success" && (
                 <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -278,7 +278,7 @@ export function SlackChannelRebacPanel({
   );
   const discoveryStatusText =
     discoveredBotChannels.length > 0
-      ? `${discoveredBotChannels.length} bot-visible found · ${discoveredNewChannelCount} new · ${channels.length} in CAIPE · ${unassignedChannelCount} missing team`
+      ? `${discoveredBotChannels.length} bot-member found · ${discoveredNewChannelCount} new · ${channels.length} in CAIPE · ${unassignedChannelCount} missing team`
       : `${channels.length} in CAIPE · ${unassignedChannelCount} missing team`;
 
   const loadChannels = useCallback(async () => {
@@ -632,12 +632,9 @@ export function SlackChannelRebacPanel({
   };
 
   const fetchBotMemberChannels = async (): Promise<DiscoveredSlackChannel[]> => {
-    // Issue #1506: previously this set `refresh=1` on the first page of every
-    // Discover click, which defeated the server-side cache entirely and
-    // tripped Slack's per-tenant rate limits on workspaces with thousands of
-    // channels. The cache TTL (10 min, server-side) is short enough for human
-    // admin workflows; a hard refresh button can be added separately if/when
-    // operators actually need it.
+    // Discovery intentionally uses Slack users.conversations only: the picker
+    // should show channels where the bot is already a member and can operate.
+    // Use the adjacent Discovery cache control to force a refresh from Slack.
     const discovered: DiscoveredSlackChannel[] = [];
     let cursor: string | null | undefined;
     do {
@@ -1474,11 +1471,11 @@ export function SlackChannelRebacPanel({
           itemSingular="channel"
           itemPlural="channels"
           discoveredLabel="bot-member channel"
-          findLabel="Find Slack Channels with Bot Integration"
-          refreshLabel="Refresh Slack Channels with Bot Integration"
-          loadingLabel="Finding Slack channels..."
+          findLabel="Find Bot-Member Slack Channels"
+          refreshLabel="Refresh Bot-Member Slack Channels"
+          loadingLabel="Finding bot-member Slack channels..."
           emptyLabel="No bot-member channels were discovered."
-          description="Find Slack channels where the bot is already installed, then choose what to import."
+          description="Find Slack channels where the bot is already installed. Channels the bot has not joined will not appear."
           discoveryStatusText={discoveryStatusText}
           discoveredCount={discoveredBotChannels.length}
           newCount={discoveredNewChannelCount}

--- a/ui/src/components/admin/rebac/__tests__/DiscoveryCacheControls.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/DiscoveryCacheControls.test.tsx
@@ -1,14 +1,14 @@
 /**
  * @jest-environment jsdom
  *
- * Inline discovery-cache popover that lives next to the "Find ... with
- * Bot Integration" button on the Slack and Webex onboarding wizards.
+ * Inline discovery-cache popover that lives next to the connector discovery
+ * button on the Slack and Webex onboarding wizards.
  * Tests cover:
  *   - Lazy GET only fires when the popover is opened (no popup = no
  *     extra round-trip on the integrations page)
  *   - TTL input is pre-filled from platform_config
  *   - Save PATCHes the right field; client-side validates the range
- *   - "Force refresh now" hits the right per-provider route with
+ *   - "Refresh from <provider> now" hits the right per-provider route with
  *     refresh=1 and fires onAfterRefresh
  *   - Read-only viewers see the TTL but no Save/refresh controls
  *
@@ -75,6 +75,7 @@ describe("DiscoveryCacheControls", () => {
 
     // The trigger is rendered; nothing was fetched yet.
     expect(screen.getByTestId("discovery-cache-controls-trigger-slack")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Slack discovery cache settings" })).toHaveTextContent("Discovery cache");
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -150,6 +151,7 @@ describe("DiscoveryCacheControls", () => {
     );
     fireEvent.click(screen.getByTestId("discovery-cache-controls-trigger-slack"));
     await screen.findByTestId("discovery-cache-ttl-input-slack");
+    expect(screen.getByRole("button", { name: "Refresh from Slack now" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("discovery-cache-refresh-slack"));
 

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -385,7 +385,7 @@ it("discovers bot-member channels and applies defaults after admin consent", asy
     target: { value: "incident-agent" },
   });
 
-  fireEvent.click(screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" }));
+  fireEvent.click(screen.getByRole("button", { name: "Find Bot-Member Slack Channels" }));
 
   expect(screen.queryByRole("dialog", { name: "Review channels found by the bot" })).not.toBeInTheDocument();
   expect(await screen.findByText(/2 bot-member channels discovered/i)).toBeInTheDocument();
@@ -395,10 +395,10 @@ it("discovers bot-member channels and applies defaults after admin consent", asy
   expect(screen.queryByText("Setup completed")).not.toBeInTheDocument();
   expect(
     screen.getByRole("status", {
-      name: /2 bot-visible found .* 1 new .* 1 in CAIPE .* 1 missing team/i,
+      name: /2 bot-member found .* 1 new .* 1 in CAIPE .* 1 missing team/i,
     })
   ).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Refresh Slack Channels with Bot Integration" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Refresh Bot-Member Slack Channels" })).toBeInTheDocument();
 
   expect(screen.getByRole("checkbox", { name: /Import #incidents/i })).toBeChecked();
   // Per-row team picker is also a TeamPicker now (2026-05-27).
@@ -465,7 +465,7 @@ it("prefills discovered Slack channels from legacy Slackbot config by default", 
   });
   expect(legacyDefaultsCheckbox).toBeChecked();
 
-  fireEvent.click(screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" }));
+  fireEvent.click(screen.getByRole("button", { name: "Find Bot-Member Slack Channels" }));
 
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith("/api/admin/slack/runtime/config-defaults", {
@@ -589,7 +589,7 @@ it("falls back to onboarding default and then alphabetical agent when legacy con
   render(<SlackChannelRebacPanel />);
 
   await screen.findByText("Step 2a: Verify Slack Channel ReBAC");
-  const discoverButton = screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" });
+  const discoverButton = screen.getByRole("button", { name: "Find Bot-Member Slack Channels" });
   await waitFor(() => expect(discoverButton).not.toBeDisabled());
   fireEvent.click(discoverButton);
   expect(await screen.findByText(/2 bot-member channels discovered/i)).toBeInTheDocument();
@@ -599,7 +599,7 @@ it("falls back to onboarding default and then alphabetical agent when legacy con
     target: { value: "incident-agent" },
   });
   fireEvent.click(screen.getByRole("checkbox", { name: /Use existing Slackbot channel agents as defaults/i }));
-  fireEvent.click(screen.getByRole("button", { name: "Refresh Slack Channels with Bot Integration" }));
+  fireEvent.click(screen.getByRole("button", { name: "Refresh Bot-Member Slack Channels" }));
 
   await waitFor(() =>
     expect(screen.getByLabelText("Dynamic Agent for #new-alerts")).toHaveValue("incident-agent")
@@ -674,7 +674,7 @@ it("discovers Slack channels even when no onboarding default team is configured"
   render(<SlackChannelRebacPanel />);
 
   await screen.findByText("Step 2a: Verify Slack Channel ReBAC");
-  const discoverButton = screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" });
+  const discoverButton = screen.getByRole("button", { name: "Find Bot-Member Slack Channels" });
   await waitFor(() => expect(discoverButton).not.toBeDisabled());
   fireEvent.click(discoverButton);
 
@@ -695,7 +695,7 @@ it("shows discovered channel setup feedback as a toast without shifting the acti
     target: { value: "incident-agent" },
   });
 
-  fireEvent.click(screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" }));
+  fireEvent.click(screen.getByRole("button", { name: "Find Bot-Member Slack Channels" }));
 
   expect(await screen.findByText(/2 bot-member channels discovered/i)).toBeInTheDocument();
   await pickTeam("Team for #new-alerts", "security");
@@ -728,7 +728,7 @@ it("uses a streamlined setup flow with icons and toast action confirmations", as
   expect(screen.getByRole("heading", { name: "Step 2b: Specify agent priority" })).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "Onboarding Default Selection" })).toBeInTheDocument();
   expect(screen.getByText(/Only changes what is preselected when you onboard channels/i)).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Find Bot-Member Slack Channels" })).toBeInTheDocument();
   expect(screen.queryByRole("button", { name: "Discover & Apply Defaults" })).not.toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Import from YAML Config" })).toBeInTheDocument();
 
@@ -760,7 +760,7 @@ it("lays out Slack setup as five subtly tinted sections in the requested order",
   fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
     target: { value: "incident-agent" },
   });
-  fireEvent.click(screen.getByRole("button", { name: "Find Slack Channels with Bot Integration" }));
+  fireEvent.click(screen.getByRole("button", { name: "Find Bot-Member Slack Channels" }));
 
   const sections = [
     await screen.findByRole("region", { name: "Step 1: Discover and Setup" }),

--- a/ui/src/components/ui/team-picker.tsx
+++ b/ui/src/components/ui/team-picker.tsx
@@ -87,6 +87,10 @@ interface CommonPickerProps {
   id?: string;
   /** ARIA: alternative label when the picker has no visible <Label>. */
   ariaLabel?: string;
+  /** ARIA: marks the combobox trigger invalid for required/error states. */
+  ariaInvalid?: boolean;
+  /** ARIA: links the trigger to help or error text. */
+  ariaDescribedBy?: string;
   /** Hide the `team:<slug>` code suffix on rows and trigger. Useful
    *  for callers that pass opaque identifiers (e.g. Mongo `_id` for
    *  KB team assignments) where rendering `team:<objectid>` is just
@@ -122,6 +126,8 @@ export function TeamPicker({
   contentClassName,
   id,
   ariaLabel,
+  ariaInvalid,
+  ariaDescribedBy,
   hideSlugSuffix = false,
   toggleOnReselect = false,
   helperText,
@@ -180,6 +186,8 @@ export function TeamPicker({
           type="button"
           id={id}
           aria-label={ariaLabel}
+          aria-invalid={ariaInvalid || undefined}
+          aria-describedby={ariaDescribedBy}
           disabled={disabled}
           className={cn(
             "inline-flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-left",

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.1.dev2"
+version = "0.5.1.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Tightens admin team, KB, Slack channel, and identity-sync ReBAC operations.\n- Updates admin operational panels and focused route/component coverage.

## Test plan

- [ ] Not run in this split pass; run affected admin UI/API tests before merge.

Made with [Cursor](https://cursor.com)