### PR TITLE
fix(rag): respect allow_non_public_urls in server-side URL validation

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/utils.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/utils.py
@@ -143,7 +143,7 @@ def is_publicly_routable_url(url: str) -> tuple[bool, str]:
   return is_publicly_routable_host(parsed.hostname or "")
 
 
-def sanitize_url(url: str) -> str:
+def sanitize_url(url: str, allow_non_public_urls: bool = False) -> str:
   url = url.strip()
   parsed = urlparse(url)  # Parse the URL
   if not parsed.scheme:  # Add default scheme if missing
@@ -152,10 +152,11 @@ def sanitize_url(url: str) -> str:
     raise ValueError(f"Invalid URL scheme. Only HTTP and HTTPS are supported, got: {parsed.scheme}")
   if not parsed.netloc:  # Validate that we have a netloc (domain)
     raise ValueError("Invalid URL: missing domain name")
-  hostname = parsed.hostname or ""
-  is_safe, reason = is_publicly_routable_host(hostname)
-  if not is_safe:
-    raise ValueError(f"Invalid URL: hostname '{hostname}' must resolve only to publicly routable IP addresses: {reason}")
+  if not allow_non_public_urls:
+    hostname = parsed.hostname or ""
+    is_safe, reason = is_publicly_routable_host(hostname)
+    if not is_safe:
+      raise ValueError(f"Invalid URL: hostname '{hostname}' must resolve only to publicly routable IP addresses: {reason}")
   url = parsed.geturl()  # Reconstruct the URL to ensure it's properly formatted
   return url
 

--- a/ai_platform_engineering/knowledge_bases/rag/common/tests/test_utils.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/tests/test_utils.py
@@ -72,3 +72,10 @@ def test_sanitize_url_rejects_unresolvable_hostname(monkeypatch):
 
   with pytest.raises(ValueError, match="could not be resolved"):
     sanitize_url("https://nonexistent.invalid/page")
+
+
+def test_sanitize_url_allows_private_when_flag_set(monkeypatch):
+  _patch_dns(monkeypatch, {"internal.example.com": ["10.1.2.3"]})
+
+  result = sanitize_url("https://internal.example.com/docs", allow_non_public_urls=True)
+  assert result == "https://internal.example.com/docs"

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -1034,7 +1034,7 @@ async def ingest_url(url_request: UrlIngestRequest, user: UserContext = Depends(
   logger.info(f"Received URL ingestion request: {url_request.url}")
 
   # Sanitize URL — skip public-routability check when operator has opted in
-  sanitized_url = sanitize_url(url_request.url, allow_non_public_urls=url_request.settings.allow_non_public_urls)
+  sanitized_url = sanitize_url(url_request.url, url_request.settings.allow_non_public_urls)
   url_request.url = sanitized_url
 
   # Generate datasource ID and create datasource

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -1033,8 +1033,8 @@ async def ingest_url(url_request: UrlIngestRequest, user: UserContext = Depends(
 
   logger.info(f"Received URL ingestion request: {url_request.url}")
 
-  # Sanitize URL
-  sanitized_url = sanitize_url(url_request.url)
+  # Sanitize URL — skip public-routability check when operator has opted in
+  sanitized_url = sanitize_url(url_request.url, allow_non_public_urls=url_request.settings.allow_non_public_urls)
   url_request.url = sanitized_url
 
   # Generate datasource ID and create datasource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.4.18+hotfix.4"
+version = "0.4.18+hotfix.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.4.18+hotfix.4"
+version = "0.4.18+hotfix.5"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Problem

When `allow_non_public_urls: true` is set in `ScrapySettings` for a web datasource, the ingestor scrapy layer correctly skips SSRF validation — but the server-side `ingest_url` endpoint calls `sanitize_url()` unconditionally before the request ever reaches the ingestor. `sanitize_url()` raises a `ValueError` (surfaced as HTTP 500) for any hostname that resolves to a private/internal IP, regardless of the flag.

This was introduced when SSRF protection was added to `sanitize_url()` — the `allow_non_public_urls` flag added in hotfix.2 was wired only into the ingestor scrapy layer, not into the server's validation gate.

## Fix

- Add `allow_non_public_urls: bool = False` parameter to `sanitize_url()` (default `False` preserves existing behavior for all callers)
- Pass `url_request.settings.allow_non_public_urls` at the call site in `ingest_url`
- Add a unit test covering the bypass path (`test_sanitize_url_allows_private_when_flag_set`)

## Testing

```
# Existing tests still pass (SSRF protection unchanged by default)
uv run pytest ai_platform_engineering/knowledge_bases/rag/common/tests/test_utils.py -v

# New test verifies the bypass
test_sanitize_url_allows_private_when_flag_set PASSED
```

[GAI]