### PR TITLE
fix(dynamic-agents): restore workflow settings dropped by 020dc937f

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
@@ -84,6 +84,25 @@ class Settings(BaseSettings):
     credential_api_url: str | None = None
     credential_service_audience: str = "caipe-credential-service"
 
+    # CAIPE UI server base URL used by workflow tools to call back into the
+    # CAIPE API (e.g. trigger a workflow run, fetch run status).
+    # Example: "http://caipe-ui:3000" (in-cluster) or "https://caipe.example.com".
+    # Required when any agent has builtin_tools.workflows configured.
+    caipe_api_url: str = ""
+
+    # OAuth2 Client Credentials flow — used by workflow tools to obtain a
+    # short-lived service token before calling caipe_api_url.
+    # oauth2_token_url:     OIDC token endpoint (e.g. /realms/{realm}/protocol/openid-connect/token)
+    # oauth2_client_id:     service-account client ID
+    # oauth2_client_secret: service-account client secret (injected via ExternalSecret)
+    # oauth2_scope:         requested scopes (space-separated; leave empty to use defaults)
+    # oauth2_audience:      token audience claim (leave empty to use defaults)
+    oauth2_token_url: str = ""
+    oauth2_client_id: str = ""
+    oauth2_client_secret: str = ""
+    oauth2_scope: str = ""
+    oauth2_audience: str = ""
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.11-dev.2"
+version = "0.5.11-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.11.dev2"
+version = "0.5.11.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Commit `020dc937f` accidentally removed `caipe_api_url` and `oauth2_*` fields from `Settings` while adding `seed_config_path` and `agent_gateway_url`
- `agent_runtime.py` still references these fields in the workflow initialization path (step 8b)
- Any agent with `builtin_tools.workflows` configured (e.g. SRE Agent in caipe-dev) crashes on startup with `AttributeError: 'Settings' object has no attribute 'caipe_api_url'`

Re-adds the six missing fields with empty-string defaults. The env vars (`CAIPE_API_URL`, `OAUTH2_TOKEN_URL`, `OAUTH2_CLIENT_ID`, `OAUTH2_CLIENT_SECRET`) are already present in the deployed ConfigMap and ExternalSecret in caipe-dev — they were silently ignored due to `extra="ignore"`.

**Closes #1765** (same fix, rebased onto prebuild/ branch for image build)

## Test plan
- [ ] Verify agents with workflow configs initialize successfully
- [ ] Verify SRE Agent can load its 5 workflow tools without crashing
- [ ] Verify `CAIPE_API_URL` and `OAUTH2_*` env vars are read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)