### PR TITLE
fix(rbac): remove legacy RAG group fallback wiring

### DIFF
--- a/scripts/migrations/0.5.0/RUN.md
+++ b/scripts/migrations/0.5.0/RUN.md
@@ -384,11 +384,6 @@ RBAC_DEFAULT_TEAM=platform
 
 # Skip the team-scope sync (useful for local dev without Keycloak)
 SKIP_TEAM_SCOPE_SYNC=0
-
-# OIDC group → role mapping (existing in 0.4.0; still required)
-RBAC_ADMIN_GROUPS=caipe_admin
-RBAC_READONLY_GROUPS=caipe_readonly
-RBAC_INGESTONLY_GROUPS=caipe_ingestonly
 ```
 
 ### Dynamic Agents

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -2880,8 +2880,7 @@ provision_ui_secret() {
     MONGODB_URI MONGODB_DATABASE MONGODB_ROOT_USERNAME MONGODB_ROOT_PASSWORD
     RAG_SERVER_URL PROMETHEUS_URL
     LANGFUSE_SECRET_KEY LANGFUSE_PUBLIC_KEY LANGFUSE_HOST
-    RBAC_ADMIN_GROUPS RBAC_READONLY_GROUPS RBAC_INGESTONLY_GROUPS
-    RBAC_DEFAULT_AUTHENTICATED_ROLE RBAC_CLIENT_CREDENTIALS_ROLE
+    RBAC_CLIENT_CREDENTIALS_ROLE
   )
 
   _create_secret_from_env "$ui_env_file" "caipe-ui-secret" caipe "${ui_keys[@]}"
@@ -3728,17 +3727,7 @@ post_deploy_patches() {
   # is healthy we disable the skip and restart RAG to run its full init checks.
   if $ENABLE_RAG; then
     _finalize_rag_startup
-    # Set RBAC_DEFAULT_ROLE=admin for anonymous/unauthenticated requests (no-SSO
-    # deployments). RBAC_DEFAULT_AUTHENTICATED_ROLE=readonly matches prod — group
-    # membership (RBAC_ADMIN_GROUPS) controls who gets admin.
-    kubectl set env deployment/rag-server -n caipe \
-      RBAC_DEFAULT_ROLE=admin \
-      RBAC_DEFAULT_AUTHENTICATED_ROLE=readonly &>/dev/null \
-      && log "rag-server: RBAC_DEFAULT_ROLE=admin, RBAC_DEFAULT_AUTHENTICATED_ROLE=readonly"
-
-    # Propagate OIDC config from caipe-ui-secret so RAG can validate tokens and
-    # check group membership for group-based RBAC (RBAC_ADMIN_GROUPS, etc.).
-    # Without this, RAG shows "No OIDC providers configured" and defaults to anonymous.
+    # Propagate OIDC config from caipe-ui-secret so RAG can validate tokens.
     # Also set OIDC_GROUP_CLAIM=members,groups to match prod group claim names.
     _rag_oidc_issuer=$(kubectl get secret caipe-ui-secret -n caipe \
       -o jsonpath='{.data.OIDC_ISSUER}' 2>/dev/null | base64 -d || true)
@@ -3748,8 +3737,6 @@ post_deploy_patches() {
       -o jsonpath='{.data.INGESTOR_OIDC_ISSUER}' 2>/dev/null | base64 -d || true)
     _rag_ingestor_client_id=$(kubectl get secret caipe-ui-secret -n caipe \
       -o jsonpath='{.data.INGESTOR_OIDC_CLIENT_ID}' 2>/dev/null | base64 -d || true)
-    _rag_admin_groups=$(kubectl get secret caipe-ui-secret -n caipe \
-      -o jsonpath='{.data.RBAC_ADMIN_GROUPS}' 2>/dev/null | base64 -d || true)
     if [[ -n "$_rag_oidc_issuer" && -n "$_rag_oidc_client_id" ]]; then
       local _rag_env_args=(
         "OIDC_ISSUER=$_rag_oidc_issuer"
@@ -3758,9 +3745,8 @@ post_deploy_patches() {
       )
       [[ -n "$_rag_ingestor_issuer" ]]    && _rag_env_args+=("INGESTOR_OIDC_ISSUER=$_rag_ingestor_issuer")
       [[ -n "$_rag_ingestor_client_id" ]] && _rag_env_args+=("INGESTOR_OIDC_CLIENT_ID=$_rag_ingestor_client_id")
-      [[ -n "$_rag_admin_groups" ]]       && _rag_env_args+=("RBAC_ADMIN_GROUPS=$_rag_admin_groups")
       kubectl set env deployment/rag-server -n caipe "${_rag_env_args[@]}" &>/dev/null \
-        && log "rag-server: OIDC providers configured (issuer=${_rag_oidc_issuer}, admin_groups=${_rag_admin_groups:-<unset>})"
+        && log "rag-server: OIDC providers configured (issuer=${_rag_oidc_issuer})"
     else
       log "rag-server: No OIDC config found in caipe-ui-secret — skipping OIDC patch (no-SSO deployment)"
     fi
@@ -4928,8 +4914,6 @@ DAEOF
       --set "caipe-ui.config.RAG_SERVER_URL=http://rag-server:${RAG_SERVER_PORT}"
       --set "rag-stack.rag-server.env.EMBEDDINGS_MODEL=${EMBEDDINGS_MODEL}"
       --set "rag-stack.rag-server.env.EMBEDDINGS_PROVIDER=${EMBEDDINGS_PROVIDER}"
-      --set 'rag-stack.rag-server.env.ALLOW_TRUSTED_NETWORK=true'
-      --set 'rag-stack.rag-server.env.TRUSTED_NETWORK_CIDRS=127.0.0.0/8\,10.0.0.0/8'
       --set 'rag-stack.milvus.cluster.enabled=false'
       --set 'rag-stack.milvus.standalone.disk.enabled=true'
       --set 'rag-stack.milvus.etcd.replicaCount=1'


### PR DESCRIPTION
## Summary

- Removes legacy RAG group fallback propagation from setup and migration docs.\n- Keeps local and Helm installs aligned with deny-by-default OpenFGA behavior.

## Test plan

- [ ] Not run in this split pass; review setup script behavior and migration docs before merge.

Made with [Cursor](https://cursor.com)