### PR TITLE
fix: validate LiteLLM MCP runtime config

### DIFF
--- a/charts/ai-platform-engineering/templates/litellm-mcp-configmap.yaml
+++ b/charts/ai-platform-engineering/templates/litellm-mcp-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.litellmMcp.enabled }}
+{{- $config := .Values.litellmMcp.config | default dict }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +10,10 @@ data:
   MCP_MODE: "http"
   MCP_HOST: "0.0.0.0"
   MCP_PORT: {{ .Values.litellmMcp.service.port | quote }}
-  {{- range $key, $value := .Values.litellmMcp.config }}
+  LITELLM_API_URL: {{ (index $config "LITELLM_API_URL" | default "https://litellm.prod.outshift.ai") | quote }}
+  {{- range $key, $value := $config }}
+  {{- if ne $key "LITELLM_API_URL" }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/templates/litellm-mcp-required-values.yaml
+++ b/charts/ai-platform-engineering/templates/litellm-mcp-required-values.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.litellmMcp.enabled -}}
+{{- $secret := .Values.litellmMcp.secret | default dict -}}
+{{- $externalSecrets := .Values.litellmMcp.externalSecrets | default dict -}}
+{{- $secretData := $secret.data | default dict -}}
+{{- $externalData := $externalSecrets.data | default list -}}
+{{- $hasInlineToken := or (hasKey $secretData "LITELLM_API_KEY") (hasKey $secretData "LITELLM_TOKEN") (hasKey $secretData "LITELLM_API_TOKEN") -}}
+{{- $hasExternalToken := false -}}
+{{- range $item := $externalData -}}
+{{- if or (eq $item.secretKey "LITELLM_API_KEY") (eq $item.secretKey "LITELLM_TOKEN") (eq $item.secretKey "LITELLM_API_TOKEN") -}}
+{{- $hasExternalToken = true -}}
+{{- end -}}
+{{- end -}}
+{{- if and $secret.create (not $hasInlineToken) -}}
+{{- fail "litellmMcp.secret.data must contain LITELLM_API_KEY, LITELLM_TOKEN, or LITELLM_API_TOKEN when litellmMcp.secret.create=true" -}}
+{{- end -}}
+{{- if and $externalSecrets.enabled (not $hasExternalToken) -}}
+{{- fail "litellmMcp.externalSecrets.data must create LITELLM_API_KEY, LITELLM_TOKEN, or LITELLM_API_TOKEN when litellmMcp.externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- if not (or .Values.litellmMcp.existingSecret $secret.create $externalSecrets.enabled) -}}
+{{- fail "litellmMcp requires a LiteLLM API token source when enabled; set litellmMcp.existingSecret, litellmMcp.secret.create, or litellmMcp.externalSecrets.enabled" -}}
+{{- end -}}
+{{- end -}}

--- a/docs/docs/agents/litellm.md
+++ b/docs/docs/agents/litellm.md
@@ -50,7 +50,10 @@ caipe-ui:
 If the Helm release name is not `ai-platform-engineering`, update the endpoint
 host to match the rendered LiteLLM MCP Service name.
 
-The `litellm-mcp-secret` Secret must contain `LITELLM_API_KEY`.
+The `litellm-mcp-secret` Secret must contain `LITELLM_API_KEY`. When
+`litellmMcp.enabled=true`, the chart requires `existingSecret`,
+`secret.create`, or `externalSecrets.enabled` so the MCP server cannot start
+without a LiteLLM API token source.
 
 ## Prod Deployment
 
@@ -88,4 +91,5 @@ If the Helm release name is not `ai-platform-engineering`, update the endpoint
 host to match the rendered LiteLLM MCP Service name.
 
 Use External Secrets or the platform secret manager for `LITELLM_API_KEY` in
-shared environments.
+shared environments. If `litellmMcp.config.LITELLM_API_URL` is left empty, the
+chart renders `https://litellm.prod.outshift.ai`.

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.3 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.4 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.3 -f your-values.yaml'}
+                  {'    --version 0.5.4 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.3 -f your-values.yaml'}
+              {'    --version 0.5.4 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.4"
+version = "0.5.4-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.4"
+version = "0.5.4.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- render the prod LiteLLM API URL by default when `litellmMcp.config.LITELLM_API_URL` is left empty
- add Helm fail-fast validation so `litellmMcp.enabled=true` requires a LiteLLM API token source
- document the required token source and rendered URL default

## Why
The LiteLLM MCP server imports its LiteLLM client at startup and requires both `LITELLM_API_URL` and a token (`LITELLM_API_KEY`, `LITELLM_TOKEN`, or `LITELLM_API_TOKEN`). The chart previously allowed rendering a pod with a blank URL and no secret source, which leads to startup failures in Argo-managed environments.

## Validation
- `git diff --check`
- `helm template` against a temporary minimal chart covering the LiteLLM MCP templates:
  - existing secret renders a ConfigMap with `https://litellm.prod.outshift.ai`
  - explicit URL override is preserved
  - missing token source fails fast
  - `secret.create=true` without a token key fails fast
  - external secret with `LITELLM_API_KEY` renders successfully

Note: the full umbrella chart render was not run because this local checkout is missing Helm dependency charts (`slim`, `slim-control-plane`, `rag-stack`).