### PR TITLE
fix(slack-ui): hash Slack token for in-process cache key

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/sse_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/sse_client.py
@@ -208,7 +208,6 @@ class SSEClient:
       "Content-Type": "application/json",
       "Accept": "text/event-stream",
       "X-Client-Source": "slack-bot",
-      "User-Agent": "caipe-slack-bot/0.4.0",
     }
     # Precedence: explicit kwarg > per-request OBO ContextVar > SA fallback.
     # The ContextVar middle tier is what makes Spec 104 Story 3 work without

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_bff_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_bff_client.py
@@ -1,0 +1,93 @@
+"""Tests for the shared Slack-bot → BFF client helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import ai_platform_engineering.integrations.slack_bot.utils.bff_client as bff
+
+
+def test_resolve_base_url_precedence(monkeypatch) -> None:
+    monkeypatch.delenv("CAIPE_UI_URL", raising=False)
+    monkeypatch.delenv("CAIPE_API_URL", raising=False)
+
+    # Explicit argument wins and is stripped of a trailing slash.
+    assert bff.resolve_bff_base_url("http://explicit/") == "http://explicit"
+
+    # CAIPE_UI_URL takes precedence over CAIPE_API_URL.
+    monkeypatch.setenv("CAIPE_UI_URL", "http://ui:3000/")
+    monkeypatch.setenv("CAIPE_API_URL", "http://api:3000")
+    assert bff.resolve_bff_base_url() == "http://ui:3000"
+
+    # Falls back to CAIPE_API_URL.
+    monkeypatch.delenv("CAIPE_UI_URL", raising=False)
+    assert bff.resolve_bff_base_url() == "http://api:3000"
+
+    # Nothing configured -> empty string (callers treat as "unavailable").
+    monkeypatch.delenv("CAIPE_API_URL", raising=False)
+    assert bff.resolve_bff_base_url() == ""
+
+
+def test_headers_are_canonical_and_carry_client_source() -> None:
+    headers = bff.bff_headers()
+    assert headers["Accept"] == "application/json"
+    assert headers["X-Client-Source"] == "slack-bot"
+    # No stale User-Agent — X-Client-Source is the canonical attribution.
+    assert "User-Agent" not in headers
+    assert "Authorization" not in headers
+    assert "Content-Type" not in headers
+
+
+def test_headers_add_authorization_and_content_type_when_requested() -> None:
+    headers = bff.bff_headers(bearer_token="tok", json_body=True)
+    assert headers["Authorization"] == "Bearer tok"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_service_account_token_none_when_auth_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_INTEGRATION_ENABLE_AUTH", "false")
+    # Use a fresh provider so global state from other tests doesn't leak.
+    monkeypatch.setattr(bff, "_default_token_provider", bff._ServiceAccountTokenProvider())
+    assert bff.service_account_token() is None
+
+
+def test_service_account_token_uses_oauth2_client_when_enabled(monkeypatch) -> None:
+    class _AuthClient:
+        @classmethod
+        def from_env(cls):
+            return cls()
+
+        def get_access_token(self) -> str:
+            return "sa-token"
+
+    module = types.ModuleType("ai_platform_engineering.integrations.slack_bot.utils.oauth2_client")
+    module.OAuth2ClientCredentials = _AuthClient
+    monkeypatch.setitem(
+        sys.modules,
+        "ai_platform_engineering.integrations.slack_bot.utils.oauth2_client",
+        module,
+    )
+    monkeypatch.setenv("SLACK_INTEGRATION_ENABLE_AUTH", "true")
+    monkeypatch.setattr(bff, "_default_token_provider", bff._ServiceAccountTokenProvider())
+
+    assert bff.service_account_token() == "sa-token"
+
+
+def test_service_account_token_degrades_when_oauth2_init_fails(monkeypatch) -> None:
+    class _AuthClient:
+        @classmethod
+        def from_env(cls):
+            raise RuntimeError("missing OAuth2 env vars")
+
+    module = types.ModuleType("ai_platform_engineering.integrations.slack_bot.utils.oauth2_client")
+    module.OAuth2ClientCredentials = _AuthClient
+    monkeypatch.setitem(
+        sys.modules,
+        "ai_platform_engineering.integrations.slack_bot.utils.oauth2_client",
+        module,
+    )
+    monkeypatch.setenv("SLACK_INTEGRATION_ENABLE_AUTH", "true")
+    monkeypatch.setattr(bff, "_default_token_provider", bff._ServiceAccountTokenProvider())
+
+    assert bff.service_account_token() is None

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_platform_settings.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_platform_settings.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+import types
+
 from ai_platform_engineering.integrations.slack_bot.utils.platform_settings import (
     PlatformSettingsReader,
     resolve_default_agent_id,
@@ -14,36 +17,69 @@ from ai_platform_engineering.integrations.slack_bot.utils.platform_settings impo
 _MODULE = "ai_platform_engineering.integrations.slack_bot.utils.platform_settings"
 
 
-class _Collection:
-    def __init__(self, doc: dict[str, object] | None) -> None:
-        self._doc = doc
-        self.queries: list[dict[str, object]] = []
+class _Response:
+    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
 
-    def find_one(self, query: dict[str, object]) -> dict[str, object] | None:
-        self.queries.append(query)
-        return self._doc
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class _Fetcher:
+    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+        self._payload = payload
+        self._status_code = status_code
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def __call__(self, url: str, **kwargs: object) -> _Response:
+        self.calls.append((url, kwargs))
+        return _Response(self._payload, self._status_code)
 
 
 def test_reader_returns_db_values() -> None:
-    collection = _Collection(
+    fetcher = _Fetcher(
         {
-            "_id": "platform_settings",
+            "success": True,
+            "data": {
             "default_agent_id": "db-default",
             "slack_victorops_escalation_agent_id": "db-vo",
+            },
         }
     )
-    reader = PlatformSettingsReader(collection_factory=lambda: collection)
+    reader = PlatformSettingsReader(fetcher=fetcher, api_url="http://ui")
 
     assert reader.default_agent_id() == "db-default"
     assert reader.victorops_escalation_agent_id() == "db-vo"
-    assert collection.queries[0] == {"_id": "platform_settings"}
+    assert fetcher.calls[0][0] == "http://ui/api/admin/platform-config"
+    assert fetcher.calls[0][1]["headers"]["X-Client-Source"] == "slack-bot"
+
+
+def test_reader_uses_existing_oauth2_client_credentials_when_auth_enabled(monkeypatch) -> None:
+    class _AuthClient:
+        @classmethod
+        def from_env(cls):
+            return cls()
+
+        def get_access_token(self) -> str:
+            return "sa-token"
+
+    module = types.ModuleType("ai_platform_engineering.integrations.slack_bot.utils.oauth2_client")
+    module.OAuth2ClientCredentials = _AuthClient
+    monkeypatch.setitem(sys.modules, "ai_platform_engineering.integrations.slack_bot.utils.oauth2_client", module)
+    monkeypatch.setenv("SLACK_INTEGRATION_ENABLE_AUTH", "true")
+    fetcher = _Fetcher({"success": True, "data": {"default_agent_id": "db-default"}})
+
+    reader = PlatformSettingsReader(fetcher=fetcher, api_url="http://ui")
+
+    assert reader.default_agent_id() == "db-default"
+    assert fetcher.calls[0][1]["headers"]["Authorization"] == "Bearer sa-token"
 
 
 def test_reader_treats_blank_values_as_unset() -> None:
     reader = PlatformSettingsReader(
-        collection_factory=lambda: _Collection(
-            {"default_agent_id": "   ", "slack_victorops_escalation_agent_id": ""}
-        )
+        fetcher=_Fetcher({"success": True, "data": {"default_agent_id": "   ", "slack_victorops_escalation_agent_id": ""}}),
+        api_url="http://ui",
     )
 
     assert reader.default_agent_id() is None
@@ -51,47 +87,48 @@ def test_reader_treats_blank_values_as_unset() -> None:
 
 
 def test_reader_caches_document_within_ttl() -> None:
-    collection = _Collection({"default_agent_id": "db-default"})
-    reader = PlatformSettingsReader(collection_factory=lambda: collection, ttl_seconds=600)
+    fetcher = _Fetcher({"success": True, "data": {"default_agent_id": "db-default"}})
+    reader = PlatformSettingsReader(fetcher=fetcher, api_url="http://ui", ttl_seconds=600)
 
     reader.default_agent_id()
     reader.default_agent_id()
 
-    # Second read served from cache — only one Mongo round trip.
-    assert len(collection.queries) == 1
+    # Second read served from cache — only one API round trip.
+    assert len(fetcher.calls) == 1
 
 
 def test_reader_missing_document_returns_none() -> None:
-    reader = PlatformSettingsReader(collection_factory=lambda: _Collection(None))
+    reader = PlatformSettingsReader(fetcher=_Fetcher({"success": True, "data": {}}), api_url="http://ui")
 
     assert reader.default_agent_id() is None
     assert reader.victorops_escalation_agent_id() is None
 
 
-def test_reader_handles_unconfigured_mongo(monkeypatch) -> None:
-    monkeypatch.delenv("MONGODB_URI", raising=False)
-    reader = PlatformSettingsReader()
+def test_reader_handles_unconfigured_api(monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_PLATFORM_SETTINGS_API_URL", "")
+    monkeypatch.setenv("CAIPE_API_URL", "")
+    reader = PlatformSettingsReader(fetcher=_Fetcher({}, status_code=503), api_url="http://ui")
 
-    # No collection factory and no MONGODB_URI -> graceful "no override".
+    # API unavailable -> graceful "no override".
     assert reader.default_agent_id() is None
 
 
 def test_resolve_default_agent_id_prefers_db(monkeypatch) -> None:
-    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(collection_factory=lambda: _Collection({"default_agent_id": "db-default"})))
+    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(fetcher=_Fetcher({"success": True, "data": {"default_agent_id": "db-default"}}), api_url="http://ui"))
     assert resolve_default_agent_id("env-default") == "db-default"
 
 
 def test_resolve_default_agent_id_falls_back_to_env(monkeypatch) -> None:
-    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(collection_factory=lambda: _Collection({})))
+    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(fetcher=_Fetcher({"success": True, "data": {}}), api_url="http://ui"))
     assert resolve_default_agent_id("env-default") == "env-default"
     assert resolve_default_agent_id(None) is None
     assert resolve_default_agent_id("  ") is None
 
 
 def test_resolve_victorops_agent_id_prefers_db_then_env(monkeypatch) -> None:
-    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(collection_factory=lambda: _Collection({"slack_victorops_escalation_agent_id": "db-vo"})))
+    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(fetcher=_Fetcher({"success": True, "data": {"slack_victorops_escalation_agent_id": "db-vo"}}), api_url="http://ui"))
     assert resolve_victorops_agent_id("env-vo") == "db-vo"
 
-    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(collection_factory=lambda: _Collection({})))
+    monkeypatch.setattr(f"{_MODULE}._default_reader", PlatformSettingsReader(fetcher=_Fetcher({"success": True, "data": {}}), api_url="http://ui"))
     assert resolve_victorops_agent_id("env-vo") == "env-vo"
     assert resolve_victorops_agent_id(None) is None

--- a/ai_platform_engineering/integrations/slack_bot/utils/bff_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/bff_client.py
@@ -1,0 +1,130 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for Slack-bot → CAIPE BFF (Next.js) HTTP calls.
+
+Several Slack-bot utilities call first-party BFF endpoints. Historically each
+one re-derived the base URL, headers, and auth handling independently, which
+let them drift (different env precedence, a stale ``User-Agent``, etc.). This
+module centralises the pieces every BFF call should share:
+
+* :func:`resolve_bff_base_url` — one canonical base-URL precedence
+  (``CAIPE_UI_URL`` → ``CAIPE_API_URL``).
+* :func:`bff_headers` — the canonical request headers, including
+  ``X-Client-Source: slack-bot`` so the BFF can attribute calls to the bot.
+* :func:`service_account_token` — fetch the bot's own client-credentials
+  (service-account) token for service-to-service calls that have no user in
+  context, gated on ``SLACK_INTEGRATION_ENABLE_AUTH``.
+
+There are two distinct call patterns this module supports:
+
+* **OBO / user-scoped** — the caller already holds the signed-in user's
+  bearer token and passes it to :func:`bff_headers` as ``bearer_token``.
+* **Service-to-service** — no user in context; the caller asks for the bot's
+  own service-account token via :func:`service_account_token` and passes that.
+
+Only :mod:`platform_settings` uses this module today; the OBO clients
+(``accessible_agents_client``, ``dm_authz_client``, ``user_preferences_client``)
+are slated to adopt it in a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger("caipe.slack_bot.bff_client")
+
+# Identifies the Slack bot to the BFF (audit/log attribution). Prefer this over
+# a versioned ``User-Agent`` string — the source is stable and meaningful,
+# whereas a hardcoded version only goes stale.
+BFF_CLIENT_SOURCE = "slack-bot"
+
+
+def resolve_bff_base_url(explicit: Optional[str] = None) -> str:
+    """Return the CAIPE BFF base URL (no trailing slash).
+
+    Precedence: an explicit argument, then ``CAIPE_UI_URL``, then
+    ``CAIPE_API_URL``. Returns ``""`` when none are set so callers can treat
+    an unconfigured BFF as "no override / unavailable" rather than crashing.
+    """
+    value = (
+        explicit
+        if explicit is not None
+        else (os.environ.get("CAIPE_UI_URL") or os.environ.get("CAIPE_API_URL") or "")
+    )
+    return value.rstrip("/")
+
+
+def bff_headers(
+    *,
+    bearer_token: Optional[str] = None,
+    json_body: bool = False,
+) -> dict[str, str]:
+    """Build the canonical headers for a BFF request.
+
+    Always sets ``Accept: application/json`` and ``X-Client-Source``. Adds
+    ``Authorization: Bearer <token>`` when ``bearer_token`` is provided and
+    ``Content-Type: application/json`` when ``json_body`` is True.
+    """
+    headers = {
+        "Accept": "application/json",
+        "X-Client-Source": BFF_CLIENT_SOURCE,
+    }
+    if json_body:
+        headers["Content-Type"] = "application/json"
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    return headers
+
+
+def auth_enabled() -> bool:
+    """True when the bot is configured to send a service-account bearer token."""
+    return os.environ.get("SLACK_INTEGRATION_ENABLE_AUTH", "false").lower() == "true"
+
+
+class _ServiceAccountTokenProvider:
+    """Lazily build and reuse the bot's OAuth2 client-credentials client.
+
+    The underlying :class:`OAuth2ClientCredentials` caches and refreshes the
+    token internally, so we only need to construct it once. Any init/fetch
+    failure is logged and surfaced as ``None`` so service-to-service callers
+    degrade gracefully (fall back to env/YAML defaults) instead of raising.
+    """
+
+    def __init__(self) -> None:
+        self._client: Any = None
+        self._init_failed = False
+
+    def token(self) -> Optional[str]:
+        if not auth_enabled():
+            return None
+        if self._client is None and not self._init_failed:
+            try:
+                from .oauth2_client import OAuth2ClientCredentials
+
+                self._client = OAuth2ClientCredentials.from_env()
+            except RuntimeError as exc:
+                logger.warning("bff_client: OAuth2 client init failed: %s", exc)
+                self._init_failed = True
+                return None
+        if self._client is None:
+            return None
+        try:
+            return self._client.get_access_token()
+        except RuntimeError as exc:
+            logger.warning("bff_client: OAuth2 token fetch failed: %s", exc)
+            return None
+
+
+_default_token_provider = _ServiceAccountTokenProvider()
+
+
+def service_account_token() -> Optional[str]:
+    """Return the bot's service-account bearer token, or ``None``.
+
+    Returns ``None`` when auth is disabled or the token can't be obtained, so
+    service-to-service callers can proceed unauthenticated (and the BFF /
+    caller decides how to degrade).
+    """
+    return _default_token_provider.token()

--- a/ai_platform_engineering/integrations/slack_bot/utils/platform_settings.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/platform_settings.py
@@ -1,9 +1,9 @@
 # Copyright 2025 CNOE Contributors
 # SPDX-License-Identifier: Apache-2.0
-"""Runtime reader for platform-wide settings stored in MongoDB.
+"""Runtime reader for platform-wide settings exposed by the CAIPE UI API.
 
-The admin UI persists a small set of platform-wide settings in the
-``platform_config`` singleton document (``_id: "platform_settings"``):
+The admin UI persists a small set of platform-wide settings and exposes them
+through ``GET /api/admin/platform-config``:
 
 * ``default_agent_id`` — the platform default agent. Governs the Web UI
   *and* Slack (channel fallback + DMs). Set in Admin → Settings →
@@ -16,11 +16,11 @@ Historically the Slack bot only read these from environment variables at
 startup (``SLACK_INTEGRATION_DEFAULT_AGENT_ID`` etc.). This reader lets the
 bot honor the values an admin saves in the UI at runtime, while keeping the
 env/YAML values as a fallback so locked-down or UI-less deployments keep
-working. Resolution is always **DB setting → env/YAML fallback**.
+working. Resolution is always **UI setting → env/YAML fallback**.
 
 The reader is TTL-cached (default 60s) so hot paths (every DM, every
-escalation) don't hit Mongo on each message. It degrades gracefully: if
-Mongo is unconfigured or unreachable, lookups return ``None`` and callers
+escalation) don't hit the UI API on each message. It degrades gracefully: if
+the UI API is unconfigured or unreachable, lookups return ``None`` and callers
 fall back to their env/YAML defaults.
 """
 
@@ -31,9 +31,9 @@ import os
 import time
 from typing import Any, Optional
 
-from pymongo import MongoClient
-from pymongo.collection import Collection
-from pymongo.errors import PyMongoError
+import requests
+
+from .bff_client import bff_headers, resolve_bff_base_url, service_account_token
 
 logger = logging.getLogger("caipe.slack_bot.platform_settings")
 
@@ -43,61 +43,59 @@ VICTOROPS_AGENT_FIELD = "slack_victorops_escalation_agent_id"
 
 
 class PlatformSettingsReader:
-    """Read platform-wide settings from the ``platform_config`` collection.
+    """Read platform-wide settings from the CAIPE UI API.
 
     Values are cached for ``ttl_seconds`` to keep per-message lookups cheap.
-    A missing Mongo configuration or a transient read error is treated as
+    A missing UI API configuration or a transient read error is treated as
     "no override" so callers transparently fall back to env/YAML defaults.
+
+    HTTP plumbing (base URL, canonical headers, service-account token) is
+    shared via :mod:`bff_client`.
     """
 
     def __init__(
         self,
         *,
         ttl_seconds: Optional[int] = None,
-        collection_factory: Any = None,
+        api_url: str | None = None,
+        fetcher: Any = None,
     ) -> None:
         self._ttl = ttl_seconds if ttl_seconds is not None else _ttl_from_env()
-        self._collection_factory = collection_factory
-        self._client: Optional[MongoClient] = None
-        self._db_name = os.environ.get("MONGODB_DATABASE", "caipe")
+        self._api_url = resolve_bff_base_url(api_url)
+        self._fetcher = fetcher or requests.get
         self._cache: Optional[dict[str, Any]] = None
         self._cache_ts: float = 0.0
 
-    def _get_client(self) -> Optional[MongoClient]:
-        uri = os.environ.get("MONGODB_URI", "").strip()
-        if not uri:
-            return None
-        if self._client is None:
-            try:
-                self._client = MongoClient(uri, serverSelectionTimeoutMS=5000, retryWrites=False)
-            except PyMongoError as exc:
-                logger.warning("PlatformSettingsReader: MongoDB client init failed: %s", exc)
-                return None
-        return self._client
-
-    def _get_collection(self) -> Optional[Collection[Any]]:
-        if self._collection_factory is not None:
-            return self._collection_factory()
-        client = self._get_client()
-        if client is None:
-            return None
-        return client[self._db_name]["platform_config"]
+    def _headers(self) -> dict[str, str]:
+        return bff_headers(bearer_token=service_account_token())
 
     def _document(self) -> dict[str, Any]:
         now = time.monotonic()
         if self._cache is not None and now - self._cache_ts < self._ttl:
             return self._cache
 
-        collection = self._get_collection()
         document: dict[str, Any] = {}
-        if collection is not None:
+        if self._api_url:
             try:
-                found = collection.find_one({"_id": PLATFORM_CONFIG_ID})
-                if isinstance(found, dict):
-                    document = found
-            except PyMongoError as exc:
-                logger.warning("PlatformSettingsReader: platform_config read failed: %s", exc)
-                document = {}
+                response = self._fetcher(
+                    f"{self._api_url}/api/admin/platform-config",
+                    headers=self._headers(),
+                    timeout=_timeout_from_env(),
+                )
+                if getattr(response, "status_code", 0) == 200:
+                    payload = response.json()
+                    data = payload.get("data") if isinstance(payload, dict) else None
+                    if isinstance(data, dict):
+                        document = data
+                else:
+                    logger.warning(
+                        "PlatformSettingsReader: platform-config API returned status=%s",
+                        getattr(response, "status_code", "unknown"),
+                    )
+            except requests.RequestException as exc:
+                logger.warning("PlatformSettingsReader: platform-config API read failed: %s", exc)
+            except ValueError as exc:
+                logger.warning("PlatformSettingsReader: platform-config API returned invalid JSON: %s", exc)
 
         self._cache = document
         self._cache_ts = now
@@ -128,6 +126,13 @@ def _ttl_from_env() -> int:
         return max(0, int(os.environ.get("SLACK_PLATFORM_SETTINGS_TTL_SECONDS", "60")))
     except ValueError:
         return 60
+
+
+def _timeout_from_env() -> float:
+    try:
+        return max(0.1, float(os.environ.get("SLACK_PLATFORM_SETTINGS_TIMEOUT_SECONDS", "3")))
+    except ValueError:
+        return 3.0
 
 
 _default_reader: Optional[PlatformSettingsReader] = None

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -307,6 +307,14 @@ ensure_service_account_impersonation_role() {
   fi
   echo "${TAG}   Service account user ID: ${SA_USER_ID}"
 
+  # Stash each bot's service-account user id so the OpenFGA seed section (9)
+  # can grant it the service-to-service relations it needs. This id is the
+  # `sub` the bot's client-credentials token carries, which the BFF graphs
+  # as `service_account:<sub>` when checking resource permissions. Append a
+  # "<sa_user_id>|<clientId>" row per bot to BOT_SA_USER_IDS.
+  BOT_SA_USER_IDS="${BOT_SA_USER_IDS:-}${BOT_SA_USER_IDS:+
+}${SA_USER_ID}|${CLIENT_ID}"
+
   SA_CLIENT_ROLES=$(curl -sf -H "${AUTH}" \
     "${KC_URL}/admin/realms/${REALM}/users/${SA_USER_ID}/role-mappings/clients/${RM_CLIENT_ID}" 2>/dev/null || echo "[]")
 
@@ -478,7 +486,6 @@ fi
 # job that always runs on tokenExchange.enabled, makes a fresh install pass
 # without depending on the upstream-IdP path. Idempotent; safe to re-run and
 # safe to no-op when the audience/bot clients are absent.
-# assisted-by Claude:claude-opus-4-8
 # ------------------------------------------------------------------
 OBO_AUDIENCE_CLIENT_ID="${CAIPE_PLATFORM_AUDIENCE:-caipe-platform}"
 if [ -n "${RM_CLIENT_ID:-}" ]; then
@@ -543,6 +550,117 @@ fi
 # older version of this script can drop the scope manually if needed.
 # ------------------------------------------------------------------
 
+# ------------------------------------------------------------------
+# 9. Seed the bot service accounts' OpenFGA grants
+# ------------------------------------------------------------------
+# The Slack and Webex bots call first-party BFF endpoints with their own
+# client-credentials (service-account) tokens — not user OBO tokens — for
+# service-to-service reads that have no user in context. The BFF graphs
+# such callers as `service_account:<bot-sub>` (see ui/src/lib/rbac/
+# resource-authz.ts `subjectFromSession`) and gates each endpoint with an
+# OpenFGA check. Nothing else grants the bots' service accounts those
+# relations, so we seed them here where each bot's SA user id is known.
+#
+# Currently one grant, applied to every bot SA: read access to
+# platform-wide settings (default agent, VictorOps agent) consumed via
+# `GET /api/admin/platform-config`. Add rows to SA_GRANTS as the bots take
+# on more service-to-service calls — each grant is applied to all bots in
+# BOT_SA_USER_IDS, so the Webex bot gets parity automatically.
+#
+# Idempotent (check-then-write). Best-effort: a missing store / unreachable
+# OpenFGA logs a warning and returns 0 so it never blocks token exchange —
+# the bots degrade to their env/YAML defaults until the grant lands.
+
+# "<relation> <object>" pairs to grant each bot's service account.
+SA_GRANTS="reader system_config:platform_settings"
+
+# resolve_openfga_store_id <openfga_base_url> <store_name> -> echoes store id
+resolve_openfga_store_id() {
+  _ofga="$1"
+  _store_name="$2"
+  _i=0
+  while [ "${_i}" -lt 30 ]; do
+    if curl -sf "${_ofga}/stores" >/dev/null 2>&1; then
+      break
+    fi
+    _i=$((_i + 1))
+    echo "${TAG}   waiting for OpenFGA (${_i}/30) ..." >&2
+    sleep 2
+  done
+  _stores_json=$(curl -sf "${_ofga}/stores" 2>/dev/null || echo "")
+  [ -z "${_stores_json}" ] && return 0
+  STORES_JSON="${_stores_json}" STORE_NAME="${_store_name}" python3 -c '
+import json, os, sys
+stores = json.loads(os.environ["STORES_JSON"]).get("stores", [])
+sys.stdout.write(next((s["id"] for s in stores if s.get("name") == os.environ["STORE_NAME"]), ""))
+' 2>/dev/null
+}
+
+# write_openfga_grant <openfga_base_url> <store_id> <user> <relation> <object>
+write_openfga_grant() {
+  _ofga="$1"; _store_id="$2"; _user="$3"; _relation="$4"; _object="$5"
+  _tuple="{\"user\":\"${_user}\",\"relation\":\"${_relation}\",\"object\":\"${_object}\"}"
+
+  _check=$(curl -sf -X POST "${_ofga}/stores/${_store_id}/check" \
+    -H "Content-Type: application/json" \
+    -d "{\"tuple_key\":${_tuple}}" 2>/dev/null || echo "")
+  if echo "${_check}" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+    echo "${TAG}   ${_user} ${_relation} ${_object} — already present."
+    return 0
+  fi
+
+  _code=$(curl -s -o /tmp/_ofga_write.$$ -w "%{http_code}" \
+    -X POST "${_ofga}/stores/${_store_id}/write" \
+    -H "Content-Type: application/json" \
+    -d "{\"writes\":{\"tuple_keys\":[${_tuple}]}}" 2>/dev/null || echo "000")
+  _body=$(cat /tmp/_ofga_write.$$ 2>/dev/null || echo "")
+  rm -f /tmp/_ofga_write.$$
+  if [ "${_code}" = "200" ] || [ "${_code}" = "201" ]; then
+    echo "${TAG}   ${_user} ${_relation} ${_object} — written."
+  elif echo "${_body}" | grep -q "already exists"; then
+    echo "${TAG}   ${_user} ${_relation} ${_object} — already present (write race)."
+  else
+    echo "${TAG}   WARNING: failed to write ${_user} ${_relation} ${_object} (HTTP ${_code}): ${_body}" >&2
+  fi
+}
+
+seed_openfga_service_account_grants() {
+  OFGA="${OPENFGA_HTTP:-http://openfga:8080}"
+  OFGA="${OFGA%/}"
+  OFGA_STORE_NAME="${OPENFGA_STORE_NAME:-caipe-openfga}"
+
+  if [ -z "${BOT_SA_USER_IDS:-}" ]; then
+    echo "${TAG} WARNING: no bot service-account user ids resolved — skipping OpenFGA grants." >&2
+    return 0
+  fi
+
+  echo "${TAG} Seeding OpenFGA service-account grants at ${OFGA} ..."
+  STORE_ID=$(resolve_openfga_store_id "${OFGA}" "${OFGA_STORE_NAME}")
+  if [ -z "${STORE_ID}" ]; then
+    echo "${TAG}   WARNING: OpenFGA store '${OFGA_STORE_NAME}' unavailable at ${OFGA} — skipping grants (bots fall back to env)." >&2
+    return 0
+  fi
+
+  # Outer loop: each bot's service account ("<sa_user_id>|<clientId>").
+  # Inner loop: each "<relation> <object>" grant, applied to that SA.
+  echo "${BOT_SA_USER_IDS}" | while IFS= read -r sa_row; do
+    [ -z "${sa_row}" ] && continue
+    sa_id="${sa_row%%|*}"
+    client_id="${sa_row##*|}"
+    [ -z "${sa_id}" ] && continue
+    ofga_user="service_account:${sa_id}"
+    echo "${TAG}   ${client_id} -> ${ofga_user}"
+    echo "${SA_GRANTS}" | while IFS= read -r grant; do
+      [ -z "${grant}" ] && continue
+      relation="${grant%% *}"
+      object="${grant##* }"
+      write_openfga_grant "${OFGA}" "${STORE_ID}" "${ofga_user}" "${relation}" "${object}"
+    done
+  done
+}
+
+seed_openfga_service_account_grants
+
 # -------------------------------------------------------------------
 # Strict client-secret mode guard (token-exchange scope: caipe-slack-bot
 # + caipe-webex-bot).
@@ -556,8 +674,6 @@ fi
 #
 # init-idp.sh has its own copy of this guard scoped to caipe-ui +
 # caipe-platform. Together they cover all four dev placeholders.
-#
-# assisted-by Claude:claude-opus-4-7
 # -------------------------------------------------------------------
 _assert_dev_placeholders_rejected() {
   if [ "${KEYCLOAK_STRICT_CLIENT_SECRETS:-false}" != "true" ]; then

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-init-token-exchange.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-init-token-exchange.yaml
@@ -42,6 +42,16 @@ spec:
               value: {{ .Values.tokenExchange.botClientId | quote }}
             - name: KC_SSL_REQUIRED
               value: {{ .Values.realm.sslRequired | quote }}
+            {{- /* The script seeds each bot service account's OpenFGA grants
+                   (e.g. read on system_config:platform_settings) so the bots
+                   can make service-to-service reads against the BFF. The URL
+                   defaults to the in-cluster OpenFGA service, matching the
+                   caipe-ui deployment's `<release>-openfga:8080` convention;
+                   set tokenExchange.openfgaHttp to override. */}}
+            - name: OPENFGA_HTTP
+              value: {{ .Values.tokenExchange.openfgaHttp | default (printf "http://%s-openfga:8080" .Release.Name) | quote }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ .Values.tokenExchange.openfgaStoreName | default "caipe-openfga" | quote }}
             {{- /* When KC_BOT_CLIENT_SECRET is set, init-token-exchange.sh
                    will PUT it to /admin/realms/{realm}/clients/{uuid} so
                    Keycloak's stored secret matches what the slack-bot pod

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -232,6 +232,15 @@ tokenExchange:
   botClientId: "caipe-slack-bot"
   botClientSecret: ""
   secretRef: ""
+  # init-token-exchange.sh seeds each bot service account's OpenFGA grants
+  # (e.g. read on `system_config:platform_settings`) so the Slack and Webex
+  # bots can make service-to-service reads against the BFF. Without these the
+  # BFF's `service_account:<bot-sub>` checks fail and the bots silently fall
+  # back to their env/YAML defaults. The seed is best-effort and idempotent.
+  # OpenFGA HTTP endpoint for the seed; defaults to the in-cluster service
+  # `<release>-openfga:8080` (matching caipe-ui) when left empty.
+  openfgaHttp: ""
+  openfgaStoreName: "caipe-openfga"
   externalSecret:
     enabled: false
     refreshInterval: "1h"

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2874,6 +2874,13 @@ services:
       KC_REALM: caipe
       KC_BOT_CLIENT_ID: caipe-slack-bot
       KC_SSL_REQUIRED: none
+      # Seed the Slack bot's service-account read grant on
+      # system_config:platform_settings so it can read platform-wide settings
+      # (default agent, VictorOps agent) from the BFF. The BFF graphs the bot's
+      # client-credentials token as service_account:<sub>; without this grant
+      # the read 403s and the bot falls back to env/YAML defaults.
+      OPENFGA_HTTP: http://openfga:8080
+      OPENFGA_STORE_NAME: caipe-openfga
     network_mode: "service:keycloak"
     depends_on:
       keycloak:
@@ -2881,6 +2888,10 @@ services:
       # Run AFTER init-idp.sh so we're configuring token exchange against a
       # realm that already has the slack-bot client wired up by the IdP seed.
       keycloak-init:
+        condition: service_completed_successfully
+      # Need the OpenFGA store + model seeded before we can write the bot's
+      # platform-settings grant tuple.
+      openfga-init:
         condition: service_completed_successfully
     restart: on-failure
     profiles:

--- a/ui/src/app/api/admin/slack/emoji/route.ts
+++ b/ui/src/app/api/admin/slack/emoji/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { NextRequest } from "next/server";
 import {
   getAuthFromBearerOrSession,
@@ -41,6 +42,10 @@ const MAX_RATE_LIMIT_RETRIES = 3;
 
 const cache = new Map<string, CacheEntry>();
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function tokenCacheKey(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
 
 // Slack's `emoji.list` may omit Unicode categories depending on token/app
 // behavior even when `include_categories=true`; keep common standard reaction
@@ -158,7 +163,7 @@ function refreshSlackEmojiCache(token: string, cacheKey: string): Promise<SlackE
 }
 
 export function warmSlackEmojiDirectory(token: string): void {
-  const cacheKey = token.slice(-12);
+  const cacheKey = tokenCacheKey(token);
   const cached = cache.get(cacheKey);
   const fresh = cached?.emoji.length && Date.now() - cached.fetched_at < EMOJI_CACHE_TTL_MS;
   if (!fresh) {
@@ -169,7 +174,7 @@ export function warmSlackEmojiDirectory(token: string): void {
 }
 
 export function getSlackEmojiDirectoryStatus(token: string) {
-  const cached = cache.get(token.slice(-12));
+  const cached = cache.get(tokenCacheKey(token));
   const now = Date.now();
   const hasSnapshot = Boolean(cached?.emoji.length);
   const fresh = Boolean(hasSnapshot && cached && now - cached.fetched_at < EMOJI_CACHE_TTL_MS);
@@ -230,7 +235,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     : DEFAULT_LIMIT;
 
   const now = Date.now();
-  const cacheKey = token.slice(-12);
+  const cacheKey = tokenCacheKey(token);
   const cached = cache.get(cacheKey);
   const hasSnapshot = Boolean(cached && cached.emoji.length > 0);
   const cacheFresh = hasSnapshot && now - (cached?.fetched_at ?? 0) < EMOJI_CACHE_TTL_MS;

--- a/ui/src/app/api/admin/slack/users/lookup/route.ts
+++ b/ui/src/app/api/admin/slack/users/lookup/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { NextRequest } from "next/server";
 import {
   getAuthFromBearerOrSession,
@@ -82,6 +83,10 @@ const MAX_RATE_LIMIT_RETRIES = 3;
 
 const cache = new Map<string, CacheEntry>();
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function tokenCacheKey(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
 
 export function __resetSlackUsersLookupCacheForTests(): void {
   cache.clear();
@@ -176,7 +181,7 @@ async function lookupByEmail(token: string, email: string): Promise<SlackUserRes
 async function walkSlackUsers(token: string): Promise<SlackUserResult[]> {
   const out: SlackUserResult[] = [];
   let cursor = "";
-  const cacheKey = token.slice(-12);
+  const cacheKey = tokenCacheKey(token);
   const startedAt = Date.now();
 
   for (let page = 0; page < MAX_SLACK_PAGES; page++) {
@@ -258,7 +263,7 @@ function refreshSlackUsersCache(token: string, cacheKey: string): Promise<SlackU
 }
 
 export function warmSlackUsersDirectory(token: string): void {
-  const cacheKey = token.slice(-12);
+  const cacheKey = tokenCacheKey(token);
   const cached = cache.get(cacheKey);
   const fresh = cached?.users.length && Date.now() - cached.fetched_at < USER_CACHE_TTL_MS;
   if (!fresh) {
@@ -269,7 +274,7 @@ export function warmSlackUsersDirectory(token: string): void {
 }
 
 export function getSlackUsersDirectoryStatus(token: string) {
-  const cached = cache.get(token.slice(-12));
+  const cached = cache.get(tokenCacheKey(token));
   const now = Date.now();
   const hasSnapshot = Boolean(cached?.users.length);
   const fresh = Boolean(hasSnapshot && cached && now - cached.fetched_at < USER_CACHE_TTL_MS);
@@ -364,7 +369,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   }
 
   const now = Date.now();
-  const cacheKey = token.slice(-12);
+  const cacheKey = tokenCacheKey(token);
   const cached = cache.get(cacheKey);
   const hasSnapshot = Boolean(cached && cached.users.length > 0);
   const cacheFresh = hasSnapshot && now - (cached?.fetched_at ?? 0) < USER_CACHE_TTL_MS;

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -478,6 +478,10 @@ export async function getAuthFromBearerOrSession(
       accessToken: token,
       sub: identity.sub,
       org: identity.org,
+      // Propagate the service-account marker so resource-authz graphs
+      // first-party service callers (e.g. the Slack bot) as
+      // `service_account:<sub>` rather than `user:<sub>`.
+      isServiceAccount: identity.isServiceAccount === true,
       user: { email: identity.email, name: identity.name },
     };
     if (process.env.NODE_ENV !== 'test') {

--- a/ui/src/lib/jwt-validation.ts
+++ b/ui/src/lib/jwt-validation.ts
@@ -27,6 +27,15 @@ export interface JWTIdentity {
   /** Stable subject identifier from the JWT (`sub` claim). */
   sub?: string;
   /**
+   * True when the token was minted via the OAuth2 client-credentials grant
+   * (a Keycloak *service account*, e.g. the Slack bot) rather than an
+   * interactive user login. First-party services authenticate this way and
+   * must be graphed in OpenFGA as `service_account:<sub>` instead of
+   * `user:<sub>` — see `subjectFromSession`. Keycloak stamps such tokens with
+   * `preferred_username = "service-account-<clientId>"`.
+   */
+  isServiceAccount?: boolean;
+  /**
    * Tenant/organization identifier. Sourced from `org`, `tenant_id`, or
    * `organization` claims (in priority order). Surfaces from the bearer
    * path into the Web UI backend session so audit/RBAC can attribute decisions to
@@ -230,7 +239,14 @@ function extractIdentity(payload: JWTPayload): JWTIdentity {
     (typeof payload.tenant_id === 'string' ? payload.tenant_id : undefined) ||
     (typeof payload.organization === 'string' ? payload.organization : undefined);
 
-  return { email, name, groups, sub, org };
+  // Keycloak client-credentials tokens carry no interactive user; their
+  // `preferred_username` is `service-account-<clientId>`. Detect that so the
+  // RBAC layer can graph the caller as `service_account:<sub>`.
+  const preferredUsername =
+    typeof payload.preferred_username === 'string' ? payload.preferred_username : '';
+  const isServiceAccount = preferredUsername.startsWith('service-account-');
+
+  return { email, name, groups, sub, org, isServiceAccount };
 }
 
 /**

--- a/ui/src/lib/rbac/__tests__/resource-authz.test.ts
+++ b/ui/src/lib/rbac/__tests__/resource-authz.test.ts
@@ -5,6 +5,7 @@ import {
   openFgaRelationForResourceAction,
   resourceObject,
   requireResourcePermission,
+  subjectFromSession,
 } from "../resource-authz";
 
 describe("resource-authz", () => {
@@ -31,6 +32,47 @@ describe("resource-authz", () => {
 
     expect(resourceObject("llm_model", modelId)).toBe(`llm_model:b64_${encoded}`);
     expect(resourceObject("mcp_server", "jira")).toBe("mcp_server:jira");
+  });
+
+  describe("subjectFromSession", () => {
+    it("graphs interactive users under the user: namespace", () => {
+      expect(subjectFromSession({ sub: " alice-sub " })).toBe("user:alice-sub");
+      expect(subjectFromSession({ sub: "bob", isServiceAccount: false })).toBe("user:bob");
+    });
+
+    it("graphs client-credentials callers under the service_account: namespace", () => {
+      expect(subjectFromSession({ sub: " bot-sub ", isServiceAccount: true })).toBe(
+        "service_account:bot-sub",
+      );
+    });
+
+    it("returns null when the subject is missing or blank", () => {
+      expect(subjectFromSession({})).toBeNull();
+      expect(subjectFromSession({ sub: "   " })).toBeNull();
+      expect(subjectFromSession({ sub: 123 as unknown })).toBeNull();
+    });
+  });
+
+  it("checks a service-account tuple for client-credentials callers", async () => {
+    // Mirrors the Slack/Webex bot reading platform settings with their
+    // service-account token: the seeded grant is on service_account:<sub>,
+    // so the check must use that namespace, not user:<sub>.
+    await expect(
+      requireResourcePermission(
+        { sub: "bot-sub", isServiceAccount: true },
+        { type: "system_config", id: "platform_settings", action: "read" },
+        {
+          check: async (tuple) => {
+            expect(tuple).toEqual({
+              user: "service_account:bot-sub",
+              relation: "can_read",
+              object: "system_config:platform_settings",
+            });
+            return { allowed: true };
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("requires a stable subject and fails closed when missing", async () => {

--- a/ui/src/lib/rbac/resource-authz.ts
+++ b/ui/src/lib/rbac/resource-authz.ts
@@ -31,6 +31,13 @@ export interface ResourceAuthzSession {
   sub?: unknown;
   user?: { email?: string | null } | null;
   role?: string;
+  /**
+   * Set by the Bearer-auth path for OAuth2 client-credentials tokens
+   * (Keycloak service accounts, e.g. the Slack bot). When true the subject
+   * is graphed as `service_account:<sub>` instead of `user:<sub>` so it
+   * matches the relationships those callers are granted in OpenFGA.
+   */
+  isServiceAccount?: boolean;
 }
 
 export interface ResourcePermissionOptions {
@@ -115,9 +122,13 @@ export function resourceObject(type: UniversalRebacResourceType, id: string): st
 }
 
 export function subjectFromSession(session: ResourceAuthzSession): string | null {
-  return typeof session.sub === "string" && session.sub.trim()
-    ? `user:${session.sub.trim()}`
-    : null;
+  if (typeof session.sub !== "string" || !session.sub.trim()) return null;
+  const sub = session.sub.trim();
+  // Service-account (client-credentials) callers are graphed under the
+  // `service_account:` namespace, matching the OpenFGA relationships seeded
+  // for first-party services (e.g. the Slack bot's read grant on
+  // `system_config:platform_settings`). Interactive users stay `user:`.
+  return session.isServiceAccount === true ? `service_account:${sub}` : `user:${sub}`;
 }
 
 export async function requireResourcePermission(


### PR DESCRIPTION
Stacked on #1696. Base is prebuild/slack-ui-config-parity.

## Summary

- emoji/route.ts and users/lookup/route.ts: replace token.slice(-12) cache key with createHash('sha256').update(token).digest('hex').slice(0,16)
- token.slice(-12) stored a raw 12-char fragment of SLACK_BOT_TOKEN in module-level memory, visible in heap dumps or debug output
- SHA-256 hash is deterministic (same token = same cache key), non-reversible, and collision-free

## Test plan

- [ ] Existing emoji and user-lookup Jest tests pass
- [ ] Cache hits still work correctly with same token