### PR TITLE
fix(rbac): harden shareable-resource access control for RAG MCP tools and KB sharing

### DIFF
--- a/ui/src/app/api/rag/[...path]/route.ts
+++ b/ui/src/app/api/rag/[...path]/route.ts
@@ -10,6 +10,7 @@ import type { RbacScope } from '@/lib/rbac/types';
 import {
   filterResourcesByPermission,
   requireResourcePermission,
+  canTransferResourceOwnership,
   type ResourcePermissionAction,
 } from '@/lib/rbac/resource-authz';
 import {
@@ -159,6 +160,10 @@ interface AuthorizedRagContext {
     sharedTeamSlugs: string[];
     /** Previously-persisted shared teams, read from config for the revoke diff. */
     previousSharedTeamSlugs: string[];
+    /** Previously-persisted owner team, read from config. When the owner team
+     *  changes, this is passed to the reconciler so the old team's grants are
+     *  revoked instead of orphaned. */
+    previousOwnerTeamSlug: string | null;
   };
 }
 
@@ -247,14 +252,23 @@ async function requireMcpToolCallPermission(
   if (!toolName) return;
 
   // Only custom tools have an mcp_tool object. Resolve the custom-tool set
-  // from the RAG server; a tool_name not in it is built-in → not gated.
+  // from the RAG server; a tool_name not in it is built-in → not gated. The
+  // gate is FAIL-CLOSED: if we cannot determine whether `tool_name` is a
+  // custom tool (listing error/parse failure), we deny rather than forward,
+  // so a transient RAG-server error cannot be used to bypass `can_call`.
   let customToolIds: Set<string>;
   try {
     const response = await fetch(`${getRagServerUrl()}/v1/mcp/custom-tools`, {
       method: 'GET',
       headers,
     });
-    if (!response.ok) return; // fail-open on listing error — RAG server still role-checks
+    if (!response.ok) {
+      throw new ApiError(
+        'Unable to verify tool-call permission. Please retry.',
+        503,
+        'mcp_tool#call_unavailable',
+      );
+    }
     const data = await response.json();
     const list = Array.isArray(data) ? data : [];
     customToolIds = new Set(
@@ -263,8 +277,13 @@ async function requireMcpToolCallPermission(
         .map((t) => (typeof t.tool_id === 'string' ? t.tool_id : ''))
         .filter(Boolean),
     );
-  } catch {
-    return;
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    throw new ApiError(
+      'Unable to verify tool-call permission. Please retry.',
+      503,
+      'mcp_tool#call_unavailable',
+    );
   }
   if (!customToolIds.has(toolName)) return; // built-in tool — not gated
 
@@ -310,7 +329,18 @@ async function reconcileMcpToolForOwnership(pending: {
   creatorSubject: string | null;
   sharedTeamSlugs: string[];
   previousSharedTeamSlugs: string[];
+  previousOwnerTeamSlug: string | null;
 }): Promise<void> {
+  // Pass the previous owner team when it differs from the next owner so the
+  // reconciler revokes the old team's grants on an ownership change (the
+  // mcp_tool builder treats it symmetrically with shared-team removals).
+  // Without this, changing owner_team_slug would orphan the old team's
+  // reader/user/manager tuples, leaving stale access.
+  const previousOwnerTeamSlug =
+    pending.previousOwnerTeamSlug &&
+    pending.previousOwnerTeamSlug !== pending.ownerTeamSlug
+      ? pending.previousOwnerTeamSlug
+      : undefined;
   await reconcileMcpToolRelationships({
     toolId: pending.toolId,
     ownerSubject: pending.ownerSubject,
@@ -318,6 +348,7 @@ async function reconcileMcpToolForOwnership(pending: {
     creatorSubject: pending.creatorSubject,
     nextSharedTeamSlugs: pending.sharedTeamSlugs,
     previousSharedTeamSlugs: pending.previousSharedTeamSlugs,
+    previousOwnerTeamSlug,
   });
 }
 
@@ -425,32 +456,87 @@ async function getAuthorizedRagContext(
       extractMcpToolId(pathSegments) ??
       (isRecord(body) ? normalizeString(body.tool_id) : null);
     if (toolId) {
-      const ownerTeamSlug = isRecord(body) ? normalizeString(body.owner_team_slug) : null;
-      if (ownerTeamSlug) {
-        await requireResourcePermission(
-          { sub: session.sub, role: session.role, user: session.user },
-          { type: 'team', id: ownerTeamSlug, action: 'use' },
-        );
-      }
       const ownerSubject = normalizeString(session.sub);
       const sharedTeamSlugs = isRecord(body)
         ? normalizeSlugList(body.shared_with_teams)
         : [];
-      // Read the previously-persisted shared set from config so the
-      // reconciler can emit revoke deletes for unshared teams (mirrors the
-      // agent route's previous-set read). Creator is set-once: keep the
-      // existing one if present.
+      // Config is the source of truth: read the previous owner/creator/shared
+      // so we can keep set-once fields, emit revoke deletes for removed teams,
+      // and detect an ownership transfer (mirrors the agent route).
       const previous = await loadMcpToolConfig(toolId, {
         accessToken: session.accessToken,
         org: session.org,
       });
+
+      const authzSession = { sub: session.sub, role: session.role, user: session.user };
+      const requestedOwnerTeamSlug = isRecord(body)
+        ? normalizeString(body.owner_team_slug)
+        : null;
+      const previousOwnerTeamSlug = previous.ownerTeamSlug;
+      // Keep the existing owner when the request omits it — the RAG server
+      // replaces the whole config on PUT, so an omitted owner must not be
+      // dropped (which would also wrongly revoke the owner team's grants).
+      const nextOwnerTeamSlug = requestedOwnerTeamSlug ?? previousOwnerTeamSlug;
+
+      const isOwnerChange =
+        requestedOwnerTeamSlug !== null &&
+        previousOwnerTeamSlug !== null &&
+        requestedOwnerTeamSlug !== previousOwnerTeamSlug;
+
+      if (isOwnerChange) {
+        // Ownership transfer (spec 2026-06-03, US3): the owner team is
+        // immutable on a normal edit and may only be reassigned by an
+        // owner-team admin or org admin. Mirrors the dynamic-agents guard.
+        const allowed = await canTransferResourceOwnership(authzSession, {
+          type: 'mcp_tool',
+          id: toolId,
+        });
+        if (!allowed) {
+          throw new ApiError(
+            'Only an owner-team admin or org admin can transfer this tool.',
+            403,
+            'TRANSFER_FORBIDDEN',
+          );
+        }
+        // A transfer to a team the caller is not a member of requires explicit
+        // confirmation (the <TeamOwnershipFields> not-a-member prompt).
+        let canUseDestination = false;
+        try {
+          await requireResourcePermission(authzSession, {
+            type: 'team',
+            id: requestedOwnerTeamSlug,
+            action: 'use',
+          });
+          canUseDestination = true;
+        } catch {
+          canUseDestination = false;
+        }
+        const confirmedNotMember = isRecord(body) && body.confirm_not_member === true;
+        if (!canUseDestination && !confirmedNotMember) {
+          throw new ApiError(
+            'You are not a member of the destination team. Confirm the transfer to proceed.',
+            409,
+            'TRANSFER_NOT_MEMBER_UNCONFIRMED',
+          );
+        }
+      } else if (requestedOwnerTeamSlug && previousOwnerTeamSlug === null) {
+        // First-set (create / pre-ownership tool): the caller must belong to
+        // the owner team they assign.
+        await requireResourcePermission(authzSession, {
+          type: 'team',
+          id: requestedOwnerTeamSlug,
+          action: 'use',
+        });
+      }
+
       pendingMcpToolOwnership = {
         toolId,
         ownerSubject,
-        ownerTeamSlug,
+        ownerTeamSlug: nextOwnerTeamSlug,
         creatorSubject: previous.creatorSubject ?? ownerSubject,
         sharedTeamSlugs,
         previousSharedTeamSlugs: previous.sharedTeamSlugs,
+        previousOwnerTeamSlug,
       };
     }
   }
@@ -860,9 +946,15 @@ export async function PUT(
     const targetPath = path.join('/');
     const targetUrl = `${ragServerUrl}/${targetPath}`;
 
+    // Parse the JSON body when present. Mirror the POST handler: attempt a
+    // parse whenever content-length is absent-but-nonempty OR positive, because
+    // the ownership/transfer logic below needs the body fields and some clients
+    // omit content-length on small JSON payloads. A parse failure leaves body
+    // undefined.
     let body: unknown = undefined;
     const contentLength = request.headers.get('content-length');
-    if (contentLength && parseInt(contentLength) > 0) {
+    const hasBody = contentLength === null || parseInt(contentLength) > 0;
+    if (hasBody) {
       try {
         body = await request.json();
       } catch {

--- a/ui/src/app/api/rag/__tests__/mcp-tool-can-call.test.ts
+++ b/ui/src/app/api/rag/__tests__/mcp-tool-can-call.test.ts
@@ -195,6 +195,38 @@ describe("POST /v1/mcp/invoke — can_call gate", () => {
     );
     expect(res.status).toBe(200);
   });
+
+  it("fails CLOSED (503, no forward) when the custom-tools listing errors", async () => {
+    await asUser("alice-sub");
+    // The custom-tools listing fails — we cannot tell if `tool_name` is a
+    // custom tool, so the gate must DENY rather than forward (deny-by-default),
+    // so a transient error can't be used to bypass `can_call`.
+    const forward = jest.fn();
+    global.fetch = jest.fn((url: string | URL) => {
+      const u = String(url);
+      if (u.includes("/v1/mcp/custom-tools")) {
+        return Promise.resolve({ ok: false, status: 500, json: async () => ({}) } as Response);
+      }
+      forward();
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response);
+    }) as jest.Mock;
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
+
+    const { POST } = await import("@/app/api/rag/[...path]/route");
+    const res = await POST(
+      ragRequest("/api/rag/v1/mcp/invoke", {
+        method: "POST",
+        body: JSON.stringify({ tool_name: "infra-search", arguments: {} }),
+        headers: { "content-type": "application/json" },
+      }),
+      INVOKE,
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("mcp_tool#call_unavailable");
+    // Critically: the invocation was never forwarded to the RAG server.
+    expect(forward).not.toHaveBeenCalled();
+  });
 });
 
 describe("DELETE /v1/mcp/custom-tools/<id> — orphan tuple cleanup", () => {

--- a/ui/src/app/api/rag/__tests__/mcp-tool-ownership.test.ts
+++ b/ui/src/app/api/rag/__tests__/mcp-tool-ownership.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * BFF tests for custom MCP tool ownership + transfer (spec 2026-06-03, US3/US6).
+ *
+ *   - PUT /v1/mcp/custom-tools/<id> changing owner_team_slug is a TRANSFER:
+ *     allowed only for an owner-team admin or org admin (canTransferResourceOwnership),
+ *     with a not-a-member confirmation gate.
+ *   - Omitting owner_team_slug keeps the existing owner (no accidental revoke).
+ *   - The previous owner team's grants are revoked on a successful transfer
+ *     (previousOwnerTeamSlug threaded to the reconciler).
+ */
+
+jest.mock("@/lib/auth-config", () => ({
+  authOptions: {},
+  isBootstrapAdmin: jest.fn().mockReturnValue(false),
+  REQUIRED_ADMIN_GROUP: "",
+}));
+
+import { NextRequest } from "next/server";
+
+const mockRequireResourcePermission = jest.fn();
+const mockFilterResourcesByPermission = jest.fn();
+const mockRequireRbacPermission = jest.fn();
+const mockCheckOpenFgaTuple = jest.fn();
+const mockCanTransferResourceOwnership = jest.fn();
+const mockReconcileMcpToolRelationships = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(message: string, public statusCode = 500, public code?: string) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
+    handleApiError: (error: unknown) =>
+      Response.json(
+        {
+          error: error instanceof Error ? error.message : "error",
+          code: (error as { code?: string }).code,
+        },
+        { status: (error as { statusCode?: number }).statusCode ?? 500 },
+      ),
+  };
+});
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
+  canTransferResourceOwnership: (...args: unknown[]) => mockCanTransferResourceOwnership(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
+jest.mock("@/lib/rbac/organization", () => ({
+  organizationObjectId: () => "organization:caipe",
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources", () => ({
+  reconcileKnowledgeBaseRelationships: jest.fn(),
+  reconcileDataSourceRelationships: jest.fn(),
+  reconcileMcpToolRelationships: (...args: unknown[]) => mockReconcileMcpToolRelationships(...args),
+  deleteAllMcpToolRelationshipTuples: jest.fn(),
+}));
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn(),
+}));
+
+const EXISTING_TOOL = {
+  tool_id: "infra-search",
+  owner_team_slug: "team-old",
+  creator_subject: "creator-x",
+  shared_with_teams: ["share-a"],
+};
+
+/**
+ * Mock fetch: the GET custom-tools listing (used by loadMcpToolConfig) returns
+ * the existing tool; the PUT forward to the RAG server returns 204.
+ */
+function mockFetch() {
+  global.fetch = jest.fn((url: string | URL, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (u.includes("/v1/mcp/custom-tools") && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => [EXISTING_TOOL],
+      } as Response);
+    }
+    // Upstream forward (PUT) — succeeds with no content.
+    return Promise.resolve({ ok: true, status: 204, json: async () => ({}) } as Response);
+  }) as jest.Mock;
+}
+
+async function asUser(sub = "alice-sub") {
+  const nextAuth = await import("next-auth");
+  jest.mocked(nextAuth.getServerSession).mockResolvedValue({
+    sub,
+    role: "user",
+    org: "team-alpha",
+    accessToken: "browser-token",
+    user: { email: `${sub}@example.com` },
+  } as never);
+}
+
+function putToolRequest(body: unknown): NextRequest {
+  const payload = JSON.stringify(body);
+  return new NextRequest(new URL("http://localhost:3000/api/rag/v1/mcp/custom-tools/infra-search"), {
+    method: "PUT",
+    body: payload,
+    headers: { "content-type": "application/json", "content-length": String(payload.length) },
+  });
+}
+
+const PUT_PARAMS = {
+  params: Promise.resolve({ path: ["v1", "mcp", "custom-tools", "infra-search"] }),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireRbacPermission.mockResolvedValue(undefined);
+  mockRequireResourcePermission.mockResolvedValue(undefined);
+  mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
+  mockReconcileMcpToolRelationships.mockResolvedValue({ enabled: true, writes: 2, deletes: 1 });
+  mockFetch();
+});
+
+describe("PUT /v1/mcp/custom-tools/<id> — ownership transfer (US3)", () => {
+  it("denies a transfer when the caller is not an owner-team/org admin (403)", async () => {
+    await asUser("mallory-sub");
+    mockCanTransferResourceOwnership.mockResolvedValue(false);
+
+    const { PUT } = await import("@/app/api/rag/[...path]/route");
+    const res = await PUT(putToolRequest({ owner_team_slug: "team-new" }), PUT_PARAMS);
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe("TRANSFER_FORBIDDEN");
+    expect(mockReconcileMcpToolRelationships).not.toHaveBeenCalled();
+  });
+
+  it("allows a transfer by an authorized admin who is a member of the destination, revoking the old owner", async () => {
+    await asUser("alice-sub");
+    mockCanTransferResourceOwnership.mockResolvedValue(true);
+    mockRequireResourcePermission.mockResolvedValue(undefined); // member of destination
+
+    const { PUT } = await import("@/app/api/rag/[...path]/route");
+    const res = await PUT(putToolRequest({ owner_team_slug: "team-new" }), PUT_PARAMS);
+
+    expect(res.status).toBe(204);
+    expect(mockReconcileMcpToolRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolId: "infra-search",
+        ownerTeamSlug: "team-new",
+        previousOwnerTeamSlug: "team-old", // old owner revoked
+        creatorSubject: "creator-x", // set-once preserved
+      }),
+    );
+  });
+
+  it("rejects a transfer to a team the caller is not a member of without confirmation (409)", async () => {
+    await asUser("alice-sub");
+    mockCanTransferResourceOwnership.mockResolvedValue(true);
+    const ApiErrorClass = jest.requireMock("@/lib/api-middleware").ApiError;
+    mockRequireResourcePermission.mockRejectedValue(new ApiErrorClass("forbidden", 403));
+
+    const { PUT } = await import("@/app/api/rag/[...path]/route");
+    const res = await PUT(putToolRequest({ owner_team_slug: "team-new" }), PUT_PARAMS);
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("TRANSFER_NOT_MEMBER_UNCONFIRMED");
+    expect(mockReconcileMcpToolRelationships).not.toHaveBeenCalled();
+  });
+
+  it("allows a transfer to a non-member team when explicitly confirmed", async () => {
+    await asUser("alice-sub");
+    mockCanTransferResourceOwnership.mockResolvedValue(true);
+    const ApiErrorClass = jest.requireMock("@/lib/api-middleware").ApiError;
+    mockRequireResourcePermission.mockRejectedValue(new ApiErrorClass("forbidden", 403));
+
+    const { PUT } = await import("@/app/api/rag/[...path]/route");
+    const res = await PUT(
+      putToolRequest({ owner_team_slug: "team-new", confirm_not_member: true }),
+      PUT_PARAMS,
+    );
+
+    expect(res.status).toBe(204);
+    expect(mockReconcileMcpToolRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerTeamSlug: "team-new", previousOwnerTeamSlug: "team-old" }),
+    );
+  });
+
+  it("keeps the existing owner (no transfer, no revoke) when owner_team_slug is omitted", async () => {
+    await asUser("alice-sub");
+
+    const { PUT } = await import("@/app/api/rag/[...path]/route");
+    const res = await PUT(putToolRequest({ shared_with_teams: ["share-a", "share-b"] }), PUT_PARAMS);
+
+    expect(res.status).toBe(204);
+    expect(mockCanTransferResourceOwnership).not.toHaveBeenCalled();
+    expect(mockReconcileMcpToolRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerTeamSlug: "team-old",
+        // prev === next ⇒ reconcile helper passes undefined (no owner revoke).
+        previousOwnerTeamSlug: undefined,
+        nextSharedTeamSlugs: ["share-a", "share-b"],
+      }),
+    );
+  });
+});

--- a/ui/src/app/api/rag/kbs/[id]/sharing/route.ts
+++ b/ui/src/app/api/rag/kbs/[id]/sharing/route.ts
@@ -258,11 +258,28 @@ export async function PUT(
         "INVALID_BODY",
       );
     }
-    const nextSlugs = normalizeTeamSlugs((body as { team_slugs?: unknown }).team_slugs);
+    const requestedSlugs = normalizeTeamSlugs((body as { team_slugs?: unknown }).team_slugs);
     const previousSlugs = await loadSharedTeamSlugs(id);
+
+    // The owner team is granted via the same `reader`/`manager` tuples as a
+    // shared team, so `loadSharedTeamSlugs` includes it in `previousSlugs`.
+    // We must pass the owner team to the reconciler (from the config — the
+    // source of truth) so it stays in the desired set; otherwise it would be
+    // in `previous \ next` and the reconciler would REVOKE the owner team's
+    // own access on every sharing update. The owner is also deduped out of
+    // the shared list (union semantics — the reconciler grants it via the
+    // owner path).
+    const { ownerTeamSlug } = await loadOwnerFromConfig(id, {
+      accessToken: session.accessToken,
+      org: session.org,
+    });
+    const nextSlugs = ownerTeamSlug
+      ? requestedSlugs.filter((slug) => slug !== ownerTeamSlug)
+      : requestedSlugs;
 
     const result = await reconcileKnowledgeBaseRelationships({
       knowledgeBaseId: id,
+      ownerTeamSlug,
       nextSharedTeamSlugs: nextSlugs,
       previousSharedTeamSlugs: previousSlugs,
     });

--- a/ui/src/app/api/rag/kbs/__tests__/sharing-route.test.ts
+++ b/ui/src/app/api/rag/kbs/__tests__/sharing-route.test.ts
@@ -170,6 +170,13 @@ describe("/api/rag/kbs/[id]/sharing", () => {
           { key: { user: "team:legacy-team#admin", relation: "manager", object: "knowledge_base:kb-1" } },
         ],
       });
+      // No owner persisted in config (pre-migration datasource).
+      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ datasources: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
 
       const res = await PUT(
         makeRequest({ team_slugs: ["data-eng", "", "ml-ops", "data-eng"] }),
@@ -182,6 +189,7 @@ describe("/api/rag/kbs/[id]/sharing", () => {
       expect(mockReconcileKnowledgeBaseRelationships).toHaveBeenCalledWith(
         expect.objectContaining({
           knowledgeBaseId: "kb-1",
+          ownerTeamSlug: null,
           nextSharedTeamSlugs: ["data-eng", "ml-ops"],
           previousSharedTeamSlugs: ["legacy-team"],
         }),
@@ -202,6 +210,51 @@ describe("/api/rag/kbs/[id]/sharing", () => {
         { type: "knowledge_base", id: "kb-1", action: "admin" },
         { bypassForOrgAdmin: true },
       );
+      fetchSpy.mockRestore();
+    });
+
+    it("preserves the owner team's grant when updating shared teams", async () => {
+      // OpenFGA reader tuples include the owner team (platform) — because the
+      // owner is granted via the same reader/manager pair as a shared team —
+      // plus a currently-shared team being removed in this update.
+      mockReadOpenFgaTuples.mockResolvedValueOnce({
+        tuples: [
+          { key: { user: "team:platform#member", relation: "reader", object: "knowledge_base:kb-1" } },
+          { key: { user: "team:old-share#member", relation: "reader", object: "knowledge_base:kb-1" } },
+        ],
+      });
+      // Config (source of truth) says platform is the owner team.
+      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            datasources: [{ datasource_id: "kb-1", owner_team_slug: "platform" }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+      // Caller shares with data-eng and (redundantly) lists the owner team.
+      const res = await PUT(
+        makeRequest({ team_slugs: ["data-eng", "platform"] }),
+        { params: Promise.resolve({ id: "kb-1" }) },
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Owner is deduped out of the shared list in the response.
+      expect(body.shared_team_slugs).toEqual(["data-eng"]);
+
+      // The reconciler must receive the owner team so it stays in the desired
+      // set; otherwise `platform` (in previous, absent from next) would be
+      // revoked — the bug this test guards against. `old-share` IS revoked.
+      expect(mockReconcileKnowledgeBaseRelationships).toHaveBeenCalledWith(
+        expect.objectContaining({
+          knowledgeBaseId: "kb-1",
+          ownerTeamSlug: "platform",
+          nextSharedTeamSlugs: ["data-eng"],
+          previousSharedTeamSlugs: ["old-share", "platform"],
+        }),
+      );
+      fetchSpy.mockRestore();
     });
 
     it("rejects malformed JSON bodies", async () => {

--- a/ui/src/components/rag/MCPToolsView.tsx
+++ b/ui/src/components/rag/MCPToolsView.tsx
@@ -565,9 +565,28 @@ function ToolFormDialog({ open, onClose, onSave, initial, isEdit }: ToolFormDial
   const toolIdValid = isEdit || (toolId.length > 0 && TOOL_ID_REGEX.test(toolId));
   const canSave = toolIdValid && parallelSearches.length > 0 && parallelSearches.every((ps) => ps.label.trim().length > 0);
 
+  // The team owner/share pickers render their dropdown in a portal to
+  // `document.body` (so it can escape this dialog's `overflow-y-auto`
+  // clipping). A Radix *modal* Dialog would then trap focus away from the
+  // portaled search box (no typing) and treat row clicks as "interact
+  // outside" (no selecting). Running the dialog non-modal disables the focus
+  // trap, and the guard below keeps the dialog open while the user is
+  // interacting with that portaled popover.
+  const keepOpenForPopover = (event: { detail?: { originalEvent?: Event } } & Event) => {
+    const original = event.detail?.originalEvent;
+    const target = (original?.target ?? event.target) as HTMLElement | null;
+    if (target?.closest?.("[data-popover-content]")) {
+      event.preventDefault();
+    }
+  };
+
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()} modal={false}>
+      <DialogContent
+        className="max-w-xl max-h-[90vh] overflow-y-auto"
+        onInteractOutside={keepOpenForPopover}
+        onFocusOutside={keepOpenForPopover}
+      >
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit MCP Tool" : "Create MCP Tool"}</DialogTitle>
         </DialogHeader>

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -238,6 +238,7 @@ export function PopoverContent({
   const node = (
     <div
       ref={contentRef}
+      data-popover-content=""
       style={{
         position: "fixed",
         top: coords?.top ?? -9999,


### PR DESCRIPTION
## Summary

Follow-up to #1708 (unified shareable-resource RBAC). Targets the **PR branch** `feat/unified-shareable-resource-rbac` and closes a handful of access-control gaps found while reviewing the feature, so #1708 can merge with these fixes already folded in rather than discovering them in production.

## How this PR helps

Each change prevents a concrete real-world failure:

### Security hardening

- **Tool calls can't be smuggled through during an outage.** Before, if the RAG server hiccuped while listing custom tools, the `can_call` check was *skipped* and the call went through (and an attacker could induce that error to bypass it). Now `/v1/mcp/invoke` **fails closed** (`503 mcp_tool#call_unavailable`, never forwarded).
- **Transferring a tool to another team is now privileged.** Before, anyone who could edit a custom MCP tool and was a member of *some* other team could reassign ownership to it. Now it requires an **owner-team admin or org admin** (`canTransferResourceOwnership`, same rule agents already had), with an explicit confirmation when the caller is not a member of the destination team.

### Correctness / silent access leaks

- **No orphaned grants on ownership change.** Changing a tool's owner team previously left the **old team still holding access** (dangling tuples); now the old team's grants are revoked (`previousOwnerTeamSlug`).
- **Editing a tool no longer wipes its owner.** The RAG server replaces the whole config on `PUT`, so an edit that omitted `owner_team_slug` could **drop the owner team's access**; the owner is now preserved.
- **Sharing a KB no longer locks out its owner.** `loadSharedTeamSlugs` includes the owner team (same `reader` tuple), so updating a KB's shared-teams list previously **revoked the owner team's own access**. The PUT now passes the config-sourced owner to the reconciler and dedupes it from the shared list.
- **Tool edits don't silently lose fields.** A `PUT` without a `content-length` header could drop the owner/shared fields; parsing now matches the `POST` path.

### Usability

- **The owner/share picker actually works.** The new "owner team + share with teams" dropdown was unusable inside the MCP tool dialog (couldn't type or click options) — fixed with a non-modal dialog + portaled popover guard.

### Net effect

Without this PR, #1708 would ship with a **bypassable permission check** and several ways for access to **silently persist or vanish** — the kind of bugs that erode trust in an authorization system. This makes the "owner team + share" model behave consistently and safely across agents, knowledge bases, and MCP tools.

## Test plan

- [x] `mcp-tool-can-call.test.ts` — added fail-closed (503, never forwarded) case
- [x] `mcp-tool-ownership.test.ts` (new) — transfer authorized / denied / not-member-unconfirmed / confirmed / keep-on-omit
- [x] `sharing-route.test.ts` — added owner-team preservation case
- [x] `npx jest src/lib/rbac src/app/api/rag src/app/api/dynamic-agents` → 522 passed (67 suites)
- [x] Lint clean on all touched files

Assisted by Cursor (Claude Opus 4.8)
