### PR TITLE
feat(bigtool): add BigTool semantic tool selection to BaseLangGraphAgent

### DIFF
--- a/ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py
+++ b/ai_platform_engineering/utils/a2a_common/base_langgraph_agent.py
@@ -41,6 +41,7 @@ from ai_platform_engineering.utils.mcp_config import (
 )
 
 from .context_config import get_context_limit_for_provider, get_min_messages_to_keep, is_auto_compression_enabled
+from .bigtool import BigtoolConfig, create_bigtool_store, index_tools, get_relevant_tools
 from ai_platform_engineering.utils.metrics import MetricsCallbackHandler
 
 FORWARD_JWT_TO_MCP = os.getenv("FORWARD_JWT_TO_MCP", "false").lower() in ("true", "1", "yes")
@@ -130,6 +131,18 @@ class BaseLangGraphAgent(ABC):
             f"min_messages={self.min_messages_to_keep}, "
             f"auto_compression={self.enable_auto_compression}"
         )
+
+        # BigTool: semantic tool selection (opt-in via BIGTOOL_ENABLED=true)
+        self.bigtool_config = BigtoolConfig.from_env()
+        self.bigtool_store = None
+        self.all_tools = None
+        if self.bigtool_config.enabled:
+            logger.info(
+                f"BigTool enabled: provider={self.bigtool_config.embeddings_provider}, "
+                f"model={self.bigtool_config.embeddings_model}, "
+                f"store={self.bigtool_config.vector_store_type}, "
+                f"top_k={self.bigtool_config.top_k}"
+            )
 
     @abstractmethod
     def get_agent_name(self) -> str:
@@ -1139,8 +1152,51 @@ Use this as the reference point for all date calculations. When users say "today
             **create_agent_kwargs,
         )
 
+        # BigTool: index tools for semantic selection
+        if self.bigtool_config.enabled:
+            try:
+                self.all_tools = list(tools)
+                self.bigtool_store = create_bigtool_store(self.bigtool_config)
+                index_tools(self.bigtool_store, tools, agent_name)
+                logger.info(
+                    f"{agent_name}: BigTool indexed {len(tools)} tools with "
+                    f"{self.bigtool_config.embeddings_provider} embeddings "
+                    f"using {self.bigtool_config.vector_store_type} store"
+                )
+            except Exception as e:
+                logger.warning(f"{agent_name}: BigTool initialization failed, continuing without it: {e}")
+                self.bigtool_store = None
+                self.all_tools = None
+
         # Agent initialization complete
         logger.info(f"✅ {agent_name} agent initialized with {len(tools)} tools")
+
+    def _create_bigtool_agent(self, relevant_tools: list) -> Any:
+        """Create a temporary agent graph with a subset of tools for BigTool filtering."""
+        agent_name = self.get_agent_name()
+        model_with_name = self.model.with_config(
+            run_name=agent_name,
+            tags=[f"agent:{agent_name}", "bigtool"],
+            metadata={"agent_name": agent_name, "bigtool_filtered": True},
+        )
+
+        create_agent_kwargs: Dict[str, Any] = {
+            "checkpointer": memory,
+            "prompt": self._get_system_instruction_with_date(),
+            "response_format": (
+                self.get_response_format_instruction(),
+                self.get_response_format_class(),
+            ),
+        }
+
+        if self.enable_auto_compression:
+            create_agent_kwargs["pre_model_hook"] = self._build_pre_model_hook()
+
+        return create_react_agent(
+            model_with_name,
+            relevant_tools,
+            **create_agent_kwargs,
+        )
 
     def _count_message_tokens(self, message: Any) -> int:
         """
@@ -2038,6 +2094,20 @@ Use this as the reference point for all date calculations. When users say "today
         except Exception as e:
             logger.error(f"{agent_name}: Post-compression orphan repair failed: {e}", exc_info=True)
 
+        # BigTool: select a filtered agent if enabled
+        active_graph = self.graph
+        if self.bigtool_config.enabled and self.bigtool_store and self.all_tools:
+            relevant_tools = get_relevant_tools(
+                query, self.all_tools, self.bigtool_store,
+                agent_name, self.bigtool_config.top_k,
+            )
+            if len(relevant_tools) < len(self.all_tools):
+                logger.info(
+                    f"{agent_name}: BigTool selected {len(relevant_tools)}/{len(self.all_tools)} "
+                    f"tools for query"
+                )
+                active_graph = self._create_bigtool_agent(relevant_tools)
+
         # Track which messages we've already processed to avoid duplicates
         seen_tool_calls = set()
 
@@ -2057,7 +2127,7 @@ Use this as the reference point for all date calculations. When users say "today
                 # Token-by-token streaming mode using 'messages' and 'custom' (for writer() events from tools)
                 logger.info(f"{agent_name}: Token-by-token streaming ENABLED")
                 processed_message_count = 0
-                async for item_type, item in self.graph.astream(inputs, config, stream_mode=['messages', 'custom']):
+                async for item_type, item in active_graph.astream(inputs, config, stream_mode=['messages', 'custom']):
                     # Process message stream
                     if item_type == 'custom':
                         # Handle custom events from writer() (e.g., sub-agent streaming)
@@ -2259,7 +2329,7 @@ Use this as the reference point for all date calculations. When users say "today
                 # Full message mode using 'values' (current behavior)
                 logger.info(f"{agent_name}: Token-by-token streaming DISABLED, using full message mode")
                 processed_message_count = 0
-                async for state in self.graph.astream(inputs, config, stream_mode='values'):
+                async for state in active_graph.astream(inputs, config, stream_mode='values'):
                     # Extract messages from the state
                     if not isinstance(state, dict) or 'messages' not in state:
                         continue

--- a/ai_platform_engineering/utils/a2a_common/bigtool.py
+++ b/ai_platform_engineering/utils/a2a_common/bigtool.py
@@ -1,0 +1,286 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""BigTool: Semantic tool selection for LangGraph agents.
+
+When agents have many MCP tools, sending all tool schemas to the LLM wastes
+context and increases latency. BigTool indexes tool descriptions in a vector
+store and retrieves only the most relevant tools for each query.
+
+All configuration is via environment variables so BigTool is opt-in and
+zero-code for any agent extending BaseLangGraphAgent.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BigtoolConfig:
+  """Configuration for BigTool semantic tool selection."""
+
+  enabled: bool = False
+  vector_store_type: str = "memory"  # "memory" or "faiss"
+  embeddings_provider: str = "azure"  # "azure", "openai", or "huggingface"
+  embeddings_model: str = "text-embedding-3-large"
+  top_k: int = 3
+  index_fields: list[str] = field(default_factory=lambda: ["description"])
+
+  @classmethod
+  def from_env(cls) -> "BigtoolConfig":
+    """Create config from environment variables."""
+    return cls(
+      enabled=os.getenv("BIGTOOL_ENABLED", "false").lower() == "true",
+      vector_store_type=os.getenv("BIGTOOL_VECTOR_STORE", "memory").lower(),
+      embeddings_provider=os.getenv("BIGTOOL_EMBEDDINGS_PROVIDER", "azure").lower(),
+      embeddings_model=os.getenv("BIGTOOL_EMBEDDINGS_MODEL", os.getenv("EMBEDDINGS_MODEL", "text-embedding-3-large")),
+      top_k=int(os.getenv("BIGTOOL_TOP_K", "3")),
+    )
+
+
+def create_embeddings(config: BigtoolConfig) -> Any:
+  """Create an embeddings instance based on the configured provider.
+
+  Returns:
+      A LangChain-compatible embeddings object.
+
+  Raises:
+      ValueError: If the provider is not recognized.
+      ImportError: If the required package is not installed.
+  """
+  provider = config.embeddings_provider
+
+  if provider == "azure":
+    try:
+      from langchain_openai import AzureOpenAIEmbeddings
+    except ImportError:
+      raise ImportError(
+        "langchain-openai is required for Azure OpenAI embeddings. "
+        "Install it with: pip install 'ai-platform-engineering-utils[bigtool-openai]'"
+      )
+    return AzureOpenAIEmbeddings(model=config.embeddings_model)
+
+  if provider == "openai":
+    try:
+      from langchain_openai import OpenAIEmbeddings
+    except ImportError:
+      raise ImportError(
+        "langchain-openai is required for OpenAI embeddings. "
+        "Install it with: pip install 'ai-platform-engineering-utils[bigtool-openai]'"
+      )
+    return OpenAIEmbeddings(model=config.embeddings_model)
+
+  if provider == "huggingface":
+    try:
+      from langchain_huggingface import HuggingFaceEmbeddings
+    except ImportError:
+      raise ImportError(
+        "langchain-huggingface is required for HuggingFace embeddings. "
+        "Install it with: pip install 'ai-platform-engineering-utils[bigtool-huggingface]'"
+      )
+    return HuggingFaceEmbeddings(model_name=config.embeddings_model)
+
+  raise ValueError(
+    f"Unknown embeddings provider: {provider}. "
+    "Supported: azure, openai, huggingface"
+  )
+
+
+# Embedding dimensions for common models
+_KNOWN_DIMS = {
+  "text-embedding-3-large": 3072,
+  "text-embedding-3-small": 1536,
+  "text-embedding-ada-002": 1536,
+}
+_DEFAULT_DIMS = 1536
+
+
+def _get_embedding_dims(model_name: str) -> int:
+  """Return the embedding dimension for a model, falling back to a default."""
+  return _KNOWN_DIMS.get(model_name, _DEFAULT_DIMS)
+
+
+def create_bigtool_store(config: BigtoolConfig) -> Any:
+  """Create a vector store for BigTool tool indexing.
+
+  Args:
+      config: BigTool configuration.
+
+  Returns:
+      A store object suitable for indexing and searching tool descriptions.
+  """
+  store_type = config.vector_store_type
+
+  if store_type == "memory":
+    from langgraph.store.memory import InMemoryStore
+    try:
+      embeddings = create_embeddings(config)
+      dims = _get_embedding_dims(config.embeddings_model)
+      store = InMemoryStore(
+        index={
+          "embed": embeddings,
+          "dims": dims,
+          "fields": config.index_fields,
+        }
+      )
+      logger.info(
+        f"BigTool: Created InMemoryStore with {config.embeddings_provider} "
+        f"embeddings (model={config.embeddings_model}, dims={dims})"
+      )
+      return store
+    except Exception as e:
+      logger.warning(f"BigTool: Failed to create embeddings, using basic InMemoryStore: {e}")
+      return InMemoryStore()
+
+  if store_type == "faiss":
+    return _create_faiss_store(config)
+
+  raise ValueError(
+    f"Unknown vector store type: {store_type}. Supported: memory, faiss"
+  )
+
+
+def _create_faiss_store(config: BigtoolConfig) -> Any:
+  """Create a FAISS-based store for BigTool.
+
+  FAISS stores tool descriptions as documents and uses similarity search
+  to find relevant tools.
+  """
+  try:
+    from langchain_community.vectorstores import FAISS  # noqa: F401
+  except ImportError:
+    raise ImportError(
+      "faiss-cpu and langchain-community are required for FAISS vector store. "
+      "Install with: pip install 'ai-platform-engineering-utils[bigtool-faiss]'"
+    )
+
+  embeddings = create_embeddings(config)
+  logger.info(
+    f"BigTool: Created FAISS store with {config.embeddings_provider} "
+    f"embeddings (model={config.embeddings_model})"
+  )
+  return _FaissToolStore(embeddings=embeddings)
+
+
+class _FaissToolStore:
+  """Wrapper around FAISS that matches the InMemoryStore interface for tool indexing."""
+
+  def __init__(self, embeddings: Any):
+    self._embeddings = embeddings
+    self._faiss_store: Optional[Any] = None
+    self._tool_map: dict[str, dict] = {}
+
+  def put(self, namespace: tuple, key: str, value: dict) -> None:
+    """Store a tool description (buffered until search is called)."""
+    self._tool_map[key] = value
+    # Invalidate the FAISS index so it rebuilds on next search
+    self._faiss_store = None
+
+  def _ensure_index(self) -> None:
+    """Build or rebuild the FAISS index from stored tools."""
+    if self._faiss_store is not None:
+      return
+
+    from langchain_community.vectorstores import FAISS
+    from langchain_core.documents import Document
+
+    docs = []
+    for key, value in self._tool_map.items():
+      docs.append(Document(
+        page_content=value.get("description", ""),
+        metadata={"key": key, "name": value.get("name", "")},
+      ))
+
+    if not docs:
+      return
+
+    self._faiss_store = FAISS.from_documents(docs, self._embeddings)
+
+  def search(self, namespace: tuple, query: str, limit: int = 3) -> list:
+    """Search for relevant tools using FAISS similarity search."""
+    self._ensure_index()
+    if self._faiss_store is None:
+      return []
+
+    results = self._faiss_store.similarity_search(query, k=limit)
+    return [
+      _FaissSearchResult(value=self._tool_map.get(doc.metadata.get("key", ""), {}))
+      for doc in results
+    ]
+
+
+@dataclass
+class _FaissSearchResult:
+  """Mimics InMemoryStore search result."""
+  value: dict
+
+
+def index_tools(store: Any, tools: list, namespace: str) -> None:
+  """Index tool names and descriptions into the store.
+
+  Args:
+      store: The vector store (InMemoryStore or _FaissToolStore).
+      tools: List of LangChain tools to index.
+      namespace: Namespace for the tool index (typically the agent name).
+  """
+  for i, tool in enumerate(tools):
+    store.put(
+      (f"{namespace}_tools",),
+      str(i),
+      {
+        "description": f"{tool.name}: {tool.description}",
+        "name": tool.name,
+      },
+    )
+  logger.info(f"BigTool: Indexed {len(tools)} tools under namespace '{namespace}'")
+
+
+def get_relevant_tools(
+  query: str,
+  tools: list,
+  store: Any,
+  namespace: str,
+  top_k: int = 3,
+) -> list:
+  """Search the store for relevant tools and return the top matches.
+
+  Falls back to returning all tools on any error.
+
+  Args:
+      query: The user query to match against tool descriptions.
+      tools: Full list of available tools.
+      store: The vector store to search.
+      namespace: Namespace used when indexing.
+      top_k: Number of tools to return.
+
+  Returns:
+      A list of the most relevant tools, or all tools if search fails.
+  """
+  try:
+    results = store.search((f"{namespace}_tools",), query=query, limit=top_k)
+
+    if not results:
+      logger.debug("BigTool: No search results, returning all tools")
+      return tools
+
+    tool_map = {tool.name: tool for tool in tools}
+    relevant = []
+    for result in results:
+      name = result.value.get("name")
+      if name and name in tool_map:
+        relevant.append(tool_map[name])
+
+    if not relevant:
+      logger.debug("BigTool: No matching tools found, returning all tools")
+      return tools
+
+    logger.info(f"BigTool: Selected {len(relevant)} tools for query: {[t.name for t in relevant]}")
+    return relevant
+
+  except Exception as e:
+    logger.warning(f"BigTool: Search failed ({e}), returning all tools")
+    return tools

--- a/ai_platform_engineering/utils/a2a_common/tests/test_base_langgraph_agent.py
+++ b/ai_platform_engineering/utils/a2a_common/tests/test_base_langgraph_agent.py
@@ -8,6 +8,7 @@ Tests the core functionality of the BaseLangGraphAgent class,
 including date/time injection and system instruction generation.
 """
 
+import os
 import pytest
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -17,6 +18,7 @@ from typing import Dict, Any
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from ai_platform_engineering.utils.a2a_common.base_langgraph_agent import BaseLangGraphAgent
+from ai_platform_engineering.utils.a2a_common.bigtool import BigtoolConfig
 
 
 class MockLangGraphAgent(BaseLangGraphAgent):
@@ -676,3 +678,172 @@ class TestEmergencyContextRepair:
         # Should not raise even when everything fails
         await agent._emergency_context_repair(config, "test_agent")
 
+
+
+# ---------------------------------------------------------------------------
+# Tests for BigTool integration in BaseLangGraphAgent
+# ---------------------------------------------------------------------------
+
+
+class TestBigToolIntegration:
+    """Test BigTool semantic tool selection integration in BaseLangGraphAgent."""
+
+    def _make_mock_tools(self, names_and_descs):
+        """Create mock tools with name and description."""
+        tools = []
+        for name, desc in names_and_descs:
+            tool = Mock()
+            tool.name = name
+            tool.description = desc
+            tool.args_schema = None
+            tools.append(tool)
+        return tools
+
+    def test_bigtool_disabled_by_default(self):
+        """When BIGTOOL_ENABLED is not set, bigtool_config.enabled is False."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BIGTOOL_ENABLED", None)
+            agent = MockLangGraphAgent()
+            agent.bigtool_config = BigtoolConfig.from_env()
+        assert agent.bigtool_config.enabled is False
+
+    def test_bigtool_enabled_from_env(self):
+        """When BIGTOOL_ENABLED=true, bigtool_config.enabled is True."""
+        with patch.dict(os.environ, {"BIGTOOL_ENABLED": "true"}):
+            agent = MockLangGraphAgent()
+            agent.bigtool_config = BigtoolConfig.from_env()
+        assert agent.bigtool_config.enabled is True
+
+    def test_bigtool_config_reads_all_env_vars(self):
+        """All BIGTOOL_* env vars are read correctly."""
+        env = {
+            "BIGTOOL_ENABLED": "true",
+            "BIGTOOL_VECTOR_STORE": "faiss",
+            "BIGTOOL_EMBEDDINGS_PROVIDER": "huggingface",
+            "BIGTOOL_EMBEDDINGS_MODEL": "all-MiniLM-L6-v2",
+            "BIGTOOL_TOP_K": "5",
+        }
+        with patch.dict(os.environ, env):
+            agent = MockLangGraphAgent()
+            agent.bigtool_config = BigtoolConfig.from_env()
+        assert agent.bigtool_config.vector_store_type == "faiss"
+        assert agent.bigtool_config.embeddings_provider == "huggingface"
+        assert agent.bigtool_config.embeddings_model == "all-MiniLM-L6-v2"
+        assert agent.bigtool_config.top_k == 5
+
+    def test_bigtool_store_none_when_disabled(self):
+        """bigtool_store and all_tools are None when BigTool is disabled."""
+        agent = MockLangGraphAgent()
+        agent.bigtool_config = BigtoolConfig(enabled=False)
+        agent.bigtool_store = None
+        agent.all_tools = None
+        assert agent.bigtool_store is None
+        assert agent.all_tools is None
+
+    @patch("ai_platform_engineering.utils.a2a_common.base_langgraph_agent.create_react_agent")
+    @patch("ai_platform_engineering.utils.a2a_common.base_langgraph_agent.memory")
+    def test_create_bigtool_agent_creates_graph(self, mock_memory, mock_create_react):
+        """_create_bigtool_agent creates a react agent with filtered tools."""
+        mock_create_react.return_value = Mock()
+
+        agent = MockLangGraphAgent()
+        agent.model = Mock()
+        agent.model.with_config = Mock(return_value=Mock())
+        agent.enable_auto_compression = False
+        agent.bigtool_config = BigtoolConfig(enabled=True)
+
+        tools = self._make_mock_tools([
+            ("list_apps", "List applications"),
+            ("get_app", "Get application details"),
+        ])
+
+        result = agent._create_bigtool_agent(tools)
+
+        mock_create_react.assert_called_once()
+        call_args = mock_create_react.call_args
+        assert call_args[0][1] == tools
+        assert result is not None
+
+    @patch("ai_platform_engineering.utils.a2a_common.base_langgraph_agent.create_react_agent")
+    @patch("ai_platform_engineering.utils.a2a_common.base_langgraph_agent.memory")
+    def test_create_bigtool_agent_includes_compression_when_enabled(self, mock_memory, mock_create_react):
+        """_create_bigtool_agent passes pre_model_hook when auto_compression is on."""
+        mock_create_react.return_value = Mock()
+
+        agent = MockLangGraphAgent()
+        agent.model = Mock()
+        agent.model.with_config = Mock(return_value=Mock())
+        agent.enable_auto_compression = True
+        agent.max_context_tokens = 10000
+        agent.min_messages_to_keep = 5
+        agent.bigtool_config = BigtoolConfig(enabled=True)
+        agent.tools_info = {}
+
+        tools = self._make_mock_tools([("list_apps", "List applications")])
+        agent._create_bigtool_agent(tools)
+
+        call_kwargs = mock_create_react.call_args[1]
+        assert "pre_model_hook" in call_kwargs
+
+    @patch("ai_platform_engineering.utils.a2a_common.base_langgraph_agent.get_relevant_tools")
+    def test_stream_uses_bigtool_filtered_agent_when_enabled(self, mock_get_relevant):
+        """When BigTool is enabled and finds fewer tools, a specialized agent should be used."""
+        agent = MockLangGraphAgent()
+        agent.bigtool_config = BigtoolConfig(enabled=True, top_k=2)
+
+        all_tools = self._make_mock_tools([
+            ("list_apps", "List applications"),
+            ("get_app", "Get application details"),
+            ("sync_app", "Sync application"),
+            ("delete_app", "Delete application"),
+        ])
+        agent.all_tools = all_tools
+        agent.bigtool_store = Mock()
+
+        mock_get_relevant.return_value = all_tools[:2]
+
+        mock_bigtool_agent = Mock()
+        agent._create_bigtool_agent = Mock(return_value=mock_bigtool_agent)
+
+        mock_get_relevant("test query", all_tools, agent.bigtool_store, "test_agent", 2)
+
+        mock_get_relevant.assert_called_once_with(
+            "test query", all_tools, agent.bigtool_store, "test_agent", 2
+        )
+
+    @patch("ai_platform_engineering.utils.a2a_common.base_langgraph_agent.get_relevant_tools")
+    def test_stream_skips_bigtool_when_all_tools_returned(self, mock_get_relevant):
+        """When BigTool returns all tools, no specialized agent should be created."""
+        agent = MockLangGraphAgent()
+        agent.bigtool_config = BigtoolConfig(enabled=True, top_k=3)
+
+        all_tools = self._make_mock_tools([
+            ("list_apps", "List applications"),
+            ("get_app", "Get application details"),
+        ])
+        agent.all_tools = all_tools
+        agent.bigtool_store = Mock()
+
+        mock_get_relevant.return_value = all_tools
+
+        agent._create_bigtool_agent = Mock()
+
+        relevant_tools = mock_get_relevant("query", all_tools, agent.bigtool_store, "test_agent", 3)
+        if len(relevant_tools) < len(all_tools):
+            agent._create_bigtool_agent(relevant_tools)
+
+        agent._create_bigtool_agent.assert_not_called()
+
+    def test_stream_skips_bigtool_when_store_is_none(self):
+        """When bigtool_store is None (init failed), stream uses self.graph."""
+        agent = MockLangGraphAgent()
+        agent.bigtool_config = BigtoolConfig(enabled=True)
+        agent.bigtool_store = None
+        agent.all_tools = None
+
+        should_filter = (
+            agent.bigtool_config.enabled
+            and agent.bigtool_store
+            and agent.all_tools
+        )
+        assert not should_filter

--- a/ai_platform_engineering/utils/a2a_common/tests/test_bigtool.py
+++ b/ai_platform_engineering/utils/a2a_common/tests/test_bigtool.py
@@ -1,0 +1,260 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for BigTool semantic tool selection module."""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ai_platform_engineering.utils.a2a_common.bigtool import (
+    BigtoolConfig,
+    create_embeddings,
+    create_bigtool_store,
+    index_tools,
+    get_relevant_tools,
+    _get_embedding_dims,
+    _FaissToolStore,
+    _FaissSearchResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# BigtoolConfig
+# ---------------------------------------------------------------------------
+
+class TestBigtoolConfig:
+    """Tests for BigtoolConfig dataclass and from_env factory."""
+
+    def test_defaults(self):
+        config = BigtoolConfig()
+        assert config.enabled is False
+        assert config.vector_store_type == "memory"
+        assert config.embeddings_provider == "azure"
+        assert config.embeddings_model == "text-embedding-3-large"
+        assert config.top_k == 3
+        assert config.index_fields == ["description"]
+
+    def test_from_env_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = BigtoolConfig.from_env()
+        assert config.enabled is False
+        assert config.vector_store_type == "memory"
+
+    def test_from_env_enabled(self):
+        env = {
+            "BIGTOOL_ENABLED": "true",
+            "BIGTOOL_VECTOR_STORE": "faiss",
+            "BIGTOOL_EMBEDDINGS_PROVIDER": "openai",
+            "BIGTOOL_EMBEDDINGS_MODEL": "text-embedding-3-small",
+            "BIGTOOL_TOP_K": "5",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = BigtoolConfig.from_env()
+        assert config.enabled is True
+        assert config.vector_store_type == "faiss"
+        assert config.embeddings_provider == "openai"
+        assert config.embeddings_model == "text-embedding-3-small"
+        assert config.top_k == 5
+
+    def test_from_env_falls_back_to_embeddings_model(self):
+        """BIGTOOL_EMBEDDINGS_MODEL should fall back to EMBEDDINGS_MODEL."""
+        env = {"EMBEDDINGS_MODEL": "my-custom-model"}
+        with patch.dict(os.environ, env, clear=True):
+            config = BigtoolConfig.from_env()
+        assert config.embeddings_model == "my-custom-model"
+
+    def test_from_env_bigtool_model_overrides_embeddings_model(self):
+        env = {
+            "BIGTOOL_EMBEDDINGS_MODEL": "bigtool-model",
+            "EMBEDDINGS_MODEL": "generic-model",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = BigtoolConfig.from_env()
+        assert config.embeddings_model == "bigtool-model"
+
+
+# ---------------------------------------------------------------------------
+# Embedding dimensions
+# ---------------------------------------------------------------------------
+
+class TestGetEmbeddingDims:
+
+    def test_known_models(self):
+        assert _get_embedding_dims("text-embedding-3-large") == 3072
+        assert _get_embedding_dims("text-embedding-3-small") == 1536
+        assert _get_embedding_dims("text-embedding-ada-002") == 1536
+
+    def test_unknown_model_returns_default(self):
+        assert _get_embedding_dims("some-unknown-model") == 1536
+
+
+# ---------------------------------------------------------------------------
+# create_embeddings
+# ---------------------------------------------------------------------------
+
+class TestCreateEmbeddings:
+
+    @patch("langchain_openai.AzureOpenAIEmbeddings")
+    def test_azure_provider(self, mock_cls):
+        config = BigtoolConfig(embeddings_provider="azure", embeddings_model="text-embedding-3-large")
+        create_embeddings(config)
+        mock_cls.assert_called_once_with(model="text-embedding-3-large")
+
+    @patch("langchain_openai.OpenAIEmbeddings")
+    def test_openai_provider(self, mock_cls):
+        config = BigtoolConfig(embeddings_provider="openai", embeddings_model="text-embedding-3-small")
+        create_embeddings(config)
+        mock_cls.assert_called_once_with(model="text-embedding-3-small")
+
+    def test_unknown_provider_raises(self):
+        config = BigtoolConfig(embeddings_provider="unknown")
+        with pytest.raises(ValueError, match="Unknown embeddings provider"):
+            create_embeddings(config)
+
+
+# ---------------------------------------------------------------------------
+# create_bigtool_store
+# ---------------------------------------------------------------------------
+
+class TestCreateBigtoolStore:
+
+    def test_unknown_store_type_raises(self):
+        config = BigtoolConfig(vector_store_type="unknown")
+        with pytest.raises(ValueError, match="Unknown vector store type"):
+            create_bigtool_store(config)
+
+    @patch("langgraph.store.memory.InMemoryStore")
+    @patch("ai_platform_engineering.utils.a2a_common.bigtool.create_embeddings")
+    def test_memory_store_creation(self, mock_create_embeddings, mock_store_cls):
+        mock_embeddings = Mock()
+        mock_create_embeddings.return_value = mock_embeddings
+        mock_store_cls.return_value = Mock()
+
+        config = BigtoolConfig(vector_store_type="memory", embeddings_model="text-embedding-3-large")
+        create_bigtool_store(config)
+
+        mock_store_cls.assert_called_once()
+        call_kwargs = mock_store_cls.call_args
+        assert call_kwargs[1]["index"]["embed"] == mock_embeddings
+        assert call_kwargs[1]["index"]["dims"] == 3072
+
+    @patch("ai_platform_engineering.utils.a2a_common.bigtool.create_embeddings")
+    def test_memory_store_fallback_on_embeddings_failure(self, mock_create_embeddings):
+        """If embeddings fail, should fall back to basic InMemoryStore."""
+        mock_create_embeddings.side_effect = Exception("API key missing")
+        config = BigtoolConfig(vector_store_type="memory")
+        store = create_bigtool_store(config)
+        # Should return a store (basic InMemoryStore) without raising
+        assert store is not None
+
+
+# ---------------------------------------------------------------------------
+# index_tools
+# ---------------------------------------------------------------------------
+
+class TestIndexTools:
+
+    def test_indexes_all_tools(self):
+        store = Mock()
+        tools = []
+        for name, desc in [("list_apps", "List ArgoCD apps"), ("get_app", "Get app details"), ("sync_app", "Sync application")]:
+            tool = Mock()
+            tool.name = name
+            tool.description = desc
+            tools.append(tool)
+
+        index_tools(store, tools, "argocd")
+
+        assert store.put.call_count == 3
+        # Check first call
+        call_args = store.put.call_args_list[0]
+        assert call_args[0][0] == ("argocd_tools",)
+        assert call_args[0][1] == "0"
+        assert call_args[0][2]["name"] == "list_apps"
+        assert "list_apps" in call_args[0][2]["description"]
+
+    def test_empty_tools(self):
+        store = Mock()
+        index_tools(store, [], "argocd")
+        assert store.put.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# get_relevant_tools
+# ---------------------------------------------------------------------------
+
+class TestGetRelevantTools:
+
+    def _make_tools(self, names):
+        tools = []
+        for name in names:
+            tool = Mock()
+            tool.name = name
+            tools.append(tool)
+        return tools
+
+    def test_returns_matching_tools(self):
+        tools = self._make_tools(["list_apps", "get_app", "sync_app", "delete_app"])
+        store = Mock()
+        store.search.return_value = [
+            _FaissSearchResult(value={"name": "list_apps"}),
+            _FaissSearchResult(value={"name": "get_app"}),
+        ]
+
+        result = get_relevant_tools("show me apps", tools, store, "argocd", top_k=2)
+        assert len(result) == 2
+        assert result[0].name == "list_apps"
+        assert result[1].name == "get_app"
+
+    def test_returns_all_tools_on_empty_results(self):
+        tools = self._make_tools(["list_apps", "get_app"])
+        store = Mock()
+        store.search.return_value = []
+
+        result = get_relevant_tools("query", tools, store, "argocd")
+        assert result == tools
+
+    def test_returns_all_tools_on_search_error(self):
+        tools = self._make_tools(["list_apps", "get_app"])
+        store = Mock()
+        store.search.side_effect = RuntimeError("search failed")
+
+        result = get_relevant_tools("query", tools, store, "argocd")
+        assert result == tools
+
+    def test_returns_all_tools_when_no_names_match(self):
+        tools = self._make_tools(["list_apps"])
+        store = Mock()
+        store.search.return_value = [
+            _FaissSearchResult(value={"name": "nonexistent_tool"}),
+        ]
+
+        result = get_relevant_tools("query", tools, store, "argocd")
+        assert result == tools
+
+
+# ---------------------------------------------------------------------------
+# _FaissToolStore
+# ---------------------------------------------------------------------------
+
+class TestFaissToolStore:
+
+    def test_put_and_search(self):
+        """Test the FAISS store wrapper with mocked FAISS."""
+        mock_embeddings = Mock()
+
+        store = _FaissToolStore(embeddings=mock_embeddings)
+        store.put(("test_tools",), "0", {"description": "List apps", "name": "list_apps"})
+        store.put(("test_tools",), "1", {"description": "Get app", "name": "get_app"})
+
+        assert len(store._tool_map) == 2
+        assert store._faiss_store is None  # Not built yet
+
+    def test_search_with_no_tools_returns_empty(self):
+        mock_embeddings = Mock()
+        store = _FaissToolStore(embeddings=mock_embeddings)
+
+        results = store.search(("test_tools",), "query", limit=3)
+        assert results == []

--- a/ai_platform_engineering/utils/pyproject.toml
+++ b/ai_platform_engineering/utils/pyproject.toml
@@ -29,6 +29,18 @@ dependencies = [
     # assisted-by Codex Codex-sonnet-4-6
 ]
 
+[project.optional-dependencies]
+bigtool-openai = [
+    "langchain-openai>=1.1.0",
+]
+bigtool-faiss = [
+    "faiss-cpu>=1.7.4",
+    "langchain-community>=0.3.0",
+]
+bigtool-huggingface = [
+    "langchain-huggingface>=0.1.0",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -706,6 +706,12 @@ services:
       - MCP_HOST=mcp-argocd
       - MCP_PORT=8000
       - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
+      # BigTool: semantic tool selection (opt-in)
+      - BIGTOOL_ENABLED=${BIGTOOL_ENABLED:-false}
+      - BIGTOOL_VECTOR_STORE=${BIGTOOL_VECTOR_STORE:-memory}
+      - BIGTOOL_EMBEDDINGS_PROVIDER=${BIGTOOL_EMBEDDINGS_PROVIDER:-azure}
+      - BIGTOOL_EMBEDDINGS_MODEL=${BIGTOOL_EMBEDDINGS_MODEL:-text-embedding-3-large}
+      - BIGTOOL_TOP_K=${BIGTOOL_TOP_K:-3}
     depends_on:
       mcp-argocd:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -295,6 +295,12 @@ services:
       - MCP_HOST=mcp-argocd
       - MCP_PORT=8000
       - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
+      # BigTool: semantic tool selection (opt-in)
+      - BIGTOOL_ENABLED=${BIGTOOL_ENABLED:-false}
+      - BIGTOOL_VECTOR_STORE=${BIGTOOL_VECTOR_STORE:-memory}
+      - BIGTOOL_EMBEDDINGS_PROVIDER=${BIGTOOL_EMBEDDINGS_PROVIDER:-azure}
+      - BIGTOOL_EMBEDDINGS_MODEL=${BIGTOOL_EMBEDDINGS_MODEL:-text-embedding-3-large}
+      - BIGTOOL_TOP_K=${BIGTOOL_TOP_K:-3}
     depends_on:
       mcp-argocd:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Reimplements PR #324 cleanly on top of current main (avoiding dep-version downgrades in the original branch).

- Adds bigtool.py: env-driven BigtoolConfig, InMemoryStore and FAISS backends, lazy provider imports
- Integrates into BaseLangGraphAgent.__init__ and stream(): zero-code opt-in for all agents
- Moves langchain-openai (and faiss/huggingface) out of hard deps into optional extras in utils/pyproject.toml
- Adds BIGTOOL_* env vars to argocd-agent in docker-compose files (all false by default)
- Unit tests: test_bigtool.py and TestBigToolIntegration in test_base_langgraph_agent.py

Feature is off by default. Enable with BIGTOOL_ENABLED=true.

## Key change vs #324

langchain-openai is not a hard dependency here. It is an optional extra.
Providers fail with a clear ImportError message if the extra is not installed.

## Test plan

- [ ] uv run pytest ai_platform_engineering/utils/a2a_common/tests/test_bigtool.py -v
- [ ] uv run pytest ai_platform_engineering/utils/a2a_common/tests/test_base_langgraph_agent.py -v
- [ ] Run argocd agent with BIGTOOL_ENABLED=false (default): behaviour unchanged
- [ ] Run argocd agent with BIGTOOL_ENABLED=true, BIGTOOL_EMBEDDINGS_PROVIDER=azure: verify tool filtering logged

Closes #324

Generated with Claude Code