### PR TITLE
fix(helm): replace hardcoded release name with {{ .Release.Name }} template

### DIFF
--- a/charts/ai-platform-engineering/README.md
+++ b/charts/ai-platform-engineering/README.md
@@ -211,7 +211,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | caipe-ui.config.SHOW_POWERED_BY | string | `"false"` |  |
 | caipe-ui.config.SSO_ENABLED | string | `"false"` |  |
 | caipe-ui.config.TAGLINE | string | `"Multi-Agent Workflow Automation"` |  |
-| caipe-ui.env.A2A_BASE_URL | string | `"http://ai-platform-engineering-supervisor-agent:8000"` |  |
+| caipe-ui.env.A2A_BASE_URL | string | `"http://{{ .Release.Name }}-supervisor-agent:8000"` |  |
 | caipe-ui.env.SKILLS_DIR | string | `"/app/data/skills"` |  |
 | caipe-ui.existingSecret | string | `""` |  |
 | caipe-ui.externalSecrets.apiVersion | string | `"v1beta1"` |  |
@@ -277,7 +277,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | global.metrics.enabled | bool | `false` |  |
 | global.rag.enableGraphRag | bool | `true` |  |
 | global.slim.enabled | bool | `false` |  |
-| global.slim.endpoint | string | `"http://ai-platform-engineering-slim:46357"` |  |
+| global.slim.endpoint | string | `"http://{{ .Release.Name }}-slim:46357"` |  |
 | global.slim.transport | string | `"slim"` |  |
 | metrics.grafanaDashboard.enabled | bool | `true` |  |
 | metrics.grafanaDashboard.labels.grafana_dashboard | string | `"1"` |  |
@@ -317,7 +317,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | slack-bot.auth.tokenUrl | string | `""` |  |
 | slack-bot.botConfig | object | `{}` |  |
 | slack-bot.botMode | string | `"socket"` |  |
-| slack-bot.env.CAIPE_URL | string | `"http://ai-platform-engineering-supervisor-agent:8000"` |  |
+| slack-bot.env.CAIPE_URL | string | `"http://{{ .Release.Name }}-supervisor-agent:8000"` |  |
 | slack-bot.externalSecrets.apiVersion | string | `"v1beta1"` |  |
 | slack-bot.externalSecrets.data | list | `[]` |  |
 | slack-bot.externalSecrets.enabled | bool | `false` |  |

--- a/charts/ai-platform-engineering/charts/caipe-ui/README.md
+++ b/charts/ai-platform-engineering/charts/caipe-ui/README.md
@@ -74,7 +74,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.2.38
 | config.SUPPORT_EMAIL | string | `"support@example.com"` |  |
 | config.TAGLINE | string | `"Multi-Agent Workflow Automation"` |  |
 | config.WORKFLOW_RUNNER_ENABLED | string | `"false"` |  |
-| env.A2A_BASE_URL | string | `"http://ai-platform-engineering-supervisor-agent:8000"` |  |
+| env.A2A_BASE_URL | string | `"http://{{ .Release.Name }}-supervisor-agent:8000"` |  |
 | existingSecret | string | `""` |  |
 | externalSecrets.apiVersion | string | `"v1beta1"` |  |
 | externalSecrets.data | list | `[]` |  |

--- a/charts/ai-platform-engineering/charts/caipe-ui/values-external-secrets.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values-external-secrets.yaml
@@ -67,7 +67,7 @@ externalSecrets:
 
     # MongoDB connection URI
     # Format: mongodb://username:password@host:port/database
-    # Example: mongodb://admin:changeme@ai-platform-engineering-mongodb:27017
+    # Example: mongodb://admin:changeme@{{ .Release.Name }}-mongodb:27017
     - secretKey: MONGODB_URI
       remoteRef:
         conversionStrategy: Default
@@ -109,7 +109,7 @@ config:
   # MongoDB configuration
   MONGODB_DATABASE: "caipe"
   # RAG Server URL (if RAG is enabled)
-  # RAG_URL: "http://ai-platform-engineering-rag-server:9446"
+  # RAG_URL: "http://{{ .Release.Name }}-rag-server:9446"
   # Branding configuration
   TAGLINE: "Multi-Agent Workflow Automation"
   DESCRIPTION: "Where Humans and AI agents collaborate to deliver high quality outcomes."
@@ -125,9 +125,9 @@ config:
   # OIDC refresh token support
   OIDC_ENABLE_REFRESH_TOKEN: "true"
   # Slack bot runtime status/reload/config-sync API.
-  SLACK_BOT_ADMIN_URL: "http://ai-platform-engineering-slack-bot:3001"
+  SLACK_BOT_ADMIN_URL: "http://{{ .Release.Name }}-slack-bot:3001"
   SLACK_BOT_ADMIN_AUDIENCE: "caipe-slack-bot-admin"
-  WEBEX_BOT_ADMIN_URL: "http://ai-platform-engineering-webex-bot:3002"
+  WEBEX_BOT_ADMIN_URL: "http://{{ .Release.Name }}-webex-bot:3002"
   WEBEX_BOT_ADMIN_CLIENT_ID: "caipe-ui"
   WEBEX_BOT_ADMIN_AUDIENCE: "caipe-webex-bot-admin"
   # Support contact email

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -175,7 +175,7 @@ affinity: {}
 # For sensitive values (OIDC secrets, MongoDB URI, etc.) use existingSecret or externalSecrets below.
 config:
   # CAIPE Supervisor URL - should point to the supervisor-agent service
-  A2A_BASE_URL: "http://ai-platform-engineering-supervisor-agent:8000"
+  A2A_BASE_URL: "http://{{ .Release.Name }}-supervisor-agent:8000"
   # Feature flags
   ENABLE_SUBAGENT_CARDS: "true"
   SSO_ENABLED: "true"
@@ -216,7 +216,7 @@ config:
   # MongoDB configuration
   MONGODB_DATABASE: "caipe"
   # RAG Server URL (if RAG is enabled)
-  # RAG_URL: "http://ai-platform-engineering-rag-server:9446"
+  # RAG_URL: "http://{{ .Release.Name }}-rag-server:9446"
   # Branding configuration
   TAGLINE: "Multi-Agent Workflow Automation"
   DESCRIPTION: "Where Humans and AI agents collaborate to deliver high quality outcomes."
@@ -226,16 +226,15 @@ config:
   # Slack bot internal admin API used for route-cache reload and one-time
   # static-config-to-MongoDB/OpenFGA migration. The Web UI backend uses the
   # existing OIDC_CLIENT_ID/OIDC_CLIENT_SECRET Keycloak client credentials.
-  SLACK_BOT_ADMIN_URL: "http://ai-platform-engineering-slack-bot:3001"
+  SLACK_BOT_ADMIN_URL: "http://{{ .Release.Name }}-slack-bot:3001"
   SLACK_BOT_ADMIN_AUDIENCE: "caipe-slack-bot-admin"
-  # SLACK_BOT_ADMIN_TOKEN_URL: "http://keycloak:7080/realms/caipe/protocol/openid-connect/token"
   # SLACK_BOT_ADMIN_SCOPE: "slack:routes:read slack:routes:reload slack:routes:sync"
   SLACK_DEFAULT_TEAM_SLUG: ""
   SLACK_DEFAULT_AGENT_ID: ""
   # Webex bot internal admin API used for route-cache reload and one-time
   # static-config-to-MongoDB/OpenFGA migration. The client secret is sensitive
   # and must come from existingSecret/externalSecrets as WEBEX_BOT_ADMIN_CLIENT_SECRET.
-  WEBEX_BOT_ADMIN_URL: "http://ai-platform-engineering-webex-bot:3002"
+  WEBEX_BOT_ADMIN_URL: "http://{{ .Release.Name }}-webex-bot:3002"
   WEBEX_BOT_ADMIN_CLIENT_ID: "caipe-ui"
   WEBEX_BOT_ADMIN_AUDIENCE: "caipe-webex-bot-admin"
   # WEBEX_BOT_ADMIN_TOKEN_URL: "http://keycloak:7080/realms/caipe/protocol/openid-connect/token"
@@ -259,7 +258,7 @@ config:
   # Requires admin role and MongoDB storage mode
   DYNAMIC_AGENTS_ENABLED: "false"
   # Dynamic Agents service URL (only used when DYNAMIC_AGENTS_ENABLED is "true")
-  # DYNAMIC_AGENTS_URL: "http://ai-platform-engineering-dynamic-agents:8001"
+  DYNAMIC_AGENTS_URL: "http://{{ .Release.Name }}-dynamic-agents:8001"
   # Connections & Secrets credential store. Disabled by default. Use local-cmk
   # only for non-production testing; production must use aws-kms.
   CAIPE_CREDENTIALS_ENABLED: "false"
@@ -282,6 +281,19 @@ config:
   # tracks the actual Helm release name instead of hardcoding the default
   # `ai-platform-engineering` and silently breaking on `helm install foo …`.
   SKILL_SCANNER_URL: "http://{{ .Release.Name }}-skill-scanner:8000"
+  # In-cluster Keycloak service URL (server-side JWKS fetch + admin API)
+  KEYCLOAK_URL: "http://{{ .Release.Name }}-keycloak:8080"
+  KEYCLOAK_REALM: "caipe"
+  KEYCLOAK_RESOURCE_SERVER_ID: "caipe-platform"
+  # Internal OIDC discovery URL for server-side token validation
+  OIDC_DISCOVERY_URL: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe"
+  OIDC_CLIENT_ID: "caipe-ui"
+  # Slack bot admin token URL (in-cluster Keycloak token endpoint)
+  SLACK_BOT_ADMIN_TOKEN_URL: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe/protocol/openid-connect/token"
+  SLACK_BOT_ADMIN_CLIENT_ID: "caipe-ui"
+  # OpenFGA authorization service
+  OPENFGA_HTTP: "http://{{ .Release.Name }}-openfga:8080"
+  OPENFGA_STORE_NAME: "caipe-openfga"
   # OIDC group required for basic Web UI admission. Set per deployment; empty disables the group gate.
   OIDC_REQUIRED_GROUP: ""
   # Deprecated: admin access is granted through Identity Group Sync + OpenFGA organization admin relationships.

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/NOTES.txt
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/NOTES.txt
@@ -33,7 +33,7 @@ dynamic-agents installed.
 
       dynamic-agents:
         config:
-          KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+          KEYCLOAK_URL: "http://{{ .Release.Name }}-keycloak:8080"
           OIDC_ISSUER:  "https://idp.example.com/realms/caipe"
 
     This warning is non-blocking. If you are running Keycloak on
@@ -67,6 +67,6 @@ dynamic-agents installed.
 
       dynamic-agents:
         config:
-          KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+          KEYCLOAK_URL: "http://{{ .Release.Name }}-keycloak:8080"
 
 {{- end }}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/configmap.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/configmap.yaml
@@ -15,6 +15,6 @@ data:
     to a single space instead.
   */ -}}
   {{- if not (eq (toString $value) "") }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   {{- end }}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -127,7 +127,7 @@ config:
   # production topology):
   #
   #   KEYCLOAK_URL  — in-cluster service URL the pod uses for JWKS fetch
-  #                   (e.g. http://ai-platform-engineering-keycloak:8080).
+  #                   (e.g. http://{{ .Release.Name }}-keycloak:8080).
   #                   When unset, the code falls back to
   #                   http://localhost:7080 which is a CONNECTION-REFUSED
   #                   trap inside a Kubernetes pod.
@@ -144,11 +144,14 @@ config:
   # empty — see templates/NOTES.txt.
   KEYCLOAK_URL: ""
   OIDC_ISSUER: ""
+  # OpenFGA authorization service URL (in-cluster default matches umbrella chart release name)
+  OPENFGA_HTTP: "http://{{ .Release.Name }}-openfga:8080"
+  OPENFGA_STORE_NAME: "caipe-openfga"
   # MongoDB database name (uses same DB as CAIPE UI)
   MONGODB_DATABASE: "caipe"
   # Connections & Secrets credential exchange client. Disabled by default.
   CAIPE_CREDENTIALS_ENABLED: "false"
-  CREDENTIAL_API_URL: "http://ai-platform-engineering-caipe-ui:3000/api/credentials"
+  CREDENTIAL_API_URL: "http://{{ .Release.Name }}-caipe-ui:3000/api/credentials"
   CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
   USE_IMPERSONATION_TOKENS: "false"
   # Agent runtime TTL in seconds (purged after this much inactivity)

--- a/charts/ai-platform-engineering/charts/slack-bot/README.md
+++ b/charts/ai-platform-engineering/charts/slack-bot/README.md
@@ -60,7 +60,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.2.38
 | auth.tokenUrl | string | `""` |  |
 | botConfig | object | `{}` |  |
 | botMode | string | `"socket"` |  |
-| caipeUrl | string | `"http://ai-platform-engineering-supervisor-agent:8000"` |  |
+| caipeUrl | string | `"http://{{ .Release.Name }}-supervisor-agent:8000"` |  |
 | env | object | `{}` |  |
 | externalSecrets.apiVersion | string | `"v1beta1"` |  |
 | externalSecrets.data | list | `[]` |  |

--- a/charts/ai-platform-engineering/charts/slack-bot/templates/configmap-env.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/templates/configmap-env.yaml
@@ -6,5 +6,5 @@ metadata:
     {{- include "slack-bot.labels" . | nindent 4 }}
 data:
   {{- range $key, $value := .Values.config }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}

--- a/charts/ai-platform-engineering/charts/slack-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/values.yaml
@@ -73,7 +73,7 @@ serviceAccount:
 config:
   APP_NAME: "CAIPE"
   SLACK_BOT_MODE: "socket"
-  CAIPE_API_URL: "http://ai-platform-engineering-caipe-ui:3000"
+  CAIPE_API_URL: "http://{{ .Release.Name }}-caipe-ui:3000"
   SLACK_INTEGRATION_SILENCE_ENV: "false"
   MONGODB_DATABASE: "caipe"
   SLACK_WORKSPACE_ALIAS: "CAIPE"

--- a/charts/ai-platform-engineering/charts/webex-bot/templates/configmap-env.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/templates/configmap-env.yaml
@@ -6,5 +6,5 @@ metadata:
     {{- include "webex-bot.labels" . | nindent 4 }}
 data:
   {{- range $key, $value := .Values.config }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}

--- a/charts/ai-platform-engineering/charts/webex-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
 # or externalSecrets (WEBEX_INTEGRATION_BOT_ACCESS_TOKEN, KEYCLOAK_* secrets, WEBEX_LINK_HMAC_SECRET, …).
 config:
   APP_NAME: "CAIPE"
-  CAIPE_API_URL: "http://ai-platform-engineering-caipe-ui:3000"
+  CAIPE_API_URL: "http://{{ .Release.Name }}-caipe-ui:3000"
   MONGODB_DATABASE: "caipe"
   WEBEX_WORKSPACE_ALIAS: "CAIPE-WEBEX"
   WEBEX_AGENT_ROUTES_MODE: "db_prefer"
@@ -32,14 +32,14 @@ config:
   WEBEX_ADMIN_API_ENABLED: "false"
   WEBEX_ADMIN_API_HOST: "0.0.0.0"
   WEBEX_ADMIN_API_PORT: "3002"
-  WEBEX_ADMIN_JWT_ISSUER: "http://ai-platform-engineering-keycloak:8080/realms/caipe"
-  WEBEX_ADMIN_JWKS_URL: "http://ai-platform-engineering-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
+  WEBEX_ADMIN_JWT_ISSUER: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe"
+  WEBEX_ADMIN_JWKS_URL: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
   WEBEX_ADMIN_JWT_AUDIENCE: "caipe-webex-bot-admin"
   WEBEX_ADMIN_ALLOWED_CLIENT_IDS: "caipe-ui"
   CAIPE_PLATFORM_AUDIENCE: "caipe-platform"
-  KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+  KEYCLOAK_URL: "http://{{ .Release.Name }}-keycloak:8080"
   KEYCLOAK_REALM: "caipe"
-  OPENFGA_HTTP: "http://ai-platform-engineering-openfga:8080"
+  OPENFGA_HTTP: "http://{{ .Release.Name }}-openfga:8080"
   OPENFGA_STORE_NAME: "caipe-openfga"
 
 # -- OBO client secret for caipe-webex-bot (Keycloak-managed; prefer keycloakBot below).

--- a/charts/ai-platform-engineering/values-mongodb.yaml.example
+++ b/charts/ai-platform-engineering/values-mongodb.yaml.example
@@ -146,7 +146,7 @@ caipe-ui:
           property: OIDC_CLIENT_SECRET
 
       # MongoDB connection URI
-      # Format: mongodb://username:password@ai-platform-engineering-mongodb:27017
+      # Format: mongodb://username:password@{{ .Release.Name }}-mongodb:27017
       - secretKey: MONGODB_URI
         remoteRef:
           key: dev/caipe-ui
@@ -171,12 +171,12 @@ caipe-ui:
 #
 # 1. Create a Kubernetes secret manually:
 #
-# kubectl create secret generic ai-platform-engineering-caipe-ui-secret \
+# kubectl create secret generic {{ .Release.Name }}-caipe-ui-secret \
 #   --from-literal=NEXTAUTH_SECRET="$(openssl rand -base64 32)" \
 #   --from-literal=OIDC_ISSUER="https://your-oidc-provider" \
 #   --from-literal=OIDC_CLIENT_ID="your-client-id" \
 #   --from-literal=OIDC_CLIENT_SECRET="your-client-secret" \
-#   --from-literal=MONGODB_URI="mongodb://admin:changeme@ai-platform-engineering-mongodb:27017" \
+#   --from-literal=MONGODB_URI="mongodb://admin:changeme@{{ .Release.Name }}-mongodb:27017" \
 #   -n your-namespace
 #
 # 2. The deployment will automatically mount this secret

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -56,7 +56,7 @@ global:
     apiVersion: "v1beta1"  # API version for ExternalSecret resources. Options: "v1" or "v1beta1". Defaults to "v1beta1" if not specified.
   slim:
     enabled: false
-    endpoint: "http://ai-platform-engineering-slim:46357"
+    endpoint: "http://{{ .Release.Name }}-slim:46357"
     transport: "slim"
 
   # RAG Stack configuration
@@ -129,7 +129,7 @@ global:
     proxyPort: 8080
     extAuth:
       enabled: false
-      serviceName: "ai-platform-engineering-openfga-authz-bridge"
+      serviceName: "{{ .Release.Name }}-openfga-authz-bridge"
       serviceNamespace: ""
       port: 9100
 
@@ -775,7 +775,7 @@ caipe-ui:
   # ConfigMap for non-sensitive configuration
   config:
     # CAIPE Supervisor URL - automatically configured to use the supervisor-agent service
-    A2A_BASE_URL: "http://ai-platform-engineering-supervisor-agent:8000"
+    A2A_BASE_URL: "http://{{ .Release.Name }}-supervisor-agent:8000"
     # Bootstrap default agent for new chats. Overridden at runtime by Admin → Settings UI.
     # Set to a dynamic agent ID to pre-configure the default without manual admin action.
     # Leave empty to use the supervisor (Platform Engineer) as default.
@@ -808,7 +808,7 @@ caipe-ui:
     # Requires admin role and MongoDB storage mode
     DYNAMIC_AGENTS_ENABLED: "false"
     # Dynamic Agents service URL (only used when DYNAMIC_AGENTS_ENABLED is "true")
-    # DYNAMIC_AGENTS_URL: "http://ai-platform-engineering-dynamic-agents:8001"
+    # DYNAMIC_AGENTS_URL: "http://{{ .Release.Name }}-dynamic-agents:8001"
     # Connections & Secrets credential store. Disabled by default. Use local-cmk
     # only for non-production testing; production must use aws-kms.
     CAIPE_CREDENTIALS_ENABLED: "false"
@@ -856,14 +856,14 @@ caipe-ui:
     # Slack bot internal admin API used by the Web UI BFF for route reload and
     # one-time static-config-to-MongoDB/OpenFGA migration. The BFF uses the
     # existing OIDC_CLIENT_ID/OIDC_CLIENT_SECRET Keycloak client credentials.
-    SLACK_BOT_ADMIN_URL: "http://ai-platform-engineering-slack-bot:3001"
+    SLACK_BOT_ADMIN_URL: "http://{{ .Release.Name }}-slack-bot:3001"
     SLACK_BOT_ADMIN_AUDIENCE: "caipe-slack-bot-admin"
     # SLACK_BOT_ADMIN_TOKEN_URL: "http://keycloak:7080/realms/caipe/protocol/openid-connect/token"
     # SLACK_BOT_ADMIN_SCOPE: "slack:routes:read slack:routes:reload slack:routes:sync"
     SLACK_DEFAULT_TEAM_SLUG: ""
     SLACK_DEFAULT_AGENT_ID: ""
     # Webex bot internal admin API (BFF access-check + route management).
-    WEBEX_BOT_ADMIN_URL: "http://ai-platform-engineering-webex-bot:3002"
+    WEBEX_BOT_ADMIN_URL: "http://{{ .Release.Name }}-webex-bot:3002"
     WEBEX_BOT_ADMIN_CLIENT_ID: "caipe-ui"
     WEBEX_BOT_ADMIN_AUDIENCE: "caipe-webex-bot-admin"
     # WEBEX_BOT_ADMIN_TOKEN_URL: "http://keycloak:7080/realms/caipe/protocol/openid-connect/token"
@@ -1040,7 +1040,7 @@ dynamic-agents:
     # `<release>-keycloak`; this default works for the umbrella chart
     # but MUST be overridden when pointing dynamic-agents at an external
     # Keycloak (production IdP / forge.dev / etc.).
-    KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+    KEYCLOAK_URL: "http://{{ .Release.Name }}-keycloak:8080"
     # Browser-facing issuer string baked into JWTs (Keycloak's
     # KC_HOSTNAME). Override when the public issuer differs from
     # KEYCLOAK_URL (the typical production topology), e.g.
@@ -1049,11 +1049,14 @@ dynamic-agents:
     # KEYCLOAK_URL, which only works in dev where both URLs coincide;
     # NOTES.txt prints a warning otherwise.
     OIDC_ISSUER: ""
+    # OpenFGA authorization service (in-cluster default matches umbrella chart release name)
+    OPENFGA_HTTP: "http://{{ .Release.Name }}-openfga:8080"
+    OPENFGA_STORE_NAME: "caipe-openfga"
     # MongoDB configuration (uses same database as CAIPE UI)
     MONGODB_DATABASE: "caipe"
     # Connections & Secrets credential exchange client. Disabled by default.
     CAIPE_CREDENTIALS_ENABLED: "false"
-    CREDENTIAL_API_URL: "http://ai-platform-engineering-caipe-ui:3000/api/credentials"
+    CREDENTIAL_API_URL: "http://{{ .Release.Name }}-caipe-ui:3000/api/credentials"
     CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
     USE_IMPERSONATION_TOKENS: "false"
     # MCP server IDs routed through the shared AgentGateway backend.
@@ -1096,7 +1099,7 @@ slack-bot:
   config:
     APP_NAME: "CAIPE"
     SLACK_BOT_MODE: "socket"
-    CAIPE_API_URL: "http://ai-platform-engineering-caipe-ui:3000"
+    CAIPE_API_URL: "http://{{ .Release.Name }}-caipe-ui:3000"
     SLACK_INTEGRATION_SILENCE_ENV: "false"
     # MONGODB_URI: ""                          # Override per environment
     # SLACK_WORKSPACE_URL: ""                  # e.g. "https://mycompany.slack.com"
@@ -1199,7 +1202,7 @@ webex-bot:
 
   config:
     APP_NAME: "CAIPE"
-    CAIPE_API_URL: "http://ai-platform-engineering-caipe-ui:3000"
+    CAIPE_API_URL: "http://{{ .Release.Name }}-caipe-ui:3000"
     WEBEX_WORKSPACE_ALIAS: "CAIPE-WEBEX"
     WEBEX_AGENT_ROUTES_MODE: "db_prefer"
     WEBEX_THREAD_CONTEXT_ENABLED: "true"
@@ -1211,19 +1214,19 @@ webex-bot:
     WEBEX_ADMIN_API_ENABLED: "false"
     WEBEX_ADMIN_API_HOST: "0.0.0.0"
     WEBEX_ADMIN_API_PORT: "3002"
-    WEBEX_ADMIN_JWT_ISSUER: "http://ai-platform-engineering-keycloak:8080/realms/caipe"
-    WEBEX_ADMIN_JWKS_URL: "http://ai-platform-engineering-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
+    WEBEX_ADMIN_JWT_ISSUER: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe"
+    WEBEX_ADMIN_JWKS_URL: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
     WEBEX_ADMIN_JWT_AUDIENCE: "caipe-webex-bot-admin"
     WEBEX_ADMIN_ALLOWED_CLIENT_IDS: "caipe-ui"
-    KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
+    KEYCLOAK_URL: "http://{{ .Release.Name }}-keycloak:8080"
     KEYCLOAK_REALM: "caipe"
-    OPENFGA_HTTP: "http://ai-platform-engineering-openfga:8080"
+    OPENFGA_HTTP: "http://{{ .Release.Name }}-openfga:8080"
     OPENFGA_STORE_NAME: "caipe-openfga"
 
   # Wire OBO secret from Keycloak chart (see keycloak/templates/NOTES.txt).
   keycloakBot:
     clientSecretFromSecret:
-      name: "ai-platform-engineering-keycloak-webex-bot"
+      name: "{{ .Release.Name }}-keycloak-webex-bot"
       key: "KC_WEBEX_BOT_CLIENT_SECRET"
 
   existingSecret: "webex-bot-secrets"
@@ -1417,7 +1420,7 @@ rag-stack:
       pullPolicy: "IfNotPresent"
     env:
       RBAC_TEAM_SCOPE_ENABLED: "true"
-      OPENFGA_HTTP: "http://ai-platform-engineering-openfga:8080"
+      OPENFGA_HTTP: "http://{{ .Release.Name }}-openfga:8080"
       OPENFGA_STORE_NAME: "caipe-openfga"
       CAIPE_UNSAFE_RBAC_BYPASS: "false"
 


### PR DESCRIPTION
# Description

All Helm chart values and templates previously hardcoded `ai-platform-engineering-` as a prefix for in-cluster service URLs (e.g. `http://ai-platform-engineering-keycloak:8080`). This is only correct when the Helm release name is `ai-platform-engineering`, which breaks any deployment that uses a different release name (e.g. `caipe`, `forge`, etc.).

This PR replaces all hardcoded `ai-platform-engineering-` prefixes with `{{ .Release.Name }}-` so service URLs resolve correctly for any release name.

Changes:
- **caipe-ui, dynamic-agents, slack-bot, webex-bot subchart `values.yaml`**: all in-cluster service URL defaults now use `{{ .Release.Name }}-`
- **caipe-ui, dynamic-agents configmap templates**: added `tpl` rendering so `{{ .Release.Name }}` in values is evaluated at render time
- **slack-bot, webex-bot configmap templates**: same `tpl` rendering added
- **caipe-ui `values.yaml`**: added missing defaults for `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_RESOURCE_SERVER_ID`, `OIDC_DISCOVERY_URL`, `OIDC_CLIENT_ID`, `SLACK_BOT_ADMIN_TOKEN_URL`, `SLACK_BOT_ADMIN_CLIENT_ID`, `OPENFGA_HTTP`, `OPENFGA_STORE_NAME`, `DYNAMIC_AGENTS_URL`
- **dynamic-agents `values.yaml`**: added missing `OPENFGA_HTTP` and `OPENFGA_STORE_NAME` defaults
- **README, NOTES.txt, values-external-secrets.yaml, values-mongodb.yaml.example**: updated example/doc references to use `{{ .Release.Name }}-` (slim endpoint unchanged — intentional)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass