### PR TITLE
fix(rag): bump twisted to 26.4.0 to fix DNS compression DoS (GHSA-grgv-6hw6-v9g4)

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/pyproject.toml
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests==2.33.0",
     "scrapy==2.16.0",
     "slack-sdk==3.38.0",
-    "twisted==25.5.0",
+    "twisted==26.4.0",
 ]
 
 [project.optional-dependencies]

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
@@ -930,7 +930,7 @@ requires-dist = [
     { name = "scrapy", specifier = "==2.16.0" },
     { name = "scrapy-playwright", marker = "extra == 'playwright'", specifier = "==0.0.46" },
     { name = "slack-sdk", specifier = "==3.38.0" },
-    { name = "twisted", specifier = "==25.5.0" },
+    { name = "twisted", specifier = "==26.4.0" },
 ]
 provides-extras = ["playwright", "dev"]
 
@@ -2638,7 +2638,7 @@ wheels = [
 
 [[package]]
 name = "twisted"
-version = "25.5.0"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2649,9 +2649,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/0f/82716ed849bf7ea4984c21385597c949944f0f9b428b5710f79d0afc084d/twisted-25.5.0.tar.gz", hash = "sha256:1deb272358cb6be1e3e8fc6f9c8b36f78eb0fa7c2233d2dbe11ec6fee04ea316", size = 3545725, upload-time = "2025-06-07T09:52:24.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/66/ab7efd8941f0bc7b2bd555b0f0471bff77df4c88e0cc31120c82737fec77/twisted-25.5.0-py3-none-any.whl", hash = "sha256:8559f654d01a54a8c3efe66d533d43f383531ebf8d81d9f9ab4769d91ca15df7", size = 3204767, upload-time = "2025-06-07T09:52:21.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps the pinned `twisted` dependency in the RAG **ingestors** image from `25.5.0` to `26.4.0`.
- Resolves code-scanning alerts **#13704** and **#13690** — **GHSA-grgv-6hw6-v9g4**: a Denial of Service in `twisted.names` via crafted DNS compression pointer chains, affecting `twisted <= 25.5.0`.
- `26.4.0` is the first patched **stable** release (advisory lists `26.4.0rc2` as first patched; `26.4.0` is now on PyPI).
- Compatible with the existing `scrapy==2.16.0` pin (`scrapy` requires `twisted>=21.7.0`).
- `uv.lock` re-locked with **no transitive churn** — only the `twisted` entry changed (version + hashes).

## Context

Surfaced by the Grype container scan on `cnoe-io/ai-platform-engineering`. This is one of several open dependency alerts; the others are tracked separately:
- AWS CLI bundled-Python criticals (CVE-2026-7210 / CVE-2026-6100) — no upstream AWS CLI fix yet (`2.34.56` is latest).
- `ecdsa` Minerva timing attack (GHSA-wj6h-64fc-37mp) — upstream `firstPatchedVersion` is null (won-fix); needs a dependency removal or risk acceptance.

## Test plan

- [ ] `uv lock --check` passes in `ai_platform_engineering/knowledge_bases/rag/ingestors`
- [ ] Ingestors image builds (prebuild CI)
- [ ] Ingestor smoke test (scrapy-based crawl path still functions)
- [ ] Grype rescan confirms GHSA-grgv-6hw6-v9g4 cleared

> Note: DCO sign-off pending — maintainer to add `Signed-off-by` (commit currently carries only the `Assisted-by` trailer per repo AI-attribution policy).
