### PR TITLE
fix(workflows): require agent#use AND workflow access for step execution

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/openfga_authz.py
@@ -421,14 +421,15 @@ async def require_agent_use_permission(
             },
         )
 
-    if (
-        not allowed
-        and workflow_config_id
-        and mongo is not None
-        and user is not None
-        and can_use_agent_via_workflow(agent_id, workflow_config_id, user, mongo)
-    ):
-        allowed = True
+    # When a workflow_config_id is present the call is a workflow step execution.
+    # Require both: the user must have direct dynamic_agent#use AND the agent must
+    # be a step in a workflow the user can run. Workflow context is additional
+    # validation, not a privilege-escalation path.
+    deny_reason = "DENY_NO_CAPABILITY"
+    if workflow_config_id and mongo is not None and user is not None:
+        if allowed and not can_use_agent_via_workflow(agent_id, workflow_config_id, user, mongo):
+            allowed = False
+            deny_reason = "DENY_WORKFLOW_ACCESS"
 
     if allowed:
         _log_openfga_rebac_audit(
@@ -445,7 +446,7 @@ async def require_agent_use_permission(
             subject=subject,
             agent_id=agent_id,
             outcome="deny",
-            reason_code="DENY_NO_CAPABILITY",
+            reason_code=deny_reason,
         )
         reset_trace_context()
         _raise_authz(

--- a/ai_platform_engineering/dynamic_agents/tests/test_workflow_execution_authz.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_workflow_execution_authz.py
@@ -52,3 +52,38 @@ def test_team_workflow_requires_shared_team() -> None:
 
     teams_coll.find.return_value = [{"slug": "other-team"}]
     assert user_can_run_workflow(workflow, user, mongo) is False
+
+
+def test_agent_not_in_workflow_steps_denied() -> None:
+    """Agent not referenced in any step is denied even if workflow is accessible."""
+    workflow = {
+        "_id": "wf-global",
+        "visibility": "global",
+        "owner_id": "system",
+        "steps": [{"type": "step", "agent_id": "agent-x"}],
+    }
+    mongo = _mongo_with_workflow(workflow)
+    user = UserContext(email="anyone@example.com")
+
+    assert can_use_agent_via_workflow("agent-not-in-steps", "wf-global", user, mongo) is False
+
+
+def test_missing_workflow_denied() -> None:
+    """Unknown workflow_config_id always denies."""
+    mongo = _mongo_with_workflow(None)
+    user = UserContext(email="anyone@example.com")
+
+    assert can_use_agent_via_workflow("agent-x", "wf-does-not-exist", user, mongo) is False
+
+
+def test_private_workflow_only_owner_can_use() -> None:
+    workflow = {
+        "_id": "wf-private",
+        "visibility": "private",
+        "owner_id": "owner@example.com",
+        "steps": [{"type": "step", "agent_id": "agent-priv"}],
+    }
+    mongo = _mongo_with_workflow(workflow)
+
+    assert can_use_agent_via_workflow("agent-priv", "wf-private", UserContext(email="owner@example.com"), mongo) is True
+    assert can_use_agent_via_workflow("agent-priv", "wf-private", UserContext(email="other@example.com"), mongo) is False


### PR DESCRIPTION
Companion fix for #1751.

## Problem

The fallback in `require_agent_use_permission` allowed workflow membership to **escalate privilege**: a user without `dynamic_agent#use` could gain access to an agent by being a member of a team that owns a workflow containing that agent as a step.

```
# Before — OR logic: workflow bypasses direct agent check
if not allowed and can_use_agent_via_workflow(...):
    allowed = True
```

## Fix

Workflow context is **additional validation**, not an escalation path. When `workflow_config_id` is present both conditions must be true:

1. **`dynamic_agent#use`** — user has direct OpenFGA permission on the agent
2. **`can_use_agent_via_workflow`** — agent is a step in the referenced workflow AND the user can run that workflow (visibility check)

```python
# After — AND logic: workflow tightens, not loosens, the check
if workflow_config_id and mongo and user:
    if allowed and not can_use_agent_via_workflow(...):
        allowed = False
        deny_reason = "DENY_WORKFLOW_ACCESS"
```

A distinct audit reason code `DENY_WORKFLOW_ACCESS` makes it easy to distinguish in audit logs from a plain missing-capability denial.

## Tests

Added 3 new unit tests covering:
- Agent not in workflow steps → denied
- Missing/unknown workflow_config_id → denied
- Private workflow owner vs non-owner

All 5 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)