### PR TITLE
docs(authz): centralized authorization service spec (CAS)

### DIFF
--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md
@@ -1,0 +1,619 @@
+# Problem Statement: Centralized BFF Authorization & PDP-Agnostic API
+
+**Status:** Draft for second-opinion review  
+**Date:** 2026-06-05  
+**Authors:** Sri Aradhyula (problem framing); AI-assisted synthesis from PR review + team discussion  
+**Audience:** Platform engineers, security architects, agents reviewing implementation options  
+
+**Related work:**
+
+| Link | Role |
+|------|------|
+| [PR #1751](https://github.com/cnoe-io/ai-platform-engineering/pull/1751) | Workflow RBAC visibility, run access, unsaved UX, agent-access modal |
+| [PR #1751 review r3362688683](https://github.com/cnoe-io/ai-platform-engineering/pull/1751#discussion_r3362688683) | @subbaksh: workflows are UI/BFF concept; DA should not own workflow RBAC |
+| [Issue #1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) | Epic: RBAC/Auth review remediation (PR #1444 follow-ups) |
+| [Issue #1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) | Skills RBAC UI parity / shared-module hygiene (#1727 follow-up) |
+| [Issue #1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455) | Runtime BFF ReBAC endpoints for Slack/Webex bots |
+| [Issue #1454](https://github.com/cnoe-io/ai-platform-engineering/issues/1454) | Refactor DA runtime auth surface |
+| [Issue #1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731) | Duplicate OpenFGA `can_use` on DA chat path |
+| [Issue #1734–#1738](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) | RAG thin PEP / Mongo in hot path |
+
+---
+
+## 1. Executive summary
+
+CAIPE has **reusable RBAC modules on the BFF** (Next.js UI server) and **CI guards** for new resource types, but authorization is still implemented inconsistently across surfaces:
+
+- **Dynamic Agents (DA)** sometimes reads **MongoDB** for UI-domain data (e.g. `workflow_configs`, `teams`) and duplicates **OpenFGA** checks the BFF already performs.
+- **RAG** still uses a **monolithic `server/rbac.py`** that mixes token validation, legacy roles, OpenFGA, and MongoDB — a different pattern than agents/KB/MCP on the BFF.
+- **Public APIs and errors** expose OpenFGA-specific concepts (`agent#use`, `pdp_denied`, tuple strings), coupling integrators and UI copy to the current PDP.
+- **HTTP authorization** is fragmented: admin-only `rebac/check`, domain-specific `access-check` routes, and no generic **runtime** evaluate API for service callers (bots, DA).
+
+After testing **0.5.9** and reviewing **PR #1751**, the team wants to:
+
+1. **Stop creating anti-patterns** (DA → Mongo for workflows; one-off RBAC per resource).
+2. **Enforce shared module usage** going forward (linters, hygiene).
+3. **Make the authorization API PDP-agnostic** so OpenFGA is an implementation detail, not a user-facing contract.
+4. **Centralize policy decisions on the BFF** where platform domain data lives (workflows, teams, visibility).
+
+This document captures the **problem statement**, **current state**, **stakeholder input**, and **implementation options** for a follow-up spec.
+
+---
+
+## 2. Problem statement
+
+### 2.1 Core problem
+
+**Authorization logic and platform domain data are scattered across BFF, Dynamic Agents, RAG, and Slack bot**, with multiple parallel patterns for the same decision (`user X may use resource Y`). This causes:
+
+1. **Architectural drift** — reviewers repeatedly flag DA/RAG reading Mongo or re-implementing visibility rules that belong on the BFF.
+2. **Duplicate PDP hops** — BFF checks OpenFGA, then DA checks OpenFGA again (latency, availability, confusion about source of truth).
+3. **Inconsistent developer experience** — agents use `shareable-resource.ts` + `resource-authz.ts`; RAG uses `rbac.py`; workflows added DA-side Mongo reads in PR #1751.
+4. **Leaky abstraction** — API consumers see OpenFGA relation names and PDP jargon instead of stable product-level denial reasons.
+5. **Weak enforcement** — CI guarantees new **types** are registered and default-deny tested, but does not force routes/services to use shared modules vs ad-hoc checks.
+
+### 2.2 Triggering incidents (this conversation)
+
+#### A. PR #1751 — workflow RBAC + DA delegation
+
+PR [#1751](https://github.com/cnoe-io/ai-platform-engineering/pull/1751) adds:
+
+- BFF: workflow visibility, run access gates, team slug normalization, unsaved UX, agent-access modal on save.
+- DA: `workflow_execution_authz.py` — reads `workflow_configs` and `teams` from Mongo; allows `agent#can_use` bypass when `workflow_config_id` is passed on chat requests.
+
+**Reviewer feedback (@subbaksh, [r3362688683](https://github.com/cnoe-io/ai-platform-engineering/pull/1751#discussion_r3362688683)):**
+
+> Workflows are purely a UI server concept. The UI invokes agents one step at a time. DA usually has no clue whether it's a workflow or a user chatting. For invocation — the DA server just has a tool (with `workflow_id` param) that it calls to invoke a workflow. The RBAC for invocation should be in UI server no?
+
+**Assessment:** The reviewer is aligned with epic [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742). Workflow lifecycle auth already exists on the BFF (`/api/workflow-runs`, `workflow-config-rebac.ts`). DA Mongo reads are an anti-pattern; the bypass exists only because the workflow engine forwards the **user JWT** to DA and DA enforces `agent#can_use` independently.
+
+#### B. Reusable modules — one path did not use them
+
+Shared modules were introduced for **unified shareable resource RBAC** (spec `2026-06-03-unified-shareable-resource-rbac`):
+
+- **Write path:** `ui/src/lib/rbac/shareable-resource.ts` → `openfga-owned-resources.ts` (`reconcileShareableResource`)
+- **Read path:** `ui/src/lib/rbac/resource-authz.ts` (`requireResourcePermission`, `filterResourcesByPermission`)
+
+Skills team sharing was fixed in [#1729](https://github.com/cnoe-io/ai-platform-engineering/pull/1729) to use `reconcileShareableResource`. Follow-up [#1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) tracks optional UI DRY (`useShareableTeams` hook) and documents explicit non-goals (skills as owner-team resources).
+
+**Gap:** Not every feature path uses the shared stack. PR #1751’s DA workflow auth is the latest example of **bypassing** BFF modules entirely.
+
+#### C. Team discussion (Kevin Kantesaria, 2026-06-05)
+
+Paraphrased Slack thread:
+
+| Speaker | Point |
+|---------|--------|
+| Sri | Created [#1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) to track cleanup after reusable modules; one instance did not use them. |
+| Kevin | Push cleanup soon so we don’t keep creating anti-patterns; unsure how to **enforce** going forward. |
+| Sri | Added basic RBAC enforcement for new resources; need linters and hygiene. |
+| Kevin | Does that enforcement **use the modules**? Original problem: **RAG and agents used different RBAC setups** — want to avoid that. |
+| Kevin / Sri | Make **OpenFGA less obvious** to end users; API should be **agnostic** if we switch PDP. |
+
+### 2.3 Goals (desired end state)
+
+1. **Single policy ownership** — BFF owns platform domain data (workflows, teams, visibility) and composes FGA + product rules.
+2. **Single module stack** — application code uses `shareable-resource` / `resource-authz` (or a thin facade), not raw `openfga.ts` or service-local Mongo policy.
+3. **PDP-agnostic public contract** — HTTP and user-facing errors use `{ resource, action, reason }`, not `can_use` / `agent#use` / `pdp_denied`.
+4. **Thin PEPs downstream** — DA, RAG, bots either trust BFF decisions via API or verify signed claims; they do not read `workflow_configs` from Mongo for authz.
+5. **Enforceable in CI** — import boundaries, create-path linter extensions, no new anti-patterns without explicit spec exception.
+
+### 2.4 Non-goals (for initial spec)
+
+- Replacing OpenFGA as the relationship store (unless a separate strategic decision).
+- Removing all OpenFGA checks from DA in v1 (tracked as [#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731); depends on [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458) dual-gate documentation).
+- Migrating skills to owner-team model ([#1708](https://github.com/cnoe-io/ai-platform-engineering/pull/1708)) — separate from this problem.
+
+---
+
+## 3. Current state (as of 2026-06-05, branch `prebuild/feat/workflow-rbac-visibility-unsaved`)
+
+### 3.1 BFF authorization layers
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  BFF route handler (ui/src/app/api/**/route.ts)                   │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         ▼                   ▼                   ▼
+  requireRbacPermission   requireResourcePermission   Domain helpers
+  (api-middleware.ts)     (resource-authz.ts)         (workflow-config-rebac,
+   org/capability gates                             slack-channel-rebac, …)
+         │                   │                   │
+         └───────────────────┼───────────────────┘
+                             ▼
+              checkOpenFgaTuple / checkUniversalRebacRelationship
+                             (openfga.ts)
+                             ▼
+                        OpenFGA HTTP API
+```
+
+#### Key modules
+
+| Module | Path | Responsibility |
+|--------|------|----------------|
+| OpenFGA transport | `ui/src/lib/rbac/openfga.ts` | `checkOpenFgaTuple`, tuple read/write/reconcile |
+| Resource ReBAC | `ui/src/lib/rbac/resource-authz.ts` | `requireResourcePermission`, `filterResourcesByPermission`, `requireAgentPermission`, `requireSkillPermission` |
+| Agent use (chat proxy) | `ui/src/lib/rbac/openfga-agent-authz.ts` | `requireAgentUsePermission` — used by `/api/v1/chat/*` |
+| Agent use (audit path) | `ui/src/lib/rbac/pdp-shared.ts` | `evaluateAgentAccess` — direct + team-union with reason codes |
+| Shareable write | `ui/src/lib/rbac/shareable-resource.ts` | `handleShareableResourceWrite`, `resolveShareableOwnershipWrite` |
+| FGA reconcile | `ui/src/lib/rbac/openfga-owned-resources.ts` | `reconcileShareableResource` |
+| Workflow policy | `ui/src/lib/rbac/workflow-config-rebac.ts` | Visibility, `workflowDelegatesAgentUse`, `reconcileWorkflowConfigAccess` (uses `reconcileShareableResource`) |
+| Access explain (admin) | `ui/src/lib/rbac/access-explainer.ts` | `explainAccess` + Mongo provenance |
+| Type registry | `ui/src/types/rbac-universal.ts` | `UniversalRebacResourceType`, `UniversalRebacRelationship` |
+| Enforcement manifest | `ui/src/lib/rbac/fga-enforcement-manifest.ts` | Per-type `rebac_enforced` / surfaces for auditors |
+
+#### HTTP APIs that expose authorization today
+
+| Endpoint | Auth gate | Purpose | Runtime-safe? |
+|----------|-----------|---------|---------------|
+| `POST /api/admin/rebac/check` | `admin_ui#view` | Explain access (`explainAccess`) | **No** — admin only |
+| `POST /api/integrations/slack/.../access-check` | Session + `slack_channel#read` | `checkSlackChannelAccess` | **Partial** — bot path evolving |
+| `POST /api/integrations/webex/.../access-check` | Same pattern | Webex space access | **Partial** |
+| `POST /api/admin/slack/.../access-check` | Admin | Diagnostics | No |
+| `POST /api/admin/openfga/relationship` | Admin | Tuple grant/revoke | No (write) |
+| `POST /api/workflow-runs` | `assertCanExecuteWorkflowRunsForConfigId` | Start run | Yes — domain API |
+| `POST /api/workflow-configs/check-agent-access` | `withAuth` | Pre-save agent gap check (PR #1751) | Yes — BFF-only |
+| DA `WorkflowApiClient` → `/api/workflow-runs` | OAuth2 client credentials | Workflow tools from agents | Yes — correct pattern |
+
+**There is no generic `POST /api/runtime/authorize` today.**
+
+Spec draft exists: `docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md` (`POST /api/admin/rebac/check` with `UniversalRebacRelationship`).
+
+### 3.2 CI enforcement (FGA coverage guarantee, spec 2026-06-04)
+
+| Layer | Artifact | What it enforces |
+|-------|----------|------------------|
+| 1 | `fga-type-coverage.test.ts` | OpenFGA model ≡ type registry ≡ chart |
+| 2 | `fga-enforcement-manifest.test.ts` | Every type classified; enforced surfaces exist on disk |
+| 3 | `scripts/validate-fga-create-paths.py` | Ownable types wire `reconcile*Relationships` from production routes |
+| 4 | `default-deny-coverage.test.ts` | New types auto-covered for deny-by-default |
+
+**Gap:** Layers 1–4 do **not** require routes to call `shareable-resource` / `resource-authz` vs ad-hoc `checkOpenFgaTuple`. They do **not** block DA/RAG Mongo reads for authz.
+
+### 3.3 Dynamic Agents — workflow-related anti-patterns
+
+| Location | Mongo / policy | Issue |
+|----------|----------------|-------|
+| `dynamic_agents/auth/workflow_execution_authz.py` | Reads `workflow_configs`, `teams` | Duplicates BFF visibility; reviewer rejected |
+| `dynamic_agents/auth/openfga_authz.py` | OpenFGA + workflow bypass | Third auth layer on chat path |
+| `dynamic_agents/services/agent_runtime.py` | Reads `workflow_configs` for builtin tool validation | Should use BFF resolve API |
+| `dynamic_agents/services/builtin_tools.py` | `WorkflowApiClient` → BFF | **Correct** pattern for invocation |
+
+### 3.4 RAG vs agents — divergent stacks
+
+| Concern | Agents / BFF resources | RAG server |
+|---------|------------------------|------------|
+| Read/use gate | `resource-authz.ts` → OpenFGA | `server/rbac.py` (mixed) |
+| Share/write | `shareable-resource.ts` | Partial (KB sharing route on BFF); ingestor paths differ |
+| Mongo in authz hot path | Mostly moved to BFF | Still present ([#1736](https://github.com/cnoe-io/ai-platform-engineering/issues/1736)) |
+| Target architecture | Unified shareable resource RBAC | [Thin PEP plan](docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md) |
+
+Kevin’s concern: **“RAG and agents used different RBAC setups”** — still true at the Python RAG layer.
+
+### 3.5 PR #1751 commit inventory (relevant)
+
+| Commit / area | BFF-aligned? | Notes |
+|---------------|--------------|-------|
+| Workflow run access (`workflow-run-access.ts`) | Yes | |
+| `workflow-config-rebac.ts` + `reconcileShareableResource` | Yes | |
+| Unsaved UX, team slugs, `TeamMultiPicker` | Yes | |
+| `check-agent-access` + `WorkflowAgentAccessModal` | Yes | Pre-grant agent tuples on save |
+| `workflow_execution_authz.py` on DA | **No** | Remove or defer to epic |
+| `workflow_config_id` on DA chat body | **No** | Remove with above |
+
+### 3.6 User-visible OpenFGA leakage (examples)
+
+From `openfga-agent-authz.ts` and `resource-authz.ts`:
+
+```json
+{
+  "success": false,
+  "error": "Permission denied",
+  "code": "agent#use",
+  "reason": "pdp_denied",
+  "action": "contact_admin"
+}
+```
+
+Admin explain responses include FGA tuple strings. Audit events use `pdp: "openfga"`. These are appropriate for **operators**, not for generic API consumers or end-user copy.
+
+---
+
+## 4. Architectural principles (agreed direction)
+
+1. **Workflows are a BFF concern** — config, visibility, run orchestration, delegation checks live in UI server + `workflow-engine.ts`.
+2. **DA invokes agents; DA workflow tools invoke workflows via BFF** — `WorkflowApiClient` is the model.
+3. **OpenFGA is the current PDP for relationships** — but **callers** should not depend on FGA tuple shape.
+4. **Defense-in-depth is optional and explicit** — duplicate DA OpenFGA ([#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731)) must be a documented choice ([#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458)), not accidental duplication.
+5. **Epic [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) phases** — runtime BFF endpoints ([#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455)) before bots/DA drop Mongo.
+
+---
+
+## 5. Options (detailed)
+
+### Option 1 — In-process Authz facade (BFF library)
+
+**Summary:** Introduce `ui/src/lib/authz/` as the **only** import surface for application authorization. OpenFGA moves behind a `PolicyEngine` interface.
+
+#### Proposed structure
+
+```text
+ui/src/lib/authz/
+  index.ts                 # authorize(), filterAccessible(), reconcileShares()
+  types.ts                 # Subject, Resource, Action, Decision (PDP-agnostic)
+  errors.ts                # PERMISSION_DENIED, AUTHZ_UNAVAILABLE
+  engines/
+    openfga-adapter.ts     # implements PolicyEngine today
+  domains/
+    workflow.ts            # workflowDelegatesAgentUse, visibility (Mongo product policy)
+    slack-channel.ts
+    webex-space.ts
+```
+
+#### Public API (sketch)
+
+```typescript
+interface AuthorizeRequest {
+  subject: { type: "user" | "service_account"; id: string };
+  resource: { type: UniversalRebacResourceType; id: string };
+  action: ResourcePermissionAction;
+  context?: Record<string, unknown>; // workflow_id, channel_id, etc.
+}
+
+interface AuthorizeDecision {
+  allowed: boolean;
+  reason: "OK" | "NO_CAPABILITY" | "AUTHZ_UNAVAILABLE" | "INVALID_REQUEST";
+  action?: "sign_in" | "contact_admin" | "retry";
+  // Admin-only extension:
+  debug?: { engine: string; path?: string };
+}
+
+async function authorize(req: AuthorizeRequest): Promise<AuthorizeDecision>;
+async function authorizeOrThrow(req: AuthorizeRequest): Promise<void>;
+```
+
+#### Migration
+
+1. Wrap existing `resource-authz.ts`, `pdp-shared.ts`, domain modules.
+2. Deprecate direct `checkOpenFgaTuple` imports outside `lib/authz/**`.
+3. Map existing `ApiError` codes to PDP-agnostic envelope.
+
+#### Pros
+
+- No new network hop; fits existing Next.js deployment.
+- Clear import boundary for ESLint.
+- Enables future non-OpenFGA engine without route changes.
+
+#### Cons
+
+- Does not alone fix DA/RAG — they don’t run inside BFF.
+- Requires disciplined migration of ~dozens of route call sites.
+
+#### Enforcement
+
+```javascript
+// eslint no-restricted-imports
+"@/lib/rbac/openfga" → only from "@/lib/authz/**"
+```
+
+---
+
+### Option 2 — Runtime HTTP authorize API (BFF routes)
+
+**Summary:** Expose authorization decisions as HTTP for **service callers** (Slack bot, Webex bot, Dynamic Agents). Implements [#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455) and generalizes `access-check` routes.
+
+#### Proposed endpoint
+
+```http
+POST /api/runtime/authorize
+Authorization: Bearer <user-jwt | service-account-token>
+Content-Type: application/json
+
+{
+  "subject": { "type": "user", "id": "<oidc-sub>" },
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "action": "use",
+  "context": {
+    "workflow_config_id": "wf-optional-hint"
+  }
+}
+```
+
+**Response (allow):**
+
+```json
+{
+  "allowed": true,
+  "reason": "OK"
+}
+```
+
+**Response (deny):**
+
+```json
+{
+  "allowed": false,
+  "reason": "NO_CAPABILITY",
+  "action": "contact_admin"
+}
+```
+
+**Response (PDP down):**
+
+```json
+{
+  "allowed": false,
+  "reason": "AUTHZ_UNAVAILABLE",
+  "action": "retry"
+}
+```
+
+#### Domain-specific endpoints (alternative/complement)
+
+Instead of one generic endpoint, extend the **access-check pattern**:
+
+| Endpoint | Caller | Checks |
+|----------|--------|--------|
+| `POST /api/runtime/authorize` | Generic | FGA + optional context handlers |
+| `POST /api/runtime/workflows/authorize-run` | DA, internal | Workflow visibility + step agents |
+| `POST /api/runtime/workflows/resolve-configs` | DA | Replace Mongo `workflow_configs` read |
+| Existing Slack/Webex `access-check` | Bots | Channel/space scoped |
+
+#### Authentication model
+
+- **User bearer** — subject must match token `sub` (or OBO chain).
+- **Service account** — `service_account:<client_id>` in FGA; may evaluate on behalf of user when `context.delegated_subject` is present and bot OBO is valid (needs threat model).
+
+#### Pros
+
+- DA/RAG/bots stop reading Mongo for policy.
+- Single HTTP contract for integrators.
+- Aligns with epic [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) prerequisite [#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455).
+
+#### Cons
+
+- Latency and availability — every DA chat could add BFF round-trip unless cached or combined with Option 3.
+- Duplicates [#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731) debate if DA **still** checks OpenFGA after BFF says allow.
+
+#### Implementation notes
+
+- Implement handlers by delegating to Option 1 facade internally.
+- Admin `POST /api/admin/rebac/check` remains explain-only with richer `debug` payload.
+
+---
+
+### Option 3 — Signed authorization claims (PEP-only downstream)
+
+**Summary:** BFF is the **sole PDP**. After `authorize()`, BFF mints a **short-lived signed claim** (JWT or HMAC macaroon) attached to downstream requests. DA/RAG verify signature + expiry only.
+
+#### Claim sketch
+
+```json
+{
+  "iss": "caipe-bff",
+  "sub": "user:<oidc-sub>",
+  "resource": "agent:platform-engineer",
+  "action": "use",
+  "iat": 1710000000,
+  "exp": 1710000060,
+  "jti": "unique-id"
+}
+```
+
+DA `require_agent_use_permission` becomes `require_authorization_claim` — no OpenFGA client in DA.
+
+#### Pros
+
+- Eliminates duplicate OpenFGA in DA ([#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731)).
+- True PDP agnostic at service boundary.
+- Workflow delegation encoded in claim issuance on BFF (no `workflow_config_id` on DA).
+
+#### Cons
+
+- Largest engineering cost: key management, revocation, clock skew, claim replay.
+- Requires [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458) dual-gate retirement plan.
+- Workflow engine currently forwards **user JWT** — would need claim issuance at run start and per step.
+
+#### When to choose
+
+- Phase 3+ of [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742), after runtime BFF API proves correct.
+
+---
+
+### Option 4 — Enforcement-first (linters + manifest, minimal API change)
+
+**Summary:** Keep current modules; **block anti-patterns in CI** without redesigning HTTP APIs yet.
+
+#### Proposed guards
+
+| Guard | Mechanism | Blocks |
+|-------|-----------|--------|
+| Import boundary | ESLint `no-restricted-imports` | `checkOpenFgaTuple` outside `lib/rbac/**` or `lib/authz/**` |
+| Service boundary | `scripts/validate-authz-boundaries.py` | `workflow_configs` / `teams` reads in `dynamic_agents/**` for authz |
+| Route coverage | Extend `validate-fga-create-paths.py` or new script | New routes must import from `resource-authz` or `authz` facade |
+| Manifest update | `fga-enforcement-manifest.ts` | Add surfaces for `task` (workflows), runtime authorize routes |
+| PR template | Checkbox | “Uses shareable-resource / resource-authz / domain wrapper” |
+
+#### Pros
+
+- Fastest win; addresses Kevin’s “don’t create more anti-patterns.”
+- Low risk; parallel to other options.
+
+#### Cons
+
+- Does not fix RAG `rbac.py` or user-visible OpenFGA strings.
+- Does not give DA a supported API without Option 2.
+
+---
+
+### Option 5 — Universal relationship contract (spec-only standardization)
+
+**Summary:** Standardize all checks on `UniversalRebacRelationship` from `rbac-universal.ts` — already in [rebac-policy-api.md](docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md).
+
+#### Request shape
+
+```json
+{
+  "subject": { "type": "user", "id": "user-123", "relation": "member" },
+  "action": "use",
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "context": { "slack_channel": "C123" }
+}
+```
+
+#### Mapping
+
+- Internal: `checkUniversalRebacRelationship(relationship)` in `openfga.ts`.
+- `action: "use"` maps to FGA relation `can_use` inside adapter — **not** exposed to clients.
+
+#### Pros
+
+- One vocabulary for docs, admin UI, runtime API, tests.
+- Natural fit for Option 1 + Option 2.
+
+#### Cons
+
+- `action` names still mirror current FGA model; true PDP swap requires adapter mapping table per engine.
+
+---
+
+## 6. PDP-agnostic public surface (cross-cutting)
+
+Regardless of option, define a **stable external contract**:
+
+### 6.1 Error envelope migration
+
+| Current | Target (public) | Admin/debug only |
+|---------|-----------------|------------------|
+| `code: "agent#use"` | `code: "PERMISSION_DENIED"` | `detail: "agent#use"` |
+| `reason: "pdp_denied"` | `reason: "NO_CAPABILITY"` | |
+| `reason: "pdp_unavailable"` | `reason: "AUTHZ_UNAVAILABLE"` | |
+| `pdp: "openfga"` in JSON body | Omit | Keep in audit logs |
+| FGA tuple in error message | Omit | `POST /api/admin/rebac/check` |
+
+### 6.2 Stable reason codes
+
+| Code | Meaning | User `action` hint |
+|------|---------|-------------------|
+| `OK` | Allowed | — |
+| `NO_CAPABILITY` | Deny — no relationship | `contact_admin` |
+| `NOT_SIGNED_IN` | Missing/invalid auth | `sign_in` |
+| `AUTHZ_UNAVAILABLE` | PDP timeout/error | `retry` |
+| `INVALID_REQUEST` | Bad resource id / malformed | `fix_request` |
+
+### 6.3 Two-tier API
+
+| Tier | Audience | OpenFGA visible? |
+|------|----------|------------------|
+| **Runtime** | UI, bots, DA, RAG PEP | No |
+| **Admin explain** | Operators, support | Yes (paths, tuples, provenance) |
+
+---
+
+## 7. Workflow-specific resolution (PR #1751)
+
+### 7.1 Correct split of responsibility
+
+| Operation | Owner | Mechanism |
+|-----------|-------|-----------|
+| Create/update workflow config | BFF | `workflow-configs` routes + `reconcileWorkflowConfigAccess` |
+| Start/list/cancel/resume run | BFF | `/api/workflow-runs` + `workflow-run-access.ts` |
+| Pre-save agent access gaps | BFF | `check-agent-access` + grant via `/api/admin/openfga/relationship` |
+| Orchestrate steps | BFF `workflow-engine.ts` | Calls DA with user auth headers |
+| Agent `#can_use` at DA | DA OpenFGA only | **No workflow Mongo** — team access via pre-granted tuples or BFF-only delegation |
+| DA workflow tools | DA → BFF | `WorkflowApiClient` /api/workflow-runs |
+
+### 7.2 `workflowDelegatesAgentUse` (exists, unused)
+
+Defined in `workflow-config-rebac.ts`:
+
+- Agent listed in workflow steps **and**
+- `workflowRunAllowedByVisibility` for caller
+
+**Action:** Wire at `POST /api/workflow-runs` and optionally before each `consumeAgentStream` in `workflow-engine.ts`. Remove DA `workflow_execution_authz.py`.
+
+### 7.3 Global workflow gap
+
+`check-agent-access` detects `(all users)` gaps but grant loop skips them. Spec should decide: org-wide agent grants vs admin-only warning.
+
+---
+
+## 8. Recommended phased approach
+
+| Phase | Scope | Options | Depends on |
+|-------|-------|---------|------------|
+| **0 — Immediate** | PR #1751 cleanup | Remove DA workflow Mongo; keep BFF-only RBAC | — |
+| **1 — Hygiene** | CI + docs | Option 4 + [#1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) UI DRY | — |
+| **2 — Facade** | BFF routes | Option 1 + Option 5 + error envelope §6 | Phase 1 |
+| **3 — Runtime API** | Bots, DA read paths | Option 2 ([#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455)) | Phase 2 |
+| **4 — RAG convergence** | `rbac.py` thin PEP | Option 1 client in Python or Option 2 HTTP | [#1734](https://github.com/cnoe-io/ai-platform-engineering/issues/1734) |
+| **5 — Optional** | DA duplicate FGA removal | Option 3 | [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458), [#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731) |
+
+---
+
+## 9. Open questions for second opinion
+
+1. **DA execution gate:** Keep OpenFGA in DA for `agent#use` ([#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731)) or move to BFF-only + signed claims (Option 3)?
+2. **Workflow delegation without agent tuples:** Is pre-grant on save (modal) sufficient for team workflows, or must runtime delegation work without prior grants?
+3. **Generic vs domain HTTP APIs:** One `POST /api/runtime/authorize` vs family of `access-check` endpoints?
+4. **RAG:** HTTP client to BFF vs shared Python library duplicating facade logic?
+5. **Service account delegation:** How should bots evaluate access **for** a user without admin UI perms?
+6. **Claim revocation:** Required for Option 3, or acceptable 60s TTL?
+7. **Breaking API changes:** Version `/api/v2/` for error envelope, or migrate in place?
+8. **Workflow `task` type in FGA:** Is Mongo visibility a permanent product layer on top of FGA, or should all run access be FGA-only eventually?
+
+---
+
+## 10. Acceptance criteria (draft for full spec)
+
+- [ ] No production authz path in `dynamic_agents/**` reads `workflow_configs` or `teams` from Mongo.
+- [ ] All new BFF routes use `authorize()` facade or documented domain wrapper — CI enforced.
+- [ ] Public API errors use §6 reason codes; no `pdp_denied` / `agent#use` in user-facing responses.
+- [ ] Runtime callers (Slack, Webex, DA workflow tools) use BFF HTTP or documented service contract — not admin rebac routes.
+- [ ] `workflowDelegatesAgentUse` wired at run start (and documented for step execution).
+- [ ] RAG plan references same contract as BFF (no third parallel RBAC vocabulary).
+- [ ] `fga-enforcement-manifest.ts` updated with new surfaces and `rebac_enforced` entries.
+- [ ] ADR or [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458) documents dual-gate retirement if DA OpenFGA is removed.
+
+---
+
+## 11. References (code & docs)
+
+### Code
+
+- `ui/src/lib/rbac/shareable-resource.ts`
+- `ui/src/lib/rbac/resource-authz.ts`
+- `ui/src/lib/rbac/openfga.ts`
+- `ui/src/lib/rbac/workflow-config-rebac.ts`
+- `ui/src/lib/rbac/fga-enforcement-manifest.ts`
+- `ui/src/app/api/admin/rebac/check/route.ts`
+- `ui/src/app/api/integrations/slack/.../access-check/route.ts`
+- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/workflow_execution_authz.py`
+- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py` (`WorkflowApiClient`)
+- `ui/src/lib/server/workflow-engine.ts`
+- `scripts/validate-fga-create-paths.py`
+
+### Docs
+
+- [PDP coverage audit](docs/docs/security/rbac/pdp-coverage-audit.md)
+- [RBAC architecture](docs/docs/security/rbac/architecture.md)
+- [Chat execution authz contract](docs/docs/specs/2026-05-16-dynamic-agent-pdp-gate/contracts/chat-execution-authz.md)
+- [Unified shareable resource RBAC](docs/docs/specs/2026-06-03-unified-shareable-resource-rbac/)
+- [RAG thin PEP plan](docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md)
+- [ReBAC policy API contract](docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md)
+
+---
+
+## 12. Instructions for reviewing agent
+
+Please evaluate:
+
+1. Whether **Option 1 + 2 + 4** is the right default combo vs Option 3 early.
+2. Whether **workflow delegation** should be FGA tuples (grant on save) vs runtime BFF check only.
+3. Gaps in **threat model** for runtime authorize API (service account, OBO, user impersonation).
+4. **Migration risk** for error code changes on existing UI/clients.
+5. Whether this should be one spec or split: (a) facade + enforcement, (b) runtime HTTP API, (c) RAG/DA convergence.
+
+Return: recommended option mix, ordered task list, and any contradictions with [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) phasing.

--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md
@@ -1,0 +1,381 @@
+# Solution Architecture: Centralized Authorization Service (BFF-resident, PDP-agnostic)
+
+**Status:** Second-opinion response to [`problem-statement.md`](./problem-statement.md)
+**Date:** 2026-06-05
+**Scope:** Architecture + security model + standalone migration. Companion to the problem statement; not yet a `/speckit` spec.
+
+---
+
+## 0. TL;DR — the decision
+
+The problem statement frames five competing options. They are **not** competing — they are layers of one design. Collapse them:
+
+> **One decision core. Two transports. One optional claim. Shadow-first migration.**
+
+```text
+                        ┌──────────────────────────────────────────────┐
+                        │     Authorization Decision Core (lib/authz)    │
+                        │  PDP-agnostic types · reason codes · domain    │
+                        │  composition · ONE OpenFGA adapter behind it   │
+                        └───────────────┬───────────────┬───────────────┘
+            in-process call             │               │        HTTP (out-of-process PEPs)
+        ┌───────────────────────────────┘               └────────────────────────────────┐
+        ▼                                                                                  ▼
+  BFF route handlers                                              POST /api/authz/v1/decisions
+  (authorize / authorizeMany / authorizeOrThrow)                  POST /api/authz/v1/decisions:batch
+  no network hop                                                  POST /api/authz/v1/explain  (admin)
+                                                                  (optional) signed decision tokens
+                                                                          ▲
+                                       ┌──────────────────────────────────┼───────────────────────┐
+                                       │                                   │                        │
+                                  Dynamic Agents                       RAG server                Slack/Webex bots
+                                  (thin PEP, no Mongo,                 (thin PEP, no Mongo,       (thin PEP)
+                                   no OpenFGA client)                   no OpenFGA client)
+```
+
+Everything the four bullets ask for falls out of this shape:
+
+| Your ask | How this delivers it |
+|----------|----------------------|
+| **No MongoDB in Dynamic Agents** | DA calls the HTTP API for decisions; the *service* owns workflow-visibility data and audit writes. DA keeps zero policy Mongo. |
+| **Reusable authz modules** | The **core** is the one reusable module. BFF imports it in-process; DA/RAG/bots consume it over HTTP. No second/third reimplementation possible. |
+| **Common PDP AuthZ APIs** | `POST /api/authz/v1/decisions` is the single contract for every out-of-process caller; the in-process `authorize()` is the same core. |
+| **HA OpenFGA + PDP-agnostic API** | OpenFGA sits behind one pooled adapter with a warm store-id, decision cache, and circuit breaker; callers see `{decision, reason}`, never `can_use`/tuples. |
+
+**Standalone, no resources touched, slow migration** is achieved by **shadow mode** (§5): the service ships and runs *observe-only* alongside the existing checks, which stay authoritative until each caller is flipped, one at a time, on measured decision parity.
+
+---
+
+## 1. Critique of the problem statement
+
+### 1.1 What it gets right
+
+- **Inventory is excellent.** The module table (§3.1), endpoint table (§3.1), and DA/RAG anti-pattern tables are accurate and rare in a problem doc.
+- **Core diagnosis is correct.** Scattered policy + duplicate PDP hops + leaky abstraction + weak enforcement is the real disease.
+- **Phasing instinct is right** (immediate cleanup → hygiene → facade → runtime → RAG).
+- **Honest non-goals.** Not replacing OpenFGA; not ripping DA checks in v1.
+
+### 1.2 Gaps to fix (these reshape the design)
+
+1. **It understates the duplication.** This is not "different patterns" — it is **three full reimplementations** of the same OpenFGA transport + decision logic (`openfga.ts`, DA `openfga_authz.py`, RAG `rbac.py`), plus **two duplicate agent-use algorithms inside the BFF itself** (`requireAgentUsePermission` vs `evaluateAgentAccess`), plus **three error envelopes**. A *library* facade (Option 1) cannot fix the Python copies — only a **service** collapses all three. The doc admits Option 1 "does not alone fix DA/RAG" but never resolves it.
+
+2. **"Facade vs Runtime API" is a false fork.** Option 1 (in-process) and Option 2 (HTTP) are the *same core* exposed two ways, not alternatives to mix. Treating them as separate phases invites two codebases drifting apart again — exactly the disease.
+
+3. **The standalone / "don't touch resources" requirement is unaddressed.** Every migration path in the doc rewrites existing call sites. There is no **shadow / dual-run / decision-parity** mechanism. That mechanism is the *only* way to satisfy "build it standalone and migrate slowly" safely (§5). Biggest omission.
+
+4. **Threat model is deferred to "open questions."** For a security-conscious central PDP, the answers must be in the design: token verification (DA currently base64-decodes the JWT and trusts upstream), subject-binding, OBO impersonation via real tuples (the doc's sketch trusts a `context.delegated_subject` body field — a spoofing hole), fail-closed + audited break-glass, decision-token replay. §4 answers all of these.
+
+5. **`#1755` is mis-scoped.** Issue #1755 is a narrow tracking issue — skills RBAC UI parity + an *optional* `useShareableTeams` hook, explicitly "no further PR required." It is **not** the centralization mandate. The real mandate is Kevin's "RAG and agents must not diverge." Don't anchor the PDP architecture to #1755; it's a small UI-DRY cleanup that ships independently.
+
+6. **Workflow delegation hides a least-privilege regression.** PR #1751's "pre-grant agent tuples on save" (the modal) writes **persistent** `team#can_use agent` tuples — the team can then use that agent *outside* the workflow forever. Runtime-scoped delegation (grant only for the duration of the run) is the least-privilege answer. The doc lists this as an open question; it should be a decision (§6).
+
+7. **Performance/HA is hand-waved.** The DA and RAG OpenFGA clients **re-resolve the store id and open a new HTTP client on nearly every call**. A central PDP needs a warm store-id, pooled connections, a short-TTL decision cache, a batch endpoint (list-filtering does N checks today), and a circuit breaker. §3.5.
+
+8. **RAG's coarse-role axis is missing from the analysis.** `rbac.py` mixes a `READONLY/INGESTONLY/ADMIN` hierarchy *with* OpenFGA. RAG cannot become a thin PEP unless the core subsumes coarse roles or they are explicitly demoted to a cheap local pre-filter (§7).
+
+9. **Contract versioning is left as a question.** A "stable external contract" must be versioned from line one (`/api/authz/v1`). Because the new API is **additive**, there is no breaking change to existing clients — answering open question #7 directly.
+
+---
+
+## 2. Design principles
+
+1. **One decision, one place.** Exactly one module computes "may subject S do action A on resource R." Everything else is transport.
+2. **The PDP is an implementation detail.** Callers send `{subject, resource, action, context}` and receive `{decision, reason}`. OpenFGA relation names and tuples never cross the boundary (except the admin `/explain` tier).
+3. **Never trust the caller's identity claims.** The service validates every token itself (JWKS) and binds the answer to who is allowed to *ask*.
+4. **Fail closed, observably.** PDP error ⇒ DENY + retriable + audit. Break-glass is explicit, time-boxed, alarmed.
+5. **Least privilege over convenience.** Delegation is runtime-scoped, not a persistent grant, unless an admin deliberately makes it persistent.
+6. **Additive first.** The service ships touching nothing. Enforcement moves caller-by-caller on measured parity.
+
+---
+
+## 3. Target architecture
+
+### 3.1 The decision core — `ui/src/lib/authz/`
+
+The single reusable module. Pure, transport-free, PDP-agnostic.
+
+```text
+ui/src/lib/authz/
+  index.ts            # authorize(), authorizeMany(), authorizeOrThrow(), filterAccessible()
+  contract.ts         # Subject, Resource, Action, Decision, ReasonCode  (the public vocabulary)
+  reasons.ts          # stable reason codes + retriable mapping + user action hints
+  compose.ts          # domain composition (workflow visibility, channel scope) layered over PDP
+  engine.ts           # PolicyEngine interface
+  engines/
+    openfga.ts        # the ONLY OpenFGA adapter (wraps today's lib/rbac/openfga.ts transport)
+  domains/
+    workflow.ts       # workflowDelegatesAgentUse, run visibility (product policy over PDP)
+    slack-channel.ts
+    webex-space.ts
+  cache.ts            # short-TTL decision cache (engine-level)
+  audit.ts            # one decision → one audit event (owns the write)
+```
+
+- **Collapses the two BFF agent-use algorithms.** `requireAgentUsePermission` and `evaluateAgentAccess` both become thin callers of `authorize({subject, resource:{type:"agent"}, action:"use"})`. One direct+team-union implementation, one reason taxonomy.
+- **`compose.ts` is where product policy lives** (workflow visibility, derive-team-from-channel) so it sits *above* the PDP and is reused identically by every transport. This is the home the DA Mongo reads should never have left.
+- The action→relation map already exists in `resource-authz.ts` (`use → can_use`); it moves into `engines/openfga.ts` as the adapter seam. The `action` vocabulary is already PDP-agnostic; only the relation strings are FGA-specific.
+
+### 3.2 Transport A — in-process (BFF routes)
+
+```ts
+await authorizeOrThrow(session, { type: "agent", id, action: "use" });
+const visible = await filterAccessible(session, agents, { type: "agent", action: "discover", id: a => a.id });
+```
+
+No network hop. Existing `requireResourcePermission` / `requireAgentPermission` / `requireSkillPermission` become 3-line wrappers over `authorize()` so call sites don't churn. ESLint forbids importing `engines/openfga` outside `lib/authz/**`.
+
+### 3.3 Transport B — the common PDP AuthZ API (HTTP)
+
+The single contract for **every out-of-process caller** (DA, RAG, bots). Versioned, additive, PDP-agnostic.
+
+```http
+POST /api/authz/v1/decisions
+Authorization: Bearer <caller-token>          # user OR service-account; VERIFIED by the service
+Content-Type: application/json
+
+{
+  "subject":  { "type": "user", "id": "<oidc-sub>" },
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "action":   "use",
+  "context":  { "workflow_run_id": "wr-123" }   // advisory only; never *expands* a grant (§4)
+}
+```
+
+**Response — evaluation succeeded (HTTP 200 for both ALLOW and DENY):**
+
+```json
+{ "decision": "ALLOW", "reason": "OK", "retriable": false, "ttl_seconds": 15 }
+```
+```json
+{ "decision": "DENY",  "reason": "NO_CAPABILITY", "retriable": false }
+```
+
+> **API design note (answers a muddle in the doc's Option 2 sketch):** a *DENY is not an HTTP error*. The evaluation succeeded; the answer is "no" ⇒ **200 with a body**. HTTP status is reserved for **meta** failures: `401` caller not authenticated, `403` caller may not ask about this subject, `400` malformed, `503` PDP unavailable (`retriable:true`). PEPs translate `DENY`→ their own 403. This keeps deny-reasoning out of status codes and makes the contract uniform.
+
+**Batch (replaces N round-trips for list filtering):**
+
+```http
+POST /api/authz/v1/decisions:batch
+{ "subject": {...}, "action": "discover", "resource_type": "agent", "ids": ["a","b","c"] }
+→ { "results": [ { "id":"a","decision":"ALLOW" }, { "id":"b","decision":"DENY","reason":"NO_CAPABILITY" }, ... ] }
+```
+
+**Admin explain tier (the *only* place FGA detail is exposed):**
+
+```http
+POST /api/authz/v1/explain          # requires can_audit / admin_ui#view
+→ { "decision":"DENY", "reason":"NO_CAPABILITY",
+    "debug": { "engine":"openfga", "checked":["user:… can_use agent:…","team:… "], "store":"…" } }
+```
+
+This **extends the existing draft** `rebac-policy-api.md` (which already defines the `{subject, action, resource}` vocabulary and a per-type action catalog) into two tiers: **runtime/decision** (new, PDP-agnostic) and **admin/explain** (already drafted, FGA-visible). One vocabulary, exactly as Kevin asked.
+
+### 3.4 Transport C (optional) — signed decision tokens
+
+For the duplicate-hop problem (workflow step execution), the API can mint a **short-lived, audience-bound decision token** instead of a bare yes/no:
+
+```jsonc
+// header: alg, kid       payload:
+{ "iss":"caipe-bff", "aud":"dynamic-agents", "sub":"user:<oidc-sub>",
+  "res":"agent:platform-engineer", "act":"use",
+  "iat":1710000000, "exp":1710000045, "jti":"…" }   // ≤60s
+```
+
+The PEP verifies **signature + aud + exp + res/act match** offline — no OpenFGA, no Mongo, no second hop.
+
+**I disagree with the doc's deferral of this to "Phase 5, optional, expensive."** Constrained as above it is cheap and is the *cleanest* way to satisfy "no Mongo in DA" + "no duplicate PDP hop" + "PDP-agnostic at the boundary" simultaneously:
+
+- **No revocation machinery** needed at ≤60s TTL — document the TTL as the bound on staleness.
+- **Symmetric signing** (shared secret in the trust boundary) is acceptable to start; move to JWKS/asymmetric when bots/3rd parties consume it.
+- It is **additive** — the workflow engine attaches the token; a PEP that doesn't understand it falls back to a `/decisions` call.
+
+Keep it optional, but design for it now (P5), don't treat it as exotic.
+
+### 3.5 PDP adapter, HA OpenFGA, caching
+
+| Concern | Today (3× duplicated) | Central service |
+|---------|------------------------|-----------------|
+| Store id | Re-resolved via `GET /stores` per call (DA, RAG) | Resolved once at boot, cached, refreshed on miss |
+| HTTP client | New `httpx`/fetch per call | One pooled client, keep-alive |
+| HA | Single OpenFGA assumed | OpenFGA replicated (stateless vs its datastore) behind a Service; adapter retries idempotent `check` across replicas |
+| Hot path | Every check hits OpenFGA | Short-TTL decision cache (≤15s) keyed `(subject,resource,action)`, per-replica bounded LRU; **write/manage/delete bypass cache or ≤2s** |
+| List filtering | N sequential checks | `decisions:batch` → `BatchCheck`/parallel with bounded concurrency |
+| Outage | Each PEP improvises | One circuit breaker; open ⇒ fail closed (`AUTHZ_UNAVAILABLE`, retriable) |
+| Consistency | n/a | Use OpenFGA `consistency: HIGHER_CONSISTENCY` for sensitive actions; cache TTL bounds staleness for the rest |
+
+### 3.6 PDP-agnostic contract (the stable surface)
+
+```ts
+type ReasonCode =
+  | "OK"                 // ALLOW
+  | "NO_CAPABILITY"      // DENY — no relationship      → action: contact_admin
+  | "NOT_AUTHENTICATED"  // missing/invalid caller auth → action: sign_in
+  | "AUTHZ_UNAVAILABLE"  // PDP timeout/error           → action: retry   (retriable)
+  | "INVALID_REQUEST";   // bad id / malformed          → action: fix_request
+
+interface Decision { decision: "ALLOW" | "DENY"; reason: ReasonCode; retriable: boolean; ttl_seconds?: number; token?: string; }
+```
+
+**Envelope migration** (one shared `error-responses` builder, used by *all* surfaces):
+
+| Current (leaky, in 3 places) | Public v1 | Admin/explain only |
+|------------------------------|-----------|--------------------|
+| `code: "agent#use"` | `reason: "NO_CAPABILITY"` | `debug.relation: "can_use"` |
+| `reason: "pdp_denied"` | `reason: "NO_CAPABILITY"` | |
+| `reason: "pdp_unavailable"` | `reason: "AUTHZ_UNAVAILABLE"` | |
+| `pdp: "openfga"` in body | *omitted* | audit log only |
+| tuple strings in messages | *omitted* | `/explain` only |
+
+---
+
+## 4. Security model (threats → controls)
+
+The service is a **trust boundary**. It assumes callers are hostile-capable and verifies everything.
+
+| # | Threat | Control |
+|---|--------|---------|
+| 1 | **Forged subject** — caller asks "can `admin-user` do X" and acts on it | **Subject-binding.** A *user* token may only evaluate `subject == token.sub`. Cross-subject queries require `can_audit` on the type (admin/explain tier). Default rejects mismatched subject with `403`. |
+| 2 | **Bot impersonation / OBO** — bot evaluates for a user | Require **both** the bot's verified client-credentials token **and** a verified user assertion (OBO token or signed envelope). Service checks a real tuple `service_account:<id> can_impersonate user:*` (or per-user). **Never trust a bare `delegated_subject` body field** — that was a hole in the doc's sketch. |
+| 3 | **Caller-decoded / forgeable identity** — DA base64-decodes the JWT payload and trusts upstream; epic **[#1730] (P1)**: privileged paths trust unsigned `X-User-Context`, forgeable if DA is reached directly | Service **always** validates signature, `exp`, `aud`, `iss` via cached JWKS. Body/header-supplied identity is treated only as the *target* subject, then authorized per #1/#2. No upstream hop or unsigned header is trusted. **This is the canonical fix for [#1730].** |
+| 4 | **PDP outage → silent allow** | **Fail closed**: `DENY` + `AUTHZ_UNAVAILABLE` + `retriable` + `503` + audit. Break-glass via explicit env flag (mirrors `CAIPE_UNSAFE_RBAC_BYPASS` but **centralized, time-boxed, alarmed, audited per request**). |
+| 5 | **Decision-token theft / replay** (Transport C) | `aud` bound to one downstream, `res`+`act` bound, `exp ≤ 60s`, `jti`, signed. PEP verifies offline; stolen token is useless elsewhere and expires fast. |
+| 6 | **Cache stale-allow** | TTL ≤15s read / ≤2s for write-class actions; per-replica; bounded LRU; revocation tolerated within TTL window (documented). Sensitive mutations may set `no-cache`. |
+| 7 | **Confused deputy via `context`** | `context` is **advisory only**. It may *narrow* (scope) but must never *expand* a decision beyond the subject's own relationships — except through server-evaluated delegation (the workflow run-authorizer in §6), which is computed inside the core, not asserted by the caller. |
+| 8 | **Enumeration / info leak** | DENY reasons are coarse (`NO_CAPABILITY`); no tuple/relation strings outside `/explain`; rate-limit per caller; every decision audited with correlation id. |
+| 9 | **Privilege via the API itself** | The decision API is **read/evaluate only in v1.** No tuple writes. Reconcile/ownership writes stay in their current modules — so standing up the service grants no new mutation surface. |
+
+---
+
+## 5. Standalone build + shadow migration (touch nothing, migrate slowly)
+
+This is the mechanism the problem statement is missing and the explicit requirement.
+
+### 5.1 Shadow mode
+
+Each existing PEP gets a thin consult wrapper behind a **per-surface** flag:
+
+```
+AUTHZ_CENTRAL_MODE = off | shadow | enforce      # per surface: da_agent_use, da_workflow, rag_kb, slack, …
+```
+
+- **`off`** — legacy only (today).
+- **`shadow`** — call the central API *best-effort, time-boxed*; **compare** to the legacy decision; emit an `authz_parity` metric/audit `{surface, legacy, central, agree}`. **Legacy stays authoritative.** Zero user-visible change. *This is "standalone without touching resources."*
+- **`enforce`** — central is authoritative; legacy code deleted.
+
+```text
+  request ─▶ legacy check ──▶ (authoritative) ──▶ response
+                │
+                └─(shadow)─▶ central /decisions ─▶ parity log  ✗ cannot change outcome
+```
+
+Flip a surface to `enforce` only after **~100% parity over N days** on a dashboard. Roll back instantly by setting the flag to `shadow`.
+
+### 5.2 Phases (standalone-first)
+
+| Phase | Scope | Touches existing behavior? | Exit gate |
+|-------|-------|----------------------------|-----------|
+| **P0 Core extraction** | Build `lib/authz` core; refactor the 2 BFF agent-use algos + `resource-authz` to call it | **No** (pure refactor, identical outputs) | Existing tests green; golden-decision parity |
+| **P1 The standalone service** | `POST /api/authz/v1/{decisions,decisions:batch,explain}` over the core | **No** (nobody calls it yet) | Contract tests + parity vs in-process core. **Ships alone, touches nothing.** |
+| **P2 Shadow** | DA, RAG, bots call central in `shadow` | **No** (observe-only) | Parity dashboard ~100% per surface |
+| **P3 Workflow enforce** | Flip `da_workflow`; delete `workflow_execution_authz.py` + `workflow_config_id` Mongo bypass; delegation via central run-authorizer (§6) | Yes (one surface) | DA reads no workflow/team Mongo |
+| **P4 Agent-use + RAG enforce** | Flip `da_agent_use`, `rag_*`; DA drops its OpenFGA client + Mongo audit writes; `rbac.py` → thin PEP | Yes (per surface) | No OpenFGA client / policy Mongo in DA or RAG |
+| **P5 (optional) Decision tokens** | Workflow engine attaches tokens; PEP verifies offline | Yes | Duplicate hop ([#1731]) gone; ADR for [#1458] |
+
+Cross-cutting: the v1 envelope (§3.6) is **native** on the new API from P1. Legacy routes adopt the shared `error-responses` builder opportunistically — **no breaking change** because the new API is additive and versioned (answers open Q#7).
+
+---
+
+## 6. Workflow delegation done right (PR #1751)
+
+**Decision: runtime-scoped delegation, not persistent pre-grants.**
+
+| Operation | Owner | Mechanism |
+|-----------|-------|-----------|
+| Create/update/list/cancel workflow + runs | BFF | existing `workflow-configs` / `workflow-runs` routes |
+| "Can this user run this workflow?" | **core `domains/workflow.ts`** | `workflowDelegatesAgentUse` = agent ∈ steps **AND** run visibility — wired at `POST /api/workflow-runs` |
+| Step execution agent-use | **central run-authorizer** | At run start the BFF computes the delegated set once; step calls carry a run-scoped decision (or token, P5). DA does **not** read `workflow_configs`. |
+| DA workflow *tools* | DA → BFF `WorkflowApiClient` | already correct — keep |
+
+**Flag the regression:** PR #1751's modal that pre-grants `team#can_use agent` tuples on save is an **over-grant** — it lets the team use the agent *outside* the workflow, permanently. Prefer runtime delegation (above). If product genuinely wants standing access, make it an **explicit, separate, admin-visible grant**, not a side effect of saving a workflow. `workflowDelegatesAgentUse` already exists and is unused — wire it instead of writing tuples.
+
+---
+
+## 7. RAG & DA convergence
+
+- **RAG becomes a thin PEP over HTTP.** A shared Python *library* would be a **fourth** reimplementation — reject it. RAG calls `POST /api/authz/v1/decisions` (and `:batch` for `inject_kb_filter`'s datasource list). The service owns the channel→team Mongo lookup (it already has the data); RAG stops reading `channel_team_mappings`/`teams`.
+- **Coarse roles** (`READONLY/INGESTONLY/ADMIN`) are **demoted to a local pre-filter**: client-credentials/automation principals short-circuit *before* calling central (cheap, preserves automation); all human/per-resource decisions go to central. Don't let coarse roles re-enter the resource decision.
+- **DA** drops `openfga_authz.py`'s OpenFGA client, its per-call store-id discovery, its Mongo audit writes, and `workflow_execution_authz.py` entirely. `require_agent_use_permission` → `require_authorization(resource, action)` calling central (or verifying a decision token in P5).
+
+---
+
+## 8. CI enforcement (aim the existing guards at the new boundary)
+
+Keep the doc's Option 4 guards, retargeted:
+
+| Guard | Blocks |
+|-------|--------|
+| ESLint `no-restricted-imports` | importing `engines/openfga` (or `lib/rbac/openfga`) outside `lib/authz/**` |
+| `validate-authz-boundaries.py` (new) | `workflow_configs`/`teams`/OpenFGA-client imports in `dynamic_agents/**` and RAG once their surface is `enforce` |
+| extend `validate-fga-create-paths.py` | new BFF routes must reach OpenFGA only via the core |
+| `fga-enforcement-manifest.ts` | add `task`/workflow + runtime `/api/authz/v1/*` surfaces |
+| Parity test (new) | central decision == legacy for a golden fixture set (gates each `shadow→enforce` flip) |
+
+---
+
+## 9. Answers to the problem statement's open questions
+
+1. **DA execution gate** — Keep OpenFGA in DA *only* during shadow (P2). At enforce (P4), DA holds **no** PDP client; it calls central or verifies a decision token. Dual-gate ([#1731]) is resolved empirically by parity, not debate.
+2. **Workflow delegation** — Runtime-scoped via the central run-authorizer (§6). Persistent pre-grants only as an explicit, separate admin action.
+3. **Generic vs domain HTTP APIs** — One generic `POST /api/authz/v1/decisions` + `:batch`. Domain endpoints (`authorize-run`) become thin wrappers that call the core with a `context`; they are conveniences, not parallel logic.
+4. **RAG** — HTTP client to the central API. **No** shared Python policy library (it would be reimplementation #4).
+5. **Service-account delegation** — Verified OBO: bot token **+** user assertion **+** real `can_impersonate` tuple. Never a trusted body field (§4 #2).
+6. **Claim revocation** — Not required at ≤60s TTL; TTL is the documented staleness bound (§3.4).
+7. **Breaking API changes** — None. New API is `/api/authz/v1` and additive; legacy clients migrate envelopes opportunistically. No `/v2` flag day.
+8. **Workflow `task` in FGA** — Mongo visibility stays a **product policy layer** in `domains/workflow.ts` *above* FGA for now; revisit folding it fully into FGA after P4, as a separate decision.
+
+---
+
+## 10. Recommendation
+
+**Option mix:** `Option 1 (core) ≡ Option 2 (HTTP)` as one thing + `Option 5 (vocabulary)` adopted into `contract.ts` + `Option 4 (enforcement)` aimed at the new boundary + **`Option 3 (decision tokens) promoted from "someday" to a real P5**, constrained.
+
+**Split into three specs** (the doc asks whether to split — yes):
+- **Spec A — Core + envelope + enforcement** (P0–P1, + §3.6, + §8). Ships the standalone service. No behavior change.
+- **Spec B — Runtime convergence** (P2–P4 shadow→enforce for DA/RAG/bots, + §6 workflow delegation).
+- **Spec C — Decision tokens** (P5, optional), gated on [#1458] ADR.
+
+**Ordered task list (Spec A first — the standalone service you asked for):**
+1. `lib/authz/contract.ts` + `reasons.ts` — PDP-agnostic types & reason codes.
+2. `engines/openfga.ts` — wrap today's transport; warm store-id; pooled client; cache hook.
+3. `index.ts` `authorize/authorizeMany/authorizeOrThrow/filterAccessible`; **fold the two agent-use algos into it**.
+4. Refactor `requireResourcePermission`/`requireAgentUsePermission`/`evaluateAgentAccess` to call the core (no behavior change; golden parity test).
+5. `domains/workflow.ts` — move visibility/`workflowDelegatesAgentUse` here.
+6. `POST /api/authz/v1/{decisions,decisions:batch,explain}` over the core; v1 envelope; caller-token verification + subject-binding (§4 #1–#3).
+7. Shared `error-responses` v1 builder; switch BFF authz throws to it.
+8. ESLint import boundary + parity test harness.
+9. **Stop.** Ship. The service is live, used by no one, touching nothing → then begin Spec B shadow.
+
+### 10.1 Alignment with the real epic [#1742] (and one correction)
+
+I verified against the epic itself — it aligns with this architecture *better* than the problem statement's own §8 table does:
+
+- **The runtime HTTP API is already a prerequisite, not a late phase.** #1742 states: *"#1455 — runtime BFF ReBAC endpoints — must land before the Slack BFF moves (#1737, #1739)."* That is exactly **Transport B / Spec A**. → **Correction:** the "facade (Phase 2) then runtime API (Phase 3)" sequencing is the *problem statement's §8*, **not** the epic. The epic supports shipping the service **first**.
+- **This service is the canonical fix for the epic's top P1.** #1730 (DA trusts unsigned, forgeable `X-User-Context`) is resolved by §4 #1–#3 — mandatory token verification + subject-binding at the central boundary. The problem statement under-weighted #1730; it should be the headline security driver.
+- **Slack P1s shrink as a side effect.** Once bots get decisions + identity linking from the BFF (#1737/#1739, gated on #1455), the bot sheds Keycloak-Admin/Mongo blast radius (#1741).
+
+**Epic sub-issue → spec map:**
+
+| Spec | Closes / enables |
+|------|------------------|
+| **A** Core + HTTP API + envelope | **#1455** (prereq), enables **#1730**; sets up #1733 (service owns audit), #1736 (service owns cached channel→team) |
+| **B** Convergence (shadow→enforce) | #1730, #1731, #1733 (DA); #1734/#1735/#1736 (RAG); #1737/#1739/#1741 (Slack) |
+| **C** Decision tokens (optional) | #1731 capstone; gated on **#1458** dual-gate ADR |
+
+**Remaining contradictions to reconcile:**
+- #1742 Phase 0 "remove DA workflow Mongo" is right, but the *replacement* (runtime delegation) must land in `domains/workflow.ts`, **not** as new DA-side logic. Sequence at P3.
+- PR #1751's modal pre-grant contradicts the least-privilege delegation in §6 — reconcile before it becomes load-bearing.
+- #1755 is **not** in scope of this architecture (narrow skills-UI DRY); keep it independent so it isn't blocked on the PDP work.
+
+---
+
+<!-- assisted-by claude code claude-opus-4-8 -->

--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/spec.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/spec.md
@@ -1,0 +1,400 @@
+# Spec: Centralized Authorization Service (CAS) — BFF-resident, PDP-agnostic
+
+**Status:** Draft for review
+**Date:** 2026-06-05
+**Owner:** Sri Aradhyula
+**Companions:** [`problem-statement.md`](./problem-statement.md) (why) · [`solution-architecture.md`](./solution-architecture.md) (critique + design rationale)
+**Tracking:** epic [#1742]; prerequisite [#1455]; security driver [#1730]; dual-gate ADR [#1458]
+
+> This is the implementation spec. It is self-contained: the architecture doc holds the critique and trade-off rationale; this doc holds **what to build, in what order, and how we prove it's safe**.
+
+---
+
+## 1. Summary
+
+Introduce one **Authorization Decision Core** in the BFF (`ui/src/lib/authz/`) and expose it through **four transports** that all share one PDP-agnostic contract. Collapse today's **three OpenFGA reimplementations** (`openfga.ts`, DA `openfga_authz.py`, RAG `rbac.py`), the **fourth at the gateway** (`openfga-authz-bridge`), the **two duplicate BFF agent-use algorithms**, and the **three error envelopes** into that one core. Ship it **standalone** (touching nothing), then migrate each Policy Enforcement Point (PEP) under **shadow mode** with measured decision parity before any flip.
+
+**Principle:** *One decision core. Four transports. One optional claim. Shadow-first migration.*
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+- **G1** Single decision authority: exactly one module computes "may subject S do action A on resource R."
+- **G2** PDP-agnostic public contract: callers send/receive `{subject, resource, action} → {decision, reason}`; OpenFGA relation names/tuples never cross the boundary except in the admin explain tier.
+- **G3** No policy MongoDB in Dynamic Agents (drop `workflow_execution_authz.py`, the `workflow_config_id` bypass, and DA-side authz audit writes).
+- **G4** Common HTTP AuthZ API for all out-of-process callers (DA, RAG, bots) = the [#1455] runtime endpoints.
+- **G5** HA OpenFGA behind one pooled adapter (warm store-id, decision cache, batch, circuit breaker).
+- **G6** Build standalone; migrate slowly via shadow mode without touching existing enforcement until each surface flips.
+- **G7** Security: verify every token at the boundary; bind decisions to who may ask; fail closed; audited break-glass — closes [#1730].
+
+### Non-goals
+- Replacing OpenFGA as the relationship store.
+- Moving the gateway `ext_authz` decision into the BFF (rejected — §7).
+- Migrating skills to an owner-team model (#1708) or the #1755 UI-DRY hook (independent).
+- Rewriting the AgentGateway routing/credential-injection logic (only its OpenFGA contract converges).
+
+---
+
+## 3. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **CAS** | Centralized Authorization Service — the decision core + its transports. BFF-resident. |
+| **PDP** | Policy Decision Point — computes allow/deny. Here: the core + OpenFGA adapter. |
+| **PEP** | Policy Enforcement Point — calls the PDP and enforces. There are 4 (§4.1). |
+| **Core** | `ui/src/lib/authz/` — the one reusable decision module. |
+| **Bridge / "OpenFGA Proxy"** | `openfga-authz-bridge` — Envoy `ext_authz` PDP adapter for the AgentGateway MCP data plane. |
+| **Decision token** | Short-lived, audience-bound signed claim minted by CAS so a downstream PEP can verify offline. |
+| **Shadow mode** | A PEP consults CAS observe-only while legacy stays authoritative; decisions compared for parity. |
+
+---
+
+## 4. Architecture
+
+### 4.1 Component overview
+
+```text
+                          ┌───────────────────────────────────────────────┐
+                          │   Authorization Decision Core  (lib/authz)      │
+                          │   contract · reasons · compose(domain) ·        │
+                          │   ONE OpenFGA adapter · cache · audit           │
+                          └───┬──────────┬───────────────┬──────────────┬───┘
+        A: in-process call    │          │ B: HTTP        │ C: token mint│ D: adapter contract
+        ┌─────────────────────┘          │                │              └──────────────┐
+        ▼                                 ▼                ▼                              ▼
+  BFF route handlers          POST /api/authz/v1/...   decision tokens          openfga-authz-bridge
+  (PEP #1, no hop)            (PEP #2/#3/#4 consume)    (attached by engine)     (PEP #4, data plane)
+                                   ▲      ▲      ▲                                      ▲
+                          Dynamic Agents  RAG   Slack/Webex bots             AgentGateway ext_authz
+                          (PEP #2)      (PEP #3) (bots)                       (per-MCP-call enforce)
+```
+
+**Four PEPs, one contract, one adapter:**
+
+| PEP | Layer | Transport | Today | Target |
+|-----|-------|-----------|-------|--------|
+| #1 BFF routes | app (in-proc) | A | `resource-authz.ts` + 2 agent-use algos | call `authorize()` |
+| #2 Dynamic Agents | app (HTTP) | B (+C) | own OpenFGA client + Mongo | thin PEP → CAS; no OpenFGA/Mongo |
+| #3 RAG server | app (HTTP) | B | `rbac.py` (roles+OpenFGA+Mongo) | thin PEP → CAS; coarse role = local pre-filter |
+| #4 AgentGateway bridge | data plane | D | bespoke OpenFGA Check + Mongo audit | shared adapter contract + audit schema |
+
+### 4.2 The decision core — `ui/src/lib/authz/`
+
+```text
+ui/src/lib/authz/
+  index.ts        # authorize(), authorizeMany(), authorizeOrThrow(), filterAccessible()
+  contract.ts     # Subject, Resource, Action, Decision, ReasonCode  (public vocabulary)
+  reasons.ts      # reason codes → {retriable, userActionHint, httpHint}
+  engine.ts       # PolicyEngine interface
+  compose.ts      # product policy layered OVER the PDP (workflow visibility, channel scope)
+  engines/
+    openfga.ts    # the ONLY OpenFGA adapter (wraps lib/rbac/openfga transport; action→relation map)
+  domains/
+    workflow.ts   # workflowDelegatesAgentUse, run visibility
+    slack-channel.ts · webex-space.ts
+  cache.ts        # short-TTL decision cache
+  audit.ts        # one decision → one audit event (CAS owns the write)
+```
+
+- Folds `requireAgentUsePermission` **and** `evaluateAgentAccess` into one direct+team-union implementation.
+- `resource-authz.ts`'s action→relation map (`use → can_use`) moves into `engines/openfga.ts`. The `action` vocabulary is already PDP-agnostic; only relation strings are FGA-specific.
+- `compose.ts` is the home product policy never should have left (kills DA's Mongo visibility duplication).
+
+### 4.3 Transports
+
+- **A — in-process** (PEP #1): `authorize()/authorizeOrThrow()/filterAccessible()`. No network hop. Existing `require*Permission` become thin wrappers.
+- **B — HTTP** (PEP #2/#3/bots): `POST /api/authz/v1/decisions` (+ `:batch`, `explain`). The [#1455] runtime API. §5.
+- **C — decision tokens** (optional, P5): short-lived audience-bound signed claims; PEP verifies offline → removes the duplicate hop for workflow step execution.
+- **D — data-plane adapter** (PEP #4): the bridge conforms to the same contract + OpenFGA adapter semantics; keeps a direct OpenFGA path (no per-request BFF hop). §7.
+
+### 4.4 PDP adapter, HA OpenFGA, caching
+
+| Concern | Today (4× duplicated) | CAS |
+|---------|------------------------|-----|
+| Store id | re-resolved per call (DA, RAG, bridge) | resolved once at boot, cached, refresh-on-miss |
+| HTTP client | new client per call | one pooled keep-alive client |
+| HA | single OpenFGA assumed | replicated behind a Service; adapter retries idempotent `check` |
+| Hot path | every check hits OpenFGA | decision cache ≤15s read / ≤2s write-class; per-replica bounded LRU |
+| List filter | N sequential checks | `:batch` → `BatchCheck`/bounded-parallel |
+| Outage | each PEP improvises | one circuit breaker; open ⇒ fail closed |
+| Consistency | n/a | `HIGHER_CONSISTENCY` for write-class; TTL bounds staleness otherwise |
+
+---
+
+## 5. The contract
+
+### 5.1 Vocabulary
+
+```ts
+type SubjectType  = "user" | "service_account";
+type ResourceType = UniversalRebacResourceType;          // agent, skill, mcp_tool, knowledge_base, data_source, task, slack_channel, …
+type Action       = "discover" | "read" | "read-metadata" | "use" | "write"
+                  | "manage" | "share" | "delete" | "ingest" | "call" | "invoke" | "audit";
+
+interface AuthorizeRequest {
+  subject:  { type: SubjectType; id: string };
+  resource: { type: ResourceType; id: string };
+  action:   Action;
+  context?: Record<string, unknown>;                     // advisory only; never EXPANDS a grant
+}
+
+type ReasonCode =
+  | "OK"                 // ALLOW
+  | "NO_CAPABILITY"      // DENY — no relationship       → contact_admin
+  | "NOT_AUTHENTICATED"  // missing/invalid caller auth  → sign_in
+  | "AUTHZ_UNAVAILABLE"  // PDP timeout/error (retriable) → retry
+  | "INVALID_REQUEST";   // bad id / malformed           → fix_request
+
+interface Decision { decision: "ALLOW" | "DENY"; reason: ReasonCode; retriable: boolean; ttl_seconds?: number; token?: string; }
+```
+
+This **extends** the existing `rebac-policy-api.md` draft (same `{subject, action, resource}` shape, same per-type action catalog) into two tiers: runtime/decision (new, agnostic) and admin/explain (drafted, FGA-visible).
+
+### 5.2 HTTP API — `/api/authz/v1`
+
+**Single decision**
+```http
+POST /api/authz/v1/decisions
+Authorization: Bearer <caller-token>     # VERIFIED by CAS (JWKS); user or service_account
+{ "subject": {"type":"user","id":"<sub>"}, "resource": {"type":"agent","id":"platform-engineer"}, "action":"use",
+  "context": {"workflow_run_id":"wr-123"} }
+→ 200 { "decision":"ALLOW", "reason":"OK", "retriable":false, "ttl_seconds":15 }
+→ 200 { "decision":"DENY",  "reason":"NO_CAPABILITY", "retriable":false }
+```
+Optional `?mint_token=true` (or `Accept: application/decision-token+jwt`) ⇒ include `token` (Transport C).
+
+**Batch (list filtering)**
+```http
+POST /api/authz/v1/decisions:batch
+{ "subject": {...}, "action":"discover", "resource_type":"agent", "ids":["a","b","c"] }
+→ 200 { "results":[ {"id":"a","decision":"ALLOW"}, {"id":"b","decision":"DENY","reason":"NO_CAPABILITY"} ] }
+```
+
+**Admin explain (only place FGA detail leaks)**
+```http
+POST /api/authz/v1/explain        # requires can_audit / admin_ui#view
+→ 200 { "decision":"DENY","reason":"NO_CAPABILITY",
+        "debug": {"engine":"openfga","relation":"can_use","checked":["user:… can_use agent:…"],"store":"…"} }
+```
+
+### 5.3 Status code semantics (deliberate)
+
+> **A DENY is not an HTTP error.** The evaluation succeeded; the answer is "no" ⇒ **200 with body**. HTTP status is reserved for **meta** failures:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | evaluation succeeded (`ALLOW` **or** `DENY` in body) |
+| `401` | caller token missing/invalid (`NOT_AUTHENTICATED`) |
+| `403` | caller may not ask about this subject (subject-binding, §6 #1) |
+| `400` | malformed (`INVALID_REQUEST`) |
+| `503` | PDP unavailable (`AUTHZ_UNAVAILABLE`, `retriable:true`) |
+
+PEPs translate `decision:"DENY"` into their own 403. Keeps deny-reasoning out of status codes.
+
+### 5.4 Error envelope migration (one shared builder, all surfaces)
+
+| Current (leaky, ×3) | Public v1 | Admin/explain only |
+|---------------------|-----------|--------------------|
+| `code:"agent#use"` | `reason:"NO_CAPABILITY"` | `debug.relation:"can_use"` |
+| `reason:"pdp_denied"` | `reason:"NO_CAPABILITY"` | |
+| `reason:"pdp_unavailable"` | `reason:"AUTHZ_UNAVAILABLE"` | |
+| `pdp:"openfga"` in body | omitted | audit log only |
+| tuple strings in messages | omitted | `/explain` only |
+
+---
+
+## 6. Security model (threats → controls)
+
+CAS is a trust boundary; it assumes callers are hostile-capable.
+
+| # | Threat | Control |
+|---|--------|---------|
+| 1 | **Forged subject** | A *user* token may only evaluate `subject == token.sub`. Cross-subject needs `can_audit` (admin/explain). Mismatch ⇒ `403`. |
+| 2 | **Bot impersonation / OBO** | Require bot's verified client-credentials token **+** verified user assertion **+** real tuple `service_account:<id> can_impersonate user:*`. **Never** trust a bare `delegated_subject` body field. |
+| 3 | **Forgeable identity** ([#1730], P1) | CAS **always** validates signature/`exp`/`aud`/`iss` via cached JWKS. Body/header identity is only the *target* subject, then authz'd per #1/#2. No unsigned `X-User-Context`, no trusted upstream hop. |
+| 4 | **PDP outage → silent allow** | Fail closed: `DENY` + `AUTHZ_UNAVAILABLE` + `retriable` + `503` + audit. Break-glass = explicit env flag, time-boxed, alarmed, audited per request. |
+| 5 | **Decision-token theft/replay** | `aud` = one downstream, `res`+`act` bound, `exp ≤ 60s`, `jti`, signed. PEP verifies offline. |
+| 6 | **Cache stale-allow** | TTL ≤15s read / ≤2s write-class; per-replica bounded LRU; revocation tolerated within TTL (documented). |
+| 7 | **Confused deputy via `context`** | `context` may only *narrow*, never *expand* a grant — except server-evaluated delegation computed inside the core (workflow run-authorizer). |
+| 8 | **Enumeration / info leak** | coarse DENY reasons; no tuple strings outside `/explain`; per-caller rate limit; every decision audited w/ correlation id. |
+| 9 | **New mutation surface** | v1 API is **read/evaluate only**. No tuple writes. Reconcile/ownership stay in current modules ⇒ standing up CAS grants no new write capability. |
+
+---
+
+## 7. The OpenFGA Proxy (`openfga-authz-bridge`) — convergence
+
+The bridge is the **data-plane PEP** for MCP routing: AgentGateway validates JWT (`jwtAuth: strict`, JWKS) then fires a per-route `extAuthz` gRPC Check (`failureMode.denyWithStatus: 403`) → bridge → OpenFGA Check (`can_call` / `mcp_gateway:*`).
+
+**Decision: it stays in the data plane; it does NOT route through the BFF.**
+
+- The BFF is not on the AgentGateway→MCP path; a per-call BFF hop would put the BFF in the availability/latency envelope of every tool call (`ext_authz` fires once per MCP route on listing, 200ms timeout). Rejected.
+- The bridge is already the **model** thin-PEP: edge JWT validation, no forgeable header, fail-closed.
+
+**What converges (Transport D):**
+1. **Vocabulary** — bridge maps Envoy `CheckRequest` → `{subject, resource, action}`; stop using bespoke relation/object strings as the contract.
+2. **Adapter semantics** — same action→relation map, warm store-id, decision cache, retry/circuit-breaker behavior as `engines/openfga.ts`; validated by the **same CI coverage tests**.
+3. **Audit schema** — same `audit_events` shape/salt the core emits (resolves [#1733]-style coupling consistently).
+4. **No new OpenFGA reimplementation** — if the bridge ever needs wire-level PDP-agnosticism, it consumes the shared adapter **library**, not an HTTP call to the BFF.
+
+**Scope:** out of scope for "no Mongo in DA / BFF-resident decisions" (it's neither DA nor BFF); **in scope** for "PDP-agnostic + one vocabulary + reusable adapter."
+
+> **Decision point D-1:** keep bridge OpenFGA-direct + contract-aligned (default, this spec) vs. route through CAS HTTP. Default chosen for data-plane latency/availability. Revisit only if a non-OpenFGA PDP lands.
+
+---
+
+## 8. Standalone build + shadow migration
+
+### 8.1 Shadow mode
+
+Per-surface flag: `AUTHZ_CENTRAL_MODE = off | shadow | enforce` (surfaces: `da_agent_use`, `da_workflow`, `rag_kb`, `rag_search`, `slack`, `webex`, …).
+
+- **off** — legacy only (today).
+- **shadow** — call CAS best-effort/time-boxed; compare to legacy; emit `authz_parity{surface,legacy,central,agree}`. **Legacy authoritative.** No user-visible change. *This is "standalone, touch nothing."*
+- **enforce** — CAS authoritative; legacy code deleted.
+
+```text
+request ─▶ legacy check ─▶ (authoritative) ─▶ response
+              └─(shadow)─▶ CAS /decisions ─▶ parity metric   ✗ cannot change outcome
+```
+
+Flip `shadow→enforce` per surface only at **~100% parity over N days**; roll back by setting `shadow`.
+
+### 8.2 Phases & tasks
+
+| Phase | Scope | Touches behavior? | Exit gate |
+|-------|-------|:-----------------:|-----------|
+| **P0** Core extraction | build `lib/authz`; refactor 2 agent-use algos + `resource-authz` to call it | No (pure) | golden-decision parity; existing tests green |
+| **P1** Standalone service | `/api/authz/v1/{decisions,:batch,explain}` over core; caller-token verify + subject-binding; v1 envelope | No (unused) | contract + parity tests. **Ships alone.** = [#1455] |
+| **P2** Shadow | DA, RAG, bots consult CAS in `shadow` | No (observe) | parity dashboard ~100%/surface |
+| **P3** Workflow enforce | flip `da_workflow`; delete `workflow_execution_authz.py` + `workflow_config_id` bypass; delegation via core run-authorizer (§9) | Yes (1 surface) | DA reads no workflow/team Mongo |
+| **P4** Agent-use + RAG enforce | flip `da_agent_use`, `rag_*`; DA drops OpenFGA client + Mongo audit; `rbac.py`→thin PEP; bridge→Transport D | Yes (per surface) | no OpenFGA client / policy Mongo in DA/RAG; bridge contract-aligned |
+| **P5** (optional) Decision tokens | engine attaches tokens; PEP verifies offline | Yes | duplicate hop [#1731] gone; [#1458] ADR |
+
+**P0 task list**
+1. `contract.ts` + `reasons.ts`.
+2. `engines/openfga.ts` — wrap transport; warm store-id; pooled client; cache hook.
+3. `index.ts` — `authorize/authorizeMany/authorizeOrThrow/filterAccessible`; fold both agent-use algos.
+4. Refactor `requireResourcePermission`/`requireAgentUsePermission`/`evaluateAgentAccess` → core (no behavior change).
+5. `domains/workflow.ts` — move visibility/`workflowDelegatesAgentUse`.
+6. golden-decision parity harness (legacy vs core).
+
+**P1 task list**
+7. routes `decisions`, `decisions:batch`, `explain`; caller-token verification (JWKS) + subject-binding.
+8. shared `error-responses` v1 builder; switch BFF authz throws.
+9. ESLint import boundary (`engines/openfga` only inside `lib/authz/**`).
+10. contract tests; OpenAPI for `/api/authz/v1`.
+
+---
+
+## 9. Workflow delegation (PR #1751)
+
+**Runtime-scoped delegation, not persistent pre-grants.**
+
+| Operation | Owner | Mechanism |
+|-----------|-------|-----------|
+| CRUD config + runs | BFF | existing routes |
+| "can user run workflow?" | core `domains/workflow.ts` | `workflowDelegatesAgentUse` (agent∈steps AND run visibility) wired at `POST /api/workflow-runs` |
+| Step agent-use | core run-authorizer | delegated set computed at run start; step carries run-scoped decision/token; **DA reads no `workflow_configs`** |
+| DA workflow tools | DA→BFF `WorkflowApiClient` | unchanged (correct) |
+
+**Flag:** PR #1751's modal pre-grants persistent `team#can_use agent` tuples ⇒ standing access *outside* the workflow (over-grant). Replace with runtime delegation; if product wants standing access, make it an explicit separate admin grant.
+
+---
+
+## 10. RAG & DA convergence
+
+- **RAG** → thin PEP over `POST /api/authz/v1/decisions` (+ `:batch` for `inject_kb_filter`). CAS owns the channel→team lookup; RAG stops reading `channel_team_mappings`/`teams`. A shared **Python policy lib is rejected** (would be reimplementation #5).
+- **Coarse roles** (`READONLY/INGESTONLY/ADMIN`) demoted to a **local pre-filter**: client-credentials/automation short-circuit before CAS; all human/per-resource decisions go to CAS.
+- **DA** drops `openfga_authz.py` OpenFGA client + per-call store discovery + Mongo audit + `workflow_execution_authz.py`. `require_agent_use_permission` → `require_authorization(resource, action)` (CAS HTTP, or token verify in P5).
+
+---
+
+## 11. CI enforcement
+
+| Guard | Blocks |
+|-------|--------|
+| ESLint `no-restricted-imports` | `engines/openfga`/`lib/rbac/openfga` outside `lib/authz/**` |
+| `validate-authz-boundaries.py` (new) | `workflow_configs`/`teams`/OpenFGA-client imports in `dynamic_agents/**` (and RAG) once surface = `enforce` |
+| extend `validate-fga-create-paths.py` | new BFF routes reach OpenFGA only via core |
+| `fga-enforcement-manifest.ts` | add `task`/workflow + `/api/authz/v1/*` + bridge `mcp_gateway` surfaces |
+| parity test (new) | CAS == legacy on golden fixtures (gates each `shadow→enforce` flip) |
+| bridge contract test | bridge's relation map/audit schema == core adapter |
+
+---
+
+## 12. Observability & audit
+
+- **CAS owns the decision audit write** (unified `audit_events`); PEPs stop writing their own ⇒ resolves [#1733] coupling and DA/bridge duplicate audit.
+- Every decision: `correlation_id`, `subject_hash` (salted), `reason_code`, `pdp`, `source`, optional trace.
+- Metrics: `authz_decision_total{surface,decision,reason}`, `authz_parity{surface,agree}`, `authz_pdp_latency_ms`, `authz_cache_hit_ratio`, `authz_circuit_state`.
+
+---
+
+## 13. Rollout & flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `AUTHZ_CENTRAL_MODE.<surface>` | `off` | off / shadow / enforce per PEP |
+| `AUTHZ_DECISION_CACHE_TTL_MS` | `15000` | read-class cache TTL |
+| `AUTHZ_BREAK_GLASS` | unset | time-boxed, alarmed, audited fail-open (non-prod posture mirrors `CAIPE_UNSAFE_RBAC_BYPASS`) |
+| `AUTHZ_DECISION_TOKEN_ENABLED` | `false` | Transport C |
+
+Additive + versioned ⇒ **no breaking change**; existing clients keep working until their surface flips.
+
+---
+
+## 14. Acceptance criteria
+
+- [ ] One module computes agent-use; `requireAgentUsePermission` and `evaluateAgentAccess` are gone/wrappers.
+- [ ] No `dynamic_agents/**` authz path reads `workflow_configs`/`teams`; `workflow_execution_authz.py` + `workflow_config_id` bypass removed.
+- [ ] DA holds no OpenFGA client and writes no authz audit to Mongo (CAS owns it).
+- [ ] `POST /api/authz/v1/decisions` (+ `:batch`, `explain`) live, versioned, OpenAPI-documented; verifies caller token + subject-binding.
+- [ ] Public errors use §5.4 reason codes; no `agent#use`/`pdp_denied` in user-facing responses.
+- [ ] RAG, Slack, Webex consume CAS (HTTP) — not admin rebac routes.
+- [ ] `rbac.py` is a thin PEP; coarse role is a local pre-filter only.
+- [ ] Bridge conforms to the shared contract + adapter semantics + audit schema (Transport D); CI bridge-contract test green.
+- [ ] `workflowDelegatesAgentUse` wired at run start; runtime-scoped delegation; modal pre-grant removed/justified.
+- [ ] Shadow→enforce gated on ~100% parity per surface; rollback to shadow verified.
+- [ ] CI: import boundary + authz-boundary + parity guards green.
+- [ ] [#1458] ADR documents dual-gate retirement before any DA OpenFGA removal.
+
+---
+
+## 15. Test plan
+
+- **Unit:** core decision matrix (direct, team-union, deny, PDP error, invalid id); reason/`retriable` mapping; subject-binding; OBO accept/reject; cache TTL + write-class bypass.
+- **Contract:** `/api/authz/v1` request/response schema; 200-DENY vs 401/403/400/503 meta-status; envelope has no FGA strings outside `explain`.
+- **Parity (gating):** golden fixtures evaluated by legacy and CAS must agree before each flip; per-surface dashboard.
+- **Security:** forged-subject 403; unsigned/forged token rejected (regression for [#1730]); PDP-down ⇒ DENY/503; decision-token aud/exp/replay; break-glass audited.
+- **Integration:** DA chat shadow→enforce; RAG query/ingest; bot channel-scoped; AgentGateway ext_authz allow/deny via bridge.
+- **Perf:** `:batch` list filtering vs N checks; cache hit ratio; ext_authz p99 within 200ms budget.
+
+---
+
+## 16. Open decisions
+
+| ID | Decision | Default |
+|----|----------|---------|
+| D-1 | Bridge OpenFGA-direct + contract-aligned vs route via CAS | **Direct + aligned** (§7) |
+| D-2 | Decision-token signing: symmetric (in-boundary) → JWKS later | symmetric to start |
+| D-3 | Workflow `task` visibility: product layer over FGA vs fold into FGA | product layer for now; revisit post-P4 |
+| D-4 | Standing team→agent access: drop modal pre-grant vs keep as explicit admin grant | drop; explicit grant if product needs it |
+| D-5 | Parity bar + soak window before enforce | ~100% over N days (set N per surface) |
+
+---
+
+## 17. Epic [#1742] mapping
+
+| Spec phase | Closes / enables |
+|------------|------------------|
+| P1 (CAS + HTTP API) | **#1455** (prereq); enables **#1730**; sets up #1733 (CAS owns audit), #1736 (CAS owns cached channel→team) |
+| P3–P4 (convergence) | #1730, #1731, #1733 (DA); #1734/#1735/#1736 (RAG); #1737/#1739/#1741 (Slack — bots shed Keycloak-Admin/Mongo blast radius) |
+| P5 (tokens) | #1731 capstone; gated on **#1458** |
+
+**Correction:** the "facade then runtime-API as separate phases" sequencing is the *problem statement's §8*, not the epic. #1742 makes the runtime API (#1455) a **prerequisite** — supporting "ship the service first." #1755 is **not** in scope (narrow skills-UI DRY); keep it independent.
+
+---
+
+<!-- assisted-by claude code claude-opus-4-8 -->

--- a/docs/docs/specs/2026-06-06-cas-implementation/spec.md
+++ b/docs/docs/specs/2026-06-06-cas-implementation/spec.md
@@ -1,0 +1,379 @@
+# Spec: Centralized Authorization Service (CAS) — BFF-resident, PDP-agnostic
+
+**Status:** Draft for review
+**Date:** 2026-06-06
+**Owner:** Sri Aradhyula
+**Context:** [`problem-statement.md`](../2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md) · [`solution-architecture.md`](../2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md)
+**Tracking:** epic [#1742]; prerequisite [#1455]; security driver [#1730]
+
+> This spec covers **only what gets built new**: `ui/src/lib/authz/` and `POST /api/authz/v1/*`. It is additive — no existing file is modified, no existing PEP is re-wired.
+
+---
+
+## 1. Summary
+
+Introduce one **Authorization Decision Core** in the BFF (`ui/src/lib/authz/`) and expose it via a versioned HTTP API (`/api/authz/v1`). The service lands **standalone**: existing authz paths (DA `openfga_authz.py`, RAG `rbac.py`, BFF `resource-authz.ts`) keep running unchanged. Migration of those surfaces to consume CAS is a separate, incremental effort.
+
+**Principle:** *One decision core. One PDP-agnostic contract. Zero changes to existing code.*
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- **G1** Single decision module: one place computes "may subject S do action A on resource R."
+- **G2** PDP-agnostic contract: callers see `{subject, resource, action} → {decision, reason}`; OpenFGA internals are invisible except in the admin explain endpoint.
+- **G3** HA OpenFGA adapter: warm store-id, pooled client, decision cache, circuit breaker.
+- **G4** HTTP API for out-of-process callers: `POST /api/authz/v1/decisions`, `:batch`, `explain`.
+- **G5** Verified caller token at every call: CAS validates JWT via JWKS; subject-binding enforced.
+- **G6** Additive only: nothing existing is modified. Existing authz paths are untouched.
+
+### Non-goals
+
+- Migrating DA, RAG, bots, or the gateway bridge to consume CAS.
+- Modifying `openfga_authz.py`, `rbac.py`, `resource-authz.ts`, or any existing authz file.
+- Replacing OpenFGA as the relationship store.
+- Routing `openfga-authz-bridge` through CAS (rejected — §7).
+- Decision tokens / Transport C (future P5, gated on [#1458]).
+
+---
+
+## 3. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **CAS** | Centralized Authorization Service — the decision core + HTTP API. |
+| **PDP** | Policy Decision Point — computes allow/deny. Here: core + OpenFGA adapter. |
+| **PEP** | Policy Enforcement Point — calls PDP and enforces. CAS is a PDP; existing code has its own PEPs. |
+| **Core** | `ui/src/lib/authz/` — the new module being built. |
+| **Subject-binding** | A user caller may only evaluate `subject == token.sub`. |
+
+---
+
+## 4. Module — `ui/src/lib/authz/`
+
+```text
+ui/src/lib/authz/
+  index.ts            # authorize(), authorizeMany(), authorizeOrThrow(), filterAccessible()
+  contract.ts         # Subject, Resource, Action, Decision, ReasonCode
+  reasons.ts          # ReasonCode → { retriable, userActionHint, httpStatusHint }
+  engine.ts           # PolicyEngine interface
+  compose.ts          # product policy layered over the PDP adapter
+  engines/
+    openfga.ts        # the only OpenFGA adapter: action→relation map, warm store-id, pooled client, cache
+  domains/
+    workflow.ts       # workflowDelegatesAgentUse, run-visibility
+    slack-channel.ts
+    webex-space.ts
+  cache.ts            # bounded per-replica LRU, TTL-aware
+  audit.ts            # one decision → one structured audit event
+```
+
+### 4.1 Public API (`index.ts`)
+
+```ts
+// Returns Decision; never throws for DENY
+authorize(req: AuthorizeRequest): Promise<Decision>
+
+// Batch: BatchCheck internally; returns one Decision per id
+authorizeMany(
+  subject: Subject,
+  action: Action,
+  resourceType: ResourceType,
+  ids: string[]
+): Promise<Map<string, Decision>>
+
+// Guard variant: throws ApiError(403) on DENY, ApiError(503) on AUTHZ_UNAVAILABLE
+authorizeOrThrow(req: AuthorizeRequest): Promise<void>
+
+// List filter: returns only ids accessible to the subject
+filterAccessible(
+  subject: Subject,
+  action: Action,
+  resourceType: ResourceType,
+  ids: string[]
+): Promise<string[]>
+```
+
+### 4.2 PolicyEngine interface (`engine.ts`)
+
+```ts
+interface PolicyEngine {
+  check(req: AuthorizeRequest): Promise<Decision>;
+  batchCheck(
+    subject: Subject,
+    action: Action,
+    resourceType: ResourceType,
+    ids: string[]
+  ): Promise<Map<string, Decision>>;
+}
+```
+
+`compose.ts` wraps a `PolicyEngine` with product policy (workflow delegation, channel scoping) and returns a `PolicyEngine`. All product rules live here; the OpenFGA adapter has no product knowledge.
+
+### 4.3 OpenFGA adapter (`engines/openfga.ts`)
+
+| Concern | Design |
+|---------|--------|
+| Store id | resolved once at boot; cached in module scope; refreshed on 404 |
+| HTTP client | one pooled keep-alive client; no per-call instantiation |
+| HA | retries idempotent `check` ≤2×, 100ms between; upstream service-level replication |
+| Decision cache | bounded LRU; TTL ≤15s read-class, ≤2s write-class |
+| Batch | `BatchCheck` for ≤50 ids; bounded parallel for overflow |
+| Circuit breaker | open ⇒ fail closed (`AUTHZ_UNAVAILABLE`); half-open probe every 30s |
+| Consistency | `HIGHER_CONSISTENCY` for write-class checks; standard otherwise |
+| Action→relation map | `use → can_use`, `call → can_call`, `manage → admin`, etc. — internal to adapter only |
+
+---
+
+## 5. Contract
+
+### 5.1 Types
+
+```ts
+type SubjectType  = "user" | "service_account";
+
+type ResourceType =
+  | "agent" | "skill" | "mcp_tool" | "knowledge_base"
+  | "data_source" | "task" | "slack_channel" | "webex_space";
+
+type Action =
+  | "discover" | "read" | "read-metadata" | "use"
+  | "write" | "manage" | "share" | "delete"
+  | "ingest" | "call" | "invoke" | "audit";
+
+interface AuthorizeRequest {
+  subject:  { type: SubjectType; id: string };
+  resource: { type: ResourceType; id: string };
+  action:   Action;
+  context?: Record<string, unknown>; // may only NARROW a grant, never expand
+}
+
+type ReasonCode =
+  | "OK"                  // ALLOW
+  | "NO_CAPABILITY"       // DENY — no relationship        → contact_admin
+  | "NOT_AUTHENTICATED"   // caller token missing/invalid  → sign_in
+  | "AUTHZ_UNAVAILABLE"   // PDP error (retriable)          → retry
+  | "INVALID_REQUEST";    // bad id / malformed             → fix_request
+
+interface Decision {
+  decision:    "ALLOW" | "DENY";
+  reason:      ReasonCode;
+  retriable:   boolean;
+  ttl_seconds?: number;
+}
+```
+
+OpenFGA relation strings (`can_use`, `can_call`, etc.) are **internal to `engines/openfga.ts`**. They do not appear in `Decision`, error bodies, or any API response except the admin `/explain` endpoint.
+
+### 5.2 HTTP API
+
+**Single decision**
+
+```http
+POST /api/authz/v1/decisions
+Authorization: Bearer <caller-token>
+Content-Type: application/json
+
+{
+  "subject":  { "type": "user", "id": "<sub>" },
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "action":   "use"
+}
+
+200  { "decision": "ALLOW", "reason": "OK",            "retriable": false, "ttl_seconds": 15 }
+200  { "decision": "DENY",  "reason": "NO_CAPABILITY", "retriable": false }
+```
+
+**Batch**
+
+```http
+POST /api/authz/v1/decisions:batch
+Authorization: Bearer <caller-token>
+
+{
+  "subject":       { "type": "user", "id": "<sub>" },
+  "action":        "discover",
+  "resource_type": "agent",
+  "ids":           ["a", "b", "c"]
+}
+
+200 {
+  "results": [
+    { "id": "a", "decision": "ALLOW", "reason": "OK" },
+    { "id": "b", "decision": "DENY",  "reason": "NO_CAPABILITY" }
+  ]
+}
+```
+
+**Admin explain** (only endpoint where OpenFGA detail appears)
+
+```http
+POST /api/authz/v1/explain
+Authorization: Bearer <caller-token>   # requires can_audit scope
+
+200 {
+  "decision": "DENY",
+  "reason":   "NO_CAPABILITY",
+  "debug": {
+    "engine":   "openfga",
+    "relation": "can_use",
+    "checked":  ["user:<sub> can_use agent:platform-engineer"],
+    "store":    "<store-id>"
+  }
+}
+```
+
+### 5.3 HTTP status semantics
+
+> **A DENY is not an error.** Evaluation succeeded; the answer is "no" ⇒ `200` with body. HTTP status codes are reserved for meta-failures only.
+
+| Status | Meaning |
+|--------|---------|
+| `200` | evaluation succeeded (`ALLOW` or `DENY` in body) |
+| `401` | caller token missing or invalid (`NOT_AUTHENTICATED`) |
+| `403` | subject-binding violation — caller may not evaluate this subject |
+| `400` | malformed request (`INVALID_REQUEST`) |
+| `503` | PDP unavailable (`AUTHZ_UNAVAILABLE`, `retriable: true`) |
+
+PEPs translate `decision: "DENY"` into their own 403 responses. Deny-reasoning stays in the body, not in status codes.
+
+### 5.4 Error envelope
+
+```json
+{
+  "error":     "human-readable message safe to surface",
+  "code":      "REASON_CODE",
+  "retriable": false
+}
+```
+
+No OpenFGA strings (`agent#use`, `pdp_denied`, tuple strings) appear in error envelopes. These are adapter-internal and surface only in `/explain`.
+
+---
+
+## 6. Security model
+
+CAS is a trust boundary. It assumes callers may be hostile.
+
+| # | Threat | Control |
+|---|--------|---------|
+| 1 | **Forged subject** | A `user` caller may only evaluate `subject.id == token.sub`. Cross-subject requires `can_audit` scope. Mismatch ⇒ `403`. |
+| 2 | **Service account impersonation** | `service_account` callers must present a verified client-credentials token and hold a `can_impersonate` tuple. No trusted `delegated_subject` body field. |
+| 3 | **Unsigned/forgeable identity** ([#1730]) | CAS validates JWT signature / `exp` / `aud` / `iss` via cached JWKS on every request. Header/body subject is only the *target*; binding is then checked per #1 and #2. |
+| 4 | **PDP outage → silent allow** | Fail closed: open circuit ⇒ `DENY` + `AUTHZ_UNAVAILABLE` + `retriable: true` + `503` + audit event. Break-glass is explicit env flag, time-boxed, and audited per request. |
+| 5 | **Cache stale-allow** | TTL ≤15s read-class, ≤2s write-class; revocation tolerated within TTL (documented bound). |
+| 6 | **`context` expansion** | `context` may only *narrow* a grant. Server-evaluated delegation (workflow run-authorizer) lives inside `compose.ts`, not in caller-supplied context. |
+| 7 | **Enumeration / info leak** | Coarse `ReasonCode` only in public responses; no tuple strings outside `/explain`; per-caller rate limit; every decision audited with `correlation_id`. |
+| 8 | **New write surface** | v1 API is **evaluate only**. No tuple writes. Standing up CAS grants no new mutation capability. |
+
+---
+
+## 7. The `openfga-authz-bridge` — not in scope
+
+The existing `openfga-authz-bridge` is the data-plane PEP for MCP routing. AgentGateway fires a per-route `ext_authz` gRPC Check at a 200ms timeout. Routing those decisions through the BFF would put the BFF in the hot path of every MCP tool call. Rejected.
+
+The bridge is not touched by this spec. Aligning its vocabulary, adapter semantics, and audit schema to match the contract defined here is a separate, incremental step.
+
+---
+
+## 8. Audit
+
+CAS writes one event per decision to `audit_events`.
+
+```json
+{
+  "audit_event_id": "<uuid>",
+  "ts":             "<iso8601>",
+  "type":           "cas_decision",
+  "tenant_id":      "<tenant>",
+  "subject_hash":   "sha256:<salted-hash>",
+  "resource_type":  "agent",
+  "resource_id":    "<id>",
+  "action":         "use",
+  "decision":       "ALLOW",
+  "reason_code":    "OK",
+  "pdp":            "openfga",
+  "source":         "cas",
+  "correlation_id": "<uuid>",
+  "trace_id":       "<otel-trace-id>",
+  "span_id":        "<otel-span-id>"
+}
+```
+
+**Metrics**
+
+| Metric | Labels |
+|--------|--------|
+| `authz_decision_total` | `resource_type, action, decision, reason` |
+| `authz_pdp_latency_ms` | `resource_type, action, cache_hit` |
+| `authz_cache_hit_ratio` | `resource_type` |
+| `authz_circuit_state`  | `state: closed\|open\|half_open` |
+
+---
+
+## 9. Configuration
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `OPENFGA_HTTP` | — | OpenFGA HTTP base URL (required) |
+| `OPENFGA_STORE_ID` | — | Explicit store id; skips store-list lookup when set |
+| `OPENFGA_STORE_NAME` | `caipe-openfga` | Store name for lookup when id is unset |
+| `AUTHZ_DECISION_CACHE_TTL_MS` | `15000` | Read-class cache TTL |
+| `AUTHZ_DECISION_CACHE_WRITE_TTL_MS` | `2000` | Write-class cache TTL |
+| `AUTHZ_BREAK_GLASS` | unset | Fail-open for non-prod emergencies; alarmed + audited per request |
+| `AUDIT_SUBJECT_SALT` | — | Salt for subject hash in audit events (required) |
+| `AUTHZ_TRACING_ENABLED` | `false` | OTLP span export for decision calls |
+
+---
+
+## 10. Tasks
+
+All new files. No existing file is modified.
+
+**Core**
+
+1. `contract.ts` — types: `Subject`, `Resource`, `Action`, `Decision`, `ReasonCode`.
+2. `reasons.ts` — `ReasonCode → { retriable, userActionHint, httpStatusHint }`.
+3. `engine.ts` — `PolicyEngine` interface (`check`, `batchCheck`).
+4. `engines/openfga.ts` — adapter: warm store-id, pooled client, action→relation map, cache, circuit breaker.
+5. `cache.ts` — bounded LRU; read/write TTL split.
+6. `audit.ts` — structured decision event writer (§8 shape).
+7. `compose.ts` + `domains/workflow.ts` — product policy layer; workflow delegation.
+8. `index.ts` — `authorize`, `authorizeMany`, `authorizeOrThrow`, `filterAccessible`.
+
+**HTTP routes**
+
+9. `POST /api/authz/v1/decisions` — JWKS verification, subject-binding, single decision.
+10. `POST /api/authz/v1/decisions:batch` — subject-binding, batch result.
+11. `POST /api/authz/v1/explain` — `can_audit` guard; OpenFGA debug block.
+12. Shared `v1ErrorResponse` builder — no OpenFGA strings in public envelopes.
+13. OpenAPI schema for `/api/authz/v1`.
+
+**Guards**
+
+14. ESLint `no-restricted-imports`: `engines/openfga` and `lib/rbac/openfga` are import errors outside `lib/authz/**`.
+
+**Tests**
+
+15. Unit: decision matrix (direct, team-union, deny, PDP error, invalid id); subject-binding accept/reject; cache TTL + write-class bypass; circuit breaker open/close.
+16. Contract: request/response schema; `200-DENY` vs `401/403/400/503`; no OpenFGA strings outside `explain`.
+17. Security regression: forged-subject `403`; unsigned token rejected ([#1730]); PDP-down ⇒ `DENY/503`; break-glass audited.
+
+---
+
+## 11. Acceptance criteria
+
+- [ ] `ui/src/lib/authz/` exists with all modules in §4; `engines/openfga` imports restricted by lint rule.
+- [ ] `POST /api/authz/v1/decisions` (+ `:batch`, `explain`) live; caller JWT verified via JWKS; subject-binding enforced.
+- [ ] `DENY` returns `200` with `ReasonCode`; meta-failures return correct status codes (§5.3).
+- [ ] No `agent#use`, `pdp_denied`, or FGA tuple strings in any non-`explain` response.
+- [ ] Adapter: store-id cached at boot; pooled client; circuit breaker; read/write TTL split.
+- [ ] Every decision produces one audit event with the shape in §8.
+- [ ] OpenAPI schema published; contract tests green.
+- [ ] No existing file was modified; no existing test was broken.
+
+---
+
+<!-- assisted-by claude code claude-sonnet-4-6 -->


### PR DESCRIPTION
## Summary

- Adds problem statement for today's fragmented authz landscape (3x OpenFGA reimplementations, 2x agent-use algorithms, no shared contract)
- Adds solution architecture doc critiquing the problem statement and proposing the CAS design
- Adds clean implementation spec for the standalone CAS: `ui/src/lib/authz/` module and `POST /api/authz/v1/*` HTTP API

**Nothing existing is modified.** This is a docs-only PR for design review.

## What the CAS spec covers

- `ui/src/lib/authz/` module structure: `contract.ts`, `engine.ts`, `engines/openfga.ts`, `compose.ts`, `cache.ts`, `audit.ts`, `index.ts`
- PDP-agnostic contract: `{subject, resource, action} -> {decision, reason}` with ReasonCode vocabulary
- HA OpenFGA adapter: warm store-id, pooled client, decision cache (TTL-split), circuit breaker
- HTTP API: `POST /api/authz/v1/decisions`, `:batch`, `explain`
- Subject-binding + JWKS token verification at every call
- Security model: 8 threats + controls (closes #1730 as a precondition)
- Audit schema + observability metrics

## What the spec does NOT cover

Migration of DA, RAG, bots, or the gateway bridge to consume CAS. Those are separate incremental steps once this service ships.

## Related

- Tracks: #1742 RBAC/Auth review epic
- Prerequisite: #1455 runtime authz API
- Security driver: #1730 forgeable X-User-Context in DA

## Test plan

- [ ] Read `docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md`
- [ ] Read `docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md`
- [ ] Read `docs/docs/specs/2026-06-06-cas-implementation/spec.md`

Generated with [Claude Code](https://claude.com/claude-code)