### PR TITLE
fix(ui): collapse consecutive identical tool chips in timeline

### DIFF
--- a/ui/src/components/chat/AgentTimeline.tsx
+++ b/ui/src/components/chat/AgentTimeline.tsx
@@ -70,6 +70,40 @@ function groupAdjacentTools(
   return items;
 }
 
+/** A tool segment plus how many consecutive identical calls it represents. */
+type CollapsedTool = SupervisorTimelineSegment & { count: number };
+
+/**
+ * Collapse consecutive identical tool calls into a single entry with a count.
+ * Two adjacent tool calls are "identical" when they share the same agent, tool
+ * name, and status. Non-consecutive repeats (interrupted by a different tool)
+ * are kept separate so the ordering stays faithful to execution.
+ */
+function coalesceConsecutiveTools(
+  tools: SupervisorTimelineSegment[],
+): CollapsedTool[] {
+  const out: CollapsedTool[] = [];
+
+  for (const seg of tools) {
+    const prev = out[out.length - 1];
+    const sameAsPrev =
+      prev &&
+      prev.toolCall &&
+      seg.toolCall &&
+      prev.toolCall.agent === seg.toolCall.agent &&
+      prev.toolCall.tool === seg.toolCall.tool &&
+      prev.toolCall.status === seg.toolCall.status;
+
+    if (sameAsPrev) {
+      prev.count += 1;
+    } else {
+      out.push({ ...seg, count: 1 });
+    }
+  }
+
+  return out;
+}
+
 // ─── Main Component ──────────────────────────────────────────────────────────
 
 interface SupervisorTimelineProps {
@@ -379,6 +413,11 @@ function ToolGroupDropdown({
   const completedCount = tools.filter((t) => t.toolCall?.status === "completed").length;
   const hasRunning = tools.some((t) => t.toolCall?.status === "running");
 
+  // Collapse consecutive identical tool calls (same agent + tool + status) into a
+  // single row with a ×N count. Chatty agents (e.g. AWS) fire the same tool dozens
+  // of times in a row, which otherwise floods the timeline with identical chips.
+  const collapsedTools = coalesceConsecutiveTools(tools);
+
   return (
     <div className="rounded-lg border border-border/50 bg-card/50 overflow-hidden">
       <button
@@ -413,8 +452,10 @@ function ToolGroupDropdown({
             exit={{ height: 0, opacity: 0 }}
             className="px-2 pb-2 space-y-1"
           >
-            {tools.map((t) =>
-              t.toolCall ? <ToolCallSegment key={t.id} tool={t.toolCall} compact /> : null,
+            {collapsedTools.map((t) =>
+              t.toolCall ? (
+                <ToolCallSegment key={t.id} tool={t.toolCall} compact count={t.count} />
+              ) : null,
             )}
           </motion.div>
         )}
@@ -536,7 +577,7 @@ function AgentBadge({ agent, muted }: { agent: string; muted?: boolean }) {
 
 // ─── Tool Call Segment ───────────────────────────────────────────────────────
 
-function ToolCallSegment({ tool, compact }: { tool: ToolCallInfo; compact?: boolean }) {
+function ToolCallSegment({ tool, compact, count }: { tool: ToolCallInfo; compact?: boolean; count?: number }) {
   const isRunning = tool.status === "running";
   const isFailed = tool.status === "failed";
 
@@ -569,6 +610,11 @@ function ToolCallSegment({ tool, compact }: { tool: ToolCallInfo; compact?: bool
         </span>
         <span className="text-foreground/40 mx-1">&rarr;</span>
         <span>{tool.tool}</span>
+        {count && count > 1 && (
+          <span className="ml-1.5 text-[10px] font-semibold text-muted-foreground/80 bg-muted/60 rounded px-1 py-0.5">
+            &times;{count}
+          </span>
+        )}
       </span>
       <span
         className={cn(

--- a/ui/src/components/chat/__tests__/AgentTimeline.test.tsx
+++ b/ui/src/components/chat/__tests__/AgentTimeline.test.tsx
@@ -175,6 +175,40 @@ describe('SupervisorTimeline', () => {
       // Completion counter shows 2/3
       expect(screen.getByText('2/3')).toBeInTheDocument()
     })
+
+    it('collapses consecutive identical tool calls into one row with a count badge', () => {
+      // Chatty agent fires the same tool many times in a row (e.g. AWS aws_cli_execute)
+      const segments: SupervisorTimelineSegment[] = [
+        makeToolSegment('tool-1', 'AWS', 'aws_cli_execute', 'completed'),
+        makeToolSegment('tool-2', 'AWS', 'aws_cli_execute', 'completed'),
+        makeToolSegment('tool-3', 'AWS', 'aws_cli_execute', 'completed'),
+      ]
+
+      render(<SupervisorTimeline segments={segments} isStreaming={true} />)
+
+      // Header still reflects the TRUE number of calls (3 tools, 3/3 done)
+      expect(screen.getByText('3 tools')).toBeInTheDocument()
+      expect(screen.getByText('3/3')).toBeInTheDocument()
+
+      // But only ONE row is rendered for the repeated tool, with a ×3 badge
+      expect(screen.getAllByText('aws_cli_execute')).toHaveLength(1)
+      expect(screen.getByText('\u00d73')).toBeInTheDocument()
+    })
+
+    it('keeps non-consecutive repeats of the same tool separate', () => {
+      const segments: SupervisorTimelineSegment[] = [
+        makeToolSegment('tool-1', 'AWS', 'aws_cli_execute', 'completed'),
+        makeToolSegment('tool-2', 'Slack', 'send_message', 'completed'),
+        makeToolSegment('tool-3', 'AWS', 'aws_cli_execute', 'completed'),
+      ]
+
+      render(<SupervisorTimeline segments={segments} isStreaming={true} />)
+
+      // Interrupted by a different tool, so the two AWS calls stay as separate rows
+      expect(screen.getAllByText('aws_cli_execute')).toHaveLength(2)
+      // No count badge since neither group has >1 consecutive call
+      expect(screen.queryByText('\u00d72')).not.toBeInTheDocument()
+    })
   })
 
   describe('final answer rendering', () => {


### PR DESCRIPTION
## Summary

Chatty agents — notably the AWS agent's `aws_cli_execute` — fire the same tool dozens of times in a row (one call per bucket/prefix/region). The chat timeline rendered each as its own `tool → tool done` chip, flooding the UI with identical rows.

This collapses **consecutive identical** tool calls (same agent + tool + status) into a single row with a `×N` count. The tool-group dropdown header still shows the true total call count, so no information is lost. Non-consecutive repeats (interrupted by a different tool) stay separate to keep execution order faithful.

Purely a presentation change in `AgentTimeline.tsx`; no backend, streaming, or agent behavior is affected.

## Test plan

- [ ] Open a chat that triggers many AWS calls (e.g. "list S3 buckets and their sizes in <account>")
- [ ] Confirm repeated `aws_cli_execute` chips collapse into one row with `×N`
- [ ] Confirm the dropdown header still shows the real tool count
- [ ] Confirm distinct/interrupted tools still render as separate rows

Made with [Cursor](https://cursor.com)