### PR TITLE
fix(rag): wire OPENFGA_HTTP default from global.rag.openfga.httpUrl in rag-server

### DIFF
--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -62,6 +62,8 @@ global:
   # RAG Stack configuration
   rag:
     enableGraphRag: true
+    openfga:
+      httpUrl: ""
 
   metrics:
     enabled: true
@@ -1486,7 +1488,6 @@ rag-stack:
       pullPolicy: "IfNotPresent"
     env:
       RBAC_TEAM_SCOPE_ENABLED: "true"
-      OPENFGA_HTTP: ""
       OPENFGA_STORE_NAME: "caipe-openfga"
       CAIPE_UNSAFE_RBAC_BYPASS: "false"
 

--- a/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
@@ -203,6 +203,23 @@ Get Ontology Agent REST API address
     {{- printf "http://%s:%s" $host ($port | toString) -}}
 {{- end -}}
 
+{{- define "rag-server.openfgaHttpUrl" -}}
+{{- $url := "" -}}
+{{- $explicit := index (.Values.env | default dict) "OPENFGA_HTTP" | default "" | trim -}}
+{{- if $explicit -}}
+    {{- $url = $explicit -}}
+{{- else -}}
+    {{- with .Values.global -}}
+        {{- with .rag -}}
+            {{- with .openfga -}}
+                {{- $url = (.httpUrl | default "" | trim) -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- $url -}}
+{{- end -}}
+
 {{- define "rag-server.appVersion" -}}
 {{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}

--- a/charts/rag-stack/charts/rag-server/templates/deployment.yaml
+++ b/charts/rag-stack/charts/rag-server/templates/deployment.yaml
@@ -72,10 +72,14 @@ spec:
             # Feature flag with global fallback
             - name: ENABLE_GRAPH_RAG
               value: {{ include "rag-server.enableGraphRag" . | quote }}
-            # All other configuration via env map
+            - name: OPENFGA_HTTP
+              value: {{ include "rag-server.openfgaHttpUrl" . | default (printf "http://%s-openfga:8080" .Release.Name) | quote }}
+            # All other configuration via env map (OPENFGA_HTTP handled above)
             {{- range $key, $value := .Values.env }}
+            {{- if ne $key "OPENFGA_HTTP" }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -17,6 +17,8 @@ global:
 
   rag:
     enableGraphRag: true
+    openfga:
+      httpUrl: ""
     ragServer:
       host: "rag-server"
       port: 9446


### PR DESCRIPTION
# Description

`rag-server` has `RBAC_TEAM_SCOPE_ENABLED=true` but no `OPENFGA_HTTP` set by default. When `OPENFGA_HTTP` is empty the Python RBAC layer skips the OpenFGA path and raises a 503 for every datasource listing request, making the Knowledge Bases → Data Sources page permanently broken on a standard install.

Changes:
- **`rag-stack/charts/rag-server/templates/_helpers.tpl`** — adds `rag-server.openfgaHttpUrl` helper that resolves `OPENFGA_HTTP` in priority order: explicit `Values.env.OPENFGA_HTTP` → `global.rag.openfga.httpUrl` → empty (falls through to deployment default)
- **`rag-stack/charts/rag-server/templates/deployment.yaml`** — emits `OPENFGA_HTTP` as a computed env var with `| default (printf "http://%s-openfga:8080" .Release.Name)` fallback; excludes `OPENFGA_HTTP` from the plain `range` to avoid duplicates
- **`rag-stack/values.yaml`** — adds `global.rag.openfga.httpUrl: ""` under the existing `global.rag` block so operators can set it once at the rag-stack level
- **`charts/ai-platform-engineering/values.yaml`** — adds `global.rag.openfga.httpUrl: ""` and removes the empty `OPENFGA_HTTP: ""` from `rag-stack.rag-server.env` (which was shadowing the computed default)

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass