### PR TITLE
feat(ui): make config-driven agent panels expandable for viewing

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.8 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.9 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.8 -f your-values.yaml'}
+                  {'    --version 0.5.9 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.8 -f your-values.yaml'}
+              {'    --version 0.5.9 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.9"
+version = "0.5.9-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/dynamic-agents/AllowedToolsPicker.tsx
+++ b/ui/src/components/dynamic-agents/AllowedToolsPicker.tsx
@@ -366,7 +366,7 @@ export function AllowedToolsPicker({ value, onChange, disabled }: AllowedToolsPi
                   variant="ghost"
                   size="sm"
                   onClick={() => handleProbe(server._id)}
-                  disabled={disabled || probe?.loading}
+                  disabled={probe?.loading}
                   className="h-7 px-2"
                 >
                   {probe?.loading ? (

--- a/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
@@ -1126,7 +1126,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
             />
           </div>
 
-          <fieldset disabled={readOnly} className={cn("space-y-4 min-w-0", readOnly && "opacity-70")}>
+          <fieldset className={cn("space-y-4 min-w-0", readOnly && "opacity-70")}>
 
           {/* Basic Info Step */}
           {activeStep === "basic" && (
@@ -1140,7 +1140,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                   placeholder="e.g., Code Review Agent"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  disabled={loading}
+                  disabled={loading || !!readOnly}
                 />
                 {/* Show generated ID */}
                 {isEditing ? (
@@ -1177,7 +1177,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                         }
                       }
                     }}
-                    disabled={loading || modelsLoading || availableModels.length === 0}
+                    disabled={loading || !!readOnly || modelsLoading || availableModels.length === 0}
                     className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {modelsLoading ? (
@@ -1213,7 +1213,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                       variant="outline"
                       size="sm"
                       className="h-7 text-xs gap-1 px-2 border-primary/30 text-primary hover:bg-primary/10"
-                      disabled={!canSuggest || loading}
+                      disabled={!canSuggest || loading || !!readOnly}
                       onClick={() => { setShowSuggestBasicInput((v) => { if (!v) setEnhanceExistingBasic(!!description.trim()); return !v; }); setShowSuggestPromptInput(false); }}
                       title={!name.trim() ? "Enter a name first" : !modelId ? "Select a model first" : "AI-generate description and theme"}
                     >
@@ -1285,7 +1285,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                   placeholder="What does this agent do?"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  disabled={loading}
+                  disabled={loading || !!readOnly}
                   rows={2}
                 />
               </div>
@@ -1308,7 +1308,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                           ? "border-primary bg-primary/10"
                           : "border-border hover:border-primary/50 hover:bg-muted/50"
                       )}
-                      disabled={loading}
+                      disabled={loading || !!readOnly}
                       title={theme.description}
                     >
                       <div
@@ -1339,7 +1339,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                           ? "border-primary bg-primary/10"
                           : "border-border hover:border-primary/50 hover:bg-muted/50"
                       )}
-                      disabled={loading}
+                      disabled={loading || !!readOnly}
                       title="Custom colors"
                     >
                       <div
@@ -1461,7 +1461,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                 ownerRequired
                 allowTransfer={isEditing}
                 resourceNoun="agent"
-                disabled={loading}
+                disabled={loading || !!readOnly}
                 showShare={visibility === "team"}
                 currentUserTeamSlugs={availableTeams
                   .map((team) => team.slug)
@@ -1567,7 +1567,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                                 ? "border-primary bg-primary/5"
                                 : "border-muted hover:border-primary/50"
                             } ${lockedByPlatformDefault ? "opacity-60 cursor-not-allowed" : ""}`}
-                            disabled={loading || lockedByPlatformDefault}
+                            disabled={loading || !!readOnly || lockedByPlatformDefault}
                           >
                             <div className="flex items-center gap-2 mb-1">
                               {opt.icon}
@@ -1621,7 +1621,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                       variant="outline"
                       size="sm"
                       className="h-7 text-xs gap-1 px-2 border-primary/30 text-primary hover:bg-primary/10"
-                      disabled={!canSuggest || loading}
+                      disabled={!canSuggest || loading || !!readOnly}
                       onClick={() => { setShowSuggestPromptInput((v) => { if (!v) setEnhanceExisting(!!systemPrompt.trim()); return !v; }); setShowSuggestBasicInput(false); }}
                       title={!name.trim() ? "Enter a name first" : !modelId ? "Select a model first" : "Generate system prompt with AI"}
                     >
@@ -1786,7 +1786,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                               indentOnInput: true,
                             }}
                             placeholder="You are a helpful AI assistant that specializes in..."
-                            editable={!loading && generatingField !== "system_prompt"}
+                            editable={!loading && !readOnly && generatingField !== "system_prompt"}
                           />
                         </React.Suspense>
                       </div>
@@ -1845,7 +1845,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
               <BuiltinToolsPicker
                 value={builtinTools}
                 onChange={setBuiltinTools}
-                disabled={loading}
+                disabled={loading || !!readOnly}
               />
 
               {/* MCP Tools */}
@@ -1861,7 +1861,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                 <AllowedToolsPicker
                   value={allowedTools}
                   onChange={setAllowedTools}
-                  disabled={loading}
+                  disabled={loading || !!readOnly}
                 />
               </div>
 
@@ -1870,7 +1870,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
                 <MiddlewarePicker
                   value={features}
                   onChange={setFeatures}
-                  disabled={loading}
+                  disabled={loading || !!readOnly}
                   availableModels={availableModels}
                 />
               </div>
@@ -1890,7 +1890,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
               <SkillsSelector
                 value={skills}
                 onChange={setSkills}
-                disabled={loading}
+                disabled={loading || !!readOnly}
               />
             </div>
           )}
@@ -1910,7 +1910,7 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
               setFeatures={setFeatures}
               availableModels={availableModels}
               setMiddlewareError={setMiddlewareError}
-              loading={loading}
+              loading={loading || !!readOnly}
               visibility={visibility}
             />
           )}

--- a/ui/src/components/dynamic-agents/InterruptConfigPicker.tsx
+++ b/ui/src/components/dynamic-agents/InterruptConfigPicker.tsx
@@ -393,7 +393,7 @@ export function InterruptConfigPicker({
                   variant="ghost"
                   size="sm"
                   onClick={() => toggleExpanded(row.id)}
-                  disabled={disabled || locked}
+                  disabled={locked}
                   className={cn("h-8 w-8 p-0", isExpanded && "text-primary")}
                   title="Configure allowed decisions"
                 >

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -238,7 +238,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-6">
-          <fieldset disabled={readOnly} className={readOnly ? "opacity-70" : ""}>
+          <fieldset className={readOnly ? "opacity-70" : ""}>
           {/* Basic Info */}
           <div className="space-y-4">
             <h3 className="text-sm font-medium">Basic Information</h3>
@@ -253,7 +253,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   placeholder="e.g., github, filesystem, postgres"
                   value={id}
                   onChange={(e) => setId(e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ""))}
-                  disabled={loading}
+                  disabled={loading || readOnly}
                   className="font-mono"
                 />
                 <p className="text-xs text-muted-foreground">
@@ -274,7 +274,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 placeholder="e.g., GitHub MCP Server"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                disabled={loading}
+                disabled={loading || readOnly}
               />
             </div>
 
@@ -285,7 +285,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 placeholder="What does this server provide?"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                disabled={loading}
+                disabled={loading || readOnly}
                 rows={2}
               />
             </div>
@@ -308,7 +308,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                         ? "border-primary bg-primary/5"
                         : "border-muted hover:border-primary/50"
                     }`}
-                    disabled={loading}
+                    disabled={loading || readOnly}
                   >
                     <div className="font-medium text-sm">{opt.label}</div>
                     <div className="text-xs text-muted-foreground">{opt.description}</div>
@@ -329,7 +329,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                     placeholder="e.g., npx, uvx, python"
                     value={command}
                     onChange={(e) => setCommand(e.target.value)}
-                    disabled={loading}
+                    disabled={loading || readOnly}
                     className="font-mono"
                   />
                 </div>
@@ -347,10 +347,10 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           handleAddArg();
                         }
                       }}
-                      disabled={loading}
+                      disabled={loading || readOnly}
                       className="font-mono"
                     />
-                    <Button type="button" variant="outline" onClick={handleAddArg} disabled={loading}>
+                    <Button type="button" variant="outline" onClick={handleAddArg} disabled={loading || readOnly}>
                       <Plus className="h-4 w-4" />
                     </Button>
                   </div>
@@ -362,6 +362,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           <button
                             type="button"
                             onClick={() => handleRemoveArg(i)}
+                            disabled={readOnly}
                             className="ml-1 hover:text-destructive"
                           >
                             <X className="h-3 w-3" />
@@ -380,7 +381,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       variant="ghost"
                       size="sm"
                       onClick={handleAddEnvVar}
-                      disabled={loading}
+                      disabled={loading || readOnly}
                     >
                       <Plus className="h-4 w-4 mr-1" />
                       Add
@@ -394,14 +395,14 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                             placeholder="KEY"
                             value={env.key}
                             onChange={(e) => handleUpdateEnvVar(i, "key", e.target.value)}
-                            disabled={loading}
+                            disabled={loading || readOnly}
                             className="font-mono flex-1"
                           />
                           <Input
                             placeholder="value"
                             value={env.value}
                             onChange={(e) => handleUpdateEnvVar(i, "value", e.target.value)}
-                            disabled={loading}
+                            disabled={loading || readOnly}
                             className="font-mono flex-[2]"
                           />
                           <Button
@@ -409,7 +410,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                             variant="ghost"
                             size="icon"
                             onClick={() => handleRemoveEnvVar(i)}
-                            disabled={loading}
+                            disabled={loading || readOnly}
                           >
                             <X className="h-4 w-4" />
                           </Button>
@@ -429,7 +430,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   placeholder={`e.g., http://localhost:3000/${transport === "sse" ? "sse" : "mcp"}`}
                   value={endpoint}
                   onChange={(e) => setEndpoint(e.target.value)}
-                  disabled={loading}
+                  disabled={loading || readOnly}
                   className="font-mono"
                 />
                 {gatewayDiscoveryLoaded && agentGatewayTargets.length > 0 ? (
@@ -478,7 +479,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 variant="ghost"
                 size="sm"
                 onClick={handleAddCredentialSource}
-                disabled={loading}
+                disabled={loading || readOnly}
               >
                 <Plus className="h-4 w-4 mr-1" />
                 Add Credential
@@ -493,6 +494,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       className="rounded-md border border-input bg-background px-3 py-2 text-sm"
                       value={source.kind}
                       onChange={(event) => handleUpdateCredentialSource(i, "kind", event.target.value)}
+                      disabled={readOnly}
                     >
                       <option value="secret_ref">Secret ref</option>
                       <option value="provider_connection">Provider connection</option>
@@ -502,6 +504,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       className="rounded-md border border-input bg-background px-3 py-2 text-sm"
                       value={source.target}
                       onChange={(event) => handleUpdateCredentialSource(i, "target", event.target.value)}
+                      disabled={readOnly}
                     >
                       <option value="env">Environment</option>
                       <option value="header">Header</option>
@@ -511,6 +514,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       placeholder={source.target === "env" ? "GITHUB_TOKEN" : "Authorization"}
                       value={source.name}
                       onChange={(event) => handleUpdateCredentialSource(i, "name", event.target.value)}
+                      disabled={readOnly}
                     />
                     <Input
                       aria-label="Credential reference"
@@ -523,13 +527,14 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           event.target.value,
                         )
                       }
+                      disabled={readOnly}
                     />
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
                       onClick={() => handleRemoveCredentialSource(i)}
-                      disabled={loading}
+                      disabled={loading || readOnly}
                     >
                       <X className="h-4 w-4" />
                     </Button>

--- a/ui/src/components/dynamic-agents/MiddlewarePicker.tsx
+++ b/ui/src/components/dynamic-agents/MiddlewarePicker.tsx
@@ -190,7 +190,6 @@ function MiddlewareEntryCard({
           type="button"
           onClick={() => setExpanded(!expanded)}
           className="flex items-center gap-1 text-muted-foreground hover:text-foreground"
-          disabled={disabled}
         >
           {expanded ? (
             <ChevronDown className="h-3.5 w-3.5" />

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.9"
+version = "0.5.9.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Config-driven agents had their entire form wrapped in `<fieldset disabled>`, which blocked expand/collapse toggles in addition to editing controls
- Remove `disabled={readOnly}` from fieldsets in `DynamicAgentEditor` and `MCPServerEditor`; propagate `readOnly` to each individual editing control instead
- Remove `disabled={disabled}` from expand buttons in `MiddlewarePicker` and `InterruptConfigPicker` so sections can be opened to view configuration
- Allow the Probe button in `AllowedToolsPicker` to work in read-only mode (fetches tool list, does not mutate)

All editing controls (inputs, selects, toggles, add/remove buttons) remain disabled for config-driven agents — users can view but not change anything.

## Test plan

- [ ] Open a config-driven agent (shows "Config" badge in the agents list)
- [ ] Navigate to the Tools tab — verify MCP server sections can be expanded to view tools
- [ ] Navigate to the Tools tab — verify middleware sections can be expanded to view params
- [ ] Navigate to the Advanced tab — verify Subagents, Human Approval, Middleware, and Workflows sections can be expanded
- [ ] Verify all inputs, selects, toggles, and add/remove buttons remain disabled/non-interactive
- [ ] Verify a non-config-driven agent still works normally (editable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)