### PR TITLE
ci(rag): self-healing retag walk-back + force_build switch

### DIFF
--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -14,6 +14,11 @@ on:
         description: 'Version tag to apply (e.g., 0.3.0-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -84,6 +89,7 @@ jobs:
         env:
           RAG_CHANGED: ${{ steps.filter.outputs.rag }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -114,7 +120,13 @@ jobs:
             IMAGE_PREFIX=""
           fi
 
-          if [ -n "$TAG_VERSION" ]; then
+          if [ "$FORCE_BUILD" == "true" ]; then
+            # Coordinated release / manual override: always build fresh so every
+            # component is published at this tag (bypasses change-detect + retag).
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$RAG_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -330,16 +342,28 @@ jobs:
 
           echo "🏷️ Processing rag-${{ matrix.component }}${VARIANT_SUFFIX}..."
 
-          # Determine source tag (previous version)
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}${VARIANT_SUFFIX}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}${VARIANT_SUFFIX}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}${VARIANT_SUFFIX}"
             fi
           else

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -11,8 +11,8 @@ on:
       - 'build/agents/Dockerfile.a2a'
   workflow_dispatch:
     inputs:
-      build_all:
-        description: 'Build all containers (skip change detection)'
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
         required: false
         default: false
         type: boolean
@@ -125,7 +125,7 @@ jobs:
         env:
           FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-          MANUAL_BUILD_ALL: ${{ inputs.build_all || 'false' }}
+          MANUAL_BUILD_ALL: ${{ inputs.force_build || 'false' }}
         with:
           script: |
             const allAgents = JSON.parse(process.env.ALL_AGENTS);
@@ -348,16 +348,28 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing agent-${{ matrix.agent }}..."
 
-          # Determine source tag (previous version)
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -11,7 +11,7 @@ on:
       - 'build/agents/Dockerfile.a2a'
   workflow_dispatch:
     inputs:
-      force_build:
+      build_all:
         description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
         required: false
         default: false
@@ -125,7 +125,7 @@ jobs:
         env:
           FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-          MANUAL_BUILD_ALL: ${{ inputs.force_build || 'false' }}
+          MANUAL_BUILD_ALL: ${{ inputs.build_all || 'false' }}
         with:
           script: |
             const allAgents = JSON.parse(process.env.ALL_AGENTS);

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -15,6 +15,11 @@ on:
         description: 'Version tag to apply (e.g., 0.3.0-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -68,6 +73,7 @@ jobs:
         env:
           UI_CHANGED: ${{ steps.filter.outputs.ui }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -98,7 +104,11 @@ jobs:
             IMAGE_PREFIX=""
           fi
 
-          if [ -n "$TAG_VERSION" ]; then
+          if [ "$FORCE_BUILD" == "true" ]; then
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$UI_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -263,15 +273,28 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing caipe-ui..."
 
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -14,6 +14,11 @@ on:
         description: 'Version tag to apply (e.g., 0.3.0-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -66,6 +71,7 @@ jobs:
         env:
           DYNAMIC_AGENTS_CHANGED: ${{ steps.filter.outputs.dynamic_agents }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -96,7 +102,11 @@ jobs:
             IMAGE_PREFIX=""
           fi
 
-          if [ -n "$TAG_VERSION" ]; then
+          if [ "$FORCE_BUILD" == "true" ]; then
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$DYNAMIC_AGENTS_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -234,16 +244,28 @@ jobs:
 
           echo "🏷️ Processing dynamic-agents..."
 
-          # Determine source tag (previous version)
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -20,6 +20,11 @@ on:
         description: 'Version tag to publish (for example: 0.8.0-rc.1-chart.1)'
         required: true
         type: string
+      force_build:
+        description: 'Force publish all charts regardless of which chart files changed. Use for coordinated pre-release builds.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -86,6 +91,13 @@ jobs:
       - name: Detect changed charts
         id: detect
         run: |
+          if [[ "${{ inputs.force_build }}" == "true" ]]; then
+            echo "🔁 force_build requested: publishing all charts"
+            echo "rag-stack-changed=true" >> "$GITHUB_OUTPUT"
+            echo "ai-platform-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if git rev-parse HEAD^ >/dev/null 2>&1; then
             CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep "^charts/" || true)
           else

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -11,8 +11,8 @@ on:
       - 'build/agents/Dockerfile.mcp'
   workflow_dispatch:
     inputs:
-      build_all:
-        description: 'Build all containers (skip change detection)'
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
         required: false
         default: false
         type: boolean
@@ -118,7 +118,7 @@ jobs:
         env:
           FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-          MANUAL_BUILD_ALL: ${{ inputs.build_all || 'false' }}
+          MANUAL_BUILD_ALL: ${{ inputs.force_build || 'false' }}
         with:
           script: |
             const allAgents = JSON.parse(process.env.ALL_AGENTS);
@@ -311,16 +311,28 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing mcp-${{ matrix.agent }}..."
 
-          # Determine source tag (previous version)
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-mcp-sub-agent.yml
+++ b/.github/workflows/ci-mcp-sub-agent.yml
@@ -11,7 +11,7 @@ on:
       - 'build/agents/Dockerfile.mcp'
   workflow_dispatch:
     inputs:
-      force_build:
+      build_all:
         description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
         required: false
         default: false
@@ -118,7 +118,7 @@ jobs:
         env:
           FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-          MANUAL_BUILD_ALL: ${{ inputs.force_build || 'false' }}
+          MANUAL_BUILD_ALL: ${{ inputs.build_all || 'false' }}
         with:
           script: |
             const allAgents = JSON.parse(process.env.ALL_AGENTS);

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -33,6 +33,11 @@ on:
         description: 'Version tag to apply (e.g., 0.4.5-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -102,6 +107,7 @@ jobs:
         env:
           SCANNER_CHANGED: ${{ steps.filter.outputs.scanner }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -132,7 +138,11 @@ jobs:
             IMAGE_PREFIX=""
           fi
 
-          if [ -n "$TAG_VERSION" ]; then
+          if [ "$FORCE_BUILD" == "true" ]; then
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$SCANNER_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -296,15 +306,28 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing skill-scanner..."
 
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -14,6 +14,11 @@ on:
         description: 'Version tag to apply (e.g., 0.3.0-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -70,6 +75,7 @@ jobs:
         env:
           SLACK_BOT_CHANGED: ${{ steps.filter.outputs.slack_bot }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -100,7 +106,11 @@ jobs:
             IMAGE_PREFIX=""
           fi
 
-          if [ -n "$TAG_VERSION" ]; then
+          if [ "$FORCE_BUILD" == "true" ]; then
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$SLACK_BOT_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -259,15 +269,28 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing slack-bot..."
 
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-supervisor-agent.yml
+++ b/.github/workflows/ci-supervisor-agent.yml
@@ -11,6 +11,11 @@ on:
         description: 'Version tag to apply (e.g., 0.3.0-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
   pull_request:
     paths:
       - 'build/Dockerfile'
@@ -80,6 +85,7 @@ jobs:
         env:
           CORE_CHANGED: ${{ steps.filter.outputs.core }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -112,10 +118,15 @@ jobs:
 
           # Build vs retag logic:
           # 1. Chart-only: skip (handled above)
-          # 2. Pre-release N>1: build changed, retag unchanged
-          # 3. First pre-release (N==1) or final release: build all
-          # 4. PR / workflow_dispatch without tag: build if changed
-          if [ -n "$TAG_VERSION" ]; then
+          # 2. force_build: always build fresh (bypasses change-detect + retag)
+          # 3. Pre-release N>1: build changed, retag unchanged
+          # 4. First pre-release (N==1) or final release: build all
+          # 5. PR / workflow_dispatch without tag: build if changed
+          if [ "$FORCE_BUILD" == "true" ]; then
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$CORE_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -248,16 +259,28 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing supervisor..."
 
-          # Determine source tag (previous version)
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else

--- a/.github/workflows/ci-webex-bot.yml
+++ b/.github/workflows/ci-webex-bot.yml
@@ -16,6 +16,11 @@ on:
         description: 'Version tag to apply (e.g., 0.3.0-dev.5)'
         required: false
         type: string
+      force_build:
+        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -67,6 +72,7 @@ jobs:
         env:
           WEBEX_BOT_CHANGED: ${{ steps.filter.outputs.webex_bot }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
           SHOULD_RETAG="false"
@@ -94,7 +100,11 @@ jobs:
             IMAGE_PREFIX=""
           fi
 
-          if [ -n "$TAG_VERSION" ]; then
+          if [ "$FORCE_BUILD" == "true" ]; then
+            SHOULD_BUILD="true"
+            SHOULD_RETAG="false"
+            echo "🔁 force_build requested: building fresh regardless of changes"
+          elif [ -n "$TAG_VERSION" ]; then
             if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
               if [ "$WEBEX_BOT_CHANGED" == "true" ]; then
                 SHOULD_BUILD="true"
@@ -234,25 +244,49 @@ jobs:
           FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           echo "🏷️ Processing webex-bot..."
 
+          # Determine source tag (previous version). Walk back from N-1 to the
+          # latest rc/hotfix that actually has a published image, so a component
+          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
+          # retags from the most recent real image (rc.8) instead of a phantom
+          # rc.9. Falls back to the base version, then to a fresh build.
           if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             SUFFIX_TYPE="${BASH_REMATCH[2]}"
             SUFFIX_NUM="${BASH_REMATCH[3]}"
 
+            SOURCE_TAG=""
             if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
+              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
+                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
+                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
+                  SOURCE_TAG="$CANDIDATE"
+                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$SOURCE_TAG" ]]; then
               SOURCE_TAG="${BASE_VERSION}"
             fi
           else
             SOURCE_TAG="latest"
           fi
 
+          echo "  Source: ${SOURCE_TAG}"
+          echo "  Target: ${TAG_VERSION}"
+
           if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"
-            echo "needs_build=false" >> $GITHUB_OUTPUT
+            echo "  ✅ Source image exists, retagging..."
+            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
+              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+            else
+              echo "  ⚠️ Retag failed unexpectedly, will build instead"
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+            fi
           else
+            echo "  ⚠️ Source image ${SOURCE_TAG} not found (may still be building)"
+            echo "  📦 Will build fresh instead of using stale fallback"
             echo "needs_build=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -1,0 +1,236 @@
+name: "[Release] Pre-release Build"
+description: "Create an rc/hotfix tag on a release/* branch and trigger a coordinated build of all containers and the Helm chart."
+
+# assisted-by claude code claude-sonnet-4-6
+
+# Usage:
+#   GitHub UI → Actions → "[Release] Pre-release Build" → Run workflow
+#   gh workflow run release-prerelease.yml -f release_branch=release/0.8.0
+#   gh workflow run release-prerelease.yml -f release_branch=release/0.8.0 -f tag_version=0.8.0-rc.12
+#
+# What this does:
+#   1. Lists available release/* branches in the job summary.
+#   2. Validates the specified branch and derives the next rc/hotfix tag (or
+#      uses the one you provide).
+#   3. Creates and pushes the rc image tag AND the matching chart tag on the
+#      release branch.  The push-tag event then triggers all container CI
+#      workflows (ci-caipe-ui, ci-dynamic-agents, ci-supervisor-agent,
+#      ci-slack-bot, ci-webex-bot, ci-skill-scanner, ci-a2a-sub-agent,
+#      ci-mcp-sub-agent, ci-a2a-rag) automatically.
+#   4. Explicitly dispatches ci-helm.yml with force_build=true so the Helm
+#      chart is published even if no chart files changed in this commit.
+#
+# To force-rebuild every container image fresh (bypass retag for unchanged
+# components), run each ci-*.yml individually via workflow_dispatch with
+# force_build=true after this workflow has created the tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: |
+          Release branch to build from (e.g. release/0.8.0 or release/0.8.0-hotfix).
+          Run without specifying a tag to see available branches in the job summary.
+        required: true
+        type: string
+      tag_version:
+        description: |
+          RC/hotfix tag to create (e.g. 0.8.0-rc.3 or 0.8.0-hotfix.2).
+          Leave blank to auto-detect and increment the latest existing tag on this branch.
+        required: false
+        type: string
+
+permissions:
+  contents: write   # push tags
+  packages: write
+  actions: write    # dispatch ci-helm.yml
+
+jobs:
+  prepare:
+    name: Validate branch, create tags
+    runs-on: ubuntu-latest
+    outputs:
+      rc_tag: ${{ steps.tag.outputs.rc_tag }}
+      chart_tag: ${{ steps.tag.outputs.chart_tag }}
+
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 🔑 Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.CI_RELEASE_APP_ID }}
+          private-key: ${{ secrets.CI_RELEASE_APP_PRIVATE_KEY }}
+
+      - name: 📥 Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: 📋 List available release branches
+        run: |
+          BRANCHES=$(git ls-remote --heads origin 'refs/heads/release/*' \
+            | awk '{print $2}' | sed 's|refs/heads/||' | sort)
+
+          echo "## Available release/* branches" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -z "$BRANCHES" ]]; then
+            echo "_No release/* branches found._" >> "$GITHUB_STEP_SUMMARY"
+          else
+            while IFS= read -r branch; do
+              echo "- \`$branch\`" >> "$GITHUB_STEP_SUMMARY"
+            done <<< "$BRANCHES"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Selected:** \`${{ inputs.release_branch }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: ✅ Validate branch and determine tags
+        id: tag
+        env:
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          TAG_VERSION: ${{ inputs.tag_version }}
+        run: |
+          # Validate branch exists on the remote
+          if ! git ls-remote --exit-code --heads origin "refs/heads/${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "❌ Branch '${RELEASE_BRANCH}' not found in remote."
+            echo "   Available release/* branches:"
+            git ls-remote --heads origin 'refs/heads/release/*' \
+              | awk '{print $2}' | sed 's|refs/heads/||' | sort | sed 's/^/     /'
+            exit 1
+          fi
+
+          # Derive base version and suffix type from branch name
+          if [[ "$RELEASE_BRANCH" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)-hotfix$ ]]; then
+            BASE_VERSION="${BASH_REMATCH[1]}"
+            SUFFIX_TYPE="hotfix"
+          elif [[ "$RELEASE_BRANCH" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            BASE_VERSION="${BASH_REMATCH[1]}"
+            SUFFIX_TYPE="rc"
+          else
+            echo "❌ Branch must match release/<x.y.z> or release/<x.y.z>-hotfix"
+            exit 1
+          fi
+
+          # Determine rc/hotfix tag
+          if [[ -n "$TAG_VERSION" ]]; then
+            RC_TAG="$TAG_VERSION"
+            # Validate provided tag matches the branch
+            if ! [[ "$RC_TAG" =~ ^${BASE_VERSION}-(rc|hotfix)\.[0-9]+$ ]]; then
+              echo "❌ tag_version '${RC_TAG}' doesn't match branch base version '${BASE_VERSION}'"
+              exit 1
+            fi
+          else
+            # Auto-detect next rc/hotfix number
+            LATEST_NUM=$(git tag --list "${BASE_VERSION}-${SUFFIX_TYPE}.*" \
+              | grep -oP "(?<=${SUFFIX_TYPE}\.)[0-9]+$" | sort -n | tail -1)
+            if [[ -n "$LATEST_NUM" ]]; then
+              NEXT_NUM=$((LATEST_NUM + 1))
+            else
+              NEXT_NUM=1
+            fi
+            RC_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${NEXT_NUM}"
+          fi
+
+          # Check the rc tag doesn't already exist
+          if git rev-parse "${RC_TAG}" >/dev/null 2>&1; then
+            echo "❌ Tag '${RC_TAG}' already exists. Provide a different tag_version."
+            exit 1
+          fi
+
+          # Determine chart tag (auto-detect next chart suffix for this rc)
+          LATEST_CHART_NUM=$(git tag --list "${RC_TAG}-chart.*" \
+            | grep -oP "(?<=chart\.)[0-9]+$" | sort -n | tail -1)
+          if [[ -n "$LATEST_CHART_NUM" ]]; then
+            NEXT_CHART_NUM=$((LATEST_CHART_NUM + 1))
+          else
+            NEXT_CHART_NUM=1
+          fi
+          CHART_TAG="${RC_TAG}-chart.${NEXT_CHART_NUM}"
+
+          echo "rc_tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
+          echo "chart_tag=${CHART_TAG}" >> "$GITHUB_OUTPUT"
+          echo "✅ rc_tag=${RC_TAG}  chart_tag=${CHART_TAG}"
+
+      - name: 🏷️ Create and push tags
+        env:
+          RC_TAG: ${{ steps.tag.outputs.rc_tag }}
+          CHART_TAG: ${{ steps.tag.outputs.chart_tag }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          git config user.name "caipe-ci-release[bot]"
+          git config user.email "caipe-ci-release[bot]@users.noreply.github.com"
+
+          git fetch origin "${RELEASE_BRANCH}"
+          BRANCH_SHA=$(git rev-parse "origin/${RELEASE_BRANCH}")
+
+          git tag -a "${RC_TAG}"    "${BRANCH_SHA}" -m "Pre-release ${RC_TAG}"
+          git tag -a "${CHART_TAG}" "${BRANCH_SHA}" -m "Pre-release chart ${CHART_TAG}"
+          git push origin "${RC_TAG}" "${CHART_TAG}"
+
+          echo "✅ Pushed: ${RC_TAG}  ${CHART_TAG}"
+
+      - name: 📊 Summary
+        env:
+          RC_TAG: ${{ steps.tag.outputs.rc_tag }}
+          CHART_TAG: ${{ steps.tag.outputs.chart_tag }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+
+          ## Tags created
+
+          | Tag | Purpose |
+          |-----|---------|
+          | \`${RC_TAG}\` | Container images |
+          | \`${CHART_TAG}\` | Helm chart |
+
+          ## What happens next
+
+          The tag push triggers these CI workflows automatically:
+          - \`ci-caipe-ui\`
+          - \`ci-dynamic-agents\`
+          - \`ci-supervisor-agent\`
+          - \`ci-slack-bot\`
+          - \`ci-webex-bot\`
+          - \`ci-skill-scanner\`
+          - \`ci-a2a-sub-agent\`
+          - \`ci-mcp-sub-agent\`
+          - \`ci-a2a-rag\`
+          - \`ci-helm\` (also dispatched explicitly with \`force_build=true\`)
+
+          > To force-rebuild every image fresh (bypass retag for unchanged components),
+          > run each \`ci-*.yml\` manually via **workflow_dispatch** with
+          > \`force_build=true\` and \`tag_version=${RC_TAG}\` after this workflow completes.
+          EOF
+
+  dispatch-helm:
+    name: Dispatch helm chart CI (force_build)
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: 🚀 Dispatch ci-helm.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHART_TAG: ${{ needs.prepare.outputs.chart_tag }}
+        run: |
+          # Dispatch at main so the latest workflow file (with force_build) is used.
+          # ci-helm.yml explicitly checks out at tag_version, so release-branch
+          # code is used for packaging regardless of which ref the workflow runs at.
+          gh workflow run ci-helm.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f tag_version="${CHART_TAG}" \
+            -f force_build=true
+
+          echo "✅ Dispatched ci-helm.yml with chart_tag=${CHART_TAG} force_build=true"


### PR DESCRIPTION
## Problem

Pre-release `rc` images drift out of sync. On the `0.6.0` line, `caipe-rag-server` and `caipe-rag-ingestors` froze at **`rc.8`** while the rest of the stack advanced to **`rc.10`**:

```
component        rc:  1 2 3 4 5 6 7 8 9 10
caipe-ui              Y Y · Y Y Y Y Y Y Y
supervisor            Y Y · Y Y Y Y Y Y Y
dynamic-agents        Y Y Y Y Y Y Y Y Y Y
rag-server            Y Y Y Y Y Y Y Y · ·   ← stuck at rc.8
rag-ingestors         Y Y Y Y Y Y Y Y · ·   ← stuck at rc.8
all mcp-* / bots      Y Y Y Y Y Y Y Y Y Y
CHART (helm)          Y · Y Y · · · · · ·   ← maxes at rc.4
```

## Root cause

In `ci-a2a-rag.yml`, when RAG is unchanged for a pre-release tag, the source tag is computed as **exactly `rc.(N-1)`**:

```bash
PREV_NUM=$((SUFFIX_NUM - 1))
SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}${VARIANT_SUFFIX}"
```

Once an intermediate rc is skipped for a component, `rc.(N-1)` is a **phantom tag** — `crane manifest` misses — the fallback build runs for the heavy RAG image and fails — the component never gets the new rc. The chain stays broken for every subsequent tag.

## Fix

### 1. Self-healing retag walk-back (`ci-a2a-rag.yml` + all 8 container CI workflows)

Instead of only checking `rc.(N-1)`, walk back to the latest rc/hotfix that **actually has a published image** (`crane manifest`), then fall back to the base version, then to a fresh build. So `rc.10` retags from `rc.8` when `rc.9` is missing — coherence repairs itself automatically.

### 2. `force_build` switch (all container CI workflows + `ci-helm.yml`)

A `workflow_dispatch` boolean input that bypasses change-detection and retag and always builds fresh. Lets a coordinated release publish every component at one tag without relying on the retag chain.

- `ci-a2a-sub-agent` and `ci-mcp-sub-agent` keep their existing `build_all` input name unchanged for full backward compatibility.

### 3. `release-prerelease.yml` (new workflow)

A `workflow_dispatch`-only workflow for kicking off a pre-release build from any `release/*` branch:
- Lists available `release/*` branches in the job summary
- Validates the selected branch and auto-detects the next `rc.N` (or accepts an explicit tag)
- Creates and pushes the rc image tag and the matching chart tag on the release branch HEAD — the `push: tags` event then fires all container CI workflows automatically
- Explicitly dispatches `ci-helm.yml` with `force_build=true` so the Helm chart is always published even when no chart files changed

## Is this safe to merge?

**Yes — fully backward compatible. The existing release structure is unchanged.**

| Change | Safety |
|--------|--------|
| Walk-back loop | If `rc.(N-1)` exists (normal case), the loop finds it on the first iteration — identical behaviour to the old code. Only improves the broken case. |
| `force_build` input | `default: false`. All existing triggers (push-tag, PR) pass no inputs, so it defaults to false — zero behaviour change. Only activates when explicitly set via `workflow_dispatch`. |
| `build_all` in a2a/mcp | Unchanged — kept original input name, no rename. |
| `release-prerelease.yml` | New file, `workflow_dispatch` only — cannot fire accidentally, does not touch any existing workflow. |
| `ci-helm.yml` `force_build` | Same pattern: `default: false`, no effect on push-tag or scheduled runs. |

The existing release structure (auto-tag → push-tag → CI → release-finalize) is **completely unchanged**.

## Cherry-pick note

`.github/workflows/` files are picked up from the commit the tag points to, so the walk-back and `force_build` fixes should also be cherry-picked onto `release/0.6.0` (first two commits only) for rc builds on that branch to benefit. `release-prerelease.yml` and the `ci-helm.yml` change only need to be on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
