### PR TITLE
fix(keycloak): use direct role endpoint to look up impersonation role ID in init-token-exchange

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -314,9 +314,9 @@ ensure_service_account_impersonation_role() {
     echo "${TAG}   impersonation role already assigned."
   else
     echo "${TAG}   Assigning impersonation role ..."
-    ROLES_RESP=$(curl -sf -H "${AUTH}" \
-      "${KC_URL}/admin/realms/${REALM}/clients/${RM_CLIENT_ID}/roles" 2>/dev/null || echo "[]")
-    IMP_ROLE_ID=$(echo "${ROLES_RESP}" | grep -B1 '"impersonation"' | grep -o '"id" *: *"[^"]*"' | sed 's/.*"\([^"]*\)"/\1/' | head -1)
+    IMP_ROLE_RESP=$(curl -sf -H "${AUTH}" \
+      "${KC_URL}/admin/realms/${REALM}/clients/${RM_CLIENT_ID}/roles/impersonation" 2>/dev/null || echo "{}")
+    IMP_ROLE_ID=$(json_field "${IMP_ROLE_RESP}" "id")
 
     if [ -n "${IMP_ROLE_ID}" ]; then
       curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \


### PR DESCRIPTION
# Description

Fixes a shell JSON-parsing bug in `init-token-exchange.sh` that caused the impersonation role assignment to silently fail for both `caipe-slack-bot` and `caipe-webex-bot`.

**Root cause:** The old code listed all `realm-management` roles and used `grep -B1 '"impersonation"'` to find the role ID. On a single-line JSON response (which Keycloak always returns), `grep -B1` produces the same line twice — so the subsequent `grep -o '"id"...'` matched the **first** `"id"` in the entire array, which belongs to a different role entirely. The wrong UUID was then POSTed to Keycloak, returning 204 (no-op or wrong assignment) while logging `WARNING: could not assign impersonation role`.

**Fix:** Replace the list-and-grep approach with a direct hit to `/clients/{rm-uuid}/roles/impersonation`, which returns exactly the one role we need. Uses the existing `json_field` helper to extract the ID safely.

**Impact:** Without this fix, bot service accounts never receive the `impersonation` realm-management role on fresh installs or after re-running the init job, causing OBO token exchange to fail with 403.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass