### PR TITLE
fix(admin): correct team KB tab link and surface KB/agent/tool counts on team cards

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.2 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.3 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.2 -f your-values.yaml'}
+                  {'    --version 0.5.3 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.2 -f your-values.yaml'}
+              {'    --version 0.5.3 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.3"
+version = "0.5.3-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -207,6 +207,12 @@ interface Team {
   // and is no longer read by the page badge — only kept on the type
   // so older fixtures and dialog state shapes continue to compile.
   member_count?: number;
+  // Server-decorated count of distinct KBs assigned to the team, sourced
+  // from the canonical `team_kb_ownership` collection (see
+  // GET /api/admin/teams). The legacy `resources.knowledge_bases` array on
+  // the team document is almost always empty, so the team-card KBs badge
+  // must prefer this field.
+  kb_count?: number;
   members?: Array<{
     user_id: string;
     role: string;
@@ -1615,7 +1621,7 @@ function AdminPage() {
                             <StatChip
                               icon={<Bot className="h-3.5 w-3.5" />}
                               label="Agents"
-                              count={team.resources?.agents?.length}
+                              count={team.resources?.agents?.length ?? 0}
                               onClick={() => openTeamDialog(team, "resources")}
                             />
                             <StatChip
@@ -1624,14 +1630,18 @@ function AdminPage() {
                               count={
                                 team.resources?.tool_wildcard
                                   ? "*"
-                                  : team.resources?.tools?.length
+                                  : (team.resources?.tools?.length ?? 0)
                               }
                               onClick={() => openTeamDialog(team, "resources")}
                             />
                             <StatChip
                               icon={<Database className="h-3.5 w-3.5" />}
                               label="KBs"
-                              count={team.resources?.knowledge_bases?.length}
+                              count={
+                                team.kb_count ??
+                                team.resources?.knowledge_bases?.length ??
+                                0
+                              }
                               onClick={() => openTeamDialog(team, "kbs")}
                             />
                             <StatChip

--- a/ui/src/app/api/__tests__/admin-teams.test.ts
+++ b/ui/src/app/api/__tests__/admin-teams.test.ts
@@ -362,6 +362,59 @@ describe('GET /api/admin/teams', () => {
     expect(byName['Platform Engineering']).toBe(2);
     expect(byName['Ghost Team']).toBe(0);
   });
+
+  it('decorates each team with kb_count from team_kb_ownership (deduped), defaulting to 0', async () => {
+    // Issue #1642 follow-up: the team-card "KBs" badge must read the
+    // canonical `team_kb_ownership` collection, not the almost-always-empty
+    // legacy `team.resources.knowledge_bases` array. A team with an
+    // ownership row reports its distinct kb_id count; a team without one
+    // reports 0 so the badge renders a number instead of hiding.
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const kbTeamId = new ObjectId();
+    const kbTeam = {
+      _id: kbTeamId,
+      name: 'KB Team',
+      slug: 'kb-team',
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    const noKbTeam = {
+      _id: new ObjectId(),
+      name: 'No KB Team',
+      slug: 'no-kb-team',
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([kbTeam, noKbTeam]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    const ownershipCol = createMockCollection();
+    ownershipCol.find = jest.fn().mockReturnValue({
+      // Duplicate kb-a must collapse to a single distinct KB → count 2.
+      toArray: jest.fn().mockResolvedValue([
+        { team_id: kbTeamId.toString(), kb_ids: ['kb-a', 'kb-b', 'kb-a'] },
+      ]),
+    });
+    mockCollections['team_kb_ownership'] = ownershipCol;
+
+    const req = makeRequest('/api/admin/teams');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    const byName = Object.fromEntries(
+      body.data.teams.map((t: { name: string; kb_count: number }) => [t.name, t.kb_count]),
+    );
+    expect(byName['KB Team']).toBe(2);
+    expect(byName['No KB Team']).toBe(0);
+  });
 });
 
 // ============================================================================

--- a/ui/src/app/api/admin/teams/route.ts
+++ b/ui/src/app/api/admin/teams/route.ts
@@ -80,11 +80,39 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     .map((team) => (typeof team.slug === 'string' ? team.slug : ''))
     .filter((slug): slug is string => slug.length > 0);
   const memberCounts = slugs.length > 0 ? await loadTeamMemberCounts(slugs) : new Map<string, number>();
+
+  // Decorate each team with `kb_count`. The canonical store for team KB
+  // assignments is the `team_kb_ownership` collection (keyed by the team's
+  // string `_id`), NOT the legacy `team.resources.knowledge_bases` array on
+  // the team document. Without this join the Admin team-card "KBs" badge
+  // reads an almost-always-empty field and shows nothing even when a team
+  // has KBs assigned (issue #1642 follow-up). We count distinct kb_ids per
+  // team in a single query, falling back to the legacy doc field when no
+  // ownership row exists yet.
+  const teamIdStrings = allTeams.map((team) => team._id.toString());
+  const kbCounts = new Map<string, number>();
+  if (teamIdStrings.length > 0) {
+    const ownership = await getCollection<{ team_id?: string; kb_ids?: string[] }>('team_kb_ownership');
+    const ownershipRows = await ownership
+      .find({ team_id: { $in: teamIdStrings } }, { projection: { team_id: 1, kb_ids: 1 } })
+      .toArray();
+    for (const row of ownershipRows) {
+      if (typeof row.team_id !== 'string') continue;
+      const ids = Array.isArray(row.kb_ids) ? row.kb_ids : [];
+      kbCounts.set(row.team_id, new Set(ids).size);
+    }
+  }
+
   const teamsWithCounts = allTeams.map((team) => {
     const slug = typeof team.slug === 'string' ? team.slug : '';
+    const idStr = team._id.toString();
+    const legacyKbCount = Array.isArray(team.resources?.knowledge_bases)
+      ? team.resources.knowledge_bases.length
+      : 0;
     return {
       ...team,
       member_count: slug ? memberCounts.get(slug) ?? 0 : 0,
+      kb_count: kbCounts.get(idStr) ?? legacyKbCount,
     };
   });
 

--- a/ui/src/components/admin/TeamKbAssignmentPanel.tsx
+++ b/ui/src/components/admin/TeamKbAssignmentPanel.tsx
@@ -397,7 +397,7 @@ export function TeamKbAssignmentPanel({
                     <span className="inline-flex items-center gap-1">
                       No knowledge bases exist yet.
                       <a
-                        href="/rag"
+                        href="/knowledge-bases"
                         className="inline-flex items-center gap-0.5 text-primary hover:underline"
                       >
                         Create one
@@ -573,7 +573,7 @@ function EmptyAssignedState({
       </p>
       {!hasAvailableKbs && kbsApiOk && (
         <a
-          href="/rag"
+          href="/knowledge-bases"
           className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
         >
           Create a knowledge base

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.3"
+version = "0.5.3.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Two related Admin → Teams fixes:

### 1. Knowledge-base link 404 (issue #1642)
The "Create knowledge base" / "Create one" links in the team editing dialog's Knowledge Bases tab pointed to `/rag`, which is only an API prefix (`/api/rag/...`) and not a UI route, so they 404'd. Both `href="/rag"` occurrences in `TeamKbAssignmentPanel.tsx` now point to `/knowledge-bases` (the real UI page).

### 2. Team-card resource counts (KBs / Agents / Tools)
The Admin team cards showed a blank "KBs" badge even when a team had KBs assigned. Root cause: the badge read `team.resources.knowledge_bases` (an almost-always-empty legacy field), but the canonical store for team KB assignments is the `team_kb_ownership` collection, which `GET /api/admin/teams` never joined in.

- `GET /api/admin/teams` now decorates each team with a `kb_count` computed from distinct `kb_ids` in `team_kb_ownership` (falling back to the legacy doc field), mirroring the existing `member_count` decoration.
- The Agents/Tools/KBs `StatChip`s now default to `0` so empty teams render "0" instead of hiding the number (consistent with the Members/Chat badges).

## Changes
- `ui/src/components/admin/TeamKbAssignmentPanel.tsx`: `href="/rag"` → `href="/knowledge-bases"` (x2).
- `ui/src/app/api/admin/teams/route.ts`: decorate teams with `kb_count` from `team_kb_ownership`.
- `ui/src/app/(app)/admin/page.tsx`: `Team.kb_count` type + KBs chip prefers `kb_count`; Agents/Tools/KBs default to 0.
- `ui/src/app/api/__tests__/admin-teams.test.ts`: new test for `kb_count` decoration (deduped, defaults to 0).

## Test plan
- [x] `jest admin-teams.test.ts` — 35 passed (incl. new kb_count test)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — no new errors (pre-existing warnings only)
- [ ] Admin → Teams: a team with a KB assigned shows the correct KBs count; the KB tab "Create" links navigate to `/knowledge-bases`.