### PR TITLE
fix(dynamic-agents): correlate subagent namespaces across langgraph tasks-chunk shapes

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
@@ -89,36 +89,69 @@ class LangGraphStreamHelper:
 
         return (namespace, mode, data)
 
+    @staticmethod
+    def _extract_task_tool_calls(task_input: Any) -> list[dict]:
+        """Return the tool_call dicts from a ``tasks``-mode chunk ``input``.
+
+        LangGraph has emitted two different shapes for the ``input`` field of a
+        ``tasks`` chunk across versions; both must be supported:
+
+        - **langgraph < 1.2** (e.g. 1.0.x): ``input`` is a dict
+          ``{"__type": "tool_call_with_context", "tool_call": {...}, "state": {...}}``
+          — a single tool_call nested under the ``tool_call`` key.
+        - **langgraph >= 1.2** (e.g. 1.2.x): ``input`` is a *list* of tool_call
+          dicts, e.g. ``[{"name": "task", "args": {...}, "id": "...", "type": "tool_call"}]``.
+
+        Returning a list normalizes both so the caller can iterate uniformly.
+        Unrecognized shapes yield an empty list.
+
+        Note: when this returns nothing for a real subagent invocation, the
+        namespace mapping stays empty and ``correlate_namespace`` falls back to
+        treating subagent events as the parent agent — which causes subagent
+        output to leak into the parent's response. Keep this tolerant of the
+        shapes langgraph emits.
+        """
+        if isinstance(task_input, dict):
+            tool_call = task_input.get("tool_call")
+            return [tool_call] if isinstance(tool_call, dict) else []
+        if isinstance(task_input, list):
+            return [tc for tc in task_input if isinstance(tc, dict)]
+        return []
+
     def _handle_tasks_chunk(self, data: Any) -> None:
         """Extract namespace UUID -> tool_call_id mapping from tasks events.
 
         LangGraph's ``tasks`` stream mode emits task metadata when a tool is
         invoked. For the ``task`` tool (subagent invocation), this contains:
         - id: The task UUID (used in namespace as "tools:{id}")
-        - input.tool_call.id: The tool_call_id from the original invocation
+        - a tool_call carrying the original ``tool_call_id`` and name
 
         We build this mapping so subagent events can be correlated to their
-        ``tool_start`` events, which clients already have.
+        ``tool_start`` events, which clients already have. The shape of the
+        ``input`` field varies across langgraph versions — see
+        ``_extract_task_tool_calls``.
         """
         # Tasks data comes as a single dict per event, not a list
         if not isinstance(data, dict):
             return
 
         task_id = data.get("id")
-        task_input = data.get("input", {})
+        if not task_id:
+            return
 
-        # The tool_call info is nested under input.tool_call for tool executions
-        tool_call = task_input.get("tool_call", {}) if isinstance(task_input, dict) else {}
-        tool_call_id = tool_call.get("id")
-        tool_name = tool_call.get("name")
-
-        # Only create mapping for "task" tool calls (subagent invocations)
-        # Other tools don't spawn subgraphs with their own namespace
-        if task_id and tool_call_id and tool_name == "task":
+        # Only create mapping for "task" tool calls (subagent invocations).
+        # Other tools don't spawn subgraphs with their own namespace.
+        for tool_call in self._extract_task_tool_calls(data.get("input")):
+            if tool_call.get("name") != "task":
+                continue
+            tool_call_id = tool_call.get("id")
+            if not tool_call_id:
+                continue
             namespace_key = f"tools:{task_id}"
             if namespace_key not in self._namespace_mapping:
                 self._namespace_mapping[namespace_key] = tool_call_id
                 logger.debug(f"[sse:tasks] Mapped {namespace_key} → {tool_call_id}")
+            break
 
     def correlate_namespace(self, namespace: tuple[str, ...]) -> tuple[str, ...]:
         """Correlate using internal namespace_mapping.

--- a/ai_platform_engineering/dynamic_agents/tests/test_agui_sse_namespace.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_agui_sse_namespace.py
@@ -194,3 +194,91 @@ class TestHandleMessagesNamespace:
 
             frames_2 = enc._handle_messages((chunk, {}), ("agent-A",))
             assert _namespace_values(frames_2) == []  # no redundant emit
+
+
+class TestTasksChunkNamespaceMapping:
+    """_handle_tasks_chunk must build the subagent namespace mapping across the
+    differing ``tasks``-mode ``input`` shapes langgraph has emitted.
+
+    Regression: langgraph >= 1.2 changed ``input`` from a
+    ``{"tool_call": {...}}`` dict to a bare list of tool_call dicts. The old
+    parser only read the dict shape, so the mapping silently stayed empty,
+    ``correlate_namespace`` fell back to treating subagent events as the parent,
+    and subagent output leaked into the parent response. Both shapes must work.
+    """
+
+    TASK_ID = "abc123-def456"
+    TOOL_CALL_ID = "toolu_subagent_1"
+
+    def _legacy_dict_chunk(self) -> dict:
+        """langgraph < 1.2: input is a tool_call_with_context dict."""
+        return {
+            "id": self.TASK_ID,
+            "name": "tools",
+            "input": {
+                "__type": "tool_call_with_context",
+                "tool_call": {
+                    "name": "task",
+                    "args": {"subagent_type": "worker", "description": "do work"},
+                    "id": self.TOOL_CALL_ID,
+                    "type": "tool_call",
+                },
+                "state": {"messages": []},
+            },
+        }
+
+    def _list_chunk(self) -> dict:
+        """langgraph >= 1.2: input is a list of tool_call dicts."""
+        return {
+            "id": self.TASK_ID,
+            "name": "tools",
+            "input": [
+                {
+                    "name": "task",
+                    "args": {"subagent_type": "worker", "description": "do work"},
+                    "id": self.TOOL_CALL_ID,
+                    "type": "tool_call",
+                }
+            ],
+        }
+
+    def test_legacy_dict_shape_populates_mapping(self):
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(self._legacy_dict_chunk())
+        assert enc._helper._namespace_mapping == {f"tools:{self.TASK_ID}": self.TOOL_CALL_ID}
+
+    def test_list_shape_populates_mapping(self):
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(self._list_chunk())
+        assert enc._helper._namespace_mapping == {f"tools:{self.TASK_ID}": self.TOOL_CALL_ID}
+
+    def test_subagent_namespace_correlates_after_list_chunk(self):
+        """End-to-end: after a list-shape tasks chunk, the langgraph internal
+        namespace correlates to the tool_call_id (not the empty/parent tuple)."""
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(self._list_chunk())
+        correlated = enc._helper.correlate_namespace((f"tools:{self.TASK_ID}",))
+        assert correlated == (self.TOOL_CALL_ID,)
+
+    def test_uncorrelated_subagent_namespace_falls_back_to_parent(self):
+        """Without a mapping entry, the namespace collapses to parent () — this
+        is the failure mode the fix prevents, asserted here as a guard."""
+        enc = AGUIStreamEncoder()
+        correlated = enc._helper.correlate_namespace((f"tools:{self.TASK_ID}",))
+        assert correlated == ()
+
+    def test_non_task_tool_calls_ignored(self):
+        """Only ``task`` tool calls spawn subgraphs; other tools must not map."""
+        enc = AGUIStreamEncoder()
+        chunk = self._list_chunk()
+        chunk["input"][0]["name"] = "get_weather"
+        enc._helper._handle_tasks_chunk(chunk)
+        assert enc._helper._namespace_mapping == {}
+
+    def test_result_chunk_without_tool_call_is_ignored(self):
+        """A tasks result chunk (no input tool_call) must not error or map."""
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(
+            {"id": self.TASK_ID, "name": "tools", "result": {"messages": []}, "interrupts": []}
+        )
+        assert enc._helper._namespace_mapping == {}


### PR DESCRIPTION
## Summary

Fixes a regression where **subagent narration leaks into the parent agent's
final response** (e.g. a streamed answer that begins with "I'll look up the
weather...", "I'll search for...", "Now let me..." before the real answer).

The leak appears after upgrading langgraph to **>= 1.2** and is **not** caused
by the LLM client choice (`ChatBedrockConverse` vs `ChatAnthropicBedrock`) —
both stream identically. The trigger is a change in the shape of langgraph's
`tasks`-mode stream metadata that silently broke subagent namespace
correlation in the AG-UI encoder.

## Root cause

`AGUIStreamEncoder` (via `LangGraphStreamHelper._handle_tasks_chunk`) builds a
`{namespace -> tool_call_id}` mapping from `tasks`-mode chunks so that subagent
events can be attributed to the `task` tool call that spawned them. Clients use
this attribution (emitted as `NAMESPACE_CONTEXT` events) to tell subagent output
apart from the parent agent's own response.

langgraph changed the shape of the `tasks` chunk `input` field between versions:

```python
# langgraph < 1.2
input = {
    "__type": "tool_call_with_context",
    "tool_call": {"name": "task", "id": "toolu_...", "type": "tool_call", ...},
    "state": {...},
}

# langgraph >= 1.2
input = [
    {"name": "task", "id": "toolu_...", "type": "tool_call", ...}
]
```

`_handle_tasks_chunk` only read the dict shape (`input.get("tool_call")`). On
langgraph >= 1.2, `input` is a list, so the lookup returned `{}`, the mapping
stayed **empty**, and `correlate_namespace` took its fallback branch:

```python
# Unknown namespace — treat as parent agent
return ()
```

Every subagent namespace was therefore classified as the parent. As a result:

1. No `NAMESPACE_CONTEXT` events were emitted (the namespace never "changed"
   from the parent's empty tuple).
2. Consumers that suppress subagent text based on namespace had nothing to key
   on, so subagent narration was rendered as the parent's answer.

This also produced a flood of `[sse:correlate] Unknown namespace ...` warnings
in the logs, which is the visible fingerprint of the bug.

## Fix

Parse **both** `input` shapes via a new `_extract_task_tool_calls` helper and
iterate the resulting tool calls. The dict (`tool_call_with_context`) and list
forms both normalize to a list of tool-call dicts, so the mapping populates
correctly regardless of langgraph version. No protocol or consumer changes are
required — restoring the mapping makes the existing `NAMESPACE_CONTEXT`
attribution work again for all clients.

## How it was verified

Reproduced end-to-end against a parent agent invoking parallel subagents,
streaming through the real `AGUIStreamEncoder`, comparing langgraph 1.0.x vs
1.2.x:

| | langgraph 1.0.x | langgraph 1.2.x (before fix) | langgraph 1.2.x (after fix) |
|---|---|---|---|
| `NAMESPACE_CONTEXT` events | present | **0** | present |
| "Unknown namespace" warnings | 0 | many | **0** |
| Subagent narration in answer | suppressed | **leaked** | **suppressed** |

## Tests

Adds `TestTasksChunkNamespaceMapping` covering:
- legacy dict shape populates the mapping
- list shape populates the mapping
- end-to-end correlation after a list-shape chunk
- the uncorrelated-fallback failure mode (guard)
- non-`task` tool calls are ignored
- result chunks without a tool call are ignored

All encoder/namespace tests pass; `ruff` clean.

## Type of Change

- [x] Bugfix
