### PR TITLE
fix(slack): fall back to event username for cross-workspace bots

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -774,6 +774,11 @@ def handle_message_events(body, say, client):
   bot_username = None
   if is_bot:
     bot_username = utils.get_username_by_bot_id(bot_id)
+    if not bot_username:
+      logger.warning(f"bots.info lookup failed for bot_id={bot_id}, falling back to event username")
+      bot_username = event.get("username")
+      if not bot_username:
+        logger.warning(f"event.get('username') also returned nothing for bot_id={bot_id}; bot_list filtering may not work correctly")
 
   sender_user_id = event.get("user") if not is_bot else None
   matches = _match_agents(channel_config, is_bot=is_bot, bot_username=bot_username, user_id=sender_user_id, listen="message")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18+hotfix.3"
+version = "0.4.18+hotfix.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18+hotfix.3"
+version = "0.4.18+hotfix.4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- \`bots.info\` returns \`bot_not_found\` for bots belonging to an external workspace — causing \`get_username_by_bot_id\` to return \`""\`, which fails \`bot_list\` filtering and silently drops workflow bot messages
- Fall back to \`event.get("username")\` when \`bots.info\` fails — the event payload already carries the correct display name
- Added warning logs when both lookups fail for observability

## Root Cause

When a Slack Workflow Builder bot belongs to a different workspace than the one the bot token is scoped to, \`bots.info\` returns \`{"ok": false, "error": "bot_not_found"}\`. This causes \`get_username_by_bot_id\` to return \`""\`, which then fails the \`bot_list\` membership check:

```python
# bot_list = ["My Workflow Bot"]
# bot_username = ""  ← bots.info failed
"" not in ["My Workflow Bot"]  # → True → message dropped
```

## Evidence

**Calling \`bots.info\` for a cross-workspace workflow bot:**
```json
POST https://slack.com/api/bots.info
{ "bot": "B0EXAMPLEID1" }

→ { "ok": false, "error": "bot_not_found" }
```

**The raw Slack event already has the name we need:**
```json
{
  "subtype": "bot_message",
  "username": "My Workflow Bot",
  "bot_id": "B0EXAMPLEID1",
  "workflow_id": "Wf0EXAMPLE123",
  "bot_profile": {
    "name": "My Workflow Bot",
    "team_id": "T0EXTERNALWKS",
    "is_workflow_bot": true
  }
}
```

**Channel config expecting \`bot_list\` to work:**
```yaml
bots:
  enabled: true
  listen: message
  bot_list:
    - My Workflow Bot
```

Before this fix: \`bot_username = ""\` → filtered out.
After this fix: \`bot_username = "My Workflow Bot"\` → passes filter.

**Channels with no \`bot_list\` were unaffected** — the filter is skipped entirely when \`bot_list\` is \`None\`, so those channels already worked.

## Test plan

- [ ] Verify a cross-workspace Slack Workflow Builder bot message passes \`bot_list\` filtering correctly
- [ ] Confirm warning log appears when \`bots.info\` returns \`bot_not_found\`
- [ ] Confirm channels with no \`bot_list\` are unaffected