### PR TITLE
fix(admin): scope migration bootstrap alerts to manifest-backed areas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.8-dev.2"
+version = "0.5.8-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
@@ -10,6 +10,7 @@ const mockRequireResourcePermission = jest.fn();
 const mockGetCollection = jest.fn();
 const mockConnectToDatabase = jest.fn();
 const mockWriteOpenFgaTuples = jest.fn();
+const mockWriteOpenFgaTupleDiff = jest.fn();
 const mockGetKeycloakRbacDiagnosticValues = jest.fn();
 
 const collections: Record<string, ReturnType<typeof createCollection>> = {};
@@ -59,6 +60,8 @@ jest.mock("@/lib/mongodb", () => ({
 
 jest.mock("@/lib/rbac/openfga", () => ({
   writeOpenFgaTuples: (...args: unknown[]) => mockWriteOpenFgaTuples(...args),
+  writeOpenFgaTupleDiff: (...args: unknown[]) => mockWriteOpenFgaTupleDiff(...args),
+  readOpenFgaTuples: jest.fn().mockResolvedValue({ tuples: [], continuationToken: undefined }),
 }));
 
 jest.mock("@/lib/rbac/keycloak-admin", () => ({
@@ -115,6 +118,7 @@ beforeEach(() => {
   mockRequireRbacPermission.mockResolvedValue(undefined);
   mockRequireResourcePermission.mockResolvedValue(undefined);
   mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
+  mockWriteOpenFgaTupleDiff.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
   mockGetCollection.mockImplementation(async (name: string) => collections[name] ?? createCollection());
   mockConnectToDatabase.mockImplementation(async () => ({
     db: {
@@ -632,7 +636,7 @@ describe("admin ReBAC migrations API", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+    expect(mockWriteOpenFgaTupleDiff).toHaveBeenCalledWith({
       writes: expect.arrayContaining([
         { user: "user:alice-sub", relation: "member", object: "team:platform" },
         { user: "team:platform#member", relation: "user", object: "agent:agent-1" },
@@ -662,7 +666,7 @@ describe("admin ReBAC migrations API", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+    expect(mockWriteOpenFgaTupleDiff).toHaveBeenCalledWith({
       writes: expect.arrayContaining([
         { user: "agent:agent-1", relation: "caller", object: "tool:github/search" },
         { user: "agent:agent-1", relation: "caller", object: "tool:github/issues" },
@@ -737,7 +741,7 @@ describe("admin ReBAC migrations API", () => {
     );
 
     expect(applyResponse.status).toBe(200);
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+    expect(mockWriteOpenFgaTupleDiff).toHaveBeenCalledWith({
       writes: expect.arrayContaining([
         { user: "slack_channel:T123--C123", relation: "user", object: "agent:agent-1" },
         { user: "slack_channel:T123--C124", relation: "user", object: "agent:agent-1" },
@@ -785,7 +789,7 @@ describe("admin ReBAC migrations API", () => {
     );
 
     expect(applyResponse.status).toBe(200);
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+    expect(mockWriteOpenFgaTupleDiff).toHaveBeenCalledWith({
       writes: expect.arrayContaining([
         { user: "webex_space:WEBEX--space-1", relation: "reader", object: "knowledge_base:kb-1" },
         { user: "webex_space:WEBEX--space-2", relation: "user", object: "agent:agent-1" },

--- a/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
@@ -10,7 +10,6 @@ const mockRequireResourcePermission = jest.fn();
 const mockGetCollection = jest.fn();
 const mockConnectToDatabase = jest.fn();
 const mockWriteOpenFgaTuples = jest.fn();
-const mockWriteOpenFgaTupleDiff = jest.fn();
 const mockGetKeycloakRbacDiagnosticValues = jest.fn();
 
 const collections: Record<string, ReturnType<typeof createCollection>> = {};
@@ -60,8 +59,6 @@ jest.mock("@/lib/mongodb", () => ({
 
 jest.mock("@/lib/rbac/openfga", () => ({
   writeOpenFgaTuples: (...args: unknown[]) => mockWriteOpenFgaTuples(...args),
-  writeOpenFgaTupleDiff: (...args: unknown[]) => mockWriteOpenFgaTupleDiff(...args),
-  readOpenFgaTuples: jest.fn().mockResolvedValue({ tuples: [], continuationToken: undefined }),
 }));
 
 jest.mock("@/lib/rbac/keycloak-admin", () => ({
@@ -118,7 +115,6 @@ beforeEach(() => {
   mockRequireRbacPermission.mockResolvedValue(undefined);
   mockRequireResourcePermission.mockResolvedValue(undefined);
   mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
-  mockWriteOpenFgaTupleDiff.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
   mockGetCollection.mockImplementation(async (name: string) => collections[name] ?? createCollection());
   mockConnectToDatabase.mockImplementation(async () => ({
     db: {
@@ -306,7 +302,7 @@ describe("admin ReBAC migrations API", () => {
     );
   });
 
-  it("includes unversioned schema areas in migration status so admins get a runtime warning", async () => {
+  it("includes actionable unversioned schema areas in migration status (not orphan collections)", async () => {
     collections.messages = createCollection();
     collections.feedback = createCollection();
     collections.data_schema_versions = createCollection([
@@ -319,8 +315,13 @@ describe("admin ReBAC migrations API", () => {
 
     expect(statusResponse.status).toBe(200);
     expect(statusBody.data.needs_version_bootstrap).toBe(true);
-    expect(statusBody.data.version_bootstrap_required_count).toBeGreaterThanOrEqual(2);
+    expect(statusBody.data.version_bootstrap_required_count).toBeGreaterThan(0);
+    // Manifest-backed areas without version rows should alert; raw Mongo collections
+    // with no migration target (messages, feedback) should not inflate the count.
     expect(statusBody.data.version_bootstrap_schema_areas).toEqual(
+      expect.arrayContaining(["dynamic_agents"]),
+    );
+    expect(statusBody.data.version_bootstrap_schema_areas).not.toEqual(
       expect.arrayContaining(["messages", "feedback"]),
     );
     expect(statusBody.data.requires_attention).toBe(true);

--- a/ui/src/components/admin/MigrationTab.tsx
+++ b/ui/src/components/admin/MigrationTab.tsx
@@ -28,6 +28,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { refreshMigrationStatus } from "@/hooks/use-migration-status";
+import { schemaAreasNeedingVersionBootstrap } from "@/lib/rbac/migrations/schema-bootstrap";
 import { cn } from "@/lib/utils";
 
 type MigrationKind = "implicit" | "explicit" | "index";
@@ -232,7 +234,7 @@ export function MigrationTab({ isAdmin }: MigrationTabProps) {
   const visibleSchemaVersions = showAllSchemaVersions ? schemaVersions : schemaVersionsNeedingMigration;
   const hiddenSchemaVersionCount = schemaVersions.length - schemaVersionsNeedingMigration.length;
   const unversionedSchemaAreaNames = useMemo(
-    () => schemaVersions.filter((schema) => schema.current_version === null).map((schema) => schema.schema_area),
+    () => schemaAreasNeedingVersionBootstrap(schemaVersions),
     [schemaVersions],
   );
 
@@ -280,6 +282,7 @@ export function MigrationTab({ isAdmin }: MigrationTabProps) {
       setMigrations(data.migrations);
       setCompletedMigrations(data.completed_migrations ?? []);
       setBlockingStatus(status);
+      refreshMigrationStatus();
       setSelectedBulkMigrationIds((current) => {
         const selectableIds = new Set(
           data.migrations

--- a/ui/src/components/admin/__tests__/MigrationTab.test.tsx
+++ b/ui/src/components/admin/__tests__/MigrationTab.test.tsx
@@ -279,6 +279,7 @@ describe("MigrationTab", () => {
             schema_versions: [
               { schema_area: "messages", current_version: null, target_version: null, status: "unknown" },
               { schema_area: "feedback", current_version: null, target_version: null, status: "unknown" },
+              { schema_area: "dynamic_agents", current_version: null, target_version: 1, status: "unknown" },
               { schema_area: "conversations", current_version: 1, target_version: 2, status: "behind" },
             ],
             migrations: [],
@@ -316,7 +317,7 @@ describe("MigrationTab", () => {
 
     render(<MigrationTab isAdmin />);
 
-    expect(await screen.findByText(/2 schema areas are missing version metadata/i)).toBeInTheDocument();
+    expect(await screen.findByText(/1 schema areas are missing version metadata/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Initialize all to v1/i }));
 
     await waitFor(() => {
@@ -325,13 +326,13 @@ describe("MigrationTab", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
-            schema_areas: ["messages", "feedback"],
+            schema_areas: ["dynamic_agents"],
             confirmation: "INITIALIZE SCHEMA VERSIONS TO v1",
           }),
         }),
       );
     });
-    expect(await screen.findByText(/schema_versions_initialized: 2/i)).toBeInTheDocument();
+    expect(await screen.findByText(/schema_versions_initialized: 1/i)).toBeInTheDocument();
   });
 
   it("allows registered migrations to be selected and dry-run", async () => {

--- a/ui/src/hooks/use-migration-status.ts
+++ b/ui/src/hooks/use-migration-status.ts
@@ -1,8 +1,8 @@
 "use client";
 
-// assisted-by Codex GPT-5.5
+// assisted-by Cursor Composer
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 
 export interface MigrationStatusSummary {
@@ -17,10 +17,36 @@ export interface MigrationStatusSummary {
   override_active: boolean;
 }
 
+/** Dispatched after the Migrations tab refreshes so the header alert pill stays in sync. */
+export const MIGRATION_STATUS_REFRESH_EVENT = "caipe:migration-status-refresh";
+
+export function refreshMigrationStatus(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(MIGRATION_STATUS_REFRESH_EVENT));
+  }
+}
+
 export function useMigrationStatus() {
   const { status: sessionStatus } = useSession();
   const [status, setStatus] = useState<MigrationStatusSummary | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+
+  const load = useCallback(async (cancelled: () => boolean) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/rbac/migration-status");
+      if (!response.ok) {
+        if (!cancelled()) setStatus(null);
+        return;
+      }
+      const body = (await response.json()) as { data?: MigrationStatusSummary };
+      if (!cancelled()) setStatus(body.data ?? null);
+    } catch {
+      if (!cancelled()) setStatus(null);
+    } finally {
+      if (!cancelled()) setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (sessionStatus !== "authenticated") {
@@ -30,27 +56,26 @@ export function useMigrationStatus() {
     }
 
     let cancelled = false;
-    setIsLoading(true);
-    fetch("/api/rbac/migration-status")
-      .then(async (response) => {
-        if (!response.ok) return null;
-        const body = (await response.json()) as { data?: MigrationStatusSummary };
-        return body.data ?? null;
-      })
-      .then((data) => {
-        if (!cancelled) setStatus(data);
-      })
-      .catch(() => {
-        if (!cancelled) setStatus(null);
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
-      });
+    const isCancelled = () => cancelled;
+
+    const refresh = () => {
+      void load(isCancelled);
+    };
+
+    refresh();
+    const intervalId = window.setInterval(refresh, 60_000);
+    const onFocus = () => refresh();
+    const onMigrationRefresh = () => refresh();
+    window.addEventListener("focus", onFocus);
+    window.addEventListener(MIGRATION_STATUS_REFRESH_EVENT, onMigrationRefresh);
 
     return () => {
       cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener(MIGRATION_STATUS_REFRESH_EVENT, onMigrationRefresh);
     };
-  }, [sessionStatus]);
+  }, [sessionStatus, load]);
 
   return { status, isLoading };
 }

--- a/ui/src/lib/rbac/migrations/__tests__/schema-bootstrap.test.ts
+++ b/ui/src/lib/rbac/migrations/__tests__/schema-bootstrap.test.ts
@@ -1,0 +1,21 @@
+import { schemaAreasNeedingVersionBootstrap } from "../schema-bootstrap";
+
+describe("schemaAreasNeedingVersionBootstrap", () => {
+  it("includes unversioned schema areas that have a migration target", () => {
+    expect(
+      schemaAreasNeedingVersionBootstrap([
+        { schema_area: "messages", current_version: null, target_version: 1, status: "unknown" },
+        { schema_area: "conversations", current_version: 2, target_version: 2, status: "current" },
+      ]),
+    ).toEqual(["messages"]);
+  });
+
+  it("excludes orphan Mongo collections with no migration target", () => {
+    expect(
+      schemaAreasNeedingVersionBootstrap([
+        { schema_area: "orphan_collection", current_version: null, target_version: null, status: "unknown" },
+        { schema_area: "feedback", current_version: null, target_version: 1, status: "unknown" },
+      ]),
+    ).toEqual(["feedback"]);
+  });
+});

--- a/ui/src/lib/rbac/migrations/agent-skill-openfga-reconcile.ts
+++ b/ui/src/lib/rbac/migrations/agent-skill-openfga-reconcile.ts
@@ -5,7 +5,11 @@ import {
   type AgentSkillReconcileDoc,
 } from "@/lib/rbac/agent-skill-openfga-reconcile";
 import { readOpenFgaTuples, writeOpenFgaTupleDiff } from "@/lib/rbac/openfga";
-import type { MigrationApplyResult, MigrationPlanResult } from "@/lib/rbac/migrations/types";
+import type {
+  MigrationApplyResult,
+  MigrationPlanResult,
+  MigrationSampleDiff,
+} from "@/lib/rbac/migrations/types";
 
 export const AGENT_SKILL_OPENFGA_RECONCILE_MIGRATION_ID = "agent_skill_openfga_reconcile_v1";
 const RELEASE_058 = "0.5.8";
@@ -103,18 +107,18 @@ export async function planAgentSkillOpenFgaReconcileMigration(): Promise<
   const inputs = await loadAgentSkillOpenFgaReconcileInputs();
   const plan = deriveAgentSkillOpenFgaReconcilePlan(inputs);
 
-  const sampleDiffs = plan.writes.slice(0, 5).map((tuple, index) => ({
+  const sampleDiffs: MigrationSampleDiff[] = plan.writes.slice(0, 5).map((tuple, index) => ({
     collection: "openfga_tuples",
     id: `${AGENT_SKILL_OPENFGA_RECONCILE_MIGRATION_ID}:write:${index}`,
     before: {},
-    after: { ...tuple },
+    after: { ...tuple } as Record<string, unknown>,
   }));
   for (const [index, tuple] of plan.deletes.slice(0, 5).entries()) {
     sampleDiffs.push({
       collection: "openfga_tuples",
       id: `${AGENT_SKILL_OPENFGA_RECONCILE_MIGRATION_ID}:delete:${index}`,
       before: { ...tuple } as Record<string, unknown>,
-      after: {} as Record<string, unknown>,
+      after: {},
     });
   }
 

--- a/ui/src/lib/rbac/migrations/registry.ts
+++ b/ui/src/lib/rbac/migrations/registry.ts
@@ -18,6 +18,7 @@ import {
   CONVERSATION_OWNER_IDENTITY_MIGRATION_ID,
   deriveConversationOwnerIdentityPlan,
 } from "./conversation-owner-identity";
+import { schemaAreasNeedingVersionBootstrap } from "./schema-bootstrap";
 export {
   getUnclassifiedSchemaAreas,
   SCHEMA_AREA_CLASSIFICATIONS,
@@ -2623,10 +2624,9 @@ export async function getMigrationBlockingStatus(input: {
   const overrideActive = isOverrideActive(override, now);
   const pendingRequired = state.migrations.filter((migration) => migration.required);
   const blockingRequired = pendingRequired.filter((migration) => migration.blocking ?? migration.required);
-  const versionBootstrapSchemaAreas = state.schema_versions
-    .filter((schema) => schema.current_version === null)
-    .map((schema) => schema.schema_area)
-    .sort((left, right) => left.localeCompare(right));
+  const versionBootstrapSchemaAreas = schemaAreasNeedingVersionBootstrap(
+    state.schema_versions,
+  );
   const needsVersionBootstrap = versionBootstrapSchemaAreas.length > 0;
   const isBlocking = blockingRequired.length > 0 && !overrideActive;
 

--- a/ui/src/lib/rbac/migrations/schema-bootstrap.ts
+++ b/ui/src/lib/rbac/migrations/schema-bootstrap.ts
@@ -1,0 +1,19 @@
+import type { MigrationSchemaVersionStatus } from "@/lib/rbac/migrations/types";
+
+/**
+ * Schema areas that are missing version metadata but participate in the
+ * migration manifest (have a target version). Orphan Mongo collections with
+ * no planned migrations are excluded — they are not actionable from the
+ * Migrations tab and should not inflate admin header alerts.
+ */
+export function schemaAreasNeedingVersionBootstrap(
+  schemaVersions: Pick<
+    MigrationSchemaVersionStatus,
+    "schema_area" | "current_version" | "target_version"
+  >[],
+): string[] {
+  return schemaVersions
+    .filter((schema) => schema.current_version === null && schema.target_version !== null)
+    .map((schema) => schema.schema_area)
+    .sort((left, right) => left.localeCompare(right));
+}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.8.dev2"
+version = "0.5.8.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Add `schemaAreasNeedingVersionBootstrap()` so version-bootstrap warnings only cover schema areas that have a migration target in the manifest (excludes orphan Mongo collections like `messages` / `feedback`).
- Use the helper in `getMigrationBlockingStatus`, the Migrations tab, and migration-status tests.
- Refresh the header migration alert pill when the Migrations tab reloads status (`refreshMigrationStatus` + focus/interval listeners).

Split from workflow PR #1751 — no workflow RBAC changes.

## Test plan

- [ ] `cd ui && npx jest src/lib/rbac/migrations/__tests__/schema-bootstrap.test.ts src/app/api/admin/rebac/__tests__/migrations-route.test.ts`
- [ ] Admin → ReBAC → Migrations: bootstrap banner lists actionable areas only; header pill updates after refresh
- [ ] Orphan collections without migration targets do not appear in `version_bootstrap_schema_areas`


Made with [Cursor](https://cursor.com)