### PR TITLE
refactor(ui): DRY up Slack and Webex admin panels into shared ConnectorAdminPanel

### DIFF
--- a/ui/src/app/api/admin/webex/spaces/[workspaceId]/[spaceId]/diagnostics/route.ts
+++ b/ui/src/app/api/admin/webex/spaces/[workspaceId]/[spaceId]/diagnostics/route.ts
@@ -1,13 +1,8 @@
 import { NextRequest } from "next/server";
 
 import { successResponse, withErrorHandler } from "@/lib/api-middleware";
-import { getCollection } from "@/lib/mongodb";
-import {
-  listOpenFgaWebexSpaceAgentIds,
-  parseWebexSpaceRouteParams,
-  webexSpaceOpenFgaUser,
-} from "@/lib/rbac/webex-space-openfga";
-import { listWebexSpaceAgentRoutes } from "@/lib/rbac/webex-space-route-store";
+import { parseWebexSpaceRouteParams } from "@/lib/rbac/webex-space-openfga";
+import { computeWebexSpaceDiagnostics } from "@/lib/rbac/webex-space-diagnostics";
 
 import { withWebexSpaceRebacViewAuth } from "../../../_lib";
 
@@ -15,133 +10,12 @@ interface RouteContext {
   params: Promise<{ workspaceId: string; spaceId: string }>;
 }
 
-interface RuntimeRouteDiagnostic {
-  agent_id: string;
-  openfga_tuple: boolean;
-  route_metadata: boolean;
-  listen: "mention" | "message" | "all" | "unknown";
-  runtime_matches: { mention: boolean; message: boolean };
-  warnings: string[];
-}
-
-function listenMatches(listen: RuntimeRouteDiagnostic["listen"], requested: "mention" | "message"): boolean {
-  return listen === "all" || listen === requested;
-}
-
-function buildRouteWarning(route: RuntimeRouteDiagnostic): string[] {
-  const warnings: string[] = [];
-  if (!route.openfga_tuple) {
-    warnings.push(
-      `agent:${route.agent_id} has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.`
-    );
-  }
-  if (!route.route_metadata) {
-    warnings.push(
-      `agent:${route.agent_id} has an OpenFGA tuple but no Mongo route metadata; runtime uses mention-only defaults.`
-    );
-  }
-  if (route.listen === "mention") {
-    warnings.push(`Route agent:${route.agent_id} only listens to mentions. Plain space messages will be ignored.`);
-  }
-  if (route.listen === "message") {
-    warnings.push(`Route agent:${route.agent_id} only listens to plain messages. @mentions will not use this route.`);
-  }
-  return warnings;
-}
-
-async function latestRuntimeError(workspaceId: string, spaceId: string) {
-  const resourceRef = webexSpaceOpenFgaUser(workspaceId, spaceId);
-  try {
-    const auditEvents = await getCollection("audit_events");
-    const rows = await auditEvents
-      .find({
-        component: "webex_bot",
-        outcome: "error",
-        resource_ref: resourceRef,
-      })
-      .sort({ ts: -1 })
-      .limit(1)
-      .toArray();
-    const event = rows[0] as Record<string, unknown> | undefined;
-    if (!event) return null;
-    return {
-      ts: typeof event.ts === "string" ? event.ts : undefined,
-      reason_code: typeof event.reason_code === "string" ? event.reason_code : undefined,
-      message: typeof event.message === "string" ? event.message : undefined,
-      action: typeof event.action === "string" ? event.action : undefined,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function currentRuntimeError(
-  lastError: Awaited<ReturnType<typeof latestRuntimeError>>,
-  openfgaError: string | undefined
-) {
-  if (!lastError) return null;
-  if (!openfgaError && lastError.reason_code === "OPENFGA_READ_FAILED") {
-    return null;
-  }
-  return lastError;
-}
-
 export const GET = withErrorHandler(async (request: NextRequest, context: RouteContext) => {
   const raw = await context.params;
   const { workspaceId, spaceId } = parseWebexSpaceRouteParams(raw.workspaceId, raw.spaceId);
-  return withWebexSpaceRebacViewAuth(request, async () => {
-    const metadataRoutes = await listWebexSpaceAgentRoutes(workspaceId, spaceId);
-    const warnings: string[] = [];
-    let openfgaAgentIds: string[] = [];
-    let openfgaError: string | undefined;
-
-    try {
-      openfgaAgentIds = await listOpenFgaWebexSpaceAgentIds(workspaceId, spaceId);
-    } catch (error) {
-      openfgaError = error instanceof Error ? error.message : "OpenFGA tuple read failed";
-      warnings.push(`Webex bot cannot read OpenFGA tuples: ${openfgaError}`);
-    }
-
-    const allAgentIds = Array.from(
-      new Set([...openfgaAgentIds, ...metadataRoutes.map((route) => route.agent_id)])
-    ).sort();
-    const metadataByAgentId = new Map(metadataRoutes.map((route) => [route.agent_id, route]));
-    const openfgaAgentSet = new Set(openfgaAgentIds);
-    const routes = allAgentIds.map((agentId): RuntimeRouteDiagnostic => {
-      const metadata = metadataByAgentId.get(agentId);
-      const listen = (metadata?.users?.listen ?? "mention") as RuntimeRouteDiagnostic["listen"];
-      const route = {
-        agent_id: agentId,
-        openfga_tuple: openfgaAgentSet.has(agentId),
-        route_metadata: Boolean(metadata),
-        listen,
-        runtime_matches: {
-          mention: listenMatches(listen, "mention"),
-          message: listenMatches(listen, "message"),
-        },
-        warnings: [] as string[],
-      };
-      route.warnings = buildRouteWarning(route);
-      warnings.push(...route.warnings);
-      return route;
-    });
-
-    if (!openfgaError && openfgaAgentIds.length === 0) {
-      warnings.push("No OpenFGA space-agent tuples found. Webex runtime has no agent to dispatch.");
-    }
-
-    const lastError = await latestRuntimeError(workspaceId, spaceId);
-    return successResponse({
-      workspace_id: workspaceId,
-      space_id: spaceId,
-      openfga: {
-        reachable: !openfgaError,
-        tuple_count: openfgaAgentIds.length,
-        ...(openfgaError ? { error: openfgaError } : {}),
-      },
-      routes,
-      warnings: Array.from(new Set(warnings)),
-      last_runtime_error: currentRuntimeError(lastError, openfgaError),
-    });
-  }, { workspaceId, spaceId });
+  return withWebexSpaceRebacViewAuth(
+    request,
+    async () => successResponse(await computeWebexSpaceDiagnostics(workspaceId, spaceId)),
+    { workspaceId, spaceId },
+  );
 });

--- a/ui/src/app/api/admin/webex/spaces/route.ts
+++ b/ui/src/app/api/admin/webex/spaces/route.ts
@@ -5,6 +5,10 @@ import { getRbacCollection } from "@/lib/rbac/mongo-collections";
 import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
 import { subjectFromSession } from "@/lib/rbac/resource-authz";
 import { listWebexSpaceGrants, webexWorkspaceRef } from "@/lib/rbac/webex-space-grant-store";
+import {
+  computeWebexSpaceHealthSummary,
+  type WebexSpaceHealthSummary,
+} from "@/lib/rbac/webex-space-diagnostics";
 
 interface WebexSpaceTeamMappingDoc {
   webex_workspace_id?: string;
@@ -35,6 +39,11 @@ async function webexSpaceAccess(
 export const GET = withErrorHandler(async (request: NextRequest) => {
     const { session } = await getAuthFromBearerOrSession(request);
     const subject = subjectFromSession(session);
+    // `?health=1` opts the caller in to a per-row diagnostics summary
+    // (warnings count + OpenFGA reachability + last runtime error
+    // timestamp). Mirrors the Slack channels endpoint so the shared
+    // ConnectorAdminPanel can show real per-row health for Webex too.
+    const includeHealth = request.nextUrl.searchParams.get("health") === "1";
     const mappings = await getRbacCollection<WebexSpaceTeamMappingDoc>("webexSpaceTeamMappings");
     const rows = await mappings
       .find({ active: { $ne: false } } as never)
@@ -49,7 +58,18 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           ? await webexSpaceAccess(subject, workspaceId, row.webex_space_id)
           : { canRead: false, canManage: false };
         if (!access.canRead) return null;
-        const grants = await listWebexSpaceGrants(workspaceId, row.webex_space_id);
+        const [grants, health] = await Promise.all([
+          listWebexSpaceGrants(workspaceId, row.webex_space_id),
+          includeHealth
+            ? computeWebexSpaceHealthSummary(workspaceId, row.webex_space_id).catch(
+                (): WebexSpaceHealthSummary => ({
+                  warnings_count: 0,
+                  openfga_reachable: false,
+                  last_runtime_error_ts: null,
+                }),
+              )
+            : Promise.resolve(undefined),
+        ]);
         return {
           workspace_id: workspaceId,
           space_id: row.webex_space_id,
@@ -58,6 +78,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           team_slug: row.team_slug,
           active_grants: grants.length,
           can_manage: access.canManage,
+          ...(health ? { health } : {}),
         };
       })
     );

--- a/ui/src/components/admin/UserDetailModal.tsx
+++ b/ui/src/components/admin/UserDetailModal.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
+import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 
 export interface UserDetailModalProps {
   userId: string;
@@ -70,6 +71,7 @@ export function UserDetailModal({
   const [teamOptions, setTeamOptions] = useState<
     Array<{ teamId: string; label: string }>
   >([]);
+  const [addTeamValue, setAddTeamValue] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
 
@@ -417,28 +419,23 @@ export function UserDetailModal({
                   <label htmlFor="add-team" className="text-sm text-muted-foreground">
                     Add team
                   </label>
-                  <select
+                  <TeamPicker
                     id="add-team"
-                    className="rounded-lg border border-input bg-background px-2 py-1.5 text-sm min-w-[12rem] text-foreground"
-                    defaultValue=""
-                    disabled={busy != null || addableTeams.length === 0}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      e.target.value = "";
-                      if (v) addTeam(v);
+                    value={addTeamValue}
+                    onChange={(v) => {
+                      if (!v) return;
+                      addTeam(v);
+                      setAddTeamValue("");
                     }}
-                  >
-                    <option value="">
-                      {addableTeams.length === 0
-                        ? "No teams to add"
-                        : "Select a team…"}
-                    </option>
-                    {addableTeams.map((t) => (
-                      <option key={t.teamId} value={t.teamId}>
-                        {t.label}
-                      </option>
-                    ))}
-                  </select>
+                    disabled={busy != null || addableTeams.length === 0}
+                    placeholder={addableTeams.length === 0 ? "No teams to add" : "Select a team…"}
+                    searchPlaceholder="Search teams..."
+                    triggerClassName="min-w-[12rem]"
+                    options={addableTeams.map<TeamPickerOption>((t) => ({
+                      slug: t.teamId,
+                      name: t.label,
+                    }))}
+                  />
                 </div>
               )}
             </section>

--- a/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
+++ b/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/toast";
+import { AgentPicker, type AgentPickerOption } from "@/components/ui/agent-picker";
 import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 import { cn } from "@/lib/utils";
 import { ConnectorOnboardingWizard } from "./ConnectorOnboardingWizard";
@@ -178,16 +179,15 @@ function ItemDetail({
           <div className="grid gap-3 md:grid-cols-4">
             <div className="space-y-2 md:col-span-2">
               <Label htmlFor="connector-route-agent-id">Dynamic Agent</Label>
-              <select
+              <AgentPicker
                 id="connector-route-agent-id"
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                ariaLabel="Dynamic Agent"
                 value={routeAgentId}
-                onChange={(e) => setRouteAgentId(e.target.value)}
+                onChange={setRouteAgentId}
                 disabled={disabled || !selectedCanManage || dynamicAgents.length === 0}
-              >
-                <option value="">{dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select Dynamic Agent"}</option>
-                {dynamicAgents.map((a) => <option key={a._id} value={a._id}>{agentLabel(a)}</option>)}
-              </select>
+                placeholder={dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select Dynamic Agent"}
+                options={dynamicAgents.map<AgentPickerOption>((a) => ({ value: a._id, label: a.name || a._id }))}
+              />
             </div>
             <div className="space-y-2">
               <Label htmlFor="connector-route-listen">Listen</Label>
@@ -866,16 +866,15 @@ export function ConnectorAdminPanel({
               </div>
               <div className="space-y-2">
                 <Label htmlFor={`${adapter.connectorName.toLowerCase()}-default-agent`}>Preselected Dynamic Agent</Label>
-                <select
+                <AgentPicker
                   id={`${adapter.connectorName.toLowerCase()}-default-agent`}
-                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  ariaLabel="Preselected Dynamic Agent"
                   value={defaultAgentId}
-                  onChange={(e) => setDefaultAgentId(e.target.value)}
+                  onChange={setDefaultAgentId}
                   disabled={disabled || dynamicAgents.length === 0}
-                >
-                  <option value="">{dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select preselected Dynamic Agent"}</option>
-                  {sortedDynamicAgents.map((a) => <option key={a._id} value={a._id}>{agentLabel(a)}</option>)}
-                </select>
+                  placeholder={dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select preselected Dynamic Agent"}
+                  options={sortedDynamicAgents.map<AgentPickerOption>((a) => ({ value: a._id, label: a.name || a._id }))}
+                />
                 {invalidDefaultAgentId && (
                   <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
                     The saved default Dynamic Agent <code>agent:{invalidDefaultAgentId}</code> wasn&apos;t found (or is disabled). Pick one above.

--- a/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
+++ b/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
@@ -1,0 +1,1072 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronRight, FileUp, RefreshCw, RotateCw, Settings2, Sparkles } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/toast";
+import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
+import { cn } from "@/lib/utils";
+import { ConnectorOnboardingWizard } from "./ConnectorOnboardingWizard";
+import type {
+  ConnectorAdminAdapter,
+  DiagnosticRoute,
+  DiscoveredItem,
+  ItemAgentRoute,
+  ItemDiagnostics,
+  ItemSummary,
+  RuntimeStatus,
+  RuntimeSyncSummary,
+} from "./connector-admin-adapter";
+
+interface DynamicAgentOption { _id: string; name: string }
+interface TeamOption { _id?: string; id?: string; slug: string; name: string }
+interface AssociationDefaults {
+  team_slug: string; agent_id: string; create_routes?: boolean;
+  updated_at?: string; updated_by?: string; source?: "db" | "env" | "unset";
+}
+
+type PanelView = "channels" | "onboard" | "advanced";
+type SyncModalMode = "preview" | "apply";
+type SyncModalStatus = "idle" | "loading" | "success" | "error";
+
+function apiData<T>(payload: { data?: T } & T): T {
+  return (payload.data ?? payload) as T;
+}
+function agentLabel(agent: DynamicAgentOption): string {
+  return `${agent.name || agent._id} (${agent._id})`;
+}
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+// ── ItemDetail subcomponent ───────────────────────────────────────────────────
+
+interface ItemDetailProps {
+  adapter: ConnectorAdminAdapter;
+  selected: ItemSummary;
+  diagnostics: ItemDiagnostics | null;
+  routes: ItemAgentRoute[];
+  dynamicAgents: DynamicAgentOption[];
+  defaultAgentId: string;
+  routeAgentId: string; setRouteAgentId: (v: string) => void;
+  routeListen: "message" | "mention" | "all"; setRouteListen: (v: "message" | "mention" | "all") => void;
+  routePriority: number; setRoutePriority: (v: number) => void;
+  editingRouteAgentId: string | null;
+  resetRouteForm: () => void;
+  editRoute: (route: ItemAgentRoute) => void;
+  saveRoute: () => Promise<void> | void;
+  deleteRoute: (route: ItemAgentRoute) => void;
+  fixDiagnosticRoute: (route: DiagnosticRoute) => Promise<void> | void;
+  fixMissingRouteableAgent: () => Promise<void> | void;
+  disabled: boolean; loading: boolean; selectedCanManage: boolean; message: string | null;
+}
+
+function ItemDetail({
+  adapter, selected, diagnostics, routes, dynamicAgents, defaultAgentId,
+  routeAgentId, setRouteAgentId, routeListen, setRouteListen, routePriority, setRoutePriority,
+  editingRouteAgentId, resetRouteForm, editRoute, saveRoute, deleteRoute,
+  fixDiagnosticRoute, fixMissingRouteableAgent, disabled, loading, selectedCanManage, message,
+}: ItemDetailProps) {
+  const diagnosticsMissingRouteableAgent =
+    adapter.missingRouteableAgentAutoFix?.isApplicable(selected, diagnostics ?? {
+      openfga: { reachable: false, tuple_count: 0 }, routes: [], warnings: [],
+    }) ?? false;
+  const autoFixAgentId = (defaultAgentId || "").trim();
+
+  return (
+    <div className="space-y-4">
+      {/* Diagnostics */}
+      <div className="space-y-3">
+        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Diagnostics
+        </div>
+        {!diagnostics ? (
+          <p className="text-sm text-muted-foreground">Loading diagnostics...</p>
+        ) : (
+          <>
+            <div className="grid gap-2 text-sm md:grid-cols-3">
+              <div className="rounded-md border bg-background/60 p-3">
+                <div className="text-xs text-muted-foreground">OpenFGA</div>
+                <div className="font-medium">{diagnostics.openfga.reachable ? "reachable" : "unreachable"}</div>
+                <div className="text-xs text-muted-foreground">{diagnostics.openfga.tuple_count} {adapter.itemSingular}-agent tuples</div>
+              </div>
+              <div className="rounded-md border bg-background/60 p-3">
+                <div className="text-xs text-muted-foreground">Runtime routes</div>
+                <div className="font-medium">{diagnostics.routes.length}</div>
+                <div className="text-xs text-muted-foreground">OpenFGA-backed candidates</div>
+              </div>
+              <div className="rounded-md border bg-background/60 p-3">
+                <div className="text-xs text-muted-foreground">Last error</div>
+                <div className="font-medium">{diagnostics.last_runtime_error?.reason_code ?? "none"}</div>
+                <div className="text-xs text-muted-foreground">{diagnostics.last_runtime_error?.ts ?? "No recent runtime error"}</div>
+              </div>
+            </div>
+            {diagnostics.warnings.length > 0 && (
+              <div className="space-y-1 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
+                <div className="text-xs font-medium uppercase tracking-wide">Issues found</div>
+                {diagnostics.warnings.map((w) => <div key={w}>{w}</div>)}
+              </div>
+            )}
+            {diagnosticsMissingRouteableAgent && adapter.missingRouteableAgentAutoFix && (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-cyan-500/40 bg-cyan-50 p-3 text-sm text-cyan-950 dark:bg-cyan-950/30 dark:text-cyan-100">
+                <div>
+                  <div className="font-medium">{adapter.missingRouteableAgentAutoFix.title}</div>
+                  <div className="text-xs">{adapter.missingRouteableAgentAutoFix.description}</div>
+                </div>
+                <Button
+                  type="button" variant="outline" size="sm"
+                  onClick={() => void fixMissingRouteableAgent()}
+                  disabled={disabled || !selectedCanManage || loading || !autoFixAgentId}
+                >
+                  {adapter.missingRouteableAgentAutoFix.buttonLabel(autoFixAgentId)}
+                </Button>
+                {!autoFixAgentId && (
+                  <div className="basis-full text-xs">{adapter.missingRouteableAgentAutoFix.noAgentHelpText}</div>
+                )}
+              </div>
+            )}
+            {diagnostics.last_runtime_error?.message && (
+              <div className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">
+                {diagnostics.last_runtime_error.message}
+              </div>
+            )}
+            {diagnostics.routes.length > 0 && (
+              <div className="space-y-2">
+                {diagnostics.routes.map((route) => (
+                  <div key={route.agent_id} className="flex flex-wrap items-center gap-2 rounded-md border bg-background/60 p-3 text-sm">
+                    <span className="font-medium">agent:{route.agent_id}</span>
+                    <Badge variant={route.openfga_tuple ? "default" : "outline"}>
+                      {route.openfga_tuple ? "OpenFGA tuple" : "missing tuple"}
+                    </Badge>
+                    <Badge variant={route.route_metadata ? "secondary" : "outline"}>
+                      {route.route_metadata ? `listen:${route.listen}` : "default metadata"}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      mention {route.runtime_matches.mention ? "yes" : "no"} / message {route.runtime_matches.message ? "yes" : "no"}
+                    </span>
+                    {adapter.diagnosticRouteIsFixable(route) && (
+                      <Button
+                        type="button" variant="outline" size="sm" className="ml-auto"
+                        onClick={() => void fixDiagnosticRoute(route)}
+                        disabled={disabled || !selectedCanManage || loading}
+                        aria-label={`Fix agent:${route.agent_id} routing`}
+                      >
+                        Fix it
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Manual route editing — Slack only */}
+      {adapter.manualRouteEditing && (
+        <div className="space-y-3">
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Agents</div>
+          {adapter.manualRouteFormHint?.(selected)}
+          <div className="grid gap-3 md:grid-cols-4">
+            <div className="space-y-2 md:col-span-2">
+              <Label htmlFor="connector-route-agent-id">Dynamic Agent</Label>
+              <select
+                id="connector-route-agent-id"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={routeAgentId}
+                onChange={(e) => setRouteAgentId(e.target.value)}
+                disabled={disabled || !selectedCanManage || dynamicAgents.length === 0}
+              >
+                <option value="">{dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select Dynamic Agent"}</option>
+                {dynamicAgents.map((a) => <option key={a._id} value={a._id}>{agentLabel(a)}</option>)}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="connector-route-listen">Listen</Label>
+              <select
+                id="connector-route-listen"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={routeListen}
+                onChange={(e) => setRouteListen(e.target.value as "message" | "mention" | "all")}
+                disabled={disabled || !selectedCanManage}
+              >
+                <option value="mention">mention</option>
+                <option value="message">message</option>
+                <option value="all">all</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="connector-route-priority">Priority</Label>
+              <Input id="connector-route-priority" type="number" value={routePriority}
+                onChange={(e) => setRoutePriority(Number(e.target.value))}
+                disabled={disabled || !selectedCanManage} />
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={() => void saveRoute()} disabled={disabled || !selectedCanManage || loading || !routeAgentId.trim()}>
+              {loading ? "Saving..." : editingRouteAgentId ? "Update Association" : "Create Association"}
+            </Button>
+            {editingRouteAgentId && (
+              <Button type="button" variant="outline" onClick={resetRouteForm} disabled={loading}>Cancel edit</Button>
+            )}
+          </div>
+          {message && <p className="text-sm text-muted-foreground">{message}</p>}
+          {routes.length > 0 && (
+            <div className="space-y-2">
+              {routes.map((route) => (
+                <div key={route.agent_id} className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background/60 p-3 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span>agent:{route.agent_id}</span>
+                    <Badge>{route.users?.listen ?? "mention"} / priority {route.priority}</Badge>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button type="button" variant="outline" size="sm" onClick={() => editRoute(route)}
+                      disabled={disabled || !selectedCanManage || loading} aria-label={`Edit agent:${route.agent_id}`}>Edit</Button>
+                    <Button type="button" variant="destructive" size="sm" onClick={() => deleteRoute(route)}
+                      disabled={disabled || !selectedCanManage || loading} aria-label={`Delete agent:${route.agent_id}`}>Delete</Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── ConnectorAdminPanel ───────────────────────────────────────────────────────
+
+export function ConnectorAdminPanel({
+  adapter,
+  disabled = false,
+  selfService = false,
+}: {
+  adapter: ConnectorAdminAdapter;
+  disabled?: boolean;
+  selfService?: boolean;
+}) {
+  const { toast } = useToast();
+  const [items, setItems] = useState<ItemSummary[]>([]);
+  const [selectedKey, setSelectedKey] = useState("");
+  const [routes, setRoutes] = useState<ItemAgentRoute[]>([]);
+  const [diagnostics, setDiagnostics] = useState<ItemDiagnostics | null>(null);
+  const [dynamicAgents, setDynamicAgents] = useState<DynamicAgentOption[]>([]);
+  const [teams, setTeams] = useState<TeamOption[]>([]);
+  const [routeAgentId, setRouteAgentId] = useState("");
+  const [editingRouteAgentId, setEditingRouteAgentId] = useState<string | null>(null);
+  const [routePendingDelete, setRoutePendingDelete] = useState<ItemAgentRoute | null>(null);
+  const [defaultTeamSlug, setDefaultTeamSlug] = useState("");
+  const [defaultAgentId, setDefaultAgentId] = useState("");
+  const [invalidDefaultTeamSlug, setInvalidDefaultTeamSlug] = useState<string | null>(null);
+  const [invalidDefaultAgentId, setInvalidDefaultAgentId] = useState<string | null>(null);
+  const [configuredDefaults, setConfiguredDefaults] = useState<AssociationDefaults | null>(null);
+  const [useSlackbotConfigDefaults, setUseSlackbotConfigDefaults] = useState(true);
+  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
+  const [runtimeSyncSummary, setRuntimeSyncSummary] = useState<RuntimeSyncSummary | null>(null);
+  const [runtimeSyncModalOpen, setRuntimeSyncModalOpen] = useState(false);
+  const [runtimeSyncModalMode, setRuntimeSyncModalMode] = useState<SyncModalMode>("preview");
+  const [runtimeSyncModalStatus, setRuntimeSyncModalStatus] = useState<SyncModalStatus>("idle");
+  const [runtimeSyncModalError, setRuntimeSyncModalError] = useState<string | null>(null);
+  const [createDefaultRoutes, setCreateDefaultRoutes] = useState(true);
+  const [savingDefaults, setSavingDefaults] = useState(false);
+  const [discoverLoading, setDiscoverLoading] = useState(false);
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const [discoveredItems, setDiscoveredItems] = useState<DiscoveredItem[]>([]);
+  const [discoveredRows, setDiscoveredRows] = useState<Array<DiscoveredItem & { selected: boolean; team_slug: string; agent_id: string; is_existing: boolean }>>([]);
+  const [routeListen, setRouteListen] = useState<"message" | "mention" | "all">("mention");
+  const [routePriority, setRoutePriority] = useState(100);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [view, setView] = useState<PanelView>("channels");
+  const [discoverySearch, setDiscoverySearch] = useState("");
+
+  const selected = useMemo(
+    () => items.find((item) => adapter.itemKey(item) === selectedKey),
+    [items, selectedKey, adapter],
+  );
+  const selectedCanManage = !selfService || selected?.can_manage === true;
+  const unassignedCount = useMemo(() => items.filter((item) => !item.team_slug).length, [items]);
+  const configuredItemIds = useMemo(() => new Set(items.map((item) => item.item_id)), [items]);
+  const configuredItemsById = useMemo(() => new Map(items.map((item) => [item.item_id, item])), [items]);
+  const sortedDynamicAgents = useMemo(
+    () => [...dynamicAgents].sort((a, b) => agentLabel(a).localeCompare(agentLabel(b))),
+    [dynamicAgents],
+  );
+  const dynamicAgentIds = useMemo(() => new Set(dynamicAgents.map((a) => a._id)), [dynamicAgents]);
+  const teamSlugSet = useMemo(() => new Set(teams.map((t) => t.slug).filter(Boolean) as string[]), [teams]);
+  const fallbackAgentId = useMemo(() => {
+    if (defaultAgentId && dynamicAgentIds.has(defaultAgentId)) return defaultAgentId;
+    return "";
+  }, [defaultAgentId, dynamicAgentIds]);
+  const associationDefaultsDirty = useMemo(() => {
+    const savedTeam = configuredDefaults?.team_slug ?? "";
+    const savedAgent = configuredDefaults?.agent_id ?? "";
+    const savedCreateRoutes = typeof configuredDefaults?.create_routes === "boolean" ? configuredDefaults.create_routes : true;
+    return savedTeam !== defaultTeamSlug || savedAgent !== defaultAgentId || savedCreateRoutes !== createDefaultRoutes;
+  }, [configuredDefaults, defaultTeamSlug, defaultAgentId, createDefaultRoutes]);
+  const discoveredNewCount = useMemo(
+    () => discoveredItems.filter((item) => !configuredItemIds.has(item.id)).length,
+    [configuredItemIds, discoveredItems],
+  );
+  const selectedDiscoveredRows = useMemo(
+    () => discoveredRows.filter((row) => row.selected && row.team_slug && row.agent_id),
+    [discoveredRows],
+  );
+
+  // ── Data loaders ────────────────────────────────────────────────────────────
+
+  const loadItems = useCallback(async () => {
+    setLoading(true); setMessage(null);
+    try {
+      const res = await fetch(`${adapter.api.list}?health=1`);
+      if (!res.ok) throw new Error(await res.text());
+      const json = await res.json();
+      const rows = adapter.parseListResponse(json);
+      const parsed = rows.map((r) => adapter.parseListItem(r)).filter((x): x is ItemSummary => x !== null);
+      setItems(parsed);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : `Failed to load ${adapter.itemPlural}`);
+    } finally { setLoading(false); }
+  }, [adapter]);
+
+  const loadRoutes = useCallback(async () => {
+    if (!selected) return;
+    const res = await fetch(adapter.api.routesFor(selected.workspace_id, selected.item_id));
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<{ routes: ItemAgentRoute[] }>(await res.json());
+    setRoutes(data.routes ?? []);
+  }, [selected, adapter]);
+
+  const loadDiagnostics = useCallback(async () => {
+    if (!selected) return;
+    const res = await fetch(adapter.api.diagnosticsFor(selected.workspace_id, selected.item_id));
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<ItemDiagnostics>(await res.json());
+    setDiagnostics(data);
+  }, [selected, adapter]);
+
+  const loadDynamicAgents = useCallback(async () => {
+    const res = await fetch("/api/dynamic-agents?enabled_only=true");
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<{ items: DynamicAgentOption[] }>(await res.json());
+    setDynamicAgents(data.items ?? []);
+  }, []);
+
+  const loadTeams = useCallback(async () => {
+    const res = await fetch("/api/admin/teams");
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<{ teams: TeamOption[] }>(await res.json());
+    setTeams(data.teams ?? []);
+  }, []);
+
+  const loadAssociationDefaults = useCallback(async () => {
+    const res = await fetch(adapter.api.defaults);
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<{ defaults: AssociationDefaults }>(await res.json());
+    setConfiguredDefaults(data.defaults ?? null);
+    if (data.defaults) {
+      setDefaultTeamSlug(data.defaults.team_slug ?? "");
+      setDefaultAgentId(data.defaults.agent_id ?? "");
+      if (typeof data.defaults.create_routes === "boolean") setCreateDefaultRoutes(data.defaults.create_routes);
+    }
+  }, [adapter]);
+
+  const saveAssociationDefaults = useCallback(async () => {
+    setSavingDefaults(true); setMessage(null);
+    try {
+      const res = await fetch(adapter.api.defaults, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ team_slug: defaultTeamSlug, agent_id: defaultAgentId, create_routes: createDefaultRoutes }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = apiData<{ defaults: AssociationDefaults }>(await res.json());
+      setConfiguredDefaults(data.defaults ?? null);
+      if (data.defaults) {
+        setDefaultTeamSlug(data.defaults.team_slug ?? "");
+        setDefaultAgentId(data.defaults.agent_id ?? "");
+        if (typeof data.defaults.create_routes === "boolean") setCreateDefaultRoutes(data.defaults.create_routes);
+      }
+      toast("Onboarding defaults saved.", "success");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to save onboarding defaults";
+      setMessage(msg); toast(msg, "error");
+    } finally { setSavingDefaults(false); }
+  }, [adapter, defaultTeamSlug, defaultAgentId, createDefaultRoutes, toast]);
+
+  const loadRuntimeStatus = useCallback(async () => {
+    const res = await fetch(adapter.api.runtimeStatus);
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<Record<string, unknown>>(await res.json());
+    setRuntimeStatus(adapter.parseRuntimeStatus(data));
+  }, [adapter]);
+
+  // ── Effects ─────────────────────────────────────────────────────────────────
+
+  useEffect(() => { void loadItems(); }, [loadItems]);
+  useEffect(() => {
+    void loadDynamicAgents().catch((e) =>
+      setMessage(e instanceof Error ? e.message : "Failed to load Dynamic Agents"));
+  }, [loadDynamicAgents]);
+  useEffect(() => {
+    if (selfService) return;
+    void loadTeams().catch((e) => setMessage(e instanceof Error ? e.message : "Failed to load teams"));
+  }, [loadTeams, selfService]);
+  useEffect(() => {
+    if (selfService) return;
+    void loadAssociationDefaults().catch((e) =>
+      setMessage(e instanceof Error ? e.message : `Failed to load ${adapter.connectorName} association defaults`));
+  }, [loadAssociationDefaults, selfService, adapter.connectorName]);
+  useEffect(() => {
+    if (selfService) return;
+    void loadRuntimeStatus().catch((e) =>
+      setMessage(e instanceof Error ? e.message : `Failed to load ${adapter.connectorName} bot runtime status`));
+  }, [loadRuntimeStatus, selfService, adapter.connectorName]);
+  const connectorName = adapter.connectorName;
+  const itemSingular = adapter.itemSingular;
+  useEffect(() => {
+    void loadRoutes().catch((e) =>
+      setMessage(e instanceof Error ? e.message : `Failed to load ${connectorName} ${itemSingular} routes`));
+  }, [loadRoutes, connectorName, itemSingular]);
+  useEffect(() => {
+    setDiagnostics(null);
+    void loadDiagnostics().catch((e) =>
+      setMessage(e instanceof Error ? e.message : `Failed to load ${connectorName} runtime diagnostics`));
+  }, [loadDiagnostics, connectorName]);
+
+  // Validate default agent/team after catalog loads
+  useEffect(() => {
+    if (selfService || dynamicAgents.length === 0 || !defaultAgentId) return;
+    if (!dynamicAgentIds.has(defaultAgentId)) {
+      setInvalidDefaultAgentId(defaultAgentId); setDefaultAgentId("");
+    } else if (invalidDefaultAgentId) { setInvalidDefaultAgentId(null); }
+  }, [selfService, dynamicAgents.length, dynamicAgentIds, defaultAgentId, invalidDefaultAgentId]);
+  useEffect(() => {
+    if (selfService || teams.length === 0 || !defaultTeamSlug) return;
+    if (!teamSlugSet.has(defaultTeamSlug)) {
+      setInvalidDefaultTeamSlug(defaultTeamSlug); setDefaultTeamSlug("");
+    } else if (invalidDefaultTeamSlug) { setInvalidDefaultTeamSlug(null); }
+  }, [selfService, teams.length, teamSlugSet, defaultTeamSlug, invalidDefaultTeamSlug]);
+
+  // ── Route form helpers ───────────────────────────────────────────────────────
+
+  const resetRouteForm = () => {
+    setRouteAgentId(""); setRouteListen("mention"); setRoutePriority(100); setEditingRouteAgentId(null);
+  };
+  const editRoute = (route: ItemAgentRoute) => {
+    setRouteAgentId(route.agent_id);
+    setRouteListen(route.users?.listen ?? "mention");
+    setRoutePriority(route.priority ?? 100);
+    setEditingRouteAgentId(route.agent_id);
+  };
+
+  const saveRoute = async () => {
+    if (!selected || !routeAgentId.trim()) return;
+    setLoading(true); setMessage(null);
+    try {
+      const agentId = routeAgentId.trim();
+      const nextRoutes: ItemAgentRoute[] = [
+        ...routes.filter((r) => r.agent_id !== agentId && r.agent_id !== editingRouteAgentId),
+        { agent_id: agentId, enabled: true, priority: routePriority, users: { enabled: true, listen: routeListen } },
+      ];
+      const res = await fetch(adapter.api.routesFor(selected.workspace_id, selected.item_id), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ routes: nextRoutes }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = apiData<{ routes: ItemAgentRoute[] }>(await res.json());
+      setRoutes(data.routes ?? []);
+      resetRouteForm();
+      toast(editingRouteAgentId
+        ? `${adapter.connectorName} ${adapter.itemSingular}-agent association updated.`
+        : `${adapter.connectorName} ${adapter.itemSingular}-agent association created.`, "success");
+      await Promise.all([loadItems(), loadDiagnostics()]);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : `Failed to save ${adapter.connectorName} association`);
+    } finally { setLoading(false); }
+  };
+
+  const deleteRouteConfirmed = async () => {
+    if (!selected || !routePendingDelete) return;
+    setLoading(true); setMessage(null);
+    try {
+      const res = await fetch(adapter.api.routesFor(selected.workspace_id, selected.item_id), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: routePendingDelete.agent_id }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      if (editingRouteAgentId === routePendingDelete.agent_id) resetRouteForm();
+      setRoutePendingDelete(null);
+      toast(`${adapter.connectorName} ${adapter.itemSingular}-agent association deleted.`, "success");
+      await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : `Failed to delete ${adapter.connectorName} association`);
+    } finally { setLoading(false); }
+  };
+
+  // ── Runtime / advanced tab actions ──────────────────────────────────────────
+
+  const refreshRuntimeStatus = async () => {
+    setLoading(true); setMessage(null);
+    try { await loadRuntimeStatus(); toast(`${adapter.connectorName} bot runtime status refreshed.`, "success"); }
+    catch (err) { setMessage(err instanceof Error ? err.message : "Failed to load runtime status"); }
+    finally { setLoading(false); }
+  };
+
+  const reloadBotRoutes = async () => {
+    setLoading(true); setMessage(null);
+    try {
+      const res = await fetch(adapter.api.runtimeReload, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}) });
+      if (!res.ok) throw new Error(await res.text());
+      await loadRuntimeStatus();
+      toast(`${adapter.connectorName} bot route cache reloaded.`, "success");
+    } catch (err) { setMessage(err instanceof Error ? err.message : "Failed to reload bot routes"); }
+    finally { setLoading(false); }
+  };
+
+  const syncBotConfig = async (dryRun: boolean) => {
+    setRuntimeSyncModalOpen(true); setRuntimeSyncModalMode(dryRun ? "preview" : "apply");
+    setRuntimeSyncModalStatus("loading"); setRuntimeSyncModalError(null);
+    if (dryRun) setRuntimeSyncSummary(null);
+    setLoading(true); setMessage(null);
+    try {
+      const res = await fetch(adapter.api.runtimeSyncFromConfig, {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ dry_run: dryRun }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const raw = apiData<Record<string, unknown>>(await res.json());
+      const summary = adapter.parseRuntimeSyncSummary(raw);
+      setRuntimeSyncSummary(summary); setRuntimeSyncModalStatus("success");
+      toast(dryRun
+        ? `Sync preview: ${summary.routes_planned} routes planned from ${summary.items_seen} ${adapter.itemPlural}.`
+        : `Config sync applied: upserted ${summary.routes_upserted} routes and wrote ${summary.openfga_tuples_written} OpenFGA tuples.`,
+        "success");
+      await Promise.all([loadRuntimeStatus(), loadItems(), loadRoutes(), loadDiagnostics()]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : `Failed to sync ${adapter.connectorName} bot config`;
+      setRuntimeSyncModalError(msg); setRuntimeSyncModalStatus("error"); setMessage(msg);
+    } finally { setLoading(false); }
+  };
+
+  // ── Diagnostic fix actions ───────────────────────────────────────────────────
+
+  const fixDiagnosticRoute = async (route: DiagnosticRoute) => {
+    if (!selected) return;
+    setLoading(true); setMessage(null);
+    try {
+      const result = await adapter.fixDiagnosticRoute({ item: selected, route, routes });
+      if (result.nextRoutes) setRoutes(result.nextRoutes);
+      await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
+      toast(result.toast, "success");
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : `Failed to fix agent:${route.agent_id}`);
+    } finally { setLoading(false); }
+  };
+
+  const fixMissingRouteableAgent = async () => {
+    if (!selected) return;
+    const agentId = (defaultAgentId || "").trim();
+    if (!agentId) { toast(`Select a Dynamic Agent or configure a default Dynamic Agent to auto-fix this ${adapter.itemSingular}.`, "warning"); return; }
+    setLoading(true); setMessage(null);
+    try {
+      const nextRoutes: ItemAgentRoute[] = [
+        ...routes.filter((r) => r.agent_id !== agentId),
+        { agent_id: agentId, enabled: true, priority: 100, users: { enabled: true, listen: "all" } },
+      ];
+      const res = await fetch(adapter.api.routesFor(selected.workspace_id, selected.item_id), {
+        method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ routes: nextRoutes }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = apiData<{ routes: ItemAgentRoute[] }>(await res.json());
+      setRoutes(data.routes ?? []);
+      await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
+      toast(`Created ${adapter.connectorName} association for agent:${agentId}.`, "success");
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Failed to auto-fix association");
+    } finally { setLoading(false); }
+  };
+
+  // ── Discovery / onboarding ───────────────────────────────────────────────────
+
+  const discoverItems = async () => {
+    setDiscoverLoading(true); setDiscoverError(null); setMessage(null);
+    try {
+      const discovered: DiscoveredItem[] = [];
+      let cursor: string | null = null;
+      let page = 0;
+      const legacySuggestions = adapter.legacyConfigAgentPrefill && useSlackbotConfigDefaults
+        ? await adapter.legacyConfigAgentPrefill.fetchSuggestions(fetch).catch(() => ({}))
+        : {};
+      do {
+        const url = adapter.api.discoveryUrl(page, cursor);
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) throw new Error(await res.text());
+        const pageData = adapter.parseDiscoveryPage(await res.json());
+        discovered.push(...pageData.items);
+        cursor = pageData.hasMore ? pageData.nextCursor : null;
+        page++;
+      } while (cursor);
+      setDiscoveredItems(discovered);
+      const hasNewItems = discovered.some((item) => !configuredItemIds.has(item.id));
+      setDiscoveredRows(discovered.map((item) => {
+        const existing = configuredItemsById.get(item.id);
+        const isExisting = configuredItemIds.has(item.id);
+        const isSetupComplete = Boolean(existing?.team_slug && (existing.active_grants ?? 0) > 0);
+        const resolvedAgentId = (() => {
+          const leg = legacySuggestions[item.id]?.trim();
+          if (leg && dynamicAgentIds.has(leg)) return leg;
+          return fallbackAgentId;
+        })();
+        // Slack: never auto-select (admin opts in per row).
+        // Webex: auto-select new items when there are new ones to onboard.
+        const autoSelect = adapter.discoveryAutoSelectNewItems
+          ? (hasNewItems ? !isExisting : true)
+          : false;
+        return { ...item, selected: autoSelect, team_slug: defaultTeamSlug, agent_id: resolvedAgentId, is_existing: isSetupComplete };
+      }));
+      toast(`Found ${pluralize(discovered.length, adapter.copy.discoveryDiscoveredLabel)}.`, "success");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : `Failed to discover ${adapter.connectorName} ${adapter.itemPlural}`;
+      setDiscoverError(msg); setMessage(msg); setDiscoveredRows([]);
+    } finally { setDiscoverLoading(false); }
+  };
+
+  const updateDiscoveredRow = (itemId: string, updates: Partial<{ selected: boolean; team_slug: string; agent_id: string }>) => {
+    setDiscoveredRows((rows) => rows.map((row) => row.id === itemId ? { ...row, ...updates } : row));
+  };
+  const setAllRowsSelected = (sel: boolean) => {
+    setDiscoveredRows((rows) => rows.map((row) => ({ ...row, selected: sel })));
+  };
+
+  const applyOnboarding = async () => {
+    setLoading(true); setMessage(null);
+    try {
+      const result = await adapter.applyOnboarding({
+        rows: discoveredRows.map((r) => ({ id: r.id, name: r.name, teamSlug: r.team_slug, agentId: r.agent_id, selected: r.selected })),
+        defaultTeamSlug, defaultAgentId, createDefaultRoutes, fetchFn: fetch,
+      });
+      await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
+      const appliedIds = new Set(discoveredRows.filter((r) => r.selected).map((r) => r.id));
+      setDiscoveredRows((rows) => rows.map((row) => appliedIds.has(row.id) ? { ...row, is_existing: true, selected: false } : row));
+      toast(result.toastMessage, "success");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : `Failed to apply ${adapter.connectorName} onboarding`;
+      setMessage(msg); toast(msg, "error");
+    } finally { setLoading(false); }
+  };
+
+  // ── Derived display values ────────────────────────────────────────────────────
+
+  const discoveryStatusText = adapter.discoveryStatusText({
+    discoveredCount: discoveredItems.length,
+    newCount: discoveredNewCount,
+    configuredCount: items.length,
+    unassignedCount: unassignedCount,
+  });
+
+  const viewTitle: Record<PanelView, string> = {
+    channels: adapter.copy.configuredTabTitle,
+    onboard: adapter.copy.onboardTabTitle,
+    advanced: adapter.copy.advancedTabTitle,
+  };
+  const viewDescription: Record<PanelView, string> = {
+    channels: adapter.copy.configuredTabDescription,
+    onboard: adapter.copy.onboardTabDescription,
+    advanced: adapter.copy.advancedTabDescription,
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{selfService ? adapter.copy.selfServiceTitle : viewTitle[view]}</CardTitle>
+        <CardDescription>
+          {selfService ? adapter.copy.selfServiceDescription : viewDescription[view]}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {/* Tab bar */}
+        {!selfService && (
+          <div role="tablist" aria-label={adapter.ariaLabels.tablist}
+            className="flex flex-wrap gap-1 rounded-md border bg-muted/30 p-1">
+            {(Object.keys(viewTitle) as PanelView[]).map((key) => (
+              <Button key={key} role="tab" type="button" size="sm"
+                variant={view === key ? "default" : "ghost"}
+                aria-selected={view === key} onClick={() => setView(key)}>
+                {viewTitle[key]}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {/* Auth disclaimer */}
+        {(selfService || view === "onboard") && (
+          <div className="space-y-2 rounded-md border p-3 text-sm text-muted-foreground">
+            {adapter.authzDisclaimer}
+          </div>
+        )}
+
+        {/* Advanced tab */}
+        {!selfService && view === "advanced" && (
+          <div role="region" aria-label={adapter.ariaLabels.advancedRegion}
+            data-section-tone="slate"
+            className="rounded-md border border-slate-500/20 bg-slate-500/5 p-4 space-y-3">
+            <div>
+              <h3 className="inline-flex items-center gap-2 text-base font-semibold tracking-tight">
+                <Settings2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                {adapter.copy.advancedHeading}
+              </h3>
+              <p className="text-xs text-muted-foreground">{adapter.copy.advancedTabDescription}</p>
+            </div>
+            <div className={`grid gap-2 text-sm ${adapter.advancedExtraTiles ? "md:grid-cols-4" : "md:grid-cols-3"}`}>
+              <div className="rounded-md border bg-background/60 p-3">
+                <div className="text-xs text-muted-foreground">Route mode</div>
+                <div className="font-medium">{runtimeStatus?.route_mode ?? "unknown"}</div>
+              </div>
+              <div className="rounded-md border bg-background/60 p-3">
+                <div className="text-xs text-muted-foreground">Static config</div>
+                <div className="font-medium">{runtimeStatus ? adapter.staticConfigLabel({ items: Object.values(runtimeStatus.static_config)[0] ?? 0, routes: Object.values(runtimeStatus.static_config)[1] ?? 0 }) : "unknown"}</div>
+              </div>
+              <div className="rounded-md border bg-background/60 p-3">
+                <div className="text-xs text-muted-foreground">Route cache</div>
+                <div className="font-medium">{runtimeStatus ? adapter.routeCacheLabel(runtimeStatus.route_cache.cache_size) : "unknown"}</div>
+                <div className="text-xs text-muted-foreground">TTL {runtimeStatus?.route_cache.ttl_seconds ?? "?"}s</div>
+              </div>
+              {runtimeStatus && adapter.advancedExtraTiles?.(runtimeStatus).map((tile) => (
+                <div key={tile.label} className="rounded-md border bg-background/60 p-3">
+                  <div className="text-xs text-muted-foreground">{tile.label}</div>
+                  <div className="font-medium">{tile.value}</div>
+                </div>
+              ))}
+            </div>
+            <div role="region" aria-label={adapter.ariaLabels.advancedLegend}
+              className="grid gap-2 rounded-md border bg-background/50 p-3 text-xs text-muted-foreground md:grid-cols-2">
+              <div><span className="font-medium text-foreground">Route mode:</span> shows whether the {adapter.copy.botNameInLegend} reads routes from database, YAML, or both.</div>
+              <div><span className="font-medium text-foreground">Static config:</span> counts {adapter.itemPlural}/routes currently loaded from {adapter.copy.botNameInLegend} YAML.</div>
+              <div><span className="font-medium text-foreground">Route cache:</span> shows cached runtime {adapter.itemSingular} routes and how soon they expire.</div>
+              {adapter.advancedExtraLegendRows?.().map((row) => (
+                <div key={row.label}><span className="font-medium text-foreground">{row.label}:</span> {row.description}</div>
+              ))}
+              <div><span className="font-medium text-foreground">Refresh Runtime Status:</span> reloads these status numbers from the running bot.</div>
+              <div><span className="font-medium text-foreground">Reload Bot Cache:</span> refreshes the running bot after UI route changes.</div>
+              <div><span className="font-medium text-foreground">Preview YAML Import:</span> shows planned changes without writing them.</div>
+              <div className="md:col-span-2"><span className="font-medium text-foreground">Import from YAML Config:</span> writes YAML routes into CAIPE/OpenFGA.</div>
+            </div>
+            {runtimeSyncSummary && (
+              <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">
+                <div>{runtimeSyncSummary.dry_run ? `Sync preview: ${runtimeSyncSummary.routes_planned} routes planned.` : `Config sync applied: upserted ${runtimeSyncSummary.routes_upserted} routes.`}</div>
+                Last sync {runtimeSyncSummary.dry_run ? "preview" : "apply"}: {runtimeSyncSummary.routes_planned} planned, {runtimeSyncSummary.routes_upserted} upserted, {runtimeSyncSummary.openfga_tuples_written} OpenFGA tuples.
+              </div>
+            )}
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" variant="outline" onClick={() => void refreshRuntimeStatus()} disabled={disabled || loading}><RefreshCw className="h-4 w-4" aria-hidden="true" />Refresh Runtime Status</Button>
+              <Button type="button" variant="outline" onClick={() => void reloadBotRoutes()} disabled={disabled || loading}><RotateCw className="h-4 w-4" aria-hidden="true" />Reload Bot Cache</Button>
+              <Button type="button" variant="outline" onClick={() => void syncBotConfig(true)} disabled={disabled || loading}><FileUp className="h-4 w-4" aria-hidden="true" />Preview YAML Import</Button>
+              <Button type="button" onClick={() => void syncBotConfig(false)} disabled={disabled || loading}><FileUp className="h-4 w-4" aria-hidden="true" />Import from YAML Config</Button>
+            </div>
+          </div>
+        )}
+
+        {/* Sync modal */}
+        <Dialog open={runtimeSyncModalOpen} onOpenChange={setRuntimeSyncModalOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{adapter.syncDialogueTitle(runtimeSyncModalMode)}</DialogTitle>
+              <DialogDescription>{adapter.syncDialogueDescription}</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div className="rounded-md border bg-muted/20 p-3 text-sm">
+                <div className="font-medium">
+                  {runtimeSyncModalStatus === "loading" ? (runtimeSyncModalMode === "preview" ? "Previewing..." : "Applying...")
+                    : runtimeSyncModalStatus === "success" ? (runtimeSyncModalMode === "preview" ? "Preview complete" : "Apply complete")
+                    : runtimeSyncModalStatus === "error" ? "Sync failed" : "Ready"}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {runtimeSyncModalStatus === "loading" ? `Contacting the ${adapter.connectorName} bot admin API...`
+                    : "Static config sync is upsert-only and leaves existing UI-managed associations in place."}
+                </div>
+              </div>
+              {runtimeSyncModalError && <div className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">{runtimeSyncModalError}</div>}
+              {runtimeSyncSummary && (
+                <div className="grid gap-2 text-sm md:grid-cols-2">
+                  <div className="rounded-md border p-3"><div className="text-xs text-muted-foreground">{adapter.syncSummaryItemsLabel}</div><div className="font-medium">{pluralize(runtimeSyncSummary.items_seen, adapter.itemSingular)} scanned</div></div>
+                  <div className="rounded-md border p-3"><div className="text-xs text-muted-foreground">Planned routes</div><div className="font-medium">{pluralize(runtimeSyncSummary.routes_planned, "route")} planned</div></div>
+                  <div className="rounded-md border p-3"><div className="text-xs text-muted-foreground">MongoDB route metadata</div><div className="font-medium">{pluralize(runtimeSyncSummary.routes_upserted, "route")} upserted</div></div>
+                  <div className="rounded-md border p-3"><div className="text-xs text-muted-foreground">OpenFGA tuples</div><div className="font-medium">{pluralize(runtimeSyncSummary.openfga_tuples_written, "OpenFGA tuple")} written</div></div>
+                </div>
+              )}
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setRuntimeSyncModalOpen(false)} disabled={runtimeSyncModalStatus === "loading"}>Close</Button>
+              {runtimeSyncModalMode === "preview" && runtimeSyncModalStatus === "success" && (
+                <Button type="button" onClick={() => void syncBotConfig(false)} disabled={disabled || loading}><FileUp className="h-4 w-4" aria-hidden="true" />Import from YAML Config</Button>
+              )}
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Onboarding defaults — shown on Onboard tab */}
+        {!selfService && view === "onboard" && (
+          <div role="region" aria-label={adapter.ariaLabels.onboardingDefaultsRegion}
+            data-section-tone="teal"
+            className="rounded-md border border-teal-500/25 bg-teal-500/5 p-4 space-y-4">
+            <div>
+              <h3 className="inline-flex items-center gap-2 text-base font-semibold tracking-tight">
+                <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
+                {adapter.copy.onboardingDefaultsHeading}
+              </h3>
+              <p className="text-xs text-muted-foreground">{adapter.copy.onboardingDefaultsDescription}</p>
+            </div>
+            <div className="rounded-md border border-teal-500/15 bg-background/60 p-3 text-xs">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium text-foreground">Last saved</span>
+                {configuredDefaults?.source === "env" && <span className="text-[10px] uppercase tracking-wide text-muted-foreground">from environment variable</span>}
+                {configuredDefaults?.source === "db" && configuredDefaults.updated_at && (
+                  <span className="text-[10px] text-muted-foreground">
+                    {new Date(configuredDefaults.updated_at).toLocaleString()}
+                    {configuredDefaults.updated_by ? ` · ${configuredDefaults.updated_by}` : ""}
+                  </span>
+                )}
+                {configuredDefaults?.source === "unset" && <span className="text-[10px] text-muted-foreground">never saved</span>}
+              </div>
+              <div className="mt-2 grid gap-2 md:grid-cols-2">
+                <div><div className="text-muted-foreground">Onboarding team</div><code>{configuredDefaults?.team_slug ? `team:${configuredDefaults.team_slug}` : "not configured"}</code></div>
+                <div><div className="text-muted-foreground">Onboarding Dynamic Agent</div><code>{configuredDefaults?.agent_id ? `agent:${configuredDefaults.agent_id}` : "not configured"}</code></div>
+              </div>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor={`${adapter.connectorName.toLowerCase()}-default-team`}>Preselected Team</Label>
+                <TeamPicker
+                  id={`${adapter.connectorName.toLowerCase()}-default-team`}
+                  value={defaultTeamSlug} onChange={setDefaultTeamSlug}
+                  disabled={disabled || teams.length === 0}
+                  placeholder={teams.length === 0 ? "No teams configured" : "Select preselected team"}
+                  searchPlaceholder="Search teams..."
+                  options={teams.map<TeamPickerOption>((t) => ({ slug: t.slug, name: t.name || t.slug, id: t.id, _id: t._id }))}
+                />
+                {invalidDefaultTeamSlug && (
+                  <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
+                    The saved default team <code>team:{invalidDefaultTeamSlug}</code> doesn&apos;t match any current team. Pick one above.
+                    {adapter.copy.invalidTeamEnvHint ? ` ${adapter.copy.invalidTeamEnvHint}` : ""}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`${adapter.connectorName.toLowerCase()}-default-agent`}>Preselected Dynamic Agent</Label>
+                <select
+                  id={`${adapter.connectorName.toLowerCase()}-default-agent`}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={defaultAgentId}
+                  onChange={(e) => setDefaultAgentId(e.target.value)}
+                  disabled={disabled || dynamicAgents.length === 0}
+                >
+                  <option value="">{dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select preselected Dynamic Agent"}</option>
+                  {sortedDynamicAgents.map((a) => <option key={a._id} value={a._id}>{agentLabel(a)}</option>)}
+                </select>
+                {invalidDefaultAgentId && (
+                  <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
+                    The saved default Dynamic Agent <code>agent:{invalidDefaultAgentId}</code> wasn&apos;t found (or is disabled). Pick one above.
+                    {adapter.copy.invalidAgentEnvHint ? ` ${adapter.copy.invalidAgentEnvHint}` : ""}
+                  </p>
+                )}
+              </div>
+            </div>
+            {/* Legacy Slackbot YAML prefill checkbox — Slack only */}
+            {adapter.legacyConfigAgentPrefill && (
+              <label className="flex items-start gap-2 rounded-md border border-teal-500/15 bg-background/60 p-3 text-sm">
+                <input type="checkbox" checked={useSlackbotConfigDefaults}
+                  onChange={(e) => setUseSlackbotConfigDefaults(e.target.checked)} disabled={disabled} />
+                <span>
+                  <span className="font-medium">Use existing Slackbot channel agents as defaults</span>
+                  <span className="block text-xs text-muted-foreground">{adapter.legacyConfigAgentPrefill.description}</span>
+                </span>
+              </label>
+            )}
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              {associationDefaultsDirty && <span role="status" className="text-[11px] text-amber-700 dark:text-amber-400">Unsaved changes</span>}
+              <Button type="button" size="sm" variant="default"
+                onClick={() => void saveAssociationDefaults()}
+                disabled={disabled || savingDefaults || !associationDefaultsDirty}
+                aria-label={`Save ${adapter.connectorName} onboarding defaults`}>
+                {savingDefaults ? "Saving…" : "Save defaults"}
+              </Button>
+            </div>
+            {(teams.length === 0 || dynamicAgents.length === 0) && (
+              <p className="text-xs text-muted-foreground">Configure a team or Dynamic Agent in the admin UI, then reload this page.</p>
+            )}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!selfService && view === "channels" && items.length === 0 && (
+          <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">No {adapter.itemPlural} configured yet.</p>
+            <p className="mt-1">Switch to <button type="button" className="underline underline-offset-2" onClick={() => setView("onboard")}>Onboard {adapter.itemPlural}</button> to find {adapter.connectorName} {adapter.itemPlural} where the bot is installed and set them up.</p>
+          </div>
+        )}
+
+        {/* Configured items table */}
+        {(selfService || view === "channels") && items.length > 0 && (
+          <div role="region" aria-label={adapter.ariaLabels.configuredRegion}
+            className="rounded-md border bg-background/60 overflow-hidden">
+            <div className="overflow-auto" style={{ maxHeight: "min(70vh, 100vh - 320px)" }}>
+              <table className="w-full text-sm">
+                <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium">{adapter.itemSingular.charAt(0).toUpperCase() + adapter.itemSingular.slice(1)}</th>
+                    <th className="px-3 py-2 text-left font-medium">Team</th>
+                    <th className="px-3 py-2 text-left font-medium">Agents</th>
+                    <th className="px-3 py-2 text-left font-medium">Health</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => {
+                    const key = adapter.itemKey(item);
+                    const isSelected = key === selectedKey;
+                    const grants = item.active_grants ?? 0;
+                    const warningsCount = isSelected && diagnostics
+                      ? diagnostics.warnings.length : item.health?.warnings_count;
+                    const health = typeof warningsCount === "number"
+                      ? warningsCount > 0
+                        ? { label: `${warningsCount} issue${warningsCount === 1 ? "" : "s"}`, className: "border-amber-300 bg-amber-50 text-amber-800" }
+                        : { label: "healthy", className: "border-emerald-300 bg-emerald-50 text-emerald-700" }
+                      : !item.team_slug
+                        ? { label: "no team", className: "border-amber-300 bg-amber-50 text-amber-800" }
+                        : grants === 0
+                          ? { label: "no agents", className: "border-amber-300 bg-amber-50 text-amber-800" }
+                          : { label: "checking…", className: "border-slate-300 bg-slate-50 text-slate-600" };
+                    const toggle = () => setSelectedKey(isSelected ? "" : key);
+                    return (
+                      <React.Fragment key={key}>
+                        <tr role="button" tabIndex={0} aria-expanded={isSelected} onClick={toggle}
+                          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
+                          className={cn("cursor-pointer border-t transition-colors hover:bg-muted/30 focus:bg-muted/30 focus:outline-none", isSelected && "bg-muted/50")}>
+                          <td className="px-3 py-2">
+                            <div className="flex items-center gap-1.5">
+                              <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform", isSelected && "rotate-90")} aria-hidden="true" />
+                              <div>
+                                <div className="font-medium">{item.item_name}</div>
+                                <div className="text-xs text-muted-foreground">{item.item_id}</div>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-3 py-2">{item.team_slug ? <Badge variant="secondary">team:{item.team_slug}</Badge> : <span className="text-xs text-muted-foreground">—</span>}</td>
+                          <td className="px-3 py-2"><span className={grants === 0 ? "text-muted-foreground" : "font-medium"}>{grants}</span></td>
+                          <td className="px-3 py-2"><Badge variant="outline" className={health.className}>{health.label}</Badge></td>
+                        </tr>
+                        {isSelected && (
+                          <tr className="border-t bg-muted/20">
+                            <td colSpan={4} className="p-4">
+                              <ItemDetail
+                                adapter={adapter} selected={item} diagnostics={diagnostics} routes={routes}
+                                dynamicAgents={dynamicAgents} defaultAgentId={defaultAgentId}
+                                routeAgentId={routeAgentId} setRouteAgentId={setRouteAgentId}
+                                routeListen={routeListen} setRouteListen={setRouteListen}
+                                routePriority={routePriority} setRoutePriority={setRoutePriority}
+                                editingRouteAgentId={editingRouteAgentId} resetRouteForm={resetRouteForm}
+                                editRoute={editRoute} saveRoute={saveRoute} deleteRoute={setRoutePendingDelete}
+                                fixDiagnosticRoute={fixDiagnosticRoute} fixMissingRouteableAgent={fixMissingRouteableAgent}
+                                disabled={disabled} loading={loading} selectedCanManage={selectedCanManage} message={message}
+                              />
+                            </td>
+                          </tr>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Onboarding wizard */}
+        {!selfService && view === "onboard" && (
+          <ConnectorOnboardingWizard
+            connectorName={adapter.connectorName}
+            provider={adapter.discoveryCacheProvider}
+            isAdmin={!selfService}
+            itemSingular={adapter.itemSingular}
+            itemPlural={adapter.itemPlural}
+            discoveredLabel={adapter.copy.discoveryDiscoveredLabel}
+            findLabel={adapter.copy.discoveryFindLabel}
+            refreshLabel={adapter.copy.discoveryRefreshLabel}
+            loadingLabel={adapter.copy.discoveryLoadingLabel}
+            emptyLabel={adapter.copy.discoveryEmptyLabel}
+            description={adapter.copy.discoveryDescription}
+            discoveryStatusText={discoveryStatusText}
+            discoveredCount={discoveredItems.length}
+            newCount={discoveredNewCount}
+            selectedCount={selectedDiscoveredRows.length}
+            rows={discoveredRows.map((row) => ({
+              id: row.id,
+              name: row.name,
+              secondary: row.secondary,
+              selected: row.selected,
+              teamSlug: row.team_slug,
+              agentId: row.agent_id,
+              isExisting: row.is_existing,
+              importLabel: `Import ${row.name}`,
+              teamLabel: `Team for ${row.name}`,
+              agentLabel: `Dynamic Agent for ${row.name}`,
+            }))}
+            teams={teams.map((t) => ({ value: t.slug, label: t.name || t.slug }))}
+            agents={sortedDynamicAgents.map((a) => ({ value: a._id, label: a.name || a._id }))}
+            error={discoverError}
+            disabled={disabled}
+            loading={loading}
+            discovering={discoverLoading}
+            searchValue={discoverySearch}
+            onSearchChange={setDiscoverySearch}
+            enableBulkApply
+            onDiscover={() => void discoverItems()}
+            onSelectAll={() => setAllRowsSelected(true)}
+            onClearSelection={() => setAllRowsSelected(false)}
+            onRowChange={(id, updates) => updateDiscoveredRow(id, {
+              ...(typeof updates.selected === "boolean" ? { selected: updates.selected } : {}),
+              ...(typeof updates.teamSlug === "string" ? { team_slug: updates.teamSlug } : {}),
+              ...(typeof updates.agentId === "string" ? { agent_id: updates.agentId } : {}),
+            })}
+            onApply={() => void applyOnboarding()}
+          />
+        )}
+
+        {/* Delete confirmation dialog */}
+        <Dialog open={Boolean(routePendingDelete)} onOpenChange={(open) => { if (!open && !loading) setRoutePendingDelete(null); }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete {adapter.itemSingular}-agent association?</DialogTitle>
+              <DialogDescription>
+                {routePendingDelete ? `This removes agent:${routePendingDelete.agent_id} from the selected ${adapter.connectorName} ${adapter.itemSingular}.` : `This removes the selected agent from the ${adapter.connectorName} ${adapter.itemSingular}.`}
+              </DialogDescription>
+            </DialogHeader>
+            <p className="text-sm text-muted-foreground">The OpenFGA tuple will be deleted, and the saved Mongo route metadata for listen mode and priority will be deleted as well.</p>
+            {routePendingDelete && (
+              <div className="rounded-md border bg-muted/30 p-3 text-sm">
+                <div><span className="font-medium">Listen:</span> {routePendingDelete.users?.listen ?? "mention"}</div>
+                <div><span className="font-medium">Priority:</span> {routePendingDelete.priority}</div>
+              </div>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setRoutePendingDelete(null)} disabled={loading}>Cancel</Button>
+              <Button type="button" variant="destructive" onClick={() => void deleteRouteConfirmed()} disabled={loading}>{loading ? "Deleting..." : "Delete association"}</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -1,423 +1,234 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  ChevronRight,
-  FileUp,
-  RefreshCw,
-  RotateCw,
-  Settings2,
-  Sparkles,
-} from "lucide-react";
-
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { useToast } from "@/components/ui/toast";
-import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
-import { cn } from "@/lib/utils";
-import { ConnectorOnboardingWizard } from "./ConnectorOnboardingWizard";
-
-interface SlackChannelSummary {
-  workspace_id: string;
-  channel_id: string;
-  channel_name: string;
-  team_slug?: string;
-  active_grants: number;
-  can_manage?: boolean;
-  health?: {
-    warnings_count: number;
-    openfga_reachable: boolean;
-    last_runtime_error_ts: string | null;
-  };
-}
-
-interface SlackChannelAgentRoute {
-  agent_id: string;
-  enabled: boolean;
-  priority: number;
-  users?: {
-    enabled?: boolean;
-    listen?: "message" | "mention" | "all";
-  };
-}
-
-interface SlackRuntimeDiagnosticRoute {
-  agent_id: string;
-  openfga_tuple: boolean;
-  route_metadata: boolean;
-  listen: "message" | "mention" | "all" | "unknown";
-  priority: number;
-  runtime_matches: {
-    mention: boolean;
-    message: boolean;
-  };
-  warnings: string[];
-}
-
-interface SlackRuntimeDiagnostics {
-  openfga: {
-    reachable: boolean;
-    tuple_count: number;
-    error?: string;
-  };
-  routes: SlackRuntimeDiagnosticRoute[];
-  warnings: string[];
-  last_runtime_error?: {
-    ts?: string;
-    reason_code?: string;
-    message?: string;
-    action?: string;
-  } | null;
-}
-
-interface DynamicAgentOption {
-  _id: string;
-  name: string;
-}
-
-interface TeamOption {
-  _id?: string;
-  id?: string;
-  slug: string;
-  name: string;
-}
-
-interface SlackChannelAssociationDefaults {
-  team_slug: string;
-  agent_id: string;
-  create_routes?: boolean;
-  /** Set by the persistence API (DB-backed); empty when value came from env. */
-  updated_at?: string;
-  /** Email of the admin who last saved; empty for env-only values. */
-  updated_by?: string;
-  /** "db" | "env" | "unset" — drives the "Saved" vs "Env default" label. */
-  source?: "db" | "env" | "unset";
-}
-
-interface SlackBotRuntimeStatus {
-  route_mode: string;
-  static_config: {
-    channels: number;
-    routes: number;
-  };
-  route_cache: {
-    ttl_seconds: number;
-    cache_size: number;
-    cached_channels?: string[];
-  };
-  last_sync?: SlackBotRuntimeSyncSummary | null;
-}
-
-interface SlackBotRuntimeSyncSummary {
-  dry_run: boolean;
-  channels_seen: number;
-  routes_planned: number;
-  routes_upserted: number;
-  openfga_tuples_written: number;
-}
-
-interface DiscoveredSlackChannel {
-  id: string;
-  name: string;
-  is_private?: boolean;
-  is_member?: boolean;
-  num_members?: number;
-}
-
-interface SlackChannelImportRow extends DiscoveredSlackChannel {
-  selected: boolean;
-  team_slug: string;
-  agent_id: string;
-  is_existing: boolean;
-}
-
-interface SlackLegacyConfigDefault {
-  suggested_agent_id?: string | null;
-  agents?: Array<{
-    agent_id?: string;
-    priority?: number;
-  }>;
-}
-
-interface SlackLegacyConfigDefaultsPayload {
-  channels?: Record<string, SlackLegacyConfigDefault>;
-}
-
-interface SlackChannelDiscoveryPayload {
-  channels: DiscoveredSlackChannel[];
-  next_cursor?: string | null;
-  has_more?: boolean;
-}
-
-interface SlackChannelDefaultsSummary {
-  channels_seen: number;
-  channels_assigned_team: number;
-  channel_grants_ensured: number;
-  routes_ensured: number;
-  channels_discovered?: number;
-  channels_onboarded?: number;
-  routes_preserved?: number;
-}
-
-type RuntimeSyncModalMode = "preview" | "apply";
-type RuntimeSyncModalStatus = "idle" | "loading" | "success" | "error";
+import React from "react";
+import { ConnectorAdminPanel } from "./ConnectorAdminPanel";
+import type {
+  ConnectorAdminAdapter,
+  DiagnosticRoute,
+  ItemSummary,
+} from "./connector-admin-adapter";
 
 function apiData<T>(payload: { data?: T } & T): T {
   return (payload.data ?? payload) as T;
-}
-
-function agentLabel(agent: DynamicAgentOption): string {
-  return `${agent.name || agent._id} (${agent._id})`;
 }
 
 function pluralize(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
-interface ChannelDetailProps {
-  selected: SlackChannelSummary;
-  diagnostics: SlackRuntimeDiagnostics | null;
-  routes: SlackChannelAgentRoute[];
-  dynamicAgents: DynamicAgentOption[];
-  routeAgentId: string;
-  setRouteAgentId: (value: string) => void;
-  routeListen: "message" | "mention" | "all";
-  setRouteListen: (value: "message" | "mention" | "all") => void;
-  routePriority: number;
-  setRoutePriority: (value: number) => void;
-  editingRouteAgentId: string | null;
-  resetRouteForm: () => void;
-  editRoute: (route: SlackChannelAgentRoute) => void;
-  saveRoute: () => Promise<void> | void;
-  deleteRoute: (route: SlackChannelAgentRoute) => void;
-  fixDiagnosticRoute: (route: SlackRuntimeDiagnosticRoute) => Promise<void> | void;
-  diagnosticRouteIsFixable: (route: SlackRuntimeDiagnosticRoute) => boolean;
-  disabled: boolean;
-  loading: boolean;
-  selectedCanManage: boolean;
-  message: string | null;
-}
+const SLACK_ADAPTER: ConnectorAdminAdapter = {
+  connectorName: "Slack",
+  itemSingular: "channel",
+  itemPlural: "channels",
 
-function ChannelDetail({
-  selected,
-  diagnostics,
-  routes,
-  dynamicAgents,
-  routeAgentId,
-  setRouteAgentId,
-  routeListen,
-  setRouteListen,
-  routePriority,
-  setRoutePriority,
-  editingRouteAgentId,
-  resetRouteForm,
-  editRoute,
-  saveRoute,
-  deleteRoute,
-  fixDiagnosticRoute,
-  diagnosticRouteIsFixable,
-  disabled,
-  loading,
-  selectedCanManage,
-  message,
-}: ChannelDetailProps) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-3">
-        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Diagnostics
-        </div>
-        {!diagnostics ? (
-          <p className="text-sm text-muted-foreground">Loading diagnostics...</p>
-        ) : (
-          <>
-            <div className="grid gap-2 text-sm md:grid-cols-3">
-              <div className="rounded-md border bg-background/60 p-3">
-                <div className="text-xs text-muted-foreground">OpenFGA</div>
-                <div className="font-medium">{diagnostics.openfga.reachable ? "reachable" : "unreachable"}</div>
-                <div className="text-xs text-muted-foreground">{diagnostics.openfga.tuple_count} channel-agent tuples</div>
-              </div>
-              <div className="rounded-md border bg-background/60 p-3">
-                <div className="text-xs text-muted-foreground">Runtime routes</div>
-                <div className="font-medium">{diagnostics.routes.length}</div>
-                <div className="text-xs text-muted-foreground">OpenFGA-backed candidates</div>
-              </div>
-              <div className="rounded-md border bg-background/60 p-3">
-                <div className="text-xs text-muted-foreground">Last error</div>
-                <div className="font-medium">{diagnostics.last_runtime_error?.reason_code ?? "none"}</div>
-                <div className="text-xs text-muted-foreground">{diagnostics.last_runtime_error?.ts ?? "No recent runtime error"}</div>
-              </div>
-            </div>
-            {diagnostics.warnings.length > 0 && (
-              <div className="space-y-1 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
-                <div className="text-xs font-medium uppercase tracking-wide">Issues found</div>
-                {diagnostics.warnings.map((warning) => (
-                  <div key={warning}>{warning}</div>
-                ))}
-              </div>
-            )}
-            {diagnostics.last_runtime_error?.message && (
-              <div className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">
-                {diagnostics.last_runtime_error.message}
-              </div>
-            )}
-            {diagnostics.routes.length > 0 && (
-              <div className="space-y-2">
-                {diagnostics.routes.map((route) => (
-                  <div key={route.agent_id} className="flex flex-wrap items-center gap-2 rounded-md border bg-background/60 p-3 text-sm">
-                    <span className="font-medium">agent:{route.agent_id}</span>
-                    <Badge variant={route.openfga_tuple ? "default" : "outline"}>
-                      {route.openfga_tuple ? "OpenFGA tuple" : "missing tuple"}
-                    </Badge>
-                    <Badge variant={route.route_metadata ? "secondary" : "outline"}>
-                      {route.route_metadata ? `listen:${route.listen}` : "default metadata"}
-                    </Badge>
-                    <span className="text-xs text-muted-foreground">
-                      mention {route.runtime_matches.mention ? "yes" : "no"} / message {route.runtime_matches.message ? "yes" : "no"}
-                    </span>
-                    {diagnosticRouteIsFixable(route) && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="ml-auto"
-                        onClick={() => void fixDiagnosticRoute(route)}
-                        disabled={disabled || !selectedCanManage || loading}
-                        aria-label={`Fix agent:${route.agent_id} routing`}
-                      >
-                        Fix it
-                      </Button>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
-        )}
-      </div>
+  api: {
+    list: "/api/admin/slack/channels",
+    discoveryUrl: (page, cursor) => {
+      const p = new URLSearchParams({ member_only: "1", limit: "500" });
+      if (cursor) p.set("cursor", cursor);
+      void page;
+      return `/api/admin/slack/available-channels?${p.toString()}`;
+    },
+    defaults: "/api/admin/slack/channels/defaults",
+    runtimeStatus: "/api/admin/slack/runtime/status",
+    runtimeReload: "/api/admin/slack/runtime/reload",
+    runtimeSyncFromConfig: "/api/admin/slack/runtime/sync-from-config",
+    routesFor: (ws, ch) => `/api/admin/slack/channels/${encodeURIComponent(ws)}/${encodeURIComponent(ch)}/routes`,
+    diagnosticsFor: (ws, ch) => `/api/admin/slack/channels/${encodeURIComponent(ws)}/${encodeURIComponent(ch)}/diagnostics`,
+    legacyConfigDefaults: "/api/admin/slack/runtime/config-defaults",
+  },
 
-      <div className="space-y-3">
-        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Agents
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Multiple agents can be associated with #{selected.channel_name}. The Slack bot picks the
-          highest-priority agent whose listen mode matches the message (mention vs. plain message).
-        </p>
-        <div className="grid gap-3 md:grid-cols-4">
-          <div className="space-y-2 md:col-span-2">
-            <Label htmlFor="slack-route-agent-id">Dynamic Agent</Label>
-            <select
-              id="slack-route-agent-id"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              value={routeAgentId}
-              onChange={(event) => setRouteAgentId(event.target.value)}
-              disabled={disabled || !selectedCanManage || dynamicAgents.length === 0}
-            >
-              <option value="">
-                {dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select Dynamic Agent"}
-              </option>
-              {dynamicAgents.map((agent) => (
-                <option key={agent._id} value={agent._id}>
-                  {agentLabel(agent)}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="slack-route-listen">Listen</Label>
-            <select
-              id="slack-route-listen"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              value={routeListen}
-              onChange={(event) => setRouteListen(event.target.value as "message" | "mention" | "all")}
-              disabled={disabled || !selectedCanManage}
-            >
-              <option value="mention">mention</option>
-              <option value="message">message</option>
-              <option value="all">all</option>
-            </select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="slack-route-priority">Priority</Label>
-            <Input
-              id="slack-route-priority"
-              type="number"
-              value={routePriority}
-              onChange={(event) => setRoutePriority(Number(event.target.value))}
-              disabled={disabled || !selectedCanManage}
-            />
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Button onClick={() => void saveRoute()} disabled={disabled || !selectedCanManage || loading || !routeAgentId.trim()}>
-            {loading
-              ? "Saving..."
-              : editingRouteAgentId
-                ? "Update Association"
-                : "Create Association"}
-          </Button>
-          {editingRouteAgentId && (
-            <Button type="button" variant="outline" onClick={resetRouteForm} disabled={loading}>
-              Cancel edit
-            </Button>
-          )}
-        </div>
-        {message && <p className="text-sm text-muted-foreground">{message}</p>}
-        {routes.length > 0 && (
-          <div className="space-y-2">
-            {routes.map((route) => (
-              <div
-                key={route.agent_id}
-                className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background/60 p-3 text-sm"
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <span>agent:{route.agent_id}</span>
-                  <Badge>
-                    {route.users?.listen ?? "mention"} / priority {route.priority}
-                  </Badge>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => editRoute(route)}
-                    disabled={disabled || !selectedCanManage || loading}
-                    aria-label={`Edit agent:${route.agent_id}`}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => deleteRoute(route)}
-                    disabled={disabled || !selectedCanManage || loading}
-                    aria-label={`Delete agent:${route.agent_id}`}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+  parseListResponse: (json) => {
+    const d = apiData<{ channels: unknown[] }>(json as { channels: unknown[] });
+    return (d.channels ?? []) as Record<string, unknown>[];
+  },
+  parseListItem: (raw) => {
+    const r = raw as Record<string, unknown>;
+    if (!r.channel_id) return null;
+    return {
+      workspace_id: String(r.workspace_id ?? ""),
+      item_id: String(r.channel_id),
+      item_name: `#${String(r.channel_name ?? r.channel_id)}`,
+      team_slug: r.team_slug ? String(r.team_slug) : undefined,
+      active_grants: Number(r.active_grants ?? 0),
+      can_manage: Boolean(r.can_manage),
+      health: r.health as ItemSummary["health"],
+    };
+  },
+  itemKey: (item) => `${item.workspace_id}/${item.item_id}`,
+  parseDiscoveryPage: (json) => {
+    const d = apiData<{ channels: unknown[]; next_cursor?: string | null; has_more?: boolean }>(
+      json as { channels: unknown[] },
+    );
+    const channels = (d.channels ?? []) as Record<string, unknown>[];
+    return {
+      items: channels
+        .filter((ch) => ch.is_member !== false)
+        .map((ch) => ({
+          id: String(ch.id ?? ""),
+          name: `#${String(ch.name ?? ch.id)}`,
+          secondary: [
+            String(ch.id ?? ""),
+            typeof ch.num_members === "number" ? pluralize(ch.num_members, "member") : "",
+          ].filter(Boolean).join(" · "),
+        })),
+      nextCursor: d.next_cursor ?? null,
+      hasMore: Boolean(d.has_more),
+    };
+  },
+  parseRuntimeStatus: (json) => {
+    const d = json as Record<string, unknown>;
+    const sc = (d.static_config ?? {}) as Record<string, number>;
+    const rc = (d.route_cache ?? {}) as Record<string, unknown>;
+    return {
+      route_mode: String(d.route_mode ?? "unknown"),
+      static_config: sc,
+      route_cache: { ttl_seconds: Number(rc.ttl_seconds ?? 0), cache_size: Number(rc.cache_size ?? 0) },
+      raw: d,
+    };
+  },
+  parseRuntimeSyncSummary: (json) => {
+    const d = json as Record<string, unknown>;
+    return {
+      dry_run: Boolean(d.dry_run),
+      items_seen: Number(d.channels_seen ?? 0),
+      routes_planned: Number(d.routes_planned ?? 0),
+      routes_upserted: Number(d.routes_upserted ?? 0),
+      openfga_tuples_written: Number(d.openfga_tuples_written ?? 0),
+    };
+  },
+
+  discoveryCacheProvider: "slack",
+
+  copy: {
+    configuredTabTitle: "Configured channels",
+    configuredTabDescription: "Channels CAIPE already knows about. Click a channel to manage its agents and diagnostics.",
+    onboardTabTitle: "Onboard channels",
+    onboardTabDescription: "Find Slack channels where the bot is installed and set them up.",
+    advancedTabTitle: "Advanced",
+    advancedTabDescription: "One-time YAML import and Slack bot runtime status. Most admins won't need this.",
+    advancedHeading: "Import from Slackbot YAML",
+    botNameInLegend: "Slackbot",
+    onboardingDefaultsHeading: "Default team and agent for new channels",
+    onboardingDefaultsDescription: "These pre-fill the picker for each discovered channel below. You can override per channel before applying.",
+    discoveryDescription: "Find Slack channels where the bot is already installed. Channels the bot has not joined will not appear.",
+    discoveryFindLabel: "Find channels",
+    discoveryRefreshLabel: "Refresh channels",
+    discoveryLoadingLabel: "Finding channels…",
+    discoveryEmptyLabel: "No bot-member channels were discovered.",
+    discoveryDiscoveredLabel: "bot-member channel",
+    invalidTeamEnvHint: "Update SLACK_DEFAULT_TEAM_SLUG in the environment to make the new choice the default for next time.",
+    invalidAgentEnvHint: "Update SLACK_DEFAULT_AGENT_ID in the environment to make the new choice the default for next time.",
+    selfServiceTitle: "My Slack Channel Settings",
+    selfServiceDescription: "Manage bot routing behavior only for Slack channels where OpenFGA grants you channel admin access.",
+  },
+  ariaLabels: {
+    tablist: "Slack admin views",
+    configuredRegion: "Configured Slack channels",
+    advancedRegion: "Advanced Setup - Import/Sync with Slackbot",
+    advancedLegend: "Slackbot sync legend",
+    onboardingDefaultsRegion: "Default team and agent for new channels",
+  },
+
+  discoveryStatusText: ({ discoveredCount, newCount, configuredCount, unassignedCount }) =>
+    discoveredCount > 0
+      ? `${discoveredCount} bot-member found · ${newCount} new · ${configuredCount} in CAIPE · ${unassignedCount} missing team`
+      : `${configuredCount} in CAIPE · ${unassignedCount} missing team`,
+
+  staticConfigLabel: ({ items, routes }) => `${items} channels / ${routes} routes`,
+  routeCacheLabel: (count) => `${count} cached channel${count === 1 ? "" : "s"}`,
+  syncDialogueTitle: (mode) => mode === "preview" ? "Slack Bot Config Sync Preview" : "Slack Bot Config Sync Apply",
+  syncDialogueDescription: "Preview reads the Slack bot's loaded static YAML config. Apply upserts matching MongoDB route metadata and channel-agent OpenFGA tuples without deleting UI-managed associations.",
+  syncSummaryItemsLabel: "Channels",
+
+  authzDisclaimer: (
+    <>
+      <div>
+        Slack authorization has two checks before dispatch: the channel must have
+        <code className="mx-1">can_use agent:&lt;id&gt;</code>, and the user&apos;s active
+        team must also have <code className="mx-1">can_use agent:&lt;id&gt;</code>.
+        If either check fails, the Slack bot denies the request before calling the agent.
       </div>
-    </div>
-  );
-}
+      <div className="rounded-md border border-amber-300/60 bg-amber-50 p-2 text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
+        <span className="font-medium">Sharing model:</span> Adding an agent to a
+        channel that is assigned to a team transitively grants <em>every member of
+        that team</em> permission to invoke the agent in this channel — even members
+        who were never granted the agent directly. If that is not what you want, share
+        the agent with a smaller subgroup (or with individual users) instead of the
+        channel&apos;s team.
+      </div>
+    </>
+  ),
+
+  manualRouteEditing: true,
+  manualRouteFormHint: (item) => (
+    <p className="text-xs text-muted-foreground">
+      Multiple agents can be associated with {item.item_name}. The Slack bot picks the
+      highest-priority agent whose listen mode matches the message (mention vs. plain message).
+    </p>
+  ),
+
+  diagnosticRouteIsFixable: (route: DiagnosticRoute) => route.route_metadata && !route.openfga_tuple,
+  fixDiagnosticRoute: async ({ item, route }) => {
+    const routeUrl = `/api/admin/slack/channels/${encodeURIComponent(item.workspace_id)}/${encodeURIComponent(item.item_id)}/routes`;
+    const res = await fetch(routeUrl, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: route.agent_id }),
+    });
+    if (!res.ok) throw new Error(await res.text());
+    return { toast: `Removed stale route metadata for agent:${route.agent_id}.` };
+  },
+
+  applyOnboarding: async ({ rows, defaultTeamSlug, defaultAgentId, createDefaultRoutes, fetchFn }) => {
+    const selectedImports = rows.filter((r) => r.selected);
+    if (selectedImports.length === 0 && (!defaultTeamSlug || !defaultAgentId)) {
+      const missing: string[] = [];
+      if (!defaultTeamSlug) missing.push("Preselected Team");
+      if (!defaultAgentId) missing.push("Preselected Dynamic Agent");
+      throw new Error(`Select ${missing.join(" and ")} in the "Default team and agent for new channels" section before running setup.`);
+    }
+    const fallbackTeamSlug = defaultTeamSlug || selectedImports[0]?.teamSlug || "";
+    const fallbackAgentId = defaultAgentId || selectedImports[0]?.agentId || "";
+    const res = await fetchFn("/api/admin/slack/channels/defaults", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        team_slug: fallbackTeamSlug,
+        agent_id: fallbackAgentId,
+        create_routes: createDefaultRoutes,
+        ...(selectedImports.length > 0 ? {
+          channel_defaults: selectedImports.map((ch) => ({ id: ch.id, name: ch.name, team_slug: ch.teamSlug, agent_id: ch.agentId })),
+        } : {}),
+      }),
+    });
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<{ summary: Record<string, number> }>(await res.json());
+    const s = data.summary;
+    return {
+      toastMessage: selectedImports.length > 0
+        ? `Discovered defaults applied: onboarded ${s.channels_onboarded ?? 0} channels, assigned ${s.channels_assigned_team} channels, ensured ${s.channel_grants_ensured} channel grants, ensured ${s.routes_ensured} routes, preserved ${s.routes_preserved ?? 0} existing routes.`
+        : `Slack channel association defaults applied: assigned ${s.channels_assigned_team} channels, ensured ${s.channel_grants_ensured} channel grants, ensured ${s.routes_ensured} routes.`,
+    };
+  },
+
+  legacyConfigAgentPrefill: {
+    description: "Checked by default for migrations. Uncheck only if you want one selected Dynamic Agent for all discovered channels.",
+    fetchSuggestions: async (fetchFn) => {
+      const res = await fetchFn("/api/admin/slack/runtime/config-defaults", { cache: "no-store" });
+      if (!res.ok) throw new Error(await res.text());
+      const data = apiData<{ channels?: Record<string, { suggested_agent_id?: string | null }> }>(await res.json());
+      const suggestions: Record<string, string> = {};
+      for (const [id, ch] of Object.entries(data.channels ?? {})) {
+        const agentId = ch.suggested_agent_id?.trim();
+        if (agentId) suggestions[id] = agentId;
+      }
+      return suggestions;
+    },
+  },
+
+  missingRouteableAgentAutoFix: null,
+};
 
 export function SlackChannelRebacPanel({
   disabled = false,
@@ -426,1332 +237,5 @@ export function SlackChannelRebacPanel({
   disabled?: boolean;
   selfService?: boolean;
 }) {
-  const { toast } = useToast();
-  const [channels, setChannels] = useState<SlackChannelSummary[]>([]);
-  const [selectedKey, setSelectedKey] = useState("");
-  const [routes, setRoutes] = useState<SlackChannelAgentRoute[]>([]);
-  const [diagnostics, setDiagnostics] = useState<SlackRuntimeDiagnostics | null>(null);
-  const [dynamicAgents, setDynamicAgents] = useState<DynamicAgentOption[]>([]);
-  const [teams, setTeams] = useState<TeamOption[]>([]);
-  const [routeAgentId, setRouteAgentId] = useState("");
-  const [editingRouteAgentId, setEditingRouteAgentId] = useState<string | null>(null);
-  const [routePendingDelete, setRoutePendingDelete] = useState<SlackChannelAgentRoute | null>(null);
-  const [defaultTeamSlug, setDefaultTeamSlug] = useState("");
-  const [defaultAgentId, setDefaultAgentId] = useState("");
-  const [invalidDefaultTeamSlug, setInvalidDefaultTeamSlug] = useState<string | null>(null);
-  const [invalidDefaultAgentId, setInvalidDefaultAgentId] = useState<string | null>(null);
-  const [configuredDefaults, setConfiguredDefaults] = useState<SlackChannelAssociationDefaults | null>(null);
-  const [useSlackbotConfigDefaults, setUseSlackbotConfigDefaults] = useState(true);
-  const [slackRuntimeStatus, setSlackRuntimeStatus] = useState<SlackBotRuntimeStatus | null>(null);
-  const [runtimeSyncSummary, setRuntimeSyncSummary] = useState<SlackBotRuntimeSyncSummary | null>(null);
-  const [runtimeSyncModalOpen, setRuntimeSyncModalOpen] = useState(false);
-  const [runtimeSyncModalMode, setRuntimeSyncModalMode] = useState<RuntimeSyncModalMode>("preview");
-  const [runtimeSyncModalStatus, setRuntimeSyncModalStatus] = useState<RuntimeSyncModalStatus>("idle");
-  const [runtimeSyncModalError, setRuntimeSyncModalError] = useState<string | null>(null);
-  const [createDefaultRoutes, setCreateDefaultRoutes] = useState(true);
-  const [savingDefaults, setSavingDefaults] = useState(false);
-  const [discoverDefaultsLoading, setDiscoverDefaultsLoading] = useState(false);
-  const [discoverDefaultsError, setDiscoverDefaultsError] = useState<string | null>(null);
-  const [discoveredBotChannels, setDiscoveredBotChannels] = useState<DiscoveredSlackChannel[]>([]);
-  const [discoveredImportRows, setDiscoveredImportRows] = useState<SlackChannelImportRow[]>([]);
-  const [routeListen, setRouteListen] = useState<"message" | "mention" | "all">("mention");
-  const [routePriority, setRoutePriority] = useState(100);
-  const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
-  // Sub-tab the admin is viewing. `channels` shows configured channels
-  // (with drill-in for diagnostics + per-channel route editing).
-  // `onboard` shows discovery + bulk import. `advanced` shows YAML
-  // import and runtime status. Self-service users always see the
-  // channel detail layout, which renders unconditionally below.
-  type SlackPanelView = "channels" | "onboard" | "advanced";
-  const [view, setView] = useState<SlackPanelView>("channels");
-  // Search box for the onboarding wizard's discovered list. Lifted to
-  // the panel so we keep the value across refresh clicks.
-  const [discoverySearch, setDiscoverySearch] = useState("");
-
-  const selected = useMemo(
-    () => channels.find((channel) => `${channel.workspace_id}/${channel.channel_id}` === selectedKey),
-    [channels, selectedKey]
-  );
-  const selectedCanManage = !selfService || selected?.can_manage === true;
-  const unassignedChannelCount = useMemo(
-    () => channels.filter((channel) => !channel.team_slug).length,
-    [channels]
-  );
-  const configuredChannelIds = useMemo(
-    () => new Set(channels.map((channel) => channel.channel_id)),
-    [channels]
-  );
-  const configuredChannelsById = useMemo(
-    () => new Map(channels.map((channel) => [channel.channel_id, channel])),
-    [channels]
-  );
-  const sortedDynamicAgents = useMemo(
-    () => [...dynamicAgents].sort((left, right) => agentLabel(left).localeCompare(agentLabel(right))),
-    [dynamicAgents]
-  );
-  const dynamicAgentIds = useMemo(
-    () => new Set(dynamicAgents.map((agent) => agent._id)),
-    [dynamicAgents]
-  );
-  const teamSlugSet = useMemo(
-    () => new Set(teams.map((team) => team.slug).filter(Boolean) as string[]),
-    [teams]
-  );
-  // Returns the agent that should pre-fill discovered rows when the
-  // legacy Slackbot YAML has no entry for that channel. Honors the
-  // admin's saved default; otherwise leaves the row's agent unset so
-  // the admin sees a "Pick an agent" status instead of getting an
-  // arbitrary alphabetical default silently submitted on their behalf.
-  const fallbackAgentId = useMemo(() => {
-    if (defaultAgentId && dynamicAgentIds.has(defaultAgentId)) return defaultAgentId;
-    return "";
-  }, [defaultAgentId, dynamicAgentIds]);
-  // True when the form picks differ from what's actually persisted —
-  // drives the dedicated "Save defaults" button's enabled state and
-  // the small "Unsaved changes" indicator next to the chips. Treat
-  // missing fields on `configuredDefaults` as empty so a never-saved
-  // tenant doesn't get a permanent "dirty" badge.
-  const associationDefaultsDirty = useMemo(() => {
-    const savedTeam = configuredDefaults?.team_slug ?? "";
-    const savedAgent = configuredDefaults?.agent_id ?? "";
-    const savedCreateRoutes =
-      typeof configuredDefaults?.create_routes === "boolean"
-        ? configuredDefaults.create_routes
-        : true;
-    return (
-      savedTeam !== defaultTeamSlug ||
-      savedAgent !== defaultAgentId ||
-      savedCreateRoutes !== createDefaultRoutes
-    );
-  }, [configuredDefaults, defaultTeamSlug, defaultAgentId, createDefaultRoutes]);
-  const discoveredNewChannelCount = useMemo(
-    () => discoveredBotChannels.filter((channel) => !configuredChannelIds.has(channel.id)).length,
-    [configuredChannelIds, discoveredBotChannels]
-  );
-  const selectedDiscoveredImportRows = useMemo(
-    () => discoveredImportRows.filter((row) => row.selected && row.team_slug && row.agent_id),
-    [discoveredImportRows]
-  );
-  const discoveryStatusText =
-    discoveredBotChannels.length > 0
-      ? `${discoveredBotChannels.length} bot-member found · ${discoveredNewChannelCount} new · ${channels.length} in CAIPE · ${unassignedChannelCount} missing team`
-      : `${channels.length} in CAIPE · ${unassignedChannelCount} missing team`;
-
-  const loadChannels = useCallback(async () => {
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/slack/channels?health=1");
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<{ channels: SlackChannelSummary[] }>(await response.json());
-      setChannels(data.channels ?? []);
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to load Slack channels");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const loadRoutes = useCallback(async () => {
-    if (!selected) return;
-    const response = await fetch(
-      `/api/admin/slack/channels/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.channel_id)}/routes`
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ routes: SlackChannelAgentRoute[] }>(await response.json());
-    setRoutes(data.routes ?? []);
-  }, [selected]);
-
-  const loadDiagnostics = useCallback(async () => {
-    if (!selected) return;
-    const response = await fetch(
-      `/api/admin/slack/channels/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.channel_id)}/diagnostics`
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<SlackRuntimeDiagnostics>(await response.json());
-    setDiagnostics(data);
-  }, [selected]);
-
-  const loadDynamicAgents = useCallback(async () => {
-    const response = await fetch("/api/dynamic-agents?enabled_only=true");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ items: DynamicAgentOption[] }>(await response.json());
-    setDynamicAgents(data.items ?? []);
-  }, []);
-
-  const loadTeams = useCallback(async () => {
-    const response = await fetch("/api/admin/teams");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ teams: TeamOption[] }>(await response.json());
-    setTeams(data.teams ?? []);
-  }, []);
-
-  const loadAssociationDefaults = useCallback(async () => {
-    const response = await fetch("/api/admin/slack/channels/defaults");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ defaults: SlackChannelAssociationDefaults }>(await response.json());
-    setConfiguredDefaults(data.defaults ?? null);
-    // Adopt the saved values verbatim — empty strings included — so
-    // clearing the save in another tab is reflected here on the next
-    // load. The previous `current || …` pattern was a one-way bridge
-    // that only ever populated empty fields, which is why admins saw
-    // stale values stick after they cleared their pick.
-    if (data.defaults) {
-      setDefaultTeamSlug(data.defaults.team_slug ?? "");
-      setDefaultAgentId(data.defaults.agent_id ?? "");
-      if (typeof data.defaults.create_routes === "boolean") {
-        setCreateDefaultRoutes(data.defaults.create_routes);
-      }
-    }
-  }, []);
-
-  // Persist the onboarding defaults to MongoDB (`platform_config`) so
-  // the admin's pick survives a page reload. This is the explicit
-  // "Save defaults" button the UI exposes — distinct from the
-  // migration POST, which only fires when the admin clicks "Apply" on
-  // the import wizard.
-  const saveAssociationDefaults = useCallback(async () => {
-    setSavingDefaults(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/slack/channels/defaults", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          team_slug: defaultTeamSlug,
-          agent_id: defaultAgentId,
-          create_routes: createDefaultRoutes,
-        }),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<{ defaults: SlackChannelAssociationDefaults }>(
-        await response.json(),
-      );
-      setConfiguredDefaults(data.defaults ?? null);
-      if (data.defaults) {
-        setDefaultTeamSlug(data.defaults.team_slug ?? "");
-        setDefaultAgentId(data.defaults.agent_id ?? "");
-        if (typeof data.defaults.create_routes === "boolean") {
-          setCreateDefaultRoutes(data.defaults.create_routes);
-        }
-      }
-      toast("Onboarding defaults saved.", "success");
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to save Slack onboarding defaults";
-      setMessage(errorMessage);
-      toast(errorMessage, "error");
-    } finally {
-      setSavingDefaults(false);
-    }
-  }, [defaultTeamSlug, defaultAgentId, createDefaultRoutes, toast]);
-
-  const loadSlackRuntimeStatus = useCallback(async () => {
-    const response = await fetch("/api/admin/slack/runtime/status");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<SlackBotRuntimeStatus>(await response.json());
-    setSlackRuntimeStatus(data);
-  }, []);
-
-  useEffect(() => {
-    void loadChannels();
-  }, [loadChannels]);
-
-  useEffect(() => {
-    void loadDynamicAgents().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Dynamic Agents")
-    );
-  }, [loadDynamicAgents]);
-
-  useEffect(() => {
-    if (selfService) return;
-    void loadTeams().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load teams")
-    );
-  }, [loadTeams, selfService]);
-
-  useEffect(() => {
-    if (selfService) return;
-    void loadAssociationDefaults().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Slack channel association defaults")
-    );
-  }, [loadAssociationDefaults, selfService]);
-
-  // Drop env-provided default Dynamic Agent / team if it no longer resolves to a
-  // real, enabled record. Otherwise the dropdown silently submits a stale id
-  // (e.g. SLACK_DEFAULT_AGENT_ID points at a deleted agent) and the API
-  // rejects with "Dynamic Agent <id> was not found or is disabled".
-  useEffect(() => {
-    if (selfService) return;
-    if (dynamicAgents.length === 0) return;
-    // Clear the stale-default warning ONLY when the admin picks a real,
-    // valid agent. We deliberately do NOT clear it when defaultAgentId
-    // is "" — that would race the same effect that just emptied the
-    // value after detecting the stale env id, and the warning would
-    // disappear on the next render before the admin saw it.
-    if (!defaultAgentId) return;
-    if (!dynamicAgentIds.has(defaultAgentId)) {
-      setInvalidDefaultAgentId(defaultAgentId);
-      setDefaultAgentId("");
-    } else if (invalidDefaultAgentId) {
-      setInvalidDefaultAgentId(null);
-    }
-  }, [selfService, dynamicAgents.length, dynamicAgentIds, defaultAgentId, invalidDefaultAgentId]);
-
-  useEffect(() => {
-    if (selfService) return;
-    if (teams.length === 0) return;
-    if (!defaultTeamSlug) return;
-    if (!teamSlugSet.has(defaultTeamSlug)) {
-      setInvalidDefaultTeamSlug(defaultTeamSlug);
-      setDefaultTeamSlug("");
-    } else if (invalidDefaultTeamSlug) {
-      setInvalidDefaultTeamSlug(null);
-    }
-  }, [selfService, teams.length, teamSlugSet, defaultTeamSlug, invalidDefaultTeamSlug]);
-
-  useEffect(() => {
-    if (selfService) return;
-    void loadSlackRuntimeStatus().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Slack bot runtime status")
-    );
-  }, [loadSlackRuntimeStatus, selfService]);
-
-  useEffect(() => {
-    void loadRoutes().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Slack channel routes")
-    );
-  }, [loadRoutes]);
-
-  useEffect(() => {
-    setDiagnostics(null);
-    void loadDiagnostics().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Slack runtime diagnostics")
-    );
-  }, [loadDiagnostics]);
-
-  const resetRouteForm = () => {
-    setRouteAgentId("");
-    setRouteListen("mention");
-    setRoutePriority(100);
-    setEditingRouteAgentId(null);
-  };
-
-  const editRoute = (route: SlackChannelAgentRoute) => {
-    setRouteAgentId(route.agent_id);
-    setRouteListen(route.users?.listen ?? "mention");
-    setRoutePriority(route.priority ?? 100);
-    setEditingRouteAgentId(route.agent_id);
-  };
-
-  const saveRoute = async () => {
-    if (!selected || !routeAgentId.trim()) return;
-    setLoading(true);
-    setMessage(null);
-    try {
-      const agentId = routeAgentId.trim();
-      const nextRoutes = [
-        ...routes.filter(
-          (route) => route.agent_id !== agentId && route.agent_id !== editingRouteAgentId
-        ),
-        {
-          agent_id: agentId,
-          enabled: true,
-          priority: routePriority,
-          users: { enabled: true, listen: routeListen },
-        },
-      ];
-      const response = await fetch(
-        `/api/admin/slack/channels/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.channel_id)}/routes`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ routes: nextRoutes }),
-        }
-      );
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<{ routes: SlackChannelAgentRoute[] }>(await response.json());
-      setRoutes(data.routes ?? []);
-      resetRouteForm();
-      toast(
-        editingRouteAgentId
-          ? "Slack channel-agent association updated."
-          : "Slack channel-agent association created.",
-        "success"
-      );
-      await Promise.all([loadChannels(), loadDiagnostics()]);
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to save Slack association");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const deleteRoute = async () => {
-    if (!selected || !routePendingDelete) return;
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch(
-        `/api/admin/slack/channels/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.channel_id)}/routes`,
-        {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent_id: routePendingDelete.agent_id }),
-        }
-      );
-      if (!response.ok) throw new Error(await response.text());
-      if (editingRouteAgentId === routePendingDelete.agent_id) {
-        resetRouteForm();
-      }
-      setRoutePendingDelete(null);
-      toast("Slack channel-agent association deleted.", "success");
-      await Promise.all([loadChannels(), loadRoutes(), loadDiagnostics()]);
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to delete Slack association");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const refreshSlackRuntimeStatus = async () => {
-    setLoading(true);
-    setMessage(null);
-    try {
-      await loadSlackRuntimeStatus();
-      toast("Slack bot runtime status refreshed.", "success");
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to load Slack bot runtime status");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const reloadSlackBotRoutes = async () => {
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/slack/runtime/reload", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      await loadSlackRuntimeStatus();
-      toast("Slack bot route cache reloaded.", "success");
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to reload Slack bot routes");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const syncSlackBotConfig = async (dryRun: boolean) => {
-    setRuntimeSyncModalOpen(true);
-    setRuntimeSyncModalMode(dryRun ? "preview" : "apply");
-    setRuntimeSyncModalStatus("loading");
-    setRuntimeSyncModalError(null);
-    if (dryRun) {
-      setRuntimeSyncSummary(null);
-    }
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/slack/runtime/sync-from-config", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dry_run: dryRun }),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<SlackBotRuntimeSyncSummary>(await response.json());
-      setRuntimeSyncSummary(data);
-      setRuntimeSyncModalStatus("success");
-      toast(
-        dryRun
-          ? `Sync preview: ${data.routes_planned} routes planned from ${data.channels_seen} channels.`
-          : `Config sync applied: upserted ${data.routes_upserted} routes and wrote ${data.openfga_tuples_written} OpenFGA tuples.`,
-        "success"
-      );
-      await Promise.all([loadSlackRuntimeStatus(), loadChannels(), loadRoutes(), loadDiagnostics()]);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to sync Slack bot config";
-      setRuntimeSyncModalError(errorMessage);
-      setRuntimeSyncModalStatus("error");
-      setMessage(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchBotMemberChannels = async (): Promise<DiscoveredSlackChannel[]> => {
-    // Discovery intentionally uses Slack users.conversations only: the picker
-    // should show channels where the bot is already a member and can operate.
-    // Use the adjacent Discovery cache control to force a refresh from Slack.
-    const discovered: DiscoveredSlackChannel[] = [];
-    let cursor: string | null | undefined;
-    do {
-      const params = new URLSearchParams({
-        member_only: "1",
-        limit: "500",
-      });
-      if (cursor) params.set("cursor", cursor);
-      const response = await fetch(`/api/admin/slack/available-channels?${params.toString()}`, {
-        cache: "no-store",
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<SlackChannelDiscoveryPayload>(await response.json());
-      discovered.push(...(data.channels ?? []));
-      cursor = data.has_more ? data.next_cursor : null;
-    } while (cursor);
-    return discovered.filter((channel) => channel.is_member !== false);
-  };
-
-  const fetchSlackbotConfigDefaults = async (): Promise<SlackLegacyConfigDefaultsPayload | null> => {
-    if (!useSlackbotConfigDefaults) return null;
-    const response = await fetch("/api/admin/slack/runtime/config-defaults", { cache: "no-store" });
-    if (!response.ok) throw new Error(await response.text());
-    return apiData<SlackLegacyConfigDefaultsPayload>(await response.json());
-  };
-
-  const resolveDiscoveredAgentId = (
-    channel: DiscoveredSlackChannel,
-    legacyDefaults: SlackLegacyConfigDefaultsPayload | null
-  ): string => {
-    const legacyAgentId = legacyDefaults?.channels?.[channel.id]?.suggested_agent_id?.trim();
-    if (legacyAgentId && dynamicAgentIds.has(legacyAgentId)) return legacyAgentId;
-    return fallbackAgentId;
-  };
-
-  const discoverDefaults = async () => {
-    setDiscoverDefaultsLoading(true);
-    setDiscoverDefaultsError(null);
-    setMessage(null);
-    try {
-      const [discovered, legacyDefaults] = await Promise.all([
-        fetchBotMemberChannels(),
-        fetchSlackbotConfigDefaults(),
-      ]);
-      setDiscoveredBotChannels(discovered);
-      setDiscoveredImportRows(
-        discovered.map((channel) => {
-          const existingChannel = configuredChannelsById.get(channel.id);
-          const isSetupComplete = Boolean(
-            existingChannel?.team_slug && (existingChannel.active_grants ?? 0) > 0
-          );
-          return {
-            ...channel,
-            selected: false,
-            team_slug: defaultTeamSlug,
-            agent_id: resolveDiscoveredAgentId(channel, legacyDefaults),
-            is_existing: isSetupComplete,
-          };
-        })
-      );
-      toast(`Found ${pluralize(discovered.length, "bot-member channel")}.`, "success");
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to discover Slack bot-member channels";
-      setDiscoverDefaultsError(errorMessage);
-      setMessage(errorMessage);
-      setDiscoveredImportRows([]);
-    } finally {
-      setDiscoverDefaultsLoading(false);
-    }
-  };
-
-  const updateDiscoveredImportRow = (
-    channelId: string,
-    updates: Partial<Pick<SlackChannelImportRow, "selected" | "team_slug" | "agent_id">>
-  ) => {
-    setDiscoveredImportRows((rows) =>
-      rows.map((row) => (row.id === channelId ? { ...row, ...updates } : row))
-    );
-  };
-
-  const setAllDiscoveredImportRowsSelected = (selected: boolean) => {
-    setDiscoveredImportRows((rows) => rows.map((row) => ({ ...row, selected })));
-  };
-
-  const confirmMigrationDefaults = async (channelImportRows: SlackChannelImportRow[] = []) => {
-    const selectedImports = channelImportRows.filter((row) => row.selected);
-    // Two valid entry points:
-    //   1. Per-row apply — every selected row carries its own team+agent.
-    //      The "Default team and agent for new channels" globals are
-    //      pre-fill convenience and have their own Save button, so we
-    //      don't gate the apply on them. The wizard's `applyDisabled`
-    //      already blocks the click when a selected row is missing
-    //      either pick, so reaching here implies every row is complete.
-    //   2. Legacy global apply — no rows selected; the admin wants to
-    //      backfill onboarded-but-team-less channels using the globals.
-    //      Here the globals are still required.
-    if (selectedImports.length === 0 && (!defaultTeamSlug || !defaultAgentId)) {
-      const missing: string[] = [];
-      if (!defaultTeamSlug) missing.push("Preselected Team");
-      if (!defaultAgentId) missing.push("Preselected Dynamic Agent");
-      const reason = `Select ${missing.join(" and ")} in the "Default team and agent for new channels" section before running setup.`;
-      setMessage(reason);
-      toast(reason, "error");
-      return;
-    }
-    setLoading(true);
-    setMessage(null);
-    try {
-      // The API still wants non-empty top-level team_slug/agent_id even
-      // when per-row defaults supply the actual values, so fall back to
-      // the first selected row's picks when the admin hasn't chosen
-      // globals. Until the API contract is relaxed, this keeps the UX
-      // honest: globals are optional pre-fills, not gates.
-      const fallbackTeamSlug = defaultTeamSlug || selectedImports[0]?.team_slug || "";
-      const fallbackAgentId = defaultAgentId || selectedImports[0]?.agent_id || "";
-      const response = await fetch("/api/admin/slack/channels/defaults", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          team_slug: fallbackTeamSlug,
-          agent_id: fallbackAgentId,
-          create_routes: createDefaultRoutes,
-          ...(selectedImports.length > 0
-            ? {
-                channel_defaults: selectedImports.map((channel) => ({
-                  id: channel.id,
-                  name: channel.name,
-                  team_slug: channel.team_slug,
-                  agent_id: channel.agent_id,
-                })),
-              }
-            : {}),
-        }),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<{
-        summary: SlackChannelDefaultsSummary;
-      }>(await response.json());
-      await Promise.all([loadChannels(), loadRoutes(), loadDiagnostics(), loadSlackRuntimeStatus()]);
-      if (selectedImports.length > 0) {
-        const selectedImportIds = new Set(selectedImports.map((channel) => channel.id));
-        setDiscoveredImportRows((rows) =>
-          rows.map((row) =>
-            selectedImportIds.has(row.id) ? { ...row, is_existing: true, selected: false } : row
-          )
-        );
-      }
-      toast(
-        selectedImports.length > 0
-          ? `Discovered defaults applied: onboarded ${data.summary.channels_onboarded ?? 0} channels, assigned ${data.summary.channels_assigned_team} channels, ensured ${data.summary.channel_grants_ensured} channel grants, ensured ${data.summary.routes_ensured} routes, preserved ${data.summary.routes_preserved ?? 0} existing routes.`
-          : `Slack channel association defaults applied: assigned ${data.summary.channels_assigned_team} channels, ensured ${data.summary.channel_grants_ensured} channel grants, ensured ${data.summary.routes_ensured} routes.`,
-        "success"
-      );
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to apply Slack channel association defaults";
-      setMessage(errorMessage);
-      toast(errorMessage, "error");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const diagnosticRouteIsFixable = (route: SlackRuntimeDiagnosticRoute) =>
-    // The only auto-fixable issue is genuine drift: the route has
-    // Mongo metadata but no OpenFGA tuple. listen=mention/message is
-    // a deliberate admin choice, not a problem to "fix".
-    route.route_metadata && !route.openfga_tuple;
-
-  const fixDiagnosticRoute = async (route: SlackRuntimeDiagnosticRoute) => {
-    if (!selected) return;
-    if (!(route.route_metadata && !route.openfga_tuple)) return;
-    setLoading(true);
-    setMessage(null);
-    try {
-      const routeUrl = `/api/admin/slack/channels/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.channel_id)}/routes`;
-      const response = await fetch(routeUrl, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ agent_id: route.agent_id }),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      await Promise.all([loadChannels(), loadRoutes(), loadDiagnostics()]);
-      toast(`Removed stale route metadata for agent:${route.agent_id}.`, "success");
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : `Failed to fix agent:${route.agent_id}`);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const viewTitle: Record<SlackPanelView, string> = {
-    channels: "Configured channels",
-    onboard: "Onboard channels",
-    advanced: "Advanced",
-  };
-  const viewDescription: Record<SlackPanelView, string> = {
-    channels: "Channels CAIPE already knows about. Click a channel to manage its agents and diagnostics.",
-    onboard: "Find Slack channels where the bot is installed and set them up.",
-    advanced: "One-time YAML import and Slack bot runtime status. Most admins won't need this.",
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>
-          {selfService ? "My Slack Channel Settings" : viewTitle[view]}
-        </CardTitle>
-        <CardDescription>
-          {selfService
-            ? "Manage bot routing behavior only for Slack channels where OpenFGA grants you channel admin access."
-            : viewDescription[view]}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        {!selfService && (
-          <div
-            role="tablist"
-            aria-label="Slack admin views"
-            className="flex flex-wrap gap-1 rounded-md border bg-muted/30 p-1"
-          >
-            {(Object.keys(viewTitle) as SlackPanelView[]).map((key) => (
-              <Button
-                key={key}
-                role="tab"
-                type="button"
-                size="sm"
-                variant={view === key ? "default" : "ghost"}
-                aria-selected={view === key}
-                onClick={() => setView(key)}
-              >
-                {viewTitle[key]}
-              </Button>
-            ))}
-          </div>
-        )}
-
-        {(selfService || view === "onboard") && (
-          <div className="space-y-2 rounded-md border p-3 text-sm text-muted-foreground">
-            <div>
-              Slack authorization has two checks before dispatch: the channel must have
-              <code className="mx-1">can_use agent:&lt;id&gt;</code>, and the user&apos;s active
-              team must also have <code className="mx-1">can_use agent:&lt;id&gt;</code>.
-              If either check fails, the Slack bot denies the request before calling the agent.
-            </div>
-            <div className="rounded-md border border-amber-300/60 bg-amber-50 p-2 text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
-              <span className="font-medium">Sharing model:</span> Adding an agent to a
-              channel that is assigned to a team transitively grants <em>every member of
-              that team</em> permission to invoke the agent in this channel — even members
-              who were never granted the agent directly. If that is not what you want, share
-              the agent with a smaller subgroup (or with individual users) instead of the
-              channel&apos;s team.
-            </div>
-          </div>
-        )}
-
-        {!selfService && view === "advanced" && (
-        <div
-          role="region"
-          aria-label="Advanced Setup - Import/Sync with Slackbot"
-          data-section-tone="slate"
-          className="rounded-md border border-slate-500/20 bg-slate-500/5 p-4 space-y-3"
-        >
-          <div>
-            <h3 className="inline-flex items-center gap-2 text-base font-semibold tracking-tight">
-              <Settings2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-              Import from Slackbot YAML
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Inspect Slack bot runtime state, reload its in-memory cache, and run the one-time YAML→DB import.
-            </p>
-          </div>
-          <div className="grid gap-2 text-sm md:grid-cols-3">
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Route mode</div>
-              <div className="font-medium">{slackRuntimeStatus?.route_mode ?? "unknown"}</div>
-            </div>
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Static config</div>
-              <div className="font-medium">
-                {slackRuntimeStatus
-                  ? `${slackRuntimeStatus.static_config.channels} channels / ${slackRuntimeStatus.static_config.routes} routes`
-                  : "unknown"}
-              </div>
-            </div>
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Route cache</div>
-              <div className="font-medium">
-                {slackRuntimeStatus
-                  ? `${slackRuntimeStatus.route_cache.cache_size} cached channel${slackRuntimeStatus.route_cache.cache_size === 1 ? "" : "s"}`
-                  : "unknown"}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                TTL {slackRuntimeStatus?.route_cache.ttl_seconds ?? "?"}s
-              </div>
-            </div>
-          </div>
-          <div
-            role="region"
-            aria-label="Slackbot sync legend"
-            className="grid gap-2 rounded-md border bg-background/50 p-3 text-xs text-muted-foreground md:grid-cols-2"
-          >
-            <div>
-              <span className="font-medium text-foreground">Route mode:</span>{" "}
-              shows whether the Slackbot reads routes from database, YAML, or both.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Static config:</span>{" "}
-              counts channel/routes currently loaded from Slackbot YAML.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Route cache:</span>{" "}
-              shows cached runtime channel routes and how soon they expire.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Refresh Runtime Status:</span>{" "}
-              reloads these status numbers from the running bot.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Reload Bot Cache:</span>{" "}
-              refreshes the running bot after UI route changes.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Preview YAML Import:</span>{" "}
-              shows planned changes without writing them.
-            </div>
-            <div className="md:col-span-2">
-              <span className="font-medium text-foreground">Import from YAML Config:</span>{" "}
-              writes YAML routes into CAIPE/OpenFGA.
-            </div>
-          </div>
-          {runtimeSyncSummary && (
-            <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">
-              <div>
-                {runtimeSyncSummary.dry_run
-                  ? `Sync preview: ${runtimeSyncSummary.routes_planned} routes planned.`
-                  : `Config sync applied: upserted ${runtimeSyncSummary.routes_upserted} routes.`}
-              </div>
-              Last sync {runtimeSyncSummary.dry_run ? "preview" : "apply"}:{" "}
-              {runtimeSyncSummary.routes_planned} planned, {runtimeSyncSummary.routes_upserted} upserted,{" "}
-              {runtimeSyncSummary.openfga_tuples_written} OpenFGA tuples.
-            </div>
-          )}
-          <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" variant="outline" onClick={refreshSlackRuntimeStatus} disabled={disabled || loading}>
-              <RefreshCw className="h-4 w-4" aria-hidden="true" />
-              Refresh Runtime Status
-            </Button>
-            <Button type="button" variant="outline" onClick={reloadSlackBotRoutes} disabled={disabled || loading}>
-              <RotateCw className="h-4 w-4" aria-hidden="true" />
-              Reload Bot Cache
-            </Button>
-            <Button type="button" variant="outline" onClick={() => syncSlackBotConfig(true)} disabled={disabled || loading}>
-              <FileUp className="h-4 w-4" aria-hidden="true" />
-              Preview YAML Import
-            </Button>
-            <Button type="button" onClick={() => syncSlackBotConfig(false)} disabled={disabled || loading}>
-              <FileUp className="h-4 w-4" aria-hidden="true" />
-              Import from YAML Config
-            </Button>
-          </div>
-        </div>
-        )}
-
-        <Dialog open={runtimeSyncModalOpen} onOpenChange={setRuntimeSyncModalOpen}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {runtimeSyncModalMode === "preview"
-                  ? "Slack Bot Config Sync Preview"
-                  : "Slack Bot Config Sync Apply"}
-              </DialogTitle>
-              <DialogDescription>
-                Preview reads the Slack bot&apos;s loaded static YAML config. Apply upserts matching
-                MongoDB route metadata and channel-agent OpenFGA tuples without deleting UI-managed associations.
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="space-y-3">
-              <div className="rounded-md border bg-muted/20 p-3 text-sm">
-                <div className="font-medium">
-                  {runtimeSyncModalStatus === "loading"
-                    ? runtimeSyncModalMode === "preview"
-                      ? "Previewing..."
-                      : "Applying..."
-                    : runtimeSyncModalStatus === "success"
-                      ? runtimeSyncModalMode === "preview"
-                        ? "Preview complete"
-                        : "Apply complete"
-                      : runtimeSyncModalStatus === "error"
-                        ? "Sync failed"
-                        : "Ready"}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {runtimeSyncModalStatus === "loading"
-                    ? "Contacting the Slack bot admin API..."
-                    : "Static config sync is upsert-only and leaves existing UI-managed associations in place."}
-                </div>
-              </div>
-
-              {runtimeSyncModalError && (
-                <div className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">
-                  {runtimeSyncModalError}
-                </div>
-              )}
-
-              {runtimeSyncSummary && (
-                <div className="grid gap-2 text-sm md:grid-cols-2">
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">Channels</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.channels_seen, "channel")} scanned
-                    </div>
-                  </div>
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">Planned routes</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.routes_planned, "route")} planned
-                    </div>
-                  </div>
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">MongoDB route metadata</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.routes_upserted, "route")} upserted
-                    </div>
-                  </div>
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">OpenFGA tuples</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.openfga_tuples_written, "OpenFGA tuple")} written
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setRuntimeSyncModalOpen(false)}
-                disabled={runtimeSyncModalStatus === "loading"}
-              >
-                Close
-              </Button>
-              {runtimeSyncModalMode === "preview" && runtimeSyncModalStatus === "success" && (
-                <Button type="button" onClick={() => syncSlackBotConfig(false)} disabled={disabled || loading}>
-                  <FileUp className="h-4 w-4" aria-hidden="true" />
-                  Import from YAML Config
-                </Button>
-              )}
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        {!selfService && view === "onboard" && (
-        <div
-          role="region"
-          aria-label="Default team and agent for new channels"
-          data-section-tone="teal"
-          className="rounded-md border border-teal-500/25 bg-teal-500/5 p-4 space-y-4"
-        >
-          <div>
-            <h3 className="inline-flex items-center gap-2 text-base font-semibold tracking-tight">
-              <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
-              Default team and agent for new channels
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              These pre-fill the picker for each discovered channel below. You can override per channel before applying.
-            </p>
-          </div>
-          <div className="rounded-md border border-teal-500/15 bg-background/60 p-3 text-xs">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <span className="font-medium text-foreground">Last saved</span>
-              {configuredDefaults?.source === "env" && (
-                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  from environment variable
-                </span>
-              )}
-              {configuredDefaults?.source === "db" && configuredDefaults?.updated_at && (
-                <span className="text-[10px] text-muted-foreground">
-                  {new Date(configuredDefaults.updated_at).toLocaleString()}
-                  {configuredDefaults?.updated_by ? ` · ${configuredDefaults.updated_by}` : ""}
-                </span>
-              )}
-              {configuredDefaults?.source === "unset" && (
-                <span className="text-[10px] text-muted-foreground">never saved</span>
-              )}
-            </div>
-            <div className="mt-2 grid gap-2 md:grid-cols-2">
-              <div>
-                <div className="text-muted-foreground">Onboarding team</div>
-                <code>{configuredDefaults?.team_slug ? `team:${configuredDefaults.team_slug}` : "not configured"}</code>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Onboarding Dynamic Agent</div>
-                <code>{configuredDefaults?.agent_id ? `agent:${configuredDefaults.agent_id}` : "not configured"}</code>
-              </div>
-            </div>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="slack-default-team">Preselected Team</Label>
-              {/* Switched from native <select> to TeamPicker on
-                  2026-05-27 — environments with hundreds of AWS-* /
-                  SSO-* teams made the dropdown unusable. Same on-disk
-                  contract (slug string); search by name or slug. */}
-              <TeamPicker
-                id="slack-default-team"
-                value={defaultTeamSlug}
-                onChange={setDefaultTeamSlug}
-                disabled={disabled || teams.length === 0}
-                placeholder={
-                  teams.length === 0 ? "No teams configured" : "Select preselected team"
-                }
-                searchPlaceholder="Search teams..."
-                options={teams.map<TeamPickerOption>((team) => ({
-                  slug: team.slug,
-                  name: team.name || team.slug,
-                  id: team.id,
-                  _id: team._id,
-                }))}
-              />
-              {invalidDefaultTeamSlug && (
-                <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
-                  The saved default team <code>team:{invalidDefaultTeamSlug}</code> doesn&apos;t match any
-                  current team. Pick one above. Update <code>SLACK_DEFAULT_TEAM_SLUG</code> in the
-                  environment to make the new choice the default for next time.
-                </p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="slack-default-agent">Preselected Dynamic Agent</Label>
-              <select
-                id="slack-default-agent"
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                value={defaultAgentId}
-                onChange={(event) => setDefaultAgentId(event.target.value)}
-                disabled={disabled || dynamicAgents.length === 0}
-              >
-                <option value="">
-                  {dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select preselected Dynamic Agent"}
-                </option>
-                {sortedDynamicAgents.map((agent) => (
-                  <option key={agent._id} value={agent._id}>
-                    {agentLabel(agent)}
-                  </option>
-                ))}
-              </select>
-              {invalidDefaultAgentId && (
-                <p className="text-xs text-amber-700 dark:text-amber-400" role="alert">
-                  The saved default Dynamic Agent <code>agent:{invalidDefaultAgentId}</code> wasn&apos;t
-                  found (or is disabled). Pick one above. Update <code>SLACK_DEFAULT_AGENT_ID</code> in
-                  the environment to make the new choice the default for next time.
-                </p>
-              )}
-            </div>
-          </div>
-          <label className="flex items-start gap-2 rounded-md border border-teal-500/15 bg-background/60 p-3 text-sm">
-            <input
-              type="checkbox"
-              checked={useSlackbotConfigDefaults}
-              onChange={(event) => setUseSlackbotConfigDefaults(event.target.checked)}
-              disabled={disabled}
-            />
-            <span>
-              <span className="font-medium">Use existing Slackbot channel agents as defaults</span>
-              <span className="block text-xs text-muted-foreground">
-                Checked by default for migrations. Uncheck only if you want one selected Dynamic Agent for all discovered channels.
-              </span>
-            </span>
-          </label>
-          {/* Dedicated Save button — distinct from "Apply" on the
-              import wizard. Persists to `platform_config`. The
-              wizard's onboarding pipeline still uses whatever the
-              admin has on screen, but you no longer need to run the
-              pipeline just to durably remember a pick. */}
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {associationDefaultsDirty && (
-              <span
-                role="status"
-                className="text-[11px] text-amber-700 dark:text-amber-400"
-              >
-                Unsaved changes
-              </span>
-            )}
-            <Button
-              type="button"
-              size="sm"
-              variant="default"
-              onClick={() => void saveAssociationDefaults()}
-              disabled={disabled || savingDefaults || !associationDefaultsDirty}
-              aria-label="Save Slack onboarding defaults"
-            >
-              {savingDefaults ? "Saving…" : "Save defaults"}
-            </Button>
-          </div>
-          {(teams.length === 0 || dynamicAgents.length === 0) && (
-            <p className="text-xs text-muted-foreground">
-              Configure a team or Dynamic Agent in the admin UI, then reload this page.
-            </p>
-          )}
-        </div>
-        )}
-
-        {!selfService && view === "channels" && channels.length === 0 && (
-          <div className="rounded-md border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
-            <p className="font-medium text-foreground">No channels configured yet.</p>
-            <p className="mt-1">
-              Switch to{" "}
-              <button
-                type="button"
-                className="underline underline-offset-2"
-                onClick={() => setView("onboard")}
-              >
-                Onboard channels
-              </button>{" "}
-              to find Slack channels where the bot is installed and set them up.
-            </p>
-          </div>
-        )}
-
-        {(selfService || view === "channels") && channels.length > 0 && (
-        <div
-          role="region"
-          aria-label="Configured Slack channels"
-          className="rounded-md border bg-background/60 overflow-hidden"
-        >
-          {/* Cap at ~70% of the viewport so the table grows with the
-              screen but never pushes the rest of the panel off the
-              page. No min — short tables size to their rows so there's
-              no dead whitespace below the last row. */}
-          <div className="overflow-auto" style={{ maxHeight: "min(70vh, 100vh - 320px)" }}>
-            <table className="w-full text-sm">
-              <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
-                <tr>
-                  <th className="px-3 py-2 text-left font-medium">Channel</th>
-                  <th className="px-3 py-2 text-left font-medium">Team</th>
-                  <th className="px-3 py-2 text-left font-medium">Agents</th>
-                  <th className="px-3 py-2 text-left font-medium">Health</th>
-                </tr>
-              </thead>
-              <tbody>
-                {channels.map((channel) => {
-                    const key = `${channel.workspace_id}/${channel.channel_id}`;
-                    const isSelected = key === selectedKey;
-                    const grants = channel.active_grants ?? 0;
-                    // Prefer the live diagnostics returned for the
-                    // expanded row (they update as the admin clicks
-                    // Fix-it / saves routes), otherwise use the
-                    // server-summarized health from the list payload.
-                    const warningsCount =
-                      isSelected && diagnostics
-                        ? diagnostics.warnings.length
-                        : channel.health?.warnings_count;
-                    const health =
-                      typeof warningsCount === "number"
-                        ? warningsCount > 0
-                          ? {
-                              label: `${warningsCount} issue${warningsCount === 1 ? "" : "s"}`,
-                              className: "border-amber-300 bg-amber-50 text-amber-800",
-                            }
-                          : {
-                              label: "healthy",
-                              className: "border-emerald-300 bg-emerald-50 text-emerald-700",
-                            }
-                        : !channel.team_slug
-                          ? { label: "no team", className: "border-amber-300 bg-amber-50 text-amber-800" }
-                          : grants === 0
-                            ? { label: "no agents", className: "border-amber-300 bg-amber-50 text-amber-800" }
-                            : { label: "checking…", className: "border-slate-300 bg-slate-50 text-slate-600" };
-                    const toggle = () => setSelectedKey(isSelected ? "" : key);
-                    return (
-                      <React.Fragment key={key}>
-                        <tr
-                          role="button"
-                          tabIndex={0}
-                          aria-expanded={isSelected}
-                          onClick={toggle}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              toggle();
-                            }
-                          }}
-                          className={cn(
-                            "cursor-pointer border-t transition-colors hover:bg-muted/30 focus:bg-muted/30 focus:outline-none",
-                            isSelected && "bg-muted/50",
-                          )}
-                        >
-                          <td className="px-3 py-2">
-                            <div className="flex items-center gap-1.5">
-                              <ChevronRight
-                                className={cn(
-                                  "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
-                                  isSelected && "rotate-90",
-                                )}
-                                aria-hidden="true"
-                              />
-                              <div>
-                                <div className="font-medium">#{channel.channel_name}</div>
-                                <div className="text-xs text-muted-foreground">{channel.channel_id}</div>
-                              </div>
-                            </div>
-                          </td>
-                          <td className="px-3 py-2">
-                            {channel.team_slug ? (
-                              <Badge variant="secondary">team:{channel.team_slug}</Badge>
-                            ) : (
-                              <span className="text-xs text-muted-foreground">—</span>
-                            )}
-                          </td>
-                          <td className="px-3 py-2">
-                            <span className={grants === 0 ? "text-muted-foreground" : "font-medium"}>
-                              {grants}
-                            </span>
-                          </td>
-                          <td className="px-3 py-2">
-                            <Badge variant="outline" className={health.className}>
-                              {health.label}
-                            </Badge>
-                          </td>
-                        </tr>
-                        {isSelected && (
-                          <tr className="border-t bg-muted/20">
-                            <td colSpan={4} className="p-4">
-                              <ChannelDetail
-                                selected={channel}
-                                diagnostics={diagnostics}
-                                routes={routes}
-                                dynamicAgents={dynamicAgents}
-                                routeAgentId={routeAgentId}
-                                setRouteAgentId={setRouteAgentId}
-                                routeListen={routeListen}
-                                setRouteListen={setRouteListen}
-                                routePriority={routePriority}
-                                setRoutePriority={setRoutePriority}
-                                editingRouteAgentId={editingRouteAgentId}
-                                resetRouteForm={resetRouteForm}
-                                editRoute={editRoute}
-                                saveRoute={saveRoute}
-                                deleteRoute={setRoutePendingDelete}
-                                fixDiagnosticRoute={fixDiagnosticRoute}
-                                diagnosticRouteIsFixable={diagnosticRouteIsFixable}
-                                disabled={disabled}
-                                loading={loading}
-                                selectedCanManage={selectedCanManage}
-                                message={message}
-                              />
-                            </td>
-                          </tr>
-                        )}
-                      </React.Fragment>
-                    );
-                  })
-                }
-              </tbody>
-            </table>
-          </div>
-        </div>
-        )}
-
-        {!selfService && view === "onboard" && (
-        <ConnectorOnboardingWizard
-          connectorName="Slack"
-          provider="slack"
-          isAdmin={!selfService}
-          itemSingular="channel"
-          itemPlural="channels"
-          discoveredLabel="bot-member channel"
-          findLabel="Find channels"
-          refreshLabel="Refresh channels"
-          loadingLabel="Finding channels…"
-          emptyLabel="No bot-member channels were discovered."
-          description="Find Slack channels where the bot is already installed. Channels the bot has not joined will not appear."
-          discoveryStatusText={discoveryStatusText}
-          discoveredCount={discoveredBotChannels.length}
-          newCount={discoveredNewChannelCount}
-          selectedCount={selectedDiscoveredImportRows.length}
-          rows={discoveredImportRows.map((channel) => ({
-            id: channel.id,
-            name: `#${channel.name}`,
-            secondary: [
-              channel.id,
-              typeof channel.num_members === "number" ? pluralize(channel.num_members, "member") : "",
-            ].filter(Boolean).join(" · "),
-            selected: channel.selected,
-            teamSlug: channel.team_slug,
-            agentId: channel.agent_id,
-            isExisting: channel.is_existing,
-            importLabel: `Import #${channel.name}`,
-            teamLabel: `Team for #${channel.name}`,
-            agentLabel: `Dynamic Agent for #${channel.name}`,
-          }))}
-          teams={teams.map((team) => ({ value: team.slug, label: team.name || team.slug }))}
-          agents={sortedDynamicAgents.map((agent) => ({ value: agent._id, label: agent.name || agent._id }))}
-          error={discoverDefaultsError}
-          disabled={disabled}
-          loading={loading}
-          discovering={discoverDefaultsLoading}
-          searchValue={discoverySearch}
-          onSearchChange={setDiscoverySearch}
-          enableBulkApply
-          onDiscover={() => void discoverDefaults()}
-          onSelectAll={() => setAllDiscoveredImportRowsSelected(true)}
-          onClearSelection={() => setAllDiscoveredImportRowsSelected(false)}
-          onRowChange={(channelId, updates) =>
-            updateDiscoveredImportRow(channelId, {
-              ...(typeof updates.selected === "boolean" ? { selected: updates.selected } : {}),
-              ...(typeof updates.teamSlug === "string" ? { team_slug: updates.teamSlug } : {}),
-              ...(typeof updates.agentId === "string" ? { agent_id: updates.agentId } : {}),
-            })
-          }
-          onApply={() => void confirmMigrationDefaults(discoveredImportRows)}
-        />
-        )}
-
-        <Dialog
-          open={Boolean(routePendingDelete)}
-          onOpenChange={(open) => {
-            if (!open && !loading) setRoutePendingDelete(null);
-          }}
-        >
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Delete channel-agent association?</DialogTitle>
-              <DialogDescription>
-                {routePendingDelete
-                  ? `This removes agent:${routePendingDelete.agent_id} from the selected Slack channel.`
-                  : "This removes the selected agent from the Slack channel."}
-              </DialogDescription>
-            </DialogHeader>
-            <p className="text-sm text-muted-foreground">
-              The OpenFGA tuple will be deleted, and the saved Mongo route metadata for listen
-              mode and priority will be deleted as well.
-            </p>
-            {routePendingDelete && (
-              <div className="rounded-md border bg-muted/30 p-3 text-sm">
-                <div>
-                  <span className="font-medium">Listen:</span>{" "}
-                  {routePendingDelete.users?.listen ?? "mention"}
-                </div>
-                <div>
-                  <span className="font-medium">Priority:</span> {routePendingDelete.priority}
-                </div>
-              </div>
-            )}
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setRoutePendingDelete(null)}
-                disabled={loading}
-              >
-                Cancel
-              </Button>
-              <Button type="button" variant="destructive" onClick={deleteRoute} disabled={loading}>
-                {loading ? "Deleting..." : "Delete association"}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </CardContent>
-    </Card>
-  );
+  return <ConnectorAdminPanel adapter={SLACK_ADAPTER} disabled={disabled} selfService={selfService} />;
 }

--- a/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
@@ -6,6 +6,7 @@ import type {
   ConnectorAdminAdapter,
   DiagnosticRoute,
   ItemAgentRoute,
+  ItemDiagnostics,
   ItemSummary,
 } from "./connector-admin-adapter";
 

--- a/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
@@ -1,203 +1,256 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  FileUp,
-  RefreshCw,
-  RotateCw,
-  Settings2,
-  Sparkles,
-} from "lucide-react";
-
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
-import { useToast } from "@/components/ui/toast";
-import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
-import { ConnectorOnboardingWizard } from "./ConnectorOnboardingWizard";
-
-interface WebexSpaceSummary {
-  workspace_id: string;
-  space_id: string;
-  space_name: string;
-  team_slug?: string;
-  active_grants: number;
-  can_manage?: boolean;
-}
-
-interface WebexSpaceAgentRoute {
-  agent_id: string;
-  enabled: boolean;
-  priority: number;
-  users?: {
-    enabled?: boolean;
-    listen?: "message" | "mention" | "all";
-  };
-}
-
-interface WebexRuntimeDiagnosticRoute {
-  agent_id: string;
-  openfga_tuple: boolean;
-  route_metadata: boolean;
-  listen: "message" | "mention" | "all" | "unknown";
-  runtime_matches: {
-    mention: boolean;
-    message: boolean;
-  };
-  warnings: string[];
-}
-
-interface WebexRuntimeDiagnostics {
-  openfga: {
-    reachable: boolean;
-    tuple_count: number;
-    error?: string;
-  };
-  routes: WebexRuntimeDiagnosticRoute[];
-  warnings: string[];
-  last_runtime_error?: {
-    ts?: string;
-    reason_code?: string;
-    message?: string;
-    action?: string;
-  } | null;
-}
-
-interface DynamicAgentOption {
-  _id: string;
-  name: string;
-}
-
-interface TeamOption {
-  _id?: string;
-  id?: string;
-  slug: string;
-  name: string;
-}
-
-interface WebexSpaceAssociationDefaults {
-  team_slug: string;
-  agent_id: string;
-  create_routes?: boolean;
-  /** ISO timestamp set by the PUT route; empty when value came from env. */
-  updated_at?: string;
-  /** Email of the admin who last saved; empty for env-only. */
-  updated_by?: string;
-  /** "db" | "env" | "unset" — drives "Saved" vs "Env default" copy. */
-  source?: "db" | "env" | "unset";
-}
-
-interface WebexBotRuntimeStatus {
-  route_mode: string;
-  static_config: {
-    spaces: number;
-    routes: number;
-  };
-  route_cache: {
-    ttl_seconds: number;
-    cache_size: number;
-    cached_spaces?: string[];
-  };
-  thread_context?: {
-    enabled: boolean;
-    max_messages: number;
-    max_chars: number;
-  };
-  last_sync?: WebexBotRuntimeSyncSummary | null;
-}
-
-interface WebexBotRuntimeSyncSummary {
-  dry_run: boolean;
-  spaces_seen: number;
-  routes_planned: number;
-  routes_upserted: number;
-  openfga_tuples_written: number;
-}
-
-interface DiscoveredWebexSpace {
-  id: string;
-  webex_room_id?: string;
-  name: string;
-  type?: string;
-  is_locked?: boolean;
-}
-
-interface WebexSpaceImportRow extends DiscoveredWebexSpace {
-  selected: boolean;
-  team_slug: string;
-  agent_id: string;
-  is_existing: boolean;
-}
-
-interface WebexSpaceDiscoveryPayload {
-  spaces: DiscoveredWebexSpace[];
-  next_cursor?: string | null;
-  has_more?: boolean;
-}
-
-interface WebexDefaultsSummary {
-  spaces_seen: number;
-  spaces_manual?: number;
-  spaces_onboarded?: number;
-  spaces_assigned_team: number;
-  space_grants_ensured: number;
-  routes_ensured: number;
-  routes_preserved?: number;
-}
-
-type RuntimeSyncModalMode = "preview" | "apply";
-type RuntimeSyncModalStatus = "idle" | "loading" | "success" | "error";
+import React from "react";
+import { ConnectorAdminPanel } from "./ConnectorAdminPanel";
+import type {
+  ConnectorAdminAdapter,
+  DiagnosticRoute,
+  ItemAgentRoute,
+  ItemSummary,
+} from "./connector-admin-adapter";
 
 function apiData<T>(payload: { data?: T } & T): T {
   return (payload.data ?? payload) as T;
 }
 
-function agentLabel(agent: DynamicAgentOption): string {
-  return `${agent.name || agent._id} (${agent._id})`;
+function threadContextLabel(raw: Record<string, unknown>): string {
+  const ctx = raw.thread_context as { enabled?: boolean; max_messages?: number; max_chars?: number } | undefined;
+  if (!ctx) return "unknown";
+  return `${ctx.enabled ? "Enabled" : "Disabled"}, ${ctx.max_messages} messages / ${ctx.max_chars} chars`;
 }
 
-function pluralize(count: number, singular: string, plural = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function threadContextLabel(status: WebexBotRuntimeStatus | null): string {
-  const context = status?.thread_context;
-  if (!context) return "unknown";
-  return `${context.enabled ? "Enabled" : "Disabled"}, ${context.max_messages} messages / ${context.max_chars} chars`;
-}
-
-async function responseErrorMessage(response: Response, fallback: string): Promise<string> {
-  const text = await response.text().catch(() => "");
-  if (!text) return `${fallback}: ${response.status}`;
+async function responseErrorMessage(res: Response, fallback: string): Promise<string> {
+  const text = await res.text().catch(() => "");
+  if (!text) return `${fallback}: ${res.status}`;
   try {
     const payload = JSON.parse(text) as { error?: unknown; message?: unknown };
-    const detail = typeof payload.error === "string"
-      ? payload.error
-      : typeof payload.message === "string"
-        ? payload.message
-        : "";
-    return detail ? `${fallback}: ${detail}` : `${fallback}: ${response.status}`;
-  } catch {
-    return `${fallback}: ${text}`;
-  }
+    const detail = typeof payload.error === "string" ? payload.error
+      : typeof payload.message === "string" ? payload.message : "";
+    return detail ? `${fallback}: ${detail}` : `${fallback}: ${res.status}`;
+  } catch { return `${fallback}: ${text}`; }
 }
 
-function webexAssociationErrorMessage(error: unknown, fallback: string): string {
-  const message = error instanceof Error ? error.message : fallback;
-  if (message.includes("fetch failed")) {
-    return `${message}. Check that the UI server can reach OpenFGA and MongoDB, especially OPENFGA_HTTP and OPENFGA_STORE_ID.`;
-  }
-  return message;
-}
+const WEBEX_ADAPTER: ConnectorAdminAdapter = {
+  connectorName: "Webex",
+  itemSingular: "space",
+  itemPlural: "spaces",
+
+  api: {
+    list: "/api/admin/webex/spaces",
+    discoveryUrl: (page, cursor) => {
+      const p = new URLSearchParams({ limit: "500" });
+      if (page === 0) p.set("refresh", "1");
+      if (cursor) p.set("cursor", cursor);
+      return `/api/admin/webex/available-spaces?${p.toString()}`;
+    },
+    defaults: "/api/admin/webex/spaces/defaults",
+    runtimeStatus: "/api/admin/webex/runtime/status",
+    runtimeReload: "/api/admin/webex/runtime/reload",
+    runtimeSyncFromConfig: "/api/admin/webex/runtime/sync-from-config",
+    routesFor: (ws, sp) => `/api/admin/webex/spaces/${encodeURIComponent(ws)}/${encodeURIComponent(sp)}/routes`,
+    diagnosticsFor: (ws, sp) => `/api/admin/webex/spaces/${encodeURIComponent(ws)}/${encodeURIComponent(sp)}/diagnostics`,
+    legacyConfigDefaults: null,
+  },
+
+  parseListResponse: (json) => {
+    const d = apiData<{ spaces: unknown[] }>(json as { spaces: unknown[] });
+    return (d.spaces ?? []) as Record<string, unknown>[];
+  },
+  parseListItem: (raw) => {
+    const r = raw as Record<string, unknown>;
+    if (!r.space_id) return null;
+    return {
+      workspace_id: String(r.workspace_id ?? ""),
+      item_id: String(r.space_id),
+      item_name: String(r.space_name ?? r.space_id),
+      team_slug: r.team_slug ? String(r.team_slug) : undefined,
+      active_grants: Number(r.active_grants ?? 0),
+      can_manage: Boolean(r.can_manage),
+      health: r.health as ItemSummary["health"],
+    };
+  },
+  itemKey: (item) => `${item.workspace_id}/${item.item_id}`,
+  parseDiscoveryPage: (json) => {
+    const d = apiData<{ spaces: unknown[]; next_cursor?: string | null; has_more?: boolean }>(
+      json as { spaces: unknown[] },
+    );
+    const spaces = (d.spaces ?? []) as Record<string, unknown>[];
+    return {
+      items: spaces.map((sp) => ({
+        id: String(sp.id ?? ""),
+        name: String(sp.name ?? sp.id),
+        secondary: [String(sp.id ?? ""), sp.type, sp.is_locked ? "locked" : ""].filter(Boolean).join(" · "),
+      })),
+      nextCursor: d.next_cursor ?? null,
+      hasMore: Boolean(d.has_more),
+    };
+  },
+  parseRuntimeStatus: (json) => {
+    const d = json as Record<string, unknown>;
+    const sc = (d.static_config ?? {}) as Record<string, number>;
+    const rc = (d.route_cache ?? {}) as Record<string, unknown>;
+    return {
+      route_mode: String(d.route_mode ?? "unknown"),
+      static_config: sc,
+      route_cache: { ttl_seconds: Number(rc.ttl_seconds ?? 0), cache_size: Number(rc.cache_size ?? 0) },
+      raw: d,
+    };
+  },
+  parseRuntimeSyncSummary: (json) => {
+    const d = json as Record<string, unknown>;
+    return {
+      dry_run: Boolean(d.dry_run),
+      items_seen: Number(d.spaces_seen ?? 0),
+      routes_planned: Number(d.routes_planned ?? 0),
+      routes_upserted: Number(d.routes_upserted ?? 0),
+      openfga_tuples_written: Number(d.openfga_tuples_written ?? 0),
+    };
+  },
+
+  discoveryCacheProvider: "webex",
+
+  copy: {
+    configuredTabTitle: "Configured spaces",
+    configuredTabDescription: "Spaces CAIPE already knows about. Click a space to manage its agents and diagnostics.",
+    onboardTabTitle: "Onboard spaces",
+    onboardTabDescription: "Find Webex spaces where the bot is installed and set them up.",
+    advancedTabTitle: "Advanced",
+    advancedTabDescription: "One-time YAML import and Webex bot runtime status. Most admins won't need this.",
+    advancedHeading: "Advanced Setup - Import/Sync with Webex Bot",
+    botNameInLegend: "Webex bot",
+    onboardingDefaultsHeading: "Onboarding Default Selection",
+    onboardingDefaultsDescription: "Only changes what is preselected when you onboard spaces. Each space still needs an explicit setup action.",
+    discoveryDescription: "Find Webex spaces where the bot is already installed, then choose what to import.",
+    discoveryFindLabel: "Find Webex Spaces with Bot Integration",
+    discoveryRefreshLabel: "Refresh Webex Spaces with Bot Integration",
+    discoveryLoadingLabel: "Finding Webex spaces...",
+    discoveryEmptyLabel: "No bot-visible Webex spaces were discovered.",
+    discoveryDiscoveredLabel: "bot-visible space",
+    selfServiceTitle: "My Webex Space Settings",
+    selfServiceDescription: "Manage bot routing behavior only for Webex spaces where OpenFGA grants you space admin access.",
+  },
+  ariaLabels: {
+    tablist: "Webex admin views",
+    configuredRegion: "Configured Webex spaces",
+    advancedRegion: "Advanced Setup - Import/Sync with Webex Bot",
+    advancedLegend: "Webex bot sync legend",
+    onboardingDefaultsRegion: "Onboarding Default Selection",
+  },
+
+  discoveryStatusText: ({ discoveredCount, newCount, configuredCount, unassignedCount }) => {
+    const base = discoveredCount > 0
+      ? `${discoveredCount} bot-visible found · ${newCount} new`
+      : `${configuredCount} managed in CAIPE`;
+    return `${base} · ${unassignedCount} missing team`;
+  },
+
+  staticConfigLabel: ({ items, routes }) => `${items} spaces / ${routes} routes`,
+  routeCacheLabel: (count) => `${count} cached space${count === 1 ? "" : "s"}`,
+  syncDialogueTitle: (mode) => mode === "preview" ? "Webex Bot Config Sync Preview" : "Webex Bot Config Sync Apply",
+  syncDialogueDescription: "Preview reads the Webex bot's loaded static YAML config. Apply upserts matching MongoDB route metadata and space-agent OpenFGA tuples without deleting UI-managed associations.",
+  syncSummaryItemsLabel: "Spaces",
+
+  advancedExtraTiles: (status) => [
+    { label: "Thread context", value: threadContextLabel(status.raw) },
+  ],
+  advancedExtraLegendRows: () => [
+    { label: "Thread context", description: "shows whether the bot sends bounded prior Webex thread messages to the selected agent." },
+  ],
+
+  authzDisclaimer: (
+    <>
+      <div>
+        Webex authorization has two checks before dispatch: the space must have
+        <code className="mx-1">can_use agent:&lt;id&gt;</code>, and the user&apos;s active
+        team must also have <code className="mx-1">can_use agent:&lt;id&gt;</code>.
+        If either check fails, the Webex bot denies the request before calling the agent.
+      </div>
+      <div className="rounded-md border border-amber-300/60 bg-amber-50 p-2 text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
+        <span className="font-medium">Sharing model:</span> Adding an agent to a
+        space that is assigned to a team transitively grants <em>every member of
+        that team</em> permission to invoke the agent in this space — even members
+        who were never granted the agent directly. If that is not what you want, share
+        the agent with a smaller subgroup (or with individual users) instead of the
+        space&apos;s team.
+      </div>
+    </>
+  ),
+
+  manualRouteEditing: false,
+
+  diagnosticRouteIsFixable: (route: DiagnosticRoute) =>
+    (route.route_metadata && !route.openfga_tuple) ||
+    (route.openfga_tuple && route.listen !== "all"),
+
+  fixDiagnosticRoute: async ({ item, route, routes }) => {
+    const routeUrl = `/api/admin/webex/spaces/${encodeURIComponent(item.workspace_id)}/${encodeURIComponent(item.item_id)}/routes`;
+    if (route.route_metadata && !route.openfga_tuple) {
+      const res = await fetch(routeUrl, {
+        method: "DELETE", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: route.agent_id }),
+      });
+      if (!res.ok) throw new Error(await responseErrorMessage(res, `Failed to fix agent:${route.agent_id}`));
+      return { toast: `Removed stale route metadata for agent:${route.agent_id}.` };
+    }
+    const currentRoute = routes.find((r) => r.agent_id === route.agent_id);
+    const nextRoutes: ItemAgentRoute[] = [
+      ...routes.filter((r) => r.agent_id !== route.agent_id),
+      { agent_id: route.agent_id, enabled: true, priority: currentRoute?.priority ?? 100, users: { enabled: true, listen: "all" } },
+    ];
+    const res = await fetch(routeUrl, {
+      method: "PUT", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ routes: nextRoutes }),
+    });
+    if (!res.ok) throw new Error(await responseErrorMessage(res, `Failed to fix agent:${route.agent_id}`));
+    const data = apiData<{ routes: ItemAgentRoute[] }>(await res.json());
+    return {
+      toast: `Updated agent:${route.agent_id} to listen to mentions and plain messages.`,
+      nextRoutes: data.routes ?? [],
+    };
+  },
+
+  applyOnboarding: async ({ rows, defaultTeamSlug, defaultAgentId, createDefaultRoutes, fetchFn }) => {
+    const selectedImports = rows.filter((r) => r.selected && r.teamSlug && r.agentId);
+    if (selectedImports.length === 0) return { toastMessage: "No spaces selected." };
+    const grouped = new Map<string, Array<{ id: string; name?: string }>>();
+    for (const sp of selectedImports) {
+      const key = `${sp.teamSlug} ${sp.agentId}`;
+      const cur = grouped.get(key) ?? [];
+      cur.push({ id: sp.id, name: sp.name });
+      grouped.set(key, cur);
+    }
+    const requests = Array.from(grouped.entries()).map(([key, spacesForGroup]) => {
+      const [teamSlug, agentId] = key.split(" ");
+      return { team_slug: teamSlug ?? defaultTeamSlug, agent_id: agentId ?? defaultAgentId, create_routes: createDefaultRoutes, manual_spaces: spacesForGroup };
+    });
+    const results = await Promise.all(requests.map(async (body) => {
+      const res = await fetchFn("/api/admin/webex/spaces/defaults", {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return apiData<{ summary: Record<string, number> }>(await res.json());
+    }));
+    const s = results.reduce<Record<string, number>>((acc, r) => {
+      for (const [k, v] of Object.entries(r.summary)) acc[k] = (acc[k] ?? 0) + v;
+      return acc;
+    }, {});
+    return {
+      toastMessage: `Discovered Webex spaces applied: onboarded ${s.spaces_onboarded ?? 0} spaces, assigned ${s.spaces_assigned_team ?? 0} spaces, ensured ${s.space_grants_ensured ?? 0} space grants, ensured ${s.routes_ensured ?? 0} routes, preserved ${s.routes_preserved ?? 0} existing routes.`,
+    };
+  },
+
+  discoveryAutoSelectNewItems: true,
+  legacyConfigAgentPrefill: null,
+
+  missingRouteableAgentAutoFix: {
+    title: "Auto-fix missing Webex association",
+    description: "Create an OpenFGA-backed route with listen mode all so the Webex runtime has an agent to dispatch.",
+    buttonLabel: (agentId) => agentId ? `Fix missing association with agent:${agentId}` : "Select an agent to auto-fix",
+    noAgentHelpText: "Select a Dynamic Agent below or configure a default Dynamic Agent first.",
+    isApplicable: (_item: ItemSummary, diagnostics: ItemDiagnostics) =>
+      Boolean(diagnostics?.openfga.reachable && diagnostics.openfga.tuple_count === 0 && diagnostics.routes.length === 0),
+  },
+};
 
 export function WebexSpaceRebacPanel({
   disabled = false,
@@ -206,1137 +259,5 @@ export function WebexSpaceRebacPanel({
   disabled?: boolean;
   selfService?: boolean;
 }) {
-  const { toast } = useToast();
-  const [spaces, setSpaces] = useState<WebexSpaceSummary[]>([]);
-  const [selectedKey, setSelectedKey] = useState("");
-  const [routes, setRoutes] = useState<WebexSpaceAgentRoute[]>([]);
-  const [diagnostics, setDiagnostics] = useState<WebexRuntimeDiagnostics | null>(null);
-  const [dynamicAgents, setDynamicAgents] = useState<DynamicAgentOption[]>([]);
-  const [teams, setTeams] = useState<TeamOption[]>([]);
-  const [defaultTeamSlug, setDefaultTeamSlug] = useState("");
-  const [defaultAgentId, setDefaultAgentId] = useState("");
-  const [configuredDefaults, setConfiguredDefaults] = useState<WebexSpaceAssociationDefaults | null>(null);
-  const [webexRuntimeStatus, setWebexRuntimeStatus] = useState<WebexBotRuntimeStatus | null>(null);
-  const [runtimeSyncSummary, setRuntimeSyncSummary] = useState<WebexBotRuntimeSyncSummary | null>(null);
-  const [runtimeSyncModalOpen, setRuntimeSyncModalOpen] = useState(false);
-  const [runtimeSyncModalMode, setRuntimeSyncModalMode] = useState<RuntimeSyncModalMode>("preview");
-  const [runtimeSyncModalStatus, setRuntimeSyncModalStatus] = useState<RuntimeSyncModalStatus>("idle");
-  const [runtimeSyncModalError, setRuntimeSyncModalError] = useState<string | null>(null);
-  const [createDefaultRoutes, setCreateDefaultRoutes] = useState(true);
-  const [savingDefaults, setSavingDefaults] = useState(false);
-  const [discoverDefaultsLoading, setDiscoverDefaultsLoading] = useState(false);
-  const [discoverDefaultsError, setDiscoverDefaultsError] = useState<string | null>(null);
-  const [discoveredBotSpaces, setDiscoveredBotSpaces] = useState<DiscoveredWebexSpace[]>([]);
-  const [discoveredImportRows, setDiscoveredImportRows] = useState<WebexSpaceImportRow[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
-
-  const selected = useMemo(
-    () => spaces.find((space) => `${space.workspace_id}/${space.space_id}` === selectedKey),
-    [spaces, selectedKey]
-  );
-  const selectedCanManage = !selfService || selected?.can_manage === true;
-  const unassignedSpaceCount = useMemo(
-    () => spaces.filter((space) => !space.team_slug).length,
-    [spaces]
-  );
-  const configuredSpaceIds = useMemo(
-    () => new Set(spaces.map((space) => space.space_id)),
-    [spaces]
-  );
-  const discoveredNewSpaceCount = useMemo(
-    () => discoveredBotSpaces.filter((space) => !configuredSpaceIds.has(space.id)).length,
-    [configuredSpaceIds, discoveredBotSpaces]
-  );
-  const selectedDiscoveredImportRows = useMemo(
-    () => discoveredImportRows.filter((space) => space.selected),
-    [discoveredImportRows]
-  );
-  const discoveryStatusText = useMemo(() => {
-    const base =
-      discoveredBotSpaces.length > 0
-        ? `${discoveredBotSpaces.length} bot-visible found · ${discoveredNewSpaceCount} new`
-        : `${spaces.length} managed in CAIPE`;
-    return `${base} · ${unassignedSpaceCount} missing team`;
-  }, [discoveredBotSpaces.length, discoveredNewSpaceCount, spaces.length, unassignedSpaceCount]);
-  const missingAssociationAutoFixAgentId = (defaultAgentId || configuredDefaults?.agent_id || "").trim();
-  const diagnosticsMissingRouteableAgent = Boolean(
-    diagnostics?.openfga.reachable &&
-    diagnostics.openfga.tuple_count === 0 &&
-    diagnostics.routes.length === 0
-  );
-  // Mirrors the Slack panel's dirty-tracking: true whenever the form
-  // diverges from what's persisted in `platform_config`. Drives the
-  // "Save defaults" button and the "Unsaved changes" badge.
-  const associationDefaultsDirty = useMemo(() => {
-    const savedTeam = configuredDefaults?.team_slug ?? "";
-    const savedAgent = configuredDefaults?.agent_id ?? "";
-    const savedCreateRoutes =
-      typeof configuredDefaults?.create_routes === "boolean"
-        ? configuredDefaults.create_routes
-        : true;
-    return (
-      savedTeam !== defaultTeamSlug ||
-      savedAgent !== defaultAgentId ||
-      savedCreateRoutes !== createDefaultRoutes
-    );
-  }, [configuredDefaults, defaultTeamSlug, defaultAgentId, createDefaultRoutes]);
-
-  const loadSpaces = useCallback(async () => {
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/webex/spaces");
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<{ spaces: WebexSpaceSummary[] }>(await response.json());
-      setSpaces(data.spaces ?? []);
-      setSelectedKey((current) => {
-        if (current) return current;
-        const first = data.spaces?.[0];
-        return first ? `${first.workspace_id}/${first.space_id}` : "";
-      });
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to load Webex spaces");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const loadRoutes = useCallback(async () => {
-    if (!selected) return;
-    const response = await fetch(
-      `/api/admin/webex/spaces/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.space_id)}/routes`
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ routes: WebexSpaceAgentRoute[] }>(await response.json());
-    setRoutes(data.routes ?? []);
-  }, [selected]);
-
-  const loadDiagnostics = useCallback(async () => {
-    if (!selected) return;
-    const response = await fetch(
-      `/api/admin/webex/spaces/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.space_id)}/diagnostics`
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<WebexRuntimeDiagnostics>(await response.json());
-    setDiagnostics(data);
-  }, [selected]);
-
-  const loadDynamicAgents = useCallback(async () => {
-    const response = await fetch("/api/dynamic-agents?enabled_only=true");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ items: DynamicAgentOption[] }>(await response.json());
-    setDynamicAgents(data.items ?? []);
-  }, []);
-
-  const loadTeams = useCallback(async () => {
-    const response = await fetch("/api/admin/teams");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ teams: TeamOption[] }>(await response.json());
-    setTeams(data.teams ?? []);
-  }, []);
-
-  const loadAssociationDefaults = useCallback(async () => {
-    const response = await fetch("/api/admin/webex/spaces/defaults");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<{ defaults: WebexSpaceAssociationDefaults }>(await response.json());
-    setConfiguredDefaults(data.defaults ?? null);
-    // Adopt the saved values verbatim — including empty strings — so
-    // clearing the pick in another tab is reflected here on next load.
-    if (data.defaults) {
-      setDefaultTeamSlug(data.defaults.team_slug ?? "");
-      setDefaultAgentId(data.defaults.agent_id ?? "");
-      if (typeof data.defaults.create_routes === "boolean") {
-        setCreateDefaultRoutes(data.defaults.create_routes);
-      }
-    }
-  }, []);
-
-  // Persist the onboarding defaults to MongoDB (`platform_config`).
-  // Distinct from the migration POST, which actually runs the
-  // onboarding pipeline. Admins now click "Save defaults" to remember
-  // their pick without touching any spaces.
-  const saveAssociationDefaults = useCallback(async () => {
-    setSavingDefaults(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/webex/spaces/defaults", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          team_slug: defaultTeamSlug,
-          agent_id: defaultAgentId,
-          create_routes: createDefaultRoutes,
-        }),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<{ defaults: WebexSpaceAssociationDefaults }>(
-        await response.json(),
-      );
-      setConfiguredDefaults(data.defaults ?? null);
-      if (data.defaults) {
-        setDefaultTeamSlug(data.defaults.team_slug ?? "");
-        setDefaultAgentId(data.defaults.agent_id ?? "");
-        if (typeof data.defaults.create_routes === "boolean") {
-          setCreateDefaultRoutes(data.defaults.create_routes);
-        }
-      }
-      toast("Onboarding defaults saved.", "success");
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to save Webex onboarding defaults";
-      setMessage(errorMessage);
-      toast(errorMessage, "error");
-    } finally {
-      setSavingDefaults(false);
-    }
-  }, [defaultTeamSlug, defaultAgentId, createDefaultRoutes, toast]);
-
-  const loadWebexRuntimeStatus = useCallback(async () => {
-    const response = await fetch("/api/admin/webex/runtime/status");
-    if (!response.ok) throw new Error(await response.text());
-    const data = apiData<WebexBotRuntimeStatus>(await response.json());
-    setWebexRuntimeStatus(data);
-  }, []);
-
-  useEffect(() => {
-    void loadSpaces();
-  }, [loadSpaces]);
-
-  useEffect(() => {
-    void loadDynamicAgents().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Dynamic Agents")
-    );
-  }, [loadDynamicAgents]);
-
-  useEffect(() => {
-    if (selfService) return;
-    void loadTeams().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load teams")
-    );
-  }, [loadTeams, selfService]);
-
-  useEffect(() => {
-    if (selfService) return;
-    void loadAssociationDefaults().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Webex space association defaults")
-    );
-  }, [loadAssociationDefaults, selfService]);
-
-  useEffect(() => {
-    if (selfService) return;
-    void loadWebexRuntimeStatus().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Webex bot runtime status")
-    );
-  }, [loadWebexRuntimeStatus, selfService]);
-
-  useEffect(() => {
-    void loadRoutes().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Webex space routes")
-    );
-  }, [loadRoutes]);
-
-  useEffect(() => {
-    setDiagnostics(null);
-    void loadDiagnostics().catch((error) =>
-      setMessage(error instanceof Error ? error.message : "Failed to load Webex runtime diagnostics")
-    );
-  }, [loadDiagnostics]);
-
-  const fixMissingRouteableAgent = async () => {
-    if (!selected) return;
-    const agentId = missingAssociationAutoFixAgentId;
-    if (!agentId) {
-      toast("Select a Dynamic Agent or configure a default Dynamic Agent to auto-fix this Webex space.", "warning");
-      return;
-    }
-    setLoading(true);
-    setMessage(null);
-    try {
-      const nextRoutes = [
-        ...routes.filter((route) => route.agent_id !== agentId),
-        {
-          agent_id: agentId,
-          enabled: true,
-          priority: 100,
-          users: { enabled: true, listen: "all" as const },
-        },
-      ];
-      const response = await fetch(
-        `/api/admin/webex/spaces/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.space_id)}/routes`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ routes: nextRoutes }),
-        }
-      );
-      if (!response.ok) {
-        throw new Error(await responseErrorMessage(response, "Failed to auto-fix Webex association"));
-      }
-      const data = apiData<{ routes: WebexSpaceAgentRoute[] }>(await response.json());
-      setRoutes(data.routes ?? []);
-      await Promise.all([loadSpaces(), loadRoutes(), loadDiagnostics()]);
-      toast(`Created Webex association for agent:${agentId}.`, "success");
-    } catch (error) {
-      setMessage(webexAssociationErrorMessage(error, "Failed to auto-fix Webex association"));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const refreshWebexRuntimeStatus = async () => {
-    setLoading(true);
-    setMessage(null);
-    try {
-      await loadWebexRuntimeStatus();
-      toast("Webex bot runtime status refreshed.", "success");
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to load Webex bot runtime status");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const reloadWebexBotRoutes = async () => {
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/webex/runtime/reload", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      await loadWebexRuntimeStatus();
-      toast("Webex bot route cache reloaded.", "success");
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to reload Webex bot routes");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const syncWebexBotConfig = async (dryRun: boolean) => {
-    setRuntimeSyncModalOpen(true);
-    setRuntimeSyncModalMode(dryRun ? "preview" : "apply");
-    setRuntimeSyncModalStatus("loading");
-    setRuntimeSyncModalError(null);
-    if (dryRun) {
-      setRuntimeSyncSummary(null);
-    }
-    setLoading(true);
-    setMessage(null);
-    try {
-      const response = await fetch("/api/admin/webex/runtime/sync-from-config", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dry_run: dryRun }),
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<WebexBotRuntimeSyncSummary>(await response.json());
-      setRuntimeSyncSummary(data);
-      setRuntimeSyncModalStatus("success");
-      toast(
-        dryRun
-          ? `Sync preview: ${data.routes_planned} routes planned from ${data.spaces_seen} spaces.`
-          : `Config sync applied: upserted ${data.routes_upserted} routes and wrote ${data.openfga_tuples_written} OpenFGA tuples.`,
-        "success"
-      );
-      await Promise.all([loadWebexRuntimeStatus(), loadSpaces(), loadRoutes(), loadDiagnostics()]);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Failed to sync Webex bot config";
-      setRuntimeSyncModalError(errorMessage);
-      setRuntimeSyncModalStatus("error");
-      setMessage(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchBotSpaces = async (): Promise<DiscoveredWebexSpace[]> => {
-    const discovered: DiscoveredWebexSpace[] = [];
-    let cursor: string | null | undefined;
-    let firstPage = true;
-    do {
-      const params = new URLSearchParams({ limit: "500" });
-      if (firstPage) params.set("refresh", "1");
-      if (cursor) params.set("cursor", cursor);
-      const response = await fetch(`/api/admin/webex/available-spaces?${params.toString()}`, {
-        cache: "no-store",
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const data = apiData<WebexSpaceDiscoveryPayload>(await response.json());
-      discovered.push(...(data.spaces ?? []));
-      cursor = data.has_more ? data.next_cursor : null;
-      firstPage = false;
-    } while (cursor);
-    return discovered;
-  };
-
-  const discoverDefaults = async () => {
-    setDiscoverDefaultsLoading(true);
-    setDiscoverDefaultsError(null);
-    setMessage(null);
-    try {
-      const discovered = await fetchBotSpaces();
-      setDiscoveredBotSpaces(discovered);
-      const hasNewSpaces = discovered.some((space) => !configuredSpaceIds.has(space.id));
-      const fallbackTeamSlug = defaultTeamSlug || teams[0]?.slug || "";
-      const fallbackAgentId = defaultAgentId || dynamicAgents[0]?._id || "";
-      setDiscoveredImportRows(
-        discovered.map((space) => {
-          const isExisting = configuredSpaceIds.has(space.id);
-          return {
-            ...space,
-            selected: hasNewSpaces ? !isExisting : true,
-            team_slug: fallbackTeamSlug,
-            agent_id: fallbackAgentId,
-            is_existing: isExisting,
-          };
-        })
-      );
-      toast(`Found ${pluralize(discovered.length, "bot-visible space")}.`, "success");
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to discover Webex bot-visible spaces";
-      setDiscoverDefaultsError(errorMessage);
-      setMessage(errorMessage);
-      setDiscoveredImportRows([]);
-    } finally {
-      setDiscoverDefaultsLoading(false);
-    }
-  };
-
-  const updateDiscoveredImportRow = (
-    spaceId: string,
-    updates: Partial<Pick<WebexSpaceImportRow, "selected" | "team_slug" | "agent_id">>
-  ) => {
-    setDiscoveredImportRows((rows) =>
-      rows.map((row) => (row.id === spaceId ? { ...row, ...updates } : row))
-    );
-  };
-
-  const setAllDiscoveredImportRowsSelected = (selected: boolean) => {
-    setDiscoveredImportRows((rows) => rows.map((row) => ({ ...row, selected })));
-  };
-
-  const confirmMigrationDefaults = async (spacesToImport: WebexSpaceImportRow[] = []) => {
-    const selectedImports = spacesToImport.filter((space) => space.selected);
-    const hasRowDefaults = selectedImports.every(
-      (space) => Boolean(space.team_slug) && Boolean(space.agent_id)
-    );
-    if (!hasRowDefaults || selectedImports.length === 0) return;
-    setLoading(true);
-    setMessage(null);
-    try {
-      const groupedImports = new Map<string, Array<{ id: string; name?: string }>>();
-      selectedImports.forEach((space) => {
-        const teamSlug = space.team_slug;
-        const agentId = space.agent_id;
-        const groupKey = `${teamSlug}\u0000${agentId}`;
-        const current = groupedImports.get(groupKey) ?? [];
-        current.push({
-          id: space.id,
-          name: space.name,
-        });
-        groupedImports.set(groupKey, current);
-      });
-      const requests =
-        groupedImports.size > 0
-          ? Array.from(groupedImports.entries()).map(([key, spacesForGroup]) => {
-              const [teamSlug, agentId] = key.split("\u0000");
-              return {
-                team_slug: teamSlug ?? defaultTeamSlug,
-                agent_id: agentId ?? defaultAgentId,
-                create_routes: createDefaultRoutes,
-                manual_spaces: spacesForGroup,
-              };
-            })
-          : [
-              {
-                team_slug: defaultTeamSlug,
-                agent_id: defaultAgentId,
-                create_routes: createDefaultRoutes,
-              },
-            ];
-      const results = await Promise.all(
-        requests.map(async (body) => {
-          const response = await fetch("/api/admin/webex/spaces/defaults", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(body),
-          });
-          if (!response.ok) throw new Error(await response.text());
-          return apiData<{ summary: WebexDefaultsSummary }>(await response.json());
-        })
-      );
-      const summary = results.reduce<WebexDefaultsSummary>(
-        (acc, result) => ({
-          spaces_seen: acc.spaces_seen + result.summary.spaces_seen,
-          spaces_manual: (acc.spaces_manual ?? 0) + (result.summary.spaces_manual ?? 0),
-          spaces_onboarded: (acc.spaces_onboarded ?? 0) + (result.summary.spaces_onboarded ?? 0),
-          spaces_assigned_team: acc.spaces_assigned_team + result.summary.spaces_assigned_team,
-          space_grants_ensured: acc.space_grants_ensured + result.summary.space_grants_ensured,
-          routes_ensured: acc.routes_ensured + result.summary.routes_ensured,
-          routes_preserved: (acc.routes_preserved ?? 0) + (result.summary.routes_preserved ?? 0),
-        }),
-        {
-          spaces_seen: 0,
-          spaces_manual: 0,
-          spaces_onboarded: 0,
-          spaces_assigned_team: 0,
-          space_grants_ensured: 0,
-          routes_ensured: 0,
-          routes_preserved: 0,
-        }
-      );
-      await Promise.all([
-        loadSpaces(),
-        loadRoutes(),
-        loadDiagnostics(),
-        loadAssociationDefaults(),
-      ]);
-      const selectedImportIds = new Set(selectedImports.map((space) => space.id));
-      setDiscoveredImportRows((rows) =>
-        rows.map((row) =>
-          selectedImportIds.has(row.id) ? { ...row, is_existing: true, selected: false } : row
-        )
-      );
-      toast(
-        `Discovered Webex spaces applied: onboarded ${summary.spaces_onboarded ?? 0} spaces, assigned ${summary.spaces_assigned_team} spaces, ensured ${summary.space_grants_ensured} space grants, ensured ${summary.routes_ensured} routes, preserved ${summary.routes_preserved ?? 0} existing routes.`,
-        "success"
-      );
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to apply Webex space association defaults");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const diagnosticRouteIsFixable = (route: WebexRuntimeDiagnosticRoute) =>
-    (route.route_metadata && !route.openfga_tuple) ||
-    (route.openfga_tuple && route.listen !== "all");
-
-  const fixDiagnosticRoute = async (route: WebexRuntimeDiagnosticRoute) => {
-    if (!selected) return;
-    setLoading(true);
-    setMessage(null);
-    try {
-      const routeUrl = `/api/admin/webex/spaces/${encodeURIComponent(selected.workspace_id)}/${encodeURIComponent(selected.space_id)}/routes`;
-      if (route.route_metadata && !route.openfga_tuple) {
-        const response = await fetch(routeUrl, {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent_id: route.agent_id }),
-        });
-        if (!response.ok) {
-          throw new Error(await responseErrorMessage(response, `Failed to fix agent:${route.agent_id}`));
-        }
-        await Promise.all([loadSpaces(), loadRoutes(), loadDiagnostics()]);
-        toast(`Removed stale route metadata for agent:${route.agent_id}.`, "success");
-        return;
-      }
-
-      const currentRoute = routes.find((candidate) => candidate.agent_id === route.agent_id);
-      const nextRoutes = [
-        ...routes.filter((candidate) => candidate.agent_id !== route.agent_id),
-        {
-          agent_id: route.agent_id,
-          enabled: true,
-          priority: currentRoute?.priority ?? 100,
-          users: { enabled: true, listen: "all" as const },
-        },
-      ];
-      const response = await fetch(routeUrl, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ routes: nextRoutes }),
-      });
-      if (!response.ok) {
-        throw new Error(await responseErrorMessage(response, `Failed to fix agent:${route.agent_id}`));
-      }
-      const data = apiData<{ routes: WebexSpaceAgentRoute[] }>(await response.json());
-      setRoutes(data.routes ?? []);
-      await Promise.all([loadSpaces(), loadRoutes(), loadDiagnostics()]);
-      toast(`Updated agent:${route.agent_id} to listen to mentions and plain messages.`, "success");
-    } catch (error) {
-      setMessage(webexAssociationErrorMessage(error, `Failed to fix agent:${route.agent_id}`));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{selfService ? "My Webex Space Settings" : "Webex Spaces"}</CardTitle>
-        <CardDescription>
-          {selfService
-            ? "Manage bot routing behavior only for Webex spaces where OpenFGA grants you space admin access."
-            : "Control which Dynamic Agents a Webex space may invoke."}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
-        <div className="order-0 space-y-2 rounded-md border p-3 text-sm text-muted-foreground">
-          <div>
-            Webex authorization has two checks before dispatch: the space must have
-            <code className="mx-1">can_use agent:&lt;id&gt;</code>, and the user&apos;s active
-            team must also have <code className="mx-1">can_use agent:&lt;id&gt;</code>.
-            If either check fails, the Webex bot denies the request before calling the agent.
-          </div>
-          <div className="rounded-md border border-amber-300/60 bg-amber-50 p-2 text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
-            <span className="font-medium">Sharing model:</span> Adding an agent to a
-            space that is assigned to a team transitively grants <em>every member of
-            that team</em> permission to invoke the agent in this space — even members
-            who were never granted the agent directly. If that is not what you want, share
-            the agent with a smaller subgroup (or with individual users) instead of the
-            space&apos;s team.
-          </div>
-        </div>
-        {message && <p className="text-sm text-muted-foreground">{message}</p>}
-
-        {!selfService && (
-        <div
-          role="region"
-          aria-label="Advanced Setup - Import/Sync with Webex Bot"
-          data-section-tone="slate"
-          data-section-order="5"
-          className="order-5 rounded-md border border-slate-500/20 bg-slate-500/5 p-4 space-y-3"
-        >
-          <div>
-            <h3 className="inline-flex items-center gap-2 text-base font-semibold tracking-tight">
-              <Settings2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-              Advanced Setup - Import/Sync with Webex Bot
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Inspect the running Webex bot route cache, force a reload, or migrate the
-              bot&apos;s static YAML space config into MongoDB/OpenFGA.
-            </p>
-          </div>
-          <div className="grid gap-2 text-sm md:grid-cols-4">
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Route mode</div>
-              <div className="font-medium">{webexRuntimeStatus?.route_mode ?? "unknown"}</div>
-            </div>
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Static config</div>
-              <div className="font-medium">
-                {webexRuntimeStatus
-                  ? `${webexRuntimeStatus.static_config.spaces} spaces / ${webexRuntimeStatus.static_config.routes} routes`
-                  : "unknown"}
-              </div>
-            </div>
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Route cache</div>
-              <div className="font-medium">
-                {webexRuntimeStatus
-                  ? `${webexRuntimeStatus.route_cache.cache_size} cached space${webexRuntimeStatus.route_cache.cache_size === 1 ? "" : "s"}`
-                  : "unknown"}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                TTL {webexRuntimeStatus?.route_cache.ttl_seconds ?? "?"}s
-              </div>
-            </div>
-            <div className="rounded-md border bg-background/60 p-3">
-              <div className="text-xs text-muted-foreground">Thread context</div>
-              <div className="font-medium">{threadContextLabel(webexRuntimeStatus)}</div>
-            </div>
-          </div>
-          <div
-            role="region"
-            aria-label="Webex bot sync legend"
-            className="grid gap-2 rounded-md border bg-background/50 p-3 text-xs text-muted-foreground md:grid-cols-2"
-          >
-            <div>
-              <span className="font-medium text-foreground">Route mode:</span>{" "}
-              shows whether the Webex bot reads routes from database, YAML, or both.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Static config:</span>{" "}
-              counts spaces/routes currently loaded from Webex bot YAML.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Route cache:</span>{" "}
-              shows cached runtime space routes and how soon they expire.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Thread context:</span>{" "}
-              shows whether the bot sends bounded prior Webex thread messages to the selected agent.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Refresh Runtime Status:</span>{" "}
-              reloads these status numbers from the running bot.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Reload Bot Cache:</span>{" "}
-              refreshes the running bot after UI route changes.
-            </div>
-            <div>
-              <span className="font-medium text-foreground">Preview YAML Import:</span>{" "}
-              shows planned changes without writing them.
-            </div>
-            <div className="md:col-span-2">
-              <span className="font-medium text-foreground">Import from YAML Config:</span>{" "}
-              writes YAML routes into CAIPE/OpenFGA.
-            </div>
-          </div>
-          {runtimeSyncSummary && (
-            <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">
-              <div>
-                {runtimeSyncSummary.dry_run
-                  ? `Sync preview: ${runtimeSyncSummary.routes_planned} routes planned.`
-                  : `Config sync applied: upserted ${runtimeSyncSummary.routes_upserted} routes.`}
-              </div>
-              Last sync {runtimeSyncSummary.dry_run ? "preview" : "apply"}:{" "}
-              {runtimeSyncSummary.routes_planned} planned, {runtimeSyncSummary.routes_upserted} upserted,{" "}
-              {runtimeSyncSummary.openfga_tuples_written} OpenFGA tuples.
-            </div>
-          )}
-          <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" variant="outline" onClick={refreshWebexRuntimeStatus} disabled={disabled || loading}>
-              <RefreshCw className="h-4 w-4" aria-hidden="true" />
-              Refresh Runtime Status
-            </Button>
-            <Button type="button" variant="outline" onClick={reloadWebexBotRoutes} disabled={disabled || loading}>
-              <RotateCw className="h-4 w-4" aria-hidden="true" />
-              Reload Bot Cache
-            </Button>
-            <Button type="button" variant="outline" onClick={() => syncWebexBotConfig(true)} disabled={disabled || loading}>
-              <FileUp className="h-4 w-4" aria-hidden="true" />
-              Preview YAML Import
-            </Button>
-            <Button type="button" onClick={() => syncWebexBotConfig(false)} disabled={disabled || loading}>
-              <FileUp className="h-4 w-4" aria-hidden="true" />
-              Import from YAML Config
-            </Button>
-          </div>
-        </div>
-        )}
-
-        <Dialog open={runtimeSyncModalOpen} onOpenChange={setRuntimeSyncModalOpen}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {runtimeSyncModalMode === "preview"
-                  ? "Webex Bot Config Sync Preview"
-                  : "Webex Bot Config Sync Apply"}
-              </DialogTitle>
-              <DialogDescription>
-                Preview reads the Webex bot&apos;s loaded static YAML config. Apply upserts matching
-                MongoDB route metadata and space-agent OpenFGA tuples without deleting UI-managed associations.
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="space-y-3">
-              <div className="rounded-md border bg-muted/20 p-3 text-sm">
-                <div className="font-medium">
-                  {runtimeSyncModalStatus === "loading"
-                    ? runtimeSyncModalMode === "preview"
-                      ? "Previewing..."
-                      : "Applying..."
-                    : runtimeSyncModalStatus === "success"
-                      ? runtimeSyncModalMode === "preview"
-                        ? "Preview complete"
-                        : "Apply complete"
-                      : runtimeSyncModalStatus === "error"
-                        ? "Sync failed"
-                        : "Ready"}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {runtimeSyncModalStatus === "loading"
-                    ? "Contacting the Webex bot admin API..."
-                    : "Static config sync is upsert-only and leaves existing UI-managed associations in place."}
-                </div>
-              </div>
-
-              {runtimeSyncModalError && (
-                <div className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">
-                  {runtimeSyncModalError}
-                </div>
-              )}
-
-              {runtimeSyncSummary && (
-                <div className="grid gap-2 text-sm md:grid-cols-2">
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">Spaces</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.spaces_seen, "space")} scanned
-                    </div>
-                  </div>
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">Planned routes</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.routes_planned, "route")} planned
-                    </div>
-                  </div>
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">MongoDB route metadata</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.routes_upserted, "route")} upserted
-                    </div>
-                  </div>
-                  <div className="rounded-md border p-3">
-                    <div className="text-xs text-muted-foreground">OpenFGA tuples</div>
-                    <div className="font-medium">
-                      {pluralize(runtimeSyncSummary.openfga_tuples_written, "OpenFGA tuple")} written
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setRuntimeSyncModalOpen(false)}
-                disabled={runtimeSyncModalStatus === "loading"}
-              >
-                Close
-              </Button>
-              {runtimeSyncModalMode === "preview" && runtimeSyncModalStatus === "success" && (
-                <Button type="button" onClick={() => syncWebexBotConfig(false)} disabled={disabled || loading}>
-                  <FileUp className="h-4 w-4" aria-hidden="true" />
-                  Import from YAML Config
-                </Button>
-              )}
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        {!selfService && (
-        <ConnectorOnboardingWizard
-          connectorName="Webex"
-          provider="webex"
-          isAdmin={!selfService}
-          itemSingular="space"
-          itemPlural="spaces"
-          discoveredLabel="bot-visible space"
-          findLabel="Find Webex Spaces with Bot Integration"
-          refreshLabel="Refresh Webex Spaces with Bot Integration"
-          loadingLabel="Finding Webex spaces..."
-          emptyLabel="No bot-visible Webex spaces were discovered."
-          description="Find Webex spaces where the bot is already installed, then choose what to import."
-          discoveryStatusText={discoveryStatusText}
-          discoveredCount={discoveredBotSpaces.length}
-          newCount={discoveredNewSpaceCount}
-          selectedCount={selectedDiscoveredImportRows.length}
-          rows={discoveredImportRows.map((space) => ({
-            id: space.id,
-            name: space.name,
-            secondary: [
-              space.id,
-              space.type,
-              space.is_locked ? "locked" : "",
-            ].filter(Boolean).join(" · "),
-            selected: space.selected,
-            teamSlug: space.team_slug,
-            agentId: space.agent_id,
-            isExisting: space.is_existing,
-            importLabel: `Import ${space.name}`,
-            teamLabel: `Team for ${space.name}`,
-            agentLabel: `Dynamic Agent for ${space.name}`,
-          }))}
-          teams={teams.map((team) => ({ value: team.slug, label: team.name || team.slug }))}
-          agents={dynamicAgents.map((agent) => ({ value: agent._id, label: agent.name || agent._id }))}
-          error={discoverDefaultsError}
-          disabled={disabled}
-          loading={loading}
-          discovering={discoverDefaultsLoading}
-          onDiscover={() => void discoverDefaults()}
-          onSelectAll={() => setAllDiscoveredImportRowsSelected(true)}
-          onClearSelection={() => setAllDiscoveredImportRowsSelected(false)}
-          onRowChange={(spaceId, updates) =>
-            updateDiscoveredImportRow(spaceId, {
-              ...(typeof updates.selected === "boolean" ? { selected: updates.selected } : {}),
-              ...(typeof updates.teamSlug === "string" ? { team_slug: updates.teamSlug } : {}),
-              ...(typeof updates.agentId === "string" ? { agent_id: updates.agentId } : {}),
-            })
-          }
-          onApply={() => void confirmMigrationDefaults(discoveredImportRows)}
-        />
-        )}
-
-        {!selfService && (
-        <div
-          role="region"
-          aria-label="Onboarding Default Selection"
-          data-section-tone="teal"
-          data-section-order="3"
-          className="order-3 rounded-md border border-teal-500/25 bg-teal-500/5 p-4 space-y-4"
-        >
-          <div>
-            <h3 className="inline-flex items-center gap-2 text-base font-semibold tracking-tight">
-              <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
-              Onboarding Default Selection
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Only changes what is preselected when you onboard spaces. Each space still needs an explicit setup action.
-            </p>
-          </div>
-          <div className="rounded-md border bg-muted/20 p-3 text-xs">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <span className="font-medium text-foreground">Last saved</span>
-              {configuredDefaults?.source === "env" && (
-                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  from environment variable
-                </span>
-              )}
-              {configuredDefaults?.source === "db" && configuredDefaults?.updated_at && (
-                <span className="text-[10px] text-muted-foreground">
-                  {new Date(configuredDefaults.updated_at).toLocaleString()}
-                  {configuredDefaults?.updated_by ? ` · ${configuredDefaults.updated_by}` : ""}
-                </span>
-              )}
-              {configuredDefaults?.source === "unset" && (
-                <span className="text-[10px] text-muted-foreground">never saved</span>
-              )}
-            </div>
-            <div className="mt-2 grid gap-2 md:grid-cols-2">
-              <div>
-                <div className="text-muted-foreground">Onboarding team</div>
-                <code>{configuredDefaults?.team_slug ? `team:${configuredDefaults.team_slug}` : "not configured"}</code>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Onboarding Dynamic Agent</div>
-                <code>{configuredDefaults?.agent_id ? `agent:${configuredDefaults.agent_id}` : "not configured"}</code>
-              </div>
-            </div>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="webex-default-team">Preselected Team</Label>
-              {/* Switched from native <select> to TeamPicker on
-                  2026-05-27 — environments with hundreds of AWS-* /
-                  SSO-* teams made the dropdown unusable. */}
-              <TeamPicker
-                id="webex-default-team"
-                value={defaultTeamSlug}
-                onChange={setDefaultTeamSlug}
-                disabled={disabled || teams.length === 0}
-                placeholder={
-                  teams.length === 0 ? "No teams configured" : "Select preselected team"
-                }
-                searchPlaceholder="Search teams..."
-                options={teams.map<TeamPickerOption>((team) => ({
-                  slug: team.slug,
-                  name: team.name || team.slug,
-                  id: team.id,
-                  _id: team._id,
-                }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="webex-default-agent">Preselected Dynamic Agent</Label>
-              <select
-                id="webex-default-agent"
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                value={defaultAgentId}
-                onChange={(event) => setDefaultAgentId(event.target.value)}
-                disabled={disabled || dynamicAgents.length === 0}
-              >
-                <option value="">
-                  {dynamicAgents.length === 0 ? "No enabled Dynamic Agents found" : "Select preselected Dynamic Agent"}
-                </option>
-                {dynamicAgents.map((agent) => (
-                  <option key={agent._id} value={agent._id}>
-                    {agentLabel(agent)}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-          {/* Dedicated Save button so admins can persist their pick
-              without running the migration pipeline. The wizard's
-              "Apply" button still uses whatever's on screen, but the
-              saved values now survive a reload. */}
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {associationDefaultsDirty && (
-              <span
-                role="status"
-                className="text-[11px] text-amber-700 dark:text-amber-400"
-              >
-                Unsaved changes
-              </span>
-            )}
-            <Button
-              type="button"
-              size="sm"
-              variant="default"
-              onClick={() => void saveAssociationDefaults()}
-              disabled={disabled || savingDefaults || !associationDefaultsDirty}
-              aria-label="Save Webex onboarding defaults"
-            >
-              {savingDefaults ? "Saving…" : "Save defaults"}
-            </Button>
-          </div>
-          {(teams.length === 0 || dynamicAgents.length === 0) && (
-            <p className="text-xs text-muted-foreground">
-              Configure a team or Dynamic Agent in the admin UI, then reload this page.
-            </p>
-          )}
-        </div>
-        )}
-
-        <div
-          role="region"
-          aria-label="Step 2a: Verify Webex Space ReBAC"
-          data-section-tone="violet"
-          data-section-order="2"
-          className="order-2 rounded-md border border-violet-500/25 bg-violet-500/5 p-4 space-y-3"
-        >
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div>
-              <h3 className="text-base font-semibold tracking-tight">Step 2a: Verify Webex Space ReBAC</h3>
-              <p className="text-xs text-muted-foreground">
-                Preflight checks for the selected space using the same OpenFGA tuple and route metadata shape the Webex bot depends on.
-              </p>
-            </div>
-            {diagnostics && (
-              <Badge variant={diagnostics.warnings.length > 0 ? "outline" : "default"}>
-                {diagnostics.warnings.length > 0 ? `${diagnostics.warnings.length} warning${diagnostics.warnings.length === 1 ? "" : "s"}` : "healthy"}
-              </Badge>
-            )}
-          </div>
-        <div className="grid gap-3 md:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="webex-space-select">Space</Label>
-            <select
-              id="webex-space-select"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-              value={selectedKey}
-              onChange={(event) => {
-                setSelectedKey(event.target.value);
-              }}
-              disabled={disabled || loading}
-            >
-              <option value="">Select a space</option>
-              {spaces.map((space) => (
-                <option
-                  key={`${space.workspace_id}/${space.space_id}`}
-                  value={`${space.workspace_id}/${space.space_id}`}
-                >
-                  {space.space_name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="space-y-2">
-            <Label>Selected Scope</Label>
-            <div className="rounded-md border p-3 text-sm">
-              {selected ? (
-                <>
-                  <div className="font-medium">{selected.space_name}</div>
-                  <div className="text-muted-foreground">
-                    {selected.space_id}
-                  </div>
-                  {selected.team_slug && <Badge variant="secondary">team:{selected.team_slug}</Badge>}
-                </>
-              ) : (
-                <span className="text-muted-foreground">No space selected</span>
-              )}
-            </div>
-          </div>
-        </div>
-
-          {!selected ? (
-            <p className="text-sm text-muted-foreground">Select a Webex space to run diagnostics.</p>
-          ) : !diagnostics ? (
-            <p className="text-sm text-muted-foreground">Loading diagnostics...</p>
-          ) : (
-            <>
-              <div className="grid gap-2 text-sm md:grid-cols-3">
-                <div className="rounded-md border p-3">
-                  <div className="text-xs text-muted-foreground">OpenFGA</div>
-                  <div className="font-medium">{diagnostics.openfga.reachable ? "reachable" : "unreachable"}</div>
-                  <div className="text-xs text-muted-foreground">{diagnostics.openfga.tuple_count} space-agent tuples</div>
-                </div>
-                <div className="rounded-md border p-3">
-                  <div className="text-xs text-muted-foreground">Runtime Routes</div>
-                  <div className="font-medium">{diagnostics.routes.length}</div>
-                  <div className="text-xs text-muted-foreground">OpenFGA-backed candidates</div>
-                </div>
-                <div className="rounded-md border p-3">
-                  <div className="text-xs text-muted-foreground">Last Error</div>
-                  <div className="font-medium">{diagnostics.last_runtime_error?.reason_code ?? "none"}</div>
-                  <div className="text-xs text-muted-foreground">{diagnostics.last_runtime_error?.ts ?? "No recent runtime error"}</div>
-                </div>
-              </div>
-              {diagnostics.warnings.length > 0 && (
-                <div className="space-y-1 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
-                  {diagnostics.warnings.map((warning) => (
-                    <div key={warning}>{warning}</div>
-                  ))}
-                </div>
-              )}
-              {diagnosticsMissingRouteableAgent && (
-                <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-cyan-500/40 bg-cyan-50 p-3 text-sm text-cyan-950 dark:bg-cyan-950/30 dark:text-cyan-100">
-                  <div>
-                    <div className="font-medium">Auto-fix missing Webex association</div>
-                    <div className="text-xs">
-                      Create an OpenFGA-backed route with listen mode <code>all</code> so the Webex
-                      runtime has an agent to dispatch.
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void fixMissingRouteableAgent()}
-                    disabled={disabled || !selectedCanManage || loading || !missingAssociationAutoFixAgentId}
-                  >
-                    {missingAssociationAutoFixAgentId
-                      ? `Fix missing association with agent:${missingAssociationAutoFixAgentId}`
-                      : "Select an agent to auto-fix"}
-                  </Button>
-                  {!missingAssociationAutoFixAgentId && (
-                    <div className="basis-full text-xs">
-                      Select a Dynamic Agent below or configure a default Dynamic Agent first.
-                    </div>
-                  )}
-                </div>
-              )}
-              {diagnostics.last_runtime_error?.message && (
-                <div className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">
-                  {diagnostics.last_runtime_error.message}
-                </div>
-              )}
-              {diagnostics.routes.length > 0 && (
-                <div className="space-y-2">
-                  {diagnostics.routes.map((route) => (
-                    <div key={route.agent_id} className="flex flex-wrap items-center gap-2 rounded-md border p-3 text-sm">
-                      <span className="font-medium">agent:{route.agent_id}</span>
-                      <Badge variant={route.openfga_tuple ? "default" : "outline"}>
-                        {route.openfga_tuple ? "OpenFGA tuple" : "missing tuple"}
-                      </Badge>
-                      <Badge variant={route.route_metadata ? "secondary" : "outline"}>
-                        {route.route_metadata ? `listen:${route.listen}` : "default metadata"}
-                      </Badge>
-                      <span className="text-xs text-muted-foreground">
-                        mention {route.runtime_matches.mention ? "yes" : "no"} / message {route.runtime_matches.message ? "yes" : "no"}
-                      </span>
-                      {diagnosticRouteIsFixable(route) && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="ml-auto"
-                          onClick={() => void fixDiagnosticRoute(route)}
-                          disabled={disabled || !selectedCanManage || loading}
-                          aria-label={`Fix agent:${route.agent_id} routing`}
-                        >
-                          Fix it
-                        </Button>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </>
-          )}
-        </div>
-
-      </CardContent>
-    </Card>
-  );
+  return <ConnectorAdminPanel adapter={WEBEX_ADAPTER} disabled={disabled} selfService={selfService} />;
 }

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -262,14 +262,11 @@ it("uses enabled Dynamic Agents dropdown for Slack channel-agent associations", 
   expect(screen.queryByLabelText("Action")).not.toBeInTheDocument();
 
   await expandChannelRow("incidents");
-  const agentSelect = await screen.findByRole("combobox", { name: "Dynamic Agent" });
-  // Only the route-agent dropdown is on screen on the default Configured tab —
-  // the Preselected Dynamic Agent dropdown lives behind the Onboard tab now.
-  await waitFor(() =>
-    expect(screen.getAllByRole("option", { name: "Test April 2025 (test-april-2025)" })).toHaveLength(1)
-  );
+  // Only the route-agent AgentPicker is on screen on the default Configured tab —
+  // the Preselected Dynamic Agent picker lives behind the Onboard tab now.
+  expect(await screen.findByLabelText("Dynamic Agent")).toBeInTheDocument();
 
-  fireEvent.change(agentSelect, { target: { value: "test-april-2025" } });
+  await pickAgent("Dynamic Agent", "test-april-2025");
   fireEvent.click(screen.getByRole("button", { name: "Create Association" }));
 
   await waitFor(() =>
@@ -380,9 +377,7 @@ it("keeps Slack onboarding defaults simple without bulk apply controls", async (
   // Preselected Team is now a searchable TeamPicker (2026-05-27).
   await screen.findByLabelText("Preselected Team");
   await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
 
   expect(screen.queryByRole("button", { name: "Apply Selection to Managed Channels" })).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: "Refresh lists" })).not.toBeInTheDocument();
@@ -395,9 +390,7 @@ it("discovers bot-member channels and applies defaults after admin consent", asy
 
   await screen.findByLabelText("Preselected Team");
   await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
 
   fireEvent.click(screen.getByRole("button", { name: "Find channels" }));
 
@@ -612,9 +605,7 @@ it("falls back to onboarding default when legacy config is ignored, and leaves a
   fireEvent.click(screen.getByRole("checkbox", { name: /Import #new-alerts/i }));
   expect(screen.getAllByText("Pick an agent").length).toBeGreaterThanOrEqual(1);
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
   fireEvent.click(screen.getByRole("checkbox", { name: /Use existing Slackbot channel agents as defaults/i }));
   fireEvent.click(screen.getByRole("button", { name: "Refresh channels" }));
 
@@ -708,9 +699,7 @@ it("shows discovered channel setup feedback as a toast without shifting the acti
 
   await screen.findByLabelText("Preselected Team");
   await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
 
   fireEvent.click(screen.getByRole("button", { name: "Find channels" }));
 
@@ -751,9 +740,7 @@ it("uses a streamlined setup flow with icons and toast action confirmations", as
   // the existing "Agents" table header — assert the buttons that only
   // appear inside the detail panel to disambiguate.
   expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
-  expect(
-    screen.getByRole("combobox", { name: "Dynamic Agent" }),
-  ).toBeInTheDocument();
+  expect(await screen.findByLabelText("Dynamic Agent")).toBeInTheDocument();
 
   // Onboard view shows the defaults selector + Find channels button.
   await switchToTab("Onboard channels");
@@ -835,11 +822,13 @@ it("labels Slack onboarding default selection and shows current configured value
   // TeamPicker trigger (which also renders `team:<slug>` text) doesn't
   // collide with these assertions.
   const savedTeamLabel = await screen.findByText("Onboarding team");
-  const savedDefaultsRow = savedTeamLabel.closest("div")?.parentElement;
-  expect(savedDefaultsRow).toBeTruthy();
-  expect(within(savedDefaultsRow!).getByText("team:platform-engineering")).toBeInTheDocument();
-  expect(screen.getByText("Onboarding Dynamic Agent")).toBeInTheDocument();
-  expect(screen.getByText("agent:incident-agent")).toBeInTheDocument();
+  // Scope to the "Last saved" info box (two levels up from the label text) to
+  // avoid colliding with TeamPicker's trigger which also renders "team:<slug>".
+  const savedInfoBox = savedTeamLabel.closest("div")?.parentElement?.parentElement;
+  expect(savedInfoBox).toBeTruthy();
+  expect(within(savedInfoBox!).getByText("team:platform-engineering")).toBeInTheDocument();
+  expect(within(savedInfoBox!).getByText("Onboarding Dynamic Agent")).toBeInTheDocument();
+  expect(within(savedInfoBox!).getByText("agent:incident-agent")).toBeInTheDocument();
   // Save button starts disabled because form picks match saved values.
   expect(
     screen.getByRole("button", { name: "Save Slack onboarding defaults" }),
@@ -1029,10 +1018,9 @@ it("clears stale env-provided default Dynamic Agent and warns the admin", async 
   render(<SlackChannelRebacPanel />);
   await switchToTab("Onboard channels");
 
-  const agentSelect = (await screen.findByRole("combobox", {
-    name: "Preselected Dynamic Agent",
-  })) as HTMLSelectElement;
-  await waitFor(() => expect(agentSelect.value).toBe(""));
+  // When the stale agent is detected, AgentPicker falls back to placeholder.
+  const agentTrigger = await screen.findByLabelText("Preselected Dynamic Agent");
+  await waitFor(() => expect(agentTrigger).toHaveTextContent(/Select preselected Dynamic Agent/));
 
   await waitFor(() => {
     const alerts = screen.queryAllByRole("alert");
@@ -1097,10 +1085,7 @@ it("persists Slack onboarding defaults via PUT when the admin clicks Save defaul
   expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
 
   await pickTeam("Preselected Team", "platform-engineering");
-  const agentSelect = screen.getByRole("combobox", {
-    name: "Preselected Dynamic Agent",
-  }) as HTMLSelectElement;
-  fireEvent.change(agentSelect, { target: { value: "incident-agent" } });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
 
   // Dirty → button enabled and "Unsaved changes" badge visible.
   await waitFor(() => expect(saveButton).toBeEnabled());

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -7,6 +7,7 @@ jest.mock("@/components/ui/toast", () => ({
 
 import { WebexSpaceRebacPanel } from "../WebexSpaceRebacPanel";
 import { pickTeam } from "@/__test-utils__/team-picker";
+import { pickAgent } from "@/__test-utils__/agent-picker";
 
 const fetchMock = jest.fn();
 
@@ -192,7 +193,7 @@ it("shows spaces in a table and expands a row to show diagnostics without manual
   expect(await screen.findByText(/OpenFGA tuple read failed/i)).toBeInTheDocument();
 
   // No manual route form — Webex routes are managed via onboarding + auto-fix
-  expect(screen.queryByRole("combobox", { name: "Dynamic Agent" })).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Dynamic Agent")).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: "Create Association" })).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /edit agent:incident-agent/i })).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /delete agent:incident-agent/i })).not.toBeInTheDocument();
@@ -265,9 +266,7 @@ it("discovers Webex bot spaces, auto-selects new ones, and POSTs per-space defau
 
   await screen.findByLabelText("Preselected Team");
   await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
 
   fireEvent.click(screen.getByRole("button", { name: "Find Webex Spaces with Bot Integration" }));
 
@@ -343,9 +342,7 @@ it("shows saved onboarding defaults and enables Save button only when form diffe
   expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
 
   await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Preselected Dynamic Agent", "incident-agent");
 
   await waitFor(() => expect(saveButton).toBeEnabled());
   expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
@@ -372,10 +369,10 @@ it("shows saved onboarding team and agent in the defaults section header row", a
   await switchToTab("Onboard spaces");
 
   const savedTeamLabel = await screen.findByText("Onboarding team");
-  const row = savedTeamLabel.closest("div")?.parentElement;
-  expect(row).toBeTruthy();
-  expect(within(row!).getByText("team:platform-engineering")).toBeInTheDocument();
-  expect(await screen.findByText("agent:incident-agent")).toBeInTheDocument();
+  const savedInfoBox = savedTeamLabel.closest("div")?.parentElement?.parentElement;
+  expect(savedInfoBox).toBeTruthy();
+  expect(within(savedInfoBox!).getByText("team:platform-engineering")).toBeInTheDocument();
+  expect(within(savedInfoBox!).getByText("agent:incident-agent")).toBeInTheDocument();
   expect(screen.getByText(/Only changes what is preselected when you onboard spaces/i)).toBeInTheDocument();
 });
 

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -10,48 +10,24 @@ import { pickTeam } from "@/__test-utils__/team-picker";
 
 const fetchMock = jest.fn();
 
-const defaultSpaces = [
-  {
-    workspace_id: "WEBEX-WORKSPACE",
-    space_id: "space-abc",
-    space_name: "Platform Alerts",
-    active_grants: 0,
-  },
-];
-
-function setupFetchMock(
-  spaces: Array<{
-    workspace_id: string;
-    space_id: string;
-    space_name: string;
-    active_grants: number;
-  }> = defaultSpaces
-) {
+function setupFetchMock() {
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url === "/api/admin/webex/spaces") {
+    if (url === "/api/admin/webex/spaces" || url === "/api/admin/webex/spaces?health=1") {
       return response({
-        data: { spaces },
+        data: {
+          spaces: [
+            { workspace_id: "WEBEX-WORKSPACE", space_id: "space-abc", space_name: "Platform Alerts", active_grants: 0 },
+          ],
+        },
       });
     }
     if (String(url).startsWith("/api/admin/webex/available-spaces")) {
       return response({
         data: {
           spaces: [
-            {
-              id: "space-abc",
-              name: "Platform Alerts",
-              type: "group",
-              is_locked: false,
-            },
-            {
-              id: "space-new-123",
-              name: "Incident War Room",
-              type: "group",
-              is_locked: false,
-            },
+            { id: "space-abc", name: "Platform Alerts", type: "group", is_locked: false },
+            { id: "space-new-123", name: "Incident War Room", type: "group", is_locked: false },
           ],
-          total_matches: 2,
-          total_visible: 2,
           has_more: false,
           next_cursor: null,
         },
@@ -69,11 +45,7 @@ function setupFetchMock(
     }
     if (url === "/api/admin/teams") {
       return response({
-        data: {
-          teams: [
-            { _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" },
-          ],
-        },
+        data: { teams: [{ _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" }] },
       });
     }
     if (url === "/api/admin/webex/spaces/defaults" && init?.method === "POST") {
@@ -81,10 +53,10 @@ function setupFetchMock(
       return response({
         data: {
           summary: {
-            spaces_seen: body.manual_spaces?.length ? 2 : 1,
-            spaces_assigned_team: body.manual_spaces?.length ? 2 : 1,
-            space_grants_ensured: body.manual_spaces?.length ? 2 : 1,
-            routes_ensured: body.manual_spaces?.length ? 2 : 1,
+            spaces_seen: body.manual_spaces?.length ?? 1,
+            spaces_assigned_team: body.manual_spaces?.length ?? 1,
+            space_grants_ensured: body.manual_spaces?.length ?? 1,
+            routes_ensured: body.manual_spaces?.length ?? 1,
             spaces_manual: body.manual_spaces?.length ?? 0,
             spaces_onboarded: body.manual_spaces?.length ?? 0,
             routes_preserved: 0,
@@ -96,23 +68,13 @@ function setupFetchMock(
       const body = JSON.parse(String(init.body ?? "{}"));
       return response({
         data: {
-          defaults: {
-            ...body,
-            source: "db",
-            updated_at: "2026-05-27T08:00:00.000Z",
-            updated_by: "admin@example.com",
-          },
+          defaults: { ...body, source: "db", updated_at: "2026-05-27T08:00:00.000Z", updated_by: "admin@example.com" },
         },
       });
     }
     if (url === "/api/admin/webex/spaces/defaults") {
       return response({
-        data: {
-          defaults: {
-            team_slug: "platform-engineering",
-            agent_id: "incident-agent",
-          },
-        },
+        data: { defaults: { team_slug: "platform-engineering", agent_id: "incident-agent" } },
       });
     }
     if (url === "/api/admin/webex/runtime/status") {
@@ -120,9 +82,8 @@ function setupFetchMock(
         data: {
           route_mode: "db_prefer",
           static_config: { spaces: 1, routes: 1 },
-          route_cache: { ttl_seconds: 60, cache_size: 1, cached_spaces: ["CAIPE/space-abc"] },
+          route_cache: { ttl_seconds: 60, cache_size: 1 },
           thread_context: { enabled: true, max_messages: 10, max_chars: 4000 },
-          last_sync: null,
         },
       });
     }
@@ -146,26 +107,10 @@ function setupFetchMock(
       return response({ data: { routes: body.routes } });
     }
     if (url.endsWith("/routes") && init?.method === "DELETE") {
-      return response({
-        data: {
-          deleted: { agent_id: "incident-agent", route_metadata_deleted: true },
-          openfga: { enabled: true, writes: 0, deletes: 1 },
-        },
-      });
+      return response({ data: { deleted: { agent_id: "foo-bar" } } });
     }
     if (url.endsWith("/routes")) {
-      return response({
-        data: {
-          routes: [
-            {
-              agent_id: "incident-agent",
-              enabled: true,
-              priority: 100,
-              users: { enabled: true, listen: "mention" },
-            },
-          ],
-        },
-      });
+      return response({ data: { routes: [{ agent_id: "incident-agent", enabled: true, priority: 100, users: { enabled: true, listen: "mention" } }] } });
     }
     if (url.endsWith("/diagnostics")) {
       return response({
@@ -173,31 +118,12 @@ function setupFetchMock(
           openfga: { reachable: true, tuple_count: 1 },
           warnings: [
             "agent:foo-bar has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.",
-            "Route agent:incident-agent only listens to mentions. Plain space messages will be ignored.",
           ],
           routes: [
-            {
-              agent_id: "foo-bar",
-              openfga_tuple: false,
-              route_metadata: true,
-              listen: "message",
-              runtime_matches: { mention: false, message: true },
-              warnings: ["OpenFGA tuple is missing."],
-            },
-            {
-              agent_id: "incident-agent",
-              openfga_tuple: true,
-              route_metadata: true,
-              listen: "mention",
-              runtime_matches: { mention: true, message: false },
-              warnings: ["Plain space messages will be ignored."],
-            },
+            { agent_id: "foo-bar", openfga_tuple: false, route_metadata: true, listen: "message", runtime_matches: { mention: false, message: true }, warnings: [] },
+            { agent_id: "incident-agent", openfga_tuple: true, route_metadata: true, listen: "mention", runtime_matches: { mention: true, message: false }, warnings: [] },
           ],
-          last_runtime_error: {
-            ts: "2026-05-18T07:50:00.000Z",
-            reason_code: "OPENFGA_READ_FAILED",
-            message: "OpenFGA tuple read failed",
-          },
+          last_runtime_error: { ts: "2026-05-18T07:50:00.000Z", reason_code: "OPENFGA_READ_FAILED", message: "OpenFGA tuple read failed" },
         },
       });
     }
@@ -212,120 +138,131 @@ beforeEach(() => {
   setupFetchMock();
 });
 
-afterEach(() => {
-  jest.useRealTimers();
-});
+afterEach(() => { jest.useRealTimers(); });
 
 function response(payload: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    json: async () => payload,
-    text: async () => JSON.stringify(payload),
-  } as Response;
+  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) } as Response;
 }
 
-it("does not refetch the space catalog when only the selected space changes", async () => {
-  setupFetchMock([
-    ...defaultSpaces,
-    {
-      workspace_id: "WEBEX-WORKSPACE",
-      space_id: "space-other",
-      space_name: "Ops Room",
-      active_grants: 0,
-    },
-  ]);
+async function switchToTab(name: "Configured spaces" | "Onboard spaces" | "Advanced") {
+  fireEvent.click(await screen.findByRole("tab", { name }));
+}
 
+async function expandSpaceRow(spaceName: string) {
+  const row = (await screen.findByText(spaceName)).closest("tr");
+  if (!row) throw new Error(`Row for "${spaceName}" not found`);
+  fireEvent.click(row);
+}
+
+// ── Tab layout ──────────────────────────────────────────────────────────────
+
+it("organises Webex admin into Configured / Onboard / Advanced tabs, mirrors Slack layout", async () => {
   render(<WebexSpaceRebacPanel />);
 
-  await screen.findByRole("option", { name: "Platform Alerts" });
-  const initialLoads = fetchMock.mock.calls.filter(
-    (call) => call[0] === "/api/admin/webex/spaces"
-  ).length;
-  expect(initialLoads).toBe(1);
+  // Configured tab is default and shows the space table once data loads
+  expect(await screen.findByRole("tab", { name: "Configured spaces" })).toHaveAttribute("aria-selected", "true");
+  expect(await screen.findByRole("region", { name: "Configured Webex spaces" })).toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: "Onboarding Default Selection" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: "Advanced Setup - Import/Sync with Webex Bot" })).not.toBeInTheDocument();
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Space" }), {
-    target: { value: "WEBEX-WORKSPACE/space-other" },
-  });
+  // Onboard tab shows defaults + wizard
+  await switchToTab("Onboard spaces");
+  expect(await screen.findByRole("region", { name: "Onboarding Default Selection" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Find Webex Spaces with Bot Integration" })).toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: "Configured Webex spaces" })).not.toBeInTheDocument();
+
+  // Advanced tab shows runtime status controls only
+  await switchToTab("Advanced");
+  expect(await screen.findByRole("region", { name: "Advanced Setup - Import/Sync with Webex Bot" })).toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: "Onboarding Default Selection" })).not.toBeInTheDocument();
+});
+
+// ── Configured spaces table + diagnostics ──────────────────────────────────
+
+it("shows spaces in a table and expands a row to show diagnostics without manual route controls", async () => {
+  render(<WebexSpaceRebacPanel />);
+
+  // Space appears in the table; no "X grants" column
+  expect(await screen.findByText("Platform Alerts")).toBeInTheDocument();
+  expect(screen.queryByText(/0 grants/i)).not.toBeInTheDocument();
+
+  // Expand the row
+  await expandSpaceRow("Platform Alerts");
+  expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
+  expect(await screen.findByText(/OpenFGA tuple read failed/i)).toBeInTheDocument();
+
+  // No manual route form — Webex routes are managed via onboarding + auto-fix
+  expect(screen.queryByRole("combobox", { name: "Dynamic Agent" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "Create Association" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /edit agent:incident-agent/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /delete agent:incident-agent/i })).not.toBeInTheDocument();
+});
+
+it("fixes stale diagnostic route metadata (orphan) by issuing DELETE", async () => {
+  render(<WebexSpaceRebacPanel />);
+  await expandSpaceRow("Platform Alerts");
+
+  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:foo-bar routing/i }));
 
   await waitFor(() =>
-    expect(screen.getByRole("region", { name: "Step 2a: Verify Webex Space ReBAC" })).toHaveTextContent("Ops Room")
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
+      expect.objectContaining({ method: "DELETE", body: JSON.stringify({ agent_id: "foo-bar" }) })
+    )
   );
-
-  const afterSelectLoads = fetchMock.mock.calls.filter(
-    (call) => call[0] === "/api/admin/webex/spaces"
-  ).length;
-  expect(afterSelectLoads).toBe(initialLoads);
 });
 
-it("does not render the manual Webex route form when the selected space changes", async () => {
-  setupFetchMock([
-    ...defaultSpaces,
-    {
-      workspace_id: "WEBEX-WORKSPACE",
-      space_id: "space-other",
-      space_name: "Ops Room",
-      active_grants: 0,
-    },
-  ]);
-
+it("fixes mention-only diagnostic route by lifting listen mode to all", async () => {
   render(<WebexSpaceRebacPanel />);
+  await expandSpaceRow("Platform Alerts");
 
-  expect(await screen.findByText("Webex Spaces")).toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Step 2b: Specify agent priority" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: /edit agent:incident-agent/i })).not.toBeInTheDocument();
+  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:incident-agent routing/i }));
 
-  fireEvent.change(screen.getByRole("combobox", { name: "Space" }), {
-    target: { value: "WEBEX-WORKSPACE/space-other" },
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
+      expect.objectContaining({ method: "PUT", body: expect.stringContaining('"listen":"all"') })
+    )
+  );
+});
+
+it("auto-fixes missing routeable agent via PUT with listen:all using the configured default", async () => {
+  const baseFetch = fetchMock.getMockImplementation();
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (url.endsWith("/diagnostics")) {
+      return response({
+        data: { openfga: { reachable: true, tuple_count: 0 }, warnings: ["No OpenFGA space-agent tuples found."], routes: [], last_runtime_error: null },
+      });
+    }
+    return baseFetch?.(url, init) ?? response({});
   });
 
-  expect(screen.queryByRole("region", { name: "Step 2b: Specify agent priority" })).not.toBeInTheDocument();
-});
-
-it("disables mutation controls when the panel is read-only", async () => {
-  render(<WebexSpaceRebacPanel disabled />);
-
-  expect(await screen.findByText("Webex Spaces")).toBeInTheDocument();
-  expect(await screen.findByRole("combobox", { name: "Space" })).toBeDisabled();
-  expect(screen.queryByRole("button", { name: "Create Association" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Apply Selection to Managed Webex Spaces" })).not.toBeInTheDocument();
-});
-
-it("renders Webex space management copy without Slack channel labels", async () => {
   render(<WebexSpaceRebacPanel />);
+  await expandSpaceRow("Platform Alerts");
 
-  expect(await screen.findByText("Webex Spaces")).toBeInTheDocument();
-  expect(screen.queryByText("Slack Channels")).not.toBeInTheDocument();
-  expect(screen.queryByLabelText("Channel")).not.toBeInTheDocument();
+  fireEvent.click(await screen.findByRole("button", { name: /Fix missing association with agent:incident-agent/i }));
+
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
+      expect.objectContaining({
+        method: "PUT",
+        body: expect.stringContaining('"agent_id":"incident-agent"'),
+      })
+    )
+  );
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
+    expect.objectContaining({ body: expect.stringContaining('"listen":"all"') })
+  );
 });
 
-it("lays out Webex setup without the manual route priority section", async () => {
+// ── Discovery + onboarding ─────────────────────────────────────────────────
+
+it("discovers Webex bot spaces, auto-selects new ones, and POSTs per-space defaults on apply", async () => {
   render(<WebexSpaceRebacPanel />);
+  await switchToTab("Onboard spaces");
 
-  expect(await screen.findByText("Webex Spaces")).toBeInTheDocument();
-  const sections = [
-    screen.getByRole("region", { name: "Discover spaces" }),
-    screen.getByRole("region", { name: "Step 2a: Verify Webex Space ReBAC" }),
-    screen.getByRole("region", { name: "Onboarding Default Selection" }),
-    screen.getByRole("region", { name: "Advanced Setup - Import/Sync with Webex Bot" }),
-  ];
-
-  expect(sections.map((section) => section.getAttribute("data-section-tone"))).toEqual([
-    "sky",
-    "violet",
-    "teal",
-    "slate",
-  ]);
-  expect(screen.getByRole("heading", { name: "Discover spaces" })).toBeInTheDocument();
-  expect(screen.getByRole("heading", { name: "Step 2a: Verify Webex Space ReBAC" })).toBeInTheDocument();
-  expect(screen.queryByRole("heading", { name: "Step 2b: Specify agent priority" })).not.toBeInTheDocument();
-  expect(screen.getByRole("heading", { name: "Onboarding Default Selection" })).toBeInTheDocument();
-});
-
-it("discovers Webex bot spaces and imports selected spaces with per-space defaults", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  // Preselected Team is now a searchable TeamPicker (2026-05-27).
   await screen.findByLabelText("Preselected Team");
   await pickTeam("Preselected Team", "platform-engineering");
   fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
@@ -334,10 +271,8 @@ it("discovers Webex bot spaces and imports selected spaces with per-space defaul
 
   fireEvent.click(screen.getByRole("button", { name: "Find Webex Spaces with Bot Integration" }));
 
+  // Only the new space (Incident War Room) is auto-selected; existing one (Platform Alerts) is not
   expect(await screen.findByText(/2 bot-visible spaces discovered/i)).toBeInTheDocument();
-  expect(screen.getByText("Ready to set up")).toBeInTheDocument();
-  expect(screen.getByText("Configured")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /^Set up \d+ spaces?$/ })).toBeInTheDocument();
   expect(screen.getByRole("checkbox", { name: /Import Incident War Room/i })).toBeChecked();
   expect(screen.getByRole("checkbox", { name: /Import Platform Alerts/i })).not.toBeChecked();
 
@@ -352,342 +287,46 @@ it("discovers Webex bot spaces and imports selected spaces with per-space defaul
           team_slug: "platform-engineering",
           agent_id: "incident-agent",
           create_routes: true,
-          manual_spaces: [
-            {
-              id: "space-new-123",
-              name: "Incident War Room",
-            },
-          ],
+          manual_spaces: [{ id: "space-new-123", name: "Incident War Room" }],
         }),
       })
     )
   );
   await waitFor(() =>
-    expect(mockToast).toHaveBeenCalledWith(
-      expect.stringContaining("Discovered Webex spaces applied"),
-      "success"
-    )
+    expect(mockToast).toHaveBeenCalledWith(expect.stringContaining("Discovered Webex spaces applied"), "success")
   );
-  expect(screen.queryByRole("dialog", { name: "Webex setup complete" })).not.toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
   expect(screen.queryByText("Ready to set up")).not.toBeInTheDocument();
-  expect(screen.getAllByText("Configured").length).toBeGreaterThanOrEqual(2);
+  expect(screen.getByText("Configured")).toBeInTheDocument();
 });
 
-it("shows discovered Webex space setup feedback as a toast without shifting the action row", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  await screen.findByLabelText("Preselected Team");
-  await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
-
-  fireEvent.click(screen.getByRole("button", { name: "Find Webex Spaces with Bot Integration" }));
-
-  expect(await screen.findByText(/2 bot-visible spaces discovered/i)).toBeInTheDocument();
-
-  const applyButton = screen.getByRole("button", { name: /^Set up \d+ spaces?$/ });
-  fireEvent.click(applyButton);
-
-  await waitFor(() =>
-    expect(mockToast).toHaveBeenCalledWith(
-      expect.stringContaining("Discovered Webex spaces applied"),
-      "success"
-    )
-  );
-  expect(applyButton.parentElement).not.toHaveTextContent(/Space setup applied/i);
-});
-
-it("allows Webex space discovery before global defaults are configured", async () => {
+it("allows discovery before global defaults are configured", async () => {
   const baseFetch = fetchMock.getMockImplementation();
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url === "/api/admin/webex/spaces/defaults" && init?.method !== "POST") {
-      return response({
-        data: {
-          defaults: {
-            team_slug: "",
-            agent_id: "",
-          },
-        },
-      });
+      return response({ data: { defaults: { team_slug: "", agent_id: "" } } });
     }
     return baseFetch?.(url, init) ?? response({});
   });
 
   render(<WebexSpaceRebacPanel />);
+  await switchToTab("Onboard spaces");
 
-  const discoverButton = await screen.findByRole("button", {
-    name: "Find Webex Spaces with Bot Integration",
-  });
+  const discoverButton = await screen.findByRole("button", { name: "Find Webex Spaces with Bot Integration" });
   await waitFor(() => expect(discoverButton).toBeEnabled());
   fireEvent.click(discoverButton);
 
   await waitFor(() =>
-    expect(
-      fetchMock.mock.calls.some(
-        ([url, init]) =>
-          String(url) === "/api/admin/webex/available-spaces?limit=500&refresh=1" &&
-          init?.cache === "no-store"
-      )
-    ).toBe(true)
+    expect(fetchMock.mock.calls.some(([url, init]) =>
+      String(url).startsWith("/api/admin/webex/available-spaces") && init?.cache === "no-store"
+    )).toBe(true)
   );
   expect(await screen.findByText(/2 bot-visible spaces discovered/i)).toBeInTheDocument();
   expect(screen.getByRole("checkbox", { name: /Import Incident War Room/i })).toBeChecked();
 });
 
-it("does not expose manual Webex space-agent association controls", async () => {
-  render(<WebexSpaceRebacPanel />);
+// ── Onboarding defaults ────────────────────────────────────────────────────
 
-  expect(await screen.findByText(/Control which Dynamic Agents a Webex space may invoke/i)).toBeInTheDocument();
-  expect(screen.queryByLabelText("Resource Type")).not.toBeInTheDocument();
-  expect(screen.queryByLabelText("Action")).not.toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Step 2b: Specify agent priority" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Create Association" })).not.toBeInTheDocument();
-  expect(screen.queryByLabelText("Priority")).not.toBeInTheDocument();
-});
-
-it("does not show legacy grant counts in the Webex space dropdown", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  const spaceSelect = await screen.findByRole("combobox", { name: "Space" });
-
-  expect(spaceSelect).toBeInTheDocument();
-  await waitFor(() => expect(screen.getByRole("option", { name: "Platform Alerts" })).toBeInTheDocument());
-  expect(screen.queryByRole("option", { name: /0 grants/i })).not.toBeInTheDocument();
-});
-
-it("fixes stale Webex runtime diagnostics by deleting orphaned route metadata", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:foo-bar routing/i }));
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
-      expect.objectContaining({
-        method: "DELETE",
-        body: JSON.stringify({ agent_id: "foo-bar" }),
-      })
-    )
-  );
-});
-
-it("surfaces Webex runtime diagnostics warnings", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  expect(await screen.findByText("Step 2a: Verify Webex Space ReBAC")).toBeInTheDocument();
-  expect(await screen.findByText(/Plain space messages will be ignored/i)).toBeInTheDocument();
-  expect(screen.getByText(/OpenFGA tuple read failed/i)).toBeInTheDocument();
-});
-
-it("fixes mention-only Webex runtime diagnostics by enabling all listen modes", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:incident-agent routing/i }));
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
-      expect.objectContaining({
-        method: "PUT",
-        body: expect.stringContaining('"listen":"all"'),
-      })
-    )
-  );
-});
-
-it("auto-fixes a Webex space with no routeable agent by creating the default association", async () => {
-  const baseFetch = fetchMock.getMockImplementation();
-  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url.endsWith("/diagnostics")) {
-      return response({
-        data: {
-          openfga: { reachable: true, tuple_count: 0 },
-          warnings: ["No OpenFGA space-agent tuples found. Webex runtime has no agent to dispatch."],
-          routes: [],
-          last_runtime_error: null,
-        },
-      });
-    }
-    if (url.endsWith("/routes") && init?.method === "PUT") {
-      const body = JSON.parse(String(init.body ?? "{}"));
-      return response({ data: { routes: body.routes } });
-    }
-    return baseFetch?.(url, init) ?? response({});
-  });
-
-  render(<WebexSpaceRebacPanel />);
-
-  fireEvent.click(
-    await screen.findByRole("button", { name: /Fix missing association with agent:incident-agent/i })
-  );
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
-      expect.objectContaining({
-        method: "PUT",
-        body: expect.stringContaining('"agent_id":"incident-agent"'),
-      })
-    )
-  );
-  expect(fetchMock).toHaveBeenCalledWith(
-    "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
-    expect.objectContaining({
-      method: "PUT",
-      body: expect.stringContaining('"listen":"all"'),
-    })
-  );
-});
-
-it("does not allow manual editing or deleting Webex space-agent associations", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  expect(await screen.findByText("Step 2a: Verify Webex Space ReBAC")).toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: /edit agent:incident-agent/i })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: /delete agent:incident-agent/i })).not.toBeInTheDocument();
-  expect(screen.queryByText("Delete space-agent association?")).not.toBeInTheDocument();
-});
-
-it("keeps Webex onboarding defaults simple without bulk apply or manual add controls", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  await screen.findByText("Onboarding Default Selection");
-  await screen.findByLabelText("Preselected Team");
-  await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
-    target: { value: "incident-agent" },
-  });
-
-  expect(screen.queryByRole("button", { name: "Apply Selection to Managed Webex Spaces" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Refresh lists" })).not.toBeInTheDocument();
-  expect(screen.queryByText(/Create matching Webex routes when onboarding/i)).not.toBeInTheDocument();
-  expect(screen.queryByText("Manually add a Webex space")).not.toBeInTheDocument();
-  expect(screen.queryByLabelText("Manual Space ID")).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Add Space with This Selection" })).not.toBeInTheDocument();
-});
-
-it("labels Webex onboarding default selection and shows current configured values", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  expect(await screen.findByText("Onboarding Default Selection")).toBeInTheDocument();
-  expect(screen.queryByText("Migration Defaults")).not.toBeInTheDocument();
-  // The "Last saved" panel was refactored on 2026-05-27 to a single
-  // row with "Onboarding team" / "Onboarding Dynamic Agent" sub-labels
-  // and a dedicated "Save defaults" button. Scope to that row so the
-  // TeamPicker trigger (which also renders `team:<slug>` text) doesn't
-  // collide with these assertions.
-  expect(await screen.findByText("Onboarding team")).toBeInTheDocument();
-  await waitFor(() => {
-    const savedTeamLabel = screen.getByText("Onboarding team");
-    const savedDefaultsRow = savedTeamLabel.closest("div")?.parentElement;
-    expect(savedDefaultsRow).toBeTruthy();
-    expect(within(savedDefaultsRow!).getByText("team:platform-engineering")).toBeInTheDocument();
-  });
-  expect(screen.getByText("Onboarding Dynamic Agent")).toBeInTheDocument();
-  expect(await screen.findByText("agent:incident-agent")).toBeInTheDocument();
-  // Save button starts disabled because form picks match saved values.
-  expect(
-    screen.getByRole("button", { name: "Save Webex onboarding defaults" }),
-  ).toBeDisabled();
-  expect(screen.queryByText("[Optional] Global Space Defaults")).not.toBeInTheDocument();
-  expect(screen.getByText(/Only changes what is preselected when you onboard spaces/i)).toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Apply Selection to Managed Webex Spaces" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Refresh lists" })).not.toBeInTheDocument();
-});
-
-it("shows Webex bot runtime sync status and triggers reload/config sync", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  expect(await screen.findByText("Advanced Setup - Import/Sync with Webex Bot")).toBeInTheDocument();
-  expect(await screen.findByText("db_prefer")).toBeInTheDocument();
-  expect(await screen.findByText(/1 cached space/i)).toBeInTheDocument();
-  expect(screen.getByText("Thread context")).toBeInTheDocument();
-  expect(screen.getByText("Enabled, 10 messages / 4000 chars")).toBeInTheDocument();
-  expect(screen.getByRole("region", { name: "Webex bot sync legend" })).toHaveTextContent(
-    "Route mode: shows whether the Webex bot reads routes from database, YAML, or both."
-  );
-
-  fireEvent.click(screen.getByRole("button", { name: "Reload Bot Cache" }));
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/reload",
-      expect.objectContaining({ method: "POST" })
-    )
-  );
-
-  fireEvent.click(screen.getByRole("button", { name: "Preview YAML Import" }));
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ dry_run: true }),
-      })
-    )
-  );
-  expect(await screen.findByText(/Sync preview: 1 routes planned/i)).toBeInTheDocument();
-
-  fireEvent.click(screen.getByRole("button", { name: "Import from YAML Config" }));
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ dry_run: false }),
-      })
-    )
-  );
-  expect(await screen.findByText(/Config sync applied: upserted 1 routes/i)).toBeInTheDocument();
-});
-
-it("opens a runtime sync modal with preview progress and apply results", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  const previewButton = await screen.findByRole("button", { name: "Preview YAML Import" });
-  await waitFor(() => expect(previewButton).toBeEnabled());
-  fireEvent.click(previewButton);
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({ method: "POST" })
-    )
-  );
-  expect(await screen.findByRole("dialog")).toBeInTheDocument();
-  expect(screen.getByText("Webex Bot Config Sync Preview")).toBeInTheDocument();
-  expect(screen.getByText("Preview complete")).toBeInTheDocument();
-  expect(screen.getByText("1 route planned")).toBeInTheDocument();
-  expect(screen.getByText("1 space scanned")).toBeInTheDocument();
-  expect(screen.getByText("0 routes upserted")).toBeInTheDocument();
-
-  fireEvent.click(screen.getByRole("button", { name: "Import from YAML Config" }));
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ dry_run: false }),
-      })
-    )
-  );
-  expect(await screen.findByText("Apply complete")).toBeInTheDocument();
-  expect(screen.getByText("1 route upserted")).toBeInTheDocument();
-  expect(screen.getByText("1 OpenFGA tuple written")).toBeInTheDocument();
-});
-
-// Save defaults flow (2026-05-27): admins picked a team/agent in the
-// UI but the choice never persisted — the GET only returned env vars
-// and the migration POST didn't write the saved defaults anywhere.
-// The new PUT /api/admin/webex/spaces/defaults route writes to
-// `platform_config` and the panel exposes a dedicated "Save defaults"
-// button that lights up only when the form diverges from the saved
-// values. This test pins that contract.
-it("persists Webex onboarding defaults via PUT when the admin clicks Save defaults", async () => {
-  // Override the GET so the form starts empty — that way picking a
-  // team and an agent produces a dirty diff and enables the button.
+it("shows saved onboarding defaults and enables Save button only when form differs", async () => {
   const baseFetch = fetchMock.getMockImplementation();
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url === "/api/admin/webex/spaces/defaults" && (!init?.method || init.method === "GET")) {
@@ -697,18 +336,16 @@ it("persists Webex onboarding defaults via PUT when the admin clicks Save defaul
   });
 
   render(<WebexSpaceRebacPanel />);
+  await switchToTab("Onboard spaces");
 
-  const saveButton = await screen.findByRole("button", {
-    name: "Save Webex onboarding defaults",
-  });
+  const saveButton = await screen.findByRole("button", { name: "Save Webex onboarding defaults" });
   expect(saveButton).toBeDisabled();
   expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
 
   await pickTeam("Preselected Team", "platform-engineering");
-  fireEvent.change(
-    await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }),
-    { target: { value: "incident-agent" } },
-  );
+  fireEvent.change(await screen.findByRole("combobox", { name: "Preselected Dynamic Agent" }), {
+    target: { value: "incident-agent" },
+  });
 
   await waitFor(() => expect(saveButton).toBeEnabled());
   expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
@@ -721,21 +358,86 @@ it("persists Webex onboarding defaults via PUT when the admin clicks Save defaul
       expect.objectContaining({
         method: "PUT",
         body: expect.stringContaining('"team_slug":"platform-engineering"'),
-      }),
-    ),
+      })
+    )
   );
-  expect(fetchMock).toHaveBeenCalledWith(
-    "/api/admin/webex/spaces/defaults",
-    expect.objectContaining({
-      method: "PUT",
-      body: expect.stringContaining('"agent_id":"incident-agent"'),
-    }),
-  );
-
   await waitFor(() => expect(saveButton).toBeDisabled());
   expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
   expect(screen.getByText(/admin@example.com/)).toBeInTheDocument();
+  await waitFor(() => expect(mockToast).toHaveBeenCalledWith("Onboarding defaults saved.", "success"));
+});
+
+it("shows saved onboarding team and agent in the defaults section header row", async () => {
+  render(<WebexSpaceRebacPanel />);
+  await switchToTab("Onboard spaces");
+
+  const savedTeamLabel = await screen.findByText("Onboarding team");
+  const row = savedTeamLabel.closest("div")?.parentElement;
+  expect(row).toBeTruthy();
+  expect(within(row!).getByText("team:platform-engineering")).toBeInTheDocument();
+  expect(await screen.findByText("agent:incident-agent")).toBeInTheDocument();
+  expect(screen.getByText(/Only changes what is preselected when you onboard spaces/i)).toBeInTheDocument();
+});
+
+// ── Advanced tab ───────────────────────────────────────────────────────────
+
+it("shows Webex-specific runtime status including Thread context tile and triggers YAML sync", async () => {
+  render(<WebexSpaceRebacPanel />);
+  await switchToTab("Advanced");
+
+  expect(await screen.findByText("db_prefer")).toBeInTheDocument();
+  expect(await screen.findByText(/1 cached space/i)).toBeInTheDocument();
+  expect(screen.getByText("Thread context")).toBeInTheDocument();
+  expect(screen.getByText("Enabled, 10 messages / 4000 chars")).toBeInTheDocument();
+
+  const legend = screen.getByRole("region", { name: "Webex bot sync legend" });
+  expect(legend).toHaveTextContent("Route mode: shows whether the Webex bot reads routes from database, YAML, or both.");
+  expect(legend).toHaveTextContent("Thread context: shows whether the bot sends bounded prior Webex thread messages to the selected agent.");
+
+  fireEvent.click(screen.getByRole("button", { name: "Preview YAML Import" }));
   await waitFor(() =>
-    expect(mockToast).toHaveBeenCalledWith("Onboarding defaults saved.", "success"),
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/webex/runtime/sync-from-config",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ dry_run: true }) })
+    )
   );
+  expect(await screen.findByText(/Sync preview: 1 routes planned/i)).toBeInTheDocument();
+
+  const importButton = await screen.findByRole("button", { name: "Import from YAML Config" });
+  await waitFor(() => expect(importButton).not.toBeDisabled());
+  fireEvent.click(importButton);
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/webex/runtime/sync-from-config",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ dry_run: false }) })
+    )
+  );
+  expect(await screen.findByText(/Config sync applied: upserted 1 routes/i)).toBeInTheDocument();
+});
+
+it("opens sync modal with accurate preview and apply counts", async () => {
+  render(<WebexSpaceRebacPanel />);
+  await switchToTab("Advanced");
+
+  const previewButton = await screen.findByRole("button", { name: "Preview YAML Import" });
+  await waitFor(() => expect(previewButton).toBeEnabled());
+  fireEvent.click(previewButton);
+
+  expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  expect(screen.getByText("Webex Bot Config Sync Preview")).toBeInTheDocument();
+  expect(await screen.findByText("Preview complete")).toBeInTheDocument();
+  expect(screen.getByText("1 route planned")).toBeInTheDocument();
+  expect(screen.getByText("1 space scanned")).toBeInTheDocument();
+  expect(screen.getByText("0 routes upserted")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: "Import from YAML Config" }));
+  await waitFor(() =>
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/webex/runtime/sync-from-config",
+      expect.objectContaining({ body: JSON.stringify({ dry_run: false }) })
+    )
+  );
+  expect(await screen.findByText("Apply complete")).toBeInTheDocument();
+  expect(screen.getByText("1 route upserted")).toBeInTheDocument();
+  expect(screen.getByText("1 OpenFGA tuple written")).toBeInTheDocument();
 });

--- a/ui/src/components/admin/rebac/connector-admin-adapter.ts
+++ b/ui/src/components/admin/rebac/connector-admin-adapter.ts
@@ -1,0 +1,226 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+// Normalised summary for a single configured item (channel / space).
+// The shared component uses these field names; each provider adapter
+// maps its API response to this shape.
+export interface ItemSummary {
+  workspace_id: string;
+  item_id: string;
+  item_name: string;
+  team_slug?: string;
+  active_grants: number;
+  can_manage?: boolean;
+  health?: {
+    warnings_count: number;
+    openfga_reachable: boolean;
+    last_runtime_error_ts: string | null;
+  };
+}
+
+export interface ItemAgentRoute {
+  agent_id: string;
+  enabled: boolean;
+  priority: number;
+  users?: { enabled?: boolean; listen?: "message" | "mention" | "all" };
+}
+
+export interface DiagnosticRoute {
+  agent_id: string;
+  openfga_tuple: boolean;
+  route_metadata: boolean;
+  listen: "message" | "mention" | "all" | "unknown";
+  priority?: number;
+  runtime_matches: { mention: boolean; message: boolean };
+  warnings: string[];
+}
+
+export interface ItemDiagnostics {
+  openfga: { reachable: boolean; tuple_count: number; error?: string };
+  routes: DiagnosticRoute[];
+  warnings: string[];
+  last_runtime_error?: {
+    ts?: string; reason_code?: string; message?: string; action?: string;
+  } | null;
+}
+
+export interface RuntimeStatus {
+  route_mode: string;
+  static_config: Record<string, number>;
+  route_cache: { ttl_seconds: number; cache_size: number };
+  raw: Record<string, unknown>;
+}
+
+export interface RuntimeSyncSummary {
+  dry_run: boolean;
+  items_seen: number;
+  routes_planned: number;
+  routes_upserted: number;
+  openfga_tuples_written: number;
+}
+
+export interface DiscoveredItem {
+  id: string;
+  name: string;
+  secondary: string;
+}
+
+export interface DiscoveryPage {
+  items: DiscoveredItem[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+export interface ConnectorAdminAdapter {
+  // ── Branding ──────────────────────────────────────────────────────────
+  connectorName: string;    // "Slack" | "Webex"
+  itemSingular: string;     // "channel" | "space"
+  itemPlural: string;       // "channels" | "spaces"
+
+  // ── API paths ─────────────────────────────────────────────────────────
+  api: {
+    list: string;                                                    // GET ?health=1
+    // Returns the paged discovery URL for the given page index + cursor.
+    // Slack: /api/admin/slack/available-channels?member_only=1&limit=500[&cursor=…]
+    // Webex: /api/admin/webex/available-spaces?limit=500[&refresh=1][&cursor=…]
+    discoveryUrl: (page: number, cursor: string | null) => string;
+    defaults: string;                                                // GET / PUT / POST
+    runtimeStatus: string;
+    runtimeReload: string;
+    runtimeSyncFromConfig: string;
+    routesFor: (workspaceId: string, itemId: string) => string;
+    diagnosticsFor: (workspaceId: string, itemId: string) => string;
+    legacyConfigDefaults?: string | null;                            // Slack only
+  };
+
+  // ── Shape adapters ────────────────────────────────────────────────────
+  // Composite key used as React key and selectedKey value.
+  itemKey: (item: ItemSummary) => string;
+  // Map a raw list-response row to ItemSummary. Return null to skip.
+  parseListItem: (raw: Record<string, unknown>) => ItemSummary | null;
+  parseListResponse: (json: unknown) => Record<string, unknown>[];
+  parseDiscoveryPage: (json: unknown) => DiscoveryPage;
+  parseRuntimeStatus: (json: unknown) => RuntimeStatus;
+  parseRuntimeSyncSummary: (json: unknown) => RuntimeSyncSummary;
+
+  // ── Copy / aria labels ────────────────────────────────────────────────
+  copy: {
+    configuredTabTitle: string;
+    configuredTabDescription: string;
+    onboardTabTitle: string;
+    onboardTabDescription: string;
+    advancedTabTitle: string;
+    advancedTabDescription: string;
+    advancedHeading: string;
+    // Used in the legend: "shows whether the Slackbot reads…" / "Webex bot reads…"
+    botNameInLegend: string;
+    onboardingDefaultsHeading: string;
+    onboardingDefaultsDescription: string;
+    discoveryDescription: string;
+    discoveryFindLabel: string;
+    discoveryRefreshLabel: string;
+    discoveryLoadingLabel: string;
+    discoveryEmptyLabel: string;
+    discoveryDiscoveredLabel: string;
+    selfServiceTitle: string;
+    selfServiceDescription: string;
+    // Optional extra text appended to the stale-default warnings.
+    // Slack tells the admin which env var to update; Webex can omit.
+    invalidTeamEnvHint?: string;
+    invalidAgentEnvHint?: string;
+  };
+  ariaLabels: {
+    tablist: string;
+    configuredRegion: string;
+    advancedRegion: string;
+    advancedLegend: string;
+    onboardingDefaultsRegion: string;
+  };
+
+  // ── Discovery status text ─────────────────────────────────────────────
+  discoveryStatusText: (counts: {
+    discoveredCount: number;
+    newCount: number;
+    configuredCount: number;
+    unassignedCount: number;
+  }) => string;
+
+  // ── Advanced tab extras ───────────────────────────────────────────────
+  // Webex shows a "Thread context" stat tile; Slack doesn't.
+  // Returns extra stat tiles to render after the base 3.
+  advancedExtraTiles?: (status: RuntimeStatus) => Array<{ label: string; value: string }>;
+  // Returns extra legend rows for the Webex "Thread context" legend entry.
+  advancedExtraLegendRows?: () => Array<{ label: string; description: string }>;
+  // How to pluralise the static-config and route-cache tile values.
+  staticConfigLabel: (counts: { items: number; routes: number }) => string;
+  routeCacheLabel: (count: number) => string;
+  // Dialogue: Slack says "Slack Bot Config Sync", Webex says "Webex Bot Config Sync".
+  syncDialogueTitle: (mode: "preview" | "apply") => string;
+  // Dialogue description differs by connector.
+  syncDialogueDescription: string;
+  // In the sync summary modal: "Channels" vs "Spaces" scanned.
+  syncSummaryItemsLabel: string;
+
+  // When true, discovered items that are not yet configured are
+  // auto-selected in the wizard. Webex uses this; Slack does not.
+  discoveryAutoSelectNewItems?: boolean;
+
+  // ── Onboarding apply ─────────────────────────────────────────────────
+  // Different connectors send different POST payloads and fire different
+  // success messages. The adapter owns the request(s) and the toast text.
+  applyOnboarding: (input: {
+    rows: Array<{ id: string; name?: string; teamSlug: string; agentId: string; selected: boolean }>;
+    defaultTeamSlug: string;
+    defaultAgentId: string;
+    createDefaultRoutes: boolean;
+    fetchFn: (url: string, init: RequestInit) => Promise<Response>;
+  }) => Promise<{ toastMessage: string }>;
+
+  // ── Route editing ─────────────────────────────────────────────────────
+  // Slack shows manual route create/edit/delete. Webex does not.
+  manualRouteEditing: boolean;
+
+  // Hint text above the manual route form (Slack channel semantics copy).
+  manualRouteFormHint?: (item: ItemSummary) => ReactNode;
+
+  // ── Discovery cache provider ─────────────────────────────────────────
+  // Optional — drives the cache-invalidation popover next to the Find button.
+  discoveryCacheProvider?: import("@/components/admin/rebac/DiscoveryCacheControls").DiscoveryCacheProvider;
+
+  // ── Authorization disclaimer ─────────────────────────────────────────
+  // Rendered above the configured-items table when selfService=true or
+  // on the Onboard tab. Slack and Webex have near-identical copy; each
+  // adapter provides the exact JSX so the panel stays generic.
+  authzDisclaimer: ReactNode;
+
+  // ── Diagnostics fixability ────────────────────────────────────────────
+  diagnosticRouteIsFixable: (route: DiagnosticRoute) => boolean;
+  // Execute the fix for a diagnostic route (delete orphan or lift listen
+  // mode). Returns the toast text and optionally the updated route list.
+  fixDiagnosticRoute: (input: {
+    item: ItemSummary;
+    route: DiagnosticRoute;
+    routes: ItemAgentRoute[];
+  }) => Promise<{ toast: string; nextRoutes?: ItemAgentRoute[] }>;
+
+  // ── Provider-specific feature flags ──────────────────────────────────
+  // Slack only: "Use existing Slackbot channel agents as defaults" checkbox.
+  legacyConfigAgentPrefill?: {
+    description: string;
+    fetchSuggestions: (fetchFn: typeof fetch) => Promise<Record<string, string>>;
+  } | null;
+
+  // Webex only: auto-fix card when a space has no routeable agent.
+  missingRouteableAgentAutoFix?: {
+    title: string;
+    description: string;
+    buttonLabel: (agentId: string) => string;
+    noAgentHelpText: string;
+    isApplicable: (item: ItemSummary, diagnostics: ItemDiagnostics) => boolean;
+  } | null;
+
+  // Webex only: extra runtime info rendered on the Advanced tab after
+  // the shared controls (e.g. thread-context block).
+  advancedTabExtras?: (status: RuntimeStatus) => ReactNode;
+}

--- a/ui/src/components/workflows/WorkflowEditor.tsx
+++ b/ui/src/components/workflows/WorkflowEditor.tsx
@@ -13,6 +13,7 @@ import {
   Code,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { AgentPicker, type AgentPickerOption } from "@/components/ui/agent-picker";
 import { cn } from "@/lib/utils";
 import type {
   WorkflowConfig,
@@ -50,9 +51,9 @@ function useDynamicAgents() {
           : [];
         if (!cancelled) {
           setAgents(
-            list.map((a: any) => ({
-              value: a._id || a.id,
-              label: a.name || a._id || a.id,
+            list.map((a: Record<string, unknown>) => ({
+              value: String(a._id ?? a.id ?? ""),
+              label: String(a.name ?? a._id ?? a.id ?? ""),
             }))
           );
         }
@@ -208,26 +209,13 @@ function StepRow({
               <div className="text-xs text-muted-foreground h-8 flex items-center">
                 Loading agents...
               </div>
-            ) : agents.length > 0 ? (
-              <select
-                value={step.agent_id}
-                onChange={(e) => update({ agent_id: e.target.value })}
-                className="flex h-8 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              >
-                <option value="">Select an agent...</option>
-                {agents.map((a) => (
-                  <option key={a.value} value={a.value}>
-                    {a.label}
-                  </option>
-                ))}
-              </select>
             ) : (
-              <input
-                type="text"
+              <AgentPicker
                 value={step.agent_id}
-                onChange={(e) => update({ agent_id: e.target.value })}
-                placeholder="e.g. agent-abc123"
-                className="flex h-8 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                onChange={(v) => update({ agent_id: v })}
+                placeholder="Select an agent..."
+                options={agents.map<AgentPickerOption>((a) => ({ value: a.value, label: a.label }))}
+                hideIdSuffix
               />
             )}
           </div>

--- a/ui/src/components/workflows/WorkflowStepSidebar.tsx
+++ b/ui/src/components/workflows/WorkflowStepSidebar.tsx
@@ -14,12 +14,11 @@ import {
   Loader2,
   MousePointerClick,
   Plus,
-  Search,
   Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { AgentAvatar } from "@/components/dynamic-agents/AgentAvatar";
+import { AgentPicker, type AgentPickerOption } from "@/components/ui/agent-picker";
 import { StepToolOverridePicker } from "./StepToolOverridePicker";
 import type { AgentAvatarAgent } from "@/components/dynamic-agents/AgentAvatar";
 import type { WorkflowStep } from "@/types/workflow-config";
@@ -53,164 +52,6 @@ interface WorkflowStepSidebarProps {
   readOnly?: boolean;
 }
 
-// ---------------------------------------------------------------------------
-// Agent Picker Dropdown
-// ---------------------------------------------------------------------------
-
-function AgentPickerDropdown({
-  agents,
-  selectedAgentId,
-  onSelect,
-  loading,
-}: {
-  agents: SidebarAgent[];
-  selectedAgentId: string;
-  onSelect: (agentId: string) => void;
-  loading: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const containerRef = useRef<HTMLDivElement>(null);
-  const searchInputRef = useRef<HTMLInputElement>(null);
-
-  const selectedAgent = agents.find((a) => a._id === selectedAgentId);
-
-  // Close on click outside
-  useEffect(() => {
-    if (!open) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    setTimeout(() => document.addEventListener("mousedown", handleClickOutside), 0);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [open]);
-
-  // Auto-focus search on open
-  useEffect(() => {
-    if (open && searchInputRef.current) {
-      setTimeout(() => searchInputRef.current?.focus(), 50);
-    }
-  }, [open]);
-
-  const query = searchQuery.toLowerCase();
-  const filtered = agents.filter(
-    (a) =>
-      a.name.toLowerCase().includes(query) ||
-      (a.description?.toLowerCase().includes(query) ?? false),
-  );
-
-  if (loading) {
-    return (
-      <div className="flex items-center gap-2 h-9 px-3 text-xs text-muted-foreground">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        Loading agents...
-      </div>
-    );
-  }
-
-  return (
-    <div ref={containerRef} className="relative">
-      {/* Trigger */}
-      <button
-        type="button"
-        onClick={() => {
-          setOpen(!open);
-          setSearchQuery("");
-        }}
-        className={cn(
-          "flex items-center gap-2 w-full h-9 px-3 rounded-md border border-input bg-transparent text-sm",
-          "transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        )}
-      >
-        {selectedAgent ? (
-          <>
-            <AgentAvatar
-              agent={selectedAgent}
-              rounded="rounded-full"
-              size="w-5 h-5"
-              iconSize="h-2.5 w-2.5"
-            />
-            <span className="flex-1 text-left truncate">{selectedAgent.name}</span>
-          </>
-        ) : (
-          <span className="flex-1 text-left text-muted-foreground">Select an agent...</span>
-        )}
-        <ChevronDown className={cn("h-3.5 w-3.5 text-muted-foreground transition-transform", open && "rotate-180")} />
-      </button>
-
-      {/* Dropdown */}
-      {open && (
-        <div className="absolute top-full left-0 right-0 mt-1 z-50 rounded-md bg-popover border border-border shadow-lg animate-in fade-in-0 zoom-in-95 slide-in-from-top-2">
-          {/* Search */}
-          <div className="px-2 pt-2 pb-1">
-            <div className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-muted/50 border border-border/50">
-              <Search className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder="Search agents..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                onKeyDown={(e) => e.stopPropagation()}
-              />
-            </div>
-          </div>
-
-          {/* List */}
-          <div className="overflow-y-auto max-h-64 py-1">
-            {filtered.length === 0 && (
-              <div className="px-3 py-2 text-sm text-muted-foreground">
-                {searchQuery ? `No agents match "${searchQuery}"` : "No agents available"}
-              </div>
-            )}
-            {filtered.map((agent) => {
-              const isSelected = agent._id === selectedAgentId;
-              return (
-                <button
-                  key={agent._id}
-                  onClick={() => {
-                    onSelect(agent._id);
-                    setOpen(false);
-                    setSearchQuery("");
-                  }}
-                  className={cn(
-                    "w-full flex items-center gap-3 px-3 py-2 text-sm text-left transition-colors",
-                    isSelected ? "bg-primary/10 text-primary" : "hover:bg-accent",
-                  )}
-                >
-                  <AgentAvatar
-                    agent={agent}
-                    rounded="rounded-full"
-                    size="w-7 h-7"
-                    iconSize="h-3.5 w-3.5"
-                  />
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium truncate">{agent.name}</div>
-                    {agent.description && (
-                      <div className="text-xs text-muted-foreground truncate">
-                        {agent.description}
-                      </div>
-                    )}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -374,12 +215,20 @@ export function WorkflowStepSidebar({
         {/* Agent */}
         <div className="space-y-2">
           <Label className="text-xs font-semibold">Agent</Label>
-          <AgentPickerDropdown
-            agents={agents}
-            selectedAgentId={step.agent_id}
-            onSelect={(agentId) => onChange({ agent_id: agentId })}
-            loading={agentsLoading}
-          />
+          {agentsLoading ? (
+            <div className="flex items-center gap-2 h-9 px-3 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading agents...
+            </div>
+          ) : (
+            <AgentPicker
+              value={step.agent_id}
+              onChange={(agentId) => onChange({ agent_id: agentId })}
+              placeholder="Select an agent..."
+              options={agents.map<AgentPickerOption>((a) => ({ value: a._id, label: a.name }))}
+              hideIdSuffix
+            />
+          )}
         </div>
 
         {/* Prompt */}

--- a/ui/src/lib/rbac/connector-diagnostics.ts
+++ b/ui/src/lib/rbac/connector-diagnostics.ts
@@ -1,0 +1,227 @@
+import { getCollection } from "@/lib/mongodb";
+
+export type ConnectorKind = "slack_channel" | "webex_space";
+
+export type ConnectorListenMode = "mention" | "message" | "all" | "unknown";
+
+export interface ConnectorRouteMetadata {
+  agent_id: string;
+  priority?: number;
+  users?: { listen?: string };
+}
+
+export interface ConnectorRuntimeRouteDiagnostic {
+  agent_id: string;
+  openfga_tuple: boolean;
+  route_metadata: boolean;
+  listen: ConnectorListenMode;
+  priority: number;
+  runtime_matches: { mention: boolean; message: boolean };
+  warnings: string[];
+}
+
+export interface ConnectorLastRuntimeError {
+  ts?: string;
+  reason_code?: string;
+  message?: string;
+  action?: string;
+}
+
+export interface ConnectorDiagnostics {
+  workspace_id: string;
+  item_id: string;
+  openfga: { reachable: boolean; tuple_count: number; error?: string };
+  routes: ConnectorRuntimeRouteDiagnostic[];
+  warnings: string[];
+  last_runtime_error: ConnectorLastRuntimeError | null;
+}
+
+export interface ConnectorHealthSummary {
+  warnings_count: number;
+  openfga_reachable: boolean;
+  last_runtime_error_ts: string | null;
+}
+
+export interface ConnectorDiagnosticsAdapter {
+  kind: ConnectorKind;
+  // Display labels used inside warning text. botLabel is the prefix
+  // for the OpenFGA-read failure ("Slack bot cannot read…"); runtimeLabel
+  // is used for the no-tuples warning ("Slack runtime has no agent…");
+  // tupleNoun is the relation noun in the no-tuples warning
+  // ("channel-agent" / "space-agent"). Keeps the warning copy
+  // byte-identical with what each panel rendered before.
+  botLabel: string;
+  runtimeLabel: string;
+  tupleNoun: string;
+  // The audit_events.component value to query for
+  // last_runtime_error. e.g. "slack_bot" / "webex_bot".
+  auditComponent: string;
+  // resource_ref the bot writes into audit_events — Slack uses
+  // `slack_channel:<workspace>--<channel>`, Webex uses
+  // `webex_space:<workspace>--<space>`.
+  auditResourceRef: (workspaceId: string, itemId: string) => string;
+  // Returns `agent_id`s the bot has OpenFGA tuples for. Slack's
+  // implementation reads `slack_channel:<id>` as user; Webex reads
+  // `webex_space:<id>` as user. Both ultimately enumerate `agent:*`
+  // objects.
+  listOpenFgaAgentIds: (workspaceId: string, itemId: string) => Promise<string[]>;
+  // Returns Mongo route metadata rows for this item. Each row needs
+  // an agent_id, optional priority, optional users.listen.
+  listRouteMetadata: (workspaceId: string, itemId: string) => Promise<ConnectorRouteMetadata[]>;
+  // Optional: Webex suppresses last_runtime_error when OpenFGA is
+  // currently reachable but the stored error reason was
+  // OPENFGA_READ_FAILED. Slack does not.
+  shouldSurfaceLastRuntimeError?: (
+    lastError: ConnectorLastRuntimeError,
+    openfgaError: string | undefined,
+  ) => boolean;
+  // Optional: Webex's per-route warnings include explicit
+  // mention-only / message-only callouts that Slack does not surface
+  // at the per-route level (Slack folds those into the ambiguous-route
+  // warning instead). Each connector contributes its own extras.
+  buildExtraRouteWarnings?: (route: ConnectorRuntimeRouteDiagnostic) => string[];
+  // Slack flags ambiguous routes (two enabled tuples that fight for
+  // the same incoming message at the same priority). Webex doesn't
+  // ship that warning today; leave optional so Webex's diagnostics
+  // stay byte-identical to the existing route handler.
+  buildAmbiguousRouteWarnings?: (routes: ConnectorRuntimeRouteDiagnostic[]) => string[];
+}
+
+function listenMatches(listen: ConnectorListenMode, requested: "mention" | "message"): boolean {
+  return listen === "all" || listen === requested;
+}
+
+function buildBaseRouteWarnings(
+  route: ConnectorRuntimeRouteDiagnostic,
+): string[] {
+  const warnings: string[] = [];
+  if (!route.openfga_tuple) {
+    warnings.push(
+      `agent:${route.agent_id} has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.`,
+    );
+  }
+  if (!route.route_metadata) {
+    warnings.push(
+      `agent:${route.agent_id} has an OpenFGA tuple but no Mongo route metadata; runtime uses mention-only defaults.`,
+    );
+  }
+  return warnings;
+}
+
+async function latestRuntimeError(
+  adapter: ConnectorDiagnosticsAdapter,
+  workspaceId: string,
+  itemId: string,
+): Promise<ConnectorLastRuntimeError | null> {
+  const resourceRef = adapter.auditResourceRef(workspaceId, itemId);
+  try {
+    const auditEvents = await getCollection("audit_events");
+    const rows = await auditEvents
+      .find({
+        component: adapter.auditComponent,
+        outcome: "error",
+        resource_ref: resourceRef,
+      })
+      .sort({ ts: -1 })
+      .limit(1)
+      .toArray();
+    const event = rows[0] as Record<string, unknown> | undefined;
+    if (!event) return null;
+    return {
+      ts: typeof event.ts === "string" ? event.ts : undefined,
+      reason_code: typeof event.reason_code === "string" ? event.reason_code : undefined,
+      message: typeof event.message === "string" ? event.message : undefined,
+      action: typeof event.action === "string" ? event.action : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function computeConnectorDiagnostics(
+  adapter: ConnectorDiagnosticsAdapter,
+  workspaceId: string,
+  itemId: string,
+): Promise<ConnectorDiagnostics> {
+  const metadataRoutes = await adapter.listRouteMetadata(workspaceId, itemId);
+  const warnings: string[] = [];
+  let openfgaAgentIds: string[] = [];
+  let openfgaError: string | undefined;
+
+  try {
+    openfgaAgentIds = await adapter.listOpenFgaAgentIds(workspaceId, itemId);
+  } catch (error) {
+    openfgaError = error instanceof Error ? error.message : "OpenFGA tuple read failed";
+    warnings.push(`${adapter.botLabel} cannot read OpenFGA tuples: ${openfgaError}`);
+  }
+
+  const allAgentIds = Array.from(
+    new Set([...openfgaAgentIds, ...metadataRoutes.map((route) => route.agent_id)]),
+  ).sort();
+  const metadataByAgentId = new Map(metadataRoutes.map((route) => [route.agent_id, route]));
+  const openfgaAgentSet = new Set(openfgaAgentIds);
+  const routes = allAgentIds.map((agentId): ConnectorRuntimeRouteDiagnostic => {
+    const metadata = metadataByAgentId.get(agentId);
+    const listen = (metadata?.users?.listen ?? "mention") as ConnectorListenMode;
+    const priority = typeof metadata?.priority === "number" ? metadata.priority : 100;
+    const route: ConnectorRuntimeRouteDiagnostic = {
+      agent_id: agentId,
+      openfga_tuple: openfgaAgentSet.has(agentId),
+      route_metadata: Boolean(metadata),
+      listen,
+      priority,
+      runtime_matches: {
+        mention: listenMatches(listen, "mention"),
+        message: listenMatches(listen, "message"),
+      },
+      warnings: [],
+    };
+    const baseWarnings = buildBaseRouteWarnings(route);
+    const extra = adapter.buildExtraRouteWarnings?.(route) ?? [];
+    route.warnings = [...baseWarnings, ...extra];
+    warnings.push(...route.warnings);
+    return route;
+  });
+
+  if (adapter.buildAmbiguousRouteWarnings) {
+    warnings.push(...adapter.buildAmbiguousRouteWarnings(routes));
+  }
+
+  if (!openfgaError && openfgaAgentIds.length === 0) {
+    warnings.push(
+      `No OpenFGA ${adapter.tupleNoun} tuples found. ${adapter.runtimeLabel} has no agent to dispatch.`,
+    );
+  }
+
+  const lastError = await latestRuntimeError(adapter, workspaceId, itemId);
+  const surfacedLastError =
+    lastError && (adapter.shouldSurfaceLastRuntimeError?.(lastError, openfgaError) ?? true)
+      ? lastError
+      : null;
+
+  return {
+    workspace_id: workspaceId,
+    item_id: itemId,
+    openfga: {
+      reachable: !openfgaError,
+      tuple_count: openfgaAgentIds.length,
+      ...(openfgaError ? { error: openfgaError } : {}),
+    },
+    routes,
+    warnings: Array.from(new Set(warnings)),
+    last_runtime_error: surfacedLastError,
+  };
+}
+
+export async function computeConnectorHealthSummary(
+  adapter: ConnectorDiagnosticsAdapter,
+  workspaceId: string,
+  itemId: string,
+): Promise<ConnectorHealthSummary> {
+  const diagnostics = await computeConnectorDiagnostics(adapter, workspaceId, itemId);
+  return {
+    warnings_count: diagnostics.warnings.length,
+    openfga_reachable: diagnostics.openfga.reachable,
+    last_runtime_error_ts: diagnostics.last_runtime_error?.ts ?? null,
+  };
+}

--- a/ui/src/lib/rbac/slack-channel-diagnostics.ts
+++ b/ui/src/lib/rbac/slack-channel-diagnostics.ts
@@ -1,43 +1,25 @@
-import { getCollection } from "@/lib/mongodb";
 import { readOpenFgaTuples } from "@/lib/rbac/openfga";
 import { slackChannelSubjectId } from "@/lib/rbac/slack-channel-grant-store";
 import { listSlackChannelAgentRoutes } from "@/lib/rbac/slack-channel-route-store";
+import {
+  type ConnectorDiagnostics,
+  type ConnectorDiagnosticsAdapter,
+  type ConnectorHealthSummary,
+  type ConnectorRouteMetadata,
+  type ConnectorRuntimeRouteDiagnostic,
+  computeConnectorDiagnostics,
+  computeConnectorHealthSummary,
+} from "@/lib/rbac/connector-diagnostics";
 
-export interface SlackRuntimeRouteDiagnostic {
-  agent_id: string;
-  openfga_tuple: boolean;
-  route_metadata: boolean;
-  listen: "mention" | "message" | "all" | "unknown";
-  priority: number;
-  runtime_matches: { mention: boolean; message: boolean };
-  warnings: string[];
-}
+export type SlackRuntimeRouteDiagnostic = ConnectorRuntimeRouteDiagnostic;
 
-export interface SlackChannelLastRuntimeError {
-  ts?: string;
-  reason_code?: string;
-  message?: string;
-  action?: string;
-}
+export type SlackChannelLastRuntimeError = NonNullable<ConnectorDiagnostics["last_runtime_error"]>;
 
-export interface SlackChannelDiagnostics {
-  workspace_id: string;
+export interface SlackChannelDiagnostics extends Omit<ConnectorDiagnostics, "item_id"> {
   channel_id: string;
-  openfga: {
-    reachable: boolean;
-    tuple_count: number;
-    error?: string;
-  };
-  routes: SlackRuntimeRouteDiagnostic[];
-  warnings: string[];
-  last_runtime_error: SlackChannelLastRuntimeError | null;
 }
 
-export interface SlackChannelHealthSummary {
-  warnings_count: number;
-  openfga_reachable: boolean;
-  last_runtime_error_ts: string | null;
-}
+export type SlackChannelHealthSummary = ConnectorHealthSummary;
 
 function agentIdFromObject(object: string): string | null {
   if (!object.startsWith("agent:")) return null;
@@ -45,29 +27,26 @@ function agentIdFromObject(object: string): string | null {
   return agentId || null;
 }
 
-function listenMatches(
-  listen: SlackRuntimeRouteDiagnostic["listen"],
-  requested: "mention" | "message",
-): boolean {
-  return listen === "all" || listen === requested;
+async function listOpenFgaSlackChannelAgentIds(workspaceId: string, channelId: string): Promise<string[]> {
+  const subject = `slack_channel:${slackChannelSubjectId(workspaceId, channelId)}`;
+  const seen = new Set<string>();
+  let continuationToken: string | undefined;
+  do {
+    const result = await readOpenFgaTuples({
+      pageSize: 100,
+      ...(continuationToken ? { continuationToken } : {}),
+    });
+    for (const tuple of result.tuples) {
+      if (tuple.key.user !== subject || tuple.key.relation !== "user") continue;
+      const agentId = agentIdFromObject(tuple.key.object);
+      if (agentId) seen.add(agentId);
+    }
+    continuationToken = result.continuationToken;
+  } while (continuationToken);
+  return Array.from(seen);
 }
 
-function buildRouteWarning(route: SlackRuntimeRouteDiagnostic): string[] {
-  const warnings: string[] = [];
-  if (!route.openfga_tuple) {
-    warnings.push(
-      `agent:${route.agent_id} has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.`,
-    );
-  }
-  if (!route.route_metadata) {
-    warnings.push(
-      `agent:${route.agent_id} has an OpenFGA tuple but no Mongo route metadata; runtime uses mention-only defaults.`,
-    );
-  }
-  return warnings;
-}
-
-function buildAmbiguousRouteWarnings(routes: SlackRuntimeRouteDiagnostic[]): string[] {
+function buildAmbiguousRouteWarnings(routes: ConnectorRuntimeRouteDiagnostic[]): string[] {
   // Surface real misconfiguration: two enabled routes that match the
   // same incoming message at the same priority. The Slack bot picks
   // first-match-wins among ties, so the result is non-deterministic.
@@ -92,130 +71,44 @@ function buildAmbiguousRouteWarnings(routes: SlackRuntimeRouteDiagnostic[]): str
   return warnings;
 }
 
-async function listOpenFgaChannelAgentIds(workspaceId: string, channelId: string): Promise<string[]> {
-  const subject = `slack_channel:${slackChannelSubjectId(workspaceId, channelId)}`;
-  const seen = new Set<string>();
-  let continuationToken: string | undefined;
-  do {
-    const result = await readOpenFgaTuples({
-      pageSize: 100,
-      ...(continuationToken ? { continuationToken } : {}),
-    });
-    for (const tuple of result.tuples) {
-      if (tuple.key.user !== subject || tuple.key.relation !== "user") continue;
-      const agentId = agentIdFromObject(tuple.key.object);
-      if (agentId) seen.add(agentId);
-    }
-    continuationToken = result.continuationToken;
-  } while (continuationToken);
-  return Array.from(seen);
-}
-
-async function latestRuntimeError(
-  workspaceId: string,
-  channelId: string,
-): Promise<SlackChannelLastRuntimeError | null> {
-  const resourceRef = `slack_channel:${slackChannelSubjectId(workspaceId, channelId)}`;
-  try {
-    const auditEvents = await getCollection("audit_events");
-    const rows = await auditEvents
-      .find({
-        component: "slack_bot",
-        outcome: "error",
-        resource_ref: resourceRef,
-      })
-      .sort({ ts: -1 })
-      .limit(1)
-      .toArray();
-    const event = rows[0] as Record<string, unknown> | undefined;
-    if (!event) return null;
-    return {
-      ts: typeof event.ts === "string" ? event.ts : undefined,
-      reason_code: typeof event.reason_code === "string" ? event.reason_code : undefined,
-      message: typeof event.message === "string" ? event.message : undefined,
-      action: typeof event.action === "string" ? event.action : undefined,
-    };
-  } catch {
-    return null;
-  }
-}
+const SLACK_DIAGNOSTICS_ADAPTER: ConnectorDiagnosticsAdapter = {
+  kind: "slack_channel",
+  botLabel: "Slack bot",
+  runtimeLabel: "Slack runtime",
+  tupleNoun: "channel-agent",
+  auditComponent: "slack_bot",
+  auditResourceRef: (workspaceId, channelId) =>
+    `slack_channel:${slackChannelSubjectId(workspaceId, channelId)}`,
+  listOpenFgaAgentIds: listOpenFgaSlackChannelAgentIds,
+  listRouteMetadata: async (workspaceId, channelId): Promise<ConnectorRouteMetadata[]> => {
+    const rows = await listSlackChannelAgentRoutes(workspaceId, channelId);
+    return rows.map((route) => ({
+      agent_id: route.agent_id,
+      priority: route.priority,
+      users: route.users ? { listen: route.users.listen } : undefined,
+    }));
+  },
+  buildAmbiguousRouteWarnings,
+};
 
 export async function computeSlackChannelDiagnostics(
   workspaceId: string,
   channelId: string,
 ): Promise<SlackChannelDiagnostics> {
-  const metadataRoutes = await listSlackChannelAgentRoutes(workspaceId, channelId);
-  const warnings: string[] = [];
-  let openfgaAgentIds: string[] = [];
-  let openfgaError: string | undefined;
-
-  try {
-    openfgaAgentIds = await listOpenFgaChannelAgentIds(workspaceId, channelId);
-  } catch (error) {
-    openfgaError = error instanceof Error ? error.message : "OpenFGA tuple read failed";
-    warnings.push(`Slack bot cannot read OpenFGA tuples: ${openfgaError}`);
-  }
-
-  const allAgentIds = Array.from(
-    new Set([...openfgaAgentIds, ...metadataRoutes.map((route) => route.agent_id)]),
-  ).sort();
-  const metadataByAgentId = new Map(metadataRoutes.map((route) => [route.agent_id, route]));
-  const openfgaAgentSet = new Set(openfgaAgentIds);
-  const routes = allAgentIds.map((agentId): SlackRuntimeRouteDiagnostic => {
-    const metadata = metadataByAgentId.get(agentId);
-    const listen = (metadata?.users?.listen ?? "mention") as SlackRuntimeRouteDiagnostic["listen"];
-    const priority = typeof metadata?.priority === "number" ? metadata.priority : 100;
-    const route: SlackRuntimeRouteDiagnostic = {
-      agent_id: agentId,
-      openfga_tuple: openfgaAgentSet.has(agentId),
-      route_metadata: Boolean(metadata),
-      listen,
-      priority,
-      runtime_matches: {
-        mention: listenMatches(listen, "mention"),
-        message: listenMatches(listen, "message"),
-      },
-      warnings: [],
-    };
-    route.warnings = buildRouteWarning(route);
-    warnings.push(...route.warnings);
-    return route;
-  });
-
-  warnings.push(...buildAmbiguousRouteWarnings(routes));
-
-  if (!openfgaError && openfgaAgentIds.length === 0) {
-    warnings.push("No OpenFGA channel-agent tuples found. Slack runtime has no agent to dispatch.");
-  }
-
+  const diagnostics = await computeConnectorDiagnostics(SLACK_DIAGNOSTICS_ADAPTER, workspaceId, channelId);
   return {
-    workspace_id: workspaceId,
-    channel_id: channelId,
-    openfga: {
-      reachable: !openfgaError,
-      tuple_count: openfgaAgentIds.length,
-      ...(openfgaError ? { error: openfgaError } : {}),
-    },
-    routes,
-    warnings: Array.from(new Set(warnings)),
-    last_runtime_error: await latestRuntimeError(workspaceId, channelId),
+    workspace_id: diagnostics.workspace_id,
+    channel_id: diagnostics.item_id,
+    openfga: diagnostics.openfga,
+    routes: diagnostics.routes,
+    warnings: diagnostics.warnings,
+    last_runtime_error: diagnostics.last_runtime_error,
   };
 }
 
-/**
- * Compact summary used by the channel list endpoint to show per-row
- * health without forcing the UI to fetch full diagnostics for every
- * channel. Same source of truth as `computeSlackChannelDiagnostics`,
- * just stripped to the fields the list view needs.
- */
 export async function computeSlackChannelHealthSummary(
   workspaceId: string,
   channelId: string,
 ): Promise<SlackChannelHealthSummary> {
-  const diagnostics = await computeSlackChannelDiagnostics(workspaceId, channelId);
-  return {
-    warnings_count: diagnostics.warnings.length,
-    openfga_reachable: diagnostics.openfga.reachable,
-    last_runtime_error_ts: diagnostics.last_runtime_error?.ts ?? null,
-  };
+  return computeConnectorHealthSummary(SLACK_DIAGNOSTICS_ADAPTER, workspaceId, channelId);
 }

--- a/ui/src/lib/rbac/webex-space-diagnostics.ts
+++ b/ui/src/lib/rbac/webex-space-diagnostics.ts
@@ -1,0 +1,91 @@
+import {
+  listOpenFgaWebexSpaceAgentIds,
+  webexSpaceOpenFgaUser,
+} from "@/lib/rbac/webex-space-openfga";
+import { listWebexSpaceAgentRoutes } from "@/lib/rbac/webex-space-route-store";
+import {
+  type ConnectorDiagnostics,
+  type ConnectorDiagnosticsAdapter,
+  type ConnectorHealthSummary,
+  type ConnectorRouteMetadata,
+  type ConnectorRuntimeRouteDiagnostic,
+  computeConnectorDiagnostics,
+  computeConnectorHealthSummary,
+} from "@/lib/rbac/connector-diagnostics";
+
+export type WebexRuntimeRouteDiagnostic = ConnectorRuntimeRouteDiagnostic;
+
+export type WebexSpaceLastRuntimeError = NonNullable<ConnectorDiagnostics["last_runtime_error"]>;
+
+export interface WebexSpaceDiagnostics extends Omit<ConnectorDiagnostics, "item_id"> {
+  space_id: string;
+}
+
+export type WebexSpaceHealthSummary = ConnectorHealthSummary;
+
+function buildExtraRouteWarnings(route: ConnectorRuntimeRouteDiagnostic): string[] {
+  // Webex surfaces explicit listen-mode warnings at the per-route
+  // level. Slack instead folds these into the ambiguous-route warning
+  // — so this function is Webex-specific and does not run for Slack.
+  const warnings: string[] = [];
+  if (route.listen === "mention") {
+    warnings.push(
+      `Route agent:${route.agent_id} only listens to mentions. Plain space messages will be ignored.`,
+    );
+  }
+  if (route.listen === "message") {
+    warnings.push(
+      `Route agent:${route.agent_id} only listens to plain messages. @mentions will not use this route.`,
+    );
+  }
+  return warnings;
+}
+
+const WEBEX_DIAGNOSTICS_ADAPTER: ConnectorDiagnosticsAdapter = {
+  kind: "webex_space",
+  botLabel: "Webex bot",
+  runtimeLabel: "Webex runtime",
+  tupleNoun: "space-agent",
+  auditComponent: "webex_bot",
+  auditResourceRef: (workspaceId, spaceId) => webexSpaceOpenFgaUser(workspaceId, spaceId),
+  listOpenFgaAgentIds: listOpenFgaWebexSpaceAgentIds,
+  listRouteMetadata: async (workspaceId, spaceId): Promise<ConnectorRouteMetadata[]> => {
+    const rows = await listWebexSpaceAgentRoutes(workspaceId, spaceId);
+    return rows.map((route) => ({
+      agent_id: route.agent_id,
+      priority: route.priority,
+      users: route.users ? { listen: route.users.listen } : undefined,
+    }));
+  },
+  buildExtraRouteWarnings,
+  shouldSurfaceLastRuntimeError: (lastError, openfgaError) => {
+    // The Webex bot logs OPENFGA_READ_FAILED into audit_events when
+    // tuple reads fail. Once OpenFGA is reachable again, the stored
+    // error is stale — suppress it so the diagnostics panel doesn't
+    // light up red after the underlying issue cleared.
+    if (!openfgaError && lastError.reason_code === "OPENFGA_READ_FAILED") return false;
+    return true;
+  },
+};
+
+export async function computeWebexSpaceDiagnostics(
+  workspaceId: string,
+  spaceId: string,
+): Promise<WebexSpaceDiagnostics> {
+  const diagnostics = await computeConnectorDiagnostics(WEBEX_DIAGNOSTICS_ADAPTER, workspaceId, spaceId);
+  return {
+    workspace_id: diagnostics.workspace_id,
+    space_id: diagnostics.item_id,
+    openfga: diagnostics.openfga,
+    routes: diagnostics.routes,
+    warnings: diagnostics.warnings,
+    last_runtime_error: diagnostics.last_runtime_error,
+  };
+}
+
+export async function computeWebexSpaceHealthSummary(
+  workspaceId: string,
+  spaceId: string,
+): Promise<WebexSpaceHealthSummary> {
+  return computeConnectorHealthSummary(WEBEX_DIAGNOSTICS_ADAPTER, workspaceId, spaceId);
+}


### PR DESCRIPTION
## Summary

- **Shared component**: Introduces `ConnectorAdminPanel` + `ConnectorAdminAdapter` type. Both panels now render the same Configured/Onboard/Advanced tabbed layout, parameterised by a small adapter object.
- **Generic diagnostics core**: Extracts `connector-diagnostics.ts` (shared compute logic); `slack-channel-diagnostics.ts` becomes a thin wrapper; adds `webex-space-diagnostics.ts` as the symmetric Webex wrapper.
- **Webex health endpoint**: Adds `?health=1` to `GET /api/admin/webex/spaces` so the Configured tab can show real per-row health (mirrors Slack).
- **Wrapper files**: `SlackChannelRebacPanel.tsx` and `WebexSpaceRebacPanel.tsx` are now ~240–260 lines each (down from 1757/1342). Admin page imports unchanged.
- **Tests**: Webex panel tests rewritten for the new tabbed layout. 93 connector-related tests pass.

## Test plan

- [x] `npx jest src/components/admin/rebac/__tests__/ src/app/api/admin/slack/ src/app/api/admin/webex/` — 93 tests pass
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npx eslint` on all changed files — clean
- [ ] Manual: Slack tab still works end-to-end (Configured/Onboard/Advanced)
- [ ] Manual: Webex tab now has tabbed layout with real per-row health
- [ ] Manual: Webex-only auto-fix card visible when space has no routeable agent