### PR TITLE
fix(auth): remove per-request bootstrap admin log spam

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.3 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.4 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.3 -f your-values.yaml'}
+                  {'    --version 0.5.4 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.3 -f your-values.yaml'}
+              {'    --version 0.5.4 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.4"
+version = "0.5.4-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -237,7 +237,6 @@ export async function getAuthenticatedUser(
   let role = 'user';
   if (isBootstrapAdminEmail(session.user.email)) {
     role = 'admin';
-    console.log(`[Auth] User ${session.user.email} is bootstrap admin via BOOTSTRAP_ADMIN_EMAILS`);
   } else if (
     process.env.NODE_ENV === 'test' &&
     session.role === 'admin' &&

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.4"
+version = "0.5.4.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Removes a `console.log` that fires on every authenticated API request for users in `BOOTSTRAP_ADMIN_EMAILS`. With active users this spams the UI pod logs with hundreds of lines per minute and provides no useful runtime signal — the bootstrap admin path is already clear from code context.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] All new and existing tests pass