### PR TITLE
fix(compose): remove duplicate volumes key in openfga-init service

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2966,8 +2966,6 @@ services:
       # Seed a dev allow tuple with a Keycloak user `sub`. If unset, OpenFGA
       # starts deny-by-default and you can write tuples later.
       OPENFGA_SEED_SUB: ${OPENFGA_SEED_SUB:-}
-    volumes:
-      - ./charts/ai-platform-engineering/charts/openfga/authorization-model.json:/app/authorization-model.json:ro
     depends_on:
       openfga:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Removes duplicate `volumes` key in the `openfga-init` service in `docker-compose.dev.yaml`
- Both occurrences were identical; the second was a stale duplicate that caused YAML parse failure

## Test plan

- [ ] Run `docker compose -f docker-compose.dev.yaml config` to confirm YAML parses cleanly
- [ ] Run the full `docker compose build` command from the issue to verify it succeeds