### PR TITLE
fix(agentgateway,keycloak): remove unsupported extAuthz timeout field and add impersonation to caipe-platform desired roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,97 @@
-## 0.5.6-dev.3-chart.1 (2026-06-02)
+## 0.5.7-dev.14 (2026-06-04)
+
+### Feat
+
+- **rbac**: org-level ingest/search capabilities + FGA coverage guarantee (#1716)
+
+### Fix
+
+- **deps**: bump uv 0.11.6 -> 0.11.18 in agent sub-packages (#1718)
+
+## 0.5.7-dev.13 (2026-06-04)
+
+### Feat
+
+- **rbac**: grant org-admin to super-admins team members
+- **rbac**: org-wide and team-invoke sharing for custom MCP tools
+
+### Fix
+
+- **rag**: authorize custom MCP tool writes via OpenFGA instead of coarse admin
+- **rbac**: harden shareable-resource access control for RAG MCP tools and KB sharing
+
+## 0.5.7-dev.12 (2026-06-04)
+
+## 0.5.7-dev.11 (2026-06-04)
+
+### Feat
+
+- **rbac**: unify group-based access control across agents, RAG datasources, and MCP tools
+
+### Fix
+
+- **deps**: bump aiohttp to 3.14.0 and uv to 0.11.18 for security advisories
+- **agentgateway**: protect built-in MCP routes from config-bridge pruning
+
+## 0.5.7-dev.10 (2026-06-03)
+
+## 0.5.7-dev.9 (2026-06-03)
+
+### Feat
+
+- **ui**: one-click "Migrate all to latest" for schema migrations (#1658)
+
+### Fix
+
+- Markdown editor scroll behaviour and theming (#1685)
+- **ui**: collapse consecutive identical tool chips in timeline (#1692)
+
+## 0.5.7-dev.8 (2026-06-03)
+
+### Feat
+
+- **credentials**: per-user OAuth scope selection at connect time
+
+### Fix
+
+- **mcp**: provider-token auth, knowledge-base RAG, and authz resilience (#1702)
+- **docs**: escape brace sets in OAuth scope-selection spec for MDX
+
+## 0.5.7-dev.7 (2026-06-03)
+
+### Feat
+
+- **rbac**: fix RAG datasource access gap, add public datasources, reorg KB admin (#1703)
+
+## 0.5.7-dev.6 (2026-06-03)
+
+### Feat
+
+- **slack-ui**: config parity, channel-admin editing, and admin save UX (#1696)
+
+### Fix
+
+- **rag**: migrate rag-server image to wolfi-base
+- **dynamic-agents**: migrate image to wolfi-base
+
+## 0.5.7-dev.2 (2026-06-03)
+
+### Fix
+
+- **rag**: migrate ingestors image to Chainguard Wolfi base
+
+## 0.5.7-dev.1 (2026-06-02)
+
+### Feat
+
+- **docs**: add release (milestone) filter to triage dashboard
+- **docs**: add open-issues triage dashboard + generator
+
+### Fix
+
+- **triage**: base release breakdown on accurate git commit ranges + per-release drill-down
+
+## 0.5.7 (2026-06-02)
 
 ## 0.5.6-dev.3 (2026-06-02)
 
@@ -81,6 +174,10 @@
 
 - **cursor**: add git branch-op permission hook and reframe worktree rule
 
+### Fix
+
+- **rbac**: backfill admin_surface:slack manager grant for org admins
+
 ## 0.5.2-dev.5 (2026-05-29)
 
 ### BREAKING CHANGE
@@ -101,6 +198,7 @@ CRD/controller-based routing.
 - **helm**: wire CAIPE UI to AgentGateway proxy for CRD-free MCP discovery
 - **ui**: label collapsed nav menu
 - **docs**: repair RBAC broken anchor and unreadable draw.io SVGs
+- **rag**: migrate agent-ontology image to wolfi-base
 
 ## 0.5.2-dev.4 (2026-05-29)
 

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.5.7-dev.14 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.8 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,36 +179,36 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.5.7-dev.14
+    version: 0.5.8
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot
   # Webex Bot Integration (client, not an agent)
   - name: webex-bot
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - webex-bot
   # Keycloak Identity Provider for CAIPE RBAC/OIDC.
@@ -217,16 +217,16 @@ dependencies:
   # wiring. There is no upstream Keycloak chart that provides these CAIPE
   # bootstrap invariants without additional Jobs/templates.
   - name: keycloak
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - keycloak
   # OpenFGA relationship authorization service
   - name: openfga
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: openfga.enabled
   # AgentGateway ext_authz bridge backed by OpenFGA
   - name: openfga-authz-bridge
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: openfgaAuthzBridge.enabled
   # AgentGateway standalone proxy for RBAC-protected MCP routing.
   # Intentional local subchart for this release: this deploys the standalone
@@ -235,5 +235,5 @@ dependencies:
   # and remain the target for a later migration once we can preserve this
   # release's static MCP routing and authz bridge contract.
   - name: agentgateway
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: agentgateway.enabled

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.7-dev.14 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.8 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/agentgateway/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agentgateway
 description: AgentGateway standalone proxy for CAIPE MCP traffic
 type: application
-version: 0.5.7-dev.14
-appVersion: 0.5.7-dev.14
+version: 0.5.8
+appVersion: 0.5.8

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.5.7-dev.14
-appVersion: "0.5.7-dev.14"
+version: 0.5.8
+appVersion: "0.5.8"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.7-dev.14 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.8 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.5.7-dev.14 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.8 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/keycloak/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
 description: Keycloak identity provider for CAIPE RBAC, token exchange, and identity federation
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.5.7-dev.14
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.5.8
 type: application

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -150,7 +150,7 @@ seed_spec104_main || echo "[init-idp] [spec-104] seed had errors (see above)"
 # BEFORE the early-exit below so dev/CI stacks that don't wire IDP_ISSUER still
 # get the correct role mapping.
 _ensure_caipe_platform_user_roles() {
-  local desired_roles="view-realm manage-realm view-users query-users manage-users query-clients view-clients manage-clients view-authorization manage-authorization"
+  local desired_roles="view-realm manage-realm view-users query-users manage-users query-clients view-clients manage-clients view-authorization manage-authorization impersonation"
   echo "[init-idp] Ensuring caipe-platform service account has realm-management roles: ${desired_roles} ..."
   # Spec 103: AUTH may not be set yet when this helper runs from the
   # pre-IdP path (we run it right after persona seeding so dev stacks without

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.7-dev.14" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.8" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openfga-authz-bridge
 description: Envoy ext_authz bridge that adapts AgentGateway authorization checks to OpenFGA
 type: application
-version: 0.5.7-dev.14
-appVersion: 0.5.7-dev.14
+version: 0.5.8
+appVersion: 0.5.8

--- a/charts/ai-platform-engineering/charts/openfga/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openfga
 description: OpenFGA authorization service for CAIPE relationship-based access control
 type: application
-version: 0.5.7-dev.14
-appVersion: 0.5.7-dev.14
+version: 0.5.8
+appVersion: 0.5.8

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.7-dev.14" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.8" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.5.7-dev.14
-appVersion: 0.5.7-dev.14
+version: 0.5.8
+appVersion: 0.5.8
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.7-dev.14 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.8 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/webex-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: webex-bot
 description: Webex bot integration for AI Platform Engineering using A2A protocol
-version: 0.5.7-dev.14
-appVersion: 0.5.7-dev.14
+version: 0.5.8
+appVersion: 0.5.8
 type: application

--- a/charts/ai-platform-engineering/templates/agentgateway-static-config.yaml
+++ b/charts/ai-platform-engineering/templates/agentgateway-static-config.yaml
@@ -62,13 +62,6 @@ data:
                     host: {{ $extAuthHost | quote }}
                     failureMode:
                       denyWithStatus: 403
-                    # The proxy default ext_authz timeout is 200ms. Concurrent
-                    # per-route Checks against a cold/loaded OpenFGA exceed it
-                    # and fail closed (403 -> "MCP server unavailable").
-                    # Default to a generous 10s; operators tune via
-                    # global.agentgateway.extAuth.timeout. Fail-closed posture
-                    # is unchanged.
-                    timeout: {{ $extAuth.timeout | default "10s" | quote }}
                     protocol:
                       grpc:
                         metadata:

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.5.7-dev.14 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.5.8 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.7-dev.14" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.5.8" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.7-dev.14" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.8" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.7-dev.14" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.5.8" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.5.7-dev.14 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.7-dev.14" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.8 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.8" # Do NOT modify. It will be updated automatically using the release workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.7-dev.14"
+version = "0.5.8"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.7.dev14"
+version = "0.5.8"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

This PR fixes two bugs introduced in chart 0.5.8:

## Bug 1: agentgateway CrashLoopBackOff — unknown field `timeout` in extAuthz

**File:** `charts/ai-platform-engineering/templates/agentgateway-static-config.yaml`

agentgateway v1.1.0 rejects unknown fields at startup with `unknown field 'timeout'`, causing a CrashLoopBackOff. The `timeout` field was added to the `extAuthz` policy block in PR #1702 along with a 6-line comment block explaining the rationale, but the agentgateway image was not bumped to a version that supports the `timeout` field in `extAuthz`.

**Fix:** Remove the `timeout` line and its associated comment block from the `extAuthz` policy block. All other fields (`host`, `failureMode`, `protocol`, `grpc.metadata`) are preserved intact.

## Bug 2: Keycloak `assignServiceAccountImpersonation` fails with 403

**File:** `charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh`

Keycloak enforces role-grant scoping: a client token can only grant roles it itself holds. The `caipe-platform` service account was missing `impersonation` from its `desired_roles` list, so the BFF reconcile always failed with 403 when trying to assign the `impersonation` role to `caipe-slack-bot` and `caipe-webex-bot` service accounts.

**Fix:** Add `impersonation` to the `desired_roles` list in `_ensure_caipe_platform_user_roles()` (line 153), so `caipe-platform` is granted the role it needs to delegate impersonation to bot service accounts.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass