### PR TITLE
feat(workflows): RBAC visibility, run access, team slugs, and unsaved UX

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
@@ -20,6 +20,9 @@ from pymongo import MongoClient
 from pymongo.errors import PyMongoError
 
 from dynamic_agents.auth.token_context import current_traceparent, current_user_token
+from dynamic_agents.auth.workflow_execution_authz import can_use_agent_via_workflow
+from dynamic_agents.models import UserContext
+from dynamic_agents.services.mongo import MongoDBService
 
 logger = logging.getLogger(__name__)
 
@@ -321,7 +324,13 @@ async def _check_agent_use(subject: str, agent_id: str) -> bool:
         return bool(body.get("allowed"))
 
 
-async def require_agent_use_permission(agent_id: str) -> None:
+async def require_agent_use_permission(
+    agent_id: str,
+    *,
+    workflow_config_id: str | None = None,
+    mongo: MongoDBService | None = None,
+    user: UserContext | None = None,
+) -> None:
     """Require the current bearer token subject to have can_use on an agent."""
     if not _is_valid_openfga_id(agent_id):
         _raise_authz(
@@ -411,6 +420,15 @@ async def require_agent_use_permission(agent_id: str) -> None:
                 "authz.tenant_id": os.getenv("TENANT_ID", "default"),
             },
         )
+
+    if (
+        not allowed
+        and workflow_config_id
+        and mongo is not None
+        and user is not None
+        and can_use_agent_via_workflow(agent_id, workflow_config_id, user, mongo)
+    ):
+        allowed = True
 
     if allowed:
         _log_openfga_rebac_audit(

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/workflow_execution_authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/workflow_execution_authz.py
@@ -1,0 +1,101 @@
+"""Authorize agent use when executing a workflow step (delegated from workflow config)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dynamic_agents.models import UserContext
+    from dynamic_agents.services.mongo import MongoDBService
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_email(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def _normalize_team_slug(value: str) -> str:
+    return value.strip().lower()
+
+
+def _agent_in_workflow_steps(workflow_doc: dict[str, Any], agent_id: str) -> bool:
+    for step in workflow_doc.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        if step.get("type") == "step" and step.get("agent_id") == agent_id:
+            return True
+    return False
+
+
+def _user_team_slugs(mongo: MongoDBService, user_email: str) -> set[str]:
+    db = getattr(mongo, "_db", None)
+    if db is None:
+        return set()
+    try:
+        rows = db["teams"].find(
+            {"members.user_id": user_email},
+            {"slug": 1},
+        )
+        return {
+            _normalize_team_slug(row["slug"])
+            for row in rows
+            if isinstance(row.get("slug"), str) and row["slug"].strip()
+        }
+    except Exception as exc:
+        logger.warning("Failed to load team slugs for %s: %s", user_email, exc)
+        return set()
+
+
+def user_can_run_workflow(workflow_doc: dict[str, Any], user: UserContext, mongo: MongoDBService) -> bool:
+    """Mirror UI workflowRunAllowedByVisibility for runtime delegation."""
+    email = _normalize_email(user.email)
+    if not email:
+        return False
+
+    visibility = workflow_doc.get("visibility") or "private"
+    if visibility == "global":
+        return True
+
+    if visibility == "team":
+        shared_raw = workflow_doc.get("shared_with_teams") or []
+        shared = {_normalize_team_slug(s) for s in shared_raw if isinstance(s, str) and s.strip()}
+        if not shared:
+            return False
+        member_slugs = _user_team_slugs(mongo, user.email or "")
+        return bool(shared.intersection(member_slugs))
+
+    owner = _normalize_email(workflow_doc.get("owner_id"))
+    return bool(owner and owner == email)
+
+
+def can_use_agent_via_workflow(
+    agent_id: str,
+    workflow_config_id: str,
+    user: UserContext,
+    mongo: MongoDBService,
+) -> bool:
+    """Allow agent use when the agent is a step in a workflow the user may run."""
+    if not workflow_config_id or not agent_id:
+        return False
+
+    db = getattr(mongo, "_db", None)
+    if db is None:
+        return False
+
+    try:
+        workflow_doc = db["workflow_configs"].find_one({"_id": workflow_config_id})
+    except Exception as exc:
+        logger.warning(
+            "Failed to load workflow config %s for agent delegation: %s",
+            workflow_config_id,
+            exc,
+        )
+        return False
+
+    if not workflow_doc:
+        return False
+    if not _agent_in_workflow_steps(workflow_doc, agent_id):
+        return False
+    return user_can_run_workflow(workflow_doc, user, mongo)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -625,6 +625,13 @@ class ChatRequest(BaseModel):
             "Ignored: ui, name, description, owner_id, visibility, enabled, is_system, config_driven."
         ),
     )
+    workflow_config_id: str | None = Field(
+        None,
+        description=(
+            "When set, agent use may be delegated from workflow execution: the caller "
+            "must be allowed to run this workflow and the agent must appear in its steps."
+        ),
+    )
 
 
 # =============================================================================

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -176,6 +176,10 @@ class ResumeStreamRequest(BaseModel):
             "since the runtime will be reconstructed against a different checkpoint store."
         ),
     )
+    workflow_config_id: str | None = Field(
+        None,
+        description="Workflow config ID when resuming a workflow step (for delegated agent use).",
+    )
 
 
 async def _generate_sse_events(
@@ -275,7 +279,12 @@ async def chat_start_stream(
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
 
-    await require_agent_use_permission(request.agent_id)
+    await require_agent_use_permission(
+        request.agent_id,
+        workflow_config_id=request.workflow_config_id,
+        mongo=mongo,
+        user=user,
+    )
 
     # Get agent config after the runtime policy check passes.
     agent = mongo.get_agent(request.agent_id)
@@ -391,7 +400,12 @@ async def chat_resume_stream(
     # Set conversation context for logging
     conversation_id_var.set(request.conversation_id)
 
-    await require_agent_use_permission(request.agent_id)
+    await require_agent_use_permission(
+        request.agent_id,
+        workflow_config_id=request.workflow_config_id,
+        mongo=mongo,
+        user=user,
+    )
 
     # Get agent config after the runtime policy check passes.
     agent = mongo.get_agent(request.agent_id)

--- a/ai_platform_engineering/dynamic_agents/tests/test_workflow_execution_authz.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_workflow_execution_authz.py
@@ -1,0 +1,54 @@
+"""Tests for workflow-delegated agent use authorization."""
+
+from unittest.mock import MagicMock
+
+from dynamic_agents.auth.workflow_execution_authz import (
+    can_use_agent_via_workflow,
+    user_can_run_workflow,
+)
+from dynamic_agents.models import UserContext
+
+
+def _mongo_with_workflow(doc: dict | None) -> MagicMock:
+    mongo = MagicMock()
+    db = MagicMock()
+    mongo._db = db
+    db.__getitem__.return_value.find_one.return_value = doc
+    db.__getitem__.return_value.find.return_value = []
+    return mongo
+
+
+def test_global_workflow_delegates_agent_in_steps() -> None:
+    workflow = {
+        "_id": "wf-movie-guessing",
+        "visibility": "global",
+        "owner_id": "system",
+        "steps": [
+            {"type": "step", "agent_id": "dynamic-agent-1", "display_text": "Ask"},
+        ],
+    }
+    mongo = _mongo_with_workflow(workflow)
+    user = UserContext(email="runner@example.com")
+
+    assert can_use_agent_via_workflow("dynamic-agent-1", "wf-movie-guessing", user, mongo) is True
+    assert can_use_agent_via_workflow("other-agent", "wf-movie-guessing", user, mongo) is False
+
+
+def test_team_workflow_requires_shared_team() -> None:
+    workflow = {
+        "_id": "wf-team",
+        "visibility": "team",
+        "owner_id": "owner@example.com",
+        "shared_with_teams": ["platform-eng"],
+        "steps": [{"type": "step", "agent_id": "agent-a"}],
+    }
+    mongo = _mongo_with_workflow(workflow)
+    teams_coll = mongo._db.__getitem__.return_value
+    teams_coll.find.return_value = [{"slug": "platform-eng"}]
+
+    user = UserContext(email="member@example.com")
+    assert user_can_run_workflow(workflow, user, mongo) is True
+    assert can_use_agent_via_workflow("agent-a", "wf-team", user, mongo) is True
+
+    teams_coll.find.return_value = [{"slug": "other-team"}]
+    assert user_can_run_workflow(workflow, user, mongo) is False

--- a/ui/src/app/api/__tests__/task-workflow-rbac.test.ts
+++ b/ui/src/app/api/__tests__/task-workflow-rbac.test.ts
@@ -51,6 +51,11 @@ jest.mock("@/lib/api-middleware", () => {
 jest.mock("@/lib/rbac/resource-authz", () => ({
   filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
   requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  subjectFromSession: () => "alice-sub",
+}));
+
+jest.mock("@/lib/rbac/openfga-team-membership", () => ({
+  listUserTeamSlugs: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/lib/rbac/keycloak-resource-sync", () => ({
@@ -95,15 +100,24 @@ describe("task/workflow config RBAC cutover", () => {
     expect(body).toEqual([expect.objectContaining({ id: "task-openfga" })]);
   });
 
-  it("loads workflow configs through OpenFGA task discover instead of legacy team visibility", async () => {
+  it("lists global workflows for non-admins via visibility and merges OpenFGA read grants", async () => {
     const configs = [
       { _id: "wf-openfga", name: "OpenFGA Workflow", visibility: "private", owner_id: "bob@example.com" },
-      { _id: "wf-denied", name: "Denied Workflow", visibility: "global" },
+      { _id: "wf-global", name: "Global Workflow", visibility: "global", owner_id: "system" },
     ];
     mockFilterResourcesByPermission.mockResolvedValue([configs[0]]);
     const sort = jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue(configs) });
     const find = jest.fn().mockReturnValue({ sort });
-    mockGetCollection.mockResolvedValue({ find });
+    const teamsCollection = {
+      find: jest.fn().mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "teams" ? teamsCollection : { find },
+    );
     const { GET } = await import("../workflow-configs/route");
 
     const response = await GET(request("/api/workflow-configs"));
@@ -115,8 +129,15 @@ describe("task/workflow config RBAC cutover", () => {
     expect(mockFilterResourcesByPermission).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
       configs,
-      { type: "task", action: "discover", id: expect.any(Function) },
+      { type: "task", action: "read", id: expect.any(Function) },
+      { bypassForOrgAdmin: true },
     );
-    expect(body).toEqual([expect.objectContaining({ _id: "wf-openfga" })]);
+    expect(body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "wf-openfga" }),
+        expect.objectContaining({ _id: "wf-global" }),
+      ]),
+    );
+    expect(body).toHaveLength(2);
   });
 });

--- a/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
+++ b/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
@@ -48,9 +48,16 @@ jest.mock("@/lib/api-middleware", () => {
   };
 });
 
+const mockListUserTeamSlugs = jest.fn().mockResolvedValue(["platform-eng"]);
+
+jest.mock("@/lib/rbac/openfga-team-membership", () => ({
+  listUserTeamSlugs: (...args: unknown[]) => mockListUserTeamSlugs(...args),
+}));
+
 jest.mock("@/lib/rbac/resource-authz", () => ({
   filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
   requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  subjectFromSession: () => "alice-sub",
 }));
 
 jest.mock("@/lib/server/workflow-engine", () => ({
@@ -114,8 +121,14 @@ describe("workflow runs OpenFGA config access", () => {
     expect(body).toEqual([{ _id: "run-1", workflow_config_id: "wf-visible" }]);
   });
 
-  it("requires OpenFGA read permission before starting a workflow run", async () => {
-    const config = { _id: "wf-visible", name: "Workflow" };
+  it("allows starting a global workflow without OpenFGA read", async () => {
+    const config = {
+      _id: "wf-visible",
+      name: "Workflow",
+      visibility: "global",
+      owner_id: "other@example.com",
+      steps: [],
+    };
     const configCollection = { findOne: jest.fn().mockResolvedValue(config) };
     mockGetCollection.mockResolvedValue(configCollection);
     const { POST } = await import("../workflow-runs/route");
@@ -129,16 +142,110 @@ describe("workflow runs OpenFGA config access", () => {
 
     expect(response.status).toBe(201);
     expect(mockGetUserTeamIds).not.toHaveBeenCalled();
-    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
-      expect.objectContaining({ sub: "alice-sub" }),
-      { type: "task", id: "wf-visible", action: "read" },
-      { bypassForOrgAdmin: true },
-    );
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
     expect(mockStartWorkflowRun).toHaveBeenCalledWith(
       config,
       null,
       expect.any(Object),
       expect.objectContaining({ user: { email: "alice@example.com", name: "Alice" } }),
     );
+  });
+
+  it("allows starting a team-shared workflow when the user is on that team", async () => {
+    const config = {
+      _id: "wf-team",
+      name: "Team workflow",
+      visibility: "team",
+      shared_with_teams: ["platform-eng"],
+      owner_id: "other@example.com",
+      steps: [],
+    };
+    const teamsCollection = {
+      find: jest.fn().mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([{ _id: "team-1", slug: "platform-eng" }]),
+        }),
+      }),
+    };
+    const configCollection = { findOne: jest.fn().mockResolvedValue(config) };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "teams" ? teamsCollection : configCollection,
+    );
+
+    const { POST } = await import("../workflow-runs/route");
+    const response = await POST(
+      request("/api/workflow-runs", {
+        method: "POST",
+        body: JSON.stringify({ workflow_config_id: "wf-team" }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+    expect(mockStartWorkflowRun).toHaveBeenCalled();
+  });
+
+  it("returns a run when the user has OpenFGA read on the parent config", async () => {
+    const run = {
+      _id: "run-read",
+      workflow_config_id: "wf-fga-read",
+      status: "running",
+    };
+    const config = {
+      _id: "wf-fga-read",
+      visibility: "private",
+      owner_id: "other@example.com",
+      shared_with_teams: [],
+    };
+    const runCollection = { findOne: jest.fn().mockResolvedValue(run) };
+    const configCollection = { findOne: jest.fn().mockResolvedValue(config) };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "workflow_runs" ? runCollection : configCollection,
+    );
+    mockRequireResourcePermission.mockImplementation(async (_session, resource) => {
+      if (resource.action === "read") {
+        return undefined;
+      }
+      throw new Error("denied");
+    });
+
+    const { GET } = await import("../workflow-runs/route");
+    const response = await GET(request("/api/workflow-runs?run_id=run-read"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body._id).toBe("run-read");
+    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "task", id: "wf-fga-read", action: "read" }),
+      expect.anything(),
+    );
+  });
+
+  it("denies run detail when the user lacks visibility and OpenFGA read/use", async () => {
+    const run = {
+      _id: "run-denied",
+      workflow_config_id: "wf-private",
+      status: "running",
+    };
+    const config = {
+      _id: "wf-private",
+      visibility: "private",
+      owner_id: "other@example.com",
+      shared_with_teams: [],
+    };
+    const runCollection = { findOne: jest.fn().mockResolvedValue(run) };
+    const configCollection = { findOne: jest.fn().mockResolvedValue(config) };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "workflow_runs" ? runCollection : configCollection,
+    );
+    mockRequireResourcePermission.mockRejectedValue(new Error("denied"));
+
+    const { GET } = await import("../workflow-runs/route");
+    const response = await GET(request("/api/workflow-runs?run_id=run-denied"));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toMatch(/permission to view workflow runs/i);
   });
 });

--- a/ui/src/app/api/workflow-configs/check-agent-access/route.ts
+++ b/ui/src/app/api/workflow-configs/check-agent-access/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-middleware";
+import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
+import { getCollection } from "@/lib/mongodb";
+
+interface StepEntry {
+  type?: string;
+  agent_id?: string;
+}
+
+interface CheckBody {
+  steps: StepEntry[];
+  visibility: "private" | "team" | "global";
+  shared_with_teams?: string[];
+}
+
+export interface AgentAccessGap {
+  agentId: string;
+  agentName: string;
+  teamsWithoutAccess: string[];
+}
+
+export interface CheckAgentAccessResponse {
+  gaps: AgentAccessGap[];
+}
+
+// Deduplicate agent IDs from workflow steps.
+function agentIdsFromSteps(steps: StepEntry[]): string[] {
+  const seen = new Set<string>();
+  for (const step of steps) {
+    if (step?.type === "step" && typeof step.agent_id === "string" && step.agent_id.trim()) {
+      seen.add(step.agent_id.trim());
+    }
+  }
+  return [...seen];
+}
+
+async function resolveAgentNames(agentIds: string[]): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  try {
+    const col = await getCollection<{ _id: string; name?: string }>("dynamic_agents");
+    const docs = await col
+      .find({ _id: { $in: agentIds } }, { projection: { name: 1 } })
+      .toArray();
+    for (const doc of docs) {
+      names.set(String(doc._id), doc.name ?? String(doc._id));
+    }
+  } catch {
+    // Non-fatal — fall back to using the ID as the name.
+  }
+  for (const id of agentIds) {
+    if (!names.has(id)) names.set(id, id);
+  }
+  return names;
+}
+
+// Check whether team:{slug}#member has the `user` relation on agent:{agentId}.
+async function teamHasAgentAccess(teamSlug: string, agentId: string): Promise<boolean> {
+  try {
+    const result = await checkOpenFgaTuple({
+      user: `team:${teamSlug}#member`,
+      relation: "user",
+      object: `agent:${agentId}`,
+    });
+    return result.allowed;
+  } catch {
+    // Treat check errors conservatively — surface the gap.
+    return false;
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withAuth(request, async () => {
+    let body: CheckBody;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const { steps = [], visibility, shared_with_teams = [] } = body;
+
+    // Only team-scoped workflows need per-team agent access checks.
+    // Global workflows are accessible to all users — surface a gap only when
+    // the agent itself is not globally accessible (user:* → user → agent:id).
+    const teamsToCheck =
+      visibility === "team"
+        ? shared_with_teams.filter((s) => typeof s === "string" && s.trim())
+        : [];
+
+    if (teamsToCheck.length === 0 && visibility !== "global") {
+      return NextResponse.json<CheckAgentAccessResponse>({ gaps: [] });
+    }
+
+    const agentIds = agentIdsFromSteps(steps);
+    if (agentIds.length === 0) {
+      return NextResponse.json<CheckAgentAccessResponse>({ gaps: [] });
+    }
+
+    const agentNames = await resolveAgentNames(agentIds);
+    const gaps: AgentAccessGap[] = [];
+
+    if (visibility === "global") {
+      // For global workflows check whether user:* has access to each agent.
+      for (const agentId of agentIds) {
+        try {
+          const result = await checkOpenFgaTuple({
+            user: "user:*",
+            relation: "user",
+            object: `agent:${agentId}`,
+          });
+          if (!result.allowed) {
+            gaps.push({
+              agentId,
+              agentName: agentNames.get(agentId) ?? agentId,
+              teamsWithoutAccess: ["(all users)"],
+            });
+          }
+        } catch {
+          gaps.push({
+            agentId,
+            agentName: agentNames.get(agentId) ?? agentId,
+            teamsWithoutAccess: ["(all users)"],
+          });
+        }
+      }
+    } else {
+      // team visibility — check each (agent, team) pair in parallel.
+      await Promise.all(
+        agentIds.map(async (agentId) => {
+          const missing = (
+            await Promise.all(
+              teamsToCheck.map(async (slug) => ({
+                slug,
+                ok: await teamHasAgentAccess(slug, agentId),
+              })),
+            )
+          )
+            .filter((r) => !r.ok)
+            .map((r) => r.slug);
+
+          if (missing.length > 0) {
+            gaps.push({
+              agentId,
+              agentName: agentNames.get(agentId) ?? agentId,
+              teamsWithoutAccess: missing,
+            });
+          }
+        }),
+      );
+    }
+
+    return NextResponse.json<CheckAgentAccessResponse>({ gaps });
+  });
+}

--- a/ui/src/app/api/workflow-configs/route.ts
+++ b/ui/src/app/api/workflow-configs/route.ts
@@ -17,6 +17,16 @@ import {
   filterResourcesByPermission,
   requireResourcePermission,
 } from "@/lib/rbac/resource-authz";
+import {
+  buildTeamRefToSlugMap,
+  filterWorkflowConfigsByRunAccess,
+  mergeWorkflowConfigsById,
+  normalizeSharedWithTeamSlugs,
+  reconcileWorkflowConfigAccess,
+  requireWorkflowConfigRunAccess,
+  requireWorkflowConfigWriteAccess,
+  resolveUserTeamSlugsForWorkflow,
+} from "@/lib/rbac/workflow-config-rebac";
 
 /**
  * Workflow Config API Routes
@@ -125,21 +135,48 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       return NextResponse.json(configs) as NextResponse;
     }
 
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+
     if (id) {
       const config = await getVisibleConfigById(id, user.email);
       if (!config) {
         throw new ApiError("Workflow config not found", 404);
       }
-      await requireResourcePermission(session, { type: "task", id, action: "read" });
+      await requireWorkflowConfigRunAccess(
+        session,
+        {
+          _id: String(config._id),
+          owner_id: config.owner_id,
+          visibility: config.visibility,
+          shared_with_teams: config.shared_with_teams,
+        },
+        user.email,
+        userTeamSlugs,
+      );
       return NextResponse.json(config) as NextResponse;
     }
 
     const configs = await getVisibleConfigs(user.email);
-    const visibleConfigs = await filterResourcesByPermission(session, configs, {
-      type: "task",
-      action: "discover",
-      id: (config) => String(config._id),
-    });
+    const teamRefToSlug = await buildTeamRefToSlugMap();
+    const byVisibility = filterWorkflowConfigsByRunAccess(
+      configs,
+      user.email,
+      userTeamSlugs,
+      teamRefToSlug,
+    );
+    // Match workflow-runs list: org-wide global workflows use Mongo visibility;
+    // FGA `read` supplements legacy per-user/team grants (discover is not written).
+    const byFga = await filterResourcesByPermission(
+      session,
+      configs,
+      {
+        type: "task",
+        action: "read",
+        id: (config) => String(config._id),
+      },
+      { bypassForOrgAdmin: true },
+    );
+    const visibleConfigs = mergeWorkflowConfigsById(byVisibility, byFga);
     return NextResponse.json(visibleConfigs) as NextResponse;
   });
 });
@@ -162,7 +199,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 
     validateSteps(body.steps);
     const visibility: WorkflowConfigVisibility = body.visibility || "global";
-    validateVisibility(visibility, body.shared_with_teams);
+    const sharedWithTeams =
+      visibility === "team"
+        ? await normalizeSharedWithTeamSlugs(body.shared_with_teams)
+        : undefined;
+    validateVisibility(visibility, sharedWithTeams);
 
     const id = `wf-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date();
@@ -174,13 +215,15 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       steps: body.steps,
       owner_id: user.email,
       visibility,
-      shared_with_teams: visibility === "team" ? body.shared_with_teams : undefined,
+      shared_with_teams: sharedWithTeams,
       created_at: now,
       updated_at: now,
     };
 
     const collection = await getCollection("workflow_configs");
     await collection.insertOne(config as any);
+
+    await reconcileWorkflowConfigAccess(session, config);
 
     return successResponse({ id, message: "Workflow config created successfully" }, 201);
   });
@@ -214,11 +257,21 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     if (!existing) {
       throw new ApiError("Workflow config not found", 404);
     }
-    if (user.role !== "admin") {
-      await requireResourcePermission(session, { type: "task", id, action: "write" });
-    }
     if ((existing as any).config_driven) {
       throw new ApiError("Cannot modify a config-driven workflow. Edit app-config.yaml instead.", 403);
+    }
+
+    if (user.role !== "admin") {
+      await requireWorkflowConfigWriteAccess(
+        session,
+        {
+          _id: id,
+          owner_id: existing.owner_id,
+          visibility: existing.visibility,
+          shared_with_teams: existing.shared_with_teams,
+        },
+        user.email,
+      );
     }
 
     if (body.steps) {
@@ -230,11 +283,47 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
         body.shared_with_teams = undefined;
       }
     }
+    if (body.shared_with_teams?.length) {
+      body.shared_with_teams = await normalizeSharedWithTeamSlugs(body.shared_with_teams);
+    }
 
-    await collection.updateOne(
-      { _id: id as any },
-      { $set: { ...body, updated_at: new Date() } }
-    );
+    const mergedVisibility = body.visibility ?? existing.visibility;
+    let mergedSharedWithTeams =
+      mergedVisibility === "team"
+        ? body.shared_with_teams ?? existing.shared_with_teams
+        : mergedVisibility !== undefined
+          ? undefined
+          : existing.shared_with_teams;
+
+    if (mergedVisibility === "team" && mergedSharedWithTeams?.length) {
+      mergedSharedWithTeams =
+        (await normalizeSharedWithTeamSlugs(mergedSharedWithTeams)) ?? undefined;
+    }
+
+    const updateFields: Record<string, unknown> = {
+      ...body,
+      updated_at: new Date(),
+    };
+    if (mergedVisibility === "team") {
+      updateFields.shared_with_teams = mergedSharedWithTeams;
+    } else if (
+      body.visibility !== undefined &&
+      (mergedVisibility === "private" || mergedVisibility === "global")
+    ) {
+      updateFields.shared_with_teams = undefined;
+    }
+
+    await collection.updateOne({ _id: id as any }, { $set: updateFields });
+
+    const merged = {
+      ...existing,
+      ...body,
+      _id: id,
+      visibility: mergedVisibility,
+      shared_with_teams: mergedSharedWithTeams,
+    };
+
+    await reconcileWorkflowConfigAccess(session, merged, existing);
 
     return successResponse({ id, message: "Workflow config updated successfully" });
   });
@@ -262,11 +351,21 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
     if (!existing) {
       throw new ApiError("Workflow config not found", 404);
     }
-    if (user.role !== "admin") {
-      await requireResourcePermission(session, { type: "task", id, action: "delete" });
-    }
     if ((existing as any).config_driven) {
       throw new ApiError("Cannot delete a config-driven workflow. Remove it from app-config.yaml instead.", 403);
+    }
+
+    if (user.role !== "admin") {
+      await requireWorkflowConfigWriteAccess(
+        session,
+        {
+          _id: id,
+          owner_id: existing.owner_id,
+          visibility: existing.visibility,
+          shared_with_teams: existing.shared_with_teams,
+        },
+        user.email,
+      );
     }
 
     await collection.deleteOne({ _id: id as any });

--- a/ui/src/app/api/workflow-runs/[id]/cancel/route.ts
+++ b/ui/src/app/api/workflow-runs/[id]/cancel/route.ts
@@ -4,9 +4,12 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
-import { getAuthFromBearerOrSession, ApiError, withErrorHandler } from "@/lib/api-middleware";
+import { ApiError, withAuth, withErrorHandler } from "@/lib/api-middleware";
 import { cancelWorkflowRun, type WorkflowRunDocument } from "@/lib/server/workflow-engine";
-import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import {
+  assertCanExecuteWorkflowRunsForConfigId,
+} from "@/lib/rbac/workflow-run-access";
+import { resolveUserTeamSlugsForWorkflow } from "@/lib/rbac/workflow-config-rebac";
 
 export const POST = withErrorHandler(async (
   request: NextRequest,
@@ -17,22 +20,24 @@ export const POST = withErrorHandler(async (
   }
 
   const { id } = await params;
-  const { session } = await getAuthFromBearerOrSession(request);
 
-  // Load run to check config access
-  const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
-  const run = await runCol.findOne({ _id: id });
-  if (!run) {
-    throw new ApiError("Workflow run not found", 404);
-  }
+  return await withAuth(request, async (_req, user, session) => {
+    const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
+    const run = await runCol.findOne({ _id: id });
+    if (!run) {
+      throw new ApiError("Workflow run not found", 404);
+    }
 
-  await requireResourcePermission(
-    session,
-    { type: "task", id: run.workflow_config_id, action: "write" },
-    { bypassForOrgAdmin: true },
-  );
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+    await assertCanExecuteWorkflowRunsForConfigId(
+      session,
+      run.workflow_config_id,
+      user.email,
+      userTeamSlugs,
+    );
 
-  await cancelWorkflowRun(id);
+    await cancelWorkflowRun(id);
 
-  return NextResponse.json({ status: "cancelled" }) as NextResponse;
+    return NextResponse.json({ status: "cancelled" }) as NextResponse;
+  });
 });

--- a/ui/src/app/api/workflow-runs/[id]/resume/route.ts
+++ b/ui/src/app/api/workflow-runs/[id]/resume/route.ts
@@ -4,9 +4,13 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
-import { getAuthFromBearerOrSession, ApiError, withErrorHandler } from "@/lib/api-middleware";
+import { ApiError, withAuth, withErrorHandler } from "@/lib/api-middleware";
 import { resumeWorkflowRun, type WorkflowRunDocument } from "@/lib/server/workflow-engine";
-import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import { buildWorkflowDaAuthHeaders } from "@/lib/server/workflow-da-auth";
+import {
+  assertCanExecuteWorkflowRunsForConfigId,
+} from "@/lib/rbac/workflow-run-access";
+import { resolveUserTeamSlugsForWorkflow } from "@/lib/rbac/workflow-config-rebac";
 
 export const POST = withErrorHandler(async (
   request: NextRequest,
@@ -17,39 +21,33 @@ export const POST = withErrorHandler(async (
   }
 
   const { id } = await params;
-  const { user, session } = await getAuthFromBearerOrSession(request);
-  const body = await request.json();
-  const { step_index, resume_data } = body;
 
-  if (step_index === undefined || resume_data === undefined) {
-    throw new ApiError("step_index and resume_data are required", 400);
-  }
+  return await withAuth(request, async (req, user, session) => {
+    const body = await req.json();
+    const { step_index, resume_data } = body;
 
-  // Load run to check config access
-  const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
-  const run = await runCol.findOne({ _id: id });
-  if (!run) {
-    throw new ApiError("Workflow run not found", 404);
-  }
+    if (step_index === undefined || resume_data === undefined) {
+      throw new ApiError("step_index and resume_data are required", 400);
+    }
 
-  await requireResourcePermission(
-    session,
-    { type: "task", id: run.workflow_config_id, action: "write" },
-    { bypassForOrgAdmin: true },
-  );
+    const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
+    const run = await runCol.findOne({ _id: id });
+    if (!run) {
+      throw new ApiError("Workflow run not found", 404);
+    }
 
-  // Build auth headers
-  const authHeaders: Record<string, string> = {};
-  const authHeader = request.headers.get("Authorization");
-  if (authHeader) {
-    authHeaders["Authorization"] = authHeader;
-  }
-  authHeaders["X-User-Context"] = Buffer.from(JSON.stringify({
-    email: user.email,
-    name: user.name,
-  })).toString("base64");
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+    await assertCanExecuteWorkflowRunsForConfigId(
+      session,
+      run.workflow_config_id,
+      user.email,
+      userTeamSlugs,
+    );
 
-  await resumeWorkflowRun(id, step_index, resume_data, authHeaders);
+    const authHeaders = buildWorkflowDaAuthHeaders(req, user, session);
 
-  return NextResponse.json({ status: "resumed" }) as NextResponse;
+    await resumeWorkflowRun(id, step_index, resume_data, authHeaders);
+
+    return NextResponse.json({ status: "resumed" }) as NextResponse;
+  });
 });

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -15,7 +15,6 @@ import {
   withErrorHandler,
   successResponse,
   ApiError,
-  getAuthFromBearerOrSession,
 } from "@/lib/api-middleware";
 import {
   startWorkflowRun,
@@ -28,6 +27,20 @@ import {
   requireResourcePermission,
   type ResourceAuthzSession,
 } from "@/lib/rbac/resource-authz";
+import {
+  buildTeamRefToSlugMap,
+  filterWorkflowConfigsByRunAccess,
+  mergeWorkflowConfigsById,
+  reconcileWorkflowConfigAccess,
+  resolveUserTeamSlugsForWorkflow,
+} from "@/lib/rbac/workflow-config-rebac";
+import {
+  assertCanExecuteWorkflowRunsForConfigId,
+  assertCanViewWorkflowRunsForConfigId,
+  canViewWorkflowRunsForConfigId,
+} from "@/lib/rbac/workflow-run-access";
+import { buildWorkflowDaAuthHeaders } from "@/lib/server/workflow-da-auth";
+import { assertWorkflowStepAgentsExist } from "@/lib/server/workflow-step-agents";
 import type { WorkflowConfig } from "@/types/workflow-config";
 
 const STORAGE_TYPE = isMongoDBConfigured ? "mongodb" : "none";
@@ -38,26 +51,6 @@ const RETENTION_DAYS = parseInt(process.env.WORKFLOW_RUN_RETENTION_DAYS ?? "7", 
 /** Throttle cleanup to run at most once per 30 minutes */
 let lastCleanupAt = 0;
 const CLEANUP_INTERVAL_MS = 30 * 60 * 1000;
-
-// ---------------------------------------------------------------------------
-// Access control helper — checks if user can access a workflow config
-// ---------------------------------------------------------------------------
-
-async function userCanAccessConfig(
-  configId: string,
-  session: ResourceAuthzSession,
-): Promise<boolean> {
-  try {
-    await requireResourcePermission(
-      session,
-      { type: "task", id: configId, action: "read" },
-      { bypassForOrgAdmin: true },
-    );
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /** Check if user can delete runs for the workflow config. */
 async function userCanDeleteConfigRuns(
@@ -143,49 +136,45 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError("MongoDB is required for workflow runs", 503);
   }
 
-  const { user, session } = await getAuthFromBearerOrSession(request);
-  const body = await request.json();
-  const { workflow_config_id, user_context, trigger_info } = body;
+  return await withAuth(request, async (req, user, session) => {
+    const body = await req.json();
+    const { workflow_config_id, user_context, trigger_info } = body;
 
-  if (!workflow_config_id) {
-    throw new ApiError("workflow_config_id is required", 400);
-  }
+    if (!workflow_config_id) {
+      throw new ApiError("workflow_config_id is required", 400);
+    }
 
-  // Load config
-  const configCol = await getCollection<WorkflowConfig>("workflow_configs");
-  const config = await configCol.findOne({ _id: workflow_config_id });
-  if (!config) {
-    throw new ApiError(`Workflow config ${workflow_config_id} not found`, 404);
-  }
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+    const config = await assertCanExecuteWorkflowRunsForConfigId(
+      session,
+      workflow_config_id,
+      user.email,
+      userTeamSlugs,
+    );
 
-  // Verify user has access to this workflow config
-  await requireResourcePermission(
-    session,
-    { type: "task", id: workflow_config_id, action: "read" },
-    { bypassForOrgAdmin: true },
-  );
+    void reconcileWorkflowConfigAccess(session, config).catch((err) => {
+      console.warn("[workflow-runs] OpenFGA backfill for workflow config failed:", err);
+    });
 
-  // Build auth headers for DA server calls
-  const authHeaders: Record<string, string> = {};
-  const authHeader = request.headers.get("Authorization");
-  if (authHeader) {
-    authHeaders["Authorization"] = authHeader;
-  }
-  authHeaders["X-User-Context"] = Buffer.from(JSON.stringify({
-    email: user.email,
-    name: user.name,
-  })).toString("base64");
+    await assertWorkflowStepAgentsExist(config);
 
-  // Enrich trigger_info with user context
-  const enrichedTriggerInfo = {
-    ...(trigger_info || {}),
-    triggered_by: trigger_info?.triggered_by || "webui",
-    user: { email: user.email, name: user.name },
-  };
+    const authHeaders = buildWorkflowDaAuthHeaders(req, user, session);
 
-  const runId = await startWorkflowRun(config, user_context || null, authHeaders, enrichedTriggerInfo);
+    const enrichedTriggerInfo = {
+      ...(trigger_info || {}),
+      triggered_by: trigger_info?.triggered_by || "webui",
+      user: { email: user.email, name: user.name },
+    };
 
-  return NextResponse.json({ run_id: runId, status: "running" }, { status: 201 });
+    const runId = await startWorkflowRun(
+      config,
+      user_context || null,
+      authHeaders,
+      enrichedTriggerInfo,
+    );
+
+    return NextResponse.json({ run_id: runId, status: "running" }, { status: 201 });
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════
@@ -197,83 +186,111 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError("MongoDB is required for workflow runs", 503);
   }
 
-  const { user, session } = await getAuthFromBearerOrSession(request);
+  return await withAuth(request, async (_req, user, session) => {
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
 
-  const { searchParams } = new URL(request.url);
-  const runId = searchParams.get("run_id");
+    const { searchParams } = new URL(request.url);
+    const runId = searchParams.get("run_id");
 
-  if (runId) {
-    // v2: Poll a specific run with events
+    if (runId) {
+      const col = await getCollection<WorkflowRunDocument>("workflow_runs");
+      const run = await col.findOne({ _id: runId });
+      if (!run) {
+        throw new ApiError(`Run ${runId} not found`, 404);
+      }
+
+      await assertCanViewWorkflowRunsForConfigId(
+        session,
+        run.workflow_config_id,
+        user.email,
+        userTeamSlugs,
+      );
+
+      const isStale = await detectStaleRun(run);
+      if (isStale) {
+        run.status = "failed";
+      }
+
+      const events = await readEventsByRun(runId);
+      const eventsObj: Record<number, unknown[]> = {};
+      for (const [stepIndex, stepEvents] of events) {
+        eventsObj[stepIndex] = stepEvents;
+      }
+
+      return NextResponse.json({ ...run, events: eventsObj }) as NextResponse;
+    }
+
+    cleanupExpiredRuns().catch(() => {});
+
     const col = await getCollection<WorkflowRunDocument>("workflow_runs");
-    const run = await col.findOne({ _id: runId });
-    if (!run) {
-      throw new ApiError(`Run ${runId} not found`, 404);
+    const workflowConfigId = searchParams.get("workflow_config_id");
+
+    if (workflowConfigId) {
+      const canView = await canViewWorkflowRunsForConfigId(
+        session,
+        workflowConfigId,
+        user.email,
+        userTeamSlugs,
+      );
+      if (!canView) {
+        return NextResponse.json([]) as NextResponse;
+      }
+      const runs = await col
+        .find({ workflow_config_id: workflowConfigId })
+        .sort({ started_at: -1 })
+        .limit(100)
+        .toArray();
+      return NextResponse.json(runs) as NextResponse;
     }
 
-    // Verify user has access to the parent workflow config
-    const hasAccess = await userCanAccessConfig(run.workflow_config_id, session);
-    if (!hasAccess) {
-      throw new ApiError(`Run ${runId} not found`, 404);
-    }
+    const configCol = await getCollection<WorkflowConfig>("workflow_configs");
+    const configCandidates = await configCol
+      .find({})
+      .project({
+        _id: 1,
+        visibility: 1,
+        shared_with_teams: 1,
+        owner_id: 1,
+        config_driven: 1,
+      })
+      .toArray();
+    const teamRefToSlug = await buildTeamRefToSlugMap();
+    const byVisibility = filterWorkflowConfigsByRunAccess(
+      configCandidates as WorkflowConfig[],
+      user.email,
+      userTeamSlugs,
+      teamRefToSlug,
+    );
+    const byFgaRead = await filterResourcesByPermission(
+      session,
+      configCandidates,
+      { type: "task", action: "read", id: (config) => String(config._id) },
+      { bypassForOrgAdmin: true },
+    );
+    const byFgaUse = await filterResourcesByPermission(
+      session,
+      configCandidates,
+      { type: "task", action: "use", id: (config) => String(config._id) },
+      { bypassForOrgAdmin: true },
+    );
+    const accessibleConfigs = mergeWorkflowConfigsById(
+      byVisibility as Array<{ _id: string }>,
+      byFgaRead as Array<{ _id: string }>,
+      byFgaUse as Array<{ _id: string }>,
+    );
 
-    // Detect stale runs
-    const isStale = await detectStaleRun(run);
-    if (isStale) {
-      run.status = "failed";
-    }
-
-    // Load events for all steps
-    const events = await readEventsByRun(runId);
-    const eventsObj: Record<number, unknown[]> = {};
-    for (const [stepIndex, stepEvents] of events) {
-      eventsObj[stepIndex] = stepEvents;
-    }
-
-    return NextResponse.json({ ...run, events: eventsObj }) as NextResponse;
-  }
-
-  // Legacy: list runs for user
-  // Fire-and-forget cleanup of expired runs
-  cleanupExpiredRuns().catch(() => {});
-
-  const col = await getCollection<WorkflowRunDocument>("workflow_runs");
-  const workflowConfigId = searchParams.get("workflow_config_id");
-
-  if (workflowConfigId) {
-    // Filter by specific config — check access once
-    const hasAccess = await userCanAccessConfig(workflowConfigId, session);
-    if (!hasAccess) {
+    const accessibleIds = accessibleConfigs.map((c) => c._id);
+    if (accessibleIds.length === 0) {
       return NextResponse.json([]) as NextResponse;
     }
+
     const runs = await col
-      .find({ workflow_config_id: workflowConfigId })
+      .find({ workflow_config_id: { $in: accessibleIds } })
       .sort({ started_at: -1 })
       .limit(100)
       .toArray();
     return NextResponse.json(runs) as NextResponse;
-  }
-
-  // List all runs — filter to only those whose configs the user can read.
-  const configCol = await getCollection<WorkflowConfig>("workflow_configs");
-  const configCandidates = await configCol.find({}).project({ _id: 1 }).toArray();
-  const accessibleConfigs = await filterResourcesByPermission(
-    session,
-    configCandidates,
-    { type: "task", action: "read", id: (config) => config._id },
-    { bypassForOrgAdmin: true },
-  );
-
-  const accessibleIds = accessibleConfigs.map((c) => c._id);
-  if (accessibleIds.length === 0) {
-    return NextResponse.json([]) as NextResponse;
-  }
-
-  const runs = await col
-    .find({ workflow_config_id: { $in: accessibleIds } })
-    .sort({ started_at: -1 })
-    .limit(100)
-    .toArray();
-  return NextResponse.json(runs) as NextResponse;
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════
@@ -297,17 +314,19 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError("At least one field must be provided for update", 400);
     }
 
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
     const col = await getCollection<WorkflowRunDocument>("workflow_runs");
     const run = await col.findOne({ _id: id });
     if (!run) {
       throw new ApiError("Workflow run not found", 404);
     }
 
-    // Verify user has access to the parent workflow config
-    const hasAccess = await userCanAccessConfig(run.workflow_config_id, session);
-    if (!hasAccess) {
-      throw new ApiError("Workflow run not found", 404);
-    }
+    await assertCanViewWorkflowRunsForConfigId(
+      session,
+      run.workflow_config_id,
+      user.email,
+      userTeamSlugs,
+    );
 
     await col.updateOne({ _id: id }, { $set: body });
 

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -89,7 +89,6 @@ const EDITOR_ROUTES_WITH_OWN_DISCARD_DIALOG = [
  */
 const EDITOR_ROUTES_WITH_HEADER_DIALOG = [
   "/task-builder",
-  "/workflows",
   "/dynamic-agents",
 ];
 

--- a/ui/src/components/workflows/WorkflowAgentAccessModal.tsx
+++ b/ui/src/components/workflows/WorkflowAgentAccessModal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React, { useState } from "react";
+import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-access/route";
+
+interface WorkflowAgentAccessModalProps {
+  gaps: AgentAccessGap[];
+  onGrantAndSave: () => Promise<void>;
+  onCancel: () => void;
+}
+
+export function WorkflowAgentAccessModal({
+  gaps,
+  onGrantAndSave,
+  onCancel,
+}: WorkflowAgentAccessModalProps) {
+  const [isGranting, setIsGranting] = useState(false);
+
+  const handleGrant = async () => {
+    setIsGranting(true);
+    try {
+      await onGrantAndSave();
+    } finally {
+      setIsGranting(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Agent access required
+          </DialogTitle>
+          <DialogDescription>
+            The following agents are not accessible to all teams this workflow is shared with.
+            Grant access to let those teams run this workflow.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2 max-h-64 overflow-y-auto">
+          {gaps.map((gap) => (
+            <div key={gap.agentId} className="rounded-md border px-3 py-2 text-sm">
+              <p className="font-medium">{gap.agentName}</p>
+              <p className="text-muted-foreground mt-0.5">
+                Not accessible to:{" "}
+                <span className="font-mono">{gap.teamsWithoutAccess.join(", ")}</span>
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={isGranting}>
+            Cancel
+          </Button>
+          <Button onClick={handleGrant} disabled={isGranting} className="gap-2">
+            <ShieldCheck className="h-4 w-4" />
+            {isGranting ? "Granting access…" : "Grant access and save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/workflows/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/WorkflowCanvas.tsx
@@ -2,6 +2,8 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { Lock } from "lucide-react";
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -33,6 +35,7 @@ import { createBlankStep } from "@/types/workflow-config";
 import { useWorkflowConfigStore } from "@/store/workflow-config-store";
 import { useWorkflowExecStore } from "@/store/workflow-exec-store";
 import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
+import { UnsavedChangesDialog } from "@/components/task-builder/UnsavedChangesDialog";
 import { useToast } from "@/components/ui/toast";
 import type { AgentAvatarAgent } from "@/components/dynamic-agents/AgentAvatar";
 
@@ -282,10 +285,19 @@ function WorkflowCanvasInner({
   initialSteps,
   onBack,
 }: WorkflowCanvasProps) {
-  const { createConfig, updateConfig, deleteConfig, closeEditor, loadConfigs } = useWorkflowConfigStore();
+  const { createConfig, updateConfig, deleteConfig, closeEditor, loadConfigs, openEditor } =
+    useWorkflowConfigStore();
+  const { data: authSession } = useSession();
   const { executeWorkflow } = useWorkflowExecStore();
-  const { setUnsaved, pendingNavigationHref, cancelNavigation, confirmNavigation } =
-    useUnsavedChangesStore();
+  const {
+    hasUnsavedChanges,
+    setUnsaved,
+    pendingNavigationHref,
+    pendingDeferredAction,
+    cancelNavigation,
+    confirmNavigation,
+    confirmDeferredAction,
+  } = useUnsavedChangesStore();
   const { agents, loading: agentsLoading } = useDynamicAgents();
   const router = useRouter();
   const { toast } = useToast();
@@ -316,16 +328,42 @@ function WorkflowCanvasInner({
   const [sharedWithTeams, setSharedWithTeams] = useState<string[]>(
     existingConfig?.shared_with_teams || [],
   );
-  const [availableTeams, setAvailableTeams] = useState<{ _id: string; name: string }[]>([]);
+  const [availableTeams, setAvailableTeams] = useState<
+    { _id: string; slug: string; name: string }[]
+  >([]);
 
   useEffect(() => {
     fetch("/api/dynamic-agents/teams")
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
-        if (data?.success && Array.isArray(data.data)) setAvailableTeams(data.data);
+        if (data?.success && Array.isArray(data.data)) {
+          setAvailableTeams(
+            data.data.filter(
+              (team: { slug?: string }) => typeof team.slug === "string" && team.slug.length > 0,
+            ),
+          );
+        }
       })
       .catch(() => {});
   }, []);
+
+  // Legacy workflows stored Mongo team _id in shared_with_teams; normalize to slug in UI.
+  useEffect(() => {
+    if (!existingConfig?.shared_with_teams?.length || availableTeams.length === 0) return;
+    setSharedWithTeams((current) => {
+      const normalized = existingConfig.shared_with_teams!.map((ref) => {
+        const refLower = ref.trim().toLowerCase();
+        const bySlug = availableTeams.find((t) => t.slug.toLowerCase() === refLower);
+        if (bySlug) return bySlug.slug;
+        const byId = availableTeams.find((t) => t._id === ref);
+        return byId?.slug ?? refLower;
+      });
+      const same =
+        current.length === normalized.length &&
+        current.every((slug, i) => slug === normalized[i]);
+      return same ? current : normalized;
+    });
+  }, [existingConfig?._id, existingConfig?.shared_with_teams, availableTeams]);
 
   const isDirtyRef = useRef(false);
 
@@ -345,7 +383,38 @@ function WorkflowCanvasInner({
   // Node click handler — handles both step selection and "+" button clicks
   // -----------------------------------------------------------------------
 
-  const isReadOnly = !!existingConfig?.config_driven;
+  const isConfigDriven = !!existingConfig?.config_driven;
+
+  const { isReadOnly, readOnlyHint } = useMemo(() => {
+    if (!existingConfig) {
+      return { isReadOnly: false, readOnlyHint: undefined };
+    }
+    if (existingConfig.config_driven) {
+      return {
+        isReadOnly: true,
+        readOnlyHint:
+          "This workflow is seeded from config/app-config.yaml and cannot be overwritten. " +
+          "Edit steps here, then use Save as copy or Run (which saves a copy first).",
+      };
+    }
+    const userEmail = authSession?.user?.email?.trim().toLowerCase();
+    const ownerId = existingConfig.owner_id?.trim().toLowerCase();
+    if (ownerId === "system") {
+      return {
+        isReadOnly: true,
+        readOnlyHint:
+          "This is a platform workflow (owner: system). Use Clone to edit to create your own editable copy.",
+      };
+    }
+    if (userEmail && ownerId && ownerId !== userEmail) {
+      return {
+        isReadOnly: true,
+        readOnlyHint:
+          "You can run this workflow, but only the owner can change it. Use Clone to edit to create your own copy.",
+      };
+    }
+    return { isReadOnly: false, readOnlyHint: undefined };
+  }, [existingConfig, authSession?.user?.email]);
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
@@ -422,30 +491,8 @@ function WorkflowCanvasInner({
     return () => setUnsaved(false);
   }, [setUnsaved]);
 
-  useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
-      if (isDirtyRef.current) e.preventDefault();
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, []);
-
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const pendingActionRef = useRef<(() => void) | null>(null);
-
-  useEffect(() => {
-    if (pendingNavigationHref && isDirtyRef.current) {
-      setShowUnsavedDialog(true);
-      pendingActionRef.current = () => {
-        const href = confirmNavigation();
-        if (href) {
-          setUnsaved(false);
-          isDirtyRef.current = false;
-          window.location.href = href;
-        }
-      };
-    }
-  }, [pendingNavigationHref, confirmNavigation, setUnsaved]);
 
   const guardAction = useCallback((action: () => void) => {
     if (isDirtyRef.current) {
@@ -456,9 +503,45 @@ function WorkflowCanvasInner({
     }
   }, []);
 
+  useEffect(() => {
+    if (!isDirtyRef.current) return;
+
+    if (pendingNavigationHref) {
+      setShowUnsavedDialog(true);
+      pendingActionRef.current = () => {
+        const href = confirmNavigation();
+        if (href) {
+          isDirtyRef.current = false;
+          setUnsaved(false);
+          window.location.href = href;
+        }
+      };
+      return;
+    }
+
+    if (pendingDeferredAction) {
+      setShowUnsavedDialog(true);
+      pendingActionRef.current = () => {
+        confirmDeferredAction();
+        isDirtyRef.current = false;
+      };
+    }
+  }, [
+    pendingNavigationHref,
+    pendingDeferredAction,
+    confirmNavigation,
+    confirmDeferredAction,
+    setUnsaved,
+  ]);
+
   const handleBack = useCallback(() => {
     guardAction(onBack);
   }, [onBack, guardAction]);
+
+  const handleCloneToEdit = useCallback(() => {
+    if (!existingConfig) return;
+    guardAction(() => openEditor("clone", existingConfig._id));
+  }, [existingConfig, openEditor, guardAction]);
 
   const handleNameChange = useCallback(
     (v: string) => { markDirty(); setName(v); },
@@ -474,40 +557,83 @@ function WorkflowCanvasInner({
   // Save
   // -----------------------------------------------------------------------
 
-  const handleSave = useCallback(async () => {
-    if (!name || steps.length === 0) return;
-    setIsSaving(true);
+  const persistWorkflow = useCallback(async (): Promise<string | null> => {
+    if (!name || steps.length === 0) {
+      toast("Workflow name and at least one step are required", "error");
+      return null;
+    }
 
+    if (existingConfig?.config_driven) {
+      const input: CreateWorkflowConfigInput = {
+        name: `${name.trim()} (editable)`,
+        description: description.trim() || undefined,
+        steps,
+        visibility,
+        shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+      };
+      const newId = await createConfig(input);
+      openEditor("edit", newId);
+      return newId;
+    }
+
+    if (existingConfig) {
+      const updates: UpdateWorkflowConfigInput = {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        steps,
+        visibility,
+        shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+      };
+      await updateConfig(existingConfig._id, updates);
+      return existingConfig._id;
+    }
+
+    const input: CreateWorkflowConfigInput = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      steps,
+      visibility,
+      shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+    };
+    const newId = await createConfig(input);
+    openEditor("edit", newId);
+    return newId;
+  }, [
+    name,
+    description,
+    steps,
+    visibility,
+    sharedWithTeams,
+    existingConfig,
+    createConfig,
+    updateConfig,
+    openEditor,
+    toast,
+  ]);
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
     try {
-      if (existingConfig) {
-        const updates: UpdateWorkflowConfigInput = {
-          name: name.trim(),
-          description: description.trim() || undefined,
-          steps,
-          visibility,
-          shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
-        };
-        await updateConfig(existingConfig._id, updates);
-      } else {
-        const input: CreateWorkflowConfigInput = {
-          name: name.trim(),
-          description: description.trim() || undefined,
-          steps,
-          visibility,
-          shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
-        };
-        await createConfig(input);
-      }
+      const savedId = await persistWorkflow();
+      if (!savedId) return;
       isDirtyRef.current = false;
       setUnsaved(false);
-      toast("Workflow saved", "success");
+      toast(
+        existingConfig?.config_driven
+          ? "Saved as a new editable workflow"
+          : "Workflow saved",
+        "success",
+      );
     } catch (error) {
       console.error("Failed to save workflow config:", error);
-      toast("Failed to save workflow", "error");
+      toast(
+        error instanceof Error ? error.message : "Failed to save workflow",
+        "error",
+      );
     } finally {
       setIsSaving(false);
     }
-  }, [name, description, steps, visibility, sharedWithTeams, existingConfig, createConfig, updateConfig, setUnsaved, toast]);
+  }, [persistWorkflow, existingConfig?.config_driven, setUnsaved, toast]);
 
   // -----------------------------------------------------------------------
   // Run workflow
@@ -515,17 +641,48 @@ function WorkflowCanvasInner({
 
   const handleRun = useCallback(async () => {
     if (!existingConfig) return;
+
+    if (isReadOnly && isDirtyRef.current) {
+      toast(
+        "Unsaved changes cannot be applied to a config-driven workflow. Click Save to create an editable copy, or Clone to edit, then run that copy.",
+        "error",
+      );
+      return;
+    }
+
+    setIsSaving(true);
+    let configId = existingConfig._id;
     try {
-      const runId = await executeWorkflow(existingConfig._id);
-      isDirtyRef.current = false;
-      setUnsaved(false);
+      if (isDirtyRef.current) {
+        const savedId = await persistWorkflow();
+        if (!savedId) return;
+        configId = savedId;
+        isDirtyRef.current = false;
+        setUnsaved(false);
+      }
+
+      const runId = await executeWorkflow(configId);
       closeEditor();
-      // Navigate directly to the new run
       router.push(`/workflows/run/${runId}`);
     } catch (error) {
       console.error("Failed to execute workflow:", error);
+      toast(
+        error instanceof Error ? error.message : "Failed to start workflow",
+        "error",
+      );
+    } finally {
+      setIsSaving(false);
     }
-  }, [existingConfig, executeWorkflow, setUnsaved, closeEditor, router]);
+  }, [
+    existingConfig,
+    isReadOnly,
+    persistWorkflow,
+    executeWorkflow,
+    setUnsaved,
+    closeEditor,
+    router,
+    toast,
+  ]);
 
   // -----------------------------------------------------------------------
   // Delete workflow
@@ -585,14 +742,24 @@ function WorkflowCanvasInner({
         setVisibility(obj.visibility);
       }
       if (Array.isArray(obj.shared_with_teams)) {
-        setSharedWithTeams(obj.shared_with_teams as string[]);
+        const refs = (obj.shared_with_teams as string[]).map((ref) => ref.trim().toLowerCase());
+        setSharedWithTeams(
+          refs
+            .map((ref) => {
+              const bySlug = availableTeams.find((t) => t.slug.toLowerCase() === ref);
+              if (bySlug) return bySlug.slug;
+              const byId = availableTeams.find((t) => t._id === ref);
+              return byId?.slug ?? ref;
+            })
+            .filter(Boolean),
+        );
       }
       if (Array.isArray(obj.steps)) {
         setSteps(obj.steps as WorkflowStep[]);
       }
       markDirty();
     },
-    [markDirty],
+    [availableTeams, markDirty],
   );
 
   // Agent objects for the sidebar (with _id, name, description, ui)
@@ -614,7 +781,7 @@ function WorkflowCanvasInner({
     cancelNavigation();
   }, [setUnsaved, cancelNavigation]);
 
-  const handleCancelDialog = useCallback(() => {
+  const handleCancelUnsavedDialog = useCallback(() => {
     setShowUnsavedDialog(false);
     pendingActionRef.current = null;
     cancelNavigation();
@@ -647,14 +814,25 @@ function WorkflowCanvasInner({
         onImport={handleImport}
         isSaving={isSaving}
         isEditing={!!existingConfig}
+        hasUnsavedChanges={hasUnsavedChanges}
         stepCount={steps.length}
-        readOnly={existingConfig?.config_driven}
+        readOnly={isReadOnly}
+        saveAsCopy={isConfigDriven}
+        readOnlyHint={readOnlyHint}
+        onCloneToEdit={existingConfig ? handleCloneToEdit : undefined}
         visibility={visibility}
         onVisibilityChange={(v) => { setVisibility(v); markDirty(); }}
         sharedWithTeams={sharedWithTeams}
         onSharedWithTeamsChange={(t) => { setSharedWithTeams(t); markDirty(); }}
         teams={availableTeams}
       />
+
+      {isReadOnly && readOnlyHint && (
+        <div className="px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/20 flex items-start gap-2 shrink-0">
+          <Lock className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-700 dark:text-amber-300 leading-relaxed">{readOnlyHint}</p>
+        </div>
+      )}
 
       <div className="flex flex-1 overflow-hidden">
         <div className="flex-1">
@@ -695,35 +873,17 @@ function WorkflowCanvasInner({
           }}
           agents={sidebarAgents}
           agentsLoading={agentsLoading}
-          readOnly={existingConfig?.config_driven}
+          readOnly={isReadOnly}
+          readOnlyHint={readOnlyHint}
         />
       </div>
 
-      {/* Unsaved changes dialog */}
-      {showUnsavedDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card border border-border rounded-lg p-6 shadow-xl max-w-sm mx-4">
-            <h3 className="text-sm font-bold text-foreground mb-2">Unsaved changes</h3>
-            <p className="text-sm text-muted-foreground mb-4">
-              You have unsaved changes. Discard them?
-            </p>
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={handleCancelDialog}
-                className="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleDiscardChanges}
-                className="px-3 py-1.5 text-sm rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
-              >
-                Discard
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <UnsavedChangesDialog
+        open={showUnsavedDialog}
+        onDiscard={handleDiscardChanges}
+        onCancel={handleCancelUnsavedDialog}
+        description="You have unsaved changes in this workflow. They will be lost if you leave without saving."
+      />
 
       {/* Delete confirmation dialog */}
       {showDeleteDialog && (

--- a/ui/src/components/workflows/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/WorkflowCanvas.tsx
@@ -36,8 +36,10 @@ import { useWorkflowConfigStore } from "@/store/workflow-config-store";
 import { useWorkflowExecStore } from "@/store/workflow-exec-store";
 import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import { UnsavedChangesDialog } from "@/components/task-builder/UnsavedChangesDialog";
+import { WorkflowAgentAccessModal } from "./WorkflowAgentAccessModal";
 import { useToast } from "@/components/ui/toast";
 import type { AgentAvatarAgent } from "@/components/dynamic-agents/AgentAvatar";
+import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-access/route";
 
 // ---------------------------------------------------------------------------
 // Node types — defined outside component to avoid re-renders
@@ -319,6 +321,8 @@ function WorkflowCanvasInner({
     existingConfig?.description || initialDescription || "",
   );
   const [isSaving, setIsSaving] = useState(false);
+  const [agentAccessGaps, setAgentAccessGaps] = useState<AgentAccessGap[]>([]);
+  const [showAccessModal, setShowAccessModal] = useState(false);
   const [selectedStepIndex, setSelectedStepIndex] = useState<number>(-1);
 
   // Visibility & sharing
@@ -611,7 +615,7 @@ function WorkflowCanvasInner({
     toast,
   ]);
 
-  const handleSave = useCallback(async () => {
+  const doSave = useCallback(async (successMsg?: string) => {
     setIsSaving(true);
     try {
       const savedId = await persistWorkflow();
@@ -619,9 +623,10 @@ function WorkflowCanvasInner({
       isDirtyRef.current = false;
       setUnsaved(false);
       toast(
-        existingConfig?.config_driven
-          ? "Saved as a new editable workflow"
-          : "Workflow saved",
+        successMsg ??
+          (existingConfig?.config_driven
+            ? "Saved as a new editable workflow"
+            : "Workflow saved"),
         "success",
       );
     } catch (error) {
@@ -634,6 +639,53 @@ function WorkflowCanvasInner({
       setIsSaving(false);
     }
   }, [persistWorkflow, existingConfig?.config_driven, setUnsaved, toast]);
+
+  const handleSave = useCallback(async () => {
+    if (visibility !== "private") {
+      let gaps: AgentAccessGap[] = [];
+      try {
+        const res = await fetch("/api/workflow-configs/check-agent-access", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ steps, visibility, shared_with_teams: sharedWithTeams }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          gaps = data.gaps ?? [];
+        }
+      } catch { /* non-fatal — proceed to save */ }
+      if (gaps.length > 0) {
+        setAgentAccessGaps(gaps);
+        setShowAccessModal(true);
+        return;
+      }
+    }
+    await doSave();
+  }, [doSave, visibility, steps, sharedWithTeams]);
+
+  const handleGrantAndSave = useCallback(async () => {
+    for (const gap of agentAccessGaps) {
+      for (const teamSlug of gap.teamsWithoutAccess) {
+        if (teamSlug === "(all users)") continue;
+        try {
+          await fetch("/api/admin/openfga/relationship", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              teamSlug,
+              resourceType: "agent",
+              resourceId: gap.agentId,
+              relation: "user",
+              operation: "grant",
+            }),
+          });
+        } catch { /* best-effort */ }
+      }
+    }
+    setShowAccessModal(false);
+    setAgentAccessGaps([]);
+    await doSave("Agent access granted and workflow saved");
+  }, [agentAccessGaps, doSave]);
 
   // -----------------------------------------------------------------------
   // Run workflow
@@ -884,6 +936,14 @@ function WorkflowCanvasInner({
         onCancel={handleCancelUnsavedDialog}
         description="You have unsaved changes in this workflow. They will be lost if you leave without saving."
       />
+
+      {showAccessModal && agentAccessGaps.length > 0 && (
+        <WorkflowAgentAccessModal
+          gaps={agentAccessGaps}
+          onGrantAndSave={handleGrantAndSave}
+          onCancel={() => { setShowAccessModal(false); setAgentAccessGaps([]); }}
+        />
+      )}
 
       {/* Delete confirmation dialog */}
       {showDeleteDialog && (

--- a/ui/src/components/workflows/WorkflowSidebar.tsx
+++ b/ui/src/components/workflows/WorkflowSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Users,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -54,6 +55,7 @@ import {
   type WfRunStatus,
 } from "@/store/workflow-exec-store";
 import { useWorkflowConfigStore } from "@/store/workflow-config-store";
+import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import type { WorkflowConfig } from "@/types/workflow-config";
 
@@ -161,6 +163,7 @@ export function WorkflowSidebar({
   onCollapse,
 }: WorkflowSidebarProps) {
   const router = useRouter();
+  const { toast } = useToast();
   const params = useParams();
   const activeRunId = params?.id as string | undefined;
 
@@ -175,6 +178,7 @@ export function WorkflowSidebar({
     editMode,
     selectedConfigId,
   } = useWorkflowConfigStore();
+  const requestDeferredAction = useUnsavedChangesStore((s) => s.requestDeferredAction);
 
   const [activeTab, setActiveTab] = useState<SidebarTab>("workflows");
   const [tabDirection, setTabDirection] = useState(0); // -1 = left, 1 = right
@@ -240,10 +244,17 @@ export function WorkflowSidebar({
   const switchTab = useCallback(
     (tab: SidebarTab) => {
       if (tab === activeTab) return;
-      setTabDirection(tab === "runs" ? 1 : -1);
-      setActiveTab(tab);
+      const doSwitch = () => {
+        setTabDirection(tab === "runs" ? 1 : -1);
+        setActiveTab(tab);
+      };
+      if (editMode) {
+        requestDeferredAction(doSwitch);
+        return;
+      }
+      doSwitch();
     },
-    [activeTab]
+    [activeTab, editMode, requestDeferredAction],
   );
 
   const handleRefresh = useCallback(async () => {
@@ -257,22 +268,29 @@ export function WorkflowSidebar({
   }, [activeTab, loadConfigs, loadRuns]);
 
   const handleSelectRun = (runId: string) => {
-    router.push(`/workflows/run/${runId}`);
+    requestDeferredAction(() => router.push(`/workflows/run/${runId}`));
   };
 
   const handleEditConfig = (config: WorkflowConfig) => {
-    openEditor("edit", config._id);
-    router.push("/workflows");
+    if (editMode === "edit" && selectedConfigId === config._id) return;
+    requestDeferredAction(() => {
+      openEditor("edit", config._id);
+      router.push("/workflows");
+    });
   };
 
   const handleCloneConfig = (config: WorkflowConfig) => {
-    openEditor("clone", config._id);
-    router.push("/workflows");
+    requestDeferredAction(() => {
+      openEditor("clone", config._id);
+      router.push("/workflows");
+    });
   };
 
   const handleNewConfig = () => {
-    openEditor("new");
-    router.push("/workflows");
+    requestDeferredAction(() => {
+      openEditor("new");
+      router.push("/workflows");
+    });
   };
 
   const handleDeleteConfig = async (config: WorkflowConfig) => {
@@ -304,7 +322,7 @@ export function WorkflowSidebar({
       switchTab("runs");
       router.push(`/workflows/run/${runId}`);
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to start workflow");
+      toast(err instanceof Error ? err.message : "Failed to start workflow", "error");
     }
   };
 

--- a/ui/src/components/workflows/WorkflowStepSidebar.tsx
+++ b/ui/src/components/workflows/WorkflowStepSidebar.tsx
@@ -50,6 +50,7 @@ interface WorkflowStepSidebarProps {
   agentsLoading: boolean;
 
   readOnly?: boolean;
+  readOnlyHint?: string;
 }
 
 
@@ -66,6 +67,7 @@ export function WorkflowStepSidebar({
   agents,
   agentsLoading,
   readOnly,
+  readOnlyHint,
 }: WorkflowStepSidebarProps) {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [configOverrideJson, setConfigOverrideJson] = useState(
@@ -168,11 +170,24 @@ export function WorkflowStepSidebar({
     // Steps exist but none selected
     return (
       <div className="w-[624px] border-l border-border bg-card/50 flex items-center justify-center">
-        <div className="text-center px-6">
-          <MousePointerClick className="h-8 w-8 text-muted-foreground/30 mx-auto mb-3" />
-          <p className="text-sm text-muted-foreground">
-            Select a step on the canvas to edit its properties
-          </p>
+        <div className="text-center px-6 max-w-sm">
+          {readOnly ? (
+            <>
+              <Lock className="h-8 w-8 text-amber-500/60 mx-auto mb-3" />
+              <p className="text-sm text-foreground font-medium mb-1">View only</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                {readOnlyHint ??
+                  "This workflow cannot be edited here. Use Clone to edit to create your own copy."}
+              </p>
+            </>
+          ) : (
+            <>
+              <MousePointerClick className="h-8 w-8 text-muted-foreground/30 mx-auto mb-3" />
+              <p className="text-sm text-muted-foreground">
+                Select a step on the canvas to edit its properties
+              </p>
+            </>
+          )}
         </div>
       </div>
     );
@@ -205,7 +220,8 @@ export function WorkflowStepSidebar({
         <div className="px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/20 flex items-center gap-2 shrink-0">
           <Lock className="h-3.5 w-3.5 text-amber-500 shrink-0" />
           <p className="text-xs text-amber-600 dark:text-amber-400">
-            This workflow is seeded from config and is not editable.
+            {readOnlyHint ??
+              "This workflow is seeded from config and is not editable."}
           </p>
         </div>
       )}

--- a/ui/src/components/workflows/WorkflowToolbar.tsx
+++ b/ui/src/components/workflows/WorkflowToolbar.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import React, { useRef, useState, useEffect } from "react";
+import React, { useMemo, useRef, useState, useEffect } from "react";
 import YAML from "yaml";
-import { ArrowLeft, Save, Play, Trash2, Download, Upload, Lock, Users, Globe } from "lucide-react";
+import { ArrowLeft, Save, Play, Trash2, Download, Upload, Lock, Users, Globe, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { TeamMultiPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 import { cn } from "@/lib/utils";
 import type { WorkflowConfigVisibility } from "@/types/workflow-config";
 
 interface Team {
   _id: string;
+  slug: string;
   name: string;
 }
 
@@ -26,8 +28,14 @@ interface WorkflowToolbarProps {
   onImport?: (config: unknown) => void;
   isSaving: boolean;
   isEditing: boolean;
+  hasUnsavedChanges?: boolean;
   stepCount: number;
   readOnly?: boolean;
+  /** When true, Save creates a new editable workflow instead of updating in place */
+  saveAsCopy?: boolean;
+  /** Shown when readOnly — explains why Save is disabled */
+  readOnlyHint?: string;
+  onCloneToEdit?: () => void;
   visibility: WorkflowConfigVisibility;
   onVisibilityChange: (v: WorkflowConfigVisibility) => void;
   sharedWithTeams: string[];
@@ -93,6 +101,18 @@ function VisibilityPopover({
 
   const config = VISIBILITY_CONFIG[visibility];
 
+  const teamOptions = useMemo<TeamPickerOption[]>(
+    () =>
+      teams
+        .filter((team): team is Team & { slug: string } => Boolean(team.slug))
+        .map((team) => ({
+          slug: team.slug,
+          name: team.name,
+          _id: team._id,
+        })),
+    [teams],
+  );
+
   return (
     <div className="relative" ref={ref}>
       <button
@@ -113,7 +133,7 @@ function VisibilityPopover({
 
       {open && (
         <div
-          className="absolute top-full left-0 mt-1 z-[100] w-64 rounded-lg border border-border bg-card shadow-lg p-2"
+          className="absolute top-full left-0 mt-1 z-[100] w-72 rounded-lg border border-border bg-card shadow-lg p-2"
           onPointerDown={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => e.stopPropagation()}
@@ -144,39 +164,25 @@ function VisibilityPopover({
             );
           })}
 
-          {/* Team selector */}
           {visibility === "team" && (
-            <div className="mt-2 pt-2 border-t border-border">
-              <div className="text-[10px] font-medium text-muted-foreground mb-1.5 px-1">
-                Share with teams
-              </div>
-              {teams.length === 0 ? (
+            <div className="mt-2 pt-2 border-t border-border px-0.5">
+              {teamOptions.length === 0 ? (
                 <p className="text-[10px] text-muted-foreground italic px-1">
                   No teams available.
                 </p>
               ) : (
-                <div className="space-y-1 max-h-32 overflow-y-auto">
-                  {teams.map((team) => (
-                    <label
-                      key={team._id}
-                      className="flex items-center gap-2 px-1 py-0.5 rounded hover:bg-muted/50 cursor-pointer"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={sharedWithTeams.includes(team._id)}
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            onSharedWithTeamsChange([...sharedWithTeams, team._id]);
-                          } else {
-                            onSharedWithTeamsChange(sharedWithTeams.filter((id) => id !== team._id));
-                          }
-                        }}
-                        className="rounded border-muted h-3 w-3"
-                      />
-                      <span className="text-xs">{team.name}</span>
-                    </label>
-                  ))}
-                </div>
+                <TeamMultiPicker
+                  options={teamOptions}
+                  selected={sharedWithTeams}
+                  onChange={onSharedWithTeamsChange}
+                  disabled={disabled}
+                  ariaLabel="Share workflow with teams"
+                  placeholder="Share with teams…"
+                  searchPlaceholder="Search teams…"
+                  emptyLabel="No teams match"
+                  triggerChipCap={1}
+                  contentClassName="z-[110]"
+                />
               )}
             </div>
           )}
@@ -199,8 +205,12 @@ export function WorkflowToolbar({
   onImport,
   isSaving,
   isEditing,
+  hasUnsavedChanges = false,
   stepCount,
   readOnly,
+  saveAsCopy,
+  readOnlyHint,
+  onCloneToEdit,
   visibility,
   onVisibilityChange,
   sharedWithTeams,
@@ -277,6 +287,15 @@ export function WorkflowToolbar({
           {stepCount} step{stepCount !== 1 ? "s" : ""}
         </span>
 
+        {hasUnsavedChanges && (
+          <span
+            className="text-xs font-medium shrink-0 px-2 py-0.5 rounded border border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+            title="Save your workflow before leaving the editor"
+          >
+            Unsaved
+          </span>
+        )}
+
         {/* Visibility button */}
         <VisibilityPopover
           visibility={visibility}
@@ -350,14 +369,27 @@ export function WorkflowToolbar({
             </Button>
           )}
 
+          {readOnly && onCloneToEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onCloneToEdit}
+              className="gap-1.5 h-8 text-xs px-3 border-primary/30 text-primary hover:bg-primary/10"
+            >
+              <Copy className="h-3.5 w-3.5" />
+              Clone to edit
+            </Button>
+          )}
+
           <Button
             size="sm"
             onClick={onSave}
-            disabled={isSaving || !name || stepCount === 0 || readOnly}
-            className="gap-1.5 h-8 text-xs px-4 gradient-primary text-white"
+            disabled={isSaving || !name || stepCount === 0 || (readOnly && !saveAsCopy)}
+            title={readOnly && !saveAsCopy ? readOnlyHint : undefined}
+            className="gap-1.5 h-8 text-xs px-4 gradient-primary text-white disabled:opacity-40"
           >
             <Save className="h-3.5 w-3.5" />
-            {isSaving ? "Saving..." : "Save"}
+            {isSaving ? "Saving..." : saveAsCopy ? "Save as copy" : "Save"}
           </Button>
         </div>
       </div>

--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -1170,6 +1170,9 @@ describe('withAuth', () => {
     });
 
     it.each([
+      ['/api/workflow-configs', 'GET', 'can_use', 'dynamic_agent#view'],
+      ['/api/workflow-configs', 'POST', 'can_manage', 'dynamic_agent#manage'],
+      ['/api/workflow-runs', 'GET', 'can_use', 'dynamic_agent#view'],
       ['/api/unclassified-feature', 'GET', 'can_audit', 'admin_ui#view'],
       ['/api/unclassified-feature', 'POST', 'can_manage', 'admin_ui#manage'],
     ])('maps fallback route %s %s to explicit %s capability', async (

--- a/ui/src/lib/__tests__/seed-config-default-agent.test.ts
+++ b/ui/src/lib/__tests__/seed-config-default-agent.test.ts
@@ -18,6 +18,7 @@
 const mockCollection = {
   countDocuments: jest.fn(),
   insertOne: jest.fn(),
+  updateOne: jest.fn(),
 };
 
 jest.mock("@/lib/mongodb", () => ({
@@ -29,8 +30,11 @@ import {
   bootstrapDefaultDynamicAgentIfEmpty,
   bootstrapDefaultIdentityGroupSyncRuleIfEmpty,
   buildAutoCreateTeamsBootstrapRule,
+  buildHelloWorldAgentDoc,
+  reconcileHelloWorldBootstrapAgent,
   AUTO_CREATE_TEAMS_BOOTSTRAP_RULE_ID,
   HELLO_WORLD_AGENT_ID,
+  HELLO_WORLD_BOOTSTRAP_REVISION,
 } from "../seed-config";
 
 describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
@@ -56,7 +60,7 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
     // Bootstrap-provisioned, not config-driven — admins must be able to
     // edit/delete it through the UI.
     expect(inserted.config_driven).toBe(false);
-    // All four built-in tools enabled.
+    // Built-in tools enabled, including workflow HITL.
     expect(inserted.builtin_tools.fetch_url).toEqual({
       enabled: true,
       allowed_domains: "*",
@@ -67,6 +71,15 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
       enabled: true,
       max_seconds: 60,
     });
+    expect(inserted.builtin_tools.request_user_input).toEqual({
+      enabled: true,
+    });
+    expect(inserted.interrupt_on).toEqual({
+      builtin: { request_user_input: true },
+    });
+    expect(inserted.hello_world_bootstrap_revision).toBe(
+      HELLO_WORLD_BOOTSTRAP_REVISION,
+    );
     // Empty model is intentional — backend default is used.
     expect(inserted.model).toEqual({ id: "", provider: "" });
     expect(inserted.subagents).toEqual([]);
@@ -99,6 +112,45 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
     await expect(bootstrapDefaultDynamicAgentIfEmpty()).rejects.toThrow(
       "connection lost",
     );
+  });
+});
+
+describe("buildHelloWorldAgentDoc", () => {
+  it("includes request_user_input and workflow-oriented system prompt", () => {
+    const doc = buildHelloWorldAgentDoc("2026-01-01T00:00:00Z");
+    expect(doc.system_prompt).toContain("request_user_input");
+    expect(doc.system_prompt).toContain("write_file");
+  });
+});
+
+describe("reconcileHelloWorldBootstrapAgent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates system-owned hello-world when bootstrap revision is behind", async () => {
+    mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+    const updated = await reconcileHelloWorldBootstrapAgent();
+
+    expect(updated).toBe(true);
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: HELLO_WORLD_AGENT_ID, owner_id: "system" }),
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          hello_world_bootstrap_revision: HELLO_WORLD_BOOTSTRAP_REVISION,
+          builtin_tools: expect.objectContaining({
+            request_user_input: { enabled: true },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("returns false when no document matched", async () => {
+    mockCollection.updateOne.mockResolvedValue({ modifiedCount: 0 });
+
+    await expect(reconcileHelloWorldBootstrapAgent()).resolves.toBe(false);
   });
 });
 

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -351,6 +351,11 @@ function resolveLegacyWithAuthRbacPolicy(request: NextRequest): RouteRbacPolicy 
       ? { resource: 'dynamic_agent', scope: 'view' }
       : { resource: 'dynamic_agent', scope: 'manage' };
   }
+  if (pathname.startsWith('/api/workflow-configs')) {
+    return method === 'GET'
+      ? { resource: 'dynamic_agent', scope: 'view' }
+      : { resource: 'dynamic_agent', scope: 'manage' };
+  }
   if (pathname.startsWith('/api/workflow-runs')) {
     return method === 'GET'
       ? { resource: 'dynamic_agent', scope: 'view' }

--- a/ui/src/lib/rbac/__tests__/workflow-config-rebac.test.ts
+++ b/ui/src/lib/rbac/__tests__/workflow-config-rebac.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @jest-environment node
+ */
+
+import { ApiError } from "@/lib/api-error";
+
+const mockRequireResourcePermission = jest.fn();
+const mockReconcileShareableResource = jest.fn();
+const mockListUserTeamSlugs = jest.fn();
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  subjectFromSession: () => "alice-sub",
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources", () => ({
+  reconcileShareableResource: (...args: unknown[]) => mockReconcileShareableResource(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga-team-membership", () => ({
+  listUserTeamSlugs: (...args: unknown[]) => mockListUserTeamSlugs(...args),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+import {
+  effectiveWorkflowVisibility,
+  filterWorkflowConfigsByRunAccess,
+  reconcileWorkflowConfigAccess,
+  requireWorkflowConfigRunAccess,
+  workflowRunAllowedByVisibility,
+  workflowWriteAllowedByVisibility,
+} from "@/lib/rbac/workflow-config-rebac";
+
+describe("workflow-config-rebac", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReconcileShareableResource.mockResolvedValue({ enabled: true, writes: 2, deletes: 0 });
+    mockListUserTeamSlugs.mockResolvedValue(["platform-eng"]);
+  });
+
+  it("reconciles workflow configs as task resources with creator owner", async () => {
+    await reconcileWorkflowConfigAccess(
+      { sub: "alice-sub" },
+      { _id: "wf-1", visibility: "global", shared_with_teams: null },
+    );
+
+    expect(mockReconcileShareableResource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectType: "task",
+        objectId: "wf-1",
+        creatorSubject: "alice-sub",
+        ownerSubject: "alice-sub",
+        sharedWithOrg: true,
+      }),
+    );
+  });
+
+  describe("effectiveWorkflowVisibility", () => {
+    it("defaults system-owned and config-driven workflows to global when visibility is missing", () => {
+      expect(
+        effectiveWorkflowVisibility({
+          visibility: undefined,
+          owner_id: "system",
+          config_driven: true,
+        }),
+      ).toBe("global");
+    });
+
+    it("treats missing visibility on user-owned workflows as private", () => {
+      expect(
+        effectiveWorkflowVisibility({
+          visibility: null,
+          owner_id: "alice@example.com",
+        }),
+      ).toBe("private");
+    });
+  });
+
+  describe("workflowRunAllowedByVisibility", () => {
+    it("allows any user for global workflows", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: "global", shared_with_teams: null, owner_id: "owner@example.com" },
+          "bob@example.com",
+          [],
+        ),
+      ).toBe(true);
+    });
+
+    it("allows any user for system-seeded workflows without a visibility field", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: undefined, shared_with_teams: null, owner_id: "system", config_driven: true },
+          "bob@example.com",
+          [],
+        ),
+      ).toBe(true);
+    });
+
+    it("allows team members when workflow is shared with their team", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          {
+            visibility: "team",
+            shared_with_teams: ["Platform-Eng"],
+            owner_id: "owner@example.com",
+          },
+          "bob@example.com",
+          ["platform-eng"],
+        ),
+      ).toBe(true);
+    });
+
+    it("denies team workflows when user is not on a shared team", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          {
+            visibility: "team",
+            shared_with_teams: ["other-team"],
+            owner_id: "owner@example.com",
+          },
+          "bob@example.com",
+          ["platform-eng"],
+        ),
+      ).toBe(false);
+    });
+
+    it("resolves legacy Mongo team _id refs via teamRefToSlug map", () => {
+      const teamRefToSlug = new Map<string, string>([
+        ["507f1f77bcf86cd799439011", "platform-eng"],
+        ["platform-eng", "platform-eng"],
+      ]);
+      expect(
+        workflowRunAllowedByVisibility(
+          {
+            visibility: "team",
+            shared_with_teams: ["507f1f77bcf86cd799439011"],
+            owner_id: "owner@example.com",
+          },
+          "bob@example.com",
+          ["platform-eng"],
+          teamRefToSlug,
+        ),
+      ).toBe(true);
+    });
+
+    it("allows only the owner for private workflows", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: "private", shared_with_teams: null, owner_id: "alice@example.com" },
+          "alice@example.com",
+          [],
+        ),
+      ).toBe(true);
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: "private", shared_with_teams: null, owner_id: "alice@example.com" },
+          "bob@example.com",
+          [],
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it("skips OpenFGA when global visibility allows run", async () => {
+    await expect(
+      requireWorkflowConfigRunAccess(
+        { sub: "alice-sub" },
+        {
+          _id: "wf-global",
+          owner_id: "owner@example.com",
+          visibility: "global",
+          shared_with_teams: null,
+        },
+        "bob@example.com",
+        [],
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("allows the documented owner when OpenFGA use is denied", async () => {
+    mockRequireResourcePermission.mockRejectedValue(new ApiError("denied", 403));
+
+    await expect(
+      requireWorkflowConfigRunAccess(
+        { sub: "alice-sub" },
+        {
+          _id: "wf-legacy",
+          owner_id: "alice@example.com",
+          visibility: "private",
+          shared_with_teams: null,
+        },
+        "alice@example.com",
+        [],
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("allows write only for the workflow owner (not system-owned)", () => {
+    expect(
+      workflowWriteAllowedByVisibility(
+        { visibility: "global", shared_with_teams: null, owner_id: "alice@example.com" },
+        "alice@example.com",
+      ),
+    ).toBe(true);
+    expect(
+      workflowWriteAllowedByVisibility(
+        { visibility: "global", shared_with_teams: null, owner_id: "system" },
+        "alice@example.com",
+      ),
+    ).toBe(false);
+    expect(
+      workflowWriteAllowedByVisibility(
+        { visibility: "global", shared_with_teams: null, owner_id: "other@example.com" },
+        "alice@example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("filters configs by visibility for list endpoints", () => {
+    const configs = [
+      {
+        _id: "wf-global",
+        visibility: "global" as const,
+        shared_with_teams: null,
+        owner_id: "a@example.com",
+      },
+      {
+        _id: "wf-team",
+        visibility: "team" as const,
+        shared_with_teams: ["platform-eng"],
+        owner_id: "a@example.com",
+      },
+      {
+        _id: "wf-private",
+        visibility: "private" as const,
+        shared_with_teams: null,
+        owner_id: "a@example.com",
+      },
+    ];
+
+    const visible = filterWorkflowConfigsByRunAccess(configs, "bob@example.com", ["platform-eng"]);
+    expect(visible.map((c) => c._id)).toEqual(["wf-global", "wf-team"]);
+  });
+});

--- a/ui/src/lib/rbac/workflow-config-rebac.ts
+++ b/ui/src/lib/rbac/workflow-config-rebac.ts
@@ -1,0 +1,410 @@
+/**
+ * OpenFGA projection for workflow_configs (stored as `task:<wf-id>`).
+ *
+ * Workflow configs historically only lived in MongoDB; runs enforced
+ * `task#read` in OpenFGA without ever writing tuples on create. This module
+ * reconciles visibility on write and applies Mongo visibility rules for run
+ * access (global = any signed-in user; team = shared team members; private = owner).
+ */
+
+import { getCollection } from "@/lib/mongodb";
+import { ApiError } from "@/lib/api-error";
+import type { OpenFgaReconcileResult } from "./openfga";
+import { reconcileShareableResource } from "./openfga-owned-resources";
+import { listUserTeamSlugs } from "./openfga-team-membership";
+import {
+  requireResourcePermission,
+  subjectFromSession,
+  type ResourceAuthzSession,
+} from "./resource-authz";
+import type { WorkflowConfigVisibility } from "@/types/workflow-config";
+
+export interface WorkflowConfigRebacSnapshot {
+  _id: string;
+  visibility?: WorkflowConfigVisibility | null;
+  shared_with_teams?: string[] | null;
+  owner_id: string;
+  config_driven?: boolean;
+}
+
+/**
+ * Resolve Mongo visibility for run/discover policy checks. Legacy rows may omit
+ * `visibility`; platform-seeded workflows (`owner_id: system`) default to global.
+ */
+export function effectiveWorkflowVisibility(
+  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "owner_id" | "config_driven">,
+): WorkflowConfigVisibility {
+  const raw =
+    typeof config.visibility === "string" ? config.visibility.trim().toLowerCase() : "";
+  if (raw === "global" || raw === "team" || raw === "private") {
+    return raw;
+  }
+  if (config.owner_id?.trim().toLowerCase() === "system" || config.config_driven) {
+    return "global";
+  }
+  return "private";
+}
+
+export function normalizeTeamSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+function normalizeTeamSlugs(slugs: string[] | null | undefined): string[] {
+  if (!slugs?.length) return [];
+  return [...new Set(slugs.map(normalizeTeamSlug).filter(Boolean))];
+}
+
+/** Maps team slug and Mongo `_id` string to canonical slug (lowercase). */
+export type TeamRefToSlugMap = Map<string, string>;
+
+export async function buildTeamRefToSlugMap(): Promise<TeamRefToSlugMap> {
+  const teams = await getCollection<{ _id: unknown; slug?: string }>("teams");
+  const rows = await teams.find({}).project({ slug: 1 }).toArray();
+  const map: TeamRefToSlugMap = new Map();
+  for (const row of rows) {
+    const slug = row.slug?.trim().toLowerCase();
+    if (!slug) continue;
+    map.set(slug, slug);
+    map.set(String(row._id), slug);
+  }
+  return map;
+}
+
+/** Resolve stored team refs (slug or legacy Mongo id) to slugs for FGA and visibility checks. */
+export function resolveSharedTeamSlugs(
+  refs: string[] | null | undefined,
+  teamRefToSlug?: TeamRefToSlugMap,
+): string[] {
+  if (!refs?.length) return [];
+  const resolved = refs.map((ref) => {
+    const trimmed = ref.trim();
+    if (!trimmed) return "";
+    const fromMap = teamRefToSlug?.get(trimmed) ?? teamRefToSlug?.get(normalizeTeamSlug(trimmed));
+    if (fromMap) return fromMap;
+    return normalizeTeamSlug(trimmed);
+  });
+  return normalizeTeamSlugs(resolved);
+}
+
+export async function normalizeSharedWithTeamSlugs(
+  refs: string[] | undefined,
+): Promise<string[] | undefined> {
+  if (!refs?.length) return undefined;
+  const map = await buildTeamRefToSlugMap();
+  const slugs = resolveSharedTeamSlugs(refs, map);
+  return slugs.length > 0 ? slugs : undefined;
+}
+
+/**
+ * Product policy: who may run (and discover) a workflow from Mongo visibility alone.
+ */
+export function agentListedInWorkflowSteps(
+  config: Pick<WorkflowConfigRebacSnapshot, "_id"> & {
+    steps?: Array<{ type?: string; agent_id?: string }>;
+  },
+  agentId: string,
+): boolean {
+  for (const step of config.steps ?? []) {
+    if (step?.type === "step" && step.agent_id === agentId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Agent use delegated from an in-flight workflow run the user may execute. */
+export function workflowDelegatesAgentUse(
+  config: WorkflowConfigRebacSnapshot & {
+    steps?: Array<{ type?: string; agent_id?: string }>;
+  },
+  agentId: string,
+  userEmail: string,
+  userTeamSlugs: string[],
+): boolean {
+  if (!agentListedInWorkflowSteps(config, agentId)) {
+    return false;
+  }
+  return workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs);
+}
+
+export function workflowRunAllowedByVisibility(
+  config: Pick<
+    WorkflowConfigRebacSnapshot,
+    "visibility" | "shared_with_teams" | "owner_id" | "config_driven"
+  >,
+  userEmail: string,
+  userTeamSlugs: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): boolean {
+  const visibility = effectiveWorkflowVisibility(config);
+
+  if (visibility === "global") {
+    return true;
+  }
+
+  if (visibility === "team") {
+    const shared = resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug);
+    if (shared.length === 0) {
+      return false;
+    }
+    const memberSlugs = new Set(normalizeTeamSlugs(userTeamSlugs));
+    return shared.some((slug) => memberSlugs.has(slug));
+  }
+
+  const owner = config.owner_id?.trim().toLowerCase();
+  return Boolean(owner && owner === userEmail.trim().toLowerCase());
+}
+
+export async function resolveUserTeamSlugsForWorkflow(
+  userEmail: string,
+  session: ResourceAuthzSession,
+): Promise<string[]> {
+  const subject = subjectFromSession(session);
+  if (subject) {
+    try {
+      const slugs = await listUserTeamSlugs({ subject });
+      if (slugs.length > 0) {
+        return slugs;
+      }
+    } catch {
+      // Fall through to Mongo membership lookup.
+    }
+  }
+
+  try {
+    const teams = await getCollection<{ slug?: string }>("teams");
+    const rows = await teams
+      .find({ "members.user_id": userEmail })
+      .project({ slug: 1 })
+      .toArray();
+    return rows.map((team) => team.slug?.trim()).filter((slug): slug is string => Boolean(slug));
+  } catch {
+    return [];
+  }
+}
+
+export function filterWorkflowConfigsByRunAccess<T extends WorkflowConfigRebacSnapshot>(
+  configs: T[],
+  userEmail: string,
+  userTeamSlugs: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): T[] {
+  return configs.filter((config) =>
+    workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs, teamRefToSlug),
+  );
+}
+
+export function mergeWorkflowConfigsById<T extends { _id: string }>(
+  ...groups: T[][]
+): T[] {
+  const byId = new Map<string, T>();
+  for (const group of groups) {
+    for (const config of group) {
+      byId.set(String(config._id), config);
+    }
+  }
+  return [...byId.values()];
+}
+
+export async function reconcileWorkflowConfigAccess(
+  session: ResourceAuthzSession,
+  config: Pick<WorkflowConfigRebacSnapshot, "_id" | "visibility" | "shared_with_teams">,
+  previous?: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams"> | null,
+): Promise<OpenFgaReconcileResult> {
+  const creatorSubject = subjectFromSession(session);
+  if (!creatorSubject) {
+    return { enabled: false, writes: 0, deletes: 0 };
+  }
+
+  const teamRefToSlug =
+    config.visibility === "team" || previous?.visibility === "team"
+      ? await buildTeamRefToSlugMap()
+      : undefined;
+
+  return reconcileShareableResource({
+    objectType: "task",
+    objectId: config._id,
+    creatorSubject,
+    ownerSubject: creatorSubject,
+    memberRelations: ["reader", "user"],
+    sharedWithOrg: config.visibility === "global",
+    previousSharedWithOrg: previous?.visibility === "global",
+    nextSharedTeamSlugs:
+      config.visibility === "team"
+        ? resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug)
+        : [],
+    previousSharedTeamSlugs:
+      previous?.visibility === "team"
+        ? resolveSharedTeamSlugs(previous.shared_with_teams, teamRefToSlug)
+        : [],
+  });
+}
+
+/** Who may edit/delete a workflow (stricter than run). */
+export function workflowWriteAllowedByVisibility(
+  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams" | "owner_id">,
+  userEmail: string,
+): boolean {
+  const owner = config.owner_id?.trim().toLowerCase();
+  const email = userEmail.trim().toLowerCase();
+  if (!owner || !email) {
+    return false;
+  }
+  // Seeded / platform workflows use a non-user owner id.
+  if (owner === "system") {
+    return false;
+  }
+  return owner === email;
+}
+
+/** Authorize updating or deleting a workflow config. */
+export async function requireWorkflowConfigWriteAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+): Promise<void> {
+  if (workflowWriteAllowedByVisibility(config, userEmail)) {
+    return;
+  }
+
+  try {
+    await requireResourcePermission(
+      session,
+      { type: "task", id: config._id, action: "write" },
+      { bypassForOrgAdmin: true },
+    );
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.statusCode === 403 &&
+      config.owner_id &&
+      config.owner_id.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Whether the caller may list or view workflow runs for a config (visibility +
+ * OpenFGA `task#read` or `task#use`). Matches the list-runs filter in
+ * `/api/workflow-runs`.
+ */
+export async function canViewWorkflowRunsForConfig(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): Promise<boolean> {
+  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  const map =
+    teamRefToSlug ??
+    (effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined);
+
+  if (workflowRunAllowedByVisibility(config, userEmail, slugs, map)) {
+    return true;
+  }
+
+  for (const action of ["read", "use"] as const) {
+    try {
+      await requireResourcePermission(
+        session,
+        { type: "task", id: config._id, action },
+        { bypassForOrgAdmin: true },
+      );
+      return true;
+    } catch {
+      // try next action
+    }
+  }
+  return false;
+}
+
+/** Authorize viewing or polling workflow runs for a config. */
+export async function requireWorkflowConfigRunViewAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<void> {
+  if (await canViewWorkflowRunsForConfig(session, config, userEmail, userTeamSlugs)) {
+    return;
+  }
+  throw new ApiError(
+    "You do not have permission to view workflow runs for this workflow.",
+    403,
+    "task#read",
+    "pdp_denied",
+    "contact_admin",
+  );
+}
+
+/** Authorize starting or viewing a workflow config (run / discover / read). */
+export async function requireWorkflowConfigRunAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<void> {
+  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  const teamRefToSlug =
+    effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined;
+
+  if (workflowRunAllowedByVisibility(config, userEmail, slugs, teamRefToSlug)) {
+    return;
+  }
+
+  try {
+    await requireResourcePermission(
+      session,
+      { type: "task", id: config._id, action: "use" },
+      { bypassForOrgAdmin: true },
+    );
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.statusCode === 403 &&
+      config.owner_id &&
+      config.owner_id.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * One-time style repair: rewrite `shared_with_teams` from legacy Mongo ids to slugs.
+ * Safe to run on UI startup after seed.
+ */
+export async function repairWorkflowConfigTeamSlugRefs(): Promise<number> {
+  const collection = await getCollection<WorkflowConfigRebacSnapshot>("workflow_configs");
+  const map = await buildTeamRefToSlugMap();
+  const teamConfigs = await collection.find({ visibility: "team" }).toArray();
+  let repaired = 0;
+
+  for (const config of teamConfigs) {
+    const resolved = resolveSharedTeamSlugs(config.shared_with_teams, map);
+    if (resolved.length === 0) continue;
+
+    const before = normalizeTeamSlugs(config.shared_with_teams);
+    const changed =
+      before.length !== resolved.length ||
+      before.some((slug, index) => slug !== resolved[index]);
+
+    if (!changed) continue;
+
+    await collection.updateOne(
+      { _id: config._id as unknown },
+      { $set: { shared_with_teams: resolved, updated_at: new Date() } },
+    );
+    repaired += 1;
+  }
+
+  return repaired;
+}
+
+/** @deprecated Use requireWorkflowConfigRunAccess */
+export const requireWorkflowConfigRead = requireWorkflowConfigRunAccess;

--- a/ui/src/lib/rbac/workflow-run-access.ts
+++ b/ui/src/lib/rbac/workflow-run-access.ts
@@ -9,7 +9,6 @@ import {
   canViewWorkflowRunsForConfig,
   requireWorkflowConfigRunAccess,
   requireWorkflowConfigRunViewAccess,
-  resolveUserTeamSlugsForWorkflow,
   type WorkflowConfigRebacSnapshot,
 } from "./workflow-config-rebac";
 import type { WorkflowConfig } from "@/types/workflow-config";

--- a/ui/src/lib/rbac/workflow-run-access.ts
+++ b/ui/src/lib/rbac/workflow-run-access.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared workflow run access helpers (list, poll, resume, cancel).
+ */
+
+import { getCollection } from "@/lib/mongodb";
+import { ApiError } from "@/lib/api-error";
+import type { ResourceAuthzSession } from "./resource-authz";
+import {
+  canViewWorkflowRunsForConfig,
+  requireWorkflowConfigRunAccess,
+  requireWorkflowConfigRunViewAccess,
+  resolveUserTeamSlugsForWorkflow,
+  type WorkflowConfigRebacSnapshot,
+} from "./workflow-config-rebac";
+import type { WorkflowConfig } from "@/types/workflow-config";
+
+export function workflowConfigAccessSnapshot(
+  config: Pick<
+    WorkflowConfig,
+    "_id" | "owner_id" | "visibility" | "shared_with_teams" | "config_driven"
+  >,
+): WorkflowConfigRebacSnapshot {
+  return {
+    _id: String(config._id),
+    owner_id: config.owner_id,
+    visibility: config.visibility,
+    shared_with_teams: config.shared_with_teams,
+    config_driven: config.config_driven,
+  };
+}
+
+export async function loadWorkflowConfigForRunAccess(
+  configId: string,
+): Promise<WorkflowConfig | null> {
+  const configCol = await getCollection<WorkflowConfig>("workflow_configs");
+  return configCol.findOne({ _id: configId as WorkflowConfig["_id"] });
+}
+
+export async function assertCanViewWorkflowRunsForConfigId(
+  session: ResourceAuthzSession,
+  configId: string,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<WorkflowConfig> {
+  const config = await loadWorkflowConfigForRunAccess(configId);
+  if (!config) {
+    throw new ApiError(`Workflow config ${configId} not found`, 404);
+  }
+  await requireWorkflowConfigRunViewAccess(
+    session,
+    workflowConfigAccessSnapshot(config),
+    userEmail,
+    userTeamSlugs,
+  );
+  return config;
+}
+
+export async function assertCanExecuteWorkflowRunsForConfigId(
+  session: ResourceAuthzSession,
+  configId: string,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<WorkflowConfig> {
+  const config = await loadWorkflowConfigForRunAccess(configId);
+  if (!config) {
+    throw new ApiError(`Workflow config ${configId} not found`, 404);
+  }
+  await requireWorkflowConfigRunAccess(
+    session,
+    workflowConfigAccessSnapshot(config),
+    userEmail,
+    userTeamSlugs,
+  );
+  return config;
+}
+
+export async function canViewWorkflowRunsForConfigId(
+  session: ResourceAuthzSession,
+  configId: string,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<boolean> {
+  const config = await loadWorkflowConfigForRunAccess(configId);
+  if (!config) {
+    return false;
+  }
+  return canViewWorkflowRunsForConfig(
+    session,
+    workflowConfigAccessSnapshot(config),
+    userEmail,
+    userTeamSlugs,
+  );
+}

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -23,8 +23,13 @@ import { BUILTIN_MCP_CREDENTIAL_SOURCES } from "@/lib/rbac/agentgateway-mcp-disc
 import {
   reconcileConfigDrivenLlmModelRelationships,
   reconcileConfigDrivenMcpServerRelationships,
+  reconcileShareableResource,
 } from "@/lib/rbac/openfga-owned-resources";
 import { reconcileAgentRelationships } from "@/lib/rbac/openfga-agent-tools";
+import {
+  normalizeSharedWithTeamSlugs,
+  repairWorkflowConfigTeamSlugRefs,
+} from "@/lib/rbac/workflow-config-rebac";
 import type {
   DynamicAgentConfig,
   MCPServerConfig,
@@ -394,6 +399,11 @@ async function seedWorkflowConfigs(
 
     const visibility = ((cfgData.visibility as string) ?? "global") as WorkflowConfigVisibility;
     const steps = (cfgData.steps ?? []) as StepEntry[];
+    let sharedWithTeams =
+      visibility === "team" ? ((cfgData.shared_with_teams as string[]) ?? undefined) : undefined;
+    if (sharedWithTeams?.length) {
+      sharedWithTeams = await normalizeSharedWithTeamSlugs(sharedWithTeams);
+    }
 
     // Ensure each step has type: "step" (YAML may omit it)
     for (const step of steps) {
@@ -409,13 +419,30 @@ async function seedWorkflowConfigs(
       steps,
       owner_id: "system",
       visibility,
-      shared_with_teams: visibility === "team" ? (cfgData.shared_with_teams as string[]) : undefined,
+      shared_with_teams: sharedWithTeams,
       config_driven: true,
       created_at: createdAt,
       updated_at: now,
     };
 
     await collection.replaceOne({ _id: cfgId }, doc, { upsert: true });
+    try {
+      await reconcileShareableResource({
+        objectType: "task",
+        objectId: cfgId,
+        sharedWithOrg: visibility === "global",
+        previousSharedWithOrg: existing?.visibility === "global" && visibility !== "global",
+        memberRelations: ["reader", "user"],
+        nextSharedTeamSlugs: visibility === "team" ? (sharedWithTeams ?? []) : [],
+        previousSharedTeamSlugs:
+          existing?.visibility === "team" ? existing.shared_with_teams ?? [] : [],
+      });
+    } catch (err) {
+      console.warn(
+        `[seed-config] OpenFGA reconcile for workflow config ${cfgId} failed:`,
+        err,
+      );
+    }
     console.log(`[seed-config] Seeded workflow config: ${cfgId}`);
     count++;
   }
@@ -540,20 +567,28 @@ export async function cleanupStaleConfigDriven(
  * - `model: { id: "", provider: "" }` defers model selection to the
  *   dynamic-agents backend default. Hard-coding a model here would
  *   couple bootstrap behavior to a specific deployment.
- * - All four built-in tools enabled with conservative defaults
- *   (`fetch_url` allow-list `*`, `sleep.max_seconds: 60`). Lock-down
- *   environments can tighten these via the UI after first login.
+ * - Built-in tools enabled with conservative defaults (`fetch_url` allow-list
+ *   `*`, `sleep.max_seconds: 60`, `request_user_input` for workflow HITL).
+ *   Lock-down environments can tighten these via the UI after first login.
  */
 export const HELLO_WORLD_AGENT_ID = "hello-world";
 
-function buildHelloWorldAgentDoc(now: string): DynamicAgentConfig {
+/** Bump when bootstrap fields change so reconcile updates existing installs. */
+export const HELLO_WORLD_BOOTSTRAP_REVISION = 2;
+
+export function buildHelloWorldAgentDoc(now: string): DynamicAgentConfig {
   return {
     _id: HELLO_WORLD_AGENT_ID,
     name: "Hello World",
     description:
-      "Default starter agent provisioned automatically when no dynamic agents exist. Has all built-in tools enabled (fetch URL, current time, user info, sleep). Edit or delete via the Custom Agents UI.",
-    system_prompt:
-      "You are Hello World, a friendly default assistant for testing and validating CAIPE. You can fetch web content, tell the current time, look up the signed-in user, and pause briefly when asked. Be concise and helpful.",
+      "Default starter agent for testing CAIPE and demo workflows. Supports structured user input (forms), fetch URL, time, user info, and short waits. Edit or delete via the Custom Agents UI.",
+    system_prompt: `You are Hello World, a friendly default assistant for testing and validating CAIPE.
+
+When you need information from the user, always use the \`request_user_input\` tool with a clear prompt and structured fields. Do not ask questions in plain chat and wait for a reply — the user is not in the agent chat during workflow runs.
+
+When a workflow step asks you to save data for later steps, use \`write_file\` on the workflow filesystem (for example \`choices.txt\` or \`movie_title.txt\` at the root). After collecting input via \`request_user_input\`, write the answers into the required files before finishing the step.
+
+Be concise and helpful.`,
     allowed_tools: {},
     model: { id: "", provider: "" },
     visibility: "global",
@@ -564,7 +599,10 @@ function buildHelloWorldAgentDoc(now: string): DynamicAgentConfig {
       current_datetime: { enabled: true },
       user_info: { enabled: true },
       sleep: { enabled: true, max_seconds: 60 },
+      request_user_input: { enabled: true },
     },
+    interrupt_on: { builtin: { request_user_input: true } },
+    hello_world_bootstrap_revision: HELLO_WORLD_BOOTSTRAP_REVISION,
     enabled: true,
     owner_id: "system",
     is_system: false,
@@ -611,6 +649,53 @@ export async function bootstrapDefaultDynamicAgentIfEmpty(): Promise<boolean> {
     `[seed-config] Provisioned default dynamic agent: ${HELLO_WORLD_AGENT_ID}`,
   );
   return true;
+}
+
+/**
+ * Refresh the bootstrap Hello World agent when it is still owned by `system`
+ * and its bootstrap revision is behind {@link HELLO_WORLD_BOOTSTRAP_REVISION}.
+ * Does not overwrite agents the operator re-owned or deleted.
+ */
+export async function reconcileHelloWorldBootstrapAgent(): Promise<boolean> {
+  if (!isMongoDBConfigured) return false;
+
+  const collection =
+    await getCollection<DynamicAgentConfig>("dynamic_agents");
+  const now = new Date().toISOString();
+  const doc = buildHelloWorldAgentDoc(now);
+
+  const result = await collection.updateOne(
+    {
+      _id: HELLO_WORLD_AGENT_ID,
+      owner_id: "system",
+      $or: [
+        { hello_world_bootstrap_revision: { $exists: false } },
+        {
+          hello_world_bootstrap_revision: {
+            $lt: HELLO_WORLD_BOOTSTRAP_REVISION,
+          },
+        },
+      ],
+    },
+    {
+      $set: {
+        description: doc.description,
+        system_prompt: doc.system_prompt,
+        builtin_tools: doc.builtin_tools,
+        interrupt_on: doc.interrupt_on,
+        hello_world_bootstrap_revision: HELLO_WORLD_BOOTSTRAP_REVISION,
+        updated_at: now,
+      },
+    },
+  );
+
+  if (result.modifiedCount > 0) {
+    console.log(
+      `[seed-config] Reconciled bootstrap agent ${HELLO_WORLD_AGENT_ID} to revision ${HELLO_WORLD_BOOTSTRAP_REVISION}`,
+    );
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -862,6 +947,12 @@ export async function applySeedConfig(): Promise<void> {
       await seedAgentGatewayAdminAccess();
       const agentCount = await seedAgents(config.agents);
       const workflowCount = await seedWorkflowConfigs(config.workflow_configs);
+      const workflowTeamSlugRepairs = await repairWorkflowConfigTeamSlugRefs();
+      if (workflowTeamSlugRepairs > 0) {
+        console.log(
+          `[seed-config] Repaired shared_with_teams slugs on ${workflowTeamSlugRepairs} team workflow(s)`,
+        );
+      }
 
       // Cleanup stale config-driven entities
       await cleanupStaleConfigDriven(
@@ -917,6 +1008,14 @@ export async function applySeedConfig(): Promise<void> {
     } catch (err) {
       console.error(
         "[seed-config] default dynamic agent bootstrap threw:",
+        err,
+      );
+    }
+    try {
+      await reconcileHelloWorldBootstrapAgent();
+    } catch (err) {
+      console.error(
+        "[seed-config] Hello World bootstrap reconcile threw:",
         err,
       );
     }

--- a/ui/src/lib/server/workflow-da-auth.ts
+++ b/ui/src/lib/server/workflow-da-auth.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+
+import type { ResourceAuthzSession } from "@/lib/rbac/resource-authz";
+
+/**
+ * Headers for server-side workflow engine calls into Dynamic Agents.
+ * Prefer the caller's Bearer token; fall back to the OIDC access token on the session.
+ */
+export function buildWorkflowDaAuthHeaders(
+  request: NextRequest,
+  user: { email: string; name?: string | null },
+  session: ResourceAuthzSession,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const incomingAuth = request.headers.get("Authorization")?.trim();
+  const sessionRecord = session as Record<string, unknown>;
+  const accessToken =
+    typeof sessionRecord.accessToken === "string" ? sessionRecord.accessToken.trim() : "";
+
+  if (incomingAuth) {
+    headers.Authorization = incomingAuth;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  headers["X-User-Context"] = Buffer.from(
+    JSON.stringify({
+      email: user.email,
+      name: user.name ?? null,
+    }),
+  ).toString("base64");
+
+  return headers;
+}

--- a/ui/src/lib/server/workflow-engine.ts
+++ b/ui/src/lib/server/workflow-engine.ts
@@ -346,6 +346,7 @@ async function executeSteps(
           message: attemptPrompt,
           conversation_id: conversationId,
           agent_id: step.agent_id,
+          workflow_config_id: workflowConfigId,
           protocol: "agui",
           config_override: {
             backend: {
@@ -525,6 +526,7 @@ async function resumeAndContinue(
     body: {
       conversation_id: conversationId,
       agent_id: step.agent_id,
+      workflow_config_id: workflowConfigId,
       resume_data: resumeData,
       protocol: "agui",
       config_override: {
@@ -718,8 +720,9 @@ function buildWorkflowContextPrefix(
 
   // --- Critical: User interaction ---
   ctx += "## Critical: User Interaction\n";
-  ctx += "The user does NOT have access to this chat. All interaction with the user must happen through the `require_user_input` tool.\n";
-  ctx += "If that tool is not available and you cannot proceed without user input, state the reason and stop.\n\n";
+  ctx += "The user does NOT have access to this chat. All interaction with the user must happen through the `request_user_input` tool.\n";
+  ctx += "When a step must pass data to later steps, call `request_user_input` if needed, then persist outputs with `write_file` (for example `choices.txt` at the filesystem root).\n";
+  ctx += "If that tool is not available and you cannot proceed without user input, write the reason to error.txt and stop.\n\n";
 
   // --- Critical: Reporting failure ---
   ctx += "## Critical: Reporting Failure\n";

--- a/ui/src/lib/server/workflow-step-agents.ts
+++ b/ui/src/lib/server/workflow-step-agents.ts
@@ -1,0 +1,38 @@
+import { ApiError } from "@/lib/api-middleware";
+import { getCollection } from "@/lib/mongodb";
+import type { WorkflowConfig, WorkflowStep } from "@/types/workflow-config";
+
+/**
+ * Fail fast when a workflow references dynamic agent IDs that are not in MongoDB.
+ */
+export async function assertWorkflowStepAgentsExist(config: WorkflowConfig): Promise<void> {
+  const agentIds = [
+    ...new Set(
+      (config.steps ?? [])
+        .filter((entry): entry is WorkflowStep => entry.type === "step")
+        .map((step) => step.agent_id)
+        .filter((id): id is string => Boolean(id?.trim())),
+    ),
+  ];
+
+  if (agentIds.length === 0) {
+    return;
+  }
+
+  const agentCol = await getCollection<{ _id: string }>("dynamic_agents");
+  const found = await agentCol
+    .find({ _id: { $in: agentIds } })
+    .project({ _id: 1 })
+    .toArray();
+  const foundIds = new Set(found.map((doc) => String(doc._id)));
+  const missing = agentIds.filter((id) => !foundIds.has(id));
+
+  if (missing.length > 0) {
+    throw new ApiError(
+      `This workflow references agent(s) that do not exist: ${missing.join(", ")}. ` +
+        "Open the workflow in the editor, select each step, and choose an agent from the catalog " +
+        "(or update config/app-config.yaml for config-driven workflows and restart the UI).",
+      400,
+    );
+  }
+}

--- a/ui/src/store/__tests__/unsaved-changes-store.test.ts
+++ b/ui/src/store/__tests__/unsaved-changes-store.test.ts
@@ -21,6 +21,7 @@ function resetStore() {
   useUnsavedChangesStore.setState({
     hasUnsavedChanges: false,
     pendingNavigationHref: null,
+    pendingDeferredAction: null,
   });
 }
 
@@ -110,6 +111,56 @@ describe("unsaved-changes-store", () => {
         href = useUnsavedChangesStore.getState().confirmNavigation();
       });
       expect(href).toBeNull();
+    });
+  });
+
+  describe("requestDeferredAction", () => {
+    it("runs immediately when there are no unsaved changes", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+      });
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBeNull();
+    });
+
+    it("queues the action when there are unsaved changes", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().setUnsaved(true);
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+      });
+      expect(action).not.toHaveBeenCalled();
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBe(action);
+    });
+  });
+
+  describe("confirmDeferredAction", () => {
+    it("runs the queued action and clears dirty state", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().setUnsaved(true);
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+      });
+      act(() => {
+        useUnsavedChangesStore.getState().confirmDeferredAction();
+      });
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(useUnsavedChangesStore.getState().hasUnsavedChanges).toBe(false);
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBeNull();
+    });
+  });
+
+  describe("cancelNavigation", () => {
+    it("clears pendingDeferredAction", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().setUnsaved(true);
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+        useUnsavedChangesStore.getState().cancelNavigation();
+      });
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBeNull();
+      expect(action).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/store/unsaved-changes-store.ts
+++ b/ui/src/store/unsaved-changes-store.ts
@@ -3,26 +3,54 @@ import { create } from "zustand";
 interface UnsavedChangesState {
   hasUnsavedChanges: boolean;
   pendingNavigationHref: string | null;
+  /** In-app action blocked until the user discards edits (e.g. switch workflow). */
+  pendingDeferredAction: (() => void) | null;
 
   setUnsaved: (dirty: boolean) => void;
   requestNavigation: (href: string) => void;
+  requestDeferredAction: (action: () => void) => void;
   cancelNavigation: () => void;
   confirmNavigation: () => string | null;
+  confirmDeferredAction: () => void;
 }
 
 export const useUnsavedChangesStore = create<UnsavedChangesState>()((set, get) => ({
   hasUnsavedChanges: false,
   pendingNavigationHref: null,
+  pendingDeferredAction: null,
 
   setUnsaved: (dirty) => set({ hasUnsavedChanges: dirty }),
 
   requestNavigation: (href) => set({ pendingNavigationHref: href }),
 
-  cancelNavigation: () => set({ pendingNavigationHref: null }),
+  requestDeferredAction: (action) => {
+    if (get().hasUnsavedChanges) {
+      set({ pendingDeferredAction: action });
+      return;
+    }
+    action();
+  },
+
+  cancelNavigation: () =>
+    set({ pendingNavigationHref: null, pendingDeferredAction: null }),
 
   confirmNavigation: () => {
     const href = get().pendingNavigationHref;
-    set({ hasUnsavedChanges: false, pendingNavigationHref: null });
+    set({
+      hasUnsavedChanges: false,
+      pendingNavigationHref: null,
+      pendingDeferredAction: null,
+    });
     return href;
+  },
+
+  confirmDeferredAction: () => {
+    const action = get().pendingDeferredAction;
+    set({
+      hasUnsavedChanges: false,
+      pendingNavigationHref: null,
+      pendingDeferredAction: null,
+    });
+    action?.();
   },
 }));

--- a/ui/src/store/workflow-exec-store.ts
+++ b/ui/src/store/workflow-exec-store.ts
@@ -11,6 +11,22 @@ import type { StreamEvent } from "@/lib/streaming/types";
  */
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readWorkflowApiError(res: Response): Promise<string> {
+  const text = await res.text();
+  try {
+    const json = JSON.parse(text) as { error?: string; message?: string };
+    if (typeof json.error === "string" && json.error.trim()) return json.error;
+    if (typeof json.message === "string" && json.message.trim()) return json.message;
+  } catch {
+    // fall through
+  }
+  return text.trim() || `Request failed (${res.status})`;
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -159,8 +175,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Execute failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       const data = await res.json();
@@ -245,8 +260,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Resume failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       // Resume polling
@@ -266,8 +280,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Cancel failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       get().stopPolling();
@@ -287,8 +300,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Delete failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       // Remove from sidebar list


### PR DESCRIPTION
## Summary

- **Workflow RBAC**: Global/team/private visibility with OpenFGA `task#read` / `task#use`; list and detail use the same view rules; runs API uses `withAuth` and returns 403 when access is denied.
- **Team sharing**: Normalize `shared_with_teams` to team slugs (not Mongo `_id`) in API, seed, and UI (`TeamMultiPicker`).
- **Non-admin access**: Map `GET/POST /api/workflow-configs` to `dynamic_agent#view` / `manage` in BFF middleware so non-admins can list/run shared workflows.
- **Execution auth**: Forward user JWT to dynamic agents for workflow runs; add `workflow_execution_authz` checks on the DA side.
- **Editor UX**: Show an **Unsaved** toolbar badge and in-app discard dialog when leaving the editor (Exit, nav links, sidebar workflow/run switches).
- **Agent access on save**: Before saving team/global workflows, check OpenFGA for agent access gaps per shared team; show `WorkflowAgentAccessModal` to bulk-grant `team#member → user → agent` tuples via admin OpenFGA API, then persist.

## Test plan

- [x] `pytest tests/test_workflow_execution_authz.py` (dynamic agents)
- [x] `npm test` — `workflow-config-rebac`, `workflow-runs-rbac`, `task-workflow-rbac`, `api-middleware`, `unsaved-changes-store`
- [ ] As non-admin (e.g. CU Generic): see global/team workflows in sidebar; runs list matches openable runs; denied run returns 403
- [ ] Edit workflow name → **Unsaved** badge; Exit / switch workflow → discard dialog
- [ ] Team workflow: share via team picker (slugs); member can run/list
- [ ] Save team workflow with agent teams cannot use → access modal lists gaps; **Grant access and save** grants tuples and saves

## Notes

- Does not include unrelated admin migration-status / schema-bootstrap changes left on local `main`.
- Global workflows: modal detects `(all users)` agent gaps but does not auto-grant (team slugs only in grant loop).

Made with [Cursor](https://cursor.com)