### PR TITLE
fix(setup-caipe): preserve deployed RAG embeddings on non-interactive upgrade

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -50,7 +50,15 @@ AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
 AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
 AWS_BEDROCK_ENABLE_PROMPT_CACHE="${AWS_BEDROCK_ENABLE_PROMPT_CACHE:-}"
 LLM_PROVIDER="${LLM_PROVIDER:-}"  # filled by cluster detection or user prompt; default applied per-use
+# Capture whether the caller set these explicitly (env/CLI) BEFORE the defaults
+# below collapse them to a non-empty value. The upgrade path
+# (detect_deployed_features) uses these flags to decide whether to inherit the
+# *deployed* RAG embeddings provider/model — mirroring LLM_PROVIDER, which is
+# empty by default and inherited from llm-secret.
+# assisted-by claude code claude-opus-4-8
+_EMBEDDINGS_MODEL_EXPLICIT="${EMBEDDINGS_MODEL:+set}"
 EMBEDDINGS_MODEL="${EMBEDDINGS_MODEL:-text-embedding-3-large}"
+_EMBEDDINGS_PROVIDER_EXPLICIT="${EMBEDDINGS_PROVIDER:+set}"
 EMBEDDINGS_PROVIDER="${EMBEDDINGS_PROVIDER:-openai}"
 # Provider-specific embeddings credentials (only the active provider's vars are required).
 # These mirror the env vars the RAG server's EmbeddingsFactory reads at runtime.
@@ -7511,6 +7519,62 @@ detect_deployed_features() {
         ;;
     esac
     log "Loaded LLM config from existing llm-secret (provider: ${LLM_PROVIDER:-unknown})"
+  fi
+
+  # ── Read RAG embeddings provider/model + creds from the deployed release ───
+  # The interactive wizard reads these in choose_features, but that block sits
+  # after choose_features' `--non-interactive` early return — so an unattended
+  # upgrade never saw it and silently reset RAG embeddings to the
+  # EMBEDDINGS_PROVIDER default (openai), dropping the deployed provider's
+  # config. Read them here (the upgrade path always runs detect_deployed_features
+  # first) so the non-interactive flow reaches parity with the interactive one.
+  # assisted-by claude code claude-opus-4-8
+  if $ENABLE_RAG; then
+    local _rag_vals
+    _rag_vals=$(helm get values caipe -n caipe -o json 2>/dev/null || true)
+    # Adopt the deployed provider/model unless the caller set them explicitly.
+    if [[ -z "${_EMBEDDINGS_PROVIDER_EXPLICIT:-}" ]]; then
+      local _dep _dem
+      _dep=$(echo "$_rag_vals" | jq -r '."rag-stack"."rag-server".env.EMBEDDINGS_PROVIDER // empty' 2>/dev/null || true)
+      _dem=$(echo "$_rag_vals" | jq -r '."rag-stack"."rag-server".env.EMBEDDINGS_MODEL // empty' 2>/dev/null || true)
+      if [[ -n "$_dep" ]]; then
+        EMBEDDINGS_PROVIDER="$_dep"
+        [[ -n "$_dem" && -z "${_EMBEDDINGS_MODEL_EXPLICIT:-}" ]] && EMBEDDINGS_MODEL="$_dem"
+        log "Detected RAG embeddings: ${EMBEDDINGS_PROVIDER}/${EMBEDDINGS_MODEL}"
+      fi
+    fi
+    # Rescue the active provider's embeddings credentials from the existing
+    # llm-secret (fills only unset vars, so explicit env creds always win). No
+    # prompts here — this is the unattended path; choose_features still prompts
+    # interactively when a credential is genuinely absent.
+    local _emb_secret
+    _emb_secret=$(kubectl get secret llm-secret -n caipe -o json 2>/dev/null || true)
+    if [[ -n "$_emb_secret" ]]; then
+      _emb_val() { echo "$_emb_secret" | jq -r --arg k "$1" '.data[$k] // empty' 2>/dev/null | base64 -d 2>/dev/null || true; }
+      case "$EMBEDDINGS_PROVIDER" in
+        openai)
+          [[ -z "${OPENAI_API_KEY:-}" ]] && OPENAI_API_KEY=$(_emb_val OPENAI_API_KEY)
+          ;;
+        azure-openai)
+          [[ -z "${AZURE_OPENAI_API_KEY:-}" ]]     && AZURE_OPENAI_API_KEY=$(_emb_val AZURE_OPENAI_API_KEY)
+          [[ -z "${AZURE_OPENAI_ENDPOINT:-}" ]]    && AZURE_OPENAI_ENDPOINT=$(_emb_val AZURE_OPENAI_ENDPOINT)
+          [[ -z "${AZURE_OPENAI_API_VERSION:-}" ]] && AZURE_OPENAI_API_VERSION=$(_emb_val AZURE_OPENAI_API_VERSION)
+          ;;
+        litellm)
+          # RAG talks to a LiteLLM-compatible endpoint (generic proxy or Voyage);
+          # recover endpoint + key so we re-point at the same backend.
+          [[ -z "${LITELLM_ENDPOINT:-}" ]] && LITELLM_ENDPOINT=$(_emb_val LITELLM_API_BASE)
+          [[ -z "${LITELLM_API_KEY:-}" ]]  && LITELLM_API_KEY=$(_emb_val LITELLM_API_KEY)
+          ;;
+        cohere)
+          [[ -z "${COHERE_API_KEY:-}" ]] && COHERE_API_KEY=$(_emb_val COHERE_API_KEY)
+          ;;
+        huggingface)
+          [[ -z "${HUGGINGFACEHUB_API_TOKEN:-}" ]] && HUGGINGFACEHUB_API_TOKEN=$(_emb_val HUGGINGFACEHUB_API_TOKEN)
+          ;;
+        # aws-bedrock embeddings reuse the LLM-side AWS creds loaded above.
+      esac
+    fi
   fi
 
   # ── Read deployment mode from Helm values ─────────────────────────────────

--- a/tests/integration/test_setup_caipe_embeddings_providers.sh
+++ b/tests/integration/test_setup_caipe_embeddings_providers.sh
@@ -29,6 +29,10 @@
 #             providers the menu offers (drift guard against the Python
 #             factory adding or removing providers without this test
 #             being updated).
+#   * Pin 8 — detect_deployed_features (the unattended upgrade path)
+#             inherits the *deployed* RAG embeddings provider/model from
+#             the live Helm values, instead of resetting them to the
+#             openai default, and still honors an explicit caller override.
 #
 # Exits 0 on success, non-zero with a clear FAIL message otherwise.
 #
@@ -199,6 +203,28 @@ if [ -f "${FACTORY_PY}" ]; then
   fi
 else
   echo "[emb-test]   SKIP: ${FACTORY_PY} not found (drift guard cannot run)"
+fi
+
+# ---------------------------------------------------------------------
+# Pin 8 — non-interactive upgrade inherits the deployed embeddings config.
+#
+# Regression guard for the bug where a `--non-interactive` re-run reset RAG
+# embeddings to the EMBEDDINGS_PROVIDER default (openai) because the
+# embeddings-from-cluster read lived only in choose_features' interactive
+# branch. The read now lives in detect_deployed_features, which the upgrade
+# path always runs.
+# ---------------------------------------------------------------------
+echo "[emb-test] Pin 8: detect_deployed_features inherits the deployed embeddings provider ..."
+detect_body=$(awk '/^detect_deployed_features\(\) \{/{f=1} f{print} f && /^\}/{exit}' "${SETUP_SCRIPT}")
+if echo "${detect_body}" | grep -q 'rag-server".env.EMBEDDINGS_PROVIDER'; then
+  _pass "detect_deployed_features reads EMBEDDINGS_PROVIDER from the deployed RAG values"
+else
+  _fail "detect_deployed_features no longer reads the deployed EMBEDDINGS_PROVIDER (non-interactive upgrade would reset RAG embeddings to the openai default)"
+fi
+if echo "${detect_body}" | grep -q '_EMBEDDINGS_PROVIDER_EXPLICIT'; then
+  _pass "detect_deployed_features honors an explicit caller override (_EMBEDDINGS_PROVIDER_EXPLICIT)"
+else
+  _fail "detect_deployed_features ignores the explicit EMBEDDINGS_PROVIDER override guard"
 fi
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
# Description

`setup-caipe.sh`'s `--non-interactive` re-run on an already-deployed cluster (the **"Upgrading existing deployment"** path) silently reset RAG embeddings to the default `EMBEDDINGS_PROVIDER` (`openai`/`text-embedding-3-large`), dropping whatever embeddings provider was actually deployed.

**Root cause:** the embeddings-from-cluster read lives in `choose_features()`, *after* its `if $NON_INTERACTIVE; then … return; fi` early return — so an unattended upgrade never ran it. `detect_deployed_features()` already inherits the LLM provider + creds from `llm-secret`, but not the embeddings config.

**Fix** — move the read into `detect_deployed_features()` (which the upgrade path always runs first):
- Adopt the deployed `EMBEDDINGS_PROVIDER` / `EMBEDDINGS_MODEL` from the live Helm values (`rag-stack.rag-server.env.*`).
- Rescue the active provider's credentials from `llm-secret` (azure-openai, litellm endpoint/key, cohere, huggingface, openai; aws-bedrock reuses the LLM AWS creds).
- Skip adoption when the caller set `EMBEDDINGS_PROVIDER`/`EMBEDDINGS_MODEL` explicitly via env/CLI (new `_EMBEDDINGS_*_EXPLICIT` flags), mirroring how `LLM_PROVIDER` is inherited from `llm-secret`.

Net effect: the non-interactive upgrade now reaches parity with the interactive flow and preserves the deployed embeddings config.

**Found while** testing the latest `setup-caipe.sh` against a Bedrock + RBAC deployment whose RAG embeddings ran through an in-cluster LiteLLM proxy (Azure `text-embedding-3-large`); an unattended re-run flipped embeddings to direct OpenAI.

## How tested
- `bash -n setup-caipe.sh` — clean.
- `tests/integration/test_setup_caipe_embeddings_providers.sh` — **28/28 pins pass**, including new **Pin 8** (regression guard: `detect_deployed_features` reads the deployed `EMBEDDINGS_PROVIDER` and honors the explicit override).
- `tests/integration/test_setup_caipe_mongodb_password.sh` — still green.
- No impact on the fresh-install CI path: `ENABLE_RAG` is false on a brand-new cluster, so the new block is skipped.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
