### PR TITLE
fix(setup-caipe): pre-create caipe-platform-secret

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -2932,6 +2932,8 @@ create_namespace_and_secrets() {
   kubectl create namespace caipe --dry-run=client -o yaml | kubectl apply -f - &>/dev/null
   log "Namespace 'caipe' ready"
 
+  _ensure_caipe_platform_secret  # must exist before helm install; see PR #1519
+
   # Rescue embeddings credentials from the existing llm-secret before we
   # overwrite it, so a LLM-provider switch doesn't silently break RAG.
   local _existing_lls
@@ -3971,6 +3973,28 @@ _resolve_mongodb_password() {
     --from-literal=MONGODB_DATABASE="caipe" \
     --dry-run=client -o yaml \
     | kubectl apply -f - &>/dev/null
+}
+
+# Pre-create caipe-platform-secret before helm install. PR #1519 wired a hard
+# secretKeyRef to this Secret in the caipe-ui Deployment unconditionally, so
+# the pod fails with CreateContainerConfigError if it is absent. Reuses the
+# existing value on re-runs; Keycloak init-idp reconciles it into the
+# caipe-platform client on first boot.
+_ensure_caipe_platform_secret() {
+  local existing
+  existing=$(kubectl get secret caipe-platform-secret -n caipe \
+    -o jsonpath='{.data.OIDC_CLIENT_SECRET}' 2>/dev/null \
+    | base64 -d 2>/dev/null || true)
+  if [[ -n "$existing" ]]; then
+    log "Reusing existing caipe-platform-secret"
+    return 0
+  fi
+  kubectl create secret generic caipe-platform-secret \
+    --namespace caipe \
+    --from-literal=OIDC_CLIENT_SECRET="$(openssl rand -hex 32)" \
+    --dry-run=client -o yaml \
+    | kubectl apply -f - &>/dev/null
+  log "Created caipe-platform-secret (OIDC_CLIENT_SECRET, 32-byte random)"
 }
 
 _ensure_dynamic_agents_mongodb() {


### PR DESCRIPTION
# Description

PR #1519 wired caipe-ui.keycloakAdminClient.secretName unconditionally in the umbrella values.yaml, causing a hard secretKeyRef in the caipe-ui Deployment. If caipe-platform-secret is absent the pod fails to start with CreateContainerConfigError regardless of whether RBAC is enabled.

Adding a function so that it is called from create_namespace_and_secrets() immediately after the namespace is ready. Reuses the existing secret value on re-runs (idempotent); generates a 32-byte random OIDC_CLIENT_SECRET on first install. Keycloak's init-idp Job reconciles the value into the caipe-platform client on first boot.

Fixes: https://github.com/cnoe-io/ai-platform-engineering/issues/1671

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
