### PR TITLE
fix(rag): migrate rag-server image to wolfi-base

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server
@@ -49,19 +49,38 @@ RUN find /app/server/.venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/
     find /app/server/.venv -type d -name "include" -path "*/site-packages/*" -exec rm -rf {} + 2>/dev/null || true
 
 
-# Then, use a final image without uv
-FROM python:3.13-slim-bookworm
-# It is important to use the image that matches the builder, as the path to the
-# Python executable must be the same, e.g., using `python:3.13-slim-bookworm`
-# will fail.
+# ---------- Stage 2: Final runtime image ----------
+# Wolfi (Chainguard) base: continuously patched, glibc-based packages with ~0
+# CVEs. Replaces python:3.13-slim-bookworm to eliminate the Debian
+# system-package CVEs (perl-base, libtiff6, krb5, systemd, libgcrypt20, etc.)
+# and the base interpreter/pip CVEs. Mirrors build/agents/Dockerfile.a2a.
+FROM cgr.dev/chainguard/wolfi-base
 
-# Patch system packages to address CVEs
-RUN apt-get update && apt-get upgrade -y --no-install-recommends \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Override APK repo to public Wolfi OS packages (no auth required).
+# cgr.dev/chainguard/wolfi-base defaults to apk.cgr.dev/chainguard which
+# requires Chainguard credentials; packages.wolfi.dev/os is free and public.
+RUN echo "https://packages.wolfi.dev/os" > /etc/apk/repositories
 
-# Create a non-root user
-RUN groupadd --gid 1001 app && \
-    useradd --uid 1001 --gid app --shell /bin/bash --create-home app
+# glibc-based Python 3.13 (matches the builder ABI so manylinux wheels such as
+# pymilvus/grpcio, pyarrow and numpy load correctly).
+# `ca-certificates-bundle` ensures outbound TLS (embeddings/LLM) works; `shadow`
+# provides useradd/groupadd. Retry to tolerate transient mirror blips.
+RUN for i in 1 2 3; do \
+        apk add --no-cache python-3.13 ca-certificates-bundle curl shadow && break; \
+        [ $i -lt 3 ] && sleep $((i * 10)); \
+    done && \
+    apk upgrade --no-cache
+
+# The builder stage (uv:python3.13-bookworm-slim) places Python at
+# /usr/local/bin/python3.13; Wolfi places it at /usr/bin/python3.13. These
+# symlinks keep the venv's internal python symlinks valid in the final image.
+RUN mkdir -p /usr/local/bin \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python3.13 \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python
+
+# Create a non-root user (uid/gid 1001)
+RUN groupadd -g 1001 app && useradd -u 1001 -g app -m app
 
 # Copy the application from the builder
 COPY --from=builder --chown=app:app /app /app
@@ -69,7 +88,8 @@ COPY --from=builder --chown=app:app /app /app
 WORKDIR /app/server
 
 # Place executables in the environment at the front of the path
-ENV PATH="/app/server/.venv/bin:$PATH"
+ENV PATH="/app/server/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
 
 # Use a non-root user to run the application
 USER app


### PR DESCRIPTION
## Summary

Migrates the **RAG server** image final stage from `python:3.13-slim-bookworm` to **`cgr.dev/chainguard/wolfi-base`**, mirroring the pattern used by the a2a/mcp agent images (`build/agents/Dockerfile.a2a`).

Eliminates the Debian base-OS CVE firehose (perl-base, libtiff6, libopenjp2-7, krb5 family, systemd, libgcrypt20, etc.) plus the base interpreter/pip CVEs Grype flags on `caipe-rag-server`, with no application or dependency changes.

## Why

The bookworm base is the single largest source of open code-scanning alerts on the RAG images. Wolfi is continuously rebuilt with patched, glibc-based packages (~0 CVEs) and ships a minimal footprint (no `perl`/`pip` in the final image). The builder stage is unchanged, so the locked dependency set is identical. The `VARIANT` arg (default/huggingface) only affects the builder, so both variants are unaffected.

This is an **independent PR** (branched off `main`), part of the RAG/dynamic-agents wolfi base migration series.

## Changes

- `build/Dockerfile.server`: final stage now `cgr.dev/chainguard/wolfi-base`
  - public Wolfi APK repo, `apk add python-3.13 ca-certificates-bundle curl shadow` + `apk upgrade`
  - `/usr/local/bin/python3.13` to `/usr/bin/python3.13` symlinks so the builder-produced venv resolves
  - non-root user uid/gid **1001** (unchanged)
  - builder stage unchanged

## Verification (local build + smoke test, default variant)

- [x] Image builds (`docker build -f build/Dockerfile.server .`)
- [x] Core/native deps import on wolfi glibc: `fastapi`, `pymilvus` (grpc), `numpy`, `pyarrow`, `pydantic`, `uvicorn` (Python 3.13.13)
- [x] `src/server` byte-compiles
- [x] Runs as non-root (`uid=1001(app)`)
- [x] OpenSSL present (3.6.2) so outbound TLS works

## Test plan

- [ ] Prebuild CI builds the `server` image (default + huggingface)
- [ ] Grype rescan shows bookworm/base CVEs cleared for `caipe-rag-server`
- [ ] Smoke test in a dev environment: RAG server starts and serves queries

> DCO: signed off under maintainer identity per the session DCO delegation; `Assisted-by` trailer included per repo AI-attribution policy.
