### PR TITLE
fix(docs): escape MDX JSX in FGA module-api spec

### DIFF
--- a/docs/docs/specs/2026-06-04-fga-projected-team-shares/contracts/module-api.md
+++ b/docs/docs/specs/2026-06-04-fga-projected-team-shares/contracts/module-api.md
@@ -45,7 +45,12 @@ export async function readSharedTeamSlugsFromOpenFga(
 **Behavior**:
 
 - If `!isOpenFgaReconciliationEnabled()` → `[]`.
-- Paginate `readOpenFgaTuples({ tuple: { object: `${objectType}:${objectId}` } })`.
+- Paginate FGA tuples for the resource object:
+
+  ```ts
+  readOpenFgaTuples({ tuple: { object: `${objectType}:${objectId}` } })
+  ```
+
 - Collect slugs via `extractTeamSlugsFromTuples`.
 - Sort/dedupe stable for tests.
 
@@ -90,7 +95,23 @@ export async function reconcileProjectedTeamShares(
 2. If `visibility` present:
    - `next !== "team"` → `nextTeamRefs` treated as `[]` for team shares.
    - `sharedWithOrg` / `previousSharedWithOrg` from `global` visibility (same as `reconcileSkillTeamShares` today).
-3. Call `reconcileShareableResource({ objectType, objectId, creatorSubject: ownerSubject, ownerSubject, ownerTeamSlug, previousOwnerTeamSlug, nextSharedTeamSlugs, previousSharedTeamSlugs, memberRelations: descriptor.memberRelations, sharedWithOrg, previousSharedWithOrg })`.
+3. Call `reconcileShareableResource` with the descriptor fields:
+
+   ```ts
+   reconcileShareableResource({
+     objectType,
+     objectId,
+     creatorSubject: ownerSubject,
+     ownerSubject,
+     ownerTeamSlug,
+     previousOwnerTeamSlug,
+     nextSharedTeamSlugs,
+     previousSharedTeamSlugs,
+     memberRelations: descriptor.memberRelations,
+     sharedWithOrg,
+     previousSharedWithOrg,
+   })
+   ```
 4. Never persist to Mongo.
 
 ## P4. Mongo hygiene


### PR DESCRIPTION
## Summary

- Fixes Docusaurus SSG failure on `docs/specs/2026-06-04-fga-projected-team-shares/contracts/module-api` caused by nested inline backticks exposing `{objectType}` to MDX as JSX (`ReferenceError: objectType is not defined`).
- Moves the affected `readOpenFgaTuples` and `reconcileShareableResource` snippets into fenced `ts` code blocks.

Unblocks:
- `[Check] Docs Build` on PRs touching `docs/**`
- `[Publish][Docs] GH Pages` on `main` (failed on 0.5.9 bump and subsequent merges)

## Test plan

- [x] `cd docs && npm run build` passes locally
- [ ] `[Check] Docs Build` CI passes on this PR


Made with [Cursor](https://cursor.com)