### PR TITLE
feat(keycloak): add PostgreSQL database support via database.enabled

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/templates/database-external-secret.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/database-external-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.database.enabled .Values.database.externalSecret.enabled }}
+apiVersion: external-secrets.io/{{ .Values.externalSecretsApiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak.fullname" . }}-db
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.database.externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.database.externalSecret.secretStoreRef.name }}
+    kind: {{ .Values.database.externalSecret.secretStoreRef.kind }}
+  target:
+    name: {{ .Values.database.existingSecret }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.database.existingSecretPasswordKey }}
+      remoteRef:
+        key: {{ .Values.database.externalSecret.remoteRef.key }}
+        property: {{ .Values.database.externalSecret.remoteRef.property }}
+{{- end }}

--- a/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
@@ -58,6 +58,12 @@ spec:
             - name: KC_METRICS_ENABLED
               value: "true"
             {{- if .Values.database.enabled }}
+            {{- if not .Values.database.host }}
+            {{- fail "keycloak.database.host is required when keycloak.database.enabled is true" }}
+            {{- end }}
+            {{- if not .Values.database.existingSecret }}
+            {{- fail "keycloak.database.existingSecret is required when keycloak.database.enabled is true" }}
+            {{- end }}
             - name: KC_DB
               value: postgres
             - name: KC_DB_URL
@@ -70,9 +76,9 @@ spec:
                   name: {{ .Values.database.existingSecret }}
                   key: {{ .Values.database.existingSecretPasswordKey }}
             - name: KC_HTTP_ENABLED
-              value: "true"
+              value: {{ .Values.database.httpEnabled | quote }}
             - name: KC_HOSTNAME_STRICT
-              value: "false"
+              value: {{ .Values.database.hostnameStrict | quote }}
             {{- end }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}

--- a/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - start-dev
+            - {{ if .Values.database.enabled }}start{{ else }}start-dev{{ end }}
             - --import-realm
             {{- $features := list }}
             {{- if .Values.features.tokenExchange }}
@@ -57,6 +57,23 @@ spec:
               value: "true"
             - name: KC_METRICS_ENABLED
               value: "true"
+            {{- if .Values.database.enabled }}
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }}"
+            - name: KC_DB_USERNAME
+              value: {{ .Values.database.username | quote }}
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretPasswordKey }}
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            {{- end }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -320,18 +320,77 @@ ingress:
   #   hosts:
   #     - idp.local
 
-# ---------- Persistence ----------
-# Keycloak uses an embedded H2 database by default.
-# For prod, configure an external PostgreSQL via KC_DB_* env vars.
-persistence:
+# ---------- Database ----------
+# When disabled (default), Keycloak runs with the embedded H2 database and
+# starts in dev mode — identical behaviour to all prior chart versions.
+# When enabled, Keycloak starts in production mode (KC_DB=postgres) and
+# requires a reachable PostgreSQL instance. The password is sourced from a
+# K8s Secret via secretKeyRef so it never appears in plain env vars.
+#
+# Password secret — two patterns, pick one:
+#
+#   (A) EXISTING SECRET — point `existingSecret` at any K8s Secret that already
+#       holds the password, regardless of how it got there: manual kubectl,
+#       Vault Agent injection, Sealed Secrets, the Zalando Postgres Operator's
+#       auto-created credential Secret, etc. The chart never touches that Secret.
+#
+#   (B) ESO-MANAGED — set `externalSecret.enabled: true` and supply the store /
+#       remoteRef. The chart emits an ExternalSecret CR; set `existingSecret` to
+#       the name ESO will write the K8s Secret to.
+#
+# Example (A) — Zalando operator (auto-creates the Secret):
+#   database:
+#     enabled: true
+#     host: keycloak-postgres-prod
+#     port: 5432
+#     name: keycloak
+#     username: keycloak
+#     existingSecret: keycloak.keycloak-postgres-prod.credentials.postgresql.acid.zalan.do
+#     existingSecretPasswordKey: password
+#
+# Example (B) — ESO from Vault:
+#   database:
+#     enabled: true
+#     host: keycloak-postgres-prod
+#     port: 5432
+#     name: keycloak
+#     username: keycloak
+#     existingSecret: keycloak-db-secret
+#     existingSecretPasswordKey: password
+#     externalSecret:
+#       enabled: true
+#       secretStoreRef:
+#         name: vault-eticloud
+#         kind: ClusterSecretStore
+#       remoteRef:
+#         key: projects/myapp/keycloak-db
+#         property: password
+database:
   enabled: false
+  host: ""
+  port: 5432
+  name: keycloak
+  username: keycloak
+  # Name of an existing K8s Secret containing the DB password.
+  # Required when database.enabled is true.
+  existingSecret: ""
+  existingSecretPasswordKey: password
+  # Optional: emit an ExternalSecret to sync the password from Vault / AWS SM.
+  # The ESO-managed Secret name must match `existingSecret` above.
+  externalSecret:
+    enabled: false
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "vault"
+      kind: "ClusterSecretStore"
+    remoteRef:
+      key: ""
+      property: ""
 
 # ---------- Extra env vars ----------
 env: {}
-  # KC_DB: postgres
-  # KC_DB_URL: "jdbc:postgresql://postgres:5432/keycloak"
-  # KC_DB_USERNAME: keycloak
-  # KC_DB_PASSWORD: changeme
+  # Additional KC_* env vars as plain strings. For secrets use database.existingSecret
+  # or the admin/idp/platformClient secretRef blocks above.
 
 # ---------- Login theme ----------
 theme:

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -375,6 +375,11 @@ database:
   # Required when database.enabled is true.
   existingSecret: ""
   existingSecretPasswordKey: password
+  # Production mode (start) requires KC_HTTP_ENABLED=true and KC_HOSTNAME_STRICT=false
+  # for typical in-cluster deployments where TLS is terminated at the ingress.
+  # Override these if your setup terminates TLS at the pod (e.g. mTLS service mesh).
+  httpEnabled: "true"
+  hostnameStrict: "false"
   # Optional: emit an ExternalSecret to sync the password from Vault / AWS SM.
   # The ESO-managed Secret name must match `existingSecret` above.
   externalSecret:


### PR DESCRIPTION
## Summary

- Adds opt-in `database` block to the Keycloak subchart for external PostgreSQL support
- **No breaking change**: `database.enabled` defaults to `false` — existing installs using H2 are completely unaffected
- When enabled, switches Keycloak from `start-dev` (H2) to `start` (production mode) with `KC_DB=postgres`

## What changes

| File | Change |
|------|--------|
| `values.yaml` | New `database:` block with `enabled`, `host`, `port`, `name`, `username`, `existingSecret`, `existingSecretPasswordKey`, and optional `externalSecret` |
| `deployment.yaml` | `start-dev` → `start` when `database.enabled=true`; injects `KC_DB*`, `KC_HTTP_ENABLED`, `KC_HOSTNAME_STRICT` env vars; password via `secretKeyRef` |
| `database-external-secret.yaml` | New template — only emits an `ExternalSecret` CR when `database.externalSecret.enabled=true` |

## Two patterns for the password Secret

**Pattern A — existing Secret** (manual `kubectl`, Vault Agent, Sealed Secrets, Zalando Postgres Operator auto-created credentials, etc). Chart never creates or touches the Secret:
```yaml
keycloak:
  database:
    enabled: true
    host: keycloak-postgres-prod
    existingSecret: keycloak.keycloak-postgres-prod.credentials.postgresql.acid.zalan.do
    existingSecretPasswordKey: password
```

**Pattern B — ESO-managed** (chart emits an `ExternalSecret` CR):
```yaml
keycloak:
  database:
    enabled: true
    host: keycloak-postgres-prod
    existingSecret: keycloak-db-secret
    externalSecret:
      enabled: true
      secretStoreRef:
        name: vault-eticloud
        kind: ClusterSecretStore
      remoteRef:
        key: projects/myapp/keycloak-db
        property: password
```

## Test plan

- [x] `helm template` with `database.enabled=false` renders `start-dev` (unchanged behaviour)
- [x] `helm template` with `database.enabled=true` renders `start` + all `KC_DB*` env vars with `secretKeyRef` for password
- [x] `helm template` with `database.externalSecret.enabled=true` renders `ExternalSecret` CR pointing at the correct Vault path
- [x] `helm template` with `database.externalSecret.enabled=false` (default) emits no `ExternalSecret`

🤖 Generated with [Claude Code](https://claude.com/claude-code)