### PR TITLE
feat(setup): shared Postgres for Keycloak/OpenFGA + opt-in unified LiteLLM front

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
@@ -57,6 +57,13 @@ spec:
               value: "true"
             - name: KC_METRICS_ENABLED
               value: "true"
+            {{- if .Values.db.passwordSecret.name }}
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.passwordSecret.name | quote }}
+                  key: {{ .Values.db.passwordSecret.key | quote }}
+            {{- end }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -326,12 +326,21 @@ ingress:
 persistence:
   enabled: false
 
+# ---------- Database ----------
+# Non-secret DB connection settings (engine, JDBC URL, username) are supplied
+# via the `env` map below (KC_DB / KC_DB_URL / KC_DB_USERNAME). The DB password
+# is injected from an existing Secret so it never lands in values/release data.
+db:
+  passwordSecret:
+    name: ""
+    key: KC_DB_PASSWORD
+
 # ---------- Extra env vars ----------
 env: {}
   # KC_DB: postgres
   # KC_DB_URL: "jdbc:postgresql://postgres:5432/keycloak"
   # KC_DB_USERNAME: keycloak
-  # KC_DB_PASSWORD: changeme
+  # (KC_DB_PASSWORD comes from db.passwordSecret above, not here)
 
 # ---------- Login theme ----------
 theme:

--- a/docs/docs/getting-started/kind/setup.md
+++ b/docs/docs/getting-started/kind/setup.md
@@ -118,6 +118,9 @@ Credentials are read from `~/.config/claude.txt` and `~/.config/openai.txt` when
 | `--rag` | Deploy the RAG stack (knowledge base, embeddings) |
 | `--graph-rag` | Deploy Graph RAG (Neo4j + ontology agent; implies `--rag`) |
 | `--tracing` | Deploy Langfuse and enable tracing |
+| `--no-shared-postgres` | Skip the shared Postgres; use Keycloak embedded H2 + OpenFGA in-memory (ephemeral — RBAC state is lost on every pod restart). Persistent Postgres is the default for RBAC installs. |
+| `--litellm` | Route chat (and OpenAI/Azure embeddings) through an in-cluster LiteLLM proxy so agents use one OpenAI-compatible endpoint and upstream provider keys stay in the proxy. Supports anthropic/openai/aws-bedrock/azure-openai. |
+| `--litellm-db` | Like `--litellm`, plus persist LiteLLM virtual keys/spend in the shared Postgres |
 | `--ingest-url=URL` | Ingest a URL into the RAG knowledge base (implies `--rag`; repeatable) |
 | `--auto-heal` | Enable auto-heal loop (every 30s) |
 | `--yes`, `-y` | Auto-confirm cleanup prompts |

--- a/docs/docs/security/rbac/architecture.md
+++ b/docs/docs/security/rbac/architecture.md
@@ -20,6 +20,13 @@ The `0.5.0` umbrella chart can own the RBAC runtime stack for demo and managed e
 
 Production installs must still supply ExternalSecrets and persistent datastore settings; the chart defaults are conservative and disabled by default.
 
+**Persistent RBAC datastores.** By default the Keycloak subchart uses an embedded H2 database and OpenFGA uses an in-memory store — both lose **all identity, realm, and authorization state on pod restart**, which makes RBAC unusable for anything beyond a throwaway demo. To persist RBAC state, point both at PostgreSQL:
+
+- **Keycloak** reads non-secret connection settings from `keycloak.env` (`KC_DB=postgres`, `KC_DB_URL`, `KC_DB_USERNAME`) and the DB password from a Secret via `keycloak.db.passwordSecret.name`/`.key` (rendered as a `secretKeyRef` on `KC_DB_PASSWORD`, so the password never lands in values or release data). With `KC_DB` set, the per-pod `persistence` PVC is unnecessary.
+- **OpenFGA** uses `openfga.datastore.engine=postgres` with `openfga.datastore.uriSecretRef.name`/`.key` supplying the `postgres://…` connection string to both the deployment and the `migrate` Job.
+
+`setup-caipe.sh` wires this automatically: it deploys a single shared `bitnami/postgresql` instance (`caipe-postgres`) with one role+database per consumer (`keycloak`, `openfga`, optional `litellm`), persists generated passwords in the `caipe-postgres-credentials` Secret, and emits the consumer-facing `caipe-keycloak-db` / `caipe-openfga-db` Secrets. This is the default for RBAC installs; `--no-shared-postgres` falls back to the ephemeral H2/in-memory stores.
+
 ---
 
 ## Component 1: Keycloak — HR & The Front Desk

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -93,6 +93,16 @@ LITELLM_DB_PASSWORD=""
 LLM_VIA_LITELLM="${LLM_VIA_LITELLM:-false}"
 # Persist LiteLLM virtual keys / spend tracking in the shared Postgres (opt-in).
 ENABLE_LITELLM_DB="${ENABLE_LITELLM_DB:-false}"
+# Captured at finalize time so the proxy's model_list can be built from the real
+# provider while agents/RAG are repointed at the proxy (the working
+# LLM_PROVIDER/EMBEDDINGS_PROVIDER get rewritten to openai/litellm).
+LITELLM_CHAT_SOURCE=""
+LITELLM_EMBED_SOURCE=""
+LITELLM_EMBED_MODEL_REAL=""
+LITELLM_ROUTE_EMBEDDINGS=false
+# Downstream key agents/RAG present to the proxy. The proxy is in-cluster and not
+# internet-exposed; this is a routing token, not an upstream provider secret.
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-caipe-litellm}"
 VLLM_MODEL="${VLLM_MODEL:-openai/gpt-oss-20b}"
 VLLM_GPU_COUNT="${VLLM_GPU_COUNT:-1}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-llama2}"
@@ -2984,7 +2994,23 @@ create_namespace_and_secrets() {
     fi
   fi
 
-  local secret_args=(
+  local secret_args=()
+
+  if $LLM_VIA_LITELLM; then
+    # Unified mode: agents talk to the in-cluster LiteLLM proxy as plain OpenAI.
+    # The real upstream provider credentials live only in litellm-upstream-secret
+    # (created by deploy_litellm), never in this agent-facing secret. The chat
+    # alias "caipe-chat" is resolved by the proxy's model_list to the real model.
+    local _lep="http://litellm-proxy.caipe.svc.cluster.local:4000/v1"
+    secret_args+=(
+      --from-literal=LLM_PROVIDER="openai"
+      --from-literal=OPENAI_API_KEY="${LITELLM_MASTER_KEY}"
+      --from-literal=OPENAI_ENDPOINT="${_lep}"
+      --from-literal=OPENAI_BASE_URL="${_lep}"
+      --from-literal=OPENAI_MODEL_NAME="caipe-chat"
+    )
+  else
+  secret_args+=(
     --from-literal=LLM_PROVIDER="$LLM_PROVIDER"
   )
 
@@ -3023,6 +3049,7 @@ create_namespace_and_secrets() {
       )
       ;;
   esac
+  fi
 
   # When using non-OpenAI LLM with OpenAI embeddings for RAG, the RAG server
   # needs OPENAI_API_KEY in the same secret.
@@ -4445,10 +4472,176 @@ deploy_vllm() {
   log "vLLM API will be available at http://vllm-router.caipe.svc.cluster.local:80/v1"
 }
 
+# Resolve unified --litellm mode once, after credential collection. Validates
+# the provider is supported, captures the *real* chat/embeddings providers (so
+# deploy_litellm can build the proxy model_list), then rewrites the working
+# LLM_PROVIDER/EMBEDDINGS_PROVIDER so agents (via llm-secret) and RAG (via helm)
+# are repointed at the in-cluster proxy. Self-disables (warn) on unsupported
+# combos so a bare --litellm never breaks an otherwise-valid install.
+_finalize_litellm_mode() {
+  $LLM_VIA_LITELLM || return 0
+  if $ENABLE_VLLM || $ENABLE_OLLAMA; then
+    warn "--litellm ignored: vLLM/Ollama mode already routes through LiteLLM"
+    LLM_VIA_LITELLM=false
+    return 0
+  fi
+  case "$LLM_PROVIDER" in
+    anthropic-claude|openai|aws-bedrock|azure-openai) ;;
+    *)
+      warn "--litellm does not support LLM provider '${LLM_PROVIDER}' yet — continuing without the proxy"
+      LLM_VIA_LITELLM=false
+      return 0
+      ;;
+  esac
+
+  LITELLM_CHAT_SOURCE="$LLM_PROVIDER"
+  LITELLM_EMBED_SOURCE="$EMBEDDINGS_PROVIDER"
+  LITELLM_EMBED_MODEL_REAL="$EMBEDDINGS_MODEL"
+  LITELLM_ENDPOINT="http://litellm-proxy.caipe.svc.cluster.local:4000/v1"
+  LITELLM_API_KEY="$LITELLM_MASTER_KEY"
+
+  # Only OpenAI-compatible embeddings can be fronted by the proxy; other
+  # embeddings providers (bedrock/cohere/huggingface/voyage) keep their native
+  # path so RAG still works.
+  case "$EMBEDDINGS_PROVIDER" in
+    openai|azure-openai)
+      LITELLM_ROUTE_EMBEDDINGS=true
+      EMBEDDINGS_PROVIDER="litellm"
+      EMBEDDINGS_MODEL="caipe-embeddings"
+      ;;
+    *)
+      LITELLM_ROUTE_EMBEDDINGS=false
+      ;;
+  esac
+
+  log "Unified LiteLLM mode ON — chat=${LITELLM_CHAT_SOURCE}, embeddings source=${LITELLM_EMBED_SOURCE} (routed via proxy: ${LITELLM_ROUTE_EMBEDDINGS})"
+}
+
+# Build the proxy model_list for unified mode from the captured real provider and
+# (re)create litellm-upstream-secret with the upstream provider credentials the
+# proxy reads via os.environ/*. Echoes the model_list YAML (6-space indented,
+# ready to drop under `model_list:`) to stdout; creates the Secret as a side
+# effect. Credentials live only in this Secret + the proxy pod — never in the
+# agent-facing llm-secret.
+_litellm_unified_assets() {
+  local up_args=(--from-literal=LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY}")
+  local ml=""
+
+  case "$LITELLM_CHAT_SOURCE" in
+    anthropic-claude)
+      ml+='      - model_name: "caipe-chat"
+        litellm_params:
+          model: "anthropic/'"${ANTHROPIC_MODEL_NAME}"'"
+          api_key: "os.environ/ANTHROPIC_API_KEY"
+'
+      up_args+=(--from-literal=ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}")
+      ;;
+    openai)
+      ml+='      - model_name: "caipe-chat"
+        litellm_params:
+          model: "openai/'"${OPENAI_MODEL_NAME}"'"
+          api_key: "os.environ/LITELLM_UPSTREAM_OPENAI_API_KEY"
+          api_base: "os.environ/LITELLM_UPSTREAM_OPENAI_BASE"
+'
+      up_args+=(--from-literal=LITELLM_UPSTREAM_OPENAI_API_KEY="${OPENAI_API_KEY}")
+      up_args+=(--from-literal=LITELLM_UPSTREAM_OPENAI_BASE="${OPENAI_ENDPOINT}")
+      ;;
+    aws-bedrock)
+      ml+='      - model_name: "caipe-chat"
+        litellm_params:
+          model: "bedrock/'"${AWS_BEDROCK_MODEL_ID}"'"
+          aws_access_key_id: "os.environ/AWS_ACCESS_KEY_ID"
+          aws_secret_access_key: "os.environ/AWS_SECRET_ACCESS_KEY"
+          aws_region_name: "os.environ/AWS_REGION"
+'
+      up_args+=(--from-literal=AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}")
+      up_args+=(--from-literal=AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}")
+      up_args+=(--from-literal=AWS_REGION="${AWS_REGION:-us-east-1}")
+      ;;
+    azure-openai)
+      ml+='      - model_name: "caipe-chat"
+        litellm_params:
+          model: "azure/'"${AZURE_OPENAI_DEPLOYMENT}"'"
+          api_base: "os.environ/AZURE_OPENAI_ENDPOINT"
+          api_key: "os.environ/AZURE_OPENAI_API_KEY"
+          api_version: "os.environ/AZURE_OPENAI_API_VERSION"
+'
+      up_args+=(--from-literal=AZURE_OPENAI_ENDPOINT="${AZURE_OPENAI_ENDPOINT}")
+      up_args+=(--from-literal=AZURE_OPENAI_API_KEY="${AZURE_OPENAI_API_KEY}")
+      up_args+=(--from-literal=AZURE_OPENAI_API_VERSION="${AZURE_OPENAI_API_VERSION:-2025-04-01-preview}")
+      ;;
+  esac
+
+  if $LITELLM_ROUTE_EMBEDDINGS; then
+    case "$LITELLM_EMBED_SOURCE" in
+      openai)
+        ml+='      - model_name: "caipe-embeddings"
+        litellm_params:
+          model: "openai/'"${LITELLM_EMBED_MODEL_REAL:-text-embedding-3-large}"'"
+          api_key: "os.environ/LITELLM_UPSTREAM_EMBED_OPENAI_API_KEY"
+'
+        up_args+=(--from-literal=LITELLM_UPSTREAM_EMBED_OPENAI_API_KEY="${OPENAI_API_KEY}")
+        ;;
+      azure-openai)
+        ml+='      - model_name: "caipe-embeddings"
+        litellm_params:
+          model: "azure/'"${AZURE_OPENAI_DEPLOYMENT}"'"
+          api_base: "os.environ/AZURE_OPENAI_ENDPOINT"
+          api_key: "os.environ/AZURE_OPENAI_API_KEY"
+          api_version: "os.environ/AZURE_OPENAI_API_VERSION"
+'
+        # Azure creds already added by the chat case above when chat is azure;
+        # add them here too for the chat!=azure combination (kubectl de-dupes
+        # only fails on duplicate keys, so guard with the chat source).
+        if [[ "$LITELLM_CHAT_SOURCE" != "azure-openai" ]]; then
+          up_args+=(--from-literal=AZURE_OPENAI_ENDPOINT="${AZURE_OPENAI_ENDPOINT}")
+          up_args+=(--from-literal=AZURE_OPENAI_API_KEY="${AZURE_OPENAI_API_KEY}")
+          up_args+=(--from-literal=AZURE_OPENAI_API_VERSION="${AZURE_OPENAI_API_VERSION:-2025-04-01-preview}")
+        fi
+        ;;
+    esac
+  fi
+
+  kubectl create secret generic litellm-upstream-secret -n caipe \
+    "${up_args[@]}" \
+    --dry-run=client -o yaml | kubectl apply -f - &>/dev/null
+
+  printf '%s' "$ml"
+}
+
 deploy_litellm() {
   step "Deploying LiteLLM Proxy"
 
-  local vllm_api_base="http://vllm-router.caipe.svc.cluster.local:80/v1"
+  local model_list_yaml="" envfrom_yaml="" general_yaml=""
+
+  if $LLM_VIA_LITELLM && ! $ENABLE_VLLM; then
+    # Unified mode: front the real provider, require the routing master key, and
+    # read upstream creds from litellm-upstream-secret (+ optional DB).
+    model_list_yaml="$(_litellm_unified_assets)"
+    general_yaml='    general_settings:
+      master_key: "os.environ/LITELLM_MASTER_KEY"'
+    envfrom_yaml='        envFrom:
+        - secretRef:
+            name: litellm-upstream-secret'
+    if $ENABLE_LITELLM_DB; then
+      envfrom_yaml+='
+        - secretRef:
+            name: caipe-litellm-db'
+    fi
+  else
+    # vLLM mode: proxy the in-cluster vLLM router as an OpenAI-compatible model.
+    local vllm_api_base="http://vllm-router.caipe.svc.cluster.local:80/v1"
+    model_list_yaml="      - model_name: \"${LITELLM_MODEL_NAME}\"
+        litellm_params:
+          model: \"openai/${VLLM_MODEL}\"
+          api_base: \"${vllm_api_base}\"
+          api_key: \"not-needed\"
+      - model_name: \"text-embedding-3-small\"
+        litellm_params:
+          model: \"openai/text-embedding-3-small\"
+          api_base: \"${vllm_api_base}\"
+          api_key: \"not-needed\""
+  fi
 
   kubectl apply -n caipe -f - <<LITELLM_EOF
 ---
@@ -4463,16 +4656,8 @@ metadata:
 data:
   config.yaml: |
     model_list:
-      - model_name: "${LITELLM_MODEL_NAME}"
-        litellm_params:
-          model: "openai/${VLLM_MODEL}"
-          api_base: "${vllm_api_base}"
-          api_key: "not-needed"
-      - model_name: "text-embedding-3-small"
-        litellm_params:
-          model: "openai/text-embedding-3-small"
-          api_base: "${vllm_api_base}"
-          api_key: "not-needed"
+${model_list_yaml}
+${general_yaml}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -4496,19 +4681,20 @@ spec:
       - name: litellm
         image: ghcr.io/berriai/litellm:main-stable
         args: ["--config", "/app/config.yaml", "--port", "4000"]
+${envfrom_yaml}
         ports:
         - containerPort: 4000
           name: http
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /health
+            path: /health/liveliness
             port: 4000
           initialDelaySeconds: 15
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /health
+            path: /health/readiness
             port: 4000
           initialDelaySeconds: 10
           periodSeconds: 5
@@ -4548,6 +4734,7 @@ spec:
     app: litellm-proxy
 LITELLM_EOF
 
+  kubectl rollout restart deployment/litellm-proxy -n caipe &>/dev/null || true
   log "LiteLLM proxy deployed (endpoint: http://litellm-proxy.caipe.svc.cluster.local:4000)"
 }
 
@@ -6765,6 +6952,12 @@ BANNER
       *) exit 1 ;;
     esac
   done
+
+  # Resolve unified LiteLLM mode before secrets/helm so the agent llm-secret and
+  # RAG embeddings config are repointed at the proxy (must run after
+  # collect_credentials, before create_namespace_and_secrets/provision_secrets).
+  _finalize_litellm_mode
+
   create_namespace_and_secrets
 
   # Shared Postgres must exist before the CAIPE Helm deploy: OpenFGA's migrate
@@ -6783,9 +6976,13 @@ BANNER
     prepare_corporate_ca
   fi
 
-  # Deploy vLLM + LiteLLM before CAIPE so the endpoints are available
+  # Deploy vLLM + LiteLLM before CAIPE so the endpoints are available.
+  # Unified --litellm mode (no vLLM) deploys just the proxy after the shared
+  # Postgres so the optional caipe-litellm-db secret exists when --litellm-db.
   if $ENABLE_VLLM; then
     deploy_vllm
+    deploy_litellm
+  elif $LLM_VIA_LITELLM; then
     deploy_litellm
   fi
 
@@ -6857,6 +7054,10 @@ Options:
   --no-rbac-runtime  Skip the RBAC runtime services
   --shared-postgres     Deploy one shared Postgres backing Keycloak + OpenFGA (persistent RBAC) — default ON
   --no-shared-postgres  Use Keycloak embedded H2 + OpenFGA in-memory (ephemeral; state lost on restart)
+  --litellm             Route chat (+ OpenAI/Azure embeddings) through an in-cluster LiteLLM proxy.
+                        Agents talk to one OpenAI-compatible endpoint; upstream provider creds live
+                        only in the proxy. Supports anthropic/openai/aws-bedrock/azure-openai. Default OFF.
+  --litellm-db          Like --litellm, plus persist LiteLLM virtual keys/spend in the shared Postgres
   --persistence      Enable Redis persistence for checkpoints and cross-thread memory — default ON
                      (deploys langgraph-redis subchart; enables fact extraction)
   --no-persistence   Skip Redis persistence (in-memory checkpointer only)
@@ -7004,6 +7205,9 @@ for arg in "$@"; do
     --no-rbac-runtime) ENABLE_RBAC_RUNTIME=false ;;
     --shared-postgres)    ENABLE_SHARED_POSTGRES=true ;;
     --no-shared-postgres) ENABLE_SHARED_POSTGRES=false ;;
+    --litellm)            LLM_VIA_LITELLM=true ;;
+    --no-litellm)         LLM_VIA_LITELLM=false ;;
+    --litellm-db)         LLM_VIA_LITELLM=true; ENABLE_LITELLM_DB=true ;;
     --persistence)     ENABLE_PERSISTENCE=true ;;
     --no-persistence)  ENABLE_PERSISTENCE=false ;;
     --metallb)         ENABLE_METALLB=true ;;

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -76,6 +76,23 @@ ENABLE_AGENTGATEWAY="${ENABLE_AGENTGATEWAY:-true}"
 # ENABLE_AGENTGATEWAY=true. Set ENABLE_RBAC_RUNTIME=false or pass
 # --no-rbac-runtime to skip.
 ENABLE_RBAC_RUNTIME="${ENABLE_RBAC_RUNTIME:-true}"
+# Shared Postgres: default ON. Deploys a single bitnami/postgresql instance that
+# backs Keycloak and OpenFGA (and optionally LiteLLM) with persistent databases,
+# replacing Keycloak's embedded H2 and OpenFGA's in-memory store (both of which
+# lose all state on pod restart). Only deployed when something actually needs it
+# (RBAC runtime, or --litellm-db). Set ENABLE_SHARED_POSTGRES=false or pass
+# --no-shared-postgres to fall back to the old ephemeral H2/in-memory stores.
+ENABLE_SHARED_POSTGRES="${ENABLE_SHARED_POSTGRES:-true}"
+SHARED_PG_SERVICE="caipe-postgres"
+SHARED_PG_ADMIN_PASSWORD=""
+KEYCLOAK_DB_PASSWORD=""
+OPENFGA_DB_PASSWORD=""
+LITELLM_DB_PASSWORD=""
+# LiteLLM unified front: route all chat + embeddings credentials through a single
+# in-cluster LiteLLM proxy (OpenAI-compatible). Set via --litellm.
+LLM_VIA_LITELLM="${LLM_VIA_LITELLM:-false}"
+# Persist LiteLLM virtual keys / spend tracking in the shared Postgres (opt-in).
+ENABLE_LITELLM_DB="${ENABLE_LITELLM_DB:-false}"
 VLLM_MODEL="${VLLM_MODEL:-openai/gpt-oss-20b}"
 VLLM_GPU_COUNT="${VLLM_GPU_COUNT:-1}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-llama2}"
@@ -3946,6 +3963,129 @@ _patch_rag_server_envfrom() {
 #
 # Mirrors the Langfuse `existing_pw` pattern already in this script
 # (see lines ~2671-2685). assisted-by Claude:claude-opus-4-7
+# True when a shared Postgres should be deployed: opt-in via ENABLE_SHARED_POSTGRES
+# AND at least one consumer that needs persistence (RBAC runtime or LiteLLM DB).
+_shared_postgres_active() {
+  $ENABLE_SHARED_POSTGRES || return 1
+  $ENABLE_RBAC_RUNTIME && return 0
+  $ENABLE_LITELLM_DB && return 0
+  return 1
+}
+
+# Resolve (reuse-or-generate) the admin + per-consumer Postgres passwords and
+# persist them in the caipe-postgres-credentials Secret so re-runs are stable.
+# Hex passwords avoid any URL-encoding pitfalls inside connection strings.
+_resolve_shared_postgres_passwords() {
+  local secret_json
+  secret_json=$(kubectl get secret caipe-postgres-credentials -n caipe -o json 2>/dev/null || true)
+  _pg_field() {
+    local key="$1"
+    [[ -n "$secret_json" ]] || return 0
+    echo "$secret_json" | python3 -c "
+import sys, json, base64
+try:
+    d = json.load(sys.stdin).get('data', {})
+    v = d.get('$key')
+    print(base64.b64decode(v).decode() if v else '')
+except Exception:
+    print('')
+" 2>/dev/null || true
+  }
+
+  SHARED_PG_ADMIN_PASSWORD="$(_pg_field POSTGRES_ADMIN_PASSWORD)"
+  KEYCLOAK_DB_PASSWORD="$(_pg_field KEYCLOAK_DB_PASSWORD)"
+  OPENFGA_DB_PASSWORD="$(_pg_field OPENFGA_DB_PASSWORD)"
+  LITELLM_DB_PASSWORD="$(_pg_field LITELLM_DB_PASSWORD)"
+
+  [[ -n "$SHARED_PG_ADMIN_PASSWORD" ]] || SHARED_PG_ADMIN_PASSWORD="$(openssl rand -hex 24)"
+  [[ -n "$KEYCLOAK_DB_PASSWORD" ]] || KEYCLOAK_DB_PASSWORD="$(openssl rand -hex 24)"
+  [[ -n "$OPENFGA_DB_PASSWORD" ]] || OPENFGA_DB_PASSWORD="$(openssl rand -hex 24)"
+  [[ -n "$LITELLM_DB_PASSWORD" ]] || LITELLM_DB_PASSWORD="$(openssl rand -hex 24)"
+
+  if [[ -n "$secret_json" ]]; then
+    log "Reusing existing Postgres passwords from caipe-postgres-credentials Secret"
+  else
+    log "Generated random Postgres passwords (admin + keycloak/openfga/litellm roles)"
+  fi
+
+  kubectl create secret generic caipe-postgres-credentials \
+    --namespace caipe \
+    --from-literal=POSTGRES_ADMIN_PASSWORD="${SHARED_PG_ADMIN_PASSWORD}" \
+    --from-literal=KEYCLOAK_DB_PASSWORD="${KEYCLOAK_DB_PASSWORD}" \
+    --from-literal=OPENFGA_DB_PASSWORD="${OPENFGA_DB_PASSWORD}" \
+    --from-literal=LITELLM_DB_PASSWORD="${LITELLM_DB_PASSWORD}" \
+    --dry-run=client -o yaml \
+    | kubectl apply -f - &>/dev/null
+}
+
+# Deploy a single shared bitnami/postgresql instance that backs Keycloak,
+# OpenFGA, and (optionally) LiteLLM. Per-consumer roles + databases are created
+# via an initdb script (runs once on an empty data dir). Consumer-facing secrets
+# (caipe-keycloak-db / caipe-openfga-db / caipe-litellm-db) carry exactly the
+# password or connection-string shape each chart expects.
+deploy_shared_postgres() {
+  _resolve_shared_postgres_passwords
+
+  # Consumer-facing secrets (created/refreshed every run so wiring stays correct
+  # even if the chart values change between runs).
+  kubectl create secret generic caipe-keycloak-db \
+    --namespace caipe \
+    --from-literal=KC_DB_PASSWORD="${KEYCLOAK_DB_PASSWORD}" \
+    --dry-run=client -o yaml | kubectl apply -f - &>/dev/null
+
+  local openfga_uri="postgres://openfga:${OPENFGA_DB_PASSWORD}@${SHARED_PG_SERVICE}:5432/openfga?sslmode=disable"
+  kubectl create secret generic caipe-openfga-db \
+    --namespace caipe \
+    --from-literal=OPENFGA_DATASTORE_URI="${openfga_uri}" \
+    --dry-run=client -o yaml | kubectl apply -f - &>/dev/null
+
+  if $ENABLE_LITELLM_DB; then
+    local litellm_uri="postgresql://litellm:${LITELLM_DB_PASSWORD}@${SHARED_PG_SERVICE}:5432/litellm"
+    kubectl create secret generic caipe-litellm-db \
+      --namespace caipe \
+      --from-literal=DATABASE_URL="${litellm_uri}" \
+      --dry-run=client -o yaml | kubectl apply -f - &>/dev/null
+  fi
+
+  if kubectl get statefulset "${SHARED_PG_SERVICE}" -n caipe &>/dev/null; then
+    log "Shared Postgres already present (${SHARED_PG_SERVICE}) — skipping install"
+    return 0
+  fi
+
+  step "Deploying shared Postgres (${SHARED_PG_SERVICE}) for Keycloak/OpenFGA"
+
+  # initdb bootstrap: create a login role + owned database per consumer. Only
+  # runs when the PVC is empty (first install); harmless to define on re-runs.
+  local initdb_file
+  initdb_file=$(mktemp /tmp/caipe-pg-initdb-XXXXXX.sql)
+  cat > "$initdb_file" <<PGINIT
+CREATE ROLE keycloak WITH LOGIN PASSWORD '${KEYCLOAK_DB_PASSWORD}';
+CREATE DATABASE keycloak OWNER keycloak;
+CREATE ROLE openfga WITH LOGIN PASSWORD '${OPENFGA_DB_PASSWORD}';
+CREATE DATABASE openfga OWNER openfga;
+PGINIT
+  if $ENABLE_LITELLM_DB; then
+    cat >> "$initdb_file" <<PGINIT
+CREATE ROLE litellm WITH LOGIN PASSWORD '${LITELLM_DB_PASSWORD}';
+CREATE DATABASE litellm OWNER litellm;
+PGINIT
+  fi
+
+  helm repo add bitnami https://charts.bitnami.com/bitnami &>/dev/null 2>&1 || true
+  helm upgrade --install "${SHARED_PG_SERVICE}" bitnami/postgresql \
+    -n caipe \
+    --set "fullnameOverride=${SHARED_PG_SERVICE}" \
+    --set architecture=standalone \
+    --set "auth.postgresPassword=${SHARED_PG_ADMIN_PASSWORD}" \
+    --set primary.persistence.size=4Gi \
+    --set-file "primary.initdb.scripts.caipe-init\.sql=${initdb_file}" \
+    --timeout 5m &>/dev/null
+  rm -f "$initdb_file"
+
+  kubectl rollout status statefulset/"${SHARED_PG_SERVICE}" -n caipe --timeout=300s &>/dev/null
+  log "Shared Postgres deployed (${SHARED_PG_SERVICE}) with keycloak/openfga databases"
+}
+
 _resolve_mongodb_password() {
   local existing_pw
   existing_pw=$(kubectl get secret caipe-mongodb-credentials -n caipe \
@@ -4420,6 +4560,35 @@ _write_rbac_runtime_values() {
     keycloak_ssl_required="none"
   fi
 
+  # When the shared Postgres is active, point Keycloak (KC_DB_*) and OpenFGA
+  # (datastore.engine=postgres) at it so RBAC state survives pod restarts.
+  # The DB password is injected from the caipe-keycloak-db Secret via the
+  # chart's db.passwordSecret hook (never written into this values file).
+  local kc_db_block="" fga_ds_block=""
+  if _shared_postgres_active; then
+    kc_db_block=$(cat <<KCDB
+  persistence:
+    enabled: false
+  db:
+    passwordSecret:
+      name: "caipe-keycloak-db"
+      key: "KC_DB_PASSWORD"
+  env:
+    KC_DB: "postgres"
+    KC_DB_URL: "jdbc:postgresql://${SHARED_PG_SERVICE}:5432/keycloak"
+    KC_DB_USERNAME: "keycloak"
+KCDB
+)
+    fga_ds_block=$(cat <<FGADB
+  datastore:
+    engine: "postgres"
+    uriSecretRef:
+      name: "caipe-openfga-db"
+      key: "OPENFGA_DATASTORE_URI"
+FGADB
+)
+  fi
+
   cat > "$values_file" <<RBACEOF
 tags:
   keycloak: true
@@ -4440,9 +4609,11 @@ global:
 keycloak:
   realm:
     sslRequired: "${keycloak_ssl_required}"
+${kc_db_block}
 
 openfga:
   enabled: true
+${fga_ds_block}
   init:
     enabled: true
     storeName: "caipe-openfga"
@@ -6596,6 +6767,13 @@ BANNER
   done
   create_namespace_and_secrets
 
+  # Shared Postgres must exist before the CAIPE Helm deploy: OpenFGA's migrate
+  # job + deployment read the caipe-openfga-db Secret, and _write_rbac_runtime_values
+  # wires Keycloak's KC_DB_* env from the passwords resolved here.
+  if _shared_postgres_active; then
+    deploy_shared_postgres
+  fi
+
   if $ENABLE_TRACING; then
     deploy_langfuse
     create_langfuse_api_keys
@@ -6677,6 +6855,8 @@ Options:
   --rbac-runtime     Install in-chart RBAC runtime services: Keycloak, OpenFGA,
                      OpenFGA ext_authz bridge, and standalone AgentGateway — default ON
   --no-rbac-runtime  Skip the RBAC runtime services
+  --shared-postgres     Deploy one shared Postgres backing Keycloak + OpenFGA (persistent RBAC) — default ON
+  --no-shared-postgres  Use Keycloak embedded H2 + OpenFGA in-memory (ephemeral; state lost on restart)
   --persistence      Enable Redis persistence for checkpoints and cross-thread memory — default ON
                      (deploys langgraph-redis subchart; enables fact extraction)
   --no-persistence   Skip Redis persistence (in-memory checkpointer only)
@@ -6822,6 +7002,8 @@ for arg in "$@"; do
     --no-agentgateway) ENABLE_AGENTGATEWAY=false; ENABLE_RBAC_RUNTIME=false ;;
     --rbac-runtime)    ENABLE_RBAC_RUNTIME=true; ENABLE_AGENTGATEWAY=true ;;
     --no-rbac-runtime) ENABLE_RBAC_RUNTIME=false ;;
+    --shared-postgres)    ENABLE_SHARED_POSTGRES=true ;;
+    --no-shared-postgres) ENABLE_SHARED_POSTGRES=false ;;
     --persistence)     ENABLE_PERSISTENCE=true ;;
     --no-persistence)  ENABLE_PERSISTENCE=false ;;
     --metallb)         ENABLE_METALLB=true ;;


### PR DESCRIPTION
## Summary

Consolidates two previously-stacked PRs (#1662 + #1663) into a single branch/PR per request.

**1. Shared Postgres persistence for RBAC** (commit `c8e564bc4`)
- Deploys one `bitnami/postgresql` instance (`caipe-postgres`) with separate roles/DBs for `keycloak`, `openfga`, and optionally `litellm`.
- Passwords generated once and stored in `caipe-postgres-credentials`; per-consumer secrets (`caipe-keycloak-db`, `caipe-openfga-db`, `caipe-litellm-db`).
- Keycloak chart gains `db.passwordSecret` so `KC_DB_PASSWORD` is injected from a Secret (never in values/release data); OpenFGA uses `datastore.engine=postgres` + `uriSecretRef`.
- Replaces ephemeral H2 (Keycloak) and in-memory (OpenFGA) stores so RBAC state survives restarts.
- Flags: `--shared-postgres` (default on), `--no-shared-postgres`.

**2. Opt-in unified LiteLLM front for chat + embeddings** (commit `7e804cee3`)
- `--litellm` routes all chat + supported embeddings through an in-cluster LiteLLM proxy as a single OpenAI-compatible endpoint.
- LiteLLM `model_list` is built from the real provider creds, stored in `litellm-upstream-secret`; agents/RAG talk to the proxy with a master key.
- Self-disables on unsupported provider combos. `--litellm-db` persists LiteLLM spend/logs on the shared Postgres.
- Flags: `--litellm`, `--no-litellm`, `--litellm-db`.

Docs updated: `docs/docs/security/rbac/architecture.md`, `docs/docs/getting-started/kind/setup.md`.

## Test plan

- [ ] `bash -n setup-caipe.sh`
- [ ] `helm template` Keycloak chart with `db.passwordSecret` set renders valid `KC_DB_PASSWORD` env from secretKeyRef
- [ ] Fresh `./setup-caipe.sh` install: Keycloak + OpenFGA come up against shared Postgres; RBAC state survives a pod restart
- [ ] `./setup-caipe.sh --litellm`: agents + RAG reach the proxy; chat and embeddings both work
