### PR TITLE
docs(specs): Service Accounts feature spec (#1677)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,4 @@ Before committing code changes, run relevant checks:
 - MongoDB (server-side via API), Zustand store (client-side) (093-fix-audit-chat-active-preserve)
 - Python + Slack Bolt, Slack SDK, httpx (SSE streaming), Pydantic (config models), requests, loguru, PyYAML — no new dependencies (100-slack-agui-migration)
 - MongoDB (LangGraph checkpointer on dynamic agents side; Slack bot is stateless beyond in-memory TTL caches) (100-slack-agui-migration)
+- Service accounts: dynamic Keycloak confidential clients + OpenFGA `service_account` tuples + Mongo `service_accounts` collection; BFF (Next.js) orchestrates create/rotate/revoke/scope; caller-keyed tool authz added to the OpenFGA ext_authz bridge (2026-06-05-service-accounts)

--- a/docs/docs/specs/2026-06-05-service-accounts/checklists/requirements.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/checklists/requirements.md
@@ -1,0 +1,46 @@
+# Specification Quality Checklist: Service Accounts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- RESOLVED: owning-team deletion behavior — team deletion is blocked while the team owns any service
+  accounts (FR-025, SC-008). No [NEEDS CLARIFICATION] markers remain.
+- Implementation choices (reuse `service_account` OpenFGA type, dynamic Keycloak client per SA, BFF
+  validation, tuple shapes) were intentionally kept OUT of the spec and live in the working notes at
+  `.claude/tickets/service-accounts-1677/` (DECISIONS.md, PLAN.md, DISCREPANCY-tool-authz.md). They
+  belong in `plan.md`, not the spec.
+- Caller-keyed tool authorization is NOW IN SCOPE for this work (was previously framed as an external
+  dependency). Confirmed by platform owner Sri in the RBAC Slack thread (2026-06-05) as a real gap
+  affecting all human users — "we need to fix it, should be a quick fix." Captured as FR-012a/FR-012b
+  + SC-010 + the "In-Scope Platform Change" section.
+- Clarifications session 2026-06-05 resolved: auditing (FR-026/FR-027/SC-009), name uniqueness
+  (FR-002a), revocation semantics (FR-018a), and the caller-keyed gap being in-scope (FR-012a/012b,
+  superseding the earlier flag/preview-gating answer).

--- a/docs/docs/specs/2026-06-05-service-accounts/contracts/service-accounts-api.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/contracts/service-accounts-api.md
@@ -1,0 +1,152 @@
+# API Contract: Service Accounts (BFF)
+
+All routes under `ui/src/app/api/admin/service-accounts/`. All require an authenticated session.
+All responses use the repo's `{ success, data?, error? }` envelope. Authorization is enforced
+per-route (team membership / `service_account#can_manage`) regardless of UI state.
+
+Common errors: `401` (unauthenticated), `403` (not a member of the relevant team / lacks
+`can_manage`), `404` (SA not found or not visible to caller), `409` (name conflict), `503` (Mongo or
+Keycloak/OpenFGA unavailable).
+
+---
+
+## `GET /api/admin/service-accounts`
+List service accounts the caller can manage (active SAs in teams the caller belongs to). *(FR-014, FR-021)*
+
+**Response 200**
+```json
+{ "success": true, "data": { "items": [
+  { "id": "<sa_sub>", "name": "incident-bot", "description": "PagerDuty",
+    "owning_team_id": "team-sre", "created_by": "<uuid>", "created_at": "…",
+    "status": "active", "scope_counts": { "agents": 2, "tools": 5 } }
+] } }
+```
+Never returns credential material. Revoked SAs excluded by default (`?include_revoked=true` optional).
+
+---
+
+## `POST /api/admin/service-accounts`
+Create a service account. *(US1; FR-001..FR-008)*
+
+**Request**
+```json
+{ "name": "incident-bot", "description": "PagerDuty integration",
+  "owning_team_id": "team-sre",
+  "scopes": [ { "type": "agent", "ref": "incident-resolver" },
+              { "type": "tool",  "ref": "jira/search" } ] }
+```
+
+**Server flow**
+1. `check(user:<caller>, member, team:<owning_team_id>)` → else `403`. *(FR-002)*
+2. Name unique among active SAs in team → else `409`. *(FR-002a)*
+3. For each requested scope: `check(user:<caller>, <rel>, <object>)`; drop/reject any not held.
+   Reject the whole request if any requested scope is unauthorized (return which). *(FR-006/008)*
+4. Keycloak: create confidential client → read back `client_uuid`, `client_secret`, and
+   service-account-user `sub`. *(WS-B)*
+5. OpenFGA: write `owner_team` tuple + one tuple per granted scope. *(data-model)*
+6. Mongo: insert `service_accounts` doc (status `active`, `scopes_snapshot`).
+7. Audit: `service_account.create`. *(FR-026)*
+
+**Response 201** — the ONLY time the secret is returned. *(FR-005)*
+```json
+{ "success": true, "data": {
+  "id": "<sa_sub>", "name": "incident-bot", "owning_team_id": "team-sre",
+  "credential": { "client_id": "caipe-sa-incident-bot-a1b2c3", "client_secret": "<shown once>",
+                  "token_url": "https://…/realms/caipe/protocol/openid-connect/token" },
+  "granted_scopes": [ … ], "rejected_scopes": [] } }
+```
+
+---
+
+## `GET /api/admin/service-accounts/:id`
+Detail + current scopes (read from OpenFGA, not the snapshot). *(FR-014)*
+`403` unless `check(user:<caller>, can_manage, service_account:<id>)`.
+
+```json
+{ "success": true, "data": {
+  "id": "<sa_sub>", "name": "incident-bot", "description": "…", "owning_team_id": "team-sre",
+  "created_by": "<uuid>", "created_at": "…", "status": "active",
+  "scopes": [ { "type": "agent", "ref": "incident-resolver" },
+              { "type": "tool",  "ref": "jira/search" } ] } }
+```
+
+---
+
+## `POST /api/admin/service-accounts/:id/scopes`
+Add a scope. *(US3; FR-015)*
+
+**Request**: `{ "type": "agent" | "tool", "ref": "<id or server/tool>" }`
+
+**Flow**: `check(can_manage)` → then `check(user:<editor>, <rel>, <object>)` (editor must hold it,
+else `403`) → write tuple → update snapshot → audit `service_account.scope_add`. *(FR-015/026)*
+
+---
+
+## `DELETE /api/admin/service-accounts/:id/scopes`
+Remove a scope. *(US3; FR-016)*
+
+**Request**: `{ "type": "agent" | "tool", "ref": "<…>" }`
+
+**Flow**: `check(can_manage)` ONLY (no requirement that the editor holds the scope) → delete tuple →
+update snapshot → audit `service_account.scope_remove`. *(FR-016/026)*
+
+---
+
+## `POST /api/admin/service-accounts/:id/rotate`
+Rotate the credential. *(US4; FR-017/019)*
+
+**Flow**: `check(can_manage)` → Keycloak `POST /clients/{client_uuid}/client-secret` → audit
+`service_account.rotate`. Scopes unchanged.
+
+**Response 200** — new secret shown ONCE:
+```json
+{ "success": true, "data": { "credential": {
+  "client_id": "caipe-sa-incident-bot-a1b2c3", "client_secret": "<new — shown once>",
+  "token_url": "…" } } }
+```
+
+---
+
+## `DELETE /api/admin/service-accounts/:id`
+Revoke (terminal). *(US4; FR-018/018a)*
+
+**Flow**: `check(can_manage)` → delete Keycloak client → delete ALL OpenFGA tuples for
+`service_account:<id>` (ownership + scopes) → mark Mongo `status: "revoked"`, `revoked_at` (retain
+doc for audit) → audit `service_account.revoke`. Name freed for reuse in the team. *(FR-018a)*
+
+**Response 200**: `{ "success": true, "data": { "id": "<sa_sub>", "status": "revoked" } }`
+
+---
+
+## `GET /api/admin/service-accounts/grantable`
+List the agents and tools the **calling user** currently holds, to populate the create/add-scope
+picker. *(FR-009)*
+
+`?team_id=` optional (does not affect the grantable set — that's the user's own perms, FR-007 — but
+may be used to pre-select the owning team).
+
+```json
+{ "success": true, "data": {
+  "agents": [ { "ref": "incident-resolver", "name": "Incident Resolver" } ],
+  "tools":  [ { "ref": "jira/search", "name": "Jira: search" },
+              { "ref": "jira/*", "name": "Jira: all tools" } ] } }
+```
+Backed by `listOpenFgaObjects(user:<caller>, can_use, agent)` and the tool equivalent. *(R-8)*
+
+---
+
+## Authentication for the resulting service account (out-of-band, not a BFF route)
+
+The SA authenticates to CAIPE like any caller — it is NOT a special endpoint:
+```
+POST {token_url}                              # Keycloak
+  grant_type=client_credentials&client_id=…&client_secret=…
+  → { access_token: <JWT, sub=sa_sub, preferred_username=service-account-…, client_id=…> }
+
+POST {CAIPE_API_URL}/api/v1/chat/invoke       # BFF (same route browsers/Slack use)
+  Authorization: Bearer <JWT>
+  → BFF validates (isServiceAccount=true) → forwards JWT to DA
+  → DA: check service_account:<sub> can_use agent:<id>           (WS-G fix)
+  → Gateway bridge per tool: agent can_call tool AND service_account:<sub> can_call tool  (WS-F)
+```
+*(FR-010/011/012/013)*

--- a/docs/docs/specs/2026-06-05-service-accounts/data-model.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/data-model.md
@@ -1,0 +1,130 @@
+# Phase 1 Data Model: Service Accounts
+
+Three stores of record, each authoritative for a different concern:
+
+| Store | Owns | Source of truth for |
+|-------|------|---------------------|
+| **Keycloak** | the confidential client + its secret | the **credential** (identity) |
+| **OpenFGA** | tuples on `service_account:<sub>` | **access** (ownership + scopes) |
+| **MongoDB** | `service_accounts` document | **display metadata** (name, description, status, links) |
+
+The Mongo doc is a convenience/index layer. Access decisions never read it; they read OpenFGA. The
+credential is never stored anywhere in CAIPE — Keycloak holds it and shows it once.
+
+---
+
+## Entity: Service Account
+
+### MongoDB document — collection `service_accounts`
+
+```ts
+// ui/src/types/mongodb.ts
+export interface ServiceAccount {
+  _id?: ObjectId;
+  sa_sub: string;            // Keycloak service-account-user UUID — the OpenFGA subject id. UNIQUE.
+  client_id: string;         // Keycloak clientId, e.g. "caipe-sa-incident-bot-a1b2c3". UNIQUE.
+  client_uuid: string;       // Keycloak internal client UUID (for admin API calls: secret/delete).
+  name: string;              // Human-friendly name, unique among ACTIVE SAs within owning_team_id.
+  description?: string;
+  owning_team_id: string;    // The single owning team (team slug/id used in OpenFGA team:<id>).
+  created_by: string;        // Keycloak sub of the creating user (audit/display).
+  created_at: Date;
+  status: "active" | "revoked";
+  revoked_at?: Date | null;
+  // Display cache ONLY — not authoritative. OpenFGA tuples are the source of truth for access.
+  scopes_snapshot?: ServiceAccountScope[];
+}
+
+export interface ServiceAccountScope {
+  type: "agent" | "tool";
+  // For agent: the agent id. For tool: "<server>/<toolname>" or "<server>/*".
+  ref: string;
+  added_by: string;          // Keycloak sub of who added this scope (audit).
+  added_at: Date;
+}
+```
+
+**No credential material is persisted** — no secret, no hash. (Contrast with `catalog_api_keys`,
+which stores a hash; here Keycloak owns the secret entirely.)
+
+### Indexes (created in `ui/src/lib/mongodb.ts` `createIndexes()`)
+
+| Index | Type | Why |
+|-------|------|-----|
+| `{ sa_sub: 1 }` | unique | primary lookup by OpenFGA subject; one SA per Keycloak SA user |
+| `{ client_id: 1 }` | unique | uniqueness of Keycloak client; lookup |
+| `{ owning_team_id: 1, status: 1 }` | compound | list active SAs for a team (the main list query) |
+| `{ owning_team_id: 1, name: 1, status: 1 }` | compound | enforce name-unique-among-active-in-team (FR-002a) |
+| `{ created_by: 1 }` | — | audit / "created by me" filters |
+
+> Name uniqueness (FR-002a) is enforced at the **application layer** on create (query active SAs in
+> the team for the name), not via a partial unique index, to keep the "freed on revoke" semantics
+> (FR-018a) simple and explicit. Documented as a deliberate choice.
+
+### State transitions
+
+```
+(none) ──create──▶ active ──rotate──▶ active        (credential changes; status unchanged)
+                     │
+                     ├──add-scope / remove-scope──▶ active   (OpenFGA tuples change; doc.scopes_snapshot updated)
+                     │
+                     └──revoke──▶ revoked            (TERMINAL — FR-018a; Keycloak client deleted, tuples removed)
+```
+
+- `revoked` is terminal and irreversible. The doc is retained for audit; excluded from the active
+  list; its `name` becomes reusable within the team (uniqueness is among `active` only).
+
+---
+
+## OpenFGA tuples (authoritative for access)
+
+Written/removed by the BFF routes. `<sub>` = `sa_sub`; `<team>` = `owning_team_id`.
+
+| Purpose | Tuple | Written when | Removed when |
+|---------|-------|--------------|--------------|
+| Ownership | `team:<team>#member` → `owner_team` → `service_account:<sub>` | create | revoke |
+| Agent grant | `service_account:<sub>` → `can_use` → `agent:<id>` | create / add-scope | remove-scope / revoke |
+| Tool grant | `service_account:<sub>` → `can_call` → `tool:<server>/<tool>` (or `…/*`) | create / add-scope | remove-scope / revoke |
+
+Management authority derives from ownership: `service_account:<sub>#can_manage` = `owner_team`
+(= any `team:<team>#member`). BFF authorizes manage actions with
+`check(user:<editor>, can_manage, service_account:<sub>)`.
+
+### Model change (`deploy/openfga/model.fga`, mirrored into `authorization-model.json`)
+
+```
+type service_account
+  relations
+    define owner_team: [team#member]
+    define can_manage: owner_team
+```
+(`service_account` is subject-only today; this is additive. `tool#caller` already permits `user` and
+`service_account` — no change needed there.)
+
+---
+
+## Validation rules (from spec FRs)
+
+- **FR-002**: `owning_team_id` MUST be a team the creating user belongs to (`check(user, member, team)`).
+- **FR-002a**: `name` unique among `active` SAs within `owning_team_id`, compared **case-insensitively**
+  (FR-002a). T007 normalizes (lowercases) the name for the uniqueness check; the original-cased name
+  is stored for display.
+- **FR-004**: a new SA has zero scope tuples until grants are written.
+- **FR-006/008/015**: every agent/tool grant write is preceded by
+  `check(user:<editor>, <relation>, <object>)`; reject on false.
+- **FR-016**: scope removal requires only `check(user:<editor>, can_manage, service_account:<sub>)`
+  (owning-team membership) — NOT holding the scope.
+- **FR-020**: scopes are static; no process re-derives them from the creator over time.
+- **FR-025**: team deletion blocked while any `service_account:<sub> owner_team team:<team>` exists.
+
+---
+
+## Entity relationships
+
+```
+team (1) ──owns──▶ (N) service_account ──grants──▶ (N) agent
+                                        └─grants──▶ (N) tool
+service_account (1) ◀──identity── (1) keycloak client ──has──▶ (1) client_secret  [shown once]
+user (creator) ──created──▶ service_account        (audit only; no ongoing authority)
+user (owning-team member) ──can_manage──▶ service_account   (via team membership)
+```

--- a/docs/docs/specs/2026-06-05-service-accounts/mongodb-migration.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/mongodb-migration.md
@@ -1,0 +1,56 @@
+# MongoDB Migration: Service Accounts
+
+**Required or no-op**: **No operator action required.** Additive only. The new `service_accounts`
+collection and its indexes are created automatically on first connection via the existing
+`createIndexes()` path in `ui/src/lib/mongodb.ts` (same mechanism as every other collection in the
+repo). No DDL, no `renameCollection`, no Alembic/Flyway-style migration.
+
+## Schema / index changes
+
+New collection: **`service_accounts`**. Document shape and rationale in
+[data-model.md](./data-model.md).
+
+Indexes to add to `createIndexes()` (mirroring how `catalog_api_keys` and others are registered):
+
+```ts
+safeCreateIndex(db, 'service_accounts', { sa_sub: 1 }, { unique: true });
+safeCreateIndex(db, 'service_accounts', { client_id: 1 }, { unique: true });
+safeCreateIndex(db, 'service_accounts', { owning_team_id: 1, status: 1 });
+safeCreateIndex(db, 'service_accounts', { owning_team_id: 1, name: 1, status: 1 });
+safeCreateIndex(db, 'service_accounts', { created_by: 1 });
+```
+
+Query patterns justifying each:
+- `{ sa_sub }` unique — auth/detail lookup by OpenFGA subject; one SA per Keycloak SA user.
+- `{ client_id }` unique — Keycloak client uniqueness + admin lookups.
+- `{ owning_team_id, status }` — the list endpoint (active SAs for the caller's teams).
+- `{ owning_team_id, name, status }` — name-uniqueness check among active SAs (FR-002a).
+- `{ created_by }` — audit / "created by me".
+
+## Data movement
+
+**None.** No backfill, no dedupe, no batch jobs. Existing deployments start with an empty
+collection; SAs appear only as users create them.
+
+## Rollback
+
+- Drop the `service_accounts` collection (`db.service_accounts.drop()`).
+- OpenFGA tuples (`service_account:*`) and Keycloak SA clients are **independent** of the Mongo
+  collection. If rolling the feature back fully, also: revoke each SA (deletes its Keycloak client +
+  OpenFGA tuples) before dropping the collection, OR clean up orphaned Keycloak clients
+  (`clientId` prefix `caipe-sa-`) and tuples manually. Dropping Mongo alone leaves those orphaned but
+  harmless (no UI path to them).
+
+## Environments
+
+No environment-specific differences. Dev (docker-compose) and prod (Helm) both create indexes on
+first connect. The Keycloak admin credential (`KEYCLOAK_ADMIN_CLIENT_ID/SECRET`, already present for
+existing admin reconciliation) must be configured — verified that `caipe-platform` holds
+`manage-clients`.
+
+## OpenFGA model deploy (related, not a Mongo migration)
+
+The `service_account` ownership relation (R-1) requires recompiling `deploy/openfga/model.fga` into
+`charts/ai-platform-engineering/charts/openfga/authorization-model.json` and re-seeding via
+`deploy/openfga/init/seed.py`. This is additive (new relation on an existing type); existing tuples
+and checks are unaffected. Tracked in WS-A, not here.

--- a/docs/docs/specs/2026-06-05-service-accounts/plan.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/plan.md
@@ -1,0 +1,216 @@
+# Implementation Plan: Service Accounts
+
+**Branch**: `2026-06-05-service-accounts` | **Date**: 2026-06-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `docs/docs/specs/2026-06-05-service-accounts/spec.md`
+
+## Summary
+
+Self-service, team-owned **service accounts**: named bot identities with their own Keycloak
+credential and their own OpenFGA-scoped access to agents and tools, bounded at creation by the
+creating user's own permissions. Managed from a new **Admin → Settings → Service Accounts** tab.
+
+Technical approach (all verified against current code — see [research.md](./research.md)):
+
+- **Identity** = a dynamically-created Keycloak confidential client (`serviceAccountsEnabled`), one
+  per service account. The client's service-account-user `sub` (UUID) is the OpenFGA subject id.
+- **Authorization** = OpenFGA tuples on the existing `service_account` type (extended with an
+  `owner_team` ownership relation). Grants mirror existing patterns: `service_account:<sub> can_use
+  agent:<id>` and `service_account:<sub> can_call tool:<server>/<tool>`.
+- **Management state** = a new Mongo `service_accounts` collection (display/metadata only; OpenFGA
+  is the source of truth for access; Keycloak owns the credential).
+- **Auth at call time** = the SA presents a Keycloak client-credentials JWT; the existing BFF JWKS
+  path already resolves it to `service_account:<sub>`. Two server-side fixes are required for the
+  identity to be honored end-to-end (DA backend + AgentGateway bridge — see below).
+- **In-scope platform fix (FR-012a/b)** = add a **caller-keyed** tool-authorization check to the
+  AgentGateway ext_authz bridge, ANDed with the existing agent-keyed check, for both `user` and
+  `service_account` subjects. Closes a pre-existing confused-deputy gap affecting human users too.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Next.js 14 App Router, React) for BFF + UI; Python 3.11 for the
+DA backend and the OpenFGA ext_authz bridge.
+**Primary Dependencies**: Next.js, MongoDB Node driver, Keycloak Admin REST API, OpenFGA HTTP API,
+`jose` (JWT), Radix UI + Tailwind; Python `httpx`, `pyjwt`, FastAPI/Starlette.
+**Storage**: MongoDB — new `service_accounts` collection. OpenFGA store holds authorization tuples.
+Keycloak holds the client credential. (See [mongodb-migration.md](./mongodb-migration.md).)
+**Testing**: Jest (TS — BFF lib + routes + components), pytest (Python — bridge + DA authz).
+**Target Platform**: Kubernetes (Helm) and docker-compose; all external traffic flows through the
+Next.js BFF (the DA backend is ClusterIP-only — verified).
+**Project Type**: Web application (Next.js BFF/UI + Python services).
+**Performance Goals**: No new latency budget beyond existing auth checks. Create/rotate/revoke are
+interactive admin actions (sub-second to a few seconds incl. Keycloak round-trips). The new
+caller-keyed tool check adds one OpenFGA `check` (+ one wildcard fallback) per tool call, parallel
+in cost to the existing agent-keyed check.
+**Constraints**: No secrets in source (Keycloak owns the credential; we never persist it). All
+scope writes guarded by an OpenFGA `check` regardless of UI. Defense in depth (UI list-objects +
+write-time check + runtime enforcement).
+**Scale/Scope**: Tens to low-hundreds of service accounts per deployment; not a hot path.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Worse is Better / II. YAGNI** — ✅ One credential per SA (no multi-token), no expiry in v1,
+  Mongo metadata only (no inline scope copies as truth). We reuse `service_account`, existing
+  Keycloak admin patterns, existing JWKS validation, and the existing bridge structure rather than
+  building new abstractions.
+- **III. Rule of Three** — ✅ `createServiceAccountClient`/`regenerate`/`delete` are net-new but
+  each is a single concrete need; we mirror existing `keycloak-admin.ts` helpers, not a framework.
+- **IV. Composition over Inheritance** — ✅ Plain functions + a lib wrapper (`service-accounts.ts`)
+  mirroring `catalog-api-keys.ts`. No class hierarchy.
+- **V. Specs as Source of Truth** — ✅ This plan derives from the approved spec; FR references
+  throughout.
+- **VI. CI Gates** — ✅ New TS code covered by Jest; bridge + DA changes covered by pytest. Lint
+  (ruff/eslint) applies.
+- **VII. Security by Default** — ✅ Credential never stored; write-time OpenFGA `check` on every
+  grant; the in-scope bridge fix *removes* a privilege-escalation surface. The SA subject is honored
+  at every enforcement layer (BFF, DA, gateway).
+
+**No violations.** Complexity Tracking table omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+docs/docs/specs/2026-06-05-service-accounts/
+├── spec.md              # Approved feature spec
+├── plan.md              # This file
+├── research.md          # Phase 0 — verified findings + decisions
+├── data-model.md        # Phase 1 — Mongo doc + OpenFGA tuples + entities
+├── mongodb-migration.md # Phase 1 — collection + indexes (storage involved)
+├── quickstart.md        # Phase 1 — end-to-end validation scenarios
+├── contracts/
+│   └── service-accounts-api.md   # BFF REST contracts
+└── checklists/
+    └── requirements.md  # spec quality checklist (already present)
+```
+
+### Source Code (repository root)
+
+```text
+ui/                                         # Next.js BFF + UI
+├── src/lib/
+│   ├── service-accounts.ts                 # NEW — Mongo lib wrapper (mirrors catalog-api-keys.ts)
+│   ├── rbac/
+│   │   ├── keycloak-admin.ts               # EDIT — add createServiceAccountClient/regenerate/delete/get-sa-user
+│   │   └── openfga.ts                       # REUSE — checkOpenFgaTuple / listOpenFgaObjects / writeOpenFgaTuples
+│   ├── mongodb.ts                           # EDIT — register service_accounts indexes
+│   └── types/mongodb.ts                     # EDIT — ServiceAccount document interface
+├── src/app/api/admin/service-accounts/      # NEW — BFF routes (see contracts/)
+│   ├── route.ts                             #   GET (list), POST (create)
+│   └── [id]/
+│       ├── route.ts                         #   GET (detail), DELETE (revoke)
+│       ├── rotate/route.ts                  #   POST (rotate credential)
+│       └── scopes/route.ts                  #   POST (add scope), DELETE (remove scope)
+├── src/app/api/admin/service-accounts/grantable/route.ts  # NEW — list user-grantable agents/tools
+└── src/components/admin/
+    └── ServiceAccountsTab.tsx               # NEW — tab UI (+ create dialog, see-once reveal, manage)
+
+ui/src/app/(app)/admin/page.tsx              # EDIT — register the Service Accounts tab in CATEGORIES
+
+ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
+                                             # EDIT — namespace subject service_account: vs user: (BUG FIX)
+
+deploy/openfga/
+├── model.fga                                # EDIT — add owner_team + can_manage to service_account
+└── bridge/main.py                           # EDIT — caller-keyed tool check + subject namespacing
+deploy/openfga/bridge/tests/test_grpc_bridge.py   # EDIT — new caller-keyed test cases
+charts/ai-platform-engineering/charts/openfga/authorization-model.json
+                                             # EDIT — recompiled model JSON (mirror model.fga)
+
+docs/docs/security/rbac/                      # EDIT — architecture + workflows (SA identity layer)
+```
+
+**Structure Decision**: Web-application layout. The feature is BFF/UI-centric (TypeScript), with two
+targeted Python edits at the enforcement layers (DA backend agent-use check; gateway bridge tool
+check) and a model change. No new services.
+
+## Workstreams & Sequencing
+
+Ordered so each is independently testable (maps to spec user stories). **WS-A and WS-F are the two
+server-side enablers**; the UI/BFF stack (WS-B…E) can be built in parallel against them.
+
+### WS-A — OpenFGA model: ownership relation *(enables US1, US5)*
+Promote `service_account` from subject-only to:
+```
+type service_account
+  relations
+    define owner_team: [team#member]
+    define can_manage: owner_team
+```
+Recompile `model.fga` → `charts/.../authorization-model.json`; confirm `deploy/openfga/init/seed.py`
+applies it. Purely additive — `service_account` as a *subject* elsewhere is unchanged.
+**Verified**: `tool#caller` already permits `user` + `service_account`, so the caller-keyed fix
+(WS-F) needs **no** model change beyond this ownership relation.
+
+### WS-B — Keycloak dynamic client provisioning *(enables US1, US4)*
+Add to `ui/src/lib/rbac/keycloak-admin.ts`, mirroring existing `adminFetch`/`assertOk` patterns:
+- `createServiceAccountClient(name)` → `POST /clients` (confidential, `serviceAccountsEnabled: true`,
+  `standardFlowEnabled: false`, `directAccessGrantsEnabled: false`), then read back the client UUID,
+  its generated secret, and its `service-account-user` `sub`.
+- `regenerateClientSecret(clientUuid)` → `POST /clients/{id}/client-secret` (rotation).
+- `deleteServiceAccountClient(clientUuid)` → `DELETE /clients/{id}` (revoke).
+**Verified**: admin client `caipe-platform` already holds `manage-clients`. Client shape mirrors
+`caipe-slack-bot`. Naming: `caipe-sa-<slug>-<short-rand>`.
+
+### WS-C — Mongo collection + lib wrapper *(enables US1, US5)*
+`ServiceAccount` interface in `types/mongodb.ts`; indexes in `mongodb.ts`; `service-accounts.ts`
+wrapper (create/list-by-teams/get/update-status) mirroring `catalog-api-keys.ts`. No secret/hash
+stored. See [data-model.md](./data-model.md) + [mongodb-migration.md](./mongodb-migration.md).
+
+### WS-D — BFF API routes *(enables US1–US5)*
+Create/list/detail/rotate/revoke + scope add/remove + grantable-resources. Each route: authorize
+caller (team membership / `service_account#can_manage`), then orchestrate Keycloak + OpenFGA + Mongo.
+Every scope add re-checks `check(user:<editor>, <rel>, <obj>)` (FR-008/FR-015); removes are
+unconditional for owning-team members (FR-016). See [contracts/](./contracts/service-accounts-api.md).
+
+### WS-E — UI tab *(enables US1, US3, US4, US5)*
+`ServiceAccountsTab.tsx` registered in `admin/page.tsx` CATEGORIES (settings group). Create dialog
+(name, description, owning-team picker, grantable scope picker), one-time credential reveal
+(`CopyButton` + see-once dialog), list, and manage view (scopes add/remove, rotate, revoke with
+confirm). **Open item**: admin page is gated by `canViewAdmin`/`isAdmin` today, but the spec wants
+self-service for any team member — resolved in research.md (R-7); the tab is gated on team
+membership, not admin role.
+
+### WS-F — Caller-keyed tool authorization (in-scope platform fix) *(enables US2 / FR-012)*
+In `deploy/openfga/bridge/main.py`:
+- Decode `client_id` from the validated JWT to namespace the subject as `service_account:<sub>` vs
+  `user:<sub>`.
+- After the existing `agent:<id> can_call tool:...` check, ADD a caller-keyed check
+  `<subject> can_call tool:<server>/<tool>` (with `tool:<server>/*` wildcard fallback). A tool call
+  is allowed only if **both** pass. New deny reason `DENY_CALLER_TOOL`.
+- Mirror existing tests in `test_grpc_bridge.py` for user-missing-tool, SA-success, SA-missing-tool.
+**Verified**: model already allows both subjects on `tool#caller`; no model change here.
+
+### WS-G — DA backend subject namespacing (bug fix) *(enables US2 / FR-011)*
+`ai_platform_engineering/dynamic_agents/.../auth/openfga_authz.py` `_check_agent_use` currently
+hardcodes `user:{subject}`. Detect service-account tokens (via `preferred_username` starting
+`service-account-` or the `client_id` claim) and check `service_account:<sub> can_use agent:<id>`
+for them. Without this, agent invocation by an SA is wrongly denied. Add pytest coverage.
+
+### WS-H — Docs
+`docs/docs/security/rbac/architecture.md` (SA identity layer) + `workflows.md` (create + external
+call sequence diagrams, and the new dual agent+caller tool check).
+
+## Database migrations
+
+See [mongodb-migration.md](./mongodb-migration.md). Summary: additive — one new collection
+(`service_accounts`) with indexes created on first connect via the existing `createIndexes()` path
+in `ui/src/lib/mongodb.ts`. No backfill, no data movement. Rollback = drop the collection; OpenFGA
+tuples and Keycloak clients are cleaned up by revoke flows (or manually) and are independent of the
+Mongo collection.
+
+## Complexity Tracking
+
+No constitution violations — table omitted.
+
+## Open items carried to /speckit.tasks
+
+- **R-7 (UI gating)**: confirm the Service Accounts tab is shown on team membership, not `isAdmin`
+  — may need a small gate addition (`canViewAdmin` currently fronts the admin page). See research.md.
+- **Subject-detection consistency**: BFF uses `preferred_username` (`service-account-`); the bridge
+  will use `client_id`. Ensure DA backend (WS-G) and bridge (WS-F) agree on the rule so the same
+  token always namespaces identically across layers. Tracked in research.md R-2/R-3.
+- **Team-deletion guard (FR-025)**: where to enforce — locate the team-delete path and add the
+  "owns service accounts?" check. Not yet code-located; flagged for tasks.

--- a/docs/docs/specs/2026-06-05-service-accounts/quickstart.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart / Validation Scenarios: Service Accounts
+
+End-to-end scenarios that validate the spec's acceptance criteria. Use these as the manual smoke
+test and as the basis for integration tests. Assumes a dev stack (docker-compose) with Keycloak,
+OpenFGA, MongoDB, BFF, DA backend, and AgentGateway + the OpenFGA ext_authz bridge enabled.
+
+## Preconditions
+- A test user **Alice** in team **`team-sre`** with `can_use agent:incident-resolver` and
+  `can_call tool:jira/search` (but NOT `tool:github/create_issue`).
+- A second user **Bob** in team **`team-marketing`** only (no overlap with Alice).
+- AgentGateway bridge enabled with `CAIPE_AGENT_CONTEXT_HMAC_SECRET` set (so tool checks run).
+
+---
+
+## S1 — Create a scoped service account *(US1; FR-001..FR-009)*
+1. As Alice, open **Admin → Settings → Service Accounts** → **Create**.
+2. Confirm the owning-team dropdown lists **team-sre** (Alice's team).
+3. Confirm the scope picker offers **incident-resolver** and **jira/search**, and does NOT offer
+   `github/create_issue` (Alice lacks it). *(FR-009)*
+4. Name it `incident-bot`, select both offered scopes, submit.
+5. **Expect**: 201; credential (`client_id` + `client_secret` + token URL) shown **once**. *(FR-005)*
+6. Dismiss the dialog, reopen the SA → **Expect**: no way to see the secret again. *(FR-005)*
+
+**Pass**: SA created, owned by team-sre, two scope tuples written, secret revealed once.
+
+## S2 — Default-deny on creation *(FR-004)*
+Create `empty-bot` with NO scopes selected → **Expect**: created with zero grants; any later call it
+makes is denied until scopes are added.
+
+## S3 — Permission bound is enforced at write time *(FR-006/008)*
+Via API (bypassing the UI), `POST /service-accounts` with a scope Alice lacks
+(`tool:github/create_issue`) → **Expect**: `403`/rejected, that scope not written, response names the
+rejected scope.
+
+## S4 — Use the service account from outside *(US2; FR-010/011)*
+1. `POST {token_url}` with `grant_type=client_credentials` + the SA's client_id/secret → get JWT.
+   Confirm `sub` = the SA's UUID and `preferred_username` = `service-account-caipe-sa-incident-bot-…`.
+2. `POST {CAIPE_API_URL}/api/v1/chat/invoke` with `Authorization: Bearer <JWT>` targeting
+   `incident-resolver`.
+3. **Expect**: authenticated as `service_account:<sub>`, agent-use allowed, agent runs. *(validates
+   the WS-G DA fix — without it this wrongly 403s)*
+
+## S5 — Agent access does NOT leak tool access *(US2; FR-012 — validates WS-F)*
+1. Grant the SA `agent:incident-resolver` but NOT `tool:jira/search` (remove it if present).
+2. Have the agent attempt a `jira/search` tool call under the SA's token.
+3. **Expect**: tool call **denied** (`DENY_CALLER_TOOL`) even though `agent:incident-resolver
+   can_call tool:jira/search` — because the SA caller lacks the tool grant.
+4. Add `tool:jira/search` to the SA; retry → **Expect**: allowed (both agent and caller authorized).
+
+## S5b — Human-user regression (the pre-existing gap) *(FR-012b — validates WS-F for users)*
+1. As a user with `can_use agent:incident-resolver` but NOT `can_call tool:jira/search`, invoke the
+   agent so it would call `jira/search`.
+2. **Expect (post-fix)**: tool call **denied** for the human user too. (Pre-fix this leaked.)
+
+## S6 — Manage scopes after creation *(US3; FR-015/016)*
+1. As Alice (owning-team member), add `tool:jira/search` she holds → **Expect**: succeeds.
+2. Add `tool:github/create_issue` she does NOT hold → **Expect**: `403`. *(FR-015)*
+3. Remove a scope (any), including one added by another member → **Expect**: succeeds
+   unconditionally. *(FR-016)*
+4. Confirm the SA's credential is unchanged throughout. *(FR-019)*
+
+## S7 — Rotate *(US4; FR-017/019)*
+Rotate `incident-bot` → new secret shown once; old client_secret no longer obtains a token; scopes
+unchanged.
+
+## S8 — Revoke is terminal *(US4; FR-018/018a)*
+Revoke `incident-bot` → its token no longer authenticates; all its OpenFGA tuples gone; it leaves the
+active list; the Mongo doc is retained (`status: revoked`); the name `incident-bot` can be reused by
+a new SA in team-sre. *(FR-018a)*
+
+## S9 — Ownership boundary *(US5; FR-021/022)*
+As Bob (team-marketing only), open Service Accounts → **Expect**: Alice's `incident-bot` is NOT
+visible; direct API `GET/DELETE` on it → `403`/`404`. No way to share it to another team. *(FR-022)*
+
+## S10 — Static access on creator permission loss *(FR-020)*
+Remove Alice's own `can_use agent:incident-resolver`. The SA's `service_account:<sub> can_use
+agent:incident-resolver` tuple is **unchanged**; the SA still works. *(FR-020)*
+
+## S11 — Team deletion guard *(FR-025)*
+Attempt to delete team-sre while it owns `incident-bot` → **Expect**: blocked with a clear message;
+deletion succeeds only after the SA is revoked.
+
+## S12 — Audit trail *(FR-026/027; SC-009)*
+After S1, S6, S7, S8: confirm audit records exist for create / scope_add / scope_remove / rotate /
+revoke (actor + target + scope). After S4/S5: confirm call-time allow/deny decisions are audited
+(service account + resource). *(FR-027)*
+
+---
+
+## Automated test mapping
+- **Bridge (pytest)** — `deploy/openfga/bridge/tests/test_grpc_bridge.py`: add cases for S5/S5b
+  (caller-keyed deny for user + service_account; allow when both granted).
+- **DA backend (pytest)** — service-account subject namespacing in `openfga_authz.py` (S4).
+- **BFF (Jest)** — `service-accounts.ts` lib + each route: create/list/detail/rotate/revoke/scopes,
+  the write-time permission bound (S3/S6), and ownership gating (S9).
+- **Model** — a check that `service_account:<sub> can_manage` resolves from `owner_team`.

--- a/docs/docs/specs/2026-06-05-service-accounts/research.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/research.md
@@ -1,0 +1,157 @@
+# Phase 0 Research: Service Accounts
+
+All items below were verified against the current codebase (not assumed). Each is a decision with
+rationale and the evidence that grounds it.
+
+## R-1 — OpenFGA identity & ownership model
+
+**Decision**: Reuse the existing `service_account` OpenFGA type as the SA identity. Add an ownership
+relation:
+```
+type service_account
+  relations
+    define owner_team: [team#member]
+    define can_manage: owner_team
+```
+SA access grants reuse existing patterns: `service_account:<sub> can_use agent:<id>` and
+`service_account:<sub> can_call tool:<server>/<tool>` (+ `tool:<server>/*` wildcard).
+
+**Rationale**: Slack/Webex bots are already modeled as `service_account` subjects; these new
+user-minted accounts are the same kind of identity with self-service management. `service_account`
+is subject-only today, so adding relations is purely additive.
+
+**Evidence**: `deploy/openfga/model.fga:29` (`type service_account`, no relations). `tool` type
+(`model.fga:199-211`) — `caller` relation already lists **both** `user` and `service_account`, so
+caller-keyed tool grants/checks need no model change. Subject convention confirmed in
+`ui/src/lib/rbac/resource-authz.ts:147-155`.
+
+**Alternatives rejected**: New `bot_account` type — more model churn and a second machine-identity
+concept for no functional gain (Kevin/Erik decision).
+
+## R-2 — Credential: dynamic Keycloak client per SA
+
+**Decision**: Each SA is a dynamically-created Keycloak **confidential client** with
+`serviceAccountsEnabled: true`. One client = one credential. The credential shown once = the Keycloak
+`client_id` + `client_secret`. Rotation = regenerate the client secret. Revoke = delete the client.
+No multi-token, no expiry in v1.
+
+**Rationale**: "Work with Keycloak as it's meant to be." The SA is a first-class identity with its
+own real JWT (client-credentials grant) — identical in kind to how Slack/Webex authenticate, just
+created at runtime instead of statically in realm JSON.
+
+**Evidence (capability verified)**:
+- Admin client `caipe-platform` already holds `realm-management` role **`manage-clients`** —
+  `charts/ai-platform-engineering/charts/keycloak/realm-config.json:719-735`. Sufficient to
+  create/regenerate/delete clients.
+- Existing admin plumbing to mirror: `ui/src/lib/rbac/keycloak-admin.ts` — `adminFetch` (l.215),
+  `assertOk` (l.241), `getAdminToken` (l.192, client_credentials), `getClientByClientId` (l.845),
+  and an existing `GET /clients/{id}/service-account-user` call (l.1324-1332).
+- Client shape to mirror: `caipe-slack-bot` — `realm-config.json:164-187` (publicClient:false,
+  serviceAccountsEnabled:true, standardFlowEnabled:false, directAccessGrantsEnabled:false).
+
+**Net-new code (none exists today)**: `createServiceAccountClient`, `regenerateClientSecret`,
+`deleteServiceAccountClient` in `keycloak-admin.ts`. Keycloak REST: `POST /clients`,
+`POST /clients/{id}/client-secret`, `DELETE /clients/{id}`, `GET /clients/{id}/service-account-user`.
+
+**Alternatives rejected**: opaque token + Mongo hash (catalog-api-keys style) → wouldn't give a real
+SA JWT for downstream MCP checks. BFF-signed JWT → second issuer to trust. Token-as-Keycloak-secret
+with N tokens → fights Keycloak's one-secret-per-client model and fragments identity.
+
+## R-3 — Subject identity = JWT `sub` (no mapping table)
+
+**Decision**: The OpenFGA subject id IS the Keycloak service-account-user `sub` (UUID). At create
+time we read it back from `GET /clients/{id}/service-account-user` and write all tuples as
+`service_account:<sub>`. Mongo stores the friendly name + client_id + sub for display.
+
+**Rationale**: Zero translation layer; reuses the existing `service_account:${sub}` convention so the
+same value works at every enforcement layer.
+
+**Evidence**: BFF detection + namespacing already exists —
+`ui/src/lib/jwt-validation.ts:243-249` sets `isServiceAccount` from
+`preferred_username.startsWith('service-account-')`; `api-middleware.ts:476-493` propagates it into
+the session; `resource-authz.ts:147-155` yields `service_account:${sub}`. So **BFF-layer authz
+already works for SAs with no change.**
+
+## R-4 — Call path: all traffic via BFF; SA JWT forwarded downstream
+
+**Decision**: External callers present the SA's client-credentials JWT to the BFF `/api/v1/chat/*`
+routes (same entry as browser + Slack/Webex). The BFF forwards the original JWT to the DA backend.
+
+**Evidence**: `ui/src/lib/da-proxy.ts` — `authenticateRequest` reads `session.accessToken` (the
+original bearer, l.106) and `buildBackendHeaders` forwards it as `Authorization: Bearer` (l.206-208).
+DA backend is ClusterIP-only (verified earlier), so BFF is the only ingress. No opaque-token path
+needed.
+
+## R-5 — DA backend subject namespacing (BUG — must fix, WS-G)
+
+**Decision**: Fix `_check_agent_use` to namespace SA subjects.
+
+**Problem found**: `ai_platform_engineering/dynamic_agents/.../auth/openfga_authz.py:304-321`
+hardcodes `"user": f"user:{subject}"`. An SA's forwarded JWT would be checked as
+`user:<sub> can_use agent:<id>` and **denied**, because SA grants are `service_account:<sub> ...`.
+The DA backend has **no** `isServiceAccount` detection today (the flag lives only in the BFF session
+and never crosses to DA).
+
+**Fix**: In the DA backend, detect service-account tokens from the validated JWT (via
+`preferred_username` starting `service-account-`, or the `client_id` claim) and build
+`service_account:<sub>` for those; keep `user:<sub>` for interactive users. Add pytest coverage.
+
+## R-6 — Caller-keyed tool authorization (in-scope fix, WS-F)
+
+**Decision**: Add a caller-keyed `<subject> can_call tool:<server>/<tool>` check to the bridge,
+ANDed with the existing `agent:<id> can_call tool:...` check. Applies to both `user` and
+`service_account` subjects (FR-012a/b).
+
+**Evidence**: `deploy/openfga/bridge/main.py:595` builds `user = f"user:{sub}"` (hardcoded);
+l.618-630 check `user→agent` then `agent→tool` — **no caller→tool check exists**. The bridge decodes
+the JWT (`_decode_verified_bearer_subject`, l.321-345) but keeps only `sub`; it can additionally read
+`client_id` to namespace the subject. Model already allows both subjects on `tool#caller` (R-1) — no
+model change. Tests to mirror: `test_tools_call_requires_user_agent_and_agent_tool_grants` and
+`test_tools_call_denies_when_agent_tool_grant_is_missing` (`test_grpc_bridge.py:247-321`). New deny
+reason code `DENY_CALLER_TOOL` following the existing `_audit_decision` pattern.
+
+**Consistency note**: BFF uses `preferred_username`, the bridge will use `client_id`. WS-F and WS-G
+must apply the **same** service-account-detection rule so a given token namespaces identically at
+every layer. Recommendation: prefer `client_id` presence as the canonical signal (present on all
+client-credentials tokens), with `preferred_username` as corroboration; finalize in tasks.
+
+## R-7 — UI placement & gating (OPEN — resolve in tasks)
+
+**Finding**: The admin page (`ui/src/app/(app)/admin/page.tsx`) uses a two-level Radix tab system;
+the "Settings" category is the right home for a "Service Accounts" sub-tab. Tabs are gated via
+`tabGateValues` and the page is fronted by `useAdminRole()` (`canViewAdmin`/`isAdmin`).
+
+**Tension**: Spec says self-service for **any team member** (not admin-only). So the tab's visibility
+must key on "user belongs to ≥1 team," not `isAdmin`. 
+
+**Decision (provisional)**: Mount under Settings, but gate the tab on team membership and rely on
+per-action authorization (owning-team check on every BFF route) as the real control — consistent
+with the spec's assumption that Admin→Settings is just *where* identity settings live. Confirm the
+exact gate mechanism (and whether non-admins can currently reach `admin/page.tsx` at all) during
+tasks; if the admin page itself is hard-gated to admins, the tab may need to live in a
+non-admin-gated settings surface instead.
+
+**Reusable components verified**: `Tabs`, `Dialog`, `CopyButton`, `TeamPicker`
+(`ui/src/components/ui/team-picker.tsx`), `SecretValueDialog`
+(`ui/src/components/credentials/`), and the fetch/`{success,data,error}` pattern
+(`PlatformSettingsTab.tsx`). Grantable resources: `/api/dynamic-agents/available` (agents) and the
+team-resources endpoint expose `available.tools`; the SA grantable list (WS-D) will use OpenFGA
+`listOpenFgaObjects` for `user:<sub>` to be authoritative.
+
+## R-8 — Grantable-set derivation (FR-006/007/009)
+
+**Decision**: UI picker = `listOpenFgaObjects(user:<sub>, can_use, agent)` and the tool equivalent,
+so only what the user holds is offered. Every write re-runs `checkOpenFgaTuple(user:<sub>, …)`
+(FR-008). `ui/src/lib/rbac/openfga.ts` provides `listOpenFgaObjects`, `checkOpenFgaTuple`,
+`writeOpenFgaTuples` — all reused, none net-new.
+
+## Resolved risks summary
+
+| Risk (from working notes) | Status |
+|---|---|
+| Keycloak admin can create clients? | ✅ Yes — `caipe-platform` has `manage-clients` |
+| SA JWT validates + namespaces at BFF? | ✅ Yes — existing `isServiceAccount` path |
+| DA agent-use check works for SA? | ❌ No — hardcoded `user:` → **WS-G fix required** |
+| `.fga`→JSON model change for caller fix? | ✅ Not needed — `tool#caller` already allows both |
+| Caller-keyed tool check exists? | ❌ No — **WS-F adds it** |
+| UI self-service vs admin-gated? | ⚠️ Open — R-7, resolve in tasks |

--- a/docs/docs/specs/2026-06-05-service-accounts/spec.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/spec.md
@@ -1,0 +1,355 @@
+# Feature Specification: Service Accounts
+
+**Feature Branch**: `2026-06-05-service-accounts`
+**Created**: 2026-06-05
+**Status**: Draft
+**Input**: User description: "Service Accounts — user-minted, team-owned bot identities for external/API access (GitHub issue #1677)."
+
+## Clarifications
+
+### Session 2026-06-05
+
+- Q: Should service-account activity be audited, and at what level? → A: Audit BOTH lifecycle events (create / scope add / scope remove / rotate / revoke, with actor + target) AND call-time authentication/authorization decisions (allow/deny) made under a service-account credential.
+- Q: Must service-account names be unique, and within what boundary? → A: Unique within the owning team (two different teams may reuse the same name).
+- Q: Is revocation reversible, and what happens to the record and its name? → A: Revocation is terminal and irreversible; the record is retained (soft-deleted) for audit, and its name is freed for reuse within the team.
+- Q: How does v1 behave if caller-keyed tool authorization (FR-012's prerequisite) isn't delivered in time? → A: SUPERSEDED — see next item. Closing the caller-keyed gap is now in scope for this work.
+- Q: Is the caller-keyed tool-authorization gap an external dependency or part of this work? → A: Part of this work. Confirmed by Sri (platform owner) in the RBAC thread as a real gap ("we are not checking the user has access to the tool at the agentgateway layer … we need to fix it, should be a quick fix"). The gap affects ALL callers (human users today, not only service accounts) — a confused-deputy/privilege-escalation surface where a caller's effective tool reach is the union of tools granted to every agent they may use. This work MUST add a caller-keyed tool-authorization check at the AgentGateway layer for both `user` and `service_account` subjects.
+
+## Overview
+
+Today, calling a CAIPE agent or tool requires an interactive user session. External systems —
+CI pipelines, monitoring alerts, incident webhooks, other internal services — have no first-class
+way to authenticate.
+
+A **Service Account** is a named, team-owned bot identity with its own credential and its own
+scoped access to specific agents and tools. External systems authenticate *as* the service
+account to call CAIPE without a human in the loop. A service account's access is independent of
+any individual user, but it can never be created with more access than the person creating it
+already has.
+
+This is distinct from the platform's internal machine identities (e.g. the Slack/Webex bots,
+which are provisioned by operators). Service accounts are **self-service** and **team-managed**.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create a service account scoped to what I can access (Priority: P1)
+
+A user who belongs to one or more teams opens **Admin → Settings → Service Accounts** and creates
+a service account. They give it a name and description, choose one of their teams to own it, and
+select the agents and tools it should be able to use — choosing only from the agents and tools they
+themselves can already access. On creation they are shown the credential exactly once and copy it
+for use by their external system.
+
+**Why this priority**: This is the core of the feature — without create + one-time credential
+reveal, there is no usable service account. It is the minimum that delivers value.
+
+**Independent Test**: Sign in as a user with access to at least one agent, create a service account
+owned by a team the user belongs to, grant it that agent, and confirm the credential is displayed
+once and can be copied.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user who belongs to at least one team, **When** they open the Service Accounts tab,
+   **Then** they can start creating a service account and must choose an owning team from the teams
+   they belong to.
+2. **Given** the create form, **When** the user picks the resources to grant, **Then** only agents
+   and tools the user currently has access to are offered for selection.
+3. **Given** a completed create form, **When** the user submits, **Then** a new service account is
+   created owned by the chosen team, granted exactly the selected scopes, and the credential is
+   displayed exactly once.
+4. **Given** the one-time credential display, **When** the user dismisses or navigates away,
+   **Then** the credential can never be retrieved again through the UI.
+5. **Given** a user attempts to grant a scope they do not personally hold (e.g. via a tampered
+   request), **When** the request is processed, **Then** that scope is rejected and not granted.
+6. **Given** a brand-new service account with no scopes selected, **When** it is created,
+   **Then** it has access to nothing.
+
+---
+
+### User Story 2 - Use a service account to call CAIPE from an external system (Priority: P1)
+
+An external system (CI job, alert handler, webhook) presents the service account's credential when
+calling a CAIPE agent. The platform recognizes the service account as its own identity and allows
+the call only if the service account was granted that agent — and allows downstream tool calls only
+if the service account was granted those tools. Holding access to an agent does not by itself grant
+access to the tools that agent can use.
+
+**Why this priority**: A service account that cannot actually authenticate and be correctly
+authorized end-to-end delivers no value. This is the other half of the MVP.
+
+**Independent Test**: With a service account granted `agent:A` but not `tool:T`, call `agent:A` with
+the credential and confirm the agent runs; confirm a call that would require `tool:T` is denied; then
+grant `tool:T` and confirm it succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a service account granted access to `agent:A`, **When** an external caller invokes
+   `agent:A` with the service account's credential, **Then** the call is authenticated and authorized.
+2. **Given** a service account NOT granted access to `agent:B`, **When** a caller invokes `agent:B`
+   with its credential, **Then** the call is denied.
+3. **Given** a service account granted `agent:A` but not `tool:T`, **When** invoking `agent:A`
+   triggers a call to `tool:T`, **Then** the tool call is denied — agent access alone does not grant
+   tool access.
+4. **Given** a service account granted both `agent:A` and `tool:T`, **When** invoking `agent:A`
+   triggers `tool:T`, **Then** the tool call is allowed.
+5. **Given** an invalid, revoked, or unknown credential, **When** a caller presents it,
+   **Then** the call is rejected.
+
+---
+
+### User Story 3 - Manage scopes after creation (Priority: P2)
+
+A member of the owning team opens an existing service account and adjusts its access: adding new
+agents or tools, or removing existing ones. Adding a scope requires that the editing member
+currently holds that scope. Removing a scope is always allowed for any owning-team member, even a
+scope they could not themselves grant.
+
+**Why this priority**: Access needs change over time; without post-create editing, users would have
+to delete and recreate (and redistribute credentials). Valuable but not required for first use.
+
+**Independent Test**: As an owning-team member, add a scope you hold (succeeds), attempt to add a
+scope you don't hold (rejected), and remove a scope that was added by someone else (succeeds).
+
+**Acceptance Scenarios**:
+
+1. **Given** an owning-team member viewing a service account, **When** they add a scope they
+   currently hold, **Then** the service account gains that access.
+2. **Given** an owning-team member, **When** they attempt to add a scope they do NOT currently hold,
+   **Then** the addition is rejected.
+3. **Given** an owning-team member, **When** they remove any existing scope (including one they could
+   not themselves grant), **Then** the service account loses that access.
+4. **Given** scopes are changed, **When** the change is saved, **Then** the service account's
+   credential is unchanged (editing scopes does not rotate the credential).
+
+---
+
+### User Story 4 - Rotate and revoke (Priority: P2)
+
+A member of the owning team rotates a service account's credential (e.g. on suspected leak),
+receiving a new credential shown once while the old one stops working. Or they revoke the service
+account entirely, after which its credential no longer authenticates and all of its access is
+removed.
+
+**Why this priority**: Credential hygiene and incident response. Important for production trust,
+but the account is usable before these exist.
+
+**Independent Test**: Rotate a service account and confirm the old credential is rejected and a new
+one is shown once; revoke a service account and confirm its credential no longer works and its
+access is gone.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owning-team member, **When** they rotate the credential, **Then** a new credential is
+   shown exactly once and the previous credential stops authenticating.
+2. **Given** an owning-team member, **When** they revoke the service account, **Then** its credential
+   no longer authenticates and all of its granted access is removed.
+3. **Given** a revoked service account, **When** anyone views the Service Accounts list,
+   **Then** it is no longer presented as usable.
+
+---
+
+### User Story 5 - Ownership and visibility boundaries (Priority: P2)
+
+Service accounts belong to exactly one team and are not shared. Only members of the owning team can
+see, manage, rotate, or revoke a given service account. A user who is not a member of the owning team
+cannot view or affect it.
+
+**Why this priority**: Defines the access-control boundary of the feature itself. Required for the
+feature to be trustworthy in a multi-team org, but layered on top of the core create/use flows.
+
+**Independent Test**: Create a service account owned by Team A; confirm a Team A member sees and can
+manage it, and a non-member (Team B only) cannot see or manage it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a service account owned by Team A, **When** a Team A member opens the Service Accounts
+   list, **Then** they see it and can manage it.
+2. **Given** the same service account, **When** a user who is only in Team B opens the list,
+   **Then** they do not see it and cannot manage, rotate, or revoke it.
+3. **Given** a service account, **When** it is created, **Then** it is owned by exactly one team and
+   cannot be shared with additional teams or individual users.
+
+---
+
+### Edge Cases
+
+- **User belongs to no team**: They cannot create a service account (no valid owning team).
+- **Creating user later loses a granted permission**: The service account KEEPS its access (access
+  is static / fire-and-forget; it is not re-derived from the creator over time).
+- **Owning team is deleted**: Team deletion is blocked while the team still owns any service
+  accounts. The team's members must revoke (or otherwise remove) its service accounts first; only
+  then can the team be deleted. This prevents orphaned, unmanageable identities. (See FR-025.)
+- **Granted agent or tool is deleted**: The corresponding grant becomes inert; calls referencing the
+  removed resource fail as they would for any caller. The service account remains otherwise usable.
+- **Two members of the owning team edit the same service account concurrently**: Scope changes are
+  applied per scope; the resulting access reflects the union of adds minus removes, with the
+  permission-bound check applied per add.
+- **Credential is lost by the operator** (never copied or misplaced): It cannot be recovered; the
+  only remedy is to rotate to obtain a new credential.
+- **A scope is removed while an external call is in flight**: The in-flight call completes under the
+  access in effect at the time of the authorization check; subsequent calls are evaluated against
+  the new scopes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Creation & identity
+- **FR-001**: The system MUST allow any authenticated user who belongs to at least one team to create
+  a service account.
+- **FR-002**: The system MUST require each service account to be owned by exactly one team, chosen
+  from the teams the creating user belongs to.
+- **FR-002a**: The system MUST require a service account's name to be unique among *active* service
+  accounts within its owning team, and MUST reject creation that would collide with an existing active
+  name in the same team. The same name MAY be reused by a different team, or reused within the team
+  once the prior holder is revoked.
+- **FR-003**: The system MUST give each service account its own distinct identity and its own
+  credential, independent of any user identity.
+- **FR-004**: A newly created service account MUST have access to nothing until scopes are explicitly
+  granted.
+- **FR-005**: The system MUST display a service account's credential exactly once, at the moment it is
+  created (and again only when rotated), and MUST NOT provide any way to retrieve it afterward.
+
+#### Permission-bounded granting
+- **FR-006**: The system MUST allow granting a service account only those agent and tool scopes that
+  the acting user currently holds.
+- **FR-007**: The grantable set MUST be based on the acting user's own effective access (which may
+  aggregate access from multiple of the user's teams), NOT on the owning team's access.
+- **FR-008**: The system MUST enforce the permission bound at the time access is written, rejecting
+  any requested scope the acting user does not currently hold — regardless of what the interface
+  offered.
+- **FR-009**: When presenting choices, the system MUST offer only resources the acting user currently
+  has access to.
+
+#### Authorization at call time
+- **FR-010**: The system MUST authenticate external callers presenting a valid service account
+  credential as that service account's identity.
+- **FR-011**: The system MUST authorize agent invocations against the service account's own granted
+  access — allowing only agents the service account was granted.
+- **FR-012**: The system MUST authorize tool calls against the service account's own granted access,
+  such that access to an agent does NOT by itself confer access to the tools that agent can use.
+- **FR-012a**: This work MUST close the existing caller-keyed tool-authorization gap as part of its
+  scope. Today the runtime enforces tool calls only against the agent's identity
+  (`agent → tool`), not the caller's, so a caller's effective tool reach is the union of tools
+  granted to every agent they may use (a confused-deputy / privilege-escalation surface). The system
+  MUST add a caller-keyed tool-authorization check at the gateway layer so that a tool call is
+  permitted only when BOTH the agent AND the calling subject are authorized for that tool.
+- **FR-012b**: The caller-keyed tool-authorization check MUST apply to ALL caller subjects — both
+  human users and service accounts — not only to service accounts. (The gap affects regular users
+  today; service accounts inherit the same enforcement.)
+- **FR-013**: The system MUST reject calls presenting an invalid, unknown, or revoked credential.
+
+#### Lifecycle & management
+- **FR-014**: The system MUST allow any member of the owning team to view a service account and its
+  current granted scopes.
+- **FR-015**: The system MUST allow an owning-team member to ADD a scope only if that member
+  currently holds the scope being added.
+- **FR-016**: The system MUST allow any owning-team member to REMOVE any existing scope, including a
+  scope that member could not themselves grant.
+- **FR-017**: The system MUST allow an owning-team member to rotate the credential, producing a new
+  credential (shown once) and invalidating the previous one.
+- **FR-018**: The system MUST allow an owning-team member to revoke a service account, after which
+  its credential no longer authenticates and all of its granted access is removed.
+- **FR-018a**: Revocation MUST be terminal and irreversible (a revoked service account cannot be
+  reactivated). The system MUST retain the revoked record for audit purposes while excluding it from
+  the active/usable list, and MUST free its name for reuse within the owning team.
+- **FR-019**: Editing scopes MUST NOT change the credential; rotating the credential MUST NOT change
+  scopes.
+- **FR-020**: The system MUST keep a service account's granted access stable over time, unaffected by
+  later changes to the creating user's own permissions.
+
+#### Ownership & visibility
+- **FR-021**: The system MUST restrict viewing and managing a service account to members of its
+  owning team; non-members MUST NOT be able to see or affect it.
+- **FR-022**: The system MUST NOT allow a service account to be shared with additional teams or
+  individual users.
+- **FR-025**: The system MUST block deletion of a team while it still owns one or more service
+  accounts; those service accounts must be revoked/removed before the team can be deleted.
+
+#### Auditing
+- **FR-026**: The system MUST record an audit event for each service-account lifecycle action —
+  creation, scope addition, scope removal, credential rotation, and revocation — capturing the
+  acting user, the target service account, and the affected scope (where applicable).
+- **FR-027**: The system MUST record an audit event for each call-time authentication/authorization
+  decision (allow or deny) made under a service-account credential, identifying the service account
+  and the resource (agent or tool) involved.
+
+#### Scope (v1 boundaries)
+- **FR-023**: The grantable resource types in v1 MUST be agents and tools; other resource types are
+  out of scope for v1.
+- **FR-024**: Credentials in v1 MUST NOT have a time-based expiry; a credential remains valid until
+  rotated or revoked.
+
+### Key Entities *(include if feature involves data)*
+
+- **Service Account**: A named, team-owned bot identity. Attributes: name (unique within the owning
+  team), description, owning team, who created it, creation time, status (active/revoked), and the set
+  of granted scopes. Has exactly one credential at a time.
+- **Owning Team**: The single team that owns a service account. Determines who may view and manage it.
+  A service account references exactly one; a team may own many service accounts.
+- **Scope / Grant**: An individual access grant tying a service account to a specific agent or tool.
+  A service account has zero or more. Adding is permission-bounded; removing is unconditional for
+  owning-team members.
+- **Credential**: The secret an external caller presents to authenticate as the service account.
+  Shown once on creation and on rotation; never retrievable otherwise. Invalidated by rotation or
+  revocation.
+
+## Assumptions
+
+- "Access a user holds" means the user's effective permission as evaluated by the platform's existing
+  authorization system at the moment of the action, aggregated across all of the user's team
+  memberships.
+- A service account's access is enforced by the same authorization checks that govern human callers,
+  evaluated against the service account's identity rather than a user's.
+- The Service Accounts management UI lives under Admin → Settings purely as the location for
+  identity/account settings; it is NOT gated to platform administrators. Per-action authorization
+  (team membership, permission bound) provides the real access control.
+- "Tool" refers to the individually addressable tools an agent can call (MCP tools), consistent with
+  how the platform already identifies and authorizes tool calls.
+
+## In-Scope Platform Change (not just a dependency)
+
+- **Caller-keyed tool authorization** (FR-012 / FR-012a / FR-012b): The platform currently evaluates
+  tool calls only against the agent's identity, not the caller's. Closing this gap is **part of this
+  work**, confirmed with the platform owner (RBAC Slack thread, 2026-06-05). Because the gap is a
+  pre-existing privilege-escalation surface affecting all human users — not only service accounts —
+  the fix is independently valuable and is a prerequisite for FR-012 to hold for service accounts.
+  Scope of the change: add a caller-keyed `subject → tool` check at the AgentGateway authorization
+  layer, evaluated together with the existing `agent → tool` check, for both `user` and
+  `service_account` subjects.
+
+## Out of Scope (v1)
+
+- Time-based credential expiry (FR-024).
+- Multiple simultaneous credentials per service account.
+- Granting resource types other than agents and tools (FR-023).
+- Sharing a service account across multiple teams or with individual users (FR-022).
+- Automatic reconciliation when the creating user's permissions change later (FR-020 — access is
+  intentionally static).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user who can access at least one agent can create a working service account and obtain
+  its credential in under 3 minutes, without operator/administrator involvement.
+- **SC-002**: An external system can authenticate as a service account and successfully invoke a
+  granted agent on the first attempt using only the credential issued at creation.
+- **SC-003**: 100% of attempts to grant a service account a scope the acting user does not hold are
+  rejected.
+- **SC-004**: 100% of calls to agents or tools a service account was not granted are denied, including
+  tool calls made while invoking an agent the service account *can* use.
+- **SC-005**: A service account is visible and manageable to 100% of its owning-team members and to 0%
+  of non-members.
+- **SC-006**: After rotation, the previous credential is rejected on its next use; after revocation,
+  the credential is rejected and the service account's access is fully removed.
+- **SC-007**: A service account's granted access is unchanged after the creating user loses one of the
+  permissions they originally used to grant it.
+- **SC-008**: 100% of attempts to delete a team that still owns one or more service accounts are
+  blocked until those service accounts are removed.
+- **SC-009**: 100% of service-account lifecycle actions and call-time authorization decisions produce
+  a retrievable audit record identifying the actor/service account, the action/decision, and the
+  affected resource.
+- **SC-010**: After the caller-keyed tool-authorization change, a caller (human user OR service
+  account) who has not been granted a tool is denied that tool even when invoking an agent that can
+  call it — closing the pre-existing escalation surface for 100% of unauthorized caller/tool pairs.

--- a/docs/docs/specs/2026-06-05-service-accounts/spec.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/spec.md
@@ -201,8 +201,9 @@ manage it, and a non-member (Team B only) cannot see or manage it.
   from the teams the creating user belongs to.
 - **FR-002a**: The system MUST require a service account's name to be unique among *active* service
   accounts within its owning team, and MUST reject creation that would collide with an existing active
-  name in the same team. The same name MAY be reused by a different team, or reused within the team
-  once the prior holder is revoked.
+  name in the same team. Name comparison for uniqueness MUST be case-insensitive (e.g.
+  "Incident-Bot" collides with "incident-bot"). The same name MAY be reused by a different team, or
+  reused within the team once the prior holder is revoked.
 - **FR-003**: The system MUST give each service account its own distinct identity and its own
   credential, independent of any user identity.
 - **FR-004**: A newly created service account MUST have access to nothing until scopes are explicitly
@@ -237,6 +238,11 @@ manage it, and a non-member (Team B only) cannot see or manage it.
 - **FR-012b**: The caller-keyed tool-authorization check MUST apply to ALL caller subjects — both
   human users and service accounts — not only to service accounts. (The gap affects regular users
   today; service accounts inherit the same enforcement.)
+- **FR-012c**: Enabling caller-keyed tool enforcement MUST NOT silently break existing human callers
+  who currently rely on transitive (agent-granted) tool access. Rollout MUST either (a) backfill
+  direct tool grants for callers based on their current effective access before enforcement is
+  turned on, or (b) gate the new check behind a configuration flag with a documented migration path.
+  The chosen approach MUST be stated in operator docs.
 - **FR-013**: The system MUST reject calls presenting an invalid, unknown, or revoked credential.
 
 #### Lifecycle & management
@@ -353,3 +359,6 @@ manage it, and a non-member (Team B only) cannot see or manage it.
 - **SC-010**: After the caller-keyed tool-authorization change, a caller (human user OR service
   account) who has not been granted a tool is denied that tool even when invoking an agent that can
   call it — closing the pre-existing escalation surface for 100% of unauthorized caller/tool pairs.
+- **SC-011**: Enabling the caller-keyed tool check causes zero unintended denials for existing
+  callers — every caller who could invoke a tool (via an agent) before the change either retains
+  access through a direct grant or is intentionally revoked per policy.

--- a/docs/docs/specs/2026-06-05-service-accounts/tasks.md
+++ b/docs/docs/specs/2026-06-05-service-accounts/tasks.md
@@ -1,0 +1,173 @@
+---
+description: "Task list for Service Accounts feature implementation"
+---
+
+# Tasks: Service Accounts
+
+**Input**: Design documents from `docs/docs/specs/2026-06-05-service-accounts/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md, mongodb-migration.md
+
+**Tests**: INCLUDED — the spec defines acceptance scenarios + quickstart test mapping, and the
+constitution mandates CI gates (Jest for TS, pytest for Python).
+
+**Organization**: Grouped by user story (US1–US5 from spec.md) so each is independently testable.
+Two server-side enablers (caller-keyed bridge fix, DA subject fix) live in US2 since they gate
+end-to-end service-account usage.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: parallelizable (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US5; Setup/Foundational/Polish have no story label
+- File paths are exact.
+
+## Path Conventions
+Web app: BFF/UI in `ui/`, Python services in `ai_platform_engineering/` and `deploy/openfga/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Resolve open item R-7 (UI gating): inspect `ui/src/app/(app)/admin/page.tsx` and `ui/src/hooks/use-admin-role.ts` to confirm whether non-admin team members can reach the admin page; decide the Service Accounts tab gate (team-membership, not `isAdmin`). Record the decision in `research.md` R-7. Blocks UI work (US1/US5).
+- [ ] T002 Finalize the service-account detection rule (consistency across layers): confirm whether to key on `client_id` claim vs `preferred_username` (`service-account-`) for namespacing `service_account:<sub>`. Document the single canonical rule in `research.md` R-2/R-3; WS-F (bridge) and WS-G (DA) MUST both use it. Blocks T030, T034.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites for all stories)
+
+**⚠️ MUST complete before user-story phases.**
+
+- [ ] T003 Add the ownership relation to the OpenFGA model in `deploy/openfga/model.fga`: extend `type service_account` with `define owner_team: [team#member]` and `define can_manage: owner_team`. (Additive; `tool#caller` already permits `user`+`service_account` — do NOT change it.)
+- [ ] T004 Recompile the model into `charts/ai-platform-engineering/charts/openfga/authorization-model.json` so it mirrors `model.fga` exactly; verify `deploy/openfga/init/seed.py` applies the new relation on seed.
+- [ ] T005 [P] Add the `ServiceAccount` + `ServiceAccountScope` TypeScript interfaces to `ui/src/types/mongodb.ts` per data-model.md (no secret/hash fields).
+- [ ] T006 [P] Register `service_accounts` indexes in `ui/src/lib/mongodb.ts` `createIndexes()` (the 5 indexes in mongodb-migration.md).
+- [ ] T007 Create the Mongo lib wrapper `ui/src/lib/service-accounts.ts` mirroring `ui/src/lib/catalog-api-keys.ts`: `createServiceAccountDoc`, `listByOwningTeams`, `getBySub`, `updateStatus`, `updateScopesSnapshot`, app-layer name-uniqueness check among active SAs in a team — **case-insensitive** (lowercase the name for the comparison; store original case for display) (FR-002a). Depends on T005, T006.
+- [ ] T008 [P] Add Keycloak admin helpers to `ui/src/lib/rbac/keycloak-admin.ts` mirroring existing `adminFetch`/`assertOk`: `createServiceAccountClient(name)` (POST /clients confidential+serviceAccountsEnabled, read back client UUID + secret + service-account-user `sub`), `regenerateClientSecret(clientUuid)` (POST /clients/{id}/client-secret), `deleteServiceAccountClient(clientUuid)` (DELETE /clients/{id}). Naming `caipe-sa-<slug>-<short-rand>`.
+- [ ] T009 [P] Unit-test the Keycloak helpers in `ui/src/lib/rbac/__tests__/keycloak-admin.service-accounts.test.ts` (mock `adminFetch`): create returns id+secret+sub, regenerate, delete, error propagation via `assertOk`.
+
+---
+
+## Phase 3: User Story 1 — Create a scoped service account (P1) 🎯 MVP
+
+**Goal**: A team member creates an SA owned by their team, scoped only to what they hold, and sees
+the credential once. **Independent test**: quickstart S1–S3.
+
+- [ ] T010 [US1] Create `GET /api/admin/service-accounts/grantable` route in `ui/src/app/api/admin/service-accounts/grantable/route.ts` — return agents+tools the caller holds via `listOpenFgaObjects(user:<caller>, can_use, agent)` and the tool equivalent (FR-009). Uses `ui/src/lib/rbac/openfga.ts`.
+- [ ] T011 [US1] Create `POST /api/admin/service-accounts` in `ui/src/app/api/admin/service-accounts/route.ts` implementing the 7-step create flow (contracts §POST): validate request body at the boundary (name length/charset, `owning_team_id` format, each scope `ref` shape — `agent` id or `server/tool`|`server/*`; reject malformed with 400) (constitution VII), team-membership check (FR-002), name-unique case-insensitive (FR-002a→409), per-scope `checkOpenFgaTuple(user:<caller>,…)` reject-if-unheld (FR-006/008), Keycloak client create (T008), OpenFGA tuple writes (owner_team + scopes), Mongo insert (T007), return credential ONCE (FR-005). Depends on T007, T008.
+- [ ] T012 [US1] Wire create-time audit events in the POST route: `service_account.create` with actor+target+scopes (FR-026), reusing the repo's audit-events mechanism. Depends on T011.
+- [ ] T013 [P] [US1] Jest test `ui/src/app/api/admin/service-accounts/__tests__/create.test.ts`: happy path (201 + secret once), name conflict incl. case-insensitive collision (409, FR-002a), unauthorized scope rejected (S3/FR-008), non-member team (403), default-deny empty scopes (S2/FR-004), malformed body rejected (400, constitution VII).
+- [ ] T014 [US1] Create `ServiceAccountsTab.tsx` in `ui/src/components/admin/` and register it in `ui/src/app/(app)/admin/page.tsx` CATEGORIES (settings group), gated per T001. Reuse `Tabs`. Depends on T001.
+- [ ] T015 [US1] Build the create dialog in `ServiceAccountsTab.tsx`: name + description inputs, owning-team picker (`TeamPicker`, teams the user belongs to), grantable scope picker (fetch T010), submit to T011. Depends on T010, T014.
+- [ ] T016 [US1] Build the one-time credential reveal (client_id + client_secret + token URL) using `CopyButton` + the see-once dialog pattern (`SecretValueDialog`); never refetchable (FR-005). Depends on T015.
+- [ ] T017 [P] [US1] List view in `ServiceAccountsTab.tsx`: fetch `GET /api/admin/service-accounts` (see T024), render name/team/created-by/status/scope-counts. Depends on T014.
+
+**Checkpoint**: A user can create a scoped SA and copy its credential once. MVP demonstrable.
+
+---
+
+## Phase 4: User Story 2 — Use a service account end-to-end (P1) 🎯 MVP
+
+**Goal**: External caller authenticates as the SA; agent-use authorized against the SA; tool calls
+authorized against the SA (not just the agent). **Independent test**: quickstart S4, S5, S5b.
+Includes the two server-side enablers.
+
+- [ ] T018 [US2] Fix DA backend subject namespacing in `ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py`: in `_check_agent_use` / `require_agent_use_permission`, detect service-account tokens (rule from T002) and build `service_account:<sub>` instead of hardcoded `user:<sub>`; keep `user:<sub>` for interactive users (R-5/WS-G).
+- [ ] T019 [P] [US2] pytest in `ai_platform_engineering/dynamic_agents/.../tests/` covering: SA token → `service_account:<sub> can_use agent:<id>` allowed; user token still `user:<sub>`; SA denied when no grant. Depends on T018.
+- [ ] T020 [US2] Add caller-keyed tool check in `deploy/openfga/bridge/main.py`: decode `client_id` to namespace subject (rule from T002); after the existing `agent:<id> can_call tool:...` check, AND a `<subject> can_call tool:<server>/<tool>` check (+ `tool:<server>/*` wildcard fallback); allow only if both pass (FR-012/012a/012b). Depends on T002.
+- [ ] T021 [US2] Add deny reason `DENY_CALLER_TOOL` audit path in `deploy/openfga/bridge/main.py` following the existing `_audit_decision` pattern (FR-027). Depends on T020.
+- [ ] T022 [P] [US2] Extend `deploy/openfga/bridge/tests/test_grpc_bridge.py` mirroring existing tool-grant tests: (a) user has agent+agent-has-tool but user lacks tool → deny (S5b); (b) service_account caller with both grants → allow (S5); (c) service_account lacks tool → deny. Depends on T020.
+- [ ] T021a [US2] Ensure call-time authorization decisions under a service-account credential are audited for BOTH allow and deny outcomes (FR-027/SC-009): the DA agent-use check (T018) emits an audit event, and the bridge emits allow events (not only `DENY_CALLER_TOOL`). Verify in the bridge `_audit_decision` and DA audit paths; add assertions to T019/T022. Depends on T018, T021.
+- [ ] T022a [US2] **Rollout safety** for the caller-keyed check (FR-012c/SC-011): inventory current effective tool reach (which `user:`/`service_account:` subjects can reach which `tool:<server>/<tool>` via `agent can_call`), and EITHER (a) backfill direct `<subject> can_call tool:...` grants via a one-off OpenFGA write script, OR (b) gate the new check behind a config flag in `deploy/openfga/bridge/main.py` (default-off) with documented enable steps. Document the chosen approach in `docs/docs/security/rbac/workflows.md`. Coordinate with platform owner (Sri). **Gates turning the check on in any shared environment.** Depends on T020.
+- [ ] T023 [P] [US2] Integration check: verify the BFF forwards the SA's original JWT to DA (`ui/src/lib/da-proxy.ts` already does — add/confirm a test that `Authorization: Bearer <sa-jwt>` is forwarded; no code change expected per R-4).
+
+**Checkpoint**: An SA can authenticate, invoke a granted agent, and is correctly denied ungranted
+tools — and the same enforcement now protects human users (S5b). **The caller-keyed check is only
+enabled in a shared environment after T022a (rollout safety) is complete.**
+
+---
+
+## Phase 5: User Story 3 — Manage scopes after creation (P2)
+
+**Goal**: Owning-team member adds (bounded) / removes (unconditional) scopes. **Test**: S6.
+
+- [ ] T024 [US3] Create `GET /api/admin/service-accounts` (list, owning-team filtered, FR-014/021) and `GET /api/admin/service-accounts/[id]` (detail + current scopes read from OpenFGA) in `ui/src/app/api/admin/service-accounts/route.ts` and `.../[id]/route.ts`. Gate via `check(user:<caller>, can_manage, service_account:<id>)`.
+- [ ] T025 [US3] Create `POST /api/admin/service-accounts/[id]/scopes` in `.../[id]/scopes/route.ts`: validate scope `ref` shape at the boundary (reject malformed with 400, constitution VII), `can_manage` check, then `checkOpenFgaTuple(user:<editor>, <rel>, <object>)` (FR-015→403 if unheld), write tuple, update snapshot, audit `service_account.scope_add`. Depends on T024.
+- [ ] T026 [US3] Add `DELETE` to `.../[id]/scopes/route.ts`: `can_manage` check ONLY (no scope-holding requirement, FR-016), delete tuple, update snapshot, audit `service_account.scope_remove`. Depends on T024.
+- [ ] T027 [P] [US3] Jest test `.../__tests__/scopes.test.ts`: add held scope (ok), add unheld scope (403), remove any scope incl. one the editor can't grant (ok), credential unchanged (FR-019).
+- [ ] T024a [P] [US3] Jest test asserting GET list (T024) and GET detail responses contain NO credential/secret field (FR-005) — the secret appears ONLY in the 201-create (T011) and rotate (T029) responses. Depends on T024.
+- [ ] T028 [US3] Manage view in `ServiceAccountsTab.tsx`: show current scopes, add-scope (picker bounded by editor via T010), remove-scope (delete-confirm pattern). Depends on T017, T025, T026.
+
+**Checkpoint**: Scopes editable post-create with the asymmetric add/remove rule.
+
+---
+
+## Phase 6: User Story 4 — Rotate and revoke (P2)
+
+**Goal**: Rotate credential (shown once); revoke terminal. **Test**: S7, S8.
+
+- [ ] T029 [US4] Create `POST /api/admin/service-accounts/[id]/rotate` in `.../[id]/rotate/route.ts`: `can_manage` check, `regenerateClientSecret` (T008), return new secret ONCE, scopes unchanged (FR-017/019), audit `service_account.rotate`. Depends on T008, T024.
+- [ ] T030 [US4] Create `DELETE /api/admin/service-accounts/[id]` in `.../[id]/route.ts`: `can_manage` check, delete Keycloak client (T008), delete ALL OpenFGA tuples for `service_account:<id>` (ownership + scopes), mark Mongo `status:revoked`+`revoked_at` (retain doc), free name for reuse (FR-018/018a), audit `service_account.revoke`. Depends on T008, T024.
+- [ ] T031 [P] [US4] Jest test `.../__tests__/rotate-revoke.test.ts`: rotate returns new secret once + old invalidated (mock Keycloak); revoke deletes client+tuples, marks revoked, name reusable (S8).
+- [ ] T032 [US4] Add rotate + revoke actions (with confirm) to the manage view in `ServiceAccountsTab.tsx`; reveal rotated secret via the see-once dialog. Depends on T016, T028, T029, T030.
+
+**Checkpoint**: Credential hygiene + terminal revoke work end-to-end.
+
+---
+
+## Phase 7: User Story 5 — Ownership & visibility boundaries (P2)
+
+**Goal**: Only owning-team members see/manage an SA; one team; no sharing. **Test**: S9.
+
+- [ ] T033 [US5] Enforce ownership filtering in `GET /api/admin/service-accounts` (only SAs in teams the caller belongs to) and `can_manage` gating on every `[id]` route; verify non-members get 403/404 (FR-021/022). Hardening pass over T024/T025/T026/T029/T030.
+- [ ] T034 [P] [US5] Jest test `.../__tests__/ownership.test.ts`: member sees+manages; non-member (different team) cannot see or mutate (S9); confirm no route accepts more than one owning team / no share path (FR-022).
+- [ ] T034a [P] [US5] Test static access (FR-020, quickstart S10): after removing the creator's own grant for a scope, assert the SA's `service_account:<sub>` tuple is unchanged and the SA still authorizes. No code — regression guard.
+
+**Checkpoint**: Cross-team isolation verified.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T035 Implement the team-deletion guard (FR-025): locate the team-delete path (BFF/admin teams API), block deletion while any `service_account:<sub> owner_team team:<id>` tuple exists, with a clear error (S11). Add a test.
+- [ ] T036 [P] Update `docs/docs/security/rbac/architecture.md` — add the service-account identity layer (Keycloak client → `service_account:<sub>` → tuples).
+- [ ] T037 [P] Update `docs/docs/security/rbac/workflows.md` — sequence diagrams for create + external-call flow, incl. the new dual agent+caller tool check.
+- [ ] T038 [P] Add a component README / section documenting the `service_accounts` collection, env requirements (`KEYCLOAK_ADMIN_CLIENT_ID/SECRET`), and the `caipe-sa-` client naming convention.
+- [ ] T039 Run quickstart.md S1–S12 end-to-end on a dev stack (bridge enabled + HMAC secret set); fix gaps. Confirm SC-001..SC-010.
+- [ ] T040 [P] Lint + gate pass: `cd ui && npm run lint && npm run build`; `uv run ruff check` + `uv run pytest` for bridge + DA changes.
+
+---
+
+## Dependencies & Execution Order
+
+**Phase gates**: Setup (T001–T002) → Foundational (T003–T009) → US1 (T010–T017) → US2 (T018–T023) →
+US3/US4/US5 (largely parallel) → Polish.
+
+**Critical path for MVP (US1+US2)**:
+`T003/T004 (model)` + `T005→T006→T007 (Mongo)` + `T008 (Keycloak)` → `T011 (create)` → demo create;
+then `T018 (DA fix)` + `T020 (bridge fix)` → demo end-to-end use.
+
+**Story independence**:
+- US1 needs Foundational. US2's enablers (T018, T020) are independent of US1's UI and can be built in
+  parallel with US1.
+- US3, US4, US5 all build on US1's routes/UI but are independent of each other (different routes/tests).
+
+**Cross-layer consistency**: T002 (SA-detection rule) blocks T018 and T020 — do it first so DA and
+bridge namespace identically.
+
+**Rollout gate**: T022a (rollout safety, FR-012c) MUST complete before the caller-keyed check (T020)
+is enabled in any shared environment — turning it on without the backfill/flag would break existing
+human users who rely on transitive tool access. T020 can be written/tested (T022) before T022a; only
+*enablement* is gated.
+
+## Parallel Execution Examples
+
+- **Foundational**: T005, T006, T008, T009 in parallel (distinct files); T007 after T005+T006.
+- **US1**: T013 (test) ∥ T017 (list UI) while T011/T015/T016 proceed on the create path.
+- **US2**: T019 ∥ T022 ∥ T023 (tests in different files) once T018/T020 land.
+- **Polish**: T036, T037, T038, T040 all parallel.
+
+## Implementation Strategy
+
+**MVP = US1 + US2** (both P1). US1 alone is demonstrable (create + see-once credential) but the
+feature only delivers value once US2's enablers (DA subject fix + caller-keyed bridge check) let the
+SA actually call CAIPE with correct authorization. Ship US1+US2 first, then layer US3/US4/US5 and
+polish. The caller-keyed bridge fix (T020/T022) is independently valuable — it closes the human-user
+escalation gap (S5b) regardless of the rest of the feature.


### PR DESCRIPTION
# Description

Adds the feature specification for **Service Accounts** — user-minted, team-owned bot identities for external/API access (closes the design phase of #1677).

**This PR is spec-only (no implementation plan).** The goal is to align on the design and scope before any code is written. Please review the *ideas*, not implementation details.

Spec: `docs/docs/specs/2026-06-05-service-accounts/spec.md`

## What a Service Account is

A named, **team-owned** bot identity with its own credential and its own scoped access to specific agents and tools. External systems (CI, alerts, webhooks, other services) authenticate *as* the service account to call CAIPE without a browser session. Distinct from the operator-provisioned Slack/Webex machine identities — these are **self-service** and **team-managed**.

## Key design decisions captured in the spec

- **Team-owned, not user-owned** — owned by exactly one team; only owning-team members view/manage/revoke. No sharing.
- **Permission-bounded creation** — a user can only grant scopes they *themselves* currently hold; a new SA has access to **nothing** by default. The bound is the user's own effective access (may aggregate multiple teams), not the owning team's.
- **Its own identity** — the SA presents its own credential and all authz checks evaluate against the SA identity.
- **Static access** — the SA keeps its grants even if the creator later loses them.
- **See-once credential**, rotate, and revoke (terminal). No expiry in v1.
- **Scope editing after creation** — adding a scope requires the editor hold it; removing is unconditional for any owning-team member.
- **Audit** of both lifecycle events and call-time authz decisions.

## ⚠️ Notable scope item — closes a confirmed RBAC gap

While investigating, we found (and @sraradhy confirmed in the RBAC thread) that tool calls are currently authorized **only against the agent's identity** (`agent → tool`), not the caller's. This lets any caller — **including regular human users today** — reach a tool by invoking an agent that can call it (a confused-deputy / privilege-escalation surface).

This work scopes in the fix: a **caller-keyed tool-authorization check** at the AgentGateway layer, evaluated together with the existing agent check, for both `user` and `service_account` subjects (FR-012a/FR-012b, SC-010). It's independently valuable beyond service accounts.

## Type of Change

- [x] Documentation
- [x] New Feature (spec for)

## Checklist

- [x] Existing issues have been referenced (#1677)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (this PR *is* the documentation)
- [ ] New code contribution is covered by automated tests (N/A — spec only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)