### PR TITLE
chore(chart): rename agent-<x> aliases/tags and MCP service DNS to mcp-<x>

### DIFF
--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -339,8 +339,8 @@ extraDeploy: []
 skillsLiveSkillsName: ""       # Variant name (looks up data/skills/live-skills.<name>.md)
 skillsLiveSkills: ""           # Inline custom live-skills skill (overrides everything)
 
-######### Sub-agent MCP server configurations #########
-# Each mcp-* block configures one agent's MCP server (alias from Chart.yaml).
+######### MCP server configurations #########
+# Each mcp-* block configures one MCP server (alias from Chart.yaml).
 
 mcp-argocd:
   nameOverride: "mcp-argocd"


### PR DESCRIPTION
# Description

Follow-up to #1728 (supervisor + A2A standalone agent removal). Renames all public-facing Helm surface from `agent-<x>` to `mcp-<x>` to reflect that these subcharts now render **only** an MCP server (no A2A agent process).

**Changes:**
- `Chart.yaml`: dependency `alias: agent-<x>` → `mcp-<x>` and matching tags
- `values.yaml`: `tags.agent-<x>` → `tags.mcp-<x>`, per-server value key blocks `agent-<x>:` → `mcp-<x>:`, and inline comments
- `templates/_helpers.tpl` (`agentgatewayMcpTargets`): value-key lookup `printf "agent-%s"` → `mcp-%s` and Service DNS `%s-agent-%s-mcp` → `%s-mcp-%s-mcp`
- Docs: helm install guides, values reference table, workshop commands updated to `tags.mcp-<name>=true`
- Workshop (`20-mas.md`, `50-tracing.md`): remove weather agent references (agent removed in #1728), clean up broken helm commands and kubectl references

**Breaking change — MCP Service DNS changes:**
```
<release>-agent-<x>-mcp.<ns>.svc.cluster.local
→ <release>-mcp-<x>-mcp.<ns>.svc.cluster.local
```
Any consumer pinning the old Service name must update after `helm upgrade`.

Closes #1707

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass