### PR TITLE
feat(agentgateway): wire config-bridge sidecar into Helm for dynamic MCP routes

### DIFF
--- a/.github/workflows/ci-agentgateway-config-bridge.yml
+++ b/.github/workflows/ci-agentgateway-config-bridge.yml
@@ -1,0 +1,149 @@
+name: "[CI] AgentGateway Config Bridge Build and Push"
+description: "Build and push the AgentGateway config-bridge Docker image"
+
+on:
+  push:
+    tags:
+      - '**'
+  pull_request:
+    paths:
+      - 'deploy/agentgateway/config_bridge.py'
+      - 'deploy/agentgateway/Dockerfile.config-bridge'
+      - '.github/workflows/ci-agentgateway-config-bridge.yml'
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: 'Version tag to apply (e.g., 0.5.0-rc.7)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  determine-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.set-outputs.outputs.should_build }}
+      tag_version: ${{ steps.version.outputs.tag_version }}
+      image_prefix: ${{ steps.set-outputs.outputs.image_prefix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine Tag
+        id: version
+        uses: ./.github/actions/determine-release-tag
+        with:
+          manual_tag: ${{ inputs.tag_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Outputs
+        id: set-outputs
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+        run: |
+          SHOULD_BUILD="true"
+          TAG_VERSION="${TAG_VERSION}"
+
+          if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
+            SHOULD_BUILD="false"
+            IMAGE_PREFIX=""
+          elif [[ "$TAG_VERSION" =~ -(rc|hotfix)\.[0-9]+ ]]; then
+            IMAGE_PREFIX="pre-release/"
+          else
+            IMAGE_PREFIX=""
+          fi
+
+          echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
+          echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: determine-changes
+    if: needs.determine-changes.outputs.should_build == 'true'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}agentgateway-config-bridge
+      DOCKERFILE: deploy/agentgateway/Dockerfile.config-bridge
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: deploy/agentgateway
+          file: ${{ env.DOCKERFILE }}
+          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          provenance: false
+          sbom: false
+
+  notify-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [determine-changes, build-and-push]
+    if: |
+      always() &&
+      needs.determine-changes.outputs.tag_version != '' &&
+      !contains(needs.determine-changes.outputs.tag_version, '-')
+    steps:
+      - name: 🔔 Notify release finalize
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
+        run: |
+          CONCLUSION="${{ needs.build-and-push.result }}"
+          if [[ "$CONCLUSION" == "skipped" ]]; then CONCLUSION="success"; fi
+
+          gh api /repos/${{ github.repository }}/dispatches --input - <<EOF
+          {
+            "event_type": "ci-completed",
+            "client_payload": {
+              "tag": "$TAG_VERSION",
+              "workflow": "${{ github.workflow }}",
+              "conclusion": "$CONCLUSION"
+            }
+          }
+          EOF

--- a/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
@@ -24,14 +24,71 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- $agwGlobal := ((.Values.global).agentgateway) | default dict }}
+      {{- $static := $agwGlobal.static | default dict }}
+      {{- $cb := $static.configBridge | default dict }}
+      {{- /*
+      The config-bridge dynamically reconciles runtime-added MCP servers
+      (Mongo `mcp_servers`) into the proxy config. It only applies in static
+      (CRD-free) routing mode; in Gateway-API mode the operator manages routes
+      via CRDs. When enabled, the agentgateway reads its config from a shared
+      emptyDir that the bridge writes (seeded from the Helm-rendered static
+      ConfigMap), instead of mounting that ConfigMap read-only directly.
+      */ -}}
+      {{- $cbEnabled := and $agwGlobal.enabled (eq ($agwGlobal.routingMode | default "static") "static") $cb.enabled }}
+      {{- $cbImage := $cb.image | default dict }}
+      {{- $cbImageRepo := $cbImage.repository | default "ghcr.io/cnoe-io/agentgateway-config-bridge" }}
+      {{- $cbImageTag := $cbImage.tag | default .Chart.AppVersion }}
+      {{- $cbImagePull := $cbImage.pullPolicy | default "IfNotPresent" }}
       serviceAccountName: {{ include "agentgateway.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if $cbEnabled }}
+      initContainers:
+        # Seed the shared config from the Helm-rendered static config so the
+        # agentgateway container always starts with a valid file (jwtAuth +
+        # static targets), even before the bridge's first Mongo reconcile.
+        - name: config-bridge-seed
+          image: "{{ $cbImageRepo }}:{{ $cbImageTag }}"
+          imagePullPolicy: {{ $cbImagePull }}
+          command:
+            - python
+            - -c
+            - |
+              import os
+              from pathlib import Path
+              import config_bridge
+              config_bridge.seed_config_from_bootstrap(
+                  Path(os.environ["AGENTGATEWAY_CONFIG_PATH"]),
+                  Path(os.environ["AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH"]),
+              )
+          env:
+            - name: AGENTGATEWAY_CONFIG_PATH
+              value: /generated/config.yaml
+            - name: AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH
+              value: /etc/agentgateway-bootstrap/config.yaml
+          volumeMounts:
+            - name: generated-config
+              mountPath: /generated
+            - name: bootstrap-config
+              mountPath: /etc/agentgateway-bootstrap
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            {{- toYaml ($cb.securityContext | default .Values.securityContext) | nindent 12 }}
+          resources:
+            {{- toYaml ($cb.resources | default .Values.resources) | nindent 12 }}
+      {{- end }}
       containers:
         - name: agentgateway
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if $cbEnabled }}
+          args: ["--file", "/generated/config.yaml"]
+          {{- else }}
           args: ["--file", "/etc/agentgateway/config.yaml"]
+          {{- end }}
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -58,23 +115,80 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 30
           volumeMounts:
+            {{- if $cbEnabled }}
+            - name: generated-config
+              mountPath: /generated
+            {{- else }}
             - name: config
               mountPath: /etc/agentgateway
               readOnly: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if $cbEnabled }}
+        # Sidecar: poll Mongo `mcp_servers` and merge /mcp/<id> routes into the
+        # shared config; agentgateway hot-reloads the file on change.
+        - name: config-bridge
+          image: "{{ $cbImageRepo }}:{{ $cbImageTag }}"
+          imagePullPolicy: {{ $cbImagePull }}
+          env:
+            - name: AGENTGATEWAY_CONFIG_PATH
+              value: /generated/config.yaml
+            - name: AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH
+              value: /etc/agentgateway-bootstrap/config.yaml
+            - name: AGENTGATEWAY_ADMIN_CONFIG_URL
+              value: {{ printf "http://localhost:%v/config" (.Values.service.adminPort | int) | quote }}
+            - name: AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS
+              value: {{ $cb.pollSeconds | default 5 | quote }}
+            - name: MONGODB_DATABASE
+              value: {{ (($cb.mongodb).database) | default "caipe" | quote }}
+            {{- if (($cb.mongodb).existingSecret).name }}
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $cb.mongodb.existingSecret.name | quote }}
+                  key: {{ ($cb.mongodb.existingSecret.key | default "MONGODB_URI") | quote }}
+            {{- else if (($cb.mongodb).uri) }}
+            - name: MONGODB_URI
+              value: {{ $cb.mongodb.uri | quote }}
+            {{- end }}
+            {{- with $cb.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: generated-config
+              mountPath: /generated
+            - name: bootstrap-config
+              mountPath: /etc/agentgateway-bootstrap
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            {{- toYaml ($cb.securityContext | default .Values.securityContext) | nindent 12 }}
+          resources:
+            {{- toYaml ($cb.resources | default .Values.resources) | nindent 12 }}
+        {{- end }}
       volumes:
+        {{- if $cbEnabled }}
+        - name: generated-config
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: bootstrap-config
+          configMap:
+            name: {{ printf "%s-agentgateway-static-config" .Release.Name }}
+        {{- else }}
         - name: config
           configMap:
-            {{- $agwGlobal := ((.Values.global).agentgateway) | default dict }}
             {{- if and $agwGlobal.enabled (eq ($agwGlobal.routingMode | default "static") "static") }}
             # Static (CRD-free) routing: mount the umbrella-rendered static config.
             name: {{ printf "%s-agentgateway-static-config" .Release.Name }}
             {{- else }}
             name: {{ include "agentgateway.fullname" . }}-config
             {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/ai-platform-engineering/charts/agentgateway/values.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/values.yaml
@@ -57,6 +57,17 @@ config:
       level: info
       format: json
 
+# Config-bridge sidecar (static routing mode only).
+#
+# This feature is configured from the UMBRELLA chart under
+# `global.agentgateway.static.configBridge` (alongside jwtAuth / extAuth /
+# extraMcpTargets), since it depends on the umbrella-rendered static config.
+# See charts/ai-platform-engineering/values.yaml for the full schema.
+#
+# The bridge containers reuse this subchart's `securityContext` and
+# `resources` by default; override via
+# `global.agentgateway.static.configBridge.{securityContext,resources}`.
+
 resources:
   requests:
     cpu: 100m

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -157,6 +157,39 @@ global:
         issuer: ""
         jwksUrl: ""
         audiences: []
+      # Dynamic MCP route reconciliation (static routing mode only).
+      #
+      # When enabled, a config-bridge sidecar runs alongside the standalone
+      # AgentGateway proxy and reconciles runtime-added MCP servers (the Mongo
+      # `mcp_servers` collection, source=agentgateway) into the proxy config so
+      # they receive a /mcp/<id> route WITHOUT a `helm upgrade` / values change.
+      #
+      # How it works:
+      #   - The Helm-rendered static config (jwtAuth + extraMcpTargets) is the
+      #     bootstrap/seed; an initContainer seeds a shared emptyDir so the
+      #     proxy always starts with a valid config.
+      #   - The sidecar polls Mongo and writes /mcp/<id> routes into that shared
+      #     file; the proxy hot-reloads on change.
+      #
+      # NOTE: route discovery only — it does NOT affect JWT authentication
+      # (jwtAuth). Ignored in `gateway-api` routing mode (CRDs manage routes).
+      configBridge:
+        enabled: false
+        image:
+          repository: ghcr.io/cnoe-io/agentgateway-config-bridge
+          tag: ""              # defaults to agentgateway subchart appVersion
+          pullPolicy: IfNotPresent
+        pollSeconds: 5
+        mongodb:
+          # MCP-server store connection. Prefer existingSecret over uri.
+          uri: ""              # plain MONGODB_URI (discouraged for real creds)
+          database: caipe
+          existingSecret:
+            name: ""           # e.g. "caipe-ui-mongodb" / your Mongo secret
+            key: MONGODB_URI
+        # securityContext: {}  # optional; defaults to agentgateway.securityContext
+        # resources: {}        # optional; defaults to agentgateway.resources
+        extraEnv: []
     extAuth:
       enabled: false
       serviceName: ""


### PR DESCRIPTION
## Summary

Wires the AgentGateway **config-bridge** (`deploy/agentgateway/config_bridge.py`) into the Helm chart so that **runtime-added MCP servers get a `/mcp/<id>` route without a `helm upgrade` / values change**, in **static routing mode**. Until now the bridge was wired only for Docker Compose; Kubernetes static mode had no dynamic route reconciliation (routes were frozen at render time).

This is **opt-in** and gated behind `global.agentgateway.static.configBridge.enabled` (default `false`). With it disabled, the rendered manifests are unchanged.

## How it works (when enabled)

- The umbrella-rendered static config ConfigMap (`<release>-agentgateway-static-config`, containing `jwtAuth` + `extraMcpTargets`) becomes the **bootstrap/seed**.
- An **initContainer** seeds a shared `emptyDir` so the proxy always starts with a valid config.
- A **sidecar** (`config-bridge`) polls Mongo `mcp_servers` (`source=agentgateway`) every `pollSeconds` and merges `/mcp/<id>` routes into the shared file; agentgateway **hot-reloads** on change.
- The `agentgateway` container reads `/generated/config.yaml` instead of the read-only ConfigMap mount.

No Python changes were needed — the bridge already supports this via env vars (`AGENTGATEWAY_CONFIG_PATH`, `AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH`, `AGENTGATEWAY_ADMIN_CONFIG_URL`, `MONGODB_URI`, `MONGODB_DATABASE`, `AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS`).

## Configuration

```yaml
global:
  agentgateway:
    enabled: true
    routingMode: static
    static:
      configBridge:
        enabled: true
        mongodb:
          existingSecret:
            name: caipe-ui-mongodb   # Secret holding MONGODB_URI
            key: MONGODB_URI
        # image.repository defaults to ghcr.io/cnoe-io/agentgateway-config-bridge
        # image.tag defaults to the agentgateway subchart appVersion
        pollSeconds: 5
```

## Changes

- `charts/.../agentgateway/templates/deployment.yaml` — gated initContainer (seed) + sidecar (reconcile) + shared `emptyDir`/`tmp`/bootstrap-ConfigMap volumes; agentgateway arg/volume switch when enabled.
- `charts/ai-platform-engineering/values.yaml` — new `global.agentgateway.static.configBridge` block (authoritative defaults + docs).
- `charts/.../agentgateway/values.yaml` — pointer note to the umbrella block.
- `.github/workflows/ci-agentgateway-config-bridge.yml` — build/push `ghcr.io/cnoe-io/agentgateway-config-bridge` from `Dockerfile.config-bridge` (modeled on `ci-openfga-authz-bridge.yml`).

## Scope / caveats

- **Does not fix 401s.** This is route *discovery* only and does not touch JWT authentication (`jwtAuth`). A 401 from probing tools is an issuer/JWKS/audience problem, separate from this PR.
- This deliberately departs from the documented "K8s should use Gateway API resources" note in `config_bridge.py`, providing a CRD-free dynamic option for static mode.
- Security: reuses the agentgateway container `securityContext` (`readOnlyRootFilesystem: true` preserved — writes go to the `emptyDir`) and `resources`; both overridable. No K8s API / RBAC needed (bridge talks only to Mongo + the in-pod admin port).

## Test plan

- [x] `helm lint` passes (subchart).
- [x] `helm template` with bridge **disabled** renders byte-for-byte as before (single `config` ConfigMap volume, `--file /etc/agentgateway/config.yaml`).
- [x] `helm template` with bridge **enabled** renders initContainer + sidecar + shared volumes; values flow via `global.agentgateway.static.configBridge`; output parses as valid YAML.
- [ ] Build the config-bridge image via the new CI workflow (tag/dispatch) and confirm push to GHCR.
- [ ] In-cluster: enable on a static-mode install, add an `mcp_servers` doc, confirm a `/mcp/<id>` route appears and the proxy hot-reloads.

Assisted-by: Claude:claude-opus-4-8

Made with [Cursor](https://cursor.com)