### PR TITLE
fix(local-dev): RBAC org-admin bypass, Slack channel admin visibility + import, agentgateway pin, agent/MCP seeding

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -896,7 +896,7 @@ def rbac_global_middleware(body, context, next, logger):
         for k in stale:
             _seen_events.pop(k, None)
         if event_id in _seen_events:
-            logger.debug("Ignoring duplicate event_id={}", event_id)
+            logger.debug("Ignoring duplicate event_id=%s", event_id)
             return _HANDLED_200
         _seen_events[event_id] = now
     if _slack_responses_suppressed():
@@ -961,7 +961,7 @@ def rbac_global_middleware(body, context, next, logger):
             )
         )
     except Exception as exc:
-        logger.error("Failed to resolve Slack user {} — denying request: {}", slack_user_id, exc)
+        logger.error("Failed to resolve Slack user %s — denying request: %s", slack_user_id, exc)
         channel = (
             body.get("event", {}).get("channel")
             or body.get("channel", {}).get("id")
@@ -975,7 +975,7 @@ def rbac_global_middleware(body, context, next, logger):
                     text="Identity verification is temporarily unavailable. Please try again later.",
                 )
             except Exception:
-                logger.warning("Could not send RBAC error message to {}", slack_user_id)
+                logger.warning("Could not send RBAC error message to %s", slack_user_id)
         return _HANDLED_200
     finally:
         loop.close()
@@ -991,7 +991,7 @@ def rbac_global_middleware(body, context, next, logger):
         now = _time.time()
         last_sent = _linking_prompt_sent.get(slack_user_id, 0)
         if now - last_sent < _LINKING_PROMPT_COOLDOWN:
-            logger.debug("Suppressing linking prompt for {} (cooldown)", slack_user_id)
+            logger.debug("Suppressing linking prompt for %s (cooldown)", slack_user_id)
             return _HANDLED_200
         if channel:
             try:
@@ -1029,33 +1029,24 @@ def rbac_global_middleware(body, context, next, logger):
                 )
                 _linking_prompt_sent[slack_user_id] = now
             except Exception:
-                logger.warning("Could not send linking prompt to {}", slack_user_id)
+                logger.warning("Could not send linking prompt to %s", slack_user_id)
         return _HANDLED_200
 
     if isinstance(rbac_status, tuple) and rbac_status[0] == "deny":
         msg = rbac_status[1]
-        # INFO-level log so denials are visible in slackbot logs. Without this
-        # the previous code returned silently and the only visible artifact was
-        # bolt-python's generic "middleware skipped calling next()" warning,
-        # which is useless for debugging "why didn't my user get a response?".
-        logger.info(
-            "RBAC denied request for slack_user={} channel={}: {}",
+        # WARNING-level log instead of posting the denial back to Slack. We
+        # deliberately do NOT notify the user in-channel: posting (even
+        # ephemerally) is noisy and leaks RBAC config details, so the denial is
+        # surfaced only in the slackbot logs for operators to debug "why didn't
+        # my user get a response?".
+        #
+        # NOTE: `logger` here is Bolt's injected stdlib logging.Logger (a
+        # function param), NOT the module-level loguru logger — so it uses
+        # %-style formatting, not {}. Using {} here raises TypeError at emit.
+        logger.warning(
+            "RBAC denied request for slack_user=%s channel=%s: %s",
             slack_user_id, channel, msg,
         )
-        if channel:
-            try:
-                # chat_postEphemeral keeps the denial visible only to the
-                # requesting user. The previous chat_postMessage broadcasted
-                # the denial (and the channel name suffix) to the entire
-                # channel, which is a UX/privacy regression — other channel
-                # members do not need to see that someone else was denied.
-                context["client"].chat_postEphemeral(
-                    channel=channel,
-                    user=slack_user_id,
-                    text=msg,
-                )
-            except Exception:
-                logger.warning("Could not send RBAC denial to {} in {}", slack_user_id, channel)
         # Return BoltResponse(200) so Slack does not retry the event 3 more
         # times — without this the same denial fires up to 4× and Bolt logs
         # the "middleware skipped calling next()" warning on every retry.

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slack_route_no_silent_failure.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slack_route_no_silent_failure.py
@@ -167,27 +167,23 @@ def test_deduplicated_event_returns_200(monkeypatch: pytest.MonkeyPatch) -> None
     assert second.status == 200
 
 
-def test_rbac_deny_posts_ephemeral_and_returns_200(
+def test_rbac_deny_logs_warning_and_returns_200(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression test for the silent-drop bug we hit on 2026-05-27.
+    """A denied request must log a warning, post nothing, and return 200.
 
-    Scenario reproduced in dev: a generic user (eti-sre-cicd.gen@cisco.com,
-    Slack id U0B67AHR0RZ) posted "how can you help?" in channel C0B6F5VRK6V
-    which is mapped to the `eti-sre-admins` team — but the user is not a
-    member of that team. `_rbac_enrich_context` correctly returned
-    ``("deny", <reason>)`` but the middleware then:
+    When ``_rbac_enrich_context`` returns a ``("deny", <reason>)`` tuple the
+    middleware must:
 
-      1. Logged nothing at INFO level — denials were invisible.
-      2. Posted the denial via ``chat_postMessage`` (visible to the whole
-         channel) instead of ``chat_postEphemeral``.
-      3. Returned ``None`` without calling ``next()``, which produced the
-         bolt-python "middleware skipped calling next()" warning AND let
-         Slack retry the same envelope up to 4 times.
-
-    This test enables RBAC and stubs ``_rbac_enrich_context`` to return the
-    deny tuple, then asserts all three regressions are fixed: ephemeral
-    posting, INFO-level deny log, and ``BoltResponse(200)`` return.
+      1. NOT call ``next()`` — denied requests don't reach listeners.
+      2. NOT post the denial back to Slack (neither ephemeral nor channel).
+         Posting is noisy and leaks RBAC config details; the denial is
+         surfaced only in the slack-bot logs.
+      3. Log the denial at WARNING level so it's visible in the logs (the
+         only artifact, now that we don't post it back).
+      4. Return ``BoltResponse(200)`` so Slack doesn't retry the envelope up
+         to 4 times (which also produced bolt-python's "middleware skipped
+         calling next()" warning).
     """
     app_module = _load_slack_app(
         monkeypatch, silence_env=False, rbac_enabled=True
@@ -205,9 +201,13 @@ def test_rbac_deny_posts_ephemeral_and_returns_200(
     class _CapturingLogger(_Logger):
         def __init__(self) -> None:
             self.info_calls: list[tuple[str, tuple[object, ...]]] = []
+            self.warning_calls: list[tuple[str, tuple[object, ...]]] = []
 
         def info(self, msg: object, *args: object, **_kwargs: object) -> None:
             self.info_calls.append((str(msg), args))
+
+        def warning(self, msg: object, *args: object, **_kwargs: object) -> None:
+            self.warning_calls.append((str(msg), args))
 
     log = _CapturingLogger()
     next_called = False
@@ -235,31 +235,25 @@ def test_rbac_deny_posts_ephemeral_and_returns_200(
     # 1. Downstream handlers must NOT run when access is denied.
     assert next_called is False, "denied requests must not reach listeners"
 
-    # 2. The denial must be visible only to the requesting user (ephemeral),
-    #    not broadcast to the whole channel.
-    assert len(client.ephemeral_posts) == 1, (
-        f"expected one ephemeral denial, got {client.ephemeral_posts!r} "
-        f"and channel posts {client.channel_posts!r}"
+    # 2. The denial must NOT be posted to Slack at all — neither ephemeral nor
+    #    channel-wide. Denials are surfaced only in the slack-bot logs (posting
+    #    is noisy and leaks RBAC config details).
+    assert client.ephemeral_posts == [], (
+        f"denials must not be posted to Slack; got ephemeral {client.ephemeral_posts!r}"
     )
-    post = client.ephemeral_posts[0]
-    assert post["channel"] == "C0B6F5VRK6V"
-    assert post["user"] == "U0B67AHR0RZ"
-    assert "access" in str(post["text"]).lower()
     assert client.channel_posts == [], (
-        "denials must NEVER be posted with chat_postMessage — that leaks "
-        "the denial to everyone in the channel."
+        f"denials must not be posted to Slack; got channel {client.channel_posts!r}"
     )
 
-    # 3. Deny path must log at INFO level so denials are visible in slack-bot
-    #    logs. Without this regression test the only log artifact was Bolt's
-    #    generic "skipped calling next()" warning.
+    # 3. Deny path must log at WARNING level so denials are visible in slack-bot
+    #    logs (the only artifact now that we don't post the denial back).
     deny_logs = [
-        call for call in log.info_calls
+        call for call in log.warning_calls
         if "RBAC denied" in call[0]
     ]
     assert deny_logs, (
-        f"deny path must log 'RBAC denied ...' at INFO; got info calls: "
-        f"{log.info_calls!r}"
+        f"deny path must log 'RBAC denied ...' at WARNING; got warning calls: "
+        f"{log.warning_calls!r}"
     )
 
     # 4. Return BoltResponse(200) so Slack does not retry the envelope.

--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -77,6 +77,11 @@ class AgentBinding(BaseModel):
 class ChannelConfig(BaseModel):
   name: str
   agents: list[AgentBinding] = Field(default_factory=list)
+  # Optional owning team slug. The YAML config has historically had no team
+  # concept; when set, the admin "import from config" flow can assign the
+  # channel to this team (writing the channel→team ReBAC binding) instead of
+  # leaving the imported channel team-less and unusable until a manual onboard.
+  team: str | None = None
 
 
 def get_escalation_config(agent_match: AgentBinding) -> EscalationConfig | None:

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_admin_api.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_admin_api.py
@@ -312,6 +312,9 @@ class SlackBotAdminService:
                     "workspace_id": workspace_ref,
                     "channel_id": channel_id,
                     "channel_name": channel.name,
+                    # Optional owning team from the YAML config; lets the import
+                    # assign the channel to a team instead of leaving it team-less.
+                    "team": channel.team,
                     "agents": [
                         _planned_agent_detail(agent, index)
                         for index, agent in enumerate(channel.agents)

--- a/deploy/agentgateway/config.yaml
+++ b/deploy/agentgateway/config.yaml
@@ -32,11 +32,6 @@ binds:
         extAuthz:
           host: openfga-authz-bridge:9100
           failureMode: { denyWithStatus: 403 }
-          # AgentGateway's default ext_authz timeout is 200ms. When the agent lists
-          # tools it fires one ext_authz Check per MCP route concurrently; under a
-          # cold OpenFGA/Postgres these serialize (75-150ms each) and blow that
-          # 200ms budget, causing fail-closed 403s that surface as "MCP server
-          # unavailable". The bridge always answers well under 10s.
           protocol:
             grpc:
               metadata:

--- a/deploy/agentgateway/config.yaml
+++ b/deploy/agentgateway/config.yaml
@@ -37,7 +37,6 @@ binds:
           # cold OpenFGA/Postgres these serialize (75-150ms each) and blow that
           # 200ms budget, causing fail-closed 403s that surface as "MCP server
           # unavailable". The bridge always answers well under 10s.
-          timeout: 10s
           protocol:
             grpc:
               metadata:
@@ -82,7 +81,6 @@ binds:
         extAuthz:
           host: openfga-authz-bridge:9100
           failureMode: { denyWithStatus: 403 }
-          timeout: 10s
           protocol:
             grpc:
               metadata:
@@ -104,7 +102,6 @@ binds:
         extAuthz:
           host: openfga-authz-bridge:9100
           failureMode: { denyWithStatus: 403 }
-          timeout: 10s
           protocol:
             grpc:
               metadata:
@@ -161,7 +158,6 @@ binds:
         extAuthz:
           host: openfga-authz-bridge:9100
           failureMode: { denyWithStatus: 403 }
-          timeout: 10s
           protocol:
             grpc:
               metadata:

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -37,12 +37,7 @@ DEFAULT_MCP_ROUTE_POLICIES: dict[str, Any] = {
     "extAuthz": {
         "host": "openfga-authz-bridge:9100",
         "failureMode": {"denyWithStatus": 403},
-        # AgentGateway's default ext_authz timeout is 200ms. Listing tools fires one
-        # ext_authz Check per MCP route concurrently; under a cold OpenFGA/Postgres
-        # these serialize (75-150ms each) and blow that 200ms budget, producing
-        # fail-closed 403s that surface as "MCP server unavailable". The bridge
-        # always answers well under 10s. Keep this in sync with
-        # deploy/agentgateway/config.yaml (bootstrap seed).
+        # Keep this in sync with deploy/agentgateway/config.yaml (bootstrap seed).
         "protocol": {
             "grpc": {
                 "metadata": {

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -43,7 +43,6 @@ DEFAULT_MCP_ROUTE_POLICIES: dict[str, Any] = {
         # fail-closed 403s that surface as "MCP server unavailable". The bridge
         # always answers well under 10s. Keep this in sync with
         # deploy/agentgateway/config.yaml (bootstrap seed).
-        "timeout": "10s",
         "protocol": {
             "grpc": {
                 "metadata": {

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2848,6 +2848,7 @@ services:
       IDP_CLIENT_SECRET: ${IDP_CLIENT_SECRET:-}
       IDP_ACCESS_GROUP: ${IDP_ACCESS_GROUP:-}
       IDP_ADMIN_GROUP: ${IDP_ADMIN_GROUP:-}
+      IDP_PKCE_ENABLED: ${IDP_PKCE_ENABLED:-false}
       KEYCLOAK_FORCE_IDP_REDIRECT: ${KEYCLOAK_FORCE_IDP_REDIRECT:-false}
       KEYCLOAK_ADMIN_FRONTEND_URL: ${KEYCLOAK_ADMIN_FRONTEND_URL:-}
       CAIPE_UNSAFE_RBAC_BYPASS: ${CAIPE_UNSAFE_RBAC_BYPASS:-false}
@@ -3071,7 +3072,7 @@ services:
         condition: service_healthy
 
   agentgateway:
-    image: ghcr.io/agentgateway/agentgateway:latest
+    image: ghcr.io/agentgateway/agentgateway:v1.1.0
     container_name: agentgateway
     restart: unless-stopped
     command: ["--file", "/etc/agentgateway/config.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.8-dev.2"
+version = "0.5.8-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
+++ b/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
@@ -108,7 +108,7 @@ describe("workflow runs OpenFGA config access", () => {
       expect.objectContaining({ sub: "alice-sub" }),
       [{ _id: "wf-visible" }, { _id: "wf-hidden" }],
       { type: "task", action: "read", id: expect.any(Function) },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
     expect(runCollection.find).toHaveBeenCalledWith({ workflow_config_id: { $in: ["wf-visible"] } });
     expect(body).toEqual([{ _id: "run-1", workflow_config_id: "wf-visible" }]);
@@ -132,7 +132,7 @@ describe("workflow runs OpenFGA config access", () => {
     expect(mockRequireResourcePermission).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
       { type: "task", id: "wf-visible", action: "read" },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
     expect(mockStartWorkflowRun).toHaveBeenCalledWith(
       config,

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -259,6 +259,11 @@ describe("Slack channel ReBAC APIs", () => {
   });
 
   it("replaces channel resource grants and writes channel OpenFGA tuples", async () => {
+    // Not an org admin (organization:caipe denied) so the per-channel can_manage
+    // check is what authorizes the actor — exercise that path explicitly.
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { relation: string; object: string }) => ({
+      allowed: tuple.object === `slack_channel:${workspaceAlias}--${channelId}`,
+    }));
     mockReadOpenFgaTuples.mockResolvedValue({
       tuples: [
         {
@@ -305,7 +310,9 @@ describe("Slack channel ReBAC APIs", () => {
   });
 
   it("does not update Slack channel grants when the actor cannot manage the team-owned channel", async () => {
-    mockCheckOpenFgaTuple.mockResolvedValueOnce({ allowed: false });
+    // Deny every probe: not an org admin (organization:caipe) AND no per-channel
+    // can_manage grant — so the actor is genuinely unauthorized → 403.
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
     const { PUT } = await import("../[workspaceId]/[channelId]/resources/route");
 
     const response = await PUT(

--- a/ui/src/app/api/admin/slack/channels/_lib.ts
+++ b/ui/src/app/api/admin/slack/channels/_lib.ts
@@ -17,11 +17,14 @@ export async function withSlackChannelRebacViewAuth<T>(
 ): Promise<T> {
   const { session } = await getAuthFromBearerOrSession(request);
   if (target) {
+    // bypassForOrgAdmin so an org admin can read a channel that has no
+    // per-channel grants yet — e.g. one just imported from config and not yet
+    // assigned to a team.
     await requireResourcePermission(session, {
       type: "slack_channel",
       id: slackChannelSubjectId(target.workspaceId, target.channelId),
       action: "read",
-    }, { allowAdminBypass: true });
+    }, { bypassForOrgAdmin: true });
   } else {
     await requireAdminSurfaceManage(session, "slack");
   }
@@ -35,11 +38,14 @@ export async function withSlackChannelRebacManageAuth<T>(
 ): Promise<T> {
   const { session } = await getAuthFromBearerOrSession(request);
   if (target) {
+    // bypassForOrgAdmin so an org admin can onboard/assign-team a channel that
+    // doesn't yet have per-channel manage grants (without it, an imported
+    // channel 403s before it can be assigned to a team).
     await requireResourcePermission(session, {
       type: "slack_channel",
       id: slackChannelSubjectId(target.workspaceId, target.channelId),
       action: "manage",
-    }, { allowAdminBypass: true });
+    }, { bypassForOrgAdmin: true });
   } else {
     await requireAdminSurfaceManage(session, "slack");
   }

--- a/ui/src/app/api/admin/slack/channels/route.ts
+++ b/ui/src/app/api/admin/slack/channels/route.ts
@@ -101,7 +101,13 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         const access = subject
           ? await slackChannelAccess(subject, workspaceId, row.slack_channel_id)
           : { canRead: false, canManage: false };
-        if (!access.canRead && !(row.source === "route_metadata" && canManageSlackSurface)) return null;
+        // A Slack surface admin can see every channel row, including
+        // team_mapping rows imported (config_sync) but not yet assigned to a
+        // team — those have no per-channel OpenFGA grants yet, so canRead is
+        // false, but the admin still needs to see them in order to onboard
+        // them. Without this, an imported-but-unassigned channel is invisible
+        // in the Configured Channels tab. Non-admins still require canRead.
+        if (!access.canRead && !canManageSlackSurface) return null;
         const [grants, routesForChannel, health] = await Promise.all([
           listSlackChannelGrants(workspaceId, row.slack_channel_id),
           routeCollection
@@ -124,7 +130,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           team_id: row.team_id,
           team_slug: row.team_slug,
           active_grants: Math.max(grants.length, routesForChannel.length),
-          can_manage: access.canManage || (row.source === "route_metadata" && canManageSlackSurface),
+          can_manage: access.canManage || canManageSlackSurface,
           ...(health ? { health } : {}),
         };
       })

--- a/ui/src/app/api/admin/slack/runtime/sync-from-config/route.ts
+++ b/ui/src/app/api/admin/slack/runtime/sync-from-config/route.ts
@@ -7,14 +7,18 @@ import {
   withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection } from "@/lib/mongodb";
+import { writeOpenFgaTupleDiff, buildUniversalRebacTupleDiff } from "@/lib/rbac/openfga";
+import { slackChannelTeamVisibilityRelationships } from "@/lib/rbac/slack-channel-rebac";
 import { slackWorkspaceRef } from "@/lib/rbac/slack-channel-grant-store";
 import { callSlackBotAdmin } from "@/lib/slack-bot-admin";
+import type { Team } from "@/types/teams";
 
 interface ChannelTeamMappingDoc {
   slack_workspace_id?: string;
   slack_channel_id: string;
   channel_name?: string;
   team_slug?: string;
+  team_id?: string;
   active?: boolean;
 }
 
@@ -22,6 +26,8 @@ interface SyncPreviewChannel {
   workspace_id?: string;
   channel_id?: string;
   channel_name?: string;
+  /** Optional owning team slug from the YAML config (channel-level `team:`). */
+  team?: string;
   agents?: unknown[];
   [key: string]: unknown;
 }
@@ -68,30 +74,82 @@ async function ensureImportedChannelRows(channels: SyncPreviewChannel[]): Promis
     updated_at?: string;
   }>("channel_team_mappings");
   const now = new Date().toISOString();
+
+  // Resolve any team slugs the config provided to their team docs, so we can
+  // bind the channel to a team on import (sets team_slug/team_id + writes the
+  // channel→team ReBAC tuples) rather than leaving it team-less and unusable.
+  const teamSlugs = Array.from(
+    new Set(
+      channels
+        .map((c) => (typeof c.team === "string" ? c.team.trim() : ""))
+        .filter((slug) => slug.length > 0),
+    ),
+  );
+  const teamBySlug = new Map<string, Team>();
+  if (teamSlugs.length > 0) {
+    const teamsCol = await getCollection<Team>("teams");
+    const teamDocs = await teamsCol.find({ slug: { $in: teamSlugs } } as never).toArray();
+    for (const team of teamDocs) teamBySlug.set(team.slug, team);
+  }
+
   for (const channel of channels) {
     if (!channel.channel_id) continue;
     const workspaceRef = slackWorkspaceRef(channel.workspace_id ? String(channel.workspace_id) : undefined);
+    const channelId = String(channel.channel_id);
+
+    // If the config named a team and it exists, bind the channel to it.
+    const requestedSlug = typeof channel.team === "string" ? channel.team.trim() : "";
+    const team = requestedSlug ? teamBySlug.get(requestedSlug) : undefined;
+    if (requestedSlug && !team) {
+      console.warn(
+        `[slack-sync] channel ${channelId} requests team '${requestedSlug}' which does not exist — importing without a team binding`,
+      );
+    }
+
+    const setOnInsert: Record<string, unknown> = {
+      slack_workspace_id: workspaceRef,
+      slack_channel_id: channelId,
+      active: true,
+      source_type: "config_sync",
+      created_at: now,
+    };
+    const set: Record<string, unknown> = {
+      channel_name: channel.channel_name ? String(channel.channel_name) : channelId,
+      updated_at: now,
+    };
+    if (team) {
+      set.team_slug = team.slug;
+      set.team_id = String(team._id);
+    }
+
     await mappings.updateOne(
       {
         slack_workspace_id: workspaceRef,
-        slack_channel_id: String(channel.channel_id),
+        slack_channel_id: channelId,
         active: { $ne: false },
       } as never,
-      {
-        $set: {
-          channel_name: channel.channel_name ? String(channel.channel_name) : String(channel.channel_id),
-          updated_at: now,
-        },
-        $setOnInsert: {
-          slack_workspace_id: workspaceRef,
-          slack_channel_id: String(channel.channel_id),
-          active: true,
-          source_type: "config_sync",
-          created_at: now,
-        },
-      } as never,
+      { $set: set, $setOnInsert: setOnInsert } as never,
       { upsert: true },
     );
+
+    // Write the channel→team ReBAC tuples (team#member→use, team#admin→manage)
+    // so the channel is actually authorized for the team's members. Without
+    // these the mapping exists but the bot's channel ReBAC check still denies.
+    if (team) {
+      try {
+        await writeOpenFgaTupleDiff(
+          buildUniversalRebacTupleDiff({
+            writes: slackChannelTeamVisibilityRelationships(workspaceRef, channelId, team.slug),
+            deletes: [],
+          }),
+        );
+      } catch (error) {
+        console.warn(
+          `[slack-sync] failed to write channel→team OpenFGA tuples for ${channelId} → ${team.slug}:`,
+          error,
+        );
+      }
+    }
   }
 }
 

--- a/ui/src/app/api/admin/slack/runtime/sync-from-config/route.ts
+++ b/ui/src/app/api/admin/slack/runtime/sync-from-config/route.ts
@@ -59,9 +59,16 @@ async function annotateChannelsWithTeam(
   }
   return channels.map((channel) => {
     const workspaceRef = slackWorkspaceRef(channel.workspace_id ? String(channel.workspace_id) : undefined);
-    const teamSlug = channel.channel_id
+    // Prefer the team the config provides (the import will bind it); fall back
+    // to the team the channel is already mapped to in the DB. Either way the
+    // channel ends up with a team, so the preview shouldn't flag it as missing.
+    const configTeam = typeof channel.team === "string" && channel.team.trim()
+      ? channel.team.trim()
+      : null;
+    const existingTeam = channel.channel_id
       ? teamByChannel.get(`${workspaceRef}/${channel.channel_id}`) ?? null
       : null;
+    const teamSlug = configTeam ?? existingTeam;
     return { ...channel, team_slug: teamSlug, has_team: Boolean(teamSlug) };
   });
 }

--- a/ui/src/app/api/admin/teams/[id]/slack-channels/route.ts
+++ b/ui/src/app/api/admin/teams/[id]/slack-channels/route.ts
@@ -156,7 +156,7 @@ export const GET = withErrorHandler(
       const teamsCol = await getCollection<Team>("teams");
       const team = await teamsCol.findOne({ _id: teamId } as never);
       if (!team) throw new ApiError("Team not found", 404);
-      await requireResourcePermission(session, { type: "team", id: teamSlug(team, teamIdStr), action: "read" }, { allowAdminBypass: true });
+      await requireResourcePermission(session, { type: "team", id: teamSlug(team, teamIdStr), action: "read" }, { bypassForOrgAdmin: true });
 
       const teamCol = await getCollection<ChannelTeamMappingDoc>("channel_team_mappings");
 
@@ -224,7 +224,7 @@ export const PUT = withErrorHandler(
       const team = await teamsCol.findOne({ _id: teamId } as never);
       if (!team) throw new ApiError("Team not found", 404);
       const ownerTeamSlug = teamSlug(team, teamIdStr);
-      await requireResourcePermission(session, { type: "team", id: ownerTeamSlug, action: "manage" }, { allowAdminBypass: true });
+      await requireResourcePermission(session, { type: "team", id: ownerTeamSlug, action: "manage" }, { bypassForOrgAdmin: true });
 
       const teamCol = await getCollection<ChannelTeamMappingDoc>("channel_team_mappings");
 

--- a/ui/src/app/api/admin/teams/[id]/webex-spaces/route.ts
+++ b/ui/src/app/api/admin/teams/[id]/webex-spaces/route.ts
@@ -140,7 +140,7 @@ export const GET = withErrorHandler(
     const teamsCol = await getCollection<Team>("teams");
     const team = await teamsCol.findOne({ _id: teamId } as never);
     if (!team) throw new ApiError("Team not found", 404);
-    await requireResourcePermission(session, { type: "team", id: teamSlug(team, teamIdStr), action: "read" }, { allowAdminBypass: true });
+    await requireResourcePermission(session, { type: "team", id: teamSlug(team, teamIdStr), action: "read" }, { bypassForOrgAdmin: true });
 
     const teamCol = await getRbacCollection<WebexSpaceTeamMappingDoc>("webexSpaceTeamMappings");
 
@@ -202,7 +202,7 @@ export const PUT = withErrorHandler(
     const team = await teamsCol.findOne({ _id: teamId } as never);
     if (!team) throw new ApiError("Team not found", 404);
     const ownerTeamSlug = teamSlug(team, teamIdStr);
-    await requireResourcePermission(session, { type: "team", id: ownerTeamSlug, action: "manage" }, { allowAdminBypass: true });
+    await requireResourcePermission(session, { type: "team", id: ownerTeamSlug, action: "manage" }, { bypassForOrgAdmin: true });
 
     const teamCol = await getRbacCollection<WebexSpaceTeamMappingDoc>("webexSpaceTeamMappings");
 

--- a/ui/src/app/api/admin/webex/spaces/__tests__/space-resources-route.test.ts
+++ b/ui/src/app/api/admin/webex/spaces/__tests__/space-resources-route.test.ts
@@ -266,6 +266,11 @@ describe("Webex space ReBAC resource APIs", () => {
   });
 
   it("replaces space resource grants and writes webex_space OpenFGA tuples with filtered reads", async () => {
+    // Not an org admin (organization:caipe denied) so the per-space can_manage
+    // check is what authorizes the actor — exercise that path explicitly.
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { relation: string; object: string }) => ({
+      allowed: tuple.object === `webex_space:${workspaceAlias}--${spaceId}`,
+    }));
     mockReadOpenFgaTuples.mockResolvedValue({
       tuples: [
         {

--- a/ui/src/app/api/admin/webex/spaces/_lib.ts
+++ b/ui/src/app/api/admin/webex/spaces/_lib.ts
@@ -21,7 +21,7 @@ export async function withWebexSpaceRebacViewAuth<T>(
       type: "webex_space",
       id: webexSpaceSubjectId(target.workspaceId, target.spaceId),
       action: "read",
-    }, { allowAdminBypass: true });
+    }, { bypassForOrgAdmin: true });
   } else {
     await requireAdminSurfaceManage(session, "webex");
   }
@@ -39,7 +39,7 @@ export async function withWebexSpaceRebacManageAuth<T>(
       type: "webex_space",
       id: webexSpaceSubjectId(target.workspaceId, target.spaceId),
       action: "manage",
-    }, { allowAdminBypass: true });
+    }, { bypassForOrgAdmin: true });
   } else {
     await requireAdminSurfaceManage(session, "webex");
   }

--- a/ui/src/app/api/rag/tools/[toolId]/route.ts
+++ b/ui/src/app/api/rag/tools/[toolId]/route.ts
@@ -61,7 +61,7 @@ export async function GET(
     await requireResourcePermission(
       { sub: session.sub, role: session.role, user: session.user },
       { type: "tool", id: toolId, action: "read" },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
 
     return NextResponse.json({ tool });
@@ -96,7 +96,7 @@ export async function PUT(
     await requireResourcePermission(
       { sub: session.sub, role: session.role, user: session.user },
       { type: "tool", id: toolId, action: "write" },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
 
     const body = await request.json();
@@ -165,7 +165,7 @@ export async function DELETE(
     await requireResourcePermission(
       { sub: session.sub, role: session.role, user: session.user },
       { type: "tool", id: toolId, action: "delete" },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
 
     await tools.updateOne(

--- a/ui/src/app/api/rag/tools/route.ts
+++ b/ui/src/app/api/rag/tools/route.ts
@@ -100,7 +100,7 @@ export async function GET() {
       { sub: session.sub, role: session.role, user: session.user },
       results,
       { type: "tool", action: "read", id: (tool) => tool.tool_id },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
 
     return NextResponse.json({ tools: visibleResults });

--- a/ui/src/app/api/workflow-runs/[id]/cancel/route.ts
+++ b/ui/src/app/api/workflow-runs/[id]/cancel/route.ts
@@ -29,7 +29,7 @@ export const POST = withErrorHandler(async (
   await requireResourcePermission(
     session,
     { type: "task", id: run.workflow_config_id, action: "write" },
-    { allowAdminBypass: true },
+    { bypassForOrgAdmin: true },
   );
 
   await cancelWorkflowRun(id);

--- a/ui/src/app/api/workflow-runs/[id]/resume/route.ts
+++ b/ui/src/app/api/workflow-runs/[id]/resume/route.ts
@@ -35,7 +35,7 @@ export const POST = withErrorHandler(async (
   await requireResourcePermission(
     session,
     { type: "task", id: run.workflow_config_id, action: "write" },
-    { allowAdminBypass: true },
+    { bypassForOrgAdmin: true },
   );
 
   // Build auth headers

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -51,7 +51,7 @@ async function userCanAccessConfig(
     await requireResourcePermission(
       session,
       { type: "task", id: configId, action: "read" },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
     return true;
   } catch {
@@ -68,7 +68,7 @@ async function userCanDeleteConfigRuns(
     await requireResourcePermission(
       session,
       { type: "task", id: configId, action: "delete" },
-      { allowAdminBypass: true },
+      { bypassForOrgAdmin: true },
     );
     return true;
   } catch {
@@ -162,7 +162,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   await requireResourcePermission(
     session,
     { type: "task", id: workflow_config_id, action: "read" },
-    { allowAdminBypass: true },
+    { bypassForOrgAdmin: true },
   );
 
   // Build auth headers for DA server calls
@@ -260,7 +260,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     session,
     configCandidates,
     { type: "task", action: "read", id: (config) => config._id },
-    { allowAdminBypass: true },
+    { bypassForOrgAdmin: true },
   );
 
   const accessibleIds = accessibleConfigs.map((c) => c._id);

--- a/ui/src/lib/rbac/__tests__/resource-authz.test.ts
+++ b/ui/src/lib/rbac/__tests__/resource-authz.test.ts
@@ -152,24 +152,44 @@ describe("resource-authz", () => {
   });
 
   it("does not bypass OpenFGA object checks for session-role admins", async () => {
+    // bypassForOrgAdmin trusts an OpenFGA org-admin tuple, NOT a session role.
+    // A `role: "admin"` claim with no org-admin tuple must still be denied.
     const check = jest.fn(async () => ({ allowed: false }));
 
     await expect(
       requireResourcePermission(
         { sub: "admin-sub", role: "admin" },
         { type: "admin_surface", id: "skill-scan-all", action: "admin" },
-        { allowAdminBypass: true, check },
+        { bypassForOrgAdmin: true, check },
       ),
     ).rejects.toMatchObject({
       statusCode: 403,
       code: "admin_surface#admin",
     });
 
+    // The org-admin bypass probe runs first (can_manage organization:caipe),
+    // then the per-resource check — both deny here.
     expect(check).toHaveBeenCalledWith({
       user: "user:admin-sub",
       relation: "can_manage",
       object: "admin_surface:skill-scan-all",
     });
+  });
+
+  it("bypasses for a real OpenFGA org admin", async () => {
+    // An org admin (can_manage organization:caipe) short-circuits to allow,
+    // even when the per-resource object check would deny.
+    const check = jest.fn(async (tuple: { object: string }) => ({
+      allowed: tuple.object === "organization:caipe",
+    }));
+
+    await expect(
+      requireResourcePermission(
+        { sub: "org-admin-sub", role: "admin" },
+        { type: "admin_surface", id: "skill-scan-all", action: "admin" },
+        { bypassForOrgAdmin: true, check },
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("filters session-role admins through OpenFGA instead of returning every resource", async () => {
@@ -184,7 +204,9 @@ describe("resource-authz", () => {
         id: (resource) => resource.id,
       },
       {
-        allowAdminBypass: true,
+        bypassForOrgAdmin: true,
+        // Not an org admin (organization:caipe denied), so the per-resource
+        // OpenFGA check still gates each resource.
         check: async (tuple) => ({ allowed: tuple.object === "mcp_server:visible" }),
       },
     );

--- a/ui/src/lib/rbac/resource-authz.ts
+++ b/ui/src/lib/rbac/resource-authz.ts
@@ -43,12 +43,6 @@ export interface ResourceAuthzSession {
 export interface ResourcePermissionOptions {
   check?: (tuple: OpenFgaTupleKey) => Promise<OpenFgaCheckResult>;
   /**
-   * @deprecated OpenFGA is the PDP for resource checks. This option is retained
-   * for source compatibility with older call sites but no longer bypasses checks.
-   * Use `bypassForOrgAdmin` to explicitly opt into the org-admin super-grant.
-   */
-  allowAdminBypass?: boolean;
-  /**
    * When true, the resource-permission helpers short-circuit to allow if the
    * caller holds `user:<sub> can_manage organization:<caipeOrgKey>` in OpenFGA.
    *

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -24,6 +24,7 @@ import {
   reconcileConfigDrivenLlmModelRelationships,
   reconcileConfigDrivenMcpServerRelationships,
 } from "@/lib/rbac/openfga-owned-resources";
+import { reconcileAgentRelationships } from "@/lib/rbac/openfga-agent-tools";
 import type {
   DynamicAgentConfig,
   MCPServerConfig,
@@ -173,6 +174,18 @@ async function seedAgents(
     const existing = await collection.findOne({ _id: agentId });
     const createdAt = existing?.created_at ?? now;
 
+    // Optional `owner_team` (slug) in the config makes the seeded agent owned by
+    // a team, which is what lets it be used in Slack channels mapped to that
+    // team — the bot's channel ReBAC check probes `team:<slug>#member can_use
+    // agent:<id>`, and only the OpenFGA reconcile below writes that tuple.
+    // `visibility: global` alone grants `user:*`, which does NOT satisfy a
+    // team-subject check.
+    const ownerTeamSlug =
+      (agentData.owner_team as string | undefined)?.trim() || null;
+    const sharedTeamSlugs = (
+      (agentData.shared_with_teams as string[] | undefined) ?? []
+    ).filter((slug) => slug && slug !== ownerTeamSlug);
+
     const doc = {
       _id: agentId,
       name: (agentData.name as string) ?? agentId,
@@ -189,7 +202,8 @@ async function seedAgents(
           },
       visibility: ((agentData.visibility as string) ?? "global") as VisibilityType,
       shared_with_teams:
-        (agentData.shared_with_teams as string[]) ?? undefined,
+        sharedTeamSlugs.length > 0 ? sharedTeamSlugs : undefined,
+      owner_team_slug: ownerTeamSlug ?? undefined,
       subagents: (agentData.subagents as SubAgentRef[]) ?? [],
       skills: (agentData.skills as string[]) ?? [],
       builtin_tools:
@@ -207,6 +221,34 @@ async function seedAgents(
     };
 
     await collection.replaceOne({ _id: agentId }, doc, { upsert: true });
+
+    // Write the OpenFGA ownership/share tuples (team#member→can_use,
+    // team#admin→can_manage) so an owner/shared team can actually use the agent
+    // — including in Slack channels mapped to that team. Without this, a seeded
+    // agent's team grants live only in Mongo and the PDP denies. Mirrors what
+    // the agent editor (POST /api/dynamic-agents) does. Best-effort: a failure
+    // here shouldn't abort seeding the rest of the config.
+    if (ownerTeamSlug) {
+      try {
+        await reconcileAgentRelationships({
+          agentId,
+          previousAllowedTools: {},
+          nextAllowedTools: doc.allowed_tools,
+          ownerSubject: null,
+          organizationId: caipeOrgKey(),
+          ownerTeamSlug,
+          nextSharedTeamSlugs: sharedTeamSlugs,
+          previousSharedTeamSlugs: [],
+          failClosed: false,
+        });
+      } catch (error) {
+        console.warn(
+          `[seed-config] Failed to reconcile OpenFGA team grants for agent ${agentId}:`,
+          error,
+        );
+      }
+    }
+
     console.log(`[seed-config] Seeded agent: ${agentId}`);
     count++;
   }

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.8.dev2"
+version = "0.5.8.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
Independent local-dev correctness fixes found running the full `docker-compose` stack (auth/SSO + RBAC + dynamic agents + Slack bot) end to end. Grouped into one PR; cataloged below.

## 1. RBAC org-admin bypass consolidation
`requireResourcePermission`/`filterResourcesByPermission` had two options: a deprecated **no-op** `allowAdminBypass` and the real OpenFGA-backed `bypassForOrgAdmin` (checks `user can_manage organization:<org>`). Several surfaces (slack channels, webex spaces, teams, workflow-runs, rag tools) still passed the no-op, so **org admins were denied on resources they don't individually own**. Removed `allowAdminBypass` entirely; migrated every call site + tests to `bypassForOrgAdmin`. The bypass still trusts an OpenFGA tuple, not a session `role` claim — preserved and explicitly tested.

## 2. Slack channel admin visibility + team import
- The Configured Channels list only surfaced `route_metadata` rows to admins; channels imported from config (`team_mapping` rows) with no per-channel grants were filtered out. A Slack surface admin now sees all channel rows.
- **New:** the bot config gains an optional channel-level `team` (slug). The "import from config" flow now binds the channel to that team — sets `team_slug`/`team_id` and writes the channel→team ReBAC tuples — instead of leaving it team-less and unusable. (`ChannelConfig.team` + sync preview emit it; `ensureImportedChannelRows` consumes it. Unknown slug → warns, proceeds; no team → unchanged.)

## 3. Seed config writes agent team grants
`seedAgents` now writes the OpenFGA ownership/share tuples (team#member→can_use, team#admin→can_manage) from an optional `owner_team` field, via `reconcileAgentRelationships` — the same path the agent editor uses. Previously a seeded agent's team ownership lived only in Mongo, so it was denied when used in that team's channels.

## 4. AgentGateway image pin + config
Compose pinned `agentgateway:latest`, which advanced to a build that rejects the `extAuthz.timeout` field the config carries — crash-looping the gateway. Pin to `v1.1.0` (matches the Helm chart `appVersion`) and drop the unsupported `extAuthz.timeout` (no released gateway image accepts it; reverts to the built-in default). Also pass `IDP_PKCE_ENABLED` through to the keycloak-init container.

## 5. Slack bot logging
The RBAC middleware logged via Bolt's injected stdlib `logging.Logger` using loguru-style `{}` placeholders → `TypeError` at emit. Switched to `%`-style. Denials now log at WARNING instead of posting the denial into the channel (noisy / leaks config).

## Test plan
- [x] `resource-authz`, `workflow-runs-rbac`, `channel-resources-route`, `space-resources-route`, `slack_admin_api`, `test_slack_route_no_silent_failure` suites pass (incl. new org-admin bypass + team-import coverage)
- [x] `tsc --noEmit` clean for changed files
- [x] agentgateway starts cleanly on v1.1.0 (no crash loop)
- [x] imported Slack channel binds to its team and is usable by an org admin