### PR TITLE
fix(dynamic-agents): pass BackendProtocol instances to deepagents

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -421,11 +421,13 @@ class AgentRuntime:
                         if self._resolve_backend_type() == BACKEND_STORE:
                             fs_ns = self._resolve_fs_namespace()
 
-                            def skills_backend(rt):
-                                return StoreBackend(
-                                    rt,
-                                    namespace=lambda ctx: fs_ns,
-                                )
+                            # Pass a BackendProtocol instance (not a factory callable);
+                            # StoreBackend resolves the store via store=/get_store() and
+                            # the namespace callable now receives a Runtime.
+                            skills_backend = StoreBackend(
+                                store=self._store,
+                                namespace=lambda rt: fs_ns,
+                            )
 
                             # Seed skill files into GridFS so SkillsMiddleware and
                             # read_file can find them via StoreBackend.
@@ -439,7 +441,7 @@ class AgentRuntime:
                                     f"{len(self._skills_files)} skill files in GridFS"
                                 )
                         else:
-                            skills_backend = StateBackend
+                            skills_backend = StateBackend()
                         skills_middleware = SkillsMiddleware(backend=skills_backend, sources=skills_sources)
                         logger.info(
                             f"Agent '{self.config.name}': loaded {len(skills_data)} skills "
@@ -566,12 +568,13 @@ class AgentRuntime:
         backend_type = self._resolve_backend_type()
         logger.info(f"resolved backend_type={backend_type}")
         if backend_type == BACKEND_STORE:
-
-            def backend(rt):
-                return StoreBackend(
-                    rt,
-                    namespace=lambda ctx: fs_ns,
-                )
+            # Pass a BackendProtocol instance (not a factory callable); StoreBackend
+            # resolves the store via store=/get_store() and the namespace callable
+            # now receives a Runtime.
+            backend = StoreBackend(
+                store=self._store,
+                namespace=lambda rt: fs_ns,
+            )
         else:
             backend = None  # defaults to StateBackend
 


### PR DESCRIPTION
## Summary

`deepagents==0.6.4` deprecated two backend-construction patterns that the dynamic-agents service still used, so every agent init emitted `LangChainDeprecationWarning`s (2–3 per request). Both patterns are removed in `deepagents==0.7.0`. This converts the backends to `BackendProtocol` instances ahead of that upgrade.

The warnings:

```
LangChainDeprecationWarning: Passing `runtime` to `StoreBackend` is deprecated and
will be removed in deepagents==0.7.0. Use `StoreBackend()` or `StoreBackend(store=my_store)` instead.

LangChainDeprecationWarning: Passing a callable (factory) as `backend` is deprecated
and will be removed in deepagents==0.7.0. Pass a `BackendProtocol` instance directly instead.
```

## Changes

In `agent_runtime.py`, at both backend call sites (the `create_deep_agent` filesystem backend and the `SkillsMiddleware` backend):

- Construct `StoreBackend` as an instance with `store=self._store` (resolved via `store=` / `get_store()` at call time) instead of wrapping it in a per-invocation factory callable that passed a positional `runtime`.
- The `namespace` callable now receives a `Runtime` (signature updated `lambda ctx` → `lambda rt`); both call sites ignore the argument, so resolution is unchanged.
- Instantiate `StateBackend()` rather than passing the bare class.

## Behavior

No functional change on `0.6.4`:

- The explicit `store` is the same store already passed to `create_deep_agent(store=...)`, so `StoreBackend` resolves to the same backing store.
- The namespace callables ignore their argument, so the `Runtime`-vs-`BackendContext` signature change has no effect.

The deprecation warnings are silenced and the call sites are ready for the `0.7.0` bump.

> [!NOTE]
> Chained on top of #1683 — base it there. Verified against the `deepagents==0.6.4` `StoreBackend` / `StateBackend` `__init__` signatures: `store=` is a valid keyword, the `runtime` positional is the deprecated path, and the namespace callable receives a `Runtime`.
