### PR TITLE
feat(slack): redesign admin Slack onboarding into Configured/Onboard/Advanced tabs

### DIFF
--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -743,6 +743,7 @@ describe('Admin Dashboard Page', () => {
         'Default Agent',
         'Release notes',
         'AI Review',
+        'Credentials',
         'Knowledge Bases',
         'Skills',
       ]);

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -637,9 +637,11 @@ describe("Slack channel ReBAC APIs", () => {
     });
     expect(body.data.warnings).toEqual(
       expect.arrayContaining([
-        expect.stringMatching(/Plain channel messages will be ignored/i),
         expect.stringMatching(/stale-mongo-agent.*OpenFGA tuple is missing/i),
       ])
+    );
+    expect(body.data.warnings).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/Plain channel messages will be ignored/i)])
     );
   });
 

--- a/ui/src/hooks/__tests__/use-admin-role.test.ts
+++ b/ui/src/hooks/__tests__/use-admin-role.test.ts
@@ -38,6 +38,7 @@ describe('useAdminRole', () => {
     mockGetConfig = {
       ssoEnabled: false,
       allowDevAdminWhenSsoDisabled: true,
+      unsafeRbacBypassEnabled: true,
       storageMode: 'mongodb',
     };
 
@@ -345,6 +346,7 @@ describe('useAdminRole — canViewAdmin', () => {
     mockGetConfig = {
       ssoEnabled: false,
       allowDevAdminWhenSsoDisabled: true,
+      unsafeRbacBypassEnabled: true,
       storageMode: 'mongodb',
     };
 
@@ -485,6 +487,7 @@ describe('useAdminRole — canAccessDynamicAgents', () => {
     mockGetConfig = {
       ssoEnabled: false,
       allowDevAdminWhenSsoDisabled: true,
+      unsafeRbacBypassEnabled: true,
       storageMode: 'mongodb',
     };
 


### PR DESCRIPTION
# Description

Reorganizes the **Admin → Integrations → Slack** panel from a single sprawling page into three sub-tabs: **Configured channels**, **Onboard channels**, and **Advanced**.

**Configured channels (default)**
- Tabular layout with columns: Channel · Team · Agents · Health.
- Health is fetched once via a new `?health=1` summary on `/api/admin/slack/channels` (warnings count, OpenFGA reachability, last runtime error timestamp). Per-row health is the same signal whether the row is expanded or not.
- Click a row to inline-expand it: the full diagnostics + agents form collapse below the row instead of in separate boxes.
- No row is auto-selected on page load.
- Table scrolls dynamically (`max-height: min(70vh, 100vh - 320px)`) — sizes to content for small lists.
- The "Heads up: every member of team:X" cascade warning is removed (it described the design contract, not an actionable risk).
- Inline errors now toast as well so 502s aren't silent.

**Onboard channels**
- Defaults selector (team + agent + create-routes toggle) followed by the discovery wizard. Defaults are pre-fill convenience and have their own Save button — no longer required to onboard channels.
- Wizard gains a search box, bulk team/agent apply across selected rows, friendlier status copy ("Configured" / "Ready to set up" / "Pick team and agent" / "Pick a team" / "Pick an agent"), and shorter button labels.
- Per-row agent control is now a searchable `AgentPicker` (mirrors `TeamPicker`).
- Discovery no longer auto-selects rows — admins opt in deliberately.
- The alphabetical-fallback agent default is removed; rows stay blank until the admin picks.
- The `Routes: …` hint badge is removed.

**Advanced**
- The one-time YAML import + runtime status / cache reload / sync modal lives here, isolated from primary onboarding.

**Diagnostics changes**
- Listen-mode warnings (`only listens to mentions` / `plain messages`) are gone — listen mode is what the admin chose, not a problem.
- New ambiguity check: warns when two enabled OpenFGA-backed routes match the same message type at the same priority (the bot picks non-deterministically).
- `diagnosticRouteIsFixable` only covers genuine config drift now (route metadata exists but OpenFGA tuple is missing).

**Slack bot quality-of-life**
- Startup no longer dumps the full parsed config JSON; it logs just the channel count.
- Silent no-op handlers added for `assistant_thread_started`, `assistant_thread_context_changed`, and `app_home_opened` to stop the slack_bolt "Unhandled request" suggestion spam.

**Other**
- `slack-channel-diagnostics.ts` extracts the diagnostics computation so the list endpoint and the per-channel endpoint share one source of truth.
- Tests updated for the new tab + table layout (40 panel tests passing).
- This PR is stacked on top of \`prebuild/local-dev-auth-provider\`; merge that first.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [x] Refactor
- [x] Documentation
- [ ] Breaking Change
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with \`pre/\` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the \`helm-prerelease\` label
- Pre-release charts are published to \`ghcr.io/cnoe-io/pre-release-helm-charts\`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass