### PR TITLE
docs(releases): add release notes for 0.5.3 and 0.5.4

### DIFF
--- a/docs/releases/2026-05-29-release-0-5-3.md
+++ b/docs/releases/2026-05-29-release-0-5-3.md
@@ -1,0 +1,195 @@
+---
+slug: release-0.5.3
+title: "Release 0.5.3 — CRD-Free Gateway and Release-Name Defaults"
+date: 2026-05-29
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-05-29
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.3`
+> Previous release: 0.5.2
+
+## Highlights
+
+0.5.3 makes AgentGateway CRD-free by default. The new `global.agentgateway.routingMode` defaults to `static`, so enabling the gateway renders the standalone proxy's own config instead of Gateway API / AgentGateway custom resources — no cluster-scoped CRDs and no controller install required, which keeps `helm diff` and `helm upgrade` clean on clusters you do not own. The chart also stops hardcoding `ai-platform-engineering-*` service URLs: in-cluster defaults are now computed from the Helm release name in the deployment templates, so installs under a custom release name resolve their supervisor, Keycloak, OpenFGA, skill-scanner, and bot URLs correctly without manual overrides. Rounding out the release, every agent gains proper Kubernetes startup/liveness/readiness probe semantics, and a Twisted bump closes a DNS-compression DoS in the RAG web loader.
+
+<!-- truncate -->
+
+## What's New
+
+### AgentGateway Routing
+- **CRD-free static routing by default** — `global.agentgateway.routingMode` now defaults to `static`, which writes MCP routes into the standalone AgentGateway proxy's static config (one `/mcp/<id>` route/backend per target) instead of rendering `Gateway`, `HTTPRoute`, `AgentgatewayBackend`, and `AgentgatewayPolicy` custom resources. Enabling AgentGateway therefore no longer depends on the `gateway.networking.k8s.io` / `agentgateway.dev` CRDs or a Gateway controller; MCP endpoints stay discoverable through the proxy admin `/config` endpoint that the CAIPE UI discover/sync flow reads. A new `global.agentgateway.static.jwtAuth` block adds optional listener-level JWT validation for the standalone proxy, and the UI recovers each MCP route path from the live `pathPrefix` shape. Set `routingMode: gateway-api` to opt back into the controller-managed Gateway data plane ([#1629](https://github.com/cnoe-io/ai-platform-engineering/pull/1629))
+
+### Helm Release-Name Defaults
+- **Release-name-aware service URLs** — in-cluster service URL defaults that were previously hardcoded to `ai-platform-engineering-*` (or a literal `{{ .Release.Name }}` string) are now left empty and computed from the actual Helm release name inside the deployment templates. This covers the supervisor (`A2A_BASE_URL`), Keycloak (`KEYCLOAK_URL`), OpenFGA (`httpUrl` / `OPENFGA_HTTP`), skill-scanner (`SKILL_SCANNER_URL`), the Slack and Webex bot admin APIs, the credential service, the SLIM endpoint, and the OpenFGA authz-bridge JWKS URL — so a `helm install foo …` resolves to `foo-keycloak`, `foo-openfga`, and so on instead of silently pointing at the wrong service. Realm URL defaults also honor `KEYCLOAK_REALM` instead of a hardcoded `caipe` ([#1612](https://github.com/cnoe-io/ai-platform-engineering/pull/1612))
+
+### Health & Probes
+- **Real Kubernetes probe semantics across agents** — agents migrate from TCP to HTTP probes and gain startup probes; the supervisor registers `/health` and `/ready` routes on the A2A app, dynamic-agents and rag-server get corrected liveness semantics, skill-scanner and langgraph-redis get startup probes, and readiness endpoints now return HTTP 503 when their dependencies are unavailable so traffic is held off until a pod is genuinely ready ([#1468](https://github.com/cnoe-io/ai-platform-engineering/pull/1468))
+
+### Docs
+- **Versioned docs generated at build time** — the documentation site now materializes versioned docs from release tags at build time rather than committing `versioned_docs/` trees, and the RBAC reference's broken anchor and unreadable draw.io SVGs are repaired
+
+## Bug Fixes
+
+- **ui**: recover the AgentGateway MCP route path from the live `pathPrefix` shape so discovered routes match the proxy config ([#1629](https://github.com/cnoe-io/ai-platform-engineering/pull/1629))
+- **helm**: wire the CAIPE UI to the AgentGateway proxy for CRD-free MCP discovery ([#1629](https://github.com/cnoe-io/ai-platform-engineering/pull/1629))
+- **helm**: fix whitespace trimming that caused YAML parse errors in deployment env blocks and compute release-name service URL defaults in templates ([#1612](https://github.com/cnoe-io/ai-platform-engineering/pull/1612))
+- **ui**: collapse the top bar on narrow screens and label the collapsed nav menu
+
+## Security
+
+- **rag**: bump Twisted to 26.4.0 to close a DNS-compression denial-of-service in the web loader
+- **deps**: bump PyJWT from 2.10.1 to 2.13.0 in the OpenFGA authz bridge, and force `uuid >= 11.1.1` via overrides in the UI and docs builds
+
+## Breaking Changes
+
+**AgentGateway routing defaults to `static` (CRD-free).** If you run with `global.agentgateway.enabled: true` and rely on the chart rendering Gateway API / AgentGateway custom resources (the controller-managed data plane), you must now set `global.agentgateway.routingMode: gateway-api` explicitly. With the default `global.agentgateway.enabled: false`, there is no impact.
+
+## Known Issues
+
+None known at this time.
+
+## Upgrade
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.3 \
+  -f your-values.yaml
+```
+
+---
+
+## Upgrade Guide: 0.5.2 → 0.5.3
+
+## Overview
+
+For a stock deployment — default release name `ai-platform-engineering`, AgentGateway disabled — 0.5.3 is a drop-in upgrade. Two things are worth knowing before you upgrade: the AgentGateway `routingMode` default flipped to `static`, and many in-cluster service URL defaults are now computed from the Helm release name instead of being hardcoded. Neither changes behavior for the default release name, but both matter if you enable AgentGateway or run under a custom release name.
+
+## Helm Values Changes
+
+### Behavioral Change: AgentGateway `routingMode`
+
+**Affected key**: `global.agentgateway.routingMode` (new key, defaults to `static`)
+
+**Before (0.5.2)**: enabling AgentGateway rendered Gateway API / AgentGateway custom resources (required the CRDs + a controller).
+
+**After (0.5.3)**:
+```yaml
+global:
+  agentgateway:
+    enabled: true
+    routingMode: static   # NEW default — no CRDs, no controller
+```
+
+**Action**: If you depend on the controller-managed Gateway data plane (Gateway API CRs), set `routingMode: gateway-api` explicitly. Otherwise no action — `static` requires no CRDs and keeps `helm upgrade` clean.
+
+### Changed Defaults: Release-Name Service URLs
+
+A set of service URL keys changed their default from a literal `ai-platform-engineering-*` / `{{ .Release.Name }}` string to an empty string (`""`), because the value is now rendered from `.Release.Name` in the deployment templates. Affected keys include `global.slim.endpoint`, `global.openfga.httpUrl`, CAIPE UI `A2A_BASE_URL` / `SKILL_SCANNER_URL` / `SLACK_BOT_ADMIN_URL` / `WEBEX_BOT_ADMIN_URL`, dynamic-agents `KEYCLOAK_URL` / `OPENFGA_HTTP` / `CREDENTIAL_API_URL`, the Slack/Webex bot `CAIPE_API_URL`, the Webex admin issuer/JWKS URLs, and the OpenFGA authz-bridge `httpUrl` / `tokenValidation.jwksUrl`.
+
+**Action**:
+- **Default release name (`ai-platform-engineering`)**: none — the rendered value is identical to the old hardcoded default.
+- **Custom release name**: you can now *remove* any manual overrides you previously added to point these at `<release>-…`; the empty default resolves correctly on its own.
+- If you explicitly set any of these to an external endpoint, your override is preserved.
+
+### New Optional Fields
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `global.agentgateway.static.jwtAuth.enabled` | `false` | Listener-level JWT validation for the standalone proxy (static routing mode) |
+| `global.agentgateway.static.jwtAuth.issuer` / `jwksUrl` / `audiences` | `""` / `""` / `[]` | JWT issuer, JWKS URL, and audiences for the static listener policy |
+| `dynamic-agents` `OPENFGA_HTTP` | `""` (release-name default) | OpenFGA HTTP endpoint for dynamic-agents authorization |
+| `dynamic-agents` `OPENFGA_STORE_NAME` | `caipe-openfga` | OpenFGA store name for dynamic-agents |
+
+## Data Migrations
+
+No MongoDB schema or data migrations are required.
+
+## Upgrade Runbook
+
+### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.3 \
+  -f your-values.yaml
+```
+
+### 2. (Only if you use AgentGateway with CRDs) Pin routing mode
+
+```yaml
+global:
+  agentgateway:
+    enabled: true
+    routingMode: gateway-api
+```
+
+### 3. Verify
+
+```bash
+kubectl get pods -n <namespace>
+
+# Probes are stricter now — confirm pods reach Ready and stay there
+kubectl get pods -n <namespace> -o wide
+```
+
+If AgentGateway is enabled in static mode, confirm MCP routes resolve through the proxy admin `/config` endpoint (the UI discover/sync flow reads from there) rather than expecting `HTTPRoute` objects.
+
+## Full Values Diff
+
+<details>
+<summary>Raw diff (0.5.2 → 0.5.3)</summary>
+
+```diff
+@@ global.slim @@
+-    endpoint: "http://ai-platform-engineering-slim:46357"
++    endpoint: ""
+@@ global.agentgateway @@
++    routingMode: static
++    static:
++      jwtAuth:
++        enabled: false
++        issuer: ""
++        jwksUrl: ""
++        audiences: []
+     extAuth:
+       enabled: false
+-      serviceName: "ai-platform-engineering-openfga-authz-bridge"
++      serviceName: ""
+@@ global.openfga @@
+-    httpUrl: "http://{{ .Release.Name }}-openfga:8080"
++    httpUrl: ""
+@@ caipe-ui.config @@
+-    A2A_BASE_URL: "http://ai-platform-engineering-supervisor-agent:8000"
++    A2A_BASE_URL: ""
+-    SKILL_SCANNER_URL: "http://{{ .Release.Name }}-skill-scanner:8000"
++    SKILL_SCANNER_URL: ""
+-    SLACK_BOT_ADMIN_URL: "http://ai-platform-engineering-slack-bot:3001"
++    SLACK_BOT_ADMIN_URL: ""
+-    WEBEX_BOT_ADMIN_URL: "http://ai-platform-engineering-webex-bot:3002"
++    WEBEX_BOT_ADMIN_URL: ""
+@@ dynamic-agents.config @@
+-    KEYCLOAK_URL: "http://ai-platform-engineering-keycloak:8080"
++    KEYCLOAK_URL: ""
++    OPENFGA_HTTP: ""
++    OPENFGA_STORE_NAME: "caipe-openfga"
+-    CREDENTIAL_API_URL: "http://ai-platform-engineering-caipe-ui:3000/api/credentials"
++    CREDENTIAL_API_URL: ""
+@@ slack-bot.config / webex-bot.config @@
+-    CAIPE_API_URL: "http://ai-platform-engineering-caipe-ui:3000"
++    CAIPE_API_URL: ""
+-    WEBEX_ADMIN_JWT_ISSUER: "http://ai-platform-engineering-keycloak:8080/realms/caipe"
+-    WEBEX_ADMIN_JWKS_URL: "http://ai-platform-engineering-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
++    WEBEX_ADMIN_JWT_ISSUER: ""
++    WEBEX_ADMIN_JWKS_URL: ""
+@@ openfga-authz-bridge @@
+-    httpUrl: "http://{{ .Release.Name }}-openfga:8080"
++    httpUrl: ""
+-    jwksUrl: "http://{{ .Release.Name }}-keycloak:8080/realms/caipe/protocol/openid-connect/certs"
++    jwksUrl: ""
+```
+
+</details>

--- a/docs/releases/2026-05-29-release-0-5-4.md
+++ b/docs/releases/2026-05-29-release-0-5-4.md
@@ -1,0 +1,89 @@
+---
+slug: release-0.5.4
+title: "Release 0.5.4 — Admin UI Polish and Keycloak Realm Fix"
+date: 2026-05-29
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-05-29
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.4`
+> Previous release: 0.5.3
+
+## Highlights
+
+0.5.4 is a small maintenance release focused on admin UI consistency and a Keycloak fix. Native agent and team `<select>` controls are replaced with the shared searchable picker components, and the Slack and Webex admin panels are consolidated into a single `ConnectorAdminPanel`, so connector management looks and behaves the same everywhere. Team cards now surface knowledge-base, agent, and tool counts at a glance, the team Knowledge tab's create links point at the correct `/knowledge-bases` route, and Keycloak renders the configured realm name instead of assuming `caipe`. There are no `values.yaml` changes — this is a drop-in upgrade from 0.5.3.
+
+<!-- truncate -->
+
+## What's New
+
+### Admin UI
+- **Shared pickers and connector panels** — native agent/team `<select>` elements are replaced with the shared searchable picker components, and the Slack (`SlackChannelRebacPanel`) and Webex (`WebexSpaceRebacPanel`) admin panels are DRYed up into one shared `ConnectorAdminPanel`, giving both connectors identical ReBAC management UX ([#1632](https://github.com/cnoe-io/ai-platform-engineering/pull/1632))
+- **Team card resource counts** — team cards now show knowledge-base, agent, and tool counts so admins can see a team's footprint without opening it ([#1643](https://github.com/cnoe-io/ai-platform-engineering/pull/1643))
+
+## Bug Fixes
+
+- **admin**: point the team Knowledge tab create links at `/knowledge-bases` instead of a stale route ([#1643](https://github.com/cnoe-io/ai-platform-engineering/pull/1643))
+- **keycloak**: render the configured realm name instead of the hardcoded `caipe` default ([#1657](https://github.com/cnoe-io/ai-platform-engineering/pull/1657))
+- **compose**: remove a duplicate `volumes` key in the `openfga-init` service that broke `docker compose` parsing ([#1638](https://github.com/cnoe-io/ai-platform-engineering/pull/1638))
+
+## Security
+
+No security-specific changes in this release.
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.3.
+
+## Known Issues
+
+None known at this time.
+
+## Upgrade
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.4 \
+  -f your-values.yaml
+```
+
+---
+
+## Upgrade Guide: 0.5.3 → 0.5.4
+
+## Overview
+
+0.5.4 is a drop-in upgrade — no `values.yaml` edits are required. The release is limited to UI refactors, two admin fixes, a Keycloak realm-name fix, and a Docker Compose parsing fix. There are no chart value changes.
+
+## Helm Values Changes
+
+No Helm values changes between 0.5.3 and 0.5.4. The `helm show values` output is byte-for-byte identical.
+
+## Data Migrations
+
+No MongoDB schema or data migrations are required.
+
+## Upgrade Runbook
+
+### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.4 \
+  -f your-values.yaml
+```
+
+### 2. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If you run Keycloak under a non-`caipe` realm name, confirm the admin UI and bot integrations now reflect the configured realm.
+
+## Full Values Diff
+
+No Helm values changes between 0.5.3 and 0.5.4 — drop-in upgrade.


### PR DESCRIPTION
## Summary

Adds the combined release blog posts (release notes + inline upgrade guide) for the two releases tagged on 2026-05-29. These show up on the [Releases blog](https://cnoe-io.github.io/ai-platform-engineering/blog/releases), which currently stops at 0.5.2.

- **`docs/releases/2026-05-29-release-0-5-3.md`** — *CRD-Free Gateway and Release-Name Defaults*
  - Headline: `global.agentgateway.routingMode` defaults to `static`, so enabling AgentGateway no longer requires Gateway API / AgentGateway CRDs or a controller ([#1629](https://github.com/cnoe-io/ai-platform-engineering/pull/1629)) — documented as a **breaking change** with the `gateway-api` opt-back.
  - Release-name-computed service URL defaults replace hardcoded `ai-platform-engineering-*` URLs ([#1612](https://github.com/cnoe-io/ai-platform-engineering/pull/1612)).
  - Stricter agent health-probe semantics ([#1468](https://github.com/cnoe-io/ai-platform-engineering/pull/1468)) and a Twisted DNS-compression DoS fix.
  - Upgrade guide covers the routingMode default flip, the changed URL defaults, and includes a trimmed values diff.

- **`docs/releases/2026-05-29-release-0-5-4.md`** — *Admin UI Polish and Keycloak Realm Fix*
  - Shared picker components + `ConnectorAdminPanel` ([#1632](https://github.com/cnoe-io/ai-platform-engineering/pull/1632)), team-card resource counts + KB tab link ([#1643](https://github.com/cnoe-io/ai-platform-engineering/pull/1643)), Keycloak realm-name fix ([#1657](https://github.com/cnoe-io/ai-platform-engineering/pull/1657)), Compose `openfga-init` fix ([#1638](https://github.com/cnoe-io/ai-platform-engineering/pull/1638)).
  - **Drop-in upgrade** — `helm show values` is byte-for-byte identical between 0.5.3 and 0.5.4.

## Notes

- Values diffs were taken from `helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering` at each version.
- Posts follow the existing house style (frontmatter, `<!-- truncate -->`, inline upgrade guide).

## Test plan

- [ ] `cd docs && npm run build` passes (MDX/Docusaurus blog build).
- [ ] Both posts render on `/blog/releases` with correct ordering and truncated excerpts.
- [ ] Upgrade-guide values diffs match `helm show values` for the respective versions.
