### PR TITLE
fix(skill-builder): handle wrapped builtin-tools API response shape

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.3 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.4 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.3 -f your-values.yaml'}
+                  {'    --version 0.5.4 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.3 -f your-values.yaml'}
+              {'    --version 0.5.4 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.4"
+version = "0.5.4-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.6-dev.2"
+version = "0.5.6-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/skills/workspace/tabs/ToolsTab.tsx
+++ b/ui/src/components/skills/workspace/tabs/ToolsTab.tsx
@@ -89,7 +89,12 @@ function useBuiltinDefinitions(): {
         const res = await fetch("/api/dynamic-agents/builtin-tools");
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = await res.json();
-        if (!cancelled) setDefinitions(json.data || []);
+        // The endpoint returns { data: { tools: [...] } }, but accept a bare
+        // array at json.data too for forward/backward compatibility.
+        const tools = Array.isArray(json.data)
+          ? json.data
+          : (json.data?.tools ?? []);
+        if (!cancelled) setDefinitions(tools);
       } catch (err) {
         if (!cancelled) {
           setError(

--- a/ui/src/components/workflows/StepToolOverridePicker.tsx
+++ b/ui/src/components/workflows/StepToolOverridePicker.tsx
@@ -131,7 +131,11 @@ export function StepToolOverridePicker({
     fetch("/api/dynamic-agents/builtin-tools")
       .then((r) => r.ok ? r.json() : null)
       .then((json) => {
-        if (json?.data) setBuiltinDefs(json.data);
+        // Endpoint returns { data: { tools: [...] } }; accept a bare array too.
+        const tools = Array.isArray(json?.data)
+          ? json.data
+          : (json?.data?.tools ?? []);
+        setBuiltinDefs(tools);
       })
       .catch(() => {});
   }, []);

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.4"
+version = "0.5.4.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.6.dev2"
+version = "0.5.6.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Fixes #1633 — the Tools step of the Skill Builder wizard crashed with `Uncaught TypeError: i.map is not a function` and rendered a blank page.

The `/api/v1/builtin-tools` endpoint returns:

```json
{ "success": true, "data": { "tools": [...] } }
```

but `ToolsTab.tsx` and `StepToolOverridePicker.tsx` set their tool definitions to `json.data` — the wrapper object `{ tools: [...] }` — instead of the array. Subsequent `.map()` calls on a non-array object threw.

- `ToolsTab.tsx`: unwrap `data.tools`, still accepting a bare array at `data`.
- `StepToolOverridePicker.tsx`: same latent bug (sets `builtinDefs = json.data` then calls `builtinDefs.map(...)`), fixed the same way.

Both now mirror how `BuiltinToolsPicker` already tolerates either response shape. Backend response left unchanged (frontend fix is simpler and consistent with the existing picker).

## Test plan

- [ ] Navigate to Skill Builder → advance to the **Tools** step → page renders the built-in tools list instead of crashing
- [ ] Per-step tool override picker in workflows renders built-in tool labels correctly
- [ ] `npm run lint` passes (both files lint clean locally)

Made with [Cursor](https://cursor.com)