### PR TITLE
fix(slack-bot): broaden exception handling, retry backoff, tighten SA detection

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/utils/bff_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/bff_client.py
@@ -94,25 +94,30 @@ class _ServiceAccountTokenProvider:
 
     def __init__(self) -> None:
         self._client: Any = None
-        self._init_failed = False
+        # Retry backoff: avoid a permanent latch so transient startup failures
+        # (env var not yet populated, one-time DNS hiccup) recover automatically
+        # after 60 s rather than requiring a pod restart.
+        self._retry_after: float = 0.0
 
     def token(self) -> Optional[str]:
+        import time as _time
+
         if not auth_enabled():
             return None
-        if self._client is None and not self._init_failed:
+        if self._client is None and _time.monotonic() >= self._retry_after:
             try:
                 from .oauth2_client import OAuth2ClientCredentials
 
                 self._client = OAuth2ClientCredentials.from_env()
-            except RuntimeError as exc:
+            except Exception as exc:
                 logger.warning("bff_client: OAuth2 client init failed: %s", exc)
-                self._init_failed = True
+                self._retry_after = _time.monotonic() + 60.0
                 return None
         if self._client is None:
             return None
         try:
             return self._client.get_access_token()
-        except RuntimeError as exc:
+        except Exception as exc:
             logger.warning("bff_client: OAuth2 token fetch failed: %s", exc)
             return None
 

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -599,7 +599,13 @@ sys.stdout.write(next((s["id"] for s in stores if s.get("name") == os.environ["S
 # write_openfga_grant <openfga_base_url> <store_id> <user> <relation> <object>
 write_openfga_grant() {
   _ofga="$1"; _store_id="$2"; _user="$3"; _relation="$4"; _object="$5"
-  _tuple="{\"user\":\"${_user}\",\"relation\":\"${_relation}\",\"object\":\"${_object}\"}"
+  # Build JSON via Python to avoid shell-variable injection (e.g. a UUID that
+  # somehow contains '"' or '\' would corrupt bare string interpolation).
+  _tuple=$(python3 -c "
+import json, sys
+u, r, o = sys.argv[1], sys.argv[2], sys.argv[3]
+print(json.dumps({'user': u, 'relation': r, 'object': o}))
+" "${_user}" "${_relation}" "${_object}")
 
   _check=$(curl -sf -X POST "${_ofga}/stores/${_store_id}/check" \
     -H "Content-Type: application/json" \

--- a/ui/src/lib/jwt-validation.ts
+++ b/ui/src/lib/jwt-validation.ts
@@ -240,11 +240,16 @@ function extractIdentity(payload: JWTPayload): JWTIdentity {
     (typeof payload.organization === 'string' ? payload.organization : undefined);
 
   // Keycloak client-credentials tokens carry no interactive user; their
-  // `preferred_username` is `service-account-<clientId>`. Detect that so the
-  // RBAC layer can graph the caller as `service_account:<sub>`.
+  // `preferred_username` is `service-account-<clientId>`. Use two signals so
+  // detection works across IdPs and resists a username like "service-account-*"
+  // being set on a real human account:
+  //   1. preferred_username starts with the Keycloak SA prefix, AND
+  //   2. no interactive-user identity claims (email + name both absent)
+  // A human token always has at least one of email/name; an SA token has neither.
   const preferredUsername =
     typeof payload.preferred_username === 'string' ? payload.preferred_username : '';
-  const isServiceAccount = preferredUsername.startsWith('service-account-');
+  const isServiceAccount =
+    preferredUsername.startsWith('service-account-') && !email && !name;
 
   return { email, name, groups, sub, org, isServiceAccount };
 }


### PR DESCRIPTION
Stacked on #1697. Base is feat/slack-bot-service-account-bff-auth.

## Summary

- bff_client.py: replace permanent _init_failed latch with 60s retry backoff so transient startup failures recover without a pod restart
- bff_client.py: broaden except RuntimeError to except Exception in both init and token-fetch paths; ValueError/ImportError/AttributeError would otherwise crash the calling request
- jwt-validation.ts: tighten isServiceAccount to require both the Keycloak SA username prefix AND absence of email+name claims, preventing a human account with a service-account-* username from being graphed as SA
- init-token-exchange.sh: build OpenFGA tuple JSON via python3 json.dumps instead of bare shell interpolation to avoid injection on malformed UUIDs

## Test plan

- [ ] Existing test_bff_client.py tests pass
- [ ] resource-authz.test.ts SA tests pass with tighter detection
- [ ] Verify Keycloak user with preferred_username=service-account-foo but present email is NOT treated as service account