### PR TITLE
fix: Markdown editor scroll behaviour and theming

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12185,7 +12185,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12185,6 +12185,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/src/components/skills/workspace/RichCodeEditor.tsx
+++ b/ui/src/components/skills/workspace/RichCodeEditor.tsx
@@ -13,7 +13,7 @@
  *   - Multi-cursor, rectangular selection
  *   - Soft-wrap toggle (controlled prop)
  *   - Lint gutter + tooltips driven by a caller-supplied `linter` callback
- *   - Theme follows the user's `prefers-color-scheme` (one-dark when dark)
+ *   - Theme follows the app's next-themes selection (one-dark when not light)
  *
  * Designed to be the single editor primitive for both the SKILL.md editor
  * (Workspace's Files tab) and the SkillFolderViewer's editor pane.
@@ -55,6 +55,7 @@ import {
 import { lintGutter, type Diagnostic } from "@codemirror/lint";
 import { linter as cmLinter } from "@codemirror/lint";
 import { oneDark } from "@codemirror/theme-one-dark";
+import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
 
@@ -112,6 +113,13 @@ export interface RichCodeEditorProps {
   maxHeight?: string;
   /** Force a fixed height (overrides min/max). */
   height?: string;
+
+  /**
+   * Fill the parent flex/grid cell and scroll inside CodeMirror only
+   * (one scrollbar). Use instead of `height="100%"` when embedded in
+   * a constrained layout like the Files tab.
+   */
+  fillContainer?: boolean;
 
   /** Extra classnames on the outer wrapper. */
   className?: string;
@@ -195,25 +203,6 @@ function pickLanguageDescription(opts: {
 }
 
 // ---------------------------------------------------------------------------
-// Theme (light vs dark)
-// ---------------------------------------------------------------------------
-
-function usePrefersDark(): boolean {
-  const [dark, setDark] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
-  });
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mql = window.matchMedia("(prefers-color-scheme: dark)");
-    const fn = (e: MediaQueryListEvent) => setDark(e.matches);
-    mql.addEventListener?.("change", fn);
-    return () => mql.removeEventListener?.("change", fn);
-  }, []);
-  return dark;
-}
-
-// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -231,11 +220,15 @@ export function RichCodeEditor({
   minHeight = "240px",
   maxHeight = "70vh",
   height,
+  fillContainer = false,
   className,
   editorRef,
 }: RichCodeEditorProps) {
-  const dark = usePrefersDark();
+  const { resolvedTheme } = useTheme();
+  const isDark =
+    resolvedTheme != null && resolvedTheme !== "light";
   const [langSupport, setLangSupport] = useState<LanguageSupport | null>(null);
+  const useContainerHeight = fillContainer || height === "100%";
 
   // Resolve and lazy-load the language for the given filename/language.
   useEffect(() => {
@@ -339,6 +332,7 @@ export function RichCodeEditor({
     <div
       className={cn(
         "rich-code-editor relative overflow-hidden rounded-md border border-border/60 bg-background",
+        useContainerHeight && "flex h-full min-h-0 flex-col",
         className,
       )}
       data-rich-editor
@@ -346,13 +340,14 @@ export function RichCodeEditor({
       <CodeMirror
         ref={editorRef ?? undefined}
         value={value}
-        height={height}
-        minHeight={height ? undefined : minHeight}
-        maxHeight={height ? undefined : maxHeight}
-        theme={dark ? oneDark : "light"}
+        height={useContainerHeight ? "100%" : height}
+        minHeight={useContainerHeight ? undefined : height ? undefined : minHeight}
+        maxHeight={useContainerHeight ? undefined : height ? undefined : maxHeight}
+        theme={isDark ? oneDark : "light"}
         extensions={extensions}
         onChange={handleChange}
         basicSetup={false}
+        className={useContainerHeight ? "min-h-0 flex-1" : undefined}
       />
     </div>
   );

--- a/ui/src/components/skills/workspace/RichCodeEditor.tsx
+++ b/ui/src/components/skills/workspace/RichCodeEditor.tsx
@@ -326,7 +326,7 @@ export function RichCodeEditor({
     [onChange],
   );
 
-  const shouldUseEditorStyling = useContainerHeight || height;
+  const shouldUseEditorStyling = Boolean(useContainerHeight || height);
 
   return (
     <div

--- a/ui/src/components/skills/workspace/RichCodeEditor.tsx
+++ b/ui/src/components/skills/workspace/RichCodeEditor.tsx
@@ -115,9 +115,7 @@ export interface RichCodeEditorProps {
   height?: string;
 
   /**
-   * Fill the parent flex/grid cell and scroll inside CodeMirror only
-   * (one scrollbar). Use instead of `height="100%"` when embedded in
-   * a constrained layout like the Files tab.
+   * Fill the parent flex/grid cell and scroll inside CodeMirror component only
    */
   fillContainer?: boolean;
 
@@ -328,6 +326,8 @@ export function RichCodeEditor({
     [onChange],
   );
 
+  const shouldUseEditorStyling = useContainerHeight || height;
+
   return (
     <div
       className={cn(
@@ -341,8 +341,8 @@ export function RichCodeEditor({
         ref={editorRef ?? undefined}
         value={value}
         height={useContainerHeight ? "100%" : height}
-        minHeight={useContainerHeight ? undefined : height ? undefined : minHeight}
-        maxHeight={useContainerHeight ? undefined : height ? undefined : maxHeight}
+        minHeight={shouldUseEditorStyling ? undefined : minHeight}
+        maxHeight={shouldUseEditorStyling ? undefined : maxHeight}
         theme={isDark ? oneDark : "light"}
         extensions={extensions}
         onChange={handleChange}

--- a/ui/src/components/skills/workspace/SkillMdEditor.tsx
+++ b/ui/src/components/skills/workspace/SkillMdEditor.tsx
@@ -229,8 +229,8 @@ export function SkillMdEditor({
   const showEditor = viewMode !== "preview";
   const showPreview = viewMode !== "edit";
 
-  // FilesTab passes height="100%". Mirror the preview pane: constrain
-  // the editor shell and let CodeMirror scroll internally (one bar).
+  // Mirror the preview pane: constrain the editor shell and let 
+  // CodeMirror component scroll internally.
   const fillParent = height === "100%";
 
   // Body layout. We use a simple grid so split mode stays balanced even

--- a/ui/src/components/skills/workspace/SkillMdEditor.tsx
+++ b/ui/src/components/skills/workspace/SkillMdEditor.tsx
@@ -247,9 +247,8 @@ export function SkillMdEditor({
     <div
       className={cn(
         "flex min-h-0 flex-col gap-2",
-        // When a fixed `height` is supplied (e.g. the FilesTab passes
-        // "100%"), fill the parent and keep scrolling inside the body
-        // panes so the toolbar stays pinned above the editor surface.
+        // When a `height` is supplied, fill the parent and scroll inside body
+        // panes so the toolbar stays pinned above the editor.
         height && "h-full overflow-hidden",
         className,
       )}

--- a/ui/src/components/skills/workspace/SkillMdEditor.tsx
+++ b/ui/src/components/skills/workspace/SkillMdEditor.tsx
@@ -229,11 +229,15 @@ export function SkillMdEditor({
   const showEditor = viewMode !== "preview";
   const showPreview = viewMode !== "edit";
 
+  // FilesTab passes height="100%". Mirror the preview pane: constrain
+  // the editor shell and let CodeMirror scroll internally (one bar).
+  const fillParent = height === "100%";
+
   // Body layout. We use a simple grid so split mode stays balanced even
   // at narrow widths (each pane gets `min-w-0` so CodeMirror's
   // horizontal scroll doesn't blow out the column).
   const bodyClass = cn(
-    "flex-1 min-h-0",
+    "min-h-0 flex-1 overflow-hidden",
     showEditor && showPreview
       ? "grid grid-cols-1 md:grid-cols-2 gap-2"
       : "flex",
@@ -242,17 +246,17 @@ export function SkillMdEditor({
   return (
     <div
       className={cn(
-        "flex flex-col gap-2",
+        "flex min-h-0 flex-col gap-2",
         // When a fixed `height` is supplied (e.g. the FilesTab passes
-        // "100%"), let the body fill the parent so split mode actually
-        // gets vertical space to render in.
-        height && "h-full",
+        // "100%"), fill the parent and keep scrolling inside the body
+        // panes so the toolbar stays pinned above the editor surface.
+        height && "h-full overflow-hidden",
         className,
       )}
     >
       {!hideToolbar && (
         <div
-          className="flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-2 py-1"
+          className="flex shrink-0 items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-2 py-1"
           data-skill-md-toolbar
         >
           {/* View-mode segmented toggle. Lives on the LEFT so it's the
@@ -362,7 +366,12 @@ export function SkillMdEditor({
 
       <div className={bodyClass}>
         {showEditor && (
-          <div className="min-w-0 min-h-0 flex-1">
+          <div
+            className={cn(
+              "min-h-0 min-w-0 flex-1 overflow-hidden rounded-md border border-border/50",
+              fillParent && "flex flex-col",
+            )}
+          >
             <RichCodeEditor
               editorRef={editorRef}
               value={value}
@@ -371,9 +380,9 @@ export function SkillMdEditor({
               readOnly={readOnly}
               wrap={wrap}
               lintSource={lintSource}
-              minHeight={minHeight}
-              maxHeight={maxHeight}
-              height={height}
+              fillContainer={fillParent}
+              minHeight={fillParent ? undefined : minHeight}
+              maxHeight={fillParent ? undefined : maxHeight}
             />
           </div>
         )}

--- a/ui/src/components/skills/workspace/__tests__/FilesTab.test.tsx
+++ b/ui/src/components/skills/workspace/__tests__/FilesTab.test.tsx
@@ -26,9 +26,14 @@ jest.mock("@/lib/config", () => ({
 // and forward their `value`/`onChange` so we can introspect what file is
 // active.
 jest.mock("@/components/skills/workspace/SkillMdEditor", () => ({
-  SkillMdEditor: (p: { value: string; onChange?: (v: string) => void }) => (
+  SkillMdEditor: (p: {
+    value: string;
+    height?: string;
+    onChange?: (v: string) => void;
+  }) => (
     <textarea
       data-testid="md-editor"
+      data-height={p.height ?? ""}
       value={p.value}
       onChange={(e) => p.onChange?.(e.target.value)}
     />
@@ -38,11 +43,13 @@ jest.mock("@/components/skills/workspace/RichCodeEditor", () => ({
   RichCodeEditor: (p: {
     value: string;
     filename?: string;
+    fillContainer?: boolean;
     onChange?: (v: string) => void;
   }) => (
     <textarea
       data-testid="rich-editor"
       data-filename={p.filename}
+      data-fill-container={p.fillContainer ? "true" : "false"}
       value={p.value}
       onChange={(e) => p.onChange?.(e.target.value)}
     />
@@ -174,6 +181,15 @@ describe("FilesTab — file selection", () => {
     expect(screen.queryByTestId("rich-editor")).toBeNull();
   });
 
+  it("passes height='100%' to SkillMdEditor for SKILL.md", () => {
+    const form = makeForm();
+    render(<FilesTab form={form} />);
+    expect(screen.getByTestId("md-editor")).toHaveAttribute(
+      "data-height",
+      "100%",
+    );
+  });
+
   it("clicking an ancillary file switches to RichCodeEditor with the right filename", () => {
     const form = makeForm({
       ancillaryFiles: { "tools.py": "print('hi')" },
@@ -183,6 +199,18 @@ describe("FilesTab — file selection", () => {
     const rich = screen.getByTestId("rich-editor");
     expect(rich).toHaveAttribute("data-filename", "tools.py");
     expect(rich).toHaveValue("print('hi')");
+  });
+
+  it("passes fillContainer to RichCodeEditor for ancillary files", () => {
+    const form = makeForm({
+      ancillaryFiles: { "tools.py": "print('hi')" },
+    });
+    render(<FilesTab form={form} />);
+    fireEvent.click(screen.getByText("tools.py"));
+    expect(screen.getByTestId("rich-editor")).toHaveAttribute(
+      "data-fill-container",
+      "true",
+    );
   });
 });
 

--- a/ui/src/components/skills/workspace/__tests__/RichCodeEditor.test.tsx
+++ b/ui/src/components/skills/workspace/__tests__/RichCodeEditor.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for RichCodeEditor — theme sync with next-themes and fillContainer
+ * layout contract. CodeMirror is mocked to a plain textarea so the test runs
+ * fast and deterministically.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { oneDark } from "@codemirror/theme-one-dark";
+
+let mockResolvedTheme: string | undefined = "light";
+let lastCodeMirrorProps: Record<string, unknown> = {};
+
+jest.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: mockResolvedTheme }),
+}));
+
+jest.mock("@uiw/react-codemirror", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    lastCodeMirrorProps = props;
+    return (
+      <div
+        data-testid="codemirror-mock"
+        data-height={String(props.height ?? "")}
+        data-min-height={String(props.minHeight ?? "")}
+        data-max-height={String(props.maxHeight ?? "")}
+        data-class-name={String(props.className ?? "")}
+      />
+    );
+  },
+}));
+
+import { RichCodeEditor } from "../RichCodeEditor";
+
+beforeEach(() => {
+  mockResolvedTheme = "light";
+  lastCodeMirrorProps = {};
+});
+
+describe("RichCodeEditor — theme", () => {
+  it("uses the light theme when resolvedTheme is light", () => {
+    mockResolvedTheme = "light";
+    render(<RichCodeEditor value="" onChange={() => {}} />);
+    expect(lastCodeMirrorProps.theme).toBe("light");
+  });
+
+  it("uses oneDark when resolvedTheme is dark", () => {
+    mockResolvedTheme = "dark";
+    render(<RichCodeEditor value="" onChange={() => {}} />);
+    expect(lastCodeMirrorProps.theme).toBe(oneDark);
+  });
+
+  it("uses oneDark for non-light app themes (e.g. cyberpunk)", () => {
+    mockResolvedTheme = "cyberpunk";
+    render(<RichCodeEditor value="" onChange={() => {}} />);
+    expect(lastCodeMirrorProps.theme).toBe(oneDark);
+  });
+});
+
+describe("RichCodeEditor — fillContainer layout", () => {
+  it("fills the parent and scrolls inside CodeMirror when fillContainer is true", () => {
+    render(
+      <RichCodeEditor value="hello" onChange={() => {}} fillContainer />,
+    );
+    const shell = screen.getByTestId("codemirror-mock").parentElement;
+    expect(shell).toHaveAttribute("data-rich-editor");
+    expect(shell?.className).toMatch(/h-full/);
+    expect(shell?.className).toMatch(/flex-col/);
+    expect(lastCodeMirrorProps.height).toBe("100%");
+    expect(lastCodeMirrorProps.minHeight).toBeUndefined();
+    expect(lastCodeMirrorProps.maxHeight).toBeUndefined();
+    expect(lastCodeMirrorProps.className).toBe("min-h-0 flex-1");
+  });
+
+  it("treats height='100%' like fillContainer", () => {
+    render(
+      <RichCodeEditor value="hello" onChange={() => {}} height="100%" />,
+    );
+    expect(lastCodeMirrorProps.height).toBe("100%");
+    expect(lastCodeMirrorProps.minHeight).toBeUndefined();
+    expect(lastCodeMirrorProps.maxHeight).toBeUndefined();
+  });
+
+  it("uses min/max height defaults when not filling the container", () => {
+    render(<RichCodeEditor value="hello" onChange={() => {}} />);
+    expect(lastCodeMirrorProps.height).toBeUndefined();
+    expect(lastCodeMirrorProps.minHeight).toBe("240px");
+    expect(lastCodeMirrorProps.maxHeight).toBe("70vh");
+    expect(lastCodeMirrorProps.className).toBeUndefined();
+  });
+});
+
+void React;

--- a/ui/src/components/skills/workspace/__tests__/SkillMdEditor.test.tsx
+++ b/ui/src/components/skills/workspace/__tests__/SkillMdEditor.test.tsx
@@ -34,6 +34,10 @@ jest.mock("@/components/skills/workspace/RichCodeEditor", () => {
     lintSource?: LintFn;
     readOnly?: boolean;
     wrap?: boolean;
+    fillContainer?: boolean;
+    minHeight?: string;
+    maxHeight?: string;
+    height?: string;
   };
   const RichCodeEditor = (props: Props) => {
     const [diags, setDiags] = React.useState<
@@ -48,7 +52,12 @@ jest.mock("@/components/skills/workspace/RichCodeEditor", () => {
       Promise.resolve(result).then((d) => setDiags(Array.isArray(d) ? d : []));
     }, [props.value, props.lintSource]);
     return (
-      <div data-rich-editor>
+      <div
+        data-rich-editor
+        data-fill-container={props.fillContainer ? "true" : "false"}
+        data-min-height={props.minHeight ?? ""}
+        data-max-height={props.maxHeight ?? ""}
+      >
         <textarea
           aria-label="rich-editor"
           value={props.value}
@@ -114,6 +123,16 @@ describe("SkillMdEditor — toolbar", () => {
     expect(editor).toHaveAttribute("data-wrap", "off");
     fireEvent.click(screen.getByLabelText("Toggle soft wrap"));
     expect(editor).toHaveAttribute("data-wrap", "on");
+  });
+
+  it("passes fillContainer and drops fixed min/max when height is 100%", () => {
+    render(
+      <SkillMdEditor value="hello" onChange={() => {}} height="100%" />,
+    );
+    const shell = screen.getByLabelText("rich-editor").closest("[data-rich-editor]");
+    expect(shell).toHaveAttribute("data-fill-container", "true");
+    expect(shell).toHaveAttribute("data-min-height", "");
+    expect(shell).toHaveAttribute("data-max-height", "");
   });
 });
 

--- a/ui/src/components/skills/workspace/tabs/FilesTab.tsx
+++ b/ui/src/components/skills/workspace/tabs/FilesTab.tsx
@@ -417,7 +417,7 @@ export function FilesTab({ form, readOnly = false, review }: FilesTabProps) {
         onChange={(next) =>
           form.setAncillaryFiles((prev) => ({ ...prev, [selected]: next }))
         }
-        height="100%"
+        fillContainer
       />
     );
   }, [selected, form, readOnly]);
@@ -603,7 +603,7 @@ export function FilesTab({ form, readOnly = false, review }: FilesTabProps) {
             readOnly={readOnly}
             className="border-r border-border/50 bg-muted/20"
           />
-          <div className="min-h-0 overflow-auto p-2 relative">
+          <div className="relative flex h-full min-h-0 flex-col overflow-hidden p-2">
             {dragOver && (
               <div className="absolute inset-2 z-10 flex items-center justify-center rounded-md border-2 border-dashed border-primary bg-primary/10 text-sm font-medium text-primary pointer-events-none">
                 Drop files to add to this skill


### PR DESCRIPTION
# Description

In the skill builder UI (more specifically, the skill content markdown editor), there were a couple small bugs in the code editor component. 
- The CodeMirror component was not being passed the correct theme when set to any of the dark modes
- The toolbar at the top of the was not staying sticky because the CodeMirror component was allowed to grow to fit the contents, resulting in the scroll bar being in a parent component, allowing a user to scroll the toolbar away in Editor and Split modes.

The fix for these were to: use the useTheme hook that is present in several other locations in the codebase, instead of attempting to parse the theme out of the document tree, and set the code editor component to only expand as far as the size of the component that is containing it. With this, it allows us to delegate the scrolling to the actual CodeMirror component, which has a good built-in scroll system, and leaves all surrounding elements (ie. the toolbar) where they are supposed to be.


## Examples
In the following examples, the content has been scrolled down to show the stickiness (or not stickiness) of the toolbar. Both a light and dark mode has been provided to show the theming fix.

### Before
<img width="1895" height="784" alt="Screenshot 2026-06-01 at 11 27 07 AM" src="https://github.com/user-attachments/assets/93f9bb84-48fa-4168-9bef-ac814abf23c7" />
<img width="1901" height="798" alt="Screenshot 2026-06-01 at 2 04 02 PM" src="https://github.com/user-attachments/assets/a9ccedc9-120a-451c-b06c-aa9d806b753d" />

https://github.com/user-attachments/assets/f548dfa9-c480-4f6d-b288-0a5437f6dc00

### After
<img width="1894" height="717" alt="Screenshot 2026-06-01 at 2 03 25 PM" src="https://github.com/user-attachments/assets/d5c6b7bd-787f-4616-8239-456cd640566e" />
<img width="962" height="386" alt="Screenshot 2026-06-01 at 2 08 26 PM" src="https://github.com/user-attachments/assets/bcc4da65-fad1-4f3c-8aa5-bafa7d9e1394" />

https://github.com/user-attachments/assets/16c8b988-c368-4bbf-82be-1f32d91a20d9

Please ensure commits conform to the [Commit Guideline](https://www.conventionalcommits.org/en/v1.0.0/)

# Testing:
- Tests have been added to cover the minor changed cases of FilesTab and SkillMdEditor
- A new test file was introduced as the RichCodeEditor.tsx file was previously untested. This change does not cover the entire component, it just sets things up and covers the changes from this PR

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [X] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
