### PR TITLE
feat(authz): Centralized Authorization Service (CAS) — core, HTTP API, admin UI

### DIFF
--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md
@@ -1,0 +1,619 @@
+# Problem Statement: Centralized BFF Authorization & PDP-Agnostic API
+
+**Status:** Draft for second-opinion review  
+**Date:** 2026-06-05  
+**Authors:** Sri Aradhyula (problem framing); AI-assisted synthesis from PR review + team discussion  
+**Audience:** Platform engineers, security architects, agents reviewing implementation options  
+
+**Related work:**
+
+| Link | Role |
+|------|------|
+| [PR #1751](https://github.com/cnoe-io/ai-platform-engineering/pull/1751) | Workflow RBAC visibility, run access, unsaved UX, agent-access modal |
+| [PR #1751 review r3362688683](https://github.com/cnoe-io/ai-platform-engineering/pull/1751#discussion_r3362688683) | @subbaksh: workflows are UI/BFF concept; DA should not own workflow RBAC |
+| [Issue #1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) | Epic: RBAC/Auth review remediation (PR #1444 follow-ups) |
+| [Issue #1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) | Skills RBAC UI parity / shared-module hygiene (#1727 follow-up) |
+| [Issue #1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455) | Runtime BFF ReBAC endpoints for Slack/Webex bots |
+| [Issue #1454](https://github.com/cnoe-io/ai-platform-engineering/issues/1454) | Refactor DA runtime auth surface |
+| [Issue #1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731) | Duplicate OpenFGA `can_use` on DA chat path |
+| [Issue #1734–#1738](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) | RAG thin PEP / Mongo in hot path |
+
+---
+
+## 1. Executive summary
+
+CAIPE has **reusable RBAC modules on the BFF** (Next.js UI server) and **CI guards** for new resource types, but authorization is still implemented inconsistently across surfaces:
+
+- **Dynamic Agents (DA)** sometimes reads **MongoDB** for UI-domain data (e.g. `workflow_configs`, `teams`) and duplicates **OpenFGA** checks the BFF already performs.
+- **RAG** still uses a **monolithic `server/rbac.py`** that mixes token validation, legacy roles, OpenFGA, and MongoDB — a different pattern than agents/KB/MCP on the BFF.
+- **Public APIs and errors** expose OpenFGA-specific concepts (`agent#use`, `pdp_denied`, tuple strings), coupling integrators and UI copy to the current PDP.
+- **HTTP authorization** is fragmented: admin-only `rebac/check`, domain-specific `access-check` routes, and no generic **runtime** evaluate API for service callers (bots, DA).
+
+After testing **0.5.9** and reviewing **PR #1751**, the team wants to:
+
+1. **Stop creating anti-patterns** (DA → Mongo for workflows; one-off RBAC per resource).
+2. **Enforce shared module usage** going forward (linters, hygiene).
+3. **Make the authorization API PDP-agnostic** so OpenFGA is an implementation detail, not a user-facing contract.
+4. **Centralize policy decisions on the BFF** where platform domain data lives (workflows, teams, visibility).
+
+This document captures the **problem statement**, **current state**, **stakeholder input**, and **implementation options** for a follow-up spec.
+
+---
+
+## 2. Problem statement
+
+### 2.1 Core problem
+
+**Authorization logic and platform domain data are scattered across BFF, Dynamic Agents, RAG, and Slack bot**, with multiple parallel patterns for the same decision (`user X may use resource Y`). This causes:
+
+1. **Architectural drift** — reviewers repeatedly flag DA/RAG reading Mongo or re-implementing visibility rules that belong on the BFF.
+2. **Duplicate PDP hops** — BFF checks OpenFGA, then DA checks OpenFGA again (latency, availability, confusion about source of truth).
+3. **Inconsistent developer experience** — agents use `shareable-resource.ts` + `resource-authz.ts`; RAG uses `rbac.py`; workflows added DA-side Mongo reads in PR #1751.
+4. **Leaky abstraction** — API consumers see OpenFGA relation names and PDP jargon instead of stable product-level denial reasons.
+5. **Weak enforcement** — CI guarantees new **types** are registered and default-deny tested, but does not force routes/services to use shared modules vs ad-hoc checks.
+
+### 2.2 Triggering incidents (this conversation)
+
+#### A. PR #1751 — workflow RBAC + DA delegation
+
+PR [#1751](https://github.com/cnoe-io/ai-platform-engineering/pull/1751) adds:
+
+- BFF: workflow visibility, run access gates, team slug normalization, unsaved UX, agent-access modal on save.
+- DA: `workflow_execution_authz.py` — reads `workflow_configs` and `teams` from Mongo; allows `agent#can_use` bypass when `workflow_config_id` is passed on chat requests.
+
+**Reviewer feedback (@subbaksh, [r3362688683](https://github.com/cnoe-io/ai-platform-engineering/pull/1751#discussion_r3362688683)):**
+
+> Workflows are purely a UI server concept. The UI invokes agents one step at a time. DA usually has no clue whether it's a workflow or a user chatting. For invocation — the DA server just has a tool (with `workflow_id` param) that it calls to invoke a workflow. The RBAC for invocation should be in UI server no?
+
+**Assessment:** The reviewer is aligned with epic [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742). Workflow lifecycle auth already exists on the BFF (`/api/workflow-runs`, `workflow-config-rebac.ts`). DA Mongo reads are an anti-pattern; the bypass exists only because the workflow engine forwards the **user JWT** to DA and DA enforces `agent#can_use` independently.
+
+#### B. Reusable modules — one path did not use them
+
+Shared modules were introduced for **unified shareable resource RBAC** (spec `2026-06-03-unified-shareable-resource-rbac`):
+
+- **Write path:** `ui/src/lib/rbac/shareable-resource.ts` → `openfga-owned-resources.ts` (`reconcileShareableResource`)
+- **Read path:** `ui/src/lib/rbac/resource-authz.ts` (`requireResourcePermission`, `filterResourcesByPermission`)
+
+Skills team sharing was fixed in [#1729](https://github.com/cnoe-io/ai-platform-engineering/pull/1729) to use `reconcileShareableResource`. Follow-up [#1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) tracks optional UI DRY (`useShareableTeams` hook) and documents explicit non-goals (skills as owner-team resources).
+
+**Gap:** Not every feature path uses the shared stack. PR #1751’s DA workflow auth is the latest example of **bypassing** BFF modules entirely.
+
+#### C. Team discussion (Kevin Kantesaria, 2026-06-05)
+
+Paraphrased Slack thread:
+
+| Speaker | Point |
+|---------|--------|
+| Sri | Created [#1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) to track cleanup after reusable modules; one instance did not use them. |
+| Kevin | Push cleanup soon so we don’t keep creating anti-patterns; unsure how to **enforce** going forward. |
+| Sri | Added basic RBAC enforcement for new resources; need linters and hygiene. |
+| Kevin | Does that enforcement **use the modules**? Original problem: **RAG and agents used different RBAC setups** — want to avoid that. |
+| Kevin / Sri | Make **OpenFGA less obvious** to end users; API should be **agnostic** if we switch PDP. |
+
+### 2.3 Goals (desired end state)
+
+1. **Single policy ownership** — BFF owns platform domain data (workflows, teams, visibility) and composes FGA + product rules.
+2. **Single module stack** — application code uses `shareable-resource` / `resource-authz` (or a thin facade), not raw `openfga.ts` or service-local Mongo policy.
+3. **PDP-agnostic public contract** — HTTP and user-facing errors use `{ resource, action, reason }`, not `can_use` / `agent#use` / `pdp_denied`.
+4. **Thin PEPs downstream** — DA, RAG, bots either trust BFF decisions via API or verify signed claims; they do not read `workflow_configs` from Mongo for authz.
+5. **Enforceable in CI** — import boundaries, create-path linter extensions, no new anti-patterns without explicit spec exception.
+
+### 2.4 Non-goals (for initial spec)
+
+- Replacing OpenFGA as the relationship store (unless a separate strategic decision).
+- Removing all OpenFGA checks from DA in v1 (tracked as [#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731); depends on [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458) dual-gate documentation).
+- Migrating skills to owner-team model ([#1708](https://github.com/cnoe-io/ai-platform-engineering/pull/1708)) — separate from this problem.
+
+---
+
+## 3. Current state (as of 2026-06-05, branch `prebuild/feat/workflow-rbac-visibility-unsaved`)
+
+### 3.1 BFF authorization layers
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  BFF route handler (ui/src/app/api/**/route.ts)                   │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         ▼                   ▼                   ▼
+  requireRbacPermission   requireResourcePermission   Domain helpers
+  (api-middleware.ts)     (resource-authz.ts)         (workflow-config-rebac,
+   org/capability gates                             slack-channel-rebac, …)
+         │                   │                   │
+         └───────────────────┼───────────────────┘
+                             ▼
+              checkOpenFgaTuple / checkUniversalRebacRelationship
+                             (openfga.ts)
+                             ▼
+                        OpenFGA HTTP API
+```
+
+#### Key modules
+
+| Module | Path | Responsibility |
+|--------|------|----------------|
+| OpenFGA transport | `ui/src/lib/rbac/openfga.ts` | `checkOpenFgaTuple`, tuple read/write/reconcile |
+| Resource ReBAC | `ui/src/lib/rbac/resource-authz.ts` | `requireResourcePermission`, `filterResourcesByPermission`, `requireAgentPermission`, `requireSkillPermission` |
+| Agent use (chat proxy) | `ui/src/lib/rbac/openfga-agent-authz.ts` | `requireAgentUsePermission` — used by `/api/v1/chat/*` |
+| Agent use (audit path) | `ui/src/lib/rbac/pdp-shared.ts` | `evaluateAgentAccess` — direct + team-union with reason codes |
+| Shareable write | `ui/src/lib/rbac/shareable-resource.ts` | `handleShareableResourceWrite`, `resolveShareableOwnershipWrite` |
+| FGA reconcile | `ui/src/lib/rbac/openfga-owned-resources.ts` | `reconcileShareableResource` |
+| Workflow policy | `ui/src/lib/rbac/workflow-config-rebac.ts` | Visibility, `workflowDelegatesAgentUse`, `reconcileWorkflowConfigAccess` (uses `reconcileShareableResource`) |
+| Access explain (admin) | `ui/src/lib/rbac/access-explainer.ts` | `explainAccess` + Mongo provenance |
+| Type registry | `ui/src/types/rbac-universal.ts` | `UniversalRebacResourceType`, `UniversalRebacRelationship` |
+| Enforcement manifest | `ui/src/lib/rbac/fga-enforcement-manifest.ts` | Per-type `rebac_enforced` / surfaces for auditors |
+
+#### HTTP APIs that expose authorization today
+
+| Endpoint | Auth gate | Purpose | Runtime-safe? |
+|----------|-----------|---------|---------------|
+| `POST /api/admin/rebac/check` | `admin_ui#view` | Explain access (`explainAccess`) | **No** — admin only |
+| `POST /api/integrations/slack/.../access-check` | Session + `slack_channel#read` | `checkSlackChannelAccess` | **Partial** — bot path evolving |
+| `POST /api/integrations/webex/.../access-check` | Same pattern | Webex space access | **Partial** |
+| `POST /api/admin/slack/.../access-check` | Admin | Diagnostics | No |
+| `POST /api/admin/openfga/relationship` | Admin | Tuple grant/revoke | No (write) |
+| `POST /api/workflow-runs` | `assertCanExecuteWorkflowRunsForConfigId` | Start run | Yes — domain API |
+| `POST /api/workflow-configs/check-agent-access` | `withAuth` | Pre-save agent gap check (PR #1751) | Yes — BFF-only |
+| DA `WorkflowApiClient` → `/api/workflow-runs` | OAuth2 client credentials | Workflow tools from agents | Yes — correct pattern |
+
+**There is no generic `POST /api/runtime/authorize` today.**
+
+Spec draft exists: `docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md` (`POST /api/admin/rebac/check` with `UniversalRebacRelationship`).
+
+### 3.2 CI enforcement (FGA coverage guarantee, spec 2026-06-04)
+
+| Layer | Artifact | What it enforces |
+|-------|----------|------------------|
+| 1 | `fga-type-coverage.test.ts` | OpenFGA model ≡ type registry ≡ chart |
+| 2 | `fga-enforcement-manifest.test.ts` | Every type classified; enforced surfaces exist on disk |
+| 3 | `scripts/validate-fga-create-paths.py` | Ownable types wire `reconcile*Relationships` from production routes |
+| 4 | `default-deny-coverage.test.ts` | New types auto-covered for deny-by-default |
+
+**Gap:** Layers 1–4 do **not** require routes to call `shareable-resource` / `resource-authz` vs ad-hoc `checkOpenFgaTuple`. They do **not** block DA/RAG Mongo reads for authz.
+
+### 3.3 Dynamic Agents — workflow-related anti-patterns
+
+| Location | Mongo / policy | Issue |
+|----------|----------------|-------|
+| `dynamic_agents/auth/workflow_execution_authz.py` | Reads `workflow_configs`, `teams` | Duplicates BFF visibility; reviewer rejected |
+| `dynamic_agents/auth/openfga_authz.py` | OpenFGA + workflow bypass | Third auth layer on chat path |
+| `dynamic_agents/services/agent_runtime.py` | Reads `workflow_configs` for builtin tool validation | Should use BFF resolve API |
+| `dynamic_agents/services/builtin_tools.py` | `WorkflowApiClient` → BFF | **Correct** pattern for invocation |
+
+### 3.4 RAG vs agents — divergent stacks
+
+| Concern | Agents / BFF resources | RAG server |
+|---------|------------------------|------------|
+| Read/use gate | `resource-authz.ts` → OpenFGA | `server/rbac.py` (mixed) |
+| Share/write | `shareable-resource.ts` | Partial (KB sharing route on BFF); ingestor paths differ |
+| Mongo in authz hot path | Mostly moved to BFF | Still present ([#1736](https://github.com/cnoe-io/ai-platform-engineering/issues/1736)) |
+| Target architecture | Unified shareable resource RBAC | [Thin PEP plan](docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md) |
+
+Kevin’s concern: **“RAG and agents used different RBAC setups”** — still true at the Python RAG layer.
+
+### 3.5 PR #1751 commit inventory (relevant)
+
+| Commit / area | BFF-aligned? | Notes |
+|---------------|--------------|-------|
+| Workflow run access (`workflow-run-access.ts`) | Yes | |
+| `workflow-config-rebac.ts` + `reconcileShareableResource` | Yes | |
+| Unsaved UX, team slugs, `TeamMultiPicker` | Yes | |
+| `check-agent-access` + `WorkflowAgentAccessModal` | Yes | Pre-grant agent tuples on save |
+| `workflow_execution_authz.py` on DA | **No** | Remove or defer to epic |
+| `workflow_config_id` on DA chat body | **No** | Remove with above |
+
+### 3.6 User-visible OpenFGA leakage (examples)
+
+From `openfga-agent-authz.ts` and `resource-authz.ts`:
+
+```json
+{
+  "success": false,
+  "error": "Permission denied",
+  "code": "agent#use",
+  "reason": "pdp_denied",
+  "action": "contact_admin"
+}
+```
+
+Admin explain responses include FGA tuple strings. Audit events use `pdp: "openfga"`. These are appropriate for **operators**, not for generic API consumers or end-user copy.
+
+---
+
+## 4. Architectural principles (agreed direction)
+
+1. **Workflows are a BFF concern** — config, visibility, run orchestration, delegation checks live in UI server + `workflow-engine.ts`.
+2. **DA invokes agents; DA workflow tools invoke workflows via BFF** — `WorkflowApiClient` is the model.
+3. **OpenFGA is the current PDP for relationships** — but **callers** should not depend on FGA tuple shape.
+4. **Defense-in-depth is optional and explicit** — duplicate DA OpenFGA ([#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731)) must be a documented choice ([#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458)), not accidental duplication.
+5. **Epic [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) phases** — runtime BFF endpoints ([#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455)) before bots/DA drop Mongo.
+
+---
+
+## 5. Options (detailed)
+
+### Option 1 — In-process Authz facade (BFF library)
+
+**Summary:** Introduce `ui/src/lib/authz/` as the **only** import surface for application authorization. OpenFGA moves behind a `PolicyEngine` interface.
+
+#### Proposed structure
+
+```text
+ui/src/lib/authz/
+  index.ts                 # authorize(), filterAccessible(), reconcileShares()
+  types.ts                 # Subject, Resource, Action, Decision (PDP-agnostic)
+  errors.ts                # PERMISSION_DENIED, AUTHZ_UNAVAILABLE
+  engines/
+    openfga-adapter.ts     # implements PolicyEngine today
+  domains/
+    workflow.ts            # workflowDelegatesAgentUse, visibility (Mongo product policy)
+    slack-channel.ts
+    webex-space.ts
+```
+
+#### Public API (sketch)
+
+```typescript
+interface AuthorizeRequest {
+  subject: { type: "user" | "service_account"; id: string };
+  resource: { type: UniversalRebacResourceType; id: string };
+  action: ResourcePermissionAction;
+  context?: Record<string, unknown>; // workflow_id, channel_id, etc.
+}
+
+interface AuthorizeDecision {
+  allowed: boolean;
+  reason: "OK" | "NO_CAPABILITY" | "AUTHZ_UNAVAILABLE" | "INVALID_REQUEST";
+  action?: "sign_in" | "contact_admin" | "retry";
+  // Admin-only extension:
+  debug?: { engine: string; path?: string };
+}
+
+async function authorize(req: AuthorizeRequest): Promise<AuthorizeDecision>;
+async function authorizeOrThrow(req: AuthorizeRequest): Promise<void>;
+```
+
+#### Migration
+
+1. Wrap existing `resource-authz.ts`, `pdp-shared.ts`, domain modules.
+2. Deprecate direct `checkOpenFgaTuple` imports outside `lib/authz/**`.
+3. Map existing `ApiError` codes to PDP-agnostic envelope.
+
+#### Pros
+
+- No new network hop; fits existing Next.js deployment.
+- Clear import boundary for ESLint.
+- Enables future non-OpenFGA engine without route changes.
+
+#### Cons
+
+- Does not alone fix DA/RAG — they don’t run inside BFF.
+- Requires disciplined migration of ~dozens of route call sites.
+
+#### Enforcement
+
+```javascript
+// eslint no-restricted-imports
+"@/lib/rbac/openfga" → only from "@/lib/authz/**"
+```
+
+---
+
+### Option 2 — Runtime HTTP authorize API (BFF routes)
+
+**Summary:** Expose authorization decisions as HTTP for **service callers** (Slack bot, Webex bot, Dynamic Agents). Implements [#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455) and generalizes `access-check` routes.
+
+#### Proposed endpoint
+
+```http
+POST /api/runtime/authorize
+Authorization: Bearer <user-jwt | service-account-token>
+Content-Type: application/json
+
+{
+  "subject": { "type": "user", "id": "<oidc-sub>" },
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "action": "use",
+  "context": {
+    "workflow_config_id": "wf-optional-hint"
+  }
+}
+```
+
+**Response (allow):**
+
+```json
+{
+  "allowed": true,
+  "reason": "OK"
+}
+```
+
+**Response (deny):**
+
+```json
+{
+  "allowed": false,
+  "reason": "NO_CAPABILITY",
+  "action": "contact_admin"
+}
+```
+
+**Response (PDP down):**
+
+```json
+{
+  "allowed": false,
+  "reason": "AUTHZ_UNAVAILABLE",
+  "action": "retry"
+}
+```
+
+#### Domain-specific endpoints (alternative/complement)
+
+Instead of one generic endpoint, extend the **access-check pattern**:
+
+| Endpoint | Caller | Checks |
+|----------|--------|--------|
+| `POST /api/runtime/authorize` | Generic | FGA + optional context handlers |
+| `POST /api/runtime/workflows/authorize-run` | DA, internal | Workflow visibility + step agents |
+| `POST /api/runtime/workflows/resolve-configs` | DA | Replace Mongo `workflow_configs` read |
+| Existing Slack/Webex `access-check` | Bots | Channel/space scoped |
+
+#### Authentication model
+
+- **User bearer** — subject must match token `sub` (or OBO chain).
+- **Service account** — `service_account:<client_id>` in FGA; may evaluate on behalf of user when `context.delegated_subject` is present and bot OBO is valid (needs threat model).
+
+#### Pros
+
+- DA/RAG/bots stop reading Mongo for policy.
+- Single HTTP contract for integrators.
+- Aligns with epic [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) prerequisite [#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455).
+
+#### Cons
+
+- Latency and availability — every DA chat could add BFF round-trip unless cached or combined with Option 3.
+- Duplicates [#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731) debate if DA **still** checks OpenFGA after BFF says allow.
+
+#### Implementation notes
+
+- Implement handlers by delegating to Option 1 facade internally.
+- Admin `POST /api/admin/rebac/check` remains explain-only with richer `debug` payload.
+
+---
+
+### Option 3 — Signed authorization claims (PEP-only downstream)
+
+**Summary:** BFF is the **sole PDP**. After `authorize()`, BFF mints a **short-lived signed claim** (JWT or HMAC macaroon) attached to downstream requests. DA/RAG verify signature + expiry only.
+
+#### Claim sketch
+
+```json
+{
+  "iss": "caipe-bff",
+  "sub": "user:<oidc-sub>",
+  "resource": "agent:platform-engineer",
+  "action": "use",
+  "iat": 1710000000,
+  "exp": 1710000060,
+  "jti": "unique-id"
+}
+```
+
+DA `require_agent_use_permission` becomes `require_authorization_claim` — no OpenFGA client in DA.
+
+#### Pros
+
+- Eliminates duplicate OpenFGA in DA ([#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731)).
+- True PDP agnostic at service boundary.
+- Workflow delegation encoded in claim issuance on BFF (no `workflow_config_id` on DA).
+
+#### Cons
+
+- Largest engineering cost: key management, revocation, clock skew, claim replay.
+- Requires [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458) dual-gate retirement plan.
+- Workflow engine currently forwards **user JWT** — would need claim issuance at run start and per step.
+
+#### When to choose
+
+- Phase 3+ of [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742), after runtime BFF API proves correct.
+
+---
+
+### Option 4 — Enforcement-first (linters + manifest, minimal API change)
+
+**Summary:** Keep current modules; **block anti-patterns in CI** without redesigning HTTP APIs yet.
+
+#### Proposed guards
+
+| Guard | Mechanism | Blocks |
+|-------|-----------|--------|
+| Import boundary | ESLint `no-restricted-imports` | `checkOpenFgaTuple` outside `lib/rbac/**` or `lib/authz/**` |
+| Service boundary | `scripts/validate-authz-boundaries.py` | `workflow_configs` / `teams` reads in `dynamic_agents/**` for authz |
+| Route coverage | Extend `validate-fga-create-paths.py` or new script | New routes must import from `resource-authz` or `authz` facade |
+| Manifest update | `fga-enforcement-manifest.ts` | Add surfaces for `task` (workflows), runtime authorize routes |
+| PR template | Checkbox | “Uses shareable-resource / resource-authz / domain wrapper” |
+
+#### Pros
+
+- Fastest win; addresses Kevin’s “don’t create more anti-patterns.”
+- Low risk; parallel to other options.
+
+#### Cons
+
+- Does not fix RAG `rbac.py` or user-visible OpenFGA strings.
+- Does not give DA a supported API without Option 2.
+
+---
+
+### Option 5 — Universal relationship contract (spec-only standardization)
+
+**Summary:** Standardize all checks on `UniversalRebacRelationship` from `rbac-universal.ts` — already in [rebac-policy-api.md](docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md).
+
+#### Request shape
+
+```json
+{
+  "subject": { "type": "user", "id": "user-123", "relation": "member" },
+  "action": "use",
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "context": { "slack_channel": "C123" }
+}
+```
+
+#### Mapping
+
+- Internal: `checkUniversalRebacRelationship(relationship)` in `openfga.ts`.
+- `action: "use"` maps to FGA relation `can_use` inside adapter — **not** exposed to clients.
+
+#### Pros
+
+- One vocabulary for docs, admin UI, runtime API, tests.
+- Natural fit for Option 1 + Option 2.
+
+#### Cons
+
+- `action` names still mirror current FGA model; true PDP swap requires adapter mapping table per engine.
+
+---
+
+## 6. PDP-agnostic public surface (cross-cutting)
+
+Regardless of option, define a **stable external contract**:
+
+### 6.1 Error envelope migration
+
+| Current | Target (public) | Admin/debug only |
+|---------|-----------------|------------------|
+| `code: "agent#use"` | `code: "PERMISSION_DENIED"` | `detail: "agent#use"` |
+| `reason: "pdp_denied"` | `reason: "NO_CAPABILITY"` | |
+| `reason: "pdp_unavailable"` | `reason: "AUTHZ_UNAVAILABLE"` | |
+| `pdp: "openfga"` in JSON body | Omit | Keep in audit logs |
+| FGA tuple in error message | Omit | `POST /api/admin/rebac/check` |
+
+### 6.2 Stable reason codes
+
+| Code | Meaning | User `action` hint |
+|------|---------|-------------------|
+| `OK` | Allowed | — |
+| `NO_CAPABILITY` | Deny — no relationship | `contact_admin` |
+| `NOT_SIGNED_IN` | Missing/invalid auth | `sign_in` |
+| `AUTHZ_UNAVAILABLE` | PDP timeout/error | `retry` |
+| `INVALID_REQUEST` | Bad resource id / malformed | `fix_request` |
+
+### 6.3 Two-tier API
+
+| Tier | Audience | OpenFGA visible? |
+|------|----------|------------------|
+| **Runtime** | UI, bots, DA, RAG PEP | No |
+| **Admin explain** | Operators, support | Yes (paths, tuples, provenance) |
+
+---
+
+## 7. Workflow-specific resolution (PR #1751)
+
+### 7.1 Correct split of responsibility
+
+| Operation | Owner | Mechanism |
+|-----------|-------|-----------|
+| Create/update workflow config | BFF | `workflow-configs` routes + `reconcileWorkflowConfigAccess` |
+| Start/list/cancel/resume run | BFF | `/api/workflow-runs` + `workflow-run-access.ts` |
+| Pre-save agent access gaps | BFF | `check-agent-access` + grant via `/api/admin/openfga/relationship` |
+| Orchestrate steps | BFF `workflow-engine.ts` | Calls DA with user auth headers |
+| Agent `#can_use` at DA | DA OpenFGA only | **No workflow Mongo** — team access via pre-granted tuples or BFF-only delegation |
+| DA workflow tools | DA → BFF | `WorkflowApiClient` /api/workflow-runs |
+
+### 7.2 `workflowDelegatesAgentUse` (exists, unused)
+
+Defined in `workflow-config-rebac.ts`:
+
+- Agent listed in workflow steps **and**
+- `workflowRunAllowedByVisibility` for caller
+
+**Action:** Wire at `POST /api/workflow-runs` and optionally before each `consumeAgentStream` in `workflow-engine.ts`. Remove DA `workflow_execution_authz.py`.
+
+### 7.3 Global workflow gap
+
+`check-agent-access` detects `(all users)` gaps but grant loop skips them. Spec should decide: org-wide agent grants vs admin-only warning.
+
+---
+
+## 8. Recommended phased approach
+
+| Phase | Scope | Options | Depends on |
+|-------|-------|---------|------------|
+| **0 — Immediate** | PR #1751 cleanup | Remove DA workflow Mongo; keep BFF-only RBAC | — |
+| **1 — Hygiene** | CI + docs | Option 4 + [#1755](https://github.com/cnoe-io/ai-platform-engineering/issues/1755) UI DRY | — |
+| **2 — Facade** | BFF routes | Option 1 + Option 5 + error envelope §6 | Phase 1 |
+| **3 — Runtime API** | Bots, DA read paths | Option 2 ([#1455](https://github.com/cnoe-io/ai-platform-engineering/issues/1455)) | Phase 2 |
+| **4 — RAG convergence** | `rbac.py` thin PEP | Option 1 client in Python or Option 2 HTTP | [#1734](https://github.com/cnoe-io/ai-platform-engineering/issues/1734) |
+| **5 — Optional** | DA duplicate FGA removal | Option 3 | [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458), [#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731) |
+
+---
+
+## 9. Open questions for second opinion
+
+1. **DA execution gate:** Keep OpenFGA in DA for `agent#use` ([#1731](https://github.com/cnoe-io/ai-platform-engineering/issues/1731)) or move to BFF-only + signed claims (Option 3)?
+2. **Workflow delegation without agent tuples:** Is pre-grant on save (modal) sufficient for team workflows, or must runtime delegation work without prior grants?
+3. **Generic vs domain HTTP APIs:** One `POST /api/runtime/authorize` vs family of `access-check` endpoints?
+4. **RAG:** HTTP client to BFF vs shared Python library duplicating facade logic?
+5. **Service account delegation:** How should bots evaluate access **for** a user without admin UI perms?
+6. **Claim revocation:** Required for Option 3, or acceptable 60s TTL?
+7. **Breaking API changes:** Version `/api/v2/` for error envelope, or migrate in place?
+8. **Workflow `task` type in FGA:** Is Mongo visibility a permanent product layer on top of FGA, or should all run access be FGA-only eventually?
+
+---
+
+## 10. Acceptance criteria (draft for full spec)
+
+- [ ] No production authz path in `dynamic_agents/**` reads `workflow_configs` or `teams` from Mongo.
+- [ ] All new BFF routes use `authorize()` facade or documented domain wrapper — CI enforced.
+- [ ] Public API errors use §6 reason codes; no `pdp_denied` / `agent#use` in user-facing responses.
+- [ ] Runtime callers (Slack, Webex, DA workflow tools) use BFF HTTP or documented service contract — not admin rebac routes.
+- [ ] `workflowDelegatesAgentUse` wired at run start (and documented for step execution).
+- [ ] RAG plan references same contract as BFF (no third parallel RBAC vocabulary).
+- [ ] `fga-enforcement-manifest.ts` updated with new surfaces and `rebac_enforced` entries.
+- [ ] ADR or [#1458](https://github.com/cnoe-io/ai-platform-engineering/issues/1458) documents dual-gate retirement if DA OpenFGA is removed.
+
+---
+
+## 11. References (code & docs)
+
+### Code
+
+- `ui/src/lib/rbac/shareable-resource.ts`
+- `ui/src/lib/rbac/resource-authz.ts`
+- `ui/src/lib/rbac/openfga.ts`
+- `ui/src/lib/rbac/workflow-config-rebac.ts`
+- `ui/src/lib/rbac/fga-enforcement-manifest.ts`
+- `ui/src/app/api/admin/rebac/check/route.ts`
+- `ui/src/app/api/integrations/slack/.../access-check/route.ts`
+- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/workflow_execution_authz.py`
+- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py` (`WorkflowApiClient`)
+- `ui/src/lib/server/workflow-engine.ts`
+- `scripts/validate-fga-create-paths.py`
+
+### Docs
+
+- [PDP coverage audit](docs/docs/security/rbac/pdp-coverage-audit.md)
+- [RBAC architecture](docs/docs/security/rbac/architecture.md)
+- [Chat execution authz contract](docs/docs/specs/2026-05-16-dynamic-agent-pdp-gate/contracts/chat-execution-authz.md)
+- [Unified shareable resource RBAC](docs/docs/specs/2026-06-03-unified-shareable-resource-rbac/)
+- [RAG thin PEP plan](docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md)
+- [ReBAC policy API contract](docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md)
+
+---
+
+## 12. Instructions for reviewing agent
+
+Please evaluate:
+
+1. Whether **Option 1 + 2 + 4** is the right default combo vs Option 3 early.
+2. Whether **workflow delegation** should be FGA tuples (grant on save) vs runtime BFF check only.
+3. Gaps in **threat model** for runtime authorize API (service account, OBO, user impersonation).
+4. **Migration risk** for error code changes on existing UI/clients.
+5. Whether this should be one spec or split: (a) facade + enforcement, (b) runtime HTTP API, (c) RAG/DA convergence.
+
+Return: recommended option mix, ordered task list, and any contradictions with [#1742](https://github.com/cnoe-io/ai-platform-engineering/issues/1742) phasing.

--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md
@@ -188,7 +188,7 @@ Spec draft exists: `docs/docs/specs/2026-05-11-identity-group-rebac/contracts/re
 | Read/use gate | `resource-authz.ts` → OpenFGA | `server/rbac.py` (mixed) |
 | Share/write | `shareable-resource.ts` | Partial (KB sharing route on BFF); ingestor paths differ |
 | Mongo in authz hot path | Mostly moved to BFF | Still present ([#1736](https://github.com/cnoe-io/ai-platform-engineering/issues/1736)) |
-| Target architecture | Unified shareable resource RBAC | [Thin PEP plan](docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md) |
+| Target architecture | Unified shareable resource RBAC | [Thin PEP plan](../2026-05-19-rag-thin-pep-openfga/plan.md) |
 
 Kevin’s concern: **“RAG and agents used different RBAC setups”** — still true at the Python RAG layer.
 
@@ -450,7 +450,7 @@ DA `require_agent_use_permission` becomes `require_authorization_claim` — no O
 
 ### Option 5 — Universal relationship contract (spec-only standardization)
 
-**Summary:** Standardize all checks on `UniversalRebacRelationship` from `rbac-universal.ts` — already in [rebac-policy-api.md](docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md).
+**Summary:** Standardize all checks on `UniversalRebacRelationship` from `rbac-universal.ts` — already in [rebac-policy-api.md](../2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md).
 
 #### Request shape
 
@@ -597,12 +597,12 @@ Defined in `workflow-config-rebac.ts`:
 
 ### Docs
 
-- [PDP coverage audit](docs/docs/security/rbac/pdp-coverage-audit.md)
-- [RBAC architecture](docs/docs/security/rbac/architecture.md)
-- [Chat execution authz contract](docs/docs/specs/2026-05-16-dynamic-agent-pdp-gate/contracts/chat-execution-authz.md)
-- [Unified shareable resource RBAC](docs/docs/specs/2026-06-03-unified-shareable-resource-rbac/)
-- [RAG thin PEP plan](docs/docs/specs/2026-05-19-rag-thin-pep-openfga/plan.md)
-- [ReBAC policy API contract](docs/docs/specs/2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md)
+- [PDP coverage audit](../../security/rbac/pdp-coverage-audit.md)
+- [RBAC architecture](../../security/rbac/architecture.md)
+- [Chat execution authz contract](../2026-05-16-dynamic-agent-pdp-gate/contracts/chat-execution-authz.md)
+- [Unified shareable resource RBAC](../2026-06-03-unified-shareable-resource-rbac/spec.md)
+- [RAG thin PEP plan](../2026-05-19-rag-thin-pep-openfga/plan.md)
+- [ReBAC policy API contract](../2026-05-11-identity-group-rebac/contracts/rebac-policy-api.md)
 
 ---
 

--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md
@@ -1,0 +1,381 @@
+# Solution Architecture: Centralized Authorization Service (BFF-resident, PDP-agnostic)
+
+**Status:** Second-opinion response to [`problem-statement.md`](./problem-statement.md)
+**Date:** 2026-06-05
+**Scope:** Architecture + security model + standalone migration. Companion to the problem statement; not yet a `/speckit` spec.
+
+---
+
+## 0. TL;DR — the decision
+
+The problem statement frames five competing options. They are **not** competing — they are layers of one design. Collapse them:
+
+> **One decision core. Two transports. One optional claim. Shadow-first migration.**
+
+```text
+                        ┌──────────────────────────────────────────────┐
+                        │     Authorization Decision Core (lib/authz)    │
+                        │  PDP-agnostic types · reason codes · domain    │
+                        │  composition · ONE OpenFGA adapter behind it   │
+                        └───────────────┬───────────────┬───────────────┘
+            in-process call             │               │        HTTP (out-of-process PEPs)
+        ┌───────────────────────────────┘               └────────────────────────────────┐
+        ▼                                                                                  ▼
+  BFF route handlers                                              POST /api/authz/v1/decisions
+  (authorize / authorizeMany / authorizeOrThrow)                  POST /api/authz/v1/decisions:batch
+  no network hop                                                  POST /api/authz/v1/explain  (admin)
+                                                                  (optional) signed decision tokens
+                                                                          ▲
+                                       ┌──────────────────────────────────┼───────────────────────┐
+                                       │                                   │                        │
+                                  Dynamic Agents                       RAG server                Slack/Webex bots
+                                  (thin PEP, no Mongo,                 (thin PEP, no Mongo,       (thin PEP)
+                                   no OpenFGA client)                   no OpenFGA client)
+```
+
+Everything the four bullets ask for falls out of this shape:
+
+| Your ask | How this delivers it |
+|----------|----------------------|
+| **No MongoDB in Dynamic Agents** | DA calls the HTTP API for decisions; the *service* owns workflow-visibility data and audit writes. DA keeps zero policy Mongo. |
+| **Reusable authz modules** | The **core** is the one reusable module. BFF imports it in-process; DA/RAG/bots consume it over HTTP. No second/third reimplementation possible. |
+| **Common PDP AuthZ APIs** | `POST /api/authz/v1/decisions` is the single contract for every out-of-process caller; the in-process `authorize()` is the same core. |
+| **HA OpenFGA + PDP-agnostic API** | OpenFGA sits behind one pooled adapter with a warm store-id, decision cache, and circuit breaker; callers see `{decision, reason}`, never `can_use`/tuples. |
+
+**Standalone, no resources touched, slow migration** is achieved by **shadow mode** (§5): the service ships and runs *observe-only* alongside the existing checks, which stay authoritative until each caller is flipped, one at a time, on measured decision parity.
+
+---
+
+## 1. Critique of the problem statement
+
+### 1.1 What it gets right
+
+- **Inventory is excellent.** The module table (§3.1), endpoint table (§3.1), and DA/RAG anti-pattern tables are accurate and rare in a problem doc.
+- **Core diagnosis is correct.** Scattered policy + duplicate PDP hops + leaky abstraction + weak enforcement is the real disease.
+- **Phasing instinct is right** (immediate cleanup → hygiene → facade → runtime → RAG).
+- **Honest non-goals.** Not replacing OpenFGA; not ripping DA checks in v1.
+
+### 1.2 Gaps to fix (these reshape the design)
+
+1. **It understates the duplication.** This is not "different patterns" — it is **three full reimplementations** of the same OpenFGA transport + decision logic (`openfga.ts`, DA `openfga_authz.py`, RAG `rbac.py`), plus **two duplicate agent-use algorithms inside the BFF itself** (`requireAgentUsePermission` vs `evaluateAgentAccess`), plus **three error envelopes**. A *library* facade (Option 1) cannot fix the Python copies — only a **service** collapses all three. The doc admits Option 1 "does not alone fix DA/RAG" but never resolves it.
+
+2. **"Facade vs Runtime API" is a false fork.** Option 1 (in-process) and Option 2 (HTTP) are the *same core* exposed two ways, not alternatives to mix. Treating them as separate phases invites two codebases drifting apart again — exactly the disease.
+
+3. **The standalone / "don't touch resources" requirement is unaddressed.** Every migration path in the doc rewrites existing call sites. There is no **shadow / dual-run / decision-parity** mechanism. That mechanism is the *only* way to satisfy "build it standalone and migrate slowly" safely (§5). Biggest omission.
+
+4. **Threat model is deferred to "open questions."** For a security-conscious central PDP, the answers must be in the design: token verification (DA currently base64-decodes the JWT and trusts upstream), subject-binding, OBO impersonation via real tuples (the doc's sketch trusts a `context.delegated_subject` body field — a spoofing hole), fail-closed + audited break-glass, decision-token replay. §4 answers all of these.
+
+5. **`#1755` is mis-scoped.** Issue #1755 is a narrow tracking issue — skills RBAC UI parity + an *optional* `useShareableTeams` hook, explicitly "no further PR required." It is **not** the centralization mandate. The real mandate is Kevin's "RAG and agents must not diverge." Don't anchor the PDP architecture to #1755; it's a small UI-DRY cleanup that ships independently.
+
+6. **Workflow delegation hides a least-privilege regression.** PR #1751's "pre-grant agent tuples on save" (the modal) writes **persistent** `team#can_use agent` tuples — the team can then use that agent *outside* the workflow forever. Runtime-scoped delegation (grant only for the duration of the run) is the least-privilege answer. The doc lists this as an open question; it should be a decision (§6).
+
+7. **Performance/HA is hand-waved.** The DA and RAG OpenFGA clients **re-resolve the store id and open a new HTTP client on nearly every call**. A central PDP needs a warm store-id, pooled connections, a short-TTL decision cache, a batch endpoint (list-filtering does N checks today), and a circuit breaker. §3.5.
+
+8. **RAG's coarse-role axis is missing from the analysis.** `rbac.py` mixes a `READONLY/INGESTONLY/ADMIN` hierarchy *with* OpenFGA. RAG cannot become a thin PEP unless the core subsumes coarse roles or they are explicitly demoted to a cheap local pre-filter (§7).
+
+9. **Contract versioning is left as a question.** A "stable external contract" must be versioned from line one (`/api/authz/v1`). Because the new API is **additive**, there is no breaking change to existing clients — answering open question #7 directly.
+
+---
+
+## 2. Design principles
+
+1. **One decision, one place.** Exactly one module computes "may subject S do action A on resource R." Everything else is transport.
+2. **The PDP is an implementation detail.** Callers send `{subject, resource, action, context}` and receive `{decision, reason}`. OpenFGA relation names and tuples never cross the boundary (except the admin `/explain` tier).
+3. **Never trust the caller's identity claims.** The service validates every token itself (JWKS) and binds the answer to who is allowed to *ask*.
+4. **Fail closed, observably.** PDP error ⇒ DENY + retriable + audit. Break-glass is explicit, time-boxed, alarmed.
+5. **Least privilege over convenience.** Delegation is runtime-scoped, not a persistent grant, unless an admin deliberately makes it persistent.
+6. **Additive first.** The service ships touching nothing. Enforcement moves caller-by-caller on measured parity.
+
+---
+
+## 3. Target architecture
+
+### 3.1 The decision core — `ui/src/lib/authz/`
+
+The single reusable module. Pure, transport-free, PDP-agnostic.
+
+```text
+ui/src/lib/authz/
+  index.ts            # authorize(), authorizeMany(), authorizeOrThrow(), filterAccessible()
+  contract.ts         # Subject, Resource, Action, Decision, ReasonCode  (the public vocabulary)
+  reasons.ts          # stable reason codes + retriable mapping + user action hints
+  compose.ts          # domain composition (workflow visibility, channel scope) layered over PDP
+  engine.ts           # PolicyEngine interface
+  engines/
+    openfga.ts        # the ONLY OpenFGA adapter (wraps today's lib/rbac/openfga.ts transport)
+  domains/
+    workflow.ts       # workflowDelegatesAgentUse, run visibility (product policy over PDP)
+    slack-channel.ts
+    webex-space.ts
+  cache.ts            # short-TTL decision cache (engine-level)
+  audit.ts            # one decision → one audit event (owns the write)
+```
+
+- **Collapses the two BFF agent-use algorithms.** `requireAgentUsePermission` and `evaluateAgentAccess` both become thin callers of `authorize({subject, resource:{type:"agent"}, action:"use"})`. One direct+team-union implementation, one reason taxonomy.
+- **`compose.ts` is where product policy lives** (workflow visibility, derive-team-from-channel) so it sits *above* the PDP and is reused identically by every transport. This is the home the DA Mongo reads should never have left.
+- The action→relation map already exists in `resource-authz.ts` (`use → can_use`); it moves into `engines/openfga.ts` as the adapter seam. The `action` vocabulary is already PDP-agnostic; only the relation strings are FGA-specific.
+
+### 3.2 Transport A — in-process (BFF routes)
+
+```ts
+await authorizeOrThrow(session, { type: "agent", id, action: "use" });
+const visible = await filterAccessible(session, agents, { type: "agent", action: "discover", id: a => a.id });
+```
+
+No network hop. Existing `requireResourcePermission` / `requireAgentPermission` / `requireSkillPermission` become 3-line wrappers over `authorize()` so call sites don't churn. ESLint forbids importing `engines/openfga` outside `lib/authz/**`.
+
+### 3.3 Transport B — the common PDP AuthZ API (HTTP)
+
+The single contract for **every out-of-process caller** (DA, RAG, bots). Versioned, additive, PDP-agnostic.
+
+```http
+POST /api/authz/v1/decisions
+Authorization: Bearer <caller-token>          # user OR service-account; VERIFIED by the service
+Content-Type: application/json
+
+{
+  "subject":  { "type": "user", "id": "<oidc-sub>" },
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "action":   "use",
+  "context":  { "workflow_run_id": "wr-123" }   // advisory only; never *expands* a grant (§4)
+}
+```
+
+**Response — evaluation succeeded (HTTP 200 for both ALLOW and DENY):**
+
+```json
+{ "decision": "ALLOW", "reason": "OK", "retriable": false, "ttl_seconds": 15 }
+```
+```json
+{ "decision": "DENY",  "reason": "NO_CAPABILITY", "retriable": false }
+```
+
+> **API design note (answers a muddle in the doc's Option 2 sketch):** a *DENY is not an HTTP error*. The evaluation succeeded; the answer is "no" ⇒ **200 with a body**. HTTP status is reserved for **meta** failures: `401` caller not authenticated, `403` caller may not ask about this subject, `400` malformed, `503` PDP unavailable (`retriable:true`). PEPs translate `DENY`→ their own 403. This keeps deny-reasoning out of status codes and makes the contract uniform.
+
+**Batch (replaces N round-trips for list filtering):**
+
+```http
+POST /api/authz/v1/decisions:batch
+{ "subject": {...}, "action": "discover", "resource_type": "agent", "ids": ["a","b","c"] }
+→ { "results": [ { "id":"a","decision":"ALLOW" }, { "id":"b","decision":"DENY","reason":"NO_CAPABILITY" }, ... ] }
+```
+
+**Admin explain tier (the *only* place FGA detail is exposed):**
+
+```http
+POST /api/authz/v1/explain          # requires can_audit / admin_ui#view
+→ { "decision":"DENY", "reason":"NO_CAPABILITY",
+    "debug": { "engine":"openfga", "checked":["user:… can_use agent:…","team:… "], "store":"…" } }
+```
+
+This **extends the existing draft** `rebac-policy-api.md` (which already defines the `{subject, action, resource}` vocabulary and a per-type action catalog) into two tiers: **runtime/decision** (new, PDP-agnostic) and **admin/explain** (already drafted, FGA-visible). One vocabulary, exactly as Kevin asked.
+
+### 3.4 Transport C (optional) — signed decision tokens
+
+For the duplicate-hop problem (workflow step execution), the API can mint a **short-lived, audience-bound decision token** instead of a bare yes/no:
+
+```jsonc
+// header: alg, kid       payload:
+{ "iss":"caipe-bff", "aud":"dynamic-agents", "sub":"user:<oidc-sub>",
+  "res":"agent:platform-engineer", "act":"use",
+  "iat":1710000000, "exp":1710000045, "jti":"…" }   // ≤60s
+```
+
+The PEP verifies **signature + aud + exp + res/act match** offline — no OpenFGA, no Mongo, no second hop.
+
+**I disagree with the doc's deferral of this to "Phase 5, optional, expensive."** Constrained as above it is cheap and is the *cleanest* way to satisfy "no Mongo in DA" + "no duplicate PDP hop" + "PDP-agnostic at the boundary" simultaneously:
+
+- **No revocation machinery** needed at ≤60s TTL — document the TTL as the bound on staleness.
+- **Symmetric signing** (shared secret in the trust boundary) is acceptable to start; move to JWKS/asymmetric when bots/3rd parties consume it.
+- It is **additive** — the workflow engine attaches the token; a PEP that doesn't understand it falls back to a `/decisions` call.
+
+Keep it optional, but design for it now (P5), don't treat it as exotic.
+
+### 3.5 PDP adapter, HA OpenFGA, caching
+
+| Concern | Today (3× duplicated) | Central service |
+|---------|------------------------|-----------------|
+| Store id | Re-resolved via `GET /stores` per call (DA, RAG) | Resolved once at boot, cached, refreshed on miss |
+| HTTP client | New `httpx`/fetch per call | One pooled client, keep-alive |
+| HA | Single OpenFGA assumed | OpenFGA replicated (stateless vs its datastore) behind a Service; adapter retries idempotent `check` across replicas |
+| Hot path | Every check hits OpenFGA | Short-TTL decision cache (≤15s) keyed `(subject,resource,action)`, per-replica bounded LRU; **write/manage/delete bypass cache or ≤2s** |
+| List filtering | N sequential checks | `decisions:batch` → `BatchCheck`/parallel with bounded concurrency |
+| Outage | Each PEP improvises | One circuit breaker; open ⇒ fail closed (`AUTHZ_UNAVAILABLE`, retriable) |
+| Consistency | n/a | Use OpenFGA `consistency: HIGHER_CONSISTENCY` for sensitive actions; cache TTL bounds staleness for the rest |
+
+### 3.6 PDP-agnostic contract (the stable surface)
+
+```ts
+type ReasonCode =
+  | "OK"                 // ALLOW
+  | "NO_CAPABILITY"      // DENY — no relationship      → action: contact_admin
+  | "NOT_AUTHENTICATED"  // missing/invalid caller auth → action: sign_in
+  | "AUTHZ_UNAVAILABLE"  // PDP timeout/error           → action: retry   (retriable)
+  | "INVALID_REQUEST";   // bad id / malformed          → action: fix_request
+
+interface Decision { decision: "ALLOW" | "DENY"; reason: ReasonCode; retriable: boolean; ttl_seconds?: number; token?: string; }
+```
+
+**Envelope migration** (one shared `error-responses` builder, used by *all* surfaces):
+
+| Current (leaky, in 3 places) | Public v1 | Admin/explain only |
+|------------------------------|-----------|--------------------|
+| `code: "agent#use"` | `reason: "NO_CAPABILITY"` | `debug.relation: "can_use"` |
+| `reason: "pdp_denied"` | `reason: "NO_CAPABILITY"` | |
+| `reason: "pdp_unavailable"` | `reason: "AUTHZ_UNAVAILABLE"` | |
+| `pdp: "openfga"` in body | *omitted* | audit log only |
+| tuple strings in messages | *omitted* | `/explain` only |
+
+---
+
+## 4. Security model (threats → controls)
+
+The service is a **trust boundary**. It assumes callers are hostile-capable and verifies everything.
+
+| # | Threat | Control |
+|---|--------|---------|
+| 1 | **Forged subject** — caller asks "can `admin-user` do X" and acts on it | **Subject-binding.** A *user* token may only evaluate `subject == token.sub`. Cross-subject queries require `can_audit` on the type (admin/explain tier). Default rejects mismatched subject with `403`. |
+| 2 | **Bot impersonation / OBO** — bot evaluates for a user | Require **both** the bot's verified client-credentials token **and** a verified user assertion (OBO token or signed envelope). Service checks a real tuple `service_account:<id> can_impersonate user:*` (or per-user). **Never trust a bare `delegated_subject` body field** — that was a hole in the doc's sketch. |
+| 3 | **Caller-decoded / forgeable identity** — DA base64-decodes the JWT payload and trusts upstream; epic **[#1730] (P1)**: privileged paths trust unsigned `X-User-Context`, forgeable if DA is reached directly | Service **always** validates signature, `exp`, `aud`, `iss` via cached JWKS. Body/header-supplied identity is treated only as the *target* subject, then authorized per #1/#2. No upstream hop or unsigned header is trusted. **This is the canonical fix for [#1730].** |
+| 4 | **PDP outage → silent allow** | **Fail closed**: `DENY` + `AUTHZ_UNAVAILABLE` + `retriable` + `503` + audit. Break-glass via explicit env flag (mirrors `CAIPE_UNSAFE_RBAC_BYPASS` but **centralized, time-boxed, alarmed, audited per request**). |
+| 5 | **Decision-token theft / replay** (Transport C) | `aud` bound to one downstream, `res`+`act` bound, `exp ≤ 60s`, `jti`, signed. PEP verifies offline; stolen token is useless elsewhere and expires fast. |
+| 6 | **Cache stale-allow** | TTL ≤15s read / ≤2s for write-class actions; per-replica; bounded LRU; revocation tolerated within TTL window (documented). Sensitive mutations may set `no-cache`. |
+| 7 | **Confused deputy via `context`** | `context` is **advisory only**. It may *narrow* (scope) but must never *expand* a decision beyond the subject's own relationships — except through server-evaluated delegation (the workflow run-authorizer in §6), which is computed inside the core, not asserted by the caller. |
+| 8 | **Enumeration / info leak** | DENY reasons are coarse (`NO_CAPABILITY`); no tuple/relation strings outside `/explain`; rate-limit per caller; every decision audited with correlation id. |
+| 9 | **Privilege via the API itself** | The decision API is **read/evaluate only in v1.** No tuple writes. Reconcile/ownership writes stay in their current modules — so standing up the service grants no new mutation surface. |
+
+---
+
+## 5. Standalone build + shadow migration (touch nothing, migrate slowly)
+
+This is the mechanism the problem statement is missing and the explicit requirement.
+
+### 5.1 Shadow mode
+
+Each existing PEP gets a thin consult wrapper behind a **per-surface** flag:
+
+```
+AUTHZ_CENTRAL_MODE = off | shadow | enforce      # per surface: da_agent_use, da_workflow, rag_kb, slack, …
+```
+
+- **`off`** — legacy only (today).
+- **`shadow`** — call the central API *best-effort, time-boxed*; **compare** to the legacy decision; emit an `authz_parity` metric/audit `{surface, legacy, central, agree}`. **Legacy stays authoritative.** Zero user-visible change. *This is "standalone without touching resources."*
+- **`enforce`** — central is authoritative; legacy code deleted.
+
+```text
+  request ─▶ legacy check ──▶ (authoritative) ──▶ response
+                │
+                └─(shadow)─▶ central /decisions ─▶ parity log  ✗ cannot change outcome
+```
+
+Flip a surface to `enforce` only after **~100% parity over N days** on a dashboard. Roll back instantly by setting the flag to `shadow`.
+
+### 5.2 Phases (standalone-first)
+
+| Phase | Scope | Touches existing behavior? | Exit gate |
+|-------|-------|----------------------------|-----------|
+| **P0 Core extraction** | Build `lib/authz` core; refactor the 2 BFF agent-use algos + `resource-authz` to call it | **No** (pure refactor, identical outputs) | Existing tests green; golden-decision parity |
+| **P1 The standalone service** | `POST /api/authz/v1/{decisions,decisions:batch,explain}` over the core | **No** (nobody calls it yet) | Contract tests + parity vs in-process core. **Ships alone, touches nothing.** |
+| **P2 Shadow** | DA, RAG, bots call central in `shadow` | **No** (observe-only) | Parity dashboard ~100% per surface |
+| **P3 Workflow enforce** | Flip `da_workflow`; delete `workflow_execution_authz.py` + `workflow_config_id` Mongo bypass; delegation via central run-authorizer (§6) | Yes (one surface) | DA reads no workflow/team Mongo |
+| **P4 Agent-use + RAG enforce** | Flip `da_agent_use`, `rag_*`; DA drops its OpenFGA client + Mongo audit writes; `rbac.py` → thin PEP | Yes (per surface) | No OpenFGA client / policy Mongo in DA or RAG |
+| **P5 (optional) Decision tokens** | Workflow engine attaches tokens; PEP verifies offline | Yes | Duplicate hop ([#1731]) gone; ADR for [#1458] |
+
+Cross-cutting: the v1 envelope (§3.6) is **native** on the new API from P1. Legacy routes adopt the shared `error-responses` builder opportunistically — **no breaking change** because the new API is additive and versioned (answers open Q#7).
+
+---
+
+## 6. Workflow delegation done right (PR #1751)
+
+**Decision: runtime-scoped delegation, not persistent pre-grants.**
+
+| Operation | Owner | Mechanism |
+|-----------|-------|-----------|
+| Create/update/list/cancel workflow + runs | BFF | existing `workflow-configs` / `workflow-runs` routes |
+| "Can this user run this workflow?" | **core `domains/workflow.ts`** | `workflowDelegatesAgentUse` = agent ∈ steps **AND** run visibility — wired at `POST /api/workflow-runs` |
+| Step execution agent-use | **central run-authorizer** | At run start the BFF computes the delegated set once; step calls carry a run-scoped decision (or token, P5). DA does **not** read `workflow_configs`. |
+| DA workflow *tools* | DA → BFF `WorkflowApiClient` | already correct — keep |
+
+**Flag the regression:** PR #1751's modal that pre-grants `team#can_use agent` tuples on save is an **over-grant** — it lets the team use the agent *outside* the workflow, permanently. Prefer runtime delegation (above). If product genuinely wants standing access, make it an **explicit, separate, admin-visible grant**, not a side effect of saving a workflow. `workflowDelegatesAgentUse` already exists and is unused — wire it instead of writing tuples.
+
+---
+
+## 7. RAG & DA convergence
+
+- **RAG becomes a thin PEP over HTTP.** A shared Python *library* would be a **fourth** reimplementation — reject it. RAG calls `POST /api/authz/v1/decisions` (and `:batch` for `inject_kb_filter`'s datasource list). The service owns the channel→team Mongo lookup (it already has the data); RAG stops reading `channel_team_mappings`/`teams`.
+- **Coarse roles** (`READONLY/INGESTONLY/ADMIN`) are **demoted to a local pre-filter**: client-credentials/automation principals short-circuit *before* calling central (cheap, preserves automation); all human/per-resource decisions go to central. Don't let coarse roles re-enter the resource decision.
+- **DA** drops `openfga_authz.py`'s OpenFGA client, its per-call store-id discovery, its Mongo audit writes, and `workflow_execution_authz.py` entirely. `require_agent_use_permission` → `require_authorization(resource, action)` calling central (or verifying a decision token in P5).
+
+---
+
+## 8. CI enforcement (aim the existing guards at the new boundary)
+
+Keep the doc's Option 4 guards, retargeted:
+
+| Guard | Blocks |
+|-------|--------|
+| ESLint `no-restricted-imports` | importing `engines/openfga` (or `lib/rbac/openfga`) outside `lib/authz/**` |
+| `validate-authz-boundaries.py` (new) | `workflow_configs`/`teams`/OpenFGA-client imports in `dynamic_agents/**` and RAG once their surface is `enforce` |
+| extend `validate-fga-create-paths.py` | new BFF routes must reach OpenFGA only via the core |
+| `fga-enforcement-manifest.ts` | add `task`/workflow + runtime `/api/authz/v1/*` surfaces |
+| Parity test (new) | central decision == legacy for a golden fixture set (gates each `shadow→enforce` flip) |
+
+---
+
+## 9. Answers to the problem statement's open questions
+
+1. **DA execution gate** — Keep OpenFGA in DA *only* during shadow (P2). At enforce (P4), DA holds **no** PDP client; it calls central or verifies a decision token. Dual-gate ([#1731]) is resolved empirically by parity, not debate.
+2. **Workflow delegation** — Runtime-scoped via the central run-authorizer (§6). Persistent pre-grants only as an explicit, separate admin action.
+3. **Generic vs domain HTTP APIs** — One generic `POST /api/authz/v1/decisions` + `:batch`. Domain endpoints (`authorize-run`) become thin wrappers that call the core with a `context`; they are conveniences, not parallel logic.
+4. **RAG** — HTTP client to the central API. **No** shared Python policy library (it would be reimplementation #4).
+5. **Service-account delegation** — Verified OBO: bot token **+** user assertion **+** real `can_impersonate` tuple. Never a trusted body field (§4 #2).
+6. **Claim revocation** — Not required at ≤60s TTL; TTL is the documented staleness bound (§3.4).
+7. **Breaking API changes** — None. New API is `/api/authz/v1` and additive; legacy clients migrate envelopes opportunistically. No `/v2` flag day.
+8. **Workflow `task` in FGA** — Mongo visibility stays a **product policy layer** in `domains/workflow.ts` *above* FGA for now; revisit folding it fully into FGA after P4, as a separate decision.
+
+---
+
+## 10. Recommendation
+
+**Option mix:** `Option 1 (core) ≡ Option 2 (HTTP)` as one thing + `Option 5 (vocabulary)` adopted into `contract.ts` + `Option 4 (enforcement)` aimed at the new boundary + **`Option 3 (decision tokens) promoted from "someday" to a real P5**, constrained.
+
+**Split into three specs** (the doc asks whether to split — yes):
+- **Spec A — Core + envelope + enforcement** (P0–P1, + §3.6, + §8). Ships the standalone service. No behavior change.
+- **Spec B — Runtime convergence** (P2–P4 shadow→enforce for DA/RAG/bots, + §6 workflow delegation).
+- **Spec C — Decision tokens** (P5, optional), gated on [#1458] ADR.
+
+**Ordered task list (Spec A first — the standalone service you asked for):**
+1. `lib/authz/contract.ts` + `reasons.ts` — PDP-agnostic types & reason codes.
+2. `engines/openfga.ts` — wrap today's transport; warm store-id; pooled client; cache hook.
+3. `index.ts` `authorize/authorizeMany/authorizeOrThrow/filterAccessible`; **fold the two agent-use algos into it**.
+4. Refactor `requireResourcePermission`/`requireAgentUsePermission`/`evaluateAgentAccess` to call the core (no behavior change; golden parity test).
+5. `domains/workflow.ts` — move visibility/`workflowDelegatesAgentUse` here.
+6. `POST /api/authz/v1/{decisions,decisions:batch,explain}` over the core; v1 envelope; caller-token verification + subject-binding (§4 #1–#3).
+7. Shared `error-responses` v1 builder; switch BFF authz throws to it.
+8. ESLint import boundary + parity test harness.
+9. **Stop.** Ship. The service is live, used by no one, touching nothing → then begin Spec B shadow.
+
+### 10.1 Alignment with the real epic [#1742] (and one correction)
+
+I verified against the epic itself — it aligns with this architecture *better* than the problem statement's own §8 table does:
+
+- **The runtime HTTP API is already a prerequisite, not a late phase.** #1742 states: *"#1455 — runtime BFF ReBAC endpoints — must land before the Slack BFF moves (#1737, #1739)."* That is exactly **Transport B / Spec A**. → **Correction:** the "facade (Phase 2) then runtime API (Phase 3)" sequencing is the *problem statement's §8*, **not** the epic. The epic supports shipping the service **first**.
+- **This service is the canonical fix for the epic's top P1.** #1730 (DA trusts unsigned, forgeable `X-User-Context`) is resolved by §4 #1–#3 — mandatory token verification + subject-binding at the central boundary. The problem statement under-weighted #1730; it should be the headline security driver.
+- **Slack P1s shrink as a side effect.** Once bots get decisions + identity linking from the BFF (#1737/#1739, gated on #1455), the bot sheds Keycloak-Admin/Mongo blast radius (#1741).
+
+**Epic sub-issue → spec map:**
+
+| Spec | Closes / enables |
+|------|------------------|
+| **A** Core + HTTP API + envelope | **#1455** (prereq), enables **#1730**; sets up #1733 (service owns audit), #1736 (service owns cached channel→team) |
+| **B** Convergence (shadow→enforce) | #1730, #1731, #1733 (DA); #1734/#1735/#1736 (RAG); #1737/#1739/#1741 (Slack) |
+| **C** Decision tokens (optional) | #1731 capstone; gated on **#1458** dual-gate ADR |
+
+**Remaining contradictions to reconcile:**
+- #1742 Phase 0 "remove DA workflow Mongo" is right, but the *replacement* (runtime delegation) must land in `domains/workflow.ts`, **not** as new DA-side logic. Sequence at P3.
+- PR #1751's modal pre-grant contradicts the least-privilege delegation in §6 — reconcile before it becomes load-bearing.
+- #1755 is **not** in scope of this architecture (narrow skills-UI DRY); keep it independent so it isn't blocked on the PDP work.
+
+---
+
+<!-- assisted-by claude code claude-opus-4-8 -->

--- a/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/spec.md
+++ b/docs/docs/specs/2026-06-05-centralized-bff-authz-pdp-agnostic/spec.md
@@ -1,0 +1,400 @@
+# Spec: Centralized Authorization Service (CAS) — BFF-resident, PDP-agnostic
+
+**Status:** Draft for review
+**Date:** 2026-06-05
+**Owner:** Sri Aradhyula
+**Companions:** [`problem-statement.md`](./problem-statement.md) (why) · [`solution-architecture.md`](./solution-architecture.md) (critique + design rationale)
+**Tracking:** epic [#1742]; prerequisite [#1455]; security driver [#1730]; dual-gate ADR [#1458]
+
+> This is the implementation spec. It is self-contained: the architecture doc holds the critique and trade-off rationale; this doc holds **what to build, in what order, and how we prove it's safe**.
+
+---
+
+## 1. Summary
+
+Introduce one **Authorization Decision Core** in the BFF (`ui/src/lib/authz/`) and expose it through **four transports** that all share one PDP-agnostic contract. Collapse today's **three OpenFGA reimplementations** (`openfga.ts`, DA `openfga_authz.py`, RAG `rbac.py`), the **fourth at the gateway** (`openfga-authz-bridge`), the **two duplicate BFF agent-use algorithms**, and the **three error envelopes** into that one core. Ship it **standalone** (touching nothing), then migrate each Policy Enforcement Point (PEP) under **shadow mode** with measured decision parity before any flip.
+
+**Principle:** *One decision core. Four transports. One optional claim. Shadow-first migration.*
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+- **G1** Single decision authority: exactly one module computes "may subject S do action A on resource R."
+- **G2** PDP-agnostic public contract: callers send/receive `{subject, resource, action} → {decision, reason}`; OpenFGA relation names/tuples never cross the boundary except in the admin explain tier.
+- **G3** No policy MongoDB in Dynamic Agents (drop `workflow_execution_authz.py`, the `workflow_config_id` bypass, and DA-side authz audit writes).
+- **G4** Common HTTP AuthZ API for all out-of-process callers (DA, RAG, bots) = the [#1455] runtime endpoints.
+- **G5** HA OpenFGA behind one pooled adapter (warm store-id, decision cache, batch, circuit breaker).
+- **G6** Build standalone; migrate slowly via shadow mode without touching existing enforcement until each surface flips.
+- **G7** Security: verify every token at the boundary; bind decisions to who may ask; fail closed; audited break-glass — closes [#1730].
+
+### Non-goals
+- Replacing OpenFGA as the relationship store.
+- Moving the gateway `ext_authz` decision into the BFF (rejected — §7).
+- Migrating skills to an owner-team model (#1708) or the #1755 UI-DRY hook (independent).
+- Rewriting the AgentGateway routing/credential-injection logic (only its OpenFGA contract converges).
+
+---
+
+## 3. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **CAS** | Centralized Authorization Service — the decision core + its transports. BFF-resident. |
+| **PDP** | Policy Decision Point — computes allow/deny. Here: the core + OpenFGA adapter. |
+| **PEP** | Policy Enforcement Point — calls the PDP and enforces. There are 4 (§4.1). |
+| **Core** | `ui/src/lib/authz/` — the one reusable decision module. |
+| **Bridge / "OpenFGA Proxy"** | `openfga-authz-bridge` — Envoy `ext_authz` PDP adapter for the AgentGateway MCP data plane. |
+| **Decision token** | Short-lived, audience-bound signed claim minted by CAS so a downstream PEP can verify offline. |
+| **Shadow mode** | A PEP consults CAS observe-only while legacy stays authoritative; decisions compared for parity. |
+
+---
+
+## 4. Architecture
+
+### 4.1 Component overview
+
+```text
+                          ┌───────────────────────────────────────────────┐
+                          │   Authorization Decision Core  (lib/authz)      │
+                          │   contract · reasons · compose(domain) ·        │
+                          │   ONE OpenFGA adapter · cache · audit           │
+                          └───┬──────────┬───────────────┬──────────────┬───┘
+        A: in-process call    │          │ B: HTTP        │ C: token mint│ D: adapter contract
+        ┌─────────────────────┘          │                │              └──────────────┐
+        ▼                                 ▼                ▼                              ▼
+  BFF route handlers          POST /api/authz/v1/...   decision tokens          openfga-authz-bridge
+  (PEP #1, no hop)            (PEP #2/#3/#4 consume)    (attached by engine)     (PEP #4, data plane)
+                                   ▲      ▲      ▲                                      ▲
+                          Dynamic Agents  RAG   Slack/Webex bots             AgentGateway ext_authz
+                          (PEP #2)      (PEP #3) (bots)                       (per-MCP-call enforce)
+```
+
+**Four PEPs, one contract, one adapter:**
+
+| PEP | Layer | Transport | Today | Target |
+|-----|-------|-----------|-------|--------|
+| #1 BFF routes | app (in-proc) | A | `resource-authz.ts` + 2 agent-use algos | call `authorize()` |
+| #2 Dynamic Agents | app (HTTP) | B (+C) | own OpenFGA client + Mongo | thin PEP → CAS; no OpenFGA/Mongo |
+| #3 RAG server | app (HTTP) | B | `rbac.py` (roles+OpenFGA+Mongo) | thin PEP → CAS; coarse role = local pre-filter |
+| #4 AgentGateway bridge | data plane | D | bespoke OpenFGA Check + Mongo audit | shared adapter contract + audit schema |
+
+### 4.2 The decision core — `ui/src/lib/authz/`
+
+```text
+ui/src/lib/authz/
+  index.ts        # authorize(), authorizeMany(), authorizeOrThrow(), filterAccessible()
+  contract.ts     # Subject, Resource, Action, Decision, ReasonCode  (public vocabulary)
+  reasons.ts      # reason codes → {retriable, userActionHint, httpHint}
+  engine.ts       # PolicyEngine interface
+  compose.ts      # product policy layered OVER the PDP (workflow visibility, channel scope)
+  engines/
+    openfga.ts    # the ONLY OpenFGA adapter (wraps lib/rbac/openfga transport; action→relation map)
+  domains/
+    workflow.ts   # workflowDelegatesAgentUse, run visibility
+    slack-channel.ts · webex-space.ts
+  cache.ts        # short-TTL decision cache
+  audit.ts        # one decision → one audit event (CAS owns the write)
+```
+
+- Folds `requireAgentUsePermission` **and** `evaluateAgentAccess` into one direct+team-union implementation.
+- `resource-authz.ts`'s action→relation map (`use → can_use`) moves into `engines/openfga.ts`. The `action` vocabulary is already PDP-agnostic; only relation strings are FGA-specific.
+- `compose.ts` is the home product policy never should have left (kills DA's Mongo visibility duplication).
+
+### 4.3 Transports
+
+- **A — in-process** (PEP #1): `authorize()/authorizeOrThrow()/filterAccessible()`. No network hop. Existing `require*Permission` become thin wrappers.
+- **B — HTTP** (PEP #2/#3/bots): `POST /api/authz/v1/decisions` (+ `:batch`, `explain`). The [#1455] runtime API. §5.
+- **C — decision tokens** (optional, P5): short-lived audience-bound signed claims; PEP verifies offline → removes the duplicate hop for workflow step execution.
+- **D — data-plane adapter** (PEP #4): the bridge conforms to the same contract + OpenFGA adapter semantics; keeps a direct OpenFGA path (no per-request BFF hop). §7.
+
+### 4.4 PDP adapter, HA OpenFGA, caching
+
+| Concern | Today (4× duplicated) | CAS |
+|---------|------------------------|-----|
+| Store id | re-resolved per call (DA, RAG, bridge) | resolved once at boot, cached, refresh-on-miss |
+| HTTP client | new client per call | one pooled keep-alive client |
+| HA | single OpenFGA assumed | replicated behind a Service; adapter retries idempotent `check` |
+| Hot path | every check hits OpenFGA | decision cache ≤15s read / ≤2s write-class; per-replica bounded LRU |
+| List filter | N sequential checks | `:batch` → `BatchCheck`/bounded-parallel |
+| Outage | each PEP improvises | one circuit breaker; open ⇒ fail closed |
+| Consistency | n/a | `HIGHER_CONSISTENCY` for write-class; TTL bounds staleness otherwise |
+
+---
+
+## 5. The contract
+
+### 5.1 Vocabulary
+
+```ts
+type SubjectType  = "user" | "service_account";
+type ResourceType = UniversalRebacResourceType;          // agent, skill, mcp_tool, knowledge_base, data_source, task, slack_channel, …
+type Action       = "discover" | "read" | "read-metadata" | "use" | "write"
+                  | "manage" | "share" | "delete" | "ingest" | "call" | "invoke" | "audit";
+
+interface AuthorizeRequest {
+  subject:  { type: SubjectType; id: string };
+  resource: { type: ResourceType; id: string };
+  action:   Action;
+  context?: Record<string, unknown>;                     // advisory only; never EXPANDS a grant
+}
+
+type ReasonCode =
+  | "OK"                 // ALLOW
+  | "NO_CAPABILITY"      // DENY — no relationship       → contact_admin
+  | "NOT_AUTHENTICATED"  // missing/invalid caller auth  → sign_in
+  | "AUTHZ_UNAVAILABLE"  // PDP timeout/error (retriable) → retry
+  | "INVALID_REQUEST";   // bad id / malformed           → fix_request
+
+interface Decision { decision: "ALLOW" | "DENY"; reason: ReasonCode; retriable: boolean; ttl_seconds?: number; token?: string; }
+```
+
+This **extends** the existing `rebac-policy-api.md` draft (same `{subject, action, resource}` shape, same per-type action catalog) into two tiers: runtime/decision (new, agnostic) and admin/explain (drafted, FGA-visible).
+
+### 5.2 HTTP API — `/api/authz/v1`
+
+**Single decision**
+```http
+POST /api/authz/v1/decisions
+Authorization: Bearer <caller-token>     # VERIFIED by CAS (JWKS); user or service_account
+{ "subject": {"type":"user","id":"<sub>"}, "resource": {"type":"agent","id":"platform-engineer"}, "action":"use",
+  "context": {"workflow_run_id":"wr-123"} }
+→ 200 { "decision":"ALLOW", "reason":"OK", "retriable":false, "ttl_seconds":15 }
+→ 200 { "decision":"DENY",  "reason":"NO_CAPABILITY", "retriable":false }
+```
+Optional `?mint_token=true` (or `Accept: application/decision-token+jwt`) ⇒ include `token` (Transport C).
+
+**Batch (list filtering)**
+```http
+POST /api/authz/v1/decisions:batch
+{ "subject": {...}, "action":"discover", "resource_type":"agent", "ids":["a","b","c"] }
+→ 200 { "results":[ {"id":"a","decision":"ALLOW"}, {"id":"b","decision":"DENY","reason":"NO_CAPABILITY"} ] }
+```
+
+**Admin explain (only place FGA detail leaks)**
+```http
+POST /api/authz/v1/explain        # requires can_audit / admin_ui#view
+→ 200 { "decision":"DENY","reason":"NO_CAPABILITY",
+        "debug": {"engine":"openfga","relation":"can_use","checked":["user:… can_use agent:…"],"store":"…"} }
+```
+
+### 5.3 Status code semantics (deliberate)
+
+> **A DENY is not an HTTP error.** The evaluation succeeded; the answer is "no" ⇒ **200 with body**. HTTP status is reserved for **meta** failures:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | evaluation succeeded (`ALLOW` **or** `DENY` in body) |
+| `401` | caller token missing/invalid (`NOT_AUTHENTICATED`) |
+| `403` | caller may not ask about this subject (subject-binding, §6 #1) |
+| `400` | malformed (`INVALID_REQUEST`) |
+| `503` | PDP unavailable (`AUTHZ_UNAVAILABLE`, `retriable:true`) |
+
+PEPs translate `decision:"DENY"` into their own 403. Keeps deny-reasoning out of status codes.
+
+### 5.4 Error envelope migration (one shared builder, all surfaces)
+
+| Current (leaky, ×3) | Public v1 | Admin/explain only |
+|---------------------|-----------|--------------------|
+| `code:"agent#use"` | `reason:"NO_CAPABILITY"` | `debug.relation:"can_use"` |
+| `reason:"pdp_denied"` | `reason:"NO_CAPABILITY"` | |
+| `reason:"pdp_unavailable"` | `reason:"AUTHZ_UNAVAILABLE"` | |
+| `pdp:"openfga"` in body | omitted | audit log only |
+| tuple strings in messages | omitted | `/explain` only |
+
+---
+
+## 6. Security model (threats → controls)
+
+CAS is a trust boundary; it assumes callers are hostile-capable.
+
+| # | Threat | Control |
+|---|--------|---------|
+| 1 | **Forged subject** | A *user* token may only evaluate `subject == token.sub`. Cross-subject needs `can_audit` (admin/explain). Mismatch ⇒ `403`. |
+| 2 | **Bot impersonation / OBO** | Require bot's verified client-credentials token **+** verified user assertion **+** real tuple `service_account:<id> can_impersonate user:*`. **Never** trust a bare `delegated_subject` body field. |
+| 3 | **Forgeable identity** ([#1730], P1) | CAS **always** validates signature/`exp`/`aud`/`iss` via cached JWKS. Body/header identity is only the *target* subject, then authz'd per #1/#2. No unsigned `X-User-Context`, no trusted upstream hop. |
+| 4 | **PDP outage → silent allow** | Fail closed: `DENY` + `AUTHZ_UNAVAILABLE` + `retriable` + `503` + audit. Break-glass = explicit env flag, time-boxed, alarmed, audited per request. |
+| 5 | **Decision-token theft/replay** | `aud` = one downstream, `res`+`act` bound, `exp ≤ 60s`, `jti`, signed. PEP verifies offline. |
+| 6 | **Cache stale-allow** | TTL ≤15s read / ≤2s write-class; per-replica bounded LRU; revocation tolerated within TTL (documented). |
+| 7 | **Confused deputy via `context`** | `context` may only *narrow*, never *expand* a grant — except server-evaluated delegation computed inside the core (workflow run-authorizer). |
+| 8 | **Enumeration / info leak** | coarse DENY reasons; no tuple strings outside `/explain`; per-caller rate limit; every decision audited w/ correlation id. |
+| 9 | **New mutation surface** | v1 API is **read/evaluate only**. No tuple writes. Reconcile/ownership stay in current modules ⇒ standing up CAS grants no new write capability. |
+
+---
+
+## 7. The OpenFGA Proxy (`openfga-authz-bridge`) — convergence
+
+The bridge is the **data-plane PEP** for MCP routing: AgentGateway validates JWT (`jwtAuth: strict`, JWKS) then fires a per-route `extAuthz` gRPC Check (`failureMode.denyWithStatus: 403`) → bridge → OpenFGA Check (`can_call` / `mcp_gateway:*`).
+
+**Decision: it stays in the data plane; it does NOT route through the BFF.**
+
+- The BFF is not on the AgentGateway→MCP path; a per-call BFF hop would put the BFF in the availability/latency envelope of every tool call (`ext_authz` fires once per MCP route on listing, 200ms timeout). Rejected.
+- The bridge is already the **model** thin-PEP: edge JWT validation, no forgeable header, fail-closed.
+
+**What converges (Transport D):**
+1. **Vocabulary** — bridge maps Envoy `CheckRequest` → `{subject, resource, action}`; stop using bespoke relation/object strings as the contract.
+2. **Adapter semantics** — same action→relation map, warm store-id, decision cache, retry/circuit-breaker behavior as `engines/openfga.ts`; validated by the **same CI coverage tests**.
+3. **Audit schema** — same `audit_events` shape/salt the core emits (resolves [#1733]-style coupling consistently).
+4. **No new OpenFGA reimplementation** — if the bridge ever needs wire-level PDP-agnosticism, it consumes the shared adapter **library**, not an HTTP call to the BFF.
+
+**Scope:** out of scope for "no Mongo in DA / BFF-resident decisions" (it's neither DA nor BFF); **in scope** for "PDP-agnostic + one vocabulary + reusable adapter."
+
+> **Decision point D-1:** keep bridge OpenFGA-direct + contract-aligned (default, this spec) vs. route through CAS HTTP. Default chosen for data-plane latency/availability. Revisit only if a non-OpenFGA PDP lands.
+
+---
+
+## 8. Standalone build + shadow migration
+
+### 8.1 Shadow mode
+
+Per-surface flag: `AUTHZ_CENTRAL_MODE = off | shadow | enforce` (surfaces: `da_agent_use`, `da_workflow`, `rag_kb`, `rag_search`, `slack`, `webex`, …).
+
+- **off** — legacy only (today).
+- **shadow** — call CAS best-effort/time-boxed; compare to legacy; emit `authz_parity{surface,legacy,central,agree}`. **Legacy authoritative.** No user-visible change. *This is "standalone, touch nothing."*
+- **enforce** — CAS authoritative; legacy code deleted.
+
+```text
+request ─▶ legacy check ─▶ (authoritative) ─▶ response
+              └─(shadow)─▶ CAS /decisions ─▶ parity metric   ✗ cannot change outcome
+```
+
+Flip `shadow→enforce` per surface only at **~100% parity over N days**; roll back by setting `shadow`.
+
+### 8.2 Phases & tasks
+
+| Phase | Scope | Touches behavior? | Exit gate |
+|-------|-------|:-----------------:|-----------|
+| **P0** Core extraction | build `lib/authz`; refactor 2 agent-use algos + `resource-authz` to call it | No (pure) | golden-decision parity; existing tests green |
+| **P1** Standalone service | `/api/authz/v1/{decisions,:batch,explain}` over core; caller-token verify + subject-binding; v1 envelope | No (unused) | contract + parity tests. **Ships alone.** = [#1455] |
+| **P2** Shadow | DA, RAG, bots consult CAS in `shadow` | No (observe) | parity dashboard ~100%/surface |
+| **P3** Workflow enforce | flip `da_workflow`; delete `workflow_execution_authz.py` + `workflow_config_id` bypass; delegation via core run-authorizer (§9) | Yes (1 surface) | DA reads no workflow/team Mongo |
+| **P4** Agent-use + RAG enforce | flip `da_agent_use`, `rag_*`; DA drops OpenFGA client + Mongo audit; `rbac.py`→thin PEP; bridge→Transport D | Yes (per surface) | no OpenFGA client / policy Mongo in DA/RAG; bridge contract-aligned |
+| **P5** (optional) Decision tokens | engine attaches tokens; PEP verifies offline | Yes | duplicate hop [#1731] gone; [#1458] ADR |
+
+**P0 task list**
+1. `contract.ts` + `reasons.ts`.
+2. `engines/openfga.ts` — wrap transport; warm store-id; pooled client; cache hook.
+3. `index.ts` — `authorize/authorizeMany/authorizeOrThrow/filterAccessible`; fold both agent-use algos.
+4. Refactor `requireResourcePermission`/`requireAgentUsePermission`/`evaluateAgentAccess` → core (no behavior change).
+5. `domains/workflow.ts` — move visibility/`workflowDelegatesAgentUse`.
+6. golden-decision parity harness (legacy vs core).
+
+**P1 task list**
+7. routes `decisions`, `decisions:batch`, `explain`; caller-token verification (JWKS) + subject-binding.
+8. shared `error-responses` v1 builder; switch BFF authz throws.
+9. ESLint import boundary (`engines/openfga` only inside `lib/authz/**`).
+10. contract tests; OpenAPI for `/api/authz/v1`.
+
+---
+
+## 9. Workflow delegation (PR #1751)
+
+**Runtime-scoped delegation, not persistent pre-grants.**
+
+| Operation | Owner | Mechanism |
+|-----------|-------|-----------|
+| CRUD config + runs | BFF | existing routes |
+| "can user run workflow?" | core `domains/workflow.ts` | `workflowDelegatesAgentUse` (agent∈steps AND run visibility) wired at `POST /api/workflow-runs` |
+| Step agent-use | core run-authorizer | delegated set computed at run start; step carries run-scoped decision/token; **DA reads no `workflow_configs`** |
+| DA workflow tools | DA→BFF `WorkflowApiClient` | unchanged (correct) |
+
+**Flag:** PR #1751's modal pre-grants persistent `team#can_use agent` tuples ⇒ standing access *outside* the workflow (over-grant). Replace with runtime delegation; if product wants standing access, make it an explicit separate admin grant.
+
+---
+
+## 10. RAG & DA convergence
+
+- **RAG** → thin PEP over `POST /api/authz/v1/decisions` (+ `:batch` for `inject_kb_filter`). CAS owns the channel→team lookup; RAG stops reading `channel_team_mappings`/`teams`. A shared **Python policy lib is rejected** (would be reimplementation #5).
+- **Coarse roles** (`READONLY/INGESTONLY/ADMIN`) demoted to a **local pre-filter**: client-credentials/automation short-circuit before CAS; all human/per-resource decisions go to CAS.
+- **DA** drops `openfga_authz.py` OpenFGA client + per-call store discovery + Mongo audit + `workflow_execution_authz.py`. `require_agent_use_permission` → `require_authorization(resource, action)` (CAS HTTP, or token verify in P5).
+
+---
+
+## 11. CI enforcement
+
+| Guard | Blocks |
+|-------|--------|
+| ESLint `no-restricted-imports` | `engines/openfga`/`lib/rbac/openfga` outside `lib/authz/**` |
+| `validate-authz-boundaries.py` (new) | `workflow_configs`/`teams`/OpenFGA-client imports in `dynamic_agents/**` (and RAG) once surface = `enforce` |
+| extend `validate-fga-create-paths.py` | new BFF routes reach OpenFGA only via core |
+| `fga-enforcement-manifest.ts` | add `task`/workflow + `/api/authz/v1/*` + bridge `mcp_gateway` surfaces |
+| parity test (new) | CAS == legacy on golden fixtures (gates each `shadow→enforce` flip) |
+| bridge contract test | bridge's relation map/audit schema == core adapter |
+
+---
+
+## 12. Observability & audit
+
+- **CAS owns the decision audit write** (unified `audit_events`); PEPs stop writing their own ⇒ resolves [#1733] coupling and DA/bridge duplicate audit.
+- Every decision: `correlation_id`, `subject_hash` (salted), `reason_code`, `pdp`, `source`, optional trace.
+- Metrics: `authz_decision_total{surface,decision,reason}`, `authz_parity{surface,agree}`, `authz_pdp_latency_ms`, `authz_cache_hit_ratio`, `authz_circuit_state`.
+
+---
+
+## 13. Rollout & flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `AUTHZ_CENTRAL_MODE.<surface>` | `off` | off / shadow / enforce per PEP |
+| `AUTHZ_DECISION_CACHE_TTL_MS` | `15000` | read-class cache TTL |
+| `AUTHZ_BREAK_GLASS` | unset | time-boxed, alarmed, audited fail-open (non-prod posture mirrors `CAIPE_UNSAFE_RBAC_BYPASS`) |
+| `AUTHZ_DECISION_TOKEN_ENABLED` | `false` | Transport C |
+
+Additive + versioned ⇒ **no breaking change**; existing clients keep working until their surface flips.
+
+---
+
+## 14. Acceptance criteria
+
+- [ ] One module computes agent-use; `requireAgentUsePermission` and `evaluateAgentAccess` are gone/wrappers.
+- [ ] No `dynamic_agents/**` authz path reads `workflow_configs`/`teams`; `workflow_execution_authz.py` + `workflow_config_id` bypass removed.
+- [ ] DA holds no OpenFGA client and writes no authz audit to Mongo (CAS owns it).
+- [ ] `POST /api/authz/v1/decisions` (+ `:batch`, `explain`) live, versioned, OpenAPI-documented; verifies caller token + subject-binding.
+- [ ] Public errors use §5.4 reason codes; no `agent#use`/`pdp_denied` in user-facing responses.
+- [ ] RAG, Slack, Webex consume CAS (HTTP) — not admin rebac routes.
+- [ ] `rbac.py` is a thin PEP; coarse role is a local pre-filter only.
+- [ ] Bridge conforms to the shared contract + adapter semantics + audit schema (Transport D); CI bridge-contract test green.
+- [ ] `workflowDelegatesAgentUse` wired at run start; runtime-scoped delegation; modal pre-grant removed/justified.
+- [ ] Shadow→enforce gated on ~100% parity per surface; rollback to shadow verified.
+- [ ] CI: import boundary + authz-boundary + parity guards green.
+- [ ] [#1458] ADR documents dual-gate retirement before any DA OpenFGA removal.
+
+---
+
+## 15. Test plan
+
+- **Unit:** core decision matrix (direct, team-union, deny, PDP error, invalid id); reason/`retriable` mapping; subject-binding; OBO accept/reject; cache TTL + write-class bypass.
+- **Contract:** `/api/authz/v1` request/response schema; 200-DENY vs 401/403/400/503 meta-status; envelope has no FGA strings outside `explain`.
+- **Parity (gating):** golden fixtures evaluated by legacy and CAS must agree before each flip; per-surface dashboard.
+- **Security:** forged-subject 403; unsigned/forged token rejected (regression for [#1730]); PDP-down ⇒ DENY/503; decision-token aud/exp/replay; break-glass audited.
+- **Integration:** DA chat shadow→enforce; RAG query/ingest; bot channel-scoped; AgentGateway ext_authz allow/deny via bridge.
+- **Perf:** `:batch` list filtering vs N checks; cache hit ratio; ext_authz p99 within 200ms budget.
+
+---
+
+## 16. Open decisions
+
+| ID | Decision | Default |
+|----|----------|---------|
+| D-1 | Bridge OpenFGA-direct + contract-aligned vs route via CAS | **Direct + aligned** (§7) |
+| D-2 | Decision-token signing: symmetric (in-boundary) → JWKS later | symmetric to start |
+| D-3 | Workflow `task` visibility: product layer over FGA vs fold into FGA | product layer for now; revisit post-P4 |
+| D-4 | Standing team→agent access: drop modal pre-grant vs keep as explicit admin grant | drop; explicit grant if product needs it |
+| D-5 | Parity bar + soak window before enforce | ~100% over N days (set N per surface) |
+
+---
+
+## 17. Epic [#1742] mapping
+
+| Spec phase | Closes / enables |
+|------------|------------------|
+| P1 (CAS + HTTP API) | **#1455** (prereq); enables **#1730**; sets up #1733 (CAS owns audit), #1736 (CAS owns cached channel→team) |
+| P3–P4 (convergence) | #1730, #1731, #1733 (DA); #1734/#1735/#1736 (RAG); #1737/#1739/#1741 (Slack — bots shed Keycloak-Admin/Mongo blast radius) |
+| P5 (tokens) | #1731 capstone; gated on **#1458** |
+
+**Correction:** the "facade then runtime-API as separate phases" sequencing is the *problem statement's §8*, not the epic. #1742 makes the runtime API (#1455) a **prerequisite** — supporting "ship the service first." #1755 is **not** in scope (narrow skills-UI DRY); keep it independent.
+
+---
+
+<!-- assisted-by claude code claude-opus-4-8 -->

--- a/docs/docs/specs/2026-06-06-cas-implementation/architecture.md
+++ b/docs/docs/specs/2026-06-06-cas-implementation/architecture.md
@@ -1,0 +1,123 @@
+# CAS Architecture Diagrams
+
+**Date:** 2026-06-07
+**Companion to:** [`spec.md`](./spec.md) · [`research.md`](./research.md) · [`../2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md`](../2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md)
+
+> One decision core, multiple transports, PDP-agnostic. Additive today; consumers migrate incrementally.
+
+---
+
+## 1. Component view
+
+What's built (solid) vs. planned (dashed / "planned" labels). CAS lives **inside the BFF**; out-of-process callers reach it over HTTP.
+
+```mermaid
+flowchart TB
+  subgraph BFF["BFF — caipe-ui (Next.js)"]
+    R["Route handlers<br/>workflow-runs ✓ migrated"]
+    V1["HTTP API<br/>/api/authz/v1<br/>decisions · batch · explain"]
+    AD["Admin API<br/>/api/admin/authz<br/>stats · explain"]
+    subgraph CAS["lib/authz — CAS core"]
+      P["authorize · authorizeMany<br/>filterAccessible · grant (planned)"]
+      CMP["compose — product policy layer"]
+      ENG["PolicyEngine + PolicyAdmin (planned)"]
+      OFA["OpenFGA adapter<br/>warm store-id · pooled client<br/>decision cache · circuit breaker"]
+      AU["audit"]
+      P --> CMP --> ENG --> OFA
+      P --> AU
+    end
+    R -->|in-process| P
+    V1 --> P
+    AD --> P
+  end
+
+  DA["Dynamic Agents — next"] -->|HTTP + user JWT| V1
+  RB["RAG · Slack · Webex — later"] -->|HTTP| V1
+  OFA --> STORE[("OpenFGA store")]
+  AU --> M[("audit_events — Mongo")]
+  M --> UIADMIN["Admin UI<br/>Authorization Insights · Permission Debugger · Audit tab"]
+  AD --> UIADMIN
+  BR["openfga-authz-bridge<br/>data-plane ext_authz (separate)"] -. Check .-> STORE
+```
+
+**Key points**
+- The **OpenFGA adapter is private** to `lib/authz` (ESLint silo boundary). Swapping in Cedar/OPA later = a new adapter behind the same `PolicyEngine` / `PolicyAdmin` interfaces.
+- The **bridge** stays data-plane (per-MCP-call `ext_authz`); it does **not** route through the BFF.
+- DA/RAG/bots are **not migrated yet** — only the in-process `workflow-runs` route consumes CAS today.
+
+---
+
+## 2. Decision request flow (read / PDP)
+
+A DENY is a successful evaluation (`200` + body). HTTP error codes are reserved for meta-failures.
+
+```mermaid
+sequenceDiagram
+  participant C as Caller (route / DA / bot)
+  participant API as /api/authz/v1/decisions
+  participant Core as CAS core
+  participant FGA as OpenFGA
+  participant Aud as audit_events
+
+  C->>API: POST {subject, resource, action} + Bearer
+  API->>API: verify JWT (JWKS)
+  API->>API: subject-binding (caller.sub == subject, or can_audit)
+  API->>Core: authorize()
+  Core->>Core: decision cache lookup
+  alt cache miss
+    Core->>FGA: Check(user, relation, object)
+    FGA-->>Core: allowed?
+  end
+  Core->>Aud: cas_decision event
+  Core-->>API: {decision, reason, retriable}
+  API-->>C: 200 ALLOW/DENY · 401/403 auth · 503 unavailable
+```
+
+---
+
+## 3. Grant flow (write / PAP — planned, Phase 1 of the #1751 rewrite)
+
+Intent-based and meta-authz'd: callers send `{resource, grantee, capability}`, never raw tuples. CAS verifies the caller may manage the resource, then writes via the adapter.
+
+```mermaid
+sequenceDiagram
+  participant M as Workflow share / agent-access modal
+  participant G as /api/authz/v1/grants
+  participant Core as CAS core
+  participant FGA as OpenFGA
+  participant Aud as audit_events
+
+  M->>G: POST {resource, grantee, capability} + Bearer
+  G->>Core: meta-authz — caller may manage resource?
+  Core->>FGA: Check(can_manage)
+  FGA-->>Core: allow
+  G->>Core: grant(intent)
+  Core->>FGA: write tuple (team→agent, or user:* for global)
+  G->>Aud: cas_grant event
+  G-->>M: 200 {granted}
+```
+
+---
+
+## 4. Migration posture
+
+```mermaid
+flowchart LR
+  subgraph now["Today (additive)"]
+    n1["workflow-runs route → CAS"]
+    n2["legacy paths untouched<br/>DA openfga_authz · RAG rbac · bridge"]
+  end
+  subgraph next["Incremental"]
+    x1["DA → CAS HTTP<br/>(delete openfga_authz, workflow_execution_authz)"]
+    x2["RAG → CAS"]
+    x3["bots → CAS"]
+    x4["bridge: align vocabulary/audit"]
+  end
+  now --> next
+```
+
+Each surface flips independently; nothing is forced. The standalone service can ship and run with a single real consumer, then absorb the rest over time.
+
+---
+
+<!-- assisted-by claude code claude-opus-4-8 -->

--- a/docs/docs/specs/2026-06-06-cas-implementation/research.md
+++ b/docs/docs/specs/2026-06-06-cas-implementation/research.md
@@ -1,0 +1,200 @@
+# Research: RBAC / PDP Inventory and CAS Migration Map
+
+**Date:** 2026-06-06
+**Purpose:** Inventory every authorization surface in the codebase, document its current approach, and map how it migrates to CAS.
+
+---
+
+## 1. Surface inventory
+
+### 1.1 BFF — `ui/src/`
+
+| File | Function | PDP | Resource / Action | Anti-patterns |
+|------|----------|-----|-------------------|---------------|
+| `lib/rbac/openfga-agent-authz.ts` | `requireAgentUsePermission` | OpenFGA direct + team-union | `agent:id / can_use` | Returns `NextResponse\|null` (mixed concerns); leaks `agent#use` + `pdp_denied` in error body |
+| `lib/rbac/pdp-shared.ts` | `evaluateAgentAccess` | OpenFGA direct + parallel team-union | `agent:id / can_use` | Second independent agent-use algorithm; different return shape from above |
+| `lib/rbac/resource-authz.ts` | `requireResourcePermission` `requireAgentPermission` `requireSkillPermission` `filterResourcesByPermission` | OpenFGA via `checkOpenFgaTuple` | All resource types / all actions | Action→relation map lives here (not in adapter); `openFgaRelationForResourceAction` is FGA-internal logic in a shared module |
+| `lib/rbac/openfga-team-membership.ts` | `listUserTeamSlugs` | OpenFGA list-objects | `team#member` | Per-subject 60s LRU cache — not shared with decision cache |
+| `lib/rbac/conversation-implicit-authz.ts` | `requireConversationResourcePermission` `filterConversationsByImplicitOrExplicitPermission` | OpenFGA + implicit owner bypass | `conversation / write` | Implicit owner logic embedded in authz module |
+| `lib/rbac/keycloak-authz.ts` | `checkPermission` `checkPermissions` `getEffectivePermissions` | Keycloak UMA (legacy) | Any | Deprecated; kept for legacy compatibility |
+| `app/api/user/check_agent_access/route.ts` | POST handler | BFF in-process (calls `evaluateAgentAccess`) | `agent:id / can_use` | Ad-hoc PDP endpoint; not versioned; used by Slack/Webex bots |
+
+### 1.2 Dynamic Agents — `ai_platform_engineering/dynamic_agents/`
+
+| File | Function | PDP | Resource / Action | Anti-patterns |
+|------|----------|-----|-------------------|---------------|
+| `auth/openfga_authz.py` | `require_agent_use_permission` | OpenFGA direct | `agent:id / can_use` | Store ID re-resolved per call via HTTP; own Mongo audit writes; JWT base64-decoded without re-verification; leaks `agent#use` + `pdp_denied` in HTTP error detail |
+| `auth/keycloak_authz.py` | `require_da_permission` | Shared util Keycloak → OpenFGA | `dynamic_agent:id#scope` | Thin wrapper; calls shared utils path |
+| `auth/access.py` | `can_view_agent` `can_use_agent` `can_access_conversation` | In-memory (no PDP) | `agent / visibility` | Visibility enum check only; no tuple enforcement; deprecated for fine-grained |
+| `auth/jwt_middleware.py` | `JwtAuthMiddleware.dispatch` | Keycloak JWKS validation | Bearer token | Lenient mode allows `X-User-Context` fallback when `DA_REQUIRE_BEARER=false` — #1730 vector |
+
+### 1.3 RAG Server — `ai_platform_engineering/knowledge_bases/rag/`
+
+| File | Function | PDP | Resource / Action | Anti-patterns |
+|------|----------|-----|-------------------|---------------|
+| `server/rbac.py:556` | `authorize_search` | OpenFGA `organization#can_search` | org / search | `RBAC_TEAM_SCOPE_ENABLED` flag scattered; client-creds bypass inline |
+| `server/rbac.py:678` | `authorize_mcp_tool_manage` | OpenFGA `mcp_tool#can_manage` | mcp_tool / manage | Coarse ADMIN bypass inline |
+| `server/rbac.py:716` | `authorize_mcp_tool_create` | OpenFGA `team#can_use` | mcp_tool / create | Mongo team-membership lookup in hot path |
+| `server/rbac.py:918` | `check_datasource_access` | OpenFGA `data_source#can_read/can_ingest/can_manage` | data_source / read, ingest, manage | Redundant org-admin bypass |
+| `server/rbac.py:874` | `get_accessible_datasource_ids` | OpenFGA list-objects | data_source / read | N sequential checks before list-objects added |
+| `server/rbac.py:831` | `derive_team_for_request` | MongoDB lookup (`channel_team_mappings → teams`) | — (team resolution) | Mongo query per request; degrades silently on Mongo failure |
+| `server/rbac.py:1101` | `inject_kb_filter` | Delegates to `get_accessible_datasource_ids` | data_source / read | Mutates query in-place; early-exit on empty set |
+| `server/rbac.py:973` | `authorize_datasource_create` | OpenFGA `team#can_use` + tuple write | data_source / create | Mongo team-slug resolution; own tuple write after create |
+| `server/auth.py` | `OIDCProvider.validate_token` `AuthManager.validate_token` | Keycloak JWKS | Bearer JWT | Dual-provider chain (UI + ingestor); 1h JWKS cache |
+
+### 1.4 Slack Bot — `ai_platform_engineering/integrations/slack_bot/`
+
+| File | Function | PDP | Resource / Action | Anti-patterns |
+|------|----------|-----|-------------------|---------------|
+| `utils/rbac_middleware.py` | `require_permission` | Shared util → Keycloak → OpenFGA | `resource#scope` (org-level) | Tenant extracted from OBO JWT `org` claim; decorator pattern leaks detail into Slack ephemeral messages |
+| `utils/dm_authz_client.py` | `DmAuthzClient.check_agent_access` | BFF `/api/user/check_agent_access` (HTTP) | `agent:id / can_use` | Calls the ad-hoc unversioned BFF PDP endpoint; fail-closed on transport error |
+
+### 1.5 Shared Utils — `ai_platform_engineering/utils/auth/`
+
+| File | Function | PDP | Resource / Action | Anti-patterns |
+|------|----------|-----|-------------------|---------------|
+| `keycloak_authz.py:250` | `require_rbac_permission` | OpenFGA `organization#<relation>` | org-level resource+scope → computed relation | Store ID re-resolved per-call (no env var set → HTTP lookup every time); token-hash cache (60s) |
+| `keycloak_authz.py:321` | `require_rbac_permission_dep` | Same, FastAPI dependency wrapper | — | Reads from `current_bearer_token` ContextVar |
+
+---
+
+## 2. Duplication map
+
+The same decision logic is implemented independently across surfaces:
+
+| Decision | Implementations | Lines |
+|----------|----------------|-------|
+| `user can_use agent` | `openfga-agent-authz.ts` · `pdp-shared.ts` · `openfga_authz.py` | ~300 lines × 3 |
+| OpenFGA store-id resolution | `openfga.ts` (BFF) · `openfga_authz.py` (DA) · `rbac.py` (RAG) · `keycloak_authz.py` (utils) | 4× |
+| OpenFGA HTTP client setup | Same 4 files | 4× |
+| Mongo audit write | `openfga_authz.py` (DA) · `rbac.py` (RAG) | 2× separate schemas |
+| Action→relation map | `resource-authz.ts` (`openFgaRelationForResourceAction`) · `keycloak_authz.py` (`_organization_relation_for`) | 2× |
+| JWT payload decode (unsigned) | `openfga_authz.py` · `keycloak_authz.py` · `rbac_middleware.py` | 3× |
+
+---
+
+## 3. Anti-patterns by severity
+
+| Severity | Anti-pattern | Location |
+|----------|-------------|----------|
+| **P1 — Security** | `X-User-Context` trusted when `DA_REQUIRE_BEARER=false` — forgeable identity [#1730] | `jwt_middleware.py` lenient mode |
+| **P1 — Security** | `agent#use` + `pdp_denied` leaked in HTTP error body → reveals PDP internals to caller | `openfga_authz.py:433`, `openfga-agent-authz.ts` |
+| **P2 — Reliability** | OpenFGA store-id re-resolved via HTTP on every authz call (4 separate implementations) | DA, RAG, utils, BFF |
+| **P2 — Reliability** | New `httpx.AsyncClient` per request in RAG `rbac.py` | `rbac.py:_openfga_check_object` |
+| **P2 — Reliability** | Mongo channel→team lookup in hot path; silent degradation on failure | `rbac.py:derive_team_for_request` |
+| **P3 — Correctness** | Two independent `user can_use agent` algorithms in BFF with different return shapes | `openfga-agent-authz.ts` vs `pdp-shared.ts` |
+| **P3 — Correctness** | `RBAC_TEAM_SCOPE_ENABLED` conditional scattered across 3 functions in `rbac.py` | lines 570, 925, 996 |
+| **P3 — Maintainability** | Action→relation map duplicated; each site could drift independently | `resource-authz.ts` vs `keycloak_authz.py` |
+| **P3 — Maintainability** | Mongo audit schema differs between DA and RAG; no shared shape | `openfga_authz.py` vs `rbac.py` |
+
+---
+
+## 4. CAS migration map
+
+Each surface migrates in two steps: (1) CAS ships standalone, (2) surface flips from its current PDP to calling CAS. Step 1 is the spec in `spec.md`. Step 2 is per-surface work.
+
+### 4.1 BFF agent-use (two algorithms → one)
+
+**Current:** `requireAgentUsePermission` (openfga-agent-authz.ts) + `evaluateAgentAccess` (pdp-shared.ts) — two independent implementations, different return shapes.
+
+**Migration:** Both become thin wrappers over `authorizeOrThrow` / `authorize` from `lib/authz/index.ts`. The direct+team-union algorithm moves into `lib/authz/index.ts` as the canonical implementation. The bot-facing `/api/user/check_agent_access` route calls `authorize()` and returns its `Decision`.
+
+**What changes:** Delete `openfga-agent-authz.ts`; `pdp-shared.ts` becomes a re-export shim then deleted. Zero behavior change.
+
+### 4.2 BFF resource authz
+
+**Current:** `resource-authz.ts` — `requireResourcePermission`, `filterResourcesByPermission`, action→relation map.
+
+**Migration:** `requireResourcePermission` → `authorizeOrThrow`. `filterResourcesByPermission` → `filterAccessible`. The action→relation map moves into `engines/openfga.ts`; `resource-authz.ts` stops knowing about FGA strings.
+
+**What changes:** `resource-authz.ts` becomes a thin call-through; action→relation map is internal to the adapter. Exported function signatures unchanged for existing callers.
+
+### 4.3 BFF bot-facing PDP endpoint
+
+**Current:** `POST /api/user/check_agent_access` — ad-hoc, unversioned, calls `evaluateAgentAccess`.
+
+**Migration:** 
+- **Option A (preferred):** Slack/Webex bots switch from `/api/user/check_agent_access` to `POST /api/authz/v1/decisions` with `resource.type=agent, action=use`. The new endpoint is versioned and carries `ReasonCode`.
+- **Option B (interim):** `/api/user/check_agent_access` internally calls `authorize()` from the core (one-line change), keeping the old URL alive until bots migrate.
+
+**What changes (option A):** `DmAuthzClient` updated to call the v1 endpoint. Old route deprecated.
+
+### 4.4 Dynamic Agents — `require_agent_use_permission`
+
+**Current:** Own OpenFGA HTTP client; store-id re-resolved per call; own Mongo audit writes; own OTEL spans.
+
+**Migration:** Replace the entire function body with `POST /api/authz/v1/decisions` (Transport B). DA sends `{subject, resource:{type:agent,id}, action:use}` with its Bearer token. CAS evaluates and audits; DA enforces the `Decision`.
+
+**What's deleted:** `openfga_authz.py` — the entire file. DA drops `httpx` OpenFGA calls, Mongo audit client, OTEL authz span export. Only the HTTP call to CAS remains.
+
+**What stays:** `jwt_middleware.py` (DA still validates its own inbound Bearer JWT). `keycloak_authz.py` coarse wrapper stays until org-level Keycloak gates also migrate.
+
+**Prerequisite:** `DA_REQUIRE_BEARER=true` must be enforced first to close [#1730] before DA can trust `token.sub` as the subject it sends to CAS.
+
+### 4.5 RAG — search, datasource, MCP tool gates
+
+**Current:** `rbac.py` (1158 lines) — roles + OpenFGA + Mongo channel→team lookup, all inline.
+
+**Migration path:**
+
+| RAG Function | CAS Call |
+|---|---|
+| `authorize_search` | `POST /api/authz/v1/decisions` `{resource:{type:knowledge_base,id:org},action:discover}` |
+| `authorize_datasource_create` | `POST /api/authz/v1/decisions` `{resource:{type:data_source,id:owner_team},action:ingest}` |
+| `check_datasource_access` | `POST /api/authz/v1/decisions` `{resource:{type:data_source,id},action:read\|ingest\|manage}` |
+| `get_accessible_datasource_ids` | `POST /api/authz/v1/decisions:batch` `{resource_type:data_source,action:read,ids:[…]}` |
+| `authorize_mcp_tool_manage` | `POST /api/authz/v1/decisions` `{resource:{type:mcp_tool,id},action:manage}` |
+| `inject_kb_filter` | calls `filterAccessible` equivalent via `:batch` |
+
+**Channel→team lookup:** `derive_team_for_request` moves into CAS `domains/slack-channel.ts` + `domains/webex-space.ts`. RAG stops reading `channel_team_mappings` from Mongo; sends `X-Channel-Id` as context to CAS, which resolves the team internally.
+
+**Coarse roles:** `READONLY/INGESTONLY/ADMIN` demoted to a local pre-filter for client-credentials/automation tokens only. Human-path decisions go to CAS.
+
+**What's deleted from `rbac.py`:** OpenFGA client, store-id resolution, Mongo channel-team lookup, audit writes. What remains: role enum, `require_authenticated_user`, coarse pre-filter, thin CAS HTTP calls.
+
+### 4.6 Slack bot middleware
+
+**Current:** `rbac_middleware.py` → shared util `require_rbac_permission` → OpenFGA `organization#<relation>`.
+
+**Migration:** Replace `check_permission(RbacCheckRequest)` call with `POST /api/authz/v1/decisions`. The decorator keeps the same interface; only the underlying HTTP call changes.
+
+**`DmAuthzClient`:** Migrates to v1 endpoint per §4.3 option A.
+
+### 4.7 Shared utils `keycloak_authz.py`
+
+**Current:** `require_rbac_permission` — org-level OpenFGA gate with token-hash cache; re-resolves store-id.
+
+**Migration:** `require_rbac_permission` → `POST /api/authz/v1/decisions` for resource+action pairs that map to CAS `ResourceType`. The token-hash cache is subsumed by CAS's own decision cache (15s TTL). The function becomes a thin HTTP wrapper.
+
+**Store-id re-resolution:** Eliminated — CAS caches this at boot.
+
+---
+
+## 5. Migration priority
+
+| Priority | Surface | Driver |
+|----------|---------|--------|
+| **1** | DA `require_agent_use_permission` | Closes [#1730] P1 (after `DA_REQUIRE_BEARER=true`); eliminates riskiest OpenFGA reimplementation |
+| **2** | BFF agent-use consolidation (two algos → one) | Correctness; prerequisite for DA migration to trust BFF decision |
+| **3** | Bot-facing endpoint `/api/user/check_agent_access` → v1 | Removes unversioned ad-hoc PDP surface |
+| **4** | RAG datasource + search gates | Removes Mongo-in-hot-path; largest volume of OpenFGA reimplementation |
+| **5** | BFF `resource-authz.ts` wrappers | Low risk; behavior-neutral refactor |
+| **6** | Slack bot middleware | Depends on shared utils migration |
+| **7** | Shared utils `keycloak_authz.py` | Last; many callers; broadest blast radius |
+
+---
+
+## 6. What CAS does NOT replace
+
+| Component | Stays as-is | Reason |
+|-----------|------------|--------|
+| `auth/jwt_middleware.py` (DA) | DA still validates its own inbound JWT | CAS validates the CAS-caller token; DA's inbound user JWT is a separate responsibility |
+| `server/auth.py` (RAG `OIDCProvider`) | RAG still validates its own inbound JWT | Same reason |
+| Tuple write paths (`write_datasource_ownership`, etc.) | CAS is evaluate-only | Ownership reconciliation stays in existing modules |
+| `openfga-authz-bridge` | Data-plane PEP; not BFF-resident | Aligning its vocabulary/adapter/audit to match the CAS contract is a separate step |
+| Keycloak UMA `keycloak-authz.ts` | Legacy compatibility shim | Delete only when all callers are confirmed migrated |
+| `access.py` visibility checks (DA) | In-memory coarse filter | Not a PDP call; used for list-endpoint visibility only |
+
+---
+
+<!-- assisted-by claude code claude-sonnet-4-6 -->

--- a/docs/docs/specs/2026-06-06-cas-implementation/spec.md
+++ b/docs/docs/specs/2026-06-06-cas-implementation/spec.md
@@ -1,0 +1,379 @@
+# Spec: Centralized Authorization Service (CAS) — BFF-resident, PDP-agnostic
+
+**Status:** Draft for review
+**Date:** 2026-06-06
+**Owner:** Sri Aradhyula
+**Context:** [`problem-statement.md`](../2026-06-05-centralized-bff-authz-pdp-agnostic/problem-statement.md) · [`solution-architecture.md`](../2026-06-05-centralized-bff-authz-pdp-agnostic/solution-architecture.md)
+**Tracking:** epic [#1742]; prerequisite [#1455]; security driver [#1730]
+
+> This spec covers **only what gets built new**: `ui/src/lib/authz/` and `POST /api/authz/v1/*`. It is additive — no existing file is modified, no existing PEP is re-wired.
+
+---
+
+## 1. Summary
+
+Introduce one **Authorization Decision Core** in the BFF (`ui/src/lib/authz/`) and expose it via a versioned HTTP API (`/api/authz/v1`). The service lands **standalone**: existing authz paths (DA `openfga_authz.py`, RAG `rbac.py`, BFF `resource-authz.ts`) keep running unchanged. Migration of those surfaces to consume CAS is a separate, incremental effort.
+
+**Principle:** *One decision core. One PDP-agnostic contract. Zero changes to existing code.*
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- **G1** Single decision module: one place computes "may subject S do action A on resource R."
+- **G2** PDP-agnostic contract: callers see `{subject, resource, action} → {decision, reason}`; OpenFGA internals are invisible except in the admin explain endpoint.
+- **G3** HA OpenFGA adapter: warm store-id, pooled client, decision cache, circuit breaker.
+- **G4** HTTP API for out-of-process callers: `POST /api/authz/v1/decisions`, `:batch`, `explain`.
+- **G5** Verified caller token at every call: CAS validates JWT via JWKS; subject-binding enforced.
+- **G6** Additive only: nothing existing is modified. Existing authz paths are untouched.
+
+### Non-goals
+
+- Migrating DA, RAG, bots, or the gateway bridge to consume CAS.
+- Modifying `openfga_authz.py`, `rbac.py`, `resource-authz.ts`, or any existing authz file.
+- Replacing OpenFGA as the relationship store.
+- Routing `openfga-authz-bridge` through CAS (rejected — §7).
+- Decision tokens / Transport C (future P5, gated on [#1458]).
+
+---
+
+## 3. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **CAS** | Centralized Authorization Service — the decision core + HTTP API. |
+| **PDP** | Policy Decision Point — computes allow/deny. Here: core + OpenFGA adapter. |
+| **PEP** | Policy Enforcement Point — calls PDP and enforces. CAS is a PDP; existing code has its own PEPs. |
+| **Core** | `ui/src/lib/authz/` — the new module being built. |
+| **Subject-binding** | A user caller may only evaluate `subject == token.sub`. |
+
+---
+
+## 4. Module — `ui/src/lib/authz/`
+
+```text
+ui/src/lib/authz/
+  index.ts            # authorize(), authorizeMany(), authorizeOrThrow(), filterAccessible()
+  contract.ts         # Subject, Resource, Action, Decision, ReasonCode
+  reasons.ts          # ReasonCode → { retriable, userActionHint, httpStatusHint }
+  engine.ts           # PolicyEngine interface
+  compose.ts          # product policy layered over the PDP adapter
+  engines/
+    openfga.ts        # the only OpenFGA adapter: action→relation map, warm store-id, pooled client, cache
+  domains/
+    workflow.ts       # workflowDelegatesAgentUse, run-visibility
+    slack-channel.ts
+    webex-space.ts
+  cache.ts            # bounded per-replica LRU, TTL-aware
+  audit.ts            # one decision → one structured audit event
+```
+
+### 4.1 Public API (`index.ts`)
+
+```ts
+// Returns Decision; never throws for DENY
+authorize(req: AuthorizeRequest): Promise<Decision>
+
+// Batch: BatchCheck internally; returns one Decision per id
+authorizeMany(
+  subject: Subject,
+  action: Action,
+  resourceType: ResourceType,
+  ids: string[]
+): Promise<Map<string, Decision>>
+
+// Guard variant: throws ApiError(403) on DENY, ApiError(503) on AUTHZ_UNAVAILABLE
+authorizeOrThrow(req: AuthorizeRequest): Promise<void>
+
+// List filter: returns only ids accessible to the subject
+filterAccessible(
+  subject: Subject,
+  action: Action,
+  resourceType: ResourceType,
+  ids: string[]
+): Promise<string[]>
+```
+
+### 4.2 PolicyEngine interface (`engine.ts`)
+
+```ts
+interface PolicyEngine {
+  check(req: AuthorizeRequest): Promise<Decision>;
+  batchCheck(
+    subject: Subject,
+    action: Action,
+    resourceType: ResourceType,
+    ids: string[]
+  ): Promise<Map<string, Decision>>;
+}
+```
+
+`compose.ts` wraps a `PolicyEngine` with product policy (workflow delegation, channel scoping) and returns a `PolicyEngine`. All product rules live here; the OpenFGA adapter has no product knowledge.
+
+### 4.3 OpenFGA adapter (`engines/openfga.ts`)
+
+| Concern | Design |
+|---------|--------|
+| Store id | resolved once at boot; cached in module scope; refreshed on 404 |
+| HTTP client | one pooled keep-alive client; no per-call instantiation |
+| HA | retries idempotent `check` ≤2×, 100ms between; upstream service-level replication |
+| Decision cache | bounded LRU; TTL ≤15s read-class, ≤2s write-class |
+| Batch | `BatchCheck` for ≤50 ids; bounded parallel for overflow |
+| Circuit breaker | open ⇒ fail closed (`AUTHZ_UNAVAILABLE`); half-open probe every 30s |
+| Consistency | `HIGHER_CONSISTENCY` for write-class checks; standard otherwise |
+| Action→relation map | `use → can_use`, `call → can_call`, `manage → admin`, etc. — internal to adapter only |
+
+---
+
+## 5. Contract
+
+### 5.1 Types
+
+```ts
+type SubjectType  = "user" | "service_account";
+
+type ResourceType =
+  | "agent" | "skill" | "mcp_tool" | "knowledge_base"
+  | "data_source" | "task" | "slack_channel" | "webex_space";
+
+type Action =
+  | "discover" | "read" | "read-metadata" | "use"
+  | "write" | "manage" | "share" | "delete"
+  | "ingest" | "call" | "invoke" | "audit";
+
+interface AuthorizeRequest {
+  subject:  { type: SubjectType; id: string };
+  resource: { type: ResourceType; id: string };
+  action:   Action;
+  context?: Record<string, unknown>; // may only NARROW a grant, never expand
+}
+
+type ReasonCode =
+  | "OK"                  // ALLOW
+  | "NO_CAPABILITY"       // DENY — no relationship        → contact_admin
+  | "NOT_AUTHENTICATED"   // caller token missing/invalid  → sign_in
+  | "AUTHZ_UNAVAILABLE"   // PDP error (retriable)          → retry
+  | "INVALID_REQUEST";    // bad id / malformed             → fix_request
+
+interface Decision {
+  decision:    "ALLOW" | "DENY";
+  reason:      ReasonCode;
+  retriable:   boolean;
+  ttl_seconds?: number;
+}
+```
+
+OpenFGA relation strings (`can_use`, `can_call`, etc.) are **internal to `engines/openfga.ts`**. They do not appear in `Decision`, error bodies, or any API response except the admin `/explain` endpoint.
+
+### 5.2 HTTP API
+
+**Single decision**
+
+```http
+POST /api/authz/v1/decisions
+Authorization: Bearer <caller-token>
+Content-Type: application/json
+
+{
+  "subject":  { "type": "user", "id": "<sub>" },
+  "resource": { "type": "agent", "id": "platform-engineer" },
+  "action":   "use"
+}
+
+200  { "decision": "ALLOW", "reason": "OK",            "retriable": false, "ttl_seconds": 15 }
+200  { "decision": "DENY",  "reason": "NO_CAPABILITY", "retriable": false }
+```
+
+**Batch**
+
+```http
+POST /api/authz/v1/decisions:batch
+Authorization: Bearer <caller-token>
+
+{
+  "subject":       { "type": "user", "id": "<sub>" },
+  "action":        "discover",
+  "resource_type": "agent",
+  "ids":           ["a", "b", "c"]
+}
+
+200 {
+  "results": [
+    { "id": "a", "decision": "ALLOW", "reason": "OK" },
+    { "id": "b", "decision": "DENY",  "reason": "NO_CAPABILITY" }
+  ]
+}
+```
+
+**Admin explain** (only endpoint where OpenFGA detail appears)
+
+```http
+POST /api/authz/v1/explain
+Authorization: Bearer <caller-token>   # requires can_audit scope
+
+200 {
+  "decision": "DENY",
+  "reason":   "NO_CAPABILITY",
+  "debug": {
+    "engine":   "openfga",
+    "relation": "can_use",
+    "checked":  ["user:<sub> can_use agent:platform-engineer"],
+    "store":    "<store-id>"
+  }
+}
+```
+
+### 5.3 HTTP status semantics
+
+> **A DENY is not an error.** Evaluation succeeded; the answer is "no" ⇒ `200` with body. HTTP status codes are reserved for meta-failures only.
+
+| Status | Meaning |
+|--------|---------|
+| `200` | evaluation succeeded (`ALLOW` or `DENY` in body) |
+| `401` | caller token missing or invalid (`NOT_AUTHENTICATED`) |
+| `403` | subject-binding violation — caller may not evaluate this subject |
+| `400` | malformed request (`INVALID_REQUEST`) |
+| `503` | PDP unavailable (`AUTHZ_UNAVAILABLE`, `retriable: true`) |
+
+PEPs translate `decision: "DENY"` into their own 403 responses. Deny-reasoning stays in the body, not in status codes.
+
+### 5.4 Error envelope
+
+```json
+{
+  "error":     "human-readable message safe to surface",
+  "code":      "REASON_CODE",
+  "retriable": false
+}
+```
+
+No OpenFGA strings (`agent#use`, `pdp_denied`, tuple strings) appear in error envelopes. These are adapter-internal and surface only in `/explain`.
+
+---
+
+## 6. Security model
+
+CAS is a trust boundary. It assumes callers may be hostile.
+
+| # | Threat | Control |
+|---|--------|---------|
+| 1 | **Forged subject** | A `user` caller may only evaluate `subject.id == token.sub`. Cross-subject requires `can_audit` scope. Mismatch ⇒ `403`. |
+| 2 | **Service account impersonation** | `service_account` callers must present a verified client-credentials token and hold a `can_impersonate` tuple. No trusted `delegated_subject` body field. |
+| 3 | **Unsigned/forgeable identity** ([#1730]) | CAS validates JWT signature / `exp` / `aud` / `iss` via cached JWKS on every request. Header/body subject is only the *target*; binding is then checked per #1 and #2. |
+| 4 | **PDP outage → silent allow** | Fail closed: open circuit ⇒ `DENY` + `AUTHZ_UNAVAILABLE` + `retriable: true` + `503` + audit event. Break-glass is explicit env flag, time-boxed, and audited per request. |
+| 5 | **Cache stale-allow** | TTL ≤15s read-class, ≤2s write-class; revocation tolerated within TTL (documented bound). |
+| 6 | **`context` expansion** | `context` may only *narrow* a grant. Server-evaluated delegation (workflow run-authorizer) lives inside `compose.ts`, not in caller-supplied context. |
+| 7 | **Enumeration / info leak** | Coarse `ReasonCode` only in public responses; no tuple strings outside `/explain`; per-caller rate limit; every decision audited with `correlation_id`. |
+| 8 | **New write surface** | v1 API is **evaluate only**. No tuple writes. Standing up CAS grants no new mutation capability. |
+
+---
+
+## 7. The `openfga-authz-bridge` — not in scope
+
+The existing `openfga-authz-bridge` is the data-plane PEP for MCP routing. AgentGateway fires a per-route `ext_authz` gRPC Check at a 200ms timeout. Routing those decisions through the BFF would put the BFF in the hot path of every MCP tool call. Rejected.
+
+The bridge is not touched by this spec. Aligning its vocabulary, adapter semantics, and audit schema to match the contract defined here is a separate, incremental step.
+
+---
+
+## 8. Audit
+
+CAS writes one event per decision to `audit_events`.
+
+```json
+{
+  "audit_event_id": "<uuid>",
+  "ts":             "<iso8601>",
+  "type":           "cas_decision",
+  "tenant_id":      "<tenant>",
+  "subject_hash":   "sha256:<salted-hash>",
+  "resource_type":  "agent",
+  "resource_id":    "<id>",
+  "action":         "use",
+  "decision":       "ALLOW",
+  "reason_code":    "OK",
+  "pdp":            "openfga",
+  "source":         "cas",
+  "correlation_id": "<uuid>",
+  "trace_id":       "<otel-trace-id>",
+  "span_id":        "<otel-span-id>"
+}
+```
+
+**Metrics**
+
+| Metric | Labels |
+|--------|--------|
+| `authz_decision_total` | `resource_type, action, decision, reason` |
+| `authz_pdp_latency_ms` | `resource_type, action, cache_hit` |
+| `authz_cache_hit_ratio` | `resource_type` |
+| `authz_circuit_state`  | `state: closed\|open\|half_open` |
+
+---
+
+## 9. Configuration
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `OPENFGA_HTTP` | — | OpenFGA HTTP base URL (required) |
+| `OPENFGA_STORE_ID` | — | Explicit store id; skips store-list lookup when set |
+| `OPENFGA_STORE_NAME` | `caipe-openfga` | Store name for lookup when id is unset |
+| `AUTHZ_DECISION_CACHE_TTL_MS` | `15000` | Read-class cache TTL |
+| `AUTHZ_DECISION_CACHE_WRITE_TTL_MS` | `2000` | Write-class cache TTL |
+| `AUTHZ_BREAK_GLASS` | unset | Fail-open for non-prod emergencies; alarmed + audited per request |
+| `AUDIT_SUBJECT_SALT` | — | Salt for subject hash in audit events (required) |
+| `AUTHZ_TRACING_ENABLED` | `false` | OTLP span export for decision calls |
+
+---
+
+## 10. Tasks
+
+All new files. No existing file is modified.
+
+**Core**
+
+1. `contract.ts` — types: `Subject`, `Resource`, `Action`, `Decision`, `ReasonCode`.
+2. `reasons.ts` — `ReasonCode → { retriable, userActionHint, httpStatusHint }`.
+3. `engine.ts` — `PolicyEngine` interface (`check`, `batchCheck`).
+4. `engines/openfga.ts` — adapter: warm store-id, pooled client, action→relation map, cache, circuit breaker.
+5. `cache.ts` — bounded LRU; read/write TTL split.
+6. `audit.ts` — structured decision event writer (§8 shape).
+7. `compose.ts` + `domains/workflow.ts` — product policy layer; workflow delegation.
+8. `index.ts` — `authorize`, `authorizeMany`, `authorizeOrThrow`, `filterAccessible`.
+
+**HTTP routes**
+
+9. `POST /api/authz/v1/decisions` — JWKS verification, subject-binding, single decision.
+10. `POST /api/authz/v1/decisions:batch` — subject-binding, batch result.
+11. `POST /api/authz/v1/explain` — `can_audit` guard; OpenFGA debug block.
+12. Shared `v1ErrorResponse` builder — no OpenFGA strings in public envelopes.
+13. OpenAPI schema for `/api/authz/v1`.
+
+**Guards**
+
+14. ESLint `no-restricted-imports`: `engines/openfga` and `lib/rbac/openfga` are import errors outside `lib/authz/**`.
+
+**Tests**
+
+15. Unit: decision matrix (direct, team-union, deny, PDP error, invalid id); subject-binding accept/reject; cache TTL + write-class bypass; circuit breaker open/close.
+16. Contract: request/response schema; `200-DENY` vs `401/403/400/503`; no OpenFGA strings outside `explain`.
+17. Security regression: forged-subject `403`; unsigned token rejected ([#1730]); PDP-down ⇒ `DENY/503`; break-glass audited.
+
+---
+
+## 11. Acceptance criteria
+
+- [ ] `ui/src/lib/authz/` exists with all modules in §4; `engines/openfga` imports restricted by lint rule.
+- [ ] `POST /api/authz/v1/decisions` (+ `:batch`, `explain`) live; caller JWT verified via JWKS; subject-binding enforced.
+- [ ] `DENY` returns `200` with `ReasonCode`; meta-failures return correct status codes (§5.3).
+- [ ] No `agent#use`, `pdp_denied`, or FGA tuple strings in any non-`explain` response.
+- [ ] Adapter: store-id cached at boot; pooled client; circuit breaker; read/write TTL split.
+- [ ] Every decision produces one audit event with the shape in §8.
+- [ ] OpenAPI schema published; contract tests green.
+- [ ] No existing file was modified; no existing test was broken.
+
+---
+
+<!-- assisted-by claude code claude-sonnet-4-6 -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.11-dev.1"
+version = "0.5.11-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -23,6 +23,29 @@ const eslintConfig = [
       "@typescript-eslint/no-explicit-any": "warn",
     },
   },
+  // CAS silo boundary: the OpenFGA transport adapters are private. The CAS
+  // core (lib/authz/**) and the legacy RBAC layer (lib/rbac/**) must never
+  // import each other's OpenFGA transport — each owns its own. App code must
+  // consume CAS only through its public entrypoint (@/lib/authz), never the
+  // engine directly.
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["src/lib/authz/**"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@/lib/authz/engines/*", "**/lib/authz/engines/*"],
+              message:
+                "Import CAS through its public API (@/lib/authz), not the engine adapter directly.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -141,6 +141,10 @@ jest.mock('@/components/admin/security/UnifiedAuditTab', () => ({
   UnifiedAuditTab: () => <div data-testid="unified-audit-tab">UnifiedAuditTab</div>,
 }));
 
+jest.mock('@/components/admin/PermissionsToolTab', () => ({
+  PermissionsToolTab: () => <div data-testid="permissions-tool-tab">PermissionsToolTab</div>,
+}));
+
 jest.mock('@/components/admin/teams/CreateTeamDialog', () => ({
   CreateTeamDialog: () => null,
 }));
@@ -666,7 +670,7 @@ describe('Admin Dashboard Page', () => {
       );
     });
 
-    it('orders Security & Policy tabs with OpenFGA ReBAC as the default', async () => {
+    it('orders Security & Policy tabs with RBAC Audit second and Permissions Tool as default', async () => {
       currentSearchParams = new URLSearchParams('cat=security');
 
       render(<AdminPage />);
@@ -677,13 +681,14 @@ describe('Admin Dashboard Page', () => {
 
       fireEvent.click(screen.getByText('Security & Policy'));
       expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
-        'OpenFGA ReBAC',
+        'Permissions Tool',
         'RBAC Audit',
+        'OpenFGA ReBAC',
         'Chat Audit',
         'Keycloak',
         'Migrations',
       ]);
-      expect(screen.getByRole('tab', { name: /OpenFGA ReBAC/i })).toHaveAttribute(
+      expect(screen.getByRole('tab', { name: /^Permissions Tool$/i })).toHaveAttribute(
         'aria-selected',
         'true'
       );
@@ -799,20 +804,21 @@ describe('Admin Dashboard Page', () => {
       expect(screen.queryByRole('tab', { name: /^Users$/i })).not.toBeInTheDocument();
     });
 
-    it('defaults bare /admin to the top-level Settings Default Agent tab', async () => {
+    it('defaults bare /admin to Security & Policy Permissions Tool tab', async () => {
       render(<AdminPage />);
 
-      expect(await screen.findByText('Settings')).toBeInTheDocument();
+      expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
-      expect(screen.getByRole('tab', { name: /default agent/i })).toHaveAttribute(
+      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('tab', { name: /^Permissions Tool$/i })).toHaveAttribute(
         'aria-selected',
         'true'
       );
-      expect(screen.getByTestId('platform-settings-tab')).toBeInTheDocument();
-      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=settings&tab=settings', {
-        scroll: false,
-      });
+      expect(screen.getByTestId('permissions-tool-tab')).toBeInTheDocument();
+      expect(replaceMock).toHaveBeenCalledWith(
+        '/admin?cat=security&tab=cas-permissions-tool',
+        { scroll: false }
+      );
     });
 
     it('opens the Release notes settings tab from the query string', async () => {

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -14,6 +14,8 @@ import { MetricsTab } from "@/components/admin/platform/MetricsTab";
 import { SkillHubsSection } from "@/components/admin/platform/SkillHubsSection";
 import { SlackStatsSection } from "@/components/admin/platform/SlackStatsSection";
 import { SupervisorSkillsStatusSection } from "@/components/admin/platform/SupervisorSkillsStatusSection";
+import { CasInsightsTab } from "@/components/admin/CasInsightsTab";
+import { PermissionsToolTab } from "@/components/admin/PermissionsToolTab";
 import { RagTeamAccessPanel } from "@/components/admin/rebac/RagTeamAccessPanel";
 import { SlackChannelRebacPanel } from "@/components/admin/rebac/SlackChannelRebacPanel";
 import { WebexSpaceRebacPanel } from "@/components/admin/rebac/WebexSpaceRebacPanel";
@@ -55,7 +57,7 @@ import { getConfig } from "@/lib/config";
 import { cn } from "@/lib/utils";
 import type { SkillMetricsAdmin } from "@/types/agent-skill";
 import type { Team as TeamType } from "@/types/teams";
-import { Activity,Bot,Calendar,CheckCircle2,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,HelpCircle,Layers,Loader2,MessageSquare,Plus,RefreshCw,Search,Settings,Share2,Shield,ShieldCheck,Star,ThumbsDown,ThumbsUp,Trash2,TrendingUp,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
+import { Activity,Bot,Bug,Calendar,CheckCircle2,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,HelpCircle,Layers,Loader2,MessageSquare,Plus,RefreshCw,Search,Settings,Share2,Shield,ShieldCheck,Star,ThumbsDown,ThumbsUp,Trash2,TrendingUp,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { usePathname,useRouter,useSearchParams } from "next/navigation";
 import React,{ useCallback,useEffect,useMemo,useRef,useState } from "react";
@@ -252,8 +254,8 @@ interface SimulationTeamOption {
   description?: string;
 }
 
-const VALID_TABS = ['users', 'teams', 'identity-sync', 'stats', 'skills', 'feedback', 'nps', 'metrics', 'health', 'credentials', 'audit-logs', 'action-audit', 'openfga', 'keycloak', 'migrations', 'ai-review', 'settings', 'release-notes', 'slack', 'webex', 'rag-access'] as const;
-const VALID_OPENFGA_SUBTABS = ['builder', 'explorer', 'graph', 'tuples', 'access', 'baseline', 'diagnostics'] as const;
+const VALID_TABS = ['users', 'teams', 'identity-sync', 'stats', 'skills', 'feedback', 'nps', 'metrics', 'health', 'cas-insights', 'credentials', 'audit-logs', 'action-audit', 'cas-permissions-tool', 'openfga', 'keycloak', 'migrations', 'ai-review', 'settings', 'release-notes', 'slack', 'webex', 'rag-access'] as const;
+const VALID_OPENFGA_SUBTABS = ['builder', 'explorer', 'graph', 'tuples', 'baseline'] as const;
 const MOVED_ADMIN_TAB_MAP = {
   insights: 'stats',
 } as const;
@@ -264,8 +266,8 @@ const MOVED_OPENFGA_DEEPLINK_TAB_MAP = {
 } as const;
 
 type CategoryKey = 'settings' | 'people' | 'integrations' | 'insights' | 'platform' | 'security';
-const DEFAULT_ADMIN_CATEGORY: CategoryKey = 'settings';
-const DEFAULT_ADMIN_TAB = 'settings';
+const DEFAULT_ADMIN_CATEGORY: CategoryKey = 'security';
+const DEFAULT_ADMIN_TAB = 'cas-permissions-tool';
 const DEFAULT_READONLY_TAB = 'users';
 
 interface Category {
@@ -330,6 +332,7 @@ const CATEGORIES: Category[] = [
     tabs: [
       { value: 'metrics', label: 'Metrics', icon: Activity, gateKey: 'metrics' },
       { value: 'health', label: 'Health', icon: Database, gateKey: 'health' },
+      { value: 'cas-insights', label: 'Authorization Insights', icon: Activity, gateKey: 'metrics' },
     ],
   },
   {
@@ -337,8 +340,9 @@ const CATEGORIES: Category[] = [
     label: 'Security & Policy',
     icon: Shield,
     tabs: [
-      { value: 'openfga', label: 'OpenFGA ReBAC', icon: Shield, gateKey: 'openfga' },
+      { value: 'cas-permissions-tool', label: 'Permissions Tool', icon: Bug, gateKey: 'openfga' },
       { value: 'action-audit', label: 'RBAC Audit', icon: Shield, gateKey: 'action_audit' },
+      { value: 'openfga', label: 'OpenFGA ReBAC', icon: Shield, gateKey: 'openfga' },
       { value: 'audit-logs', label: 'Chat Audit', icon: FileText, gateKey: 'audit_logs' },
       { value: 'keycloak', label: 'Keycloak', icon: ShieldCheck, gateKey: 'migrations' },
       { value: 'migrations', label: 'Migrations', icon: Database, gateKey: 'migrations' },
@@ -3142,9 +3146,23 @@ function AdminPage() {
                 <HealthTab />
               </TabsContent>
 
+              {/* CAS Insights — authorization service health + decision stats */}
+              {tabGateValues.metrics && (
+                <TabsContent value="cas-insights" className="space-y-4">
+                  <CasInsightsTab isAdmin={isAdmin} />
+                </TabsContent>
+              )}
+
               {tabGateValues.audit_logs && (
                 <TabsContent value="audit-logs" className="space-y-4">
                   <AuditLogsTab isAdmin={isAdmin} onUserClick={setSelectedUserEmail} />
+                </TabsContent>
+              )}
+
+              {/* Permission Debugger — interactive OpenFGA /explain */}
+              {tabGateValues.openfga && (
+                <TabsContent value="cas-permissions-tool" className="space-y-4">
+                  <PermissionsToolTab isAdmin={isAdmin} />
                 </TabsContent>
               )}
 

--- a/ui/src/app/api/__tests__/authz-admin-explain.test.ts
+++ b/ui/src/app/api/__tests__/authz-admin-explain.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockGetServerSession = jest.fn();
+const mockRequireRbac = jest.fn();
+const mockAuthorize = jest.fn();
+const mockDescribe = jest.fn();
+const mockReadOpenFgaTuples = jest.fn();
+
+jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(message: string, public statusCode = 500, public code?: string) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    requireRbacPermission: (...a: unknown[]) => mockRequireRbac(...a),
+    withErrorHandler:
+      <T,>(h: (...a: unknown[]) => Promise<T>) =>
+      async (...a: unknown[]) => {
+        try {
+          return await h(...a);
+        } catch (e) {
+          return Response.json(
+            { success: false, error: e instanceof Error ? e.message : "error" },
+            { status: (e as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+  describeFgaCheck: (...a: unknown[]) => mockDescribe(...a),
+}));
+jest.mock("@/lib/rbac/openfga", () => ({
+  readOpenFgaTuples: (...a: unknown[]) => mockReadOpenFgaTuples(...a),
+}));
+
+import { POST } from "../admin/authz/explain/route";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest(new URL("/api/admin/authz/explain", "http://localhost:3000"), {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  subject: { type: "user", id: "bob" },
+  resource: { type: "agent", id: "pe" },
+  action: "use",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue({ user: { email: "admin@acme.com" }, sub: "admin", org: "acme" });
+  mockRequireRbac.mockResolvedValue(undefined);
+  mockReadOpenFgaTuples.mockResolvedValue({ tuples: [] });
+});
+
+it("returns the decision plus the OpenFGA debug block for an admin", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY", retriable: false });
+  mockDescribe.mockReturnValue({ engine: "openfga", relation: "can_use", user: "user:bob", object: "agent:pe", store: "store-xyz" });
+  const res = await POST(post(validBody));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    decision: "DENY",
+    reason: "NO_CAPABILITY",
+    debug: { engine: "openfga", relation: "can_use", checked: ["user:bob can_use agent:pe"], store: "store-xyz" },
+  });
+  expect(mockRequireRbac).toHaveBeenCalledWith(expect.anything(), "admin_ui", "audit.view");
+});
+
+it("evaluates a permission matrix when actions[] is provided", async () => {
+  mockAuthorize.mockImplementation(async (req: { action: string }) =>
+    req.action === "use"
+      ? { decision: "ALLOW", reason: "OK", retriable: false, via: "org_admin" }
+      : { decision: "DENY", reason: "NO_CAPABILITY", retriable: false },
+  );
+  mockDescribe.mockImplementation((req: { action: string }) => ({
+    engine: "openfga",
+    relation: `can_${req.action}`,
+    user: "user:bob",
+    object: "agent:pe",
+    store: "store-xyz",
+  }));
+  const res = await POST(
+    post({ subject: { type: "user", id: "bob" }, resource: { type: "agent", id: "pe" }, actions: ["use", "read"] }),
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.results).toHaveLength(2);
+  const use = body.results.find((r: { action: string }) => r.action === "use");
+  const read = body.results.find((r: { action: string }) => r.action === "read");
+  expect(use.decision).toBe("ALLOW");
+  expect(use.via).toBe("org_admin"); // source surfaced for the matrix
+  expect(read.decision).toBe("DENY");
+  expect(read.debug.relation).toBe("can_read");
+});
+
+it("marks unsupported resource actions without querying OpenFGA", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false, via: "tuple" });
+  mockDescribe.mockImplementation((req: { action: string }) => ({
+    engine: "openfga",
+    relation: `can_${req.action}`,
+    user: "user:bob",
+    object: "agent:pe",
+    store: "store-xyz",
+  }));
+
+  const res = await POST(
+    post({ subject: { type: "user", id: "bob" }, resource: { type: "agent", id: "pe" }, actions: ["use", "ingest"] }),
+  );
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  const ingest = body.results.find((r: { action: string }) => r.action === "ingest");
+  expect(ingest).toMatchObject({
+    supported: false,
+    decision: "DENY",
+    reason: "INVALID_REQUEST",
+    unsupportedReason: "capability is not supported for this resource type",
+  });
+  expect(mockAuthorize).toHaveBeenCalledTimes(1);
+  expect(mockAuthorize).toHaveBeenCalledWith(expect.objectContaining({ action: "use" }), expect.anything());
+});
+
+it("marks inherited tuple allows as not directly revocable", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false, via: "tuple" });
+  mockDescribe.mockReturnValue({
+    engine: "openfga",
+    relation: "can_use",
+    user: "user:bob",
+    object: "agent:pe",
+    store: "store-xyz",
+  });
+  mockReadOpenFgaTuples.mockResolvedValue({ tuples: [] });
+
+  const res = await POST(post(validBody));
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({
+    decision: "ALLOW",
+    directGrant: {
+      tuple: "user:bob user agent:pe",
+      present: false,
+      revocable: false,
+    },
+  });
+  expect(mockReadOpenFgaTuples).toHaveBeenCalledWith({
+    tuple: { user: "user:bob", relation: "user", object: "agent:pe" },
+    pageSize: 1,
+  });
+});
+
+it("returns 401 when there is no session", async () => {
+  mockGetServerSession.mockResolvedValue(null);
+  const res = await POST(post(validBody));
+  expect(res.status).toBe(401);
+  expect(mockAuthorize).not.toHaveBeenCalled();
+});
+
+it("returns 400 for an invalid subject (validation via shared parsers)", async () => {
+  const res = await POST(post({ ...validBody, subject: { type: "user", id: "agent:*" } }));
+  expect(res.status).toBe(400);
+  expect(mockAuthorize).not.toHaveBeenCalled();
+});
+
+it("returns 400 for an unrecognized action", async () => {
+  const res = await POST(post({ ...validBody, action: "frobnicate" }));
+  expect(res.status).toBe(400);
+});
+
+it("returns 400 on malformed JSON", async () => {
+  const r = new NextRequest(new URL("/api/admin/authz/explain", "http://localhost:3000"), { method: "POST", body: "{bad" });
+  expect((await POST(r)).status).toBe(400);
+});
+
+it("returns 400 when the body is not an object", async () => {
+  const r = new NextRequest(new URL("/api/admin/authz/explain", "http://localhost:3000"), { method: "POST", body: "42" });
+  expect((await POST(r)).status).toBe(400);
+});

--- a/ui/src/app/api/__tests__/authz-batch.test.ts
+++ b/ui/src/app/api/__tests__/authz-batch.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockAuthorize = jest.fn();
+const mockAuthorizeMany = jest.fn();
+const mockGetAuth = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => ({
+  getAuthFromBearerOrSession: (...a: unknown[]) => mockGetAuth(...a),
+}));
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+  authorizeMany: (...a: unknown[]) => mockAuthorizeMany(...a),
+}));
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn(), isMongoDBConfigured: false }));
+
+import { POST } from "../authz/v1/decisions/batch/route";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest(new URL("/api/authz/v1/decisions/batch", "http://localhost:3000"), {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAuth.mockResolvedValue({ session: { sub: "alice" } });
+});
+
+it("returns one decision per id with retriable flag, preserving input order", async () => {
+  mockAuthorizeMany.mockResolvedValue(
+    new Map([
+      ["a", { decision: "ALLOW", reason: "OK", retriable: false }],
+      ["b", { decision: "DENY", reason: "NO_CAPABILITY", retriable: false }],
+    ]),
+  );
+  const res = await POST(
+    post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["a", "b"] }),
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.results).toEqual([
+    { id: "a", decision: "ALLOW", reason: "OK", retriable: false },
+    { id: "b", decision: "DENY", reason: "NO_CAPABILITY", retriable: false },
+  ]);
+  expect(body.degraded).toBeUndefined();
+});
+
+it("emits degraded+retriable at top-level when any id is AUTHZ_UNAVAILABLE", async () => {
+  // engine returns results for only one of two ids (the other is fail-closed)
+  mockAuthorizeMany.mockResolvedValue(new Map([["a", { decision: "ALLOW", reason: "OK", retriable: false }]]));
+  const res = await POST(
+    post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["a", "b"] }),
+  );
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  expect(body.results).toEqual([
+    { id: "a", decision: "ALLOW", reason: "OK", retriable: false },
+    { id: "b", decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true },
+  ]);
+  expect(body.degraded).toBe(true);
+  expect(body.retriable).toBe(true);
+});
+
+it("emits degraded+retriable when the engine returns AUTHZ_UNAVAILABLE for an id", async () => {
+  mockAuthorizeMany.mockResolvedValue(
+    new Map([
+      ["a", { decision: "ALLOW", reason: "OK", retriable: false }],
+      ["b", { decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true }],
+    ]),
+  );
+  const res = await POST(
+    post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["a", "b"] }),
+  );
+  const body = await res.json();
+  expect(body.degraded).toBe(true);
+  expect(body.retriable).toBe(true);
+  expect(body.results[1].retriable).toBe(true);
+});
+
+it("rejects an empty id list with 400", async () => {
+  const res = await POST(
+    post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: [] }),
+  );
+  expect(res.status).toBe(400);
+});
+
+it("rejects an id that smuggles OpenFGA structure", async () => {
+  const res = await POST(
+    post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["ok", "agent:*"] }),
+  );
+  expect(res.status).toBe(400);
+  expect(mockAuthorizeMany).not.toHaveBeenCalled();
+});
+
+it("returns 403 cross-subject without can_audit", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+  const res = await POST(
+    post({ subject: { type: "user", id: "bob" }, action: "discover", resource_type: "agent", ids: ["a"] }),
+  );
+  expect(res.status).toBe(403);
+});
+
+it("returns 401 when the caller token is missing/invalid", async () => {
+  mockGetAuth.mockRejectedValue(new Error("no auth"));
+  const res = await POST(post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["a"] }));
+  expect(res.status).toBe(401);
+});
+
+it("returns 401 when the caller has no stable sub", async () => {
+  mockGetAuth.mockResolvedValue({ session: { catalogKey: "k" } });
+  const res = await POST(post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["a"] }));
+  expect(res.status).toBe(401);
+});
+
+it("returns 400 on malformed JSON", async () => {
+  const r = new NextRequest(new URL("/api/authz/v1/decisions/batch", "http://localhost:3000"), { method: "POST", body: "{bad" });
+  expect((await POST(r)).status).toBe(400);
+});
+
+it("returns 400 when the body is not an object", async () => {
+  const r = new NextRequest(new URL("/api/authz/v1/decisions/batch", "http://localhost:3000"), { method: "POST", body: "42" });
+  expect((await POST(r)).status).toBe(400);
+});
+
+it("re-throws non-authz errors", async () => {
+  mockAuthorizeMany.mockRejectedValue(new Error("boom"));
+  await expect(
+    POST(post({ subject: { type: "user", id: "alice" }, action: "discover", resource_type: "agent", ids: ["a"] })),
+  ).rejects.toThrow("boom");
+});

--- a/ui/src/app/api/__tests__/authz-decisions.test.ts
+++ b/ui/src/app/api/__tests__/authz-decisions.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockAuthorize = jest.fn();
+const mockGetAuth = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => ({
+  getAuthFromBearerOrSession: (...a: unknown[]) => mockGetAuth(...a),
+}));
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+}));
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn(), isMongoDBConfigured: false }));
+
+import { POST } from "../authz/v1/decisions/route";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest(new URL("/api/authz/v1/decisions", "http://localhost:3000"), {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const selfSubject = { type: "user", id: "alice" };
+const resource = { type: "agent", id: "pe" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAuth.mockResolvedValue({ session: { sub: "alice", org: "acme" } });
+});
+
+it("returns 200 ALLOW for a self-subject grant", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false, ttl_seconds: 15 });
+  const res = await POST(post({ subject: selfSubject, resource, action: "use" }));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ decision: "ALLOW", reason: "OK" });
+});
+
+it("returns 200 DENY (not 403) when the decision is no", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY", retriable: false });
+  const res = await POST(post({ subject: selfSubject, resource, action: "use" }));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ decision: "DENY", reason: "NO_CAPABILITY" });
+});
+
+it("returns 503 on AUTHZ_UNAVAILABLE", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true });
+  const res = await POST(post({ subject: selfSubject, resource, action: "use" }));
+  expect(res.status).toBe(503);
+  expect(await res.json()).toMatchObject({ code: "AUTHZ_UNAVAILABLE", retriable: true });
+});
+
+it("returns 401 when the caller token is missing/invalid", async () => {
+  mockGetAuth.mockRejectedValue(new Error("no auth"));
+  const res = await POST(post({ subject: selfSubject, resource, action: "use" }));
+  expect(res.status).toBe(401);
+});
+
+it("returns 401 (fail closed) when the caller has no stable sub", async () => {
+  mockGetAuth.mockResolvedValue({ session: { role: "user", catalogKey: "k" } });
+  const res = await POST(post({ subject: selfSubject, resource, action: "use" }));
+  expect(res.status).toBe(401);
+  expect(mockAuthorize).not.toHaveBeenCalled();
+});
+
+it("returns 403 for cross-subject evaluation without can_audit", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" }); // the audit gate
+  const res = await POST(post({ subject: { type: "user", id: "bob" }, resource, action: "use" }));
+  expect(res.status).toBe(403);
+  expect(await res.json()).toMatchObject({ code: "FORBIDDEN" });
+});
+
+it("returns 400 for an unrecognized action", async () => {
+  const res = await POST(post({ subject: selfSubject, resource, action: "frobnicate" }));
+  expect(res.status).toBe(400);
+  expect(mockAuthorize).not.toHaveBeenCalled();
+});
+
+it("returns 400 for malformed JSON", async () => {
+  const res = await POST(post("{not json"));
+  expect(res.status).toBe(400);
+});
+
+it("returns 400 when the body is valid JSON but not an object", async () => {
+  const res = await POST(post("42"));
+  expect(res.status).toBe(400);
+});
+
+it("re-throws non-authz errors instead of swallowing them", async () => {
+  mockAuthorize.mockRejectedValue(new Error("boom"));
+  await expect(POST(post({ subject: selfSubject, resource, action: "use" }))).rejects.toThrow("boom");
+});
+
+it("forwards advisory context but strips reserved workflow delegation keys", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false });
+  await POST(post({
+    subject: selfSubject,
+    resource,
+    action: "use",
+    context: { channel_id: "C123", workflow_run_id: "wr-1" },
+  }));
+  expect(mockAuthorize).toHaveBeenCalledWith(
+    expect.objectContaining({ context: { channel_id: "C123" } }),
+    expect.anything(),
+  );
+});
+
+it("never leaks OpenFGA strings in a public response body", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY", retriable: false });
+  const res = await POST(post({ subject: selfSubject, resource, action: "use" }));
+  const text = JSON.stringify(await res.json());
+  expect(text).not.toMatch(/can_use|pdp_denied|agent#use/);
+});

--- a/ui/src/app/api/__tests__/authz-explain.test.ts
+++ b/ui/src/app/api/__tests__/authz-explain.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockAuthorize = jest.fn();
+const mockDescribe = jest.fn();
+const mockGetAuth = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => ({
+  getAuthFromBearerOrSession: (...a: unknown[]) => mockGetAuth(...a),
+}));
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+  describeFgaCheck: (...a: unknown[]) => mockDescribe(...a),
+}));
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn(), isMongoDBConfigured: false }));
+
+import { POST } from "../authz/v1/explain/route";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest(new URL("/api/authz/v1/explain", "http://localhost:3000"), {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const body = {
+  subject: { type: "user", id: "bob" },
+  resource: { type: "agent", id: "pe" },
+  action: "use",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAuth.mockResolvedValue({ session: { sub: "admin-sub" } });
+});
+
+it("denies non-auditors with 403", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" }); // audit gate fails
+  const res = await POST(post(body));
+  expect(res.status).toBe(403);
+});
+
+it("returns the decision plus an OpenFGA debug block for auditors", async () => {
+  // The audit gate must ALLOW (caller is an auditor); the evaluated decision
+  // itself is a DENY we want to explain.
+  mockAuthorize.mockImplementation(async (req: { action: string }) =>
+    req.action === "audit"
+      ? { decision: "ALLOW", reason: "OK", retriable: false }
+      : { decision: "DENY", reason: "NO_CAPABILITY", retriable: false },
+  );
+  mockDescribe.mockReturnValue({
+    engine: "openfga",
+    relation: "can_use",
+    user: "user:bob",
+    object: "agent:pe",
+    store: "store-xyz",
+  });
+  const res = await POST(post(body));
+  expect(res.status).toBe(200);
+  const json = await res.json();
+  expect(json).toMatchObject({
+    decision: "DENY",
+    reason: "NO_CAPABILITY",
+    debug: { engine: "openfga", relation: "can_use", checked: ["user:bob can_use agent:pe"] },
+  });
+});
+
+it("returns 401 when the caller has no stable sub", async () => {
+  mockGetAuth.mockResolvedValue({ session: {} });
+  const res = await POST(post(body));
+  expect(res.status).toBe(401);
+});
+
+it("returns 401 when the caller token is missing/invalid", async () => {
+  mockGetAuth.mockRejectedValue(new Error("no auth"));
+  const res = await POST(post(body));
+  expect(res.status).toBe(401);
+});
+
+it("returns 400 on malformed JSON (after passing the audit gate)", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false });
+  const r = new NextRequest(new URL("/api/authz/v1/explain", "http://localhost:3000"), { method: "POST", body: "{bad" });
+  expect((await POST(r)).status).toBe(400);
+});
+
+it("returns 400 when the body is not an object", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false });
+  const r = new NextRequest(new URL("/api/authz/v1/explain", "http://localhost:3000"), { method: "POST", body: "42" });
+  expect((await POST(r)).status).toBe(400);
+});
+
+it("re-throws non-authz errors", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK", retriable: false });
+  mockDescribe.mockImplementation(() => {
+    throw new Error("boom");
+  });
+  await expect(POST(post(body))).rejects.toThrow("boom");
+});

--- a/ui/src/app/api/__tests__/authz-grants.test.ts
+++ b/ui/src/app/api/__tests__/authz-grants.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+// assisted-by Codex Codex-sonnet-4-6
+
+const mockGetServerSession = jest.fn();
+const mockAuthorize = jest.fn();
+const mockGrant = jest.fn();
+const mockRevoke = jest.fn();
+const mockEmitGrantAudit = jest.fn();
+
+jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(message: string, public statusCode = 500, public code?: string) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    withErrorHandler:
+      <T,>(h: (...a: unknown[]) => Promise<T>) =>
+      async (...a: unknown[]) => {
+        try {
+          return await h(...a);
+        } catch (e) {
+          return Response.json(
+            { success: false, error: e instanceof Error ? e.message : "error" },
+            { status: (e as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+// requireManage (real, from http.ts) uses authorize from @/lib/authz → mock it.
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+  grant: (...a: unknown[]) => mockGrant(...a),
+  revoke: (...a: unknown[]) => mockRevoke(...a),
+}));
+jest.mock("@/lib/authz/audit", () => ({
+  emitGrantAudit: (...a: unknown[]) => mockEmitGrantAudit(...a),
+}));
+
+import { POST, DELETE } from "../admin/authz/grants/route";
+
+function body(b: unknown, method = "POST"): NextRequest {
+  return new NextRequest(new URL("/api/admin/authz/grants", "http://localhost:3000"), { method, body: JSON.stringify(b) });
+}
+const validGrant = { resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue({ user: { email: "admin@acme.com" }, sub: "admin", org: "acme" });
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK" }); // caller can manage
+});
+
+it("grants when the caller can manage the resource", async () => {
+  const res = await POST(body(validGrant));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ granted: true });
+  expect(mockGrant).toHaveBeenCalledWith(
+    { resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" },
+    expect.objectContaining({
+      tenantId: "acme",
+      caller: { type: "user", id: "admin" },
+      correlationId: expect.any(String),
+    }),
+  );
+  expect(mockEmitGrantAudit).not.toHaveBeenCalled();
+});
+
+it("grants when the caller is an organization admin without direct resource manage", async () => {
+  mockAuthorize
+    .mockResolvedValueOnce({ decision: "DENY", reason: "NO_CAPABILITY", retriable: false })
+    .mockResolvedValueOnce({ decision: "ALLOW", reason: "OK", retriable: false, via: "org_admin" });
+
+  const res = await POST(body(validGrant));
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ granted: true });
+  expect(mockAuthorize).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({ resource: { type: "agent", id: "pe" }, action: "manage" }),
+    expect.objectContaining({ tenantId: "acme" }),
+  );
+  expect(mockAuthorize).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({ resource: { type: "organization", id: "caipe" }, action: "manage" }),
+    expect.objectContaining({ tenantId: "acme" }),
+  );
+  expect(mockGrant).toHaveBeenCalled();
+});
+
+it("revokes on DELETE", async () => {
+  const res = await DELETE(body(validGrant, "DELETE"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ revoked: true });
+  expect(mockRevoke).toHaveBeenCalled();
+});
+
+it("returns 403 (meta-authz) when the caller cannot manage the resource", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+  const res = await POST(body(validGrant));
+  expect(res.status).toBe(403);
+  expect(mockGrant).not.toHaveBeenCalled();
+  expect(mockEmitGrantAudit).toHaveBeenCalledWith(
+    "grant",
+    { resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" },
+    expect.objectContaining({ caller: { type: "user", id: "admin" }, tenantId: "acme" }),
+    { outcome: "error", reasonCode: "NO_CAPABILITY" },
+  );
+});
+
+it("threads x-correlation-id into grant context", async () => {
+  const res = await POST(
+    new NextRequest(new URL("/api/admin/authz/grants", "http://localhost:3000"), {
+      method: "POST",
+      headers: { "x-correlation-id": "corr-admin-grant" },
+      body: JSON.stringify(validGrant),
+    }),
+  );
+  expect(res.status).toBe(200);
+  expect(mockGrant).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ correlationId: "corr-admin-grant" }),
+  );
+});
+
+it("returns 400 for an invalid grant body", async () => {
+  const res = await POST(body({ resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "frobnicate" }));
+  expect(res.status).toBe(400);
+  expect(mockGrant).not.toHaveBeenCalled();
+});
+
+it("returns 400 when the capability is unsupported by the resource type", async () => {
+  const res = await POST(body({ resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "ingest" }));
+  expect(res.status).toBe(400);
+  expect(mockGrant).not.toHaveBeenCalled();
+});
+
+it("returns 400 for high-risk everyone grants", async () => {
+  const res = await POST(body({ resource: { type: "agent", id: "pe" }, grantee: { type: "everyone" }, capability: "manage" }));
+  expect(res.status).toBe(400);
+  expect(mockGrant).not.toHaveBeenCalled();
+});
+
+it("returns 401 without a session", async () => {
+  mockGetServerSession.mockResolvedValue(null);
+  const res = await POST(body(validGrant));
+  expect(res.status).toBe(401);
+});
+
+it("does not require admin_ui/audit.view — resource managers may grant", async () => {
+  const res = await POST(body(validGrant));
+  // Succeeds purely on can_manage (no admin gate)
+  expect(res.status).toBe(200);
+});

--- a/ui/src/app/api/__tests__/authz-resources.test.ts
+++ b/ui/src/app/api/__tests__/authz-resources.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockGetServerSession = jest.fn();
+const mockRequireRbac = jest.fn();
+const mockReadTuples = jest.fn();
+const mockToArray = jest.fn();
+
+jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(message: string, public statusCode = 500, public code?: string) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    requireRbacPermission: (...a: unknown[]) => mockRequireRbac(...a),
+    withErrorHandler:
+      <T,>(h: (...a: unknown[]) => Promise<T>) =>
+      async (...a: unknown[]) => {
+        try {
+          return await h(...a);
+        } catch (e) {
+          return Response.json(
+            { success: false, error: e instanceof Error ? e.message : "error" },
+            { status: (e as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+jest.mock("@/lib/rbac/openfga", () => ({ readOpenFgaTuples: (...a: unknown[]) => mockReadTuples(...a) }));
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: jest.fn(async (name: string) => ({
+    find: () => ({ limit: () => ({ toArray: () => mockToArray(name) }) }),
+  })),
+}));
+jest.mock("@/lib/rbac/slack-channel-grant-store", () => ({ slackChannelSubjectId: (w: string, c: string) => `${w}--${c}` }));
+jest.mock("@/lib/rbac/webex-space-grant-store", () => ({ webexSpaceSubjectId: (w: string, s: string) => `${w}--${s}` }));
+
+import { GET } from "../admin/authz/resources/route";
+
+function req(qs = ""): NextRequest {
+  return new NextRequest(new URL(`/api/admin/authz/resources${qs}`, "http://localhost:3000"));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue({ user: { email: "admin@acme.com" }, sub: "admin", org: "acme" });
+  mockRequireRbac.mockResolvedValue(undefined);
+  mockToArray.mockResolvedValue([]);
+});
+
+it("returns distinct ids (label = id) for the requested type, filtering out other types/wildcards/usersets", async () => {
+  mockReadTuples.mockResolvedValue({
+    tuples: [
+      { key: { object: "agent:pe" } },
+      { key: { object: "agent:agent-sre-agent" } },
+      { key: { object: "agent:pe" } }, // duplicate → deduped
+      { key: { object: "agent:*" } }, // wildcard → excluded
+      { key: { object: "team:eng" } }, // other type → excluded
+      { key: { object: "skill:foo" } }, // other type → excluded
+    ],
+    continuationToken: undefined,
+  });
+  const res = await GET(req("?type=agent"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.resources).toEqual([
+    { id: "agent-sre-agent", label: "agent-sre-agent" },
+    { id: "pe", label: "pe" },
+  ]);
+  expect(mockReadTuples.mock.calls[0][0]?.tuple).toBeUndefined(); // no bare type-prefix filter
+});
+
+it("labels slack_channel ids with their canonical channel name", async () => {
+  mockReadTuples.mockResolvedValue({
+    tuples: [{ key: { object: "slack_channel:caipe--C06H2HEG6N" } }],
+    continuationToken: undefined,
+  });
+  mockToArray.mockImplementation(async (name: string) =>
+    name === "channel_team_mappings"
+      ? [{ slack_workspace_id: "caipe", slack_channel_id: "C06H2HEG6N", channel_name: "platform-eng" }]
+      : [],
+  );
+  const res = await GET(req("?type=slack_channel"));
+  const body = await res.json();
+  expect(body.resources).toEqual([{ id: "caipe--C06H2HEG6N", label: "platform-eng" }]);
+});
+
+it("labels task ids with the workflow's canonical name", async () => {
+  mockReadTuples.mockResolvedValue({
+    tuples: [{ key: { object: "task:wf-1780625072483-fz5heofst" } }],
+    continuationToken: undefined,
+  });
+  mockToArray.mockImplementation(async (name: string) =>
+    name === "workflow_configs"
+      ? [{ _id: "wf-1780625072483-fz5heofst", name: "Movie guessing workflow" }]
+      : [],
+  );
+  const res = await GET(req("?type=task"));
+  const body = await res.json();
+  expect(body.resources).toEqual([{ id: "wf-1780625072483-fz5heofst", label: "Movie guessing workflow" }]);
+});
+
+it("rejects an unknown resource type with 400", async () => {
+  const res = await GET(req("?type=nope"));
+  expect(res.status).toBe(400);
+  expect(mockReadTuples).not.toHaveBeenCalled();
+});
+
+it("returns 401 without a session", async () => {
+  mockGetServerSession.mockResolvedValue(null);
+  const res = await GET(req("?type=agent"));
+  expect(res.status).toBe(401);
+});
+
+it("degrades to an empty catalog when OpenFGA read fails", async () => {
+  mockReadTuples.mockRejectedValue(new Error("openfga down"));
+  const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  const res = await GET(req("?type=agent"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ resources: [], error: "catalog_unavailable" });
+  warn.mockRestore();
+});
+
+it("enforces the audit.view admin gate", async () => {
+  mockReadTuples.mockResolvedValue({ tuples: [], continuationToken: undefined });
+  await GET(req("?type=skill"));
+  expect(mockRequireRbac).toHaveBeenCalledWith(expect.anything(), "admin_ui", "audit.view");
+});

--- a/ui/src/app/api/__tests__/authz-stats.test.ts
+++ b/ui/src/app/api/__tests__/authz-stats.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockGetAuth = jest.fn();
+const mockRequireBaseline = jest.fn();
+const mockGetEngineStats = jest.fn();
+const mockGetCollection = jest.fn();
+let mongoConfigured = true;
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(message: string, public statusCode = 500, public code?: string) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...a: unknown[]) => mockGetAuth(...a),
+    withErrorHandler:
+      <T,>(h: (...a: unknown[]) => Promise<T>) =>
+      async (...a: unknown[]) => {
+        try {
+          return await h(...a);
+        } catch (e) {
+          return Response.json(
+            { success: false, error: e instanceof Error ? e.message : "error" },
+            { status: (e as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+jest.mock("@/lib/rbac/require-openfga", () => ({
+  requireBaselineAdminSurfaceRead: (...a: unknown[]) => mockRequireBaseline(...a),
+}));
+jest.mock("@/lib/authz", () => ({ getEngineStats: (...a: unknown[]) => mockGetEngineStats(...a) }));
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...a: unknown[]) => mockGetCollection(...a),
+  get isMongoDBConfigured() {
+    return mongoConfigured;
+  },
+}));
+
+import { GET } from "../admin/authz/stats/route";
+
+function req(qs = ""): NextRequest {
+  return new NextRequest(new URL(`/api/admin/authz/stats${qs}`, "http://localhost:3000"));
+}
+
+const ENGINE = { circuitState: "closed", cacheSize: 3, cacheHits: 7, cacheMisses: 3, cacheHitRatio: 0.7 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mongoConfigured = true;
+  mockGetAuth.mockResolvedValue({ session: { org: "acme" } });
+  mockRequireBaseline.mockResolvedValue(undefined);
+  mockGetEngineStats.mockReturnValue(ENGINE);
+});
+
+it("aggregates decision stats from audit_events and includes the live engine snapshot", async () => {
+  const aggregate = jest.fn((pipeline: unknown[]) => {
+    const grp = (pipeline[1] as { $group: { _id: string } }).$group._id;
+    const rows = grp === "$reason_code"
+      ? [{ _id: "OK", count: 8 }, { _id: "NO_CAPABILITY", count: 2 }]
+      : [{ _id: "agent:pe", count: 2 }];
+    return { toArray: async () => rows };
+  });
+  const countDocuments = jest
+    .fn()
+    .mockResolvedValueOnce(10) // total
+    .mockResolvedValueOnce(8) // allow
+    .mockResolvedValueOnce(2); // deny
+  mockGetCollection.mockResolvedValue({ countDocuments, aggregate });
+
+  const res = await GET(req("?window=24h"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.engine).toEqual(ENGINE);
+  expect(body.persistence).toBe(true);
+  expect(body.decisions).toMatchObject({
+    total: 10,
+    allow: 8,
+    deny: 2,
+    denyRate: 0.2,
+    byReason: [{ reason: "OK", count: 8 }, { reason: "NO_CAPABILITY", count: 2 }],
+    topDenied: [{ resource: "agent:pe", count: 2 }],
+  });
+  // tenant scoping applied
+  expect(countDocuments.mock.calls[0][0]).toMatchObject({ type: "cas_decision", tenant_id: "acme" });
+});
+
+it("returns engine-only stats with persistence:false when Mongo is unconfigured", async () => {
+  mongoConfigured = false;
+  const res = await GET(req("?window=1h"));
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({ engine: ENGINE, decisions: null, persistence: false });
+  expect(mockGetCollection).not.toHaveBeenCalled();
+});
+
+it("rejects an invalid window with 400", async () => {
+  const res = await GET(req("?window=99y"));
+  expect(res.status).toBe(400);
+});
+
+it("enforces the metrics admin surface gate", async () => {
+  await GET(req("?window=24h"));
+  expect(mockRequireBaseline).toHaveBeenCalledWith(expect.anything(), "metrics");
+});

--- a/ui/src/app/api/__tests__/authz-v1-grants.test.ts
+++ b/ui/src/app/api/__tests__/authz-v1-grants.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+const mockGetAuth = jest.fn();
+const mockAuthorize = jest.fn();
+const mockGrant = jest.fn();
+const mockRevoke = jest.fn();
+const mockEmitGrantAudit = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => ({
+  getAuthFromBearerOrSession: (...a: unknown[]) => mockGetAuth(...a),
+}));
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+  grant: (...a: unknown[]) => mockGrant(...a),
+  revoke: (...a: unknown[]) => mockRevoke(...a),
+}));
+jest.mock("@/lib/authz/audit", () => ({
+  emitGrantAudit: (...a: unknown[]) => mockEmitGrantAudit(...a),
+}));
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn(), isMongoDBConfigured: false }));
+
+import { POST, DELETE } from "../authz/v1/grants/route";
+
+function req(b: unknown, method = "POST"): NextRequest {
+  return new NextRequest(new URL("/api/authz/v1/grants", "http://localhost:3000"), {
+    method,
+    body: JSON.stringify(b),
+  });
+}
+
+const validGrant = { resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAuth.mockResolvedValue({ session: { sub: "alice", org: "acme" } });
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK" });
+});
+
+it("grants when the caller can manage the resource", async () => {
+  const res = await POST(req(validGrant));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ granted: true });
+  expect(mockGrant).toHaveBeenCalledWith(
+    { resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" },
+    expect.objectContaining({
+      tenantId: "acme",
+      caller: { type: "user", id: "alice" },
+      correlationId: expect.any(String),
+    }),
+  );
+  expect(mockEmitGrantAudit).not.toHaveBeenCalled();
+});
+
+it("revokes on DELETE", async () => {
+  const res = await DELETE(req(validGrant, "DELETE"));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ revoked: true });
+  expect(mockRevoke).toHaveBeenCalled();
+});
+
+it("returns 403 when caller cannot manage the resource", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+  const res = await POST(req(validGrant));
+  expect(res.status).toBe(403);
+  expect(mockGrant).not.toHaveBeenCalled();
+  expect(mockEmitGrantAudit).toHaveBeenCalledWith(
+    "grant",
+    { resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" },
+    expect.objectContaining({ caller: { type: "user", id: "alice" }, tenantId: "acme" }),
+    { outcome: "error", reasonCode: "NO_CAPABILITY" },
+  );
+});
+
+it("audits failed revoke attempts on meta-authz deny", async () => {
+  mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE" });
+  const res = await DELETE(req(validGrant, "DELETE"));
+  expect(res.status).toBe(503);
+  expect(mockRevoke).not.toHaveBeenCalled();
+  expect(mockEmitGrantAudit).toHaveBeenCalledWith(
+    "revoke",
+    expect.any(Object),
+    expect.objectContaining({ caller: { type: "user", id: "alice" } }),
+    { outcome: "error", reasonCode: "AUTHZ_UNAVAILABLE" },
+  );
+});
+
+it("threads x-correlation-id into grant context", async () => {
+  const r = new NextRequest(new URL("/api/authz/v1/grants", "http://localhost:3000"), {
+    method: "POST",
+    headers: { "x-correlation-id": "corr-v1-grant" },
+    body: JSON.stringify(validGrant),
+  });
+  const res = await POST(r);
+  expect(res.status).toBe(200);
+  expect(mockGrant).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ correlationId: "corr-v1-grant" }),
+  );
+});
+
+it("returns 401 with no auth", async () => {
+  mockGetAuth.mockRejectedValue(new Error("no auth"));
+  const res = await POST(req(validGrant));
+  expect(res.status).toBe(401);
+});
+
+it("returns 401 when session has no stable sub", async () => {
+  mockGetAuth.mockResolvedValue({ session: { catalogKey: "k" } });
+  const res = await POST(req(validGrant));
+  expect(res.status).toBe(401);
+});
+
+it("returns 400 for an unrecognized capability", async () => {
+  const res = await POST(req({ ...validGrant, capability: "frobnicate" }));
+  expect(res.status).toBe(400);
+  expect(mockGrant).not.toHaveBeenCalled();
+});
+
+it("returns 400 when the capability is unsupported by the resource type", async () => {
+  const res = await POST(req({ ...validGrant, capability: "ingest" }));
+  expect(res.status).toBe(400);
+  expect(mockGrant).not.toHaveBeenCalled();
+});
+
+it("returns 400 for high-risk everyone grants", async () => {
+  const res = await POST(req({ ...validGrant, grantee: { type: "everyone" }, capability: "manage" }));
+  expect(res.status).toBe(400);
+  expect(mockGrant).not.toHaveBeenCalled();
+});
+
+it("returns 400 for malformed JSON", async () => {
+  const r = new NextRequest(new URL("/api/authz/v1/grants", "http://localhost:3000"), { method: "POST", body: "{bad" });
+  expect((await POST(r)).status).toBe(400);
+});
+
+it("does not require admin_ui/audit.view — any resource manager may grant", async () => {
+  // Regular user (no admin role) with can_manage on the resource
+  mockGetAuth.mockResolvedValue({ session: { sub: "regular-user" } });
+  mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK" });
+  const res = await POST(req(validGrant));
+  expect(res.status).toBe(200);
+});

--- a/ui/src/app/api/admin/audit-events/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/audit-events/__tests__/route.test.ts
@@ -2,6 +2,8 @@
  * @jest-environment node
  */
 
+// assisted-by Codex Codex-sonnet-4-6
+
 import { NextRequest } from "next/server";
 
 const mockGetServerSession = jest.fn();
@@ -48,12 +50,25 @@ interface TestAuditDoc {
   type: string;
   tenant_id: string;
   subject_hash: string;
+  user_email?: string;
   action: string;
   outcome: string;
   correlation_id: string;
   source: string;
   agent_name?: string;
   tool_name?: string;
+  actor_hash?: string;
+  caller_ref?: string;
+  grantee_ref?: string;
+  operation?: string;
+  reason_code?: string;
+  resource_ref?: string;
+  resource_type?: string;
+  resource_id?: string;
+  workflow_run_id?: string;
+  decision_via?: string;
+  component?: string;
+  pdp?: string;
 }
 
 const docs: TestAuditDoc[] = [
@@ -61,7 +76,8 @@ const docs: TestAuditDoc[] = [
     ts: new Date("2026-05-17T16:59:23.000Z"),
     type: "auth",
     tenant_id: "default",
-    subject_hash: "hash-admin-view",
+    subject_hash: "sha256:workflow-owner",
+    user_email: "sraradhy@cisco.com",
     action: "admin_ui#view",
     outcome: "allow",
     correlation_id: "admin-view-correlation",
@@ -120,11 +136,69 @@ const docs: TestAuditDoc[] = [
     correlation_id: "openfga-correlation",
     source: "webui_backend",
   },
+  {
+    ts: new Date("2026-05-17T16:59:28.500Z"),
+    type: "cas_decision",
+    tenant_id: "default",
+    subject_hash: "sha256:workflow-owner",
+    action: "use",
+    outcome: "allow",
+    correlation_id: "wfrun-20260517165928-abc",
+    source: "cas",
+    reason_code: "OK",
+    resource_ref: "agent:hello-world",
+    resource_type: "agent",
+    resource_id: "hello-world",
+    workflow_run_id: "wfrun-20260517165928-abc",
+    decision_via: "tuple",
+    component: "cas",
+    pdp: "openfga",
+  },
+  {
+    ts: new Date("2026-05-17T16:59:29.000Z"),
+    type: "cas_grant",
+    tenant_id: "acme",
+    subject_hash: "hash-caller",
+    actor_hash: "hash-caller",
+    action: "use",
+    outcome: "success",
+    correlation_id: "grant-success-correlation",
+    source: "cas",
+    caller_ref: "user:alice",
+    grantee_ref: "team:eng",
+    operation: "grant",
+    resource_ref: "agent:platform-engineer",
+    component: "cas",
+    pdp: "openfga",
+  },
+  {
+    ts: new Date("2026-05-17T16:59:30.000Z"),
+    type: "cas_grant",
+    tenant_id: "acme",
+    subject_hash: "hash-caller",
+    actor_hash: "hash-caller",
+    action: "use",
+    outcome: "error",
+    correlation_id: "grant-deny-correlation",
+    source: "cas",
+    caller_ref: "user:alice",
+    grantee_ref: "team:eng",
+    operation: "grant",
+    reason_code: "NO_CAPABILITY",
+    resource_ref: "agent:platform-engineer",
+    component: "cas",
+    pdp: "openfga",
+  },
 ];
 
 function applyFilter(filter: Record<string, unknown>): TestAuditDoc[] {
   return docs.filter((doc) => {
     if (filter.type && doc.type !== filter.type) return false;
+    const subjectHash = filter.subject_hash as { $in?: string[] } | undefined;
+    if (subjectHash?.$in && !subjectHash.$in.includes(doc.subject_hash)) return false;
+    const emailFilter = filter.user_email as { $exists?: boolean; $ne?: unknown } | undefined;
+    if (emailFilter?.$exists === true && !doc.user_email) return false;
+    if (emailFilter?.$ne === "" && doc.user_email === "") return false;
     const action = filter.action as { $ne?: string; $nin?: string[] } | undefined;
     if (action?.$ne && doc.action === action.$ne) return false;
     if (action?.$nin?.includes(doc.action)) return false;
@@ -139,6 +213,7 @@ function mockAuditCollection() {
       const filtered = applyFilter(filter);
       const chain = {
         sort: jest.fn(() => chain),
+        project: jest.fn(() => chain),
         skip: jest.fn(() => chain),
         limit: jest.fn(() => chain),
         toArray: jest.fn(async () => filtered),
@@ -179,6 +254,9 @@ describe("GET /api/admin/audit-events", () => {
       "argocd_list_applications",
       "delegate_to_argocd",
       "agent#use",
+      "use",
+      "use",
+      "use",
     ]);
     expect(body.records.map((record: TestAuditDoc) => record.type)).toEqual([
       "auth",
@@ -187,6 +265,9 @@ describe("GET /api/admin/audit-events", () => {
       "tool_action",
       "agent_delegation",
       "openfga_rebac",
+      "cas_decision",
+      "cas_grant",
+      "cas_grant",
     ]);
   });
 
@@ -202,5 +283,70 @@ describe("GET /api/admin/audit-events", () => {
       "admin_ui#audit.view",
       "system_config#read",
     ]);
+  });
+
+  it("filters cas_grant policy-change events and maps grant audit fields", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/audit-events?type=cas_grant"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.records).toHaveLength(2);
+    expect(body.records[0]).toMatchObject({
+      type: "cas_grant",
+      outcome: "success",
+      operation: "grant",
+      caller_ref: "user:alice",
+      grantee_ref: "team:eng",
+      resource_ref: "agent:platform-engineer",
+      source: "cas",
+      tenant_id: "acme",
+    });
+    expect(body.records[1]).toMatchObject({
+      type: "cas_grant",
+      outcome: "error",
+      reason_code: "NO_CAPABILITY",
+      operation: "grant",
+    });
+  });
+
+  it("preserves CAS resource and workflow fields for downloadable audit evidence", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/audit-events?type=cas_decision"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]).toMatchObject({
+      type: "cas_decision",
+      outcome: "allow",
+      action: "use",
+      reason_code: "OK",
+      resource_ref: "agent:hello-world",
+      resource_type: "agent",
+      resource_id: "hello-world",
+      workflow_run_id: "wfrun-20260517165928-abc",
+      decision_via: "tuple",
+      user_email: "sraradhy@cisco.com",
+      source: "cas",
+      component: "cas",
+      pdp: "openfga",
+    });
+  });
+
+  it("enriches rows missing user_email from matching subject_hash audit rows", async () => {
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/audit-events?type=cas_decision"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.records[0]).toMatchObject({
+      type: "cas_decision",
+      subject_hash: "sha256:workflow-owner",
+      user_email: "sraradhy@cisco.com",
+    });
   });
 });

--- a/ui/src/app/api/admin/audit-events/route.ts
+++ b/ui/src/app/api/admin/audit-events/route.ts
@@ -9,9 +9,11 @@ UnifiedAuditOutcome,
 import { getServerSession } from "next-auth";
 import { NextRequest,NextResponse } from "next/server";
 
+// assisted-by Codex Codex-sonnet-4-6
+
 const COLLECTION = "audit_events";
 
-const VALID_TYPES: AuditEventType[] = ["auth", "tool_action", "agent_delegation", "openfga_rebac"];
+const VALID_TYPES: AuditEventType[] = ["auth", "tool_action", "agent_delegation", "openfga_rebac", "cas_decision", "cas_grant"];
 const VALID_OUTCOMES: UnifiedAuditOutcome[] = ["allow", "deny", "success", "error"];
 
 interface AuditEventDocument {
@@ -31,11 +33,19 @@ interface AuditEventDocument {
   context_id?: string;
   component?: string;
   resource_ref?: string;
+  resource_type?: string;
+  resource_id?: string;
+  workflow_run_id?: string;
+  decision_via?: string;
   pdp?: string;
   source: string;
   trace_id?: string;
   span_id?: string;
   trace_url?: string;
+  actor_hash?: string;
+  caller_ref?: string;
+  grantee_ref?: string;
+  operation?: "grant" | "revoke";
 }
 
 function normalizeAuditSource(source: string): UnifiedAuditEvent["source"] {
@@ -76,11 +86,61 @@ function documentToEvent(doc: AuditEventDocument): UnifiedAuditEvent {
     context_id: doc.context_id,
     component: doc.component,
     resource_ref: doc.resource_ref,
+    resource_type: doc.resource_type,
+    resource_id: doc.resource_id,
+    workflow_run_id: doc.workflow_run_id,
+    decision_via: doc.decision_via,
     pdp: doc.pdp,
     source: normalizeAuditSource(doc.source),
+    actor_hash: doc.actor_hash,
+    caller_ref: doc.caller_ref,
+    grantee_ref: doc.grantee_ref,
+    operation: doc.operation,
     trace_id: doc.trace_id,
     span_id: doc.span_id,
   };
+}
+
+async function enrichMissingUserEmails(
+  coll: Awaited<ReturnType<typeof getCollection<AuditEventDocument>>>,
+  records: UnifiedAuditEvent[],
+): Promise<UnifiedAuditEvent[]> {
+  const hashes = Array.from(
+    new Set(
+      records
+        .filter((record) => !record.user_email && record.subject_hash)
+        .map((record) => record.subject_hash),
+    ),
+  );
+  if (hashes.length === 0) return records;
+
+  const lookupRows = await coll
+    .find({
+      subject_hash: { $in: hashes },
+      user_email: { $exists: true, $ne: "" },
+    } as Record<string, unknown>)
+    .sort({ ts: -1 })
+    .project({ subject_hash: 1, user_email: 1 })
+    .limit(hashes.length * 5)
+    .toArray();
+
+  const emailByHash = new Map<string, string>();
+  for (const row of lookupRows) {
+    if (emailByHash.has(row.subject_hash)) continue;
+    if (typeof row.user_email === "string" && row.user_email.trim()) {
+      emailByHash.set(row.subject_hash, row.user_email.trim());
+    }
+  }
+
+  if (emailByHash.size === 0) return records;
+  return records.map((record) =>
+    record.user_email
+      ? record
+      : {
+          ...record,
+          user_email: emailByHash.get(record.subject_hash),
+        },
+  );
 }
 
 export const GET = withErrorHandler(async (request: NextRequest): Promise<NextResponse> => {
@@ -203,7 +263,7 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
       .toArray(),
   ]);
 
-  const records: UnifiedAuditEvent[] = docs.map(documentToEvent);
+  const records = await enrichMissingUserEmails(coll, docs.map(documentToEvent));
 
   return NextResponse.json({ records, total, page, limit });
 });

--- a/ui/src/app/api/admin/authz/explain/route.ts
+++ b/ui/src/app/api/admin/authz/explain/route.ts
@@ -1,0 +1,174 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// POST /api/admin/authz/explain — admin permission debugger.
+//
+// "Why can/can't subject S do action A on resource R?" Returns the CAS
+// decision plus the OpenFGA debug block (the relation actually checked).
+// Admin-gated (admin_ui / audit.view); no subject-binding because this is a
+// privileged forensic tool, not a self-service decision call.
+//
+// Single action  → { decision, reason, retriable, debug }            (back-compat)
+// `actions: [..]` (or neither field) → { results: [ {action, decision, reason, retriable, debug} ] }
+//   — the permission-matrix view: every action for one subject+resource at once.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth-config";
+import { requireRbacPermission, withErrorHandler, ApiError } from "@/lib/api-middleware";
+import { authorize, describeFgaCheck, type Action, type Resource, type Subject } from "@/lib/authz";
+import { HttpAuthzError, parseAction, parseResource, parseSubject } from "@/lib/authz/http";
+import { readOpenFgaTuples, type OpenFgaTupleKey } from "@/lib/rbac/openfga";
+import { isSupportedResourceAction, listResourceTypeDefinitions } from "@/lib/rbac/resource-model";
+import { openFgaObject, openFgaRelation } from "@/lib/rbac/tuple-builders";
+
+const ALL_ACTIONS = Array.from(
+  new Set(listResourceTypeDefinitions().flatMap((definition) => definition.actions)),
+) as Action[];
+
+function directGrantTuple(subject: Subject, resource: Resource, action: Action): OpenFgaTupleKey {
+  return {
+    user: `${subject.type}:${subject.id}`,
+    relation: openFgaRelation(action),
+    object: openFgaObject(resource),
+  };
+}
+
+function tupleLabel(tuple: OpenFgaTupleKey): string {
+  return `${tuple.user} ${tuple.relation} ${tuple.object}`;
+}
+
+function tupleMatches(a: OpenFgaTupleKey, b: OpenFgaTupleKey): boolean {
+  return a.user === b.user && a.relation === b.relation && a.object === b.object;
+}
+
+async function explainDirectGrant(subject: Subject, resource: Resource, action: Action) {
+  const tuple = directGrantTuple(subject, resource, action);
+  try {
+    const page = await readOpenFgaTuples({ tuple, pageSize: 1 });
+    const present = page.tuples.some((entry) => tupleMatches(entry.key, tuple));
+    return {
+      tuple: tupleLabel(tuple),
+      present,
+      revocable: present,
+    };
+  } catch {
+    return {
+      tuple: tupleLabel(tuple),
+      present: false,
+      revocable: false,
+      lookup_error: "DIRECT_GRANT_LOOKUP_FAILED",
+    };
+  }
+}
+
+function explainOne(subject: Subject, resource: Resource, action: Action, tenantId?: string) {
+  return (async () => {
+    const req = { subject, resource, action };
+    const fga = describeFgaCheck(req);
+    if (!isSupportedResourceAction(resource.type, action)) {
+      return {
+        action,
+        supported: false,
+        decision: "DENY" as const,
+        reason: "INVALID_REQUEST" as const,
+        unsupportedReason: "capability is not supported for this resource type",
+        retriable: false,
+        via: null,
+        debug: {
+          engine: fga.engine,
+          relation: fga.relation,
+          checked: [`${fga.user} ${fga.relation} ${fga.object}`],
+          store: fga.store,
+        },
+      };
+    }
+    const result = await authorize(req, { tenantId });
+    const directGrant =
+      result.decision === "ALLOW" && result.via === "tuple"
+        ? await explainDirectGrant(subject, resource, action)
+        : undefined;
+    return {
+      action,
+      decision: result.decision,
+      supported: true,
+      reason: result.reason,
+      retriable: result.retriable,
+      via: result.via ?? null,
+      ...(directGrant ? { directGrant } : {}),
+      debug: {
+        engine: fga.engine,
+        relation: fga.relation,
+        checked: [`${fga.user} ${fga.relation} ${fga.object}`],
+        store: fga.store,
+      },
+    };
+  })();
+}
+
+export const POST = withErrorHandler(async (request: NextRequest): Promise<NextResponse> => {
+  const session = (await getServerSession(authOptions)) as {
+    accessToken?: string;
+    sub?: string;
+    org?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email) {
+    throw new ApiError("Unauthorized", 401);
+  }
+
+  await requireRbacPermission(
+    {
+      accessToken: session.accessToken,
+      sub: session.sub,
+      org: session.org,
+      user: { email: session.user.email ?? undefined },
+    },
+    "admin_ui",
+    "audit.view",
+  );
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new ApiError("Request body must be valid JSON", 400, "VALIDATION_ERROR");
+  }
+  if (!body || typeof body !== "object") {
+    throw new ApiError("Request body must be an object", 400, "VALIDATION_ERROR");
+  }
+  const b = body as Record<string, unknown>;
+
+  let subject: Subject;
+  let resource: Resource;
+  let singleAction: Action | null = null;
+  let actions: Action[];
+  try {
+    subject = parseSubject(b.subject);
+    resource = parseResource(b.resource);
+    if (Array.isArray(b.actions)) {
+      // Matrix mode: validate each requested action (empty → all).
+      actions = (b.actions.length > 0 ? b.actions : ALL_ACTIONS).map(parseAction);
+    } else if (b.action != null) {
+      singleAction = parseAction(b.action);
+      actions = [singleAction];
+    } else {
+      // Neither field → evaluate the full matrix.
+      actions = ALL_ACTIONS;
+    }
+  } catch (err) {
+    if (err instanceof HttpAuthzError) {
+      throw new ApiError(err.message, err.status, err.code);
+    }
+    throw err;
+  }
+
+  const results = await Promise.all(actions.map((a) => explainOne(subject, resource, a, session.org)));
+
+  // Back-compat: a single `action` returns the flat shape; everything else
+  // (matrix) returns { results: [...] }.
+  const payload = singleAction !== null ? results[0] : { results };
+
+  return NextResponse.json(payload, { headers: { "Cache-Control": "no-store" } });
+});

--- a/ui/src/app/api/admin/authz/grants/route.ts
+++ b/ui/src/app/api/admin/authz/grants/route.ts
@@ -1,0 +1,60 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// POST   /api/admin/authz/grants  — grant a capability to a grantee on a resource
+// DELETE /api/admin/authz/grants  — revoke it
+//
+// Auth: authenticated session with a stable subject + per-resource meta-authz
+// (caller must hold `manage` on the resource; org admins bypass via CAS).
+// No admin_ui/audit.view prerequisite — resource managers can grant without
+// needing admin-console access. For admin-UI consumers use this endpoint;
+// for product sharing flows use /api/authz/v1/grants (same auth, versioned).
+// Body: { resource:{type,id}, grantee:{type,id?}, capability }
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth-config";
+import { withErrorHandler, ApiError } from "@/lib/api-middleware";
+import { grant, revoke } from "@/lib/authz";
+import { HttpAuthzError, decisionContext, parseGrantIntent, requireManage } from "@/lib/authz/http";
+
+async function handle(request: NextRequest, op: "grant" | "revoke"): Promise<NextResponse> {
+  const session = (await getServerSession(authOptions)) as {
+    accessToken?: string;
+    sub?: string;
+    org?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email) throw new ApiError("Unauthorized", 401);
+  if (!session.sub) throw new ApiError("A stable subject is required", 401, "NO_SUBJECT");
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new ApiError("Request body must be valid JSON", 400, "VALIDATION_ERROR");
+  }
+
+  const caller = { type: "user" as const, id: session.sub };
+  const ctx = decisionContext(session, caller, request);
+  try {
+    const intent = parseGrantIntent(body);
+    await requireManage(caller, intent.resource, ctx, { operation: op, intent });
+    if (op === "grant") {
+      await grant(intent, ctx);
+    } else {
+      await revoke(intent, ctx);
+    }
+    return NextResponse.json(
+      op === "grant" ? { granted: true } : { revoked: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    if (err instanceof HttpAuthzError) throw new ApiError(err.message, err.status, err.code);
+    throw err;
+  }
+}
+
+export const POST = withErrorHandler((request: NextRequest) => handle(request, "grant"));
+export const DELETE = withErrorHandler((request: NextRequest) => handle(request, "revoke"));

--- a/ui/src/app/api/admin/authz/resources/route.ts
+++ b/ui/src/app/api/admin/authz/resources/route.ts
@@ -1,0 +1,130 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// GET /api/admin/authz/resources?type=<resourceType>
+//
+// Lists the distinct resource ids of a given type that actually exist in the
+// OpenFGA authorization graph (objects that appear in any tuple). This is the
+// right source for the Permission Debugger's resource picker: it reflects what
+// the PDP can actually decide on — including built-in agents that aren't in the
+// dynamic_agents Mongo collection. Admin-gated (admin_ui / audit.view).
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth-config";
+import { requireRbacPermission, withErrorHandler, ApiError } from "@/lib/api-middleware";
+import { listResourceTypeDefinitions } from "@/lib/rbac/resource-model";
+import { readOpenFgaTuples } from "@/lib/rbac/openfga";
+import { getCollection } from "@/lib/mongodb";
+import { slackChannelSubjectId } from "@/lib/rbac/slack-channel-grant-store";
+import { webexSpaceSubjectId } from "@/lib/rbac/webex-space-grant-store";
+import type { ResourceType } from "@/lib/authz";
+
+const RESOURCE_TYPES: ReadonlySet<ResourceType> = new Set(
+  listResourceTypeDefinitions().map((definition) => definition.type),
+);
+
+// OpenFGA Read rejects a bare `object: "type:"` filter (it requires an object
+// id or a user). So we page through the whole tuple set and filter by type
+// prefix in code — bounded by MAX_PAGES for safety on large stores.
+const MAX_PAGES = 25;
+const PAGE_SIZE = 100;
+const LABEL_LOOKUP_LIMIT = 2000;
+
+/**
+ * Map opaque OpenFGA ids to human-readable names where a source of truth
+ * exists: slack/webex channels (mapping collections) and workflows (the
+ * `task` type → workflow_configs). Best-effort: falls back to the id.
+ */
+async function buildLabelMap(type: ResourceType): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    if (type === "slack_channel") {
+      const coll = await getCollection<{ slack_workspace_id?: string; slack_channel_id?: string; channel_name?: string }>("channel_team_mappings");
+      const rows = await coll.find({}).limit(LABEL_LOOKUP_LIMIT).toArray();
+      for (const r of rows) {
+        if (!r.slack_channel_id || !r.channel_name) continue;
+        map.set(slackChannelSubjectId(r.slack_workspace_id ?? "", r.slack_channel_id), r.channel_name);
+      }
+    } else if (type === "webex_space") {
+      const coll = await getCollection<{ webex_workspace_id?: string; webex_space_id?: string; space_name?: string; space_title?: string }>("webex_space_team_mappings");
+      const rows = await coll.find({}).limit(LABEL_LOOKUP_LIMIT).toArray();
+      for (const r of rows) {
+        if (!r.webex_space_id) continue;
+        const name = r.space_name ?? r.space_title;
+        if (name) map.set(webexSpaceSubjectId(r.webex_workspace_id ?? "", r.webex_space_id), name);
+      }
+    } else if (type === "task") {
+      // Workflows are graphed as `task` — surface the workflow's display name.
+      const coll = await getCollection<{ _id: unknown; name?: string }>("workflow_configs");
+      const rows = await coll.find({}).limit(LABEL_LOOKUP_LIMIT).toArray();
+      for (const r of rows) {
+        const id = typeof r._id === "string" ? r._id : String(r._id);
+        if (id && r.name) map.set(id, r.name);
+      }
+    }
+  } catch {
+    // best-effort — ids remain usable as labels
+  }
+  return map;
+}
+
+export const GET = withErrorHandler(async (request: NextRequest): Promise<NextResponse> => {
+  const session = (await getServerSession(authOptions)) as {
+    accessToken?: string;
+    sub?: string;
+    org?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email) {
+    throw new ApiError("Unauthorized", 401);
+  }
+  await requireRbacPermission(
+    {
+      accessToken: session.accessToken,
+      sub: session.sub,
+      org: session.org,
+      user: { email: session.user.email ?? undefined },
+    },
+    "admin_ui",
+    "audit.view",
+  );
+
+  const rawType = new URL(request.url).searchParams.get("type")?.trim();
+  if (!rawType || !RESOURCE_TYPES.has(rawType as ResourceType)) {
+    throw new ApiError(`\`type\` must be one of: ${[...RESOURCE_TYPES].join(", ")}`, 400, "VALIDATION_ERROR");
+  }
+  const type = rawType as ResourceType;
+
+  const prefix = `${type}:`;
+  const ids = new Set<string>();
+  let continuationToken: string | undefined;
+  let pages = 0;
+
+  try {
+    do {
+      const { tuples, continuationToken: next } = await readOpenFgaTuples({
+        pageSize: PAGE_SIZE,
+        continuationToken,
+      });
+      for (const t of tuples) {
+        const object = t.key?.object ?? "";
+        if (!object.startsWith(prefix)) continue;
+        const id = object.slice(prefix.length);
+        // Skip wildcards (`*`) and usersets (`team:x#member`); they aren't pickable resources.
+        if (id && id !== "*" && !id.includes("#")) ids.add(id);
+      }
+      continuationToken = next;
+      pages += 1;
+    } while (continuationToken && pages < MAX_PAGES);
+  } catch (err) {
+    // The debugger degrades to a text field if the catalog can't be read.
+    console.warn("[authz/resources] read failed:", err instanceof Error ? err.message : String(err));
+    return NextResponse.json({ resources: [], error: "catalog_unavailable" }, { headers: { "Cache-Control": "no-store" } });
+  }
+
+  const labels = await buildLabelMap(type);
+  const resources = [...ids].sort().map((id) => ({ id, label: labels.get(id) ?? id }));
+  return NextResponse.json({ resources }, { headers: { "Cache-Control": "no-store" } });
+});

--- a/ui/src/app/api/admin/authz/stats/route.ts
+++ b/ui/src/app/api/admin/authz/stats/route.ts
@@ -1,0 +1,94 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// GET /api/admin/authz/stats — CAS health + decision statistics.
+//
+//   engine    — live, per-replica adapter snapshot (circuit state, cache).
+//   decisions — durable aggregation over `audit_events` (cas_decision) in a
+//               time window: totals, deny rate, by-reason, top-denied.
+//
+// Gated by the same baseline "metrics" admin surface as /api/admin/metrics.
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthFromBearerOrSession, withErrorHandler, ApiError } from "@/lib/api-middleware";
+import { requireBaselineAdminSurfaceRead } from "@/lib/rbac/require-openfga";
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
+import { getEngineStats } from "@/lib/authz";
+
+const WINDOWS: Record<string, number> = {
+  "1h": 60 * 60 * 1000,
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+};
+
+interface CountRow {
+  _id: string;
+  count: number;
+}
+
+export const GET = withErrorHandler(async (request: NextRequest): Promise<NextResponse> => {
+  const { session } = await getAuthFromBearerOrSession(request);
+  await requireBaselineAdminSurfaceRead(session, "metrics");
+
+  const url = new URL(request.url);
+  const windowKey = url.searchParams.get("window") ?? "24h";
+  const windowMs = WINDOWS[windowKey];
+  if (!windowMs) {
+    throw new ApiError(`\`window\` must be one of: ${Object.keys(WINDOWS).join(", ")}`, 400, "VALIDATION_ERROR");
+  }
+
+  const engine = getEngineStats();
+
+  if (!isMongoDBConfigured) {
+    // Live engine stats still work without Mongo; decision history does not.
+    return NextResponse.json(
+      { engine, decisions: null, window: windowKey, persistence: false },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  const from = new Date(Date.now() - windowMs);
+  const baseFilter: Record<string, unknown> = { type: "cas_decision", ts: { $gte: from } };
+  const org = (session as { org?: string } | null)?.org;
+  if (org) baseFilter.tenant_id = org;
+
+  const coll = await getCollection<Record<string, unknown>>("audit_events");
+
+  const [total, allow, deny, byReasonRaw, topDeniedRaw] = await Promise.all([
+    coll.countDocuments(baseFilter),
+    coll.countDocuments({ ...baseFilter, outcome: "allow" }),
+    coll.countDocuments({ ...baseFilter, outcome: "deny" }),
+    coll
+      .aggregate<CountRow>([
+        { $match: baseFilter },
+        { $group: { _id: "$reason_code", count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ])
+      .toArray(),
+    coll
+      .aggregate<CountRow>([
+        { $match: { ...baseFilter, outcome: "deny" } },
+        { $group: { _id: "$resource_ref", count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 },
+      ])
+      .toArray(),
+  ]);
+
+  return NextResponse.json(
+    {
+      engine,
+      window: windowKey,
+      persistence: true,
+      decisions: {
+        total,
+        allow,
+        deny,
+        denyRate: total > 0 ? deny / total : 0,
+        byReason: byReasonRaw.map((r) => ({ reason: r._id ?? "UNKNOWN", count: r.count })),
+        topDenied: topDeniedRaw.map((r) => ({ resource: r._id ?? "unknown", count: r.count })),
+      },
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+});

--- a/ui/src/app/api/authz/v1/decisions/batch/route.ts
+++ b/ui/src/app/api/authz/v1/decisions/batch/route.ts
@@ -1,0 +1,84 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// POST /api/authz/v1/decisions/batch — batch decision: one subject + action
+// across a list of resource ids. Returns one Decision per id. Used for
+// list-filtering (accessible agents, datasources, workflow configs, …).
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthFromBearerOrSession } from "@/lib/api-middleware";
+import { authorizeMany } from "@/lib/authz";
+import {
+  HttpAuthzError,
+  decisionContext,
+  enforceSubjectBinding,
+  isValidId,
+  metaErrorResponse,
+  parseAction,
+  parseResourceType,
+  parseSubject,
+  resolveCaller,
+} from "@/lib/authz/http";
+
+export const dynamic = "force-dynamic";
+
+const MAX_IDS = 200;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let session: unknown;
+  try {
+    session = (await getAuthFromBearerOrSession(request)).session;
+  } catch {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  const caller = resolveCaller(session);
+  if (!caller) {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  try {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be valid JSON");
+    }
+    if (!body || typeof body !== "object") {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be an object");
+    }
+    const b = body as Record<string, unknown>;
+
+    const subject = parseSubject(b.subject);
+    const action = parseAction(b.action);
+    const resourceType = parseResourceType(b.resource_type);
+    const ctx = decisionContext(session);
+
+    if (!Array.isArray(b.ids) || b.ids.length === 0 || b.ids.length > MAX_IDS) {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", `ids must be a non-empty array of at most ${MAX_IDS} items`);
+    }
+    if (!b.ids.every(isValidId)) {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "ids contains an invalid identifier");
+    }
+    const ids = b.ids as string[];
+
+    await enforceSubjectBinding(caller, subject, ctx);
+
+    const results = await authorizeMany(subject, action, resourceType, ids, ctx);
+    const out = ids.map((id) => {
+      const r = results.get(id);
+      const result = r ?? { decision: "DENY" as const, reason: "AUTHZ_UNAVAILABLE" as const, retriable: true };
+      return { id, decision: result.decision, reason: result.reason, retriable: result.retriable ?? false };
+    });
+
+    // Surface PDP outage so callers can distinguish "no access" from "PDP down".
+    const degraded = out.some((r) => r.reason === "AUTHZ_UNAVAILABLE");
+    return NextResponse.json(
+      { results: out, ...(degraded ? { degraded: true, retriable: true } : {}) },
+      { status: 200 },
+    );
+  } catch (err) {
+    if (err instanceof HttpAuthzError) return metaErrorResponse(err);
+    throw err;
+  }
+}

--- a/ui/src/app/api/authz/v1/decisions/route.ts
+++ b/ui/src/app/api/authz/v1/decisions/route.ts
@@ -1,0 +1,75 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// POST /api/authz/v1/decisions — single authorization decision.
+// Verifies the caller JWT, enforces subject-binding, evaluates via CAS.
+// A DENY is a 200 with body (see spec §5.3); HTTP error codes are reserved
+// for meta-failures (401/403/400/503).
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthFromBearerOrSession } from "@/lib/api-middleware";
+import { authorize } from "@/lib/authz";
+import {
+  HttpAuthzError,
+  decisionContext,
+  enforceSubjectBinding,
+  metaErrorResponse,
+  parseAction,
+  parseResource,
+  parseSubject,
+  resolveCaller,
+  sanitizeAdvisoryContext,
+} from "@/lib/authz/http";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let session: unknown;
+  try {
+    session = (await getAuthFromBearerOrSession(request)).session;
+  } catch {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  const caller = resolveCaller(session);
+  if (!caller) {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  try {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be valid JSON");
+    }
+    if (!body || typeof body !== "object") {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be an object");
+    }
+    const b = body as Record<string, unknown>;
+
+    const subject = parseSubject(b.subject);
+    const resource = parseResource(b.resource);
+    const action = parseAction(b.action);
+    const ctx = decisionContext(session);
+
+    await enforceSubjectBinding(caller, subject, ctx);
+
+    const context = sanitizeAdvisoryContext(b.context);
+    const result = await authorize(
+      { subject, resource, action, ...(context ? { context } : {}) },
+      ctx,
+    );
+
+    if (result.reason === "AUTHZ_UNAVAILABLE") {
+      return NextResponse.json(
+        { error: "Authorization service temporarily unavailable", code: "AUTHZ_UNAVAILABLE", retriable: true },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof HttpAuthzError) return metaErrorResponse(err);
+    throw err;
+  }
+}

--- a/ui/src/app/api/authz/v1/explain/route.ts
+++ b/ui/src/app/api/authz/v1/explain/route.ts
@@ -1,0 +1,78 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// POST /api/authz/v1/explain — admin-only. The ONLY endpoint that surfaces
+// OpenFGA internals (relation strings, tuple shape, store id). Gated on
+// can_audit on the organization.
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthFromBearerOrSession } from "@/lib/api-middleware";
+import { authorize, describeFgaCheck } from "@/lib/authz";
+import {
+  HttpAuthzError,
+  decisionContext,
+  metaErrorResponse,
+  parseAction,
+  parseResource,
+  parseSubject,
+  requireAuditCapability,
+  resolveCaller,
+} from "@/lib/authz/http";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let session: unknown;
+  try {
+    session = (await getAuthFromBearerOrSession(request)).session;
+  } catch {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  const caller = resolveCaller(session);
+  if (!caller) {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  try {
+    const ctx = decisionContext(session);
+    await requireAuditCapability(caller, ctx);
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be valid JSON");
+    }
+    if (!body || typeof body !== "object") {
+      throw new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be an object");
+    }
+    const b = body as Record<string, unknown>;
+
+    const subject = parseSubject(b.subject);
+    const resource = parseResource(b.resource);
+    const action = parseAction(b.action);
+
+    const req = { subject, resource, action };
+    const result = await authorize(req, ctx);
+    const fga = describeFgaCheck(req);
+
+    return NextResponse.json(
+      {
+        decision: result.decision,
+        reason: result.reason,
+        retriable: result.retriable,
+        debug: {
+          engine: fga.engine,
+          relation: fga.relation,
+          checked: [`${fga.user} ${fga.relation} ${fga.object}`],
+          store: fga.store,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    if (err instanceof HttpAuthzError) return metaErrorResponse(err);
+    throw err;
+  }
+}

--- a/ui/src/app/api/authz/v1/grants/route.ts
+++ b/ui/src/app/api/authz/v1/grants/route.ts
@@ -1,0 +1,68 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// POST   /api/authz/v1/grants  — grant a capability to a grantee on a resource
+// DELETE /api/authz/v1/grants  — revoke it
+//
+// Product-facing PAP endpoint: resource managers (not just org admins) can
+// grant access to resources they own. Auth: authenticated session + subject-
+// binding + per-resource meta-authz (caller holds `manage` on the resource).
+// No admin_ui / audit.view prerequisite — this is the path for product sharing
+// flows (workflow share modal, agent-access modal, etc.).
+// Body: { resource:{type,id}, grantee:{type,id?}, capability }
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAuthFromBearerOrSession } from "@/lib/api-middleware";
+import { grant, revoke } from "@/lib/authz";
+import {
+  HttpAuthzError,
+  decisionContext,
+  metaErrorResponse,
+  parseGrantIntent,
+  requireManage,
+  resolveCaller,
+} from "@/lib/authz/http";
+
+export const dynamic = "force-dynamic";
+
+async function handle(request: NextRequest, op: "grant" | "revoke"): Promise<NextResponse> {
+  let session: unknown;
+  try {
+    session = (await getAuthFromBearerOrSession(request)).session;
+  } catch {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  const caller = resolveCaller(session);
+  if (!caller) {
+    return metaErrorResponse(new HttpAuthzError(401, "NOT_AUTHENTICATED", "Authentication required"));
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return metaErrorResponse(new HttpAuthzError(400, "INVALID_REQUEST", "Request body must be valid JSON"));
+  }
+
+  const ctx = decisionContext(session, caller, request);
+  try {
+    const intent = parseGrantIntent(body);
+    await requireManage(caller, intent.resource, ctx, { operation: op, intent });
+    if (op === "grant") {
+      await grant(intent, ctx);
+    } else {
+      await revoke(intent, ctx);
+    }
+    return NextResponse.json(
+      op === "grant" ? { granted: true } : { revoked: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    if (err instanceof HttpAuthzError) return metaErrorResponse(err);
+    throw err;
+  }
+}
+
+export const POST = (request: NextRequest) => handle(request, "grant");
+export const DELETE = (request: NextRequest) => handle(request, "revoke");

--- a/ui/src/components/admin/CasInsightsTab.tsx
+++ b/ui/src/components/admin/CasInsightsTab.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+// assisted-by claude code claude-opus-4-8
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Activity, RefreshCw, Loader2, ShieldCheck, ShieldX, Gauge, Database, Zap } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+interface EngineStats {
+  circuitState: "closed" | "open" | "half_open";
+  cacheSize: number;
+  cacheHits: number;
+  cacheMisses: number;
+  cacheHitRatio: number;
+}
+interface DecisionStats {
+  total: number;
+  allow: number;
+  deny: number;
+  denyRate: number;
+  byReason: { reason: string; count: number }[];
+  topDenied: { resource: string; count: number }[];
+}
+interface StatsResponse {
+  engine: EngineStats;
+  decisions: DecisionStats | null;
+  window: string;
+  persistence: boolean;
+}
+
+const WINDOW_OPTIONS = [
+  { value: "1h", label: "Last hour" },
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+];
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function CircuitBadge({ state }: { state: EngineStats["circuitState"] }) {
+  if (state === "closed")
+    return <Badge variant="outline" className="text-green-600 border-green-300 bg-green-50 dark:bg-green-950 gap-1"><Zap className="h-3 w-3" />Closed (healthy)</Badge>;
+  if (state === "half_open")
+    return <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50 dark:bg-amber-950 gap-1"><Zap className="h-3 w-3" />Half-open (probing)</Badge>;
+  return <Badge variant="outline" className="text-red-600 border-red-300 bg-red-50 dark:bg-red-950 gap-1"><Zap className="h-3 w-3" />Open (failing closed)</Badge>;
+}
+
+function StatCard({ title, value, subtitle, icon }: { title: string; value: string; subtitle?: string; icon: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CasInsightsTab({ isAdmin }: { isAdmin: boolean }) {
+  const [data, setData] = useState<StatsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [windowKey, setWindowKey] = useState("24h");
+
+  const fetchStats = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/authz/stats?window=${windowKey}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      setData((await res.json()) as StatsResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load CAS stats");
+    } finally {
+      setLoading(false);
+    }
+  }, [windowKey]);
+
+  useEffect(() => {
+    if (isAdmin) void fetchStats();
+  }, [isAdmin, fetchStats]);
+
+  if (!isAdmin) {
+    return <p className="text-sm text-muted-foreground">Admin access required.</p>;
+  }
+
+  const engine = data?.engine;
+  const decisions = data?.decisions;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold flex items-center gap-2"><Activity className="h-5 w-5" />Centralized Authorization Service</h3>
+          <p className="text-sm text-muted-foreground">Authorization service health &amp; decision statistics.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={windowKey}
+            onChange={(e) => setWindowKey(e.target.value)}
+            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+          >
+            {WINDOW_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+          <Button variant="outline" size="sm" onClick={() => void fetchStats()} disabled={loading}>
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {/* Live engine health (per-replica) */}
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Adapter health (live, this replica)</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Circuit breaker</CardTitle>
+              <Gauge className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>{engine ? <CircuitBadge state={engine.circuitState} /> : <span className="text-muted-foreground">—</span>}</CardContent>
+          </Card>
+          <StatCard
+            title="Cache hit ratio"
+            value={engine ? pct(engine.cacheHitRatio) : "—"}
+            subtitle={engine ? `${engine.cacheHits} hits / ${engine.cacheMisses} misses` : undefined}
+            icon={<Zap className="h-4 w-4 text-muted-foreground" />}
+          />
+          <StatCard
+            title="Cached decisions"
+            value={engine ? String(engine.cacheSize) : "—"}
+            subtitle="entries held this replica"
+            icon={<Database className="h-4 w-4 text-muted-foreground" />}
+          />
+        </div>
+      </div>
+
+      {/* Durable decision stats */}
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Decisions ({data?.window ?? windowKey})</p>
+        {!data?.persistence ? (
+          <Card><CardContent className="py-4 text-sm text-muted-foreground">MongoDB is not configured — decision history is unavailable. Live adapter health above still applies.</CardContent></Card>
+        ) : decisions ? (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <StatCard title="Total decisions" value={String(decisions.total)} icon={<Activity className="h-4 w-4 text-muted-foreground" />} />
+              <StatCard title="Allowed" value={String(decisions.allow)} icon={<ShieldCheck className="h-4 w-4 text-green-600" />} />
+              <StatCard title="Denied" value={String(decisions.deny)} subtitle={`${pct(decisions.denyRate)} deny rate`} icon={<ShieldX className="h-4 w-4 text-red-600" />} />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+              <Card>
+                <CardHeader><CardTitle className="text-sm">By reason</CardTitle><CardDescription>Decision outcomes grouped by reason code</CardDescription></CardHeader>
+                <CardContent className="space-y-1">
+                  {decisions.byReason.length === 0 ? <p className="text-sm text-muted-foreground">No decisions in window.</p> :
+                    decisions.byReason.map((r) => (
+                      <div key={r.reason} className="flex items-center justify-between text-sm">
+                        <span className="font-mono">{r.reason}</span>
+                        <Badge variant="outline">{r.count}</Badge>
+                      </div>
+                    ))}
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader><CardTitle className="text-sm">Top denied resources</CardTitle><CardDescription>Most-denied resources in window</CardDescription></CardHeader>
+                <CardContent className="space-y-1">
+                  {decisions.topDenied.length === 0 ? <p className="text-sm text-muted-foreground">No denials in window.</p> :
+                    decisions.topDenied.map((r) => (
+                      <div key={r.resource} className="flex items-center justify-between text-sm">
+                        <span className="font-mono truncate mr-2">{r.resource}</span>
+                        <Badge variant="outline" className="text-red-600 border-red-300">{r.count}</Badge>
+                      </div>
+                    ))}
+                </CardContent>
+              </Card>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/admin/PermissionsToolTab.tsx
+++ b/ui/src/components/admin/PermissionsToolTab.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+// assisted-by claude code claude-opus-4-8
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Search, Loader2, ShieldCheck, ShieldX, Bug, RefreshCw } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+const SUBJECT_TYPES = ["user", "service_account"];
+const RESOURCE_TYPES = [
+  "agent", "skill", "mcp_tool", "knowledge_base", "data_source",
+  "task", "slack_channel", "webex_space", "organization", "team", "conversation",
+];
+// Friendlier labels where the OpenFGA type name isn't self-evident. Workflows
+// are graphed as `task`, so surface that so admins can find them.
+const RESOURCE_TYPE_LABELS: Record<string, string> = {
+  task: "workflow (task)",
+};
+const ACTIONS = [
+  "discover", "read", "read-metadata", "use", "write", "create",
+  "manage", "share", "delete", "ingest", "call", "invoke", "audit",
+];
+
+interface Option { value: string; label: string }
+
+interface ExplainRow {
+  action: string;
+  supported?: boolean;
+  decision: "ALLOW" | "DENY";
+  reason: string;
+  unsupportedReason?: string;
+  retriable: boolean;
+  via?: "tuple" | "org_admin" | null;
+  directGrant?: {
+    tuple: string;
+    present: boolean;
+    revocable: boolean;
+    lookup_error?: string;
+  };
+  debug: { engine: string; relation: string; checked: string[]; store: string };
+}
+
+const VIA_LABEL: Record<string, string> = {
+  tuple: "tuple",
+  org_admin: "admin bypass",
+};
+
+const SELECT_CLS = "h-9 rounded-md border border-input bg-background px-3 text-sm";
+
+function pickArray(data: unknown): Record<string, unknown>[] {
+  if (Array.isArray(data)) return data as Record<string, unknown>[];
+  if (data && typeof data === "object") {
+    for (const key of ["users", "resources", "items", "data", "results"]) {
+      const v = (data as Record<string, unknown>)[key];
+      if (Array.isArray(v)) return v as Record<string, unknown>[];
+    }
+  }
+  return [];
+}
+
+function firstStr(item: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = item[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+    if (typeof v === "number") return String(v);
+  }
+  return undefined;
+}
+
+async function fetchOptions(url: string, idKeys: string[], labelKeys: string[]): Promise<Option[]> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    return pickArray(await res.json())
+      .map((item) => {
+        const value = firstStr(item, idKeys);
+        if (!value) return null;
+        return { value, label: firstStr(item, labelKeys) ?? value };
+      })
+      .filter((o): o is Option => o !== null);
+  } catch {
+    return [];
+  }
+}
+
+export function PermissionsToolTab({ isAdmin }: { isAdmin: boolean }) {
+  const [subjectType, setSubjectType] = useState("user");
+  const [subjectId, setSubjectId] = useState("");
+  const [resourceType, setResourceType] = useState("agent");
+  const [resourceId, setResourceId] = useState("");
+
+  const [subjectOptions, setSubjectOptions] = useState<Option[]>([]);
+  const [resourceOptions, setResourceOptions] = useState<Option[]>([]);
+  const [refreshingSubject, setRefreshingSubject] = useState(false);
+  const [refreshingResource, setRefreshingResource] = useState(false);
+
+  const [results, setResults] = useState<ExplainRow[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+
+  const loadSubjectOptions = useCallback(async () => {
+    // Users are pickable by email; service accounts have no list endpoint.
+    if (subjectType !== "user") { setSubjectOptions([]); return; }
+    setRefreshingSubject(true);
+    setSubjectOptions(await fetchOptions("/api/admin/users", ["id", "sub"], ["email", "username"]));
+    setRefreshingSubject(false);
+  }, [subjectType]);
+
+  const loadResourceOptions = useCallback(async () => {
+    // One uniform source: resources that exist in the OpenFGA graph for this type
+    // (covers built-in agents, etc.). The endpoint attaches canonical labels for
+    // channel-like types (slack/webex); the value sent to CAS is always the id.
+    setRefreshingResource(true);
+    setResourceOptions(await fetchOptions(`/api/admin/authz/resources?type=${encodeURIComponent(resourceType)}`, ["id"], ["label", "id"]));
+    setRefreshingResource(false);
+  }, [resourceType]);
+
+  useEffect(() => { if (isAdmin) void loadSubjectOptions(); }, [isAdmin, loadSubjectOptions]);
+  useEffect(() => { if (isAdmin) void loadResourceOptions(); }, [isAdmin, loadResourceOptions]);
+
+  const run = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setResults(null);
+    try {
+      const res = await fetch("/api/admin/authz/explain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subject: { type: subjectType, id: subjectId.trim() },
+          resource: { type: resourceType, id: resourceId.trim() },
+          actions: ACTIONS, // evaluate the whole matrix at once
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`);
+      setResults((body.results ?? []) as ExplainRow[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Explain failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [subjectType, subjectId, resourceType, resourceId]);
+
+  const grantRevoke = useCallback(async (action: string, op: "grant" | "revoke") => {
+    setBusyAction(action);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/authz/grants", {
+        method: op === "grant" ? "POST" : "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          resource: { type: resourceType, id: resourceId.trim() },
+          grantee: { type: subjectType, id: subjectId.trim() },
+          capability: action,
+        }),
+      });
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        throw new Error(b.error || `HTTP ${res.status}`);
+      }
+      await run(); // re-evaluate the matrix so the new decision shows
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Grant/revoke failed");
+    } finally {
+      setBusyAction(null);
+    }
+  }, [resourceType, resourceId, subjectType, subjectId, run]);
+
+  if (!isAdmin) return <p className="text-sm text-muted-foreground">Admin access required.</p>;
+
+  const canRun = subjectId.trim().length > 0 && resourceId.trim().length > 0 && !loading;
+
+  // A value field = [pick dropdown of all available] + [editable text] + [refresh].
+  // Pick reflects the current id when it matches a known option; the text field
+  // is always the submitted value and accepts custom ids.
+  function valueField(
+    kind: "Subject" | "Resource",
+    options: Option[],
+    value: string,
+    setValue: (v: string) => void,
+    refresh: () => void,
+    refreshing: boolean,
+    placeholder: string,
+  ) {
+    const pickValue = options.some((o) => o.value === value) ? value : "";
+    return (
+      <>
+        {options.length > 0 && (
+          <select
+            aria-label={`${kind} options`}
+            value={pickValue}
+            onChange={(e) => { if (e.target.value) setValue(e.target.value); }}
+            className={`${SELECT_CLS} flex-1 min-w-[150px]`}
+          >
+            <option value="">— pick —</option>
+            {options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        )}
+        <Input aria-label={kind} placeholder={placeholder} value={value} onChange={(e) => setValue(e.target.value)} className="h-9 flex-1 min-w-[150px]" />
+        <Button type="button" aria-label={`Refresh ${kind.toLowerCase()} choices`} variant="outline" size="sm" onClick={refresh} disabled={refreshing} className="shrink-0">
+          {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+        </Button>
+      </>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold flex items-center gap-2"><Bug className="h-5 w-5" />Permissions Tool</h3>
+        <p className="text-sm text-muted-foreground">Check what a subject can do on a resource via the Centralized Authorization Service, and grant or revoke access — all in one place.</p>
+      </div>
+
+      <Card>
+        <CardHeader><CardTitle className="text-sm">Evaluate a decision</CardTitle></CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Subject</label>
+            <div className="flex gap-2 flex-wrap items-center">
+              <select aria-label="Subject type" value={subjectType} onChange={(e) => { setSubjectType(e.target.value); setSubjectId(""); }} className={`${SELECT_CLS} w-40`}>
+                {SUBJECT_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+              </select>
+              {valueField("Subject", subjectOptions, subjectId, setSubjectId, () => void loadSubjectOptions(), refreshingSubject, "subject id (sub / email)")}
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Resource</label>
+            <div className="flex gap-2 flex-wrap items-center">
+              <select aria-label="Resource type" value={resourceType} onChange={(e) => { setResourceType(e.target.value); setResourceId(""); }} className={`${SELECT_CLS} w-44`}>
+                {RESOURCE_TYPES.map((t) => <option key={t} value={t}>{RESOURCE_TYPE_LABELS[t] ?? t}</option>)}
+              </select>
+              {valueField("Resource", resourceOptions, resourceId, setResourceId, () => void loadResourceOptions(), refreshingResource, "resource id")}
+            </div>
+          </div>
+
+          <div className="flex justify-end">
+            <Button onClick={() => void run()} disabled={!canRun} className="gap-1.5">
+              {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Search className="h-3.5 w-3.5" />}
+              Explain all actions
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {results && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Permission matrix</CardTitle>
+            <CardDescription>
+              <span className="font-mono">{subjectType}:{subjectId}</span> on <span className="font-mono">{resourceType}:{resourceId}</span> — every action evaluated via OpenFGA
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground border-b border-border">
+                  <th className="py-2 pr-3 font-medium">Action</th>
+                  <th className="py-2 pr-3 font-medium">Decision</th>
+                  <th className="py-2 pr-3 font-medium">Granted via</th>
+                  <th className="py-2 pr-3 font-medium">Relation</th>
+                  <th className="py-2 pr-3 font-medium">Checked tuple</th>
+                  <th className="py-2 font-medium">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((r) => {
+                  const unsupported = r.supported === false;
+                  return (
+                  <tr
+                    key={r.action}
+                    data-testid={`permission-row-${r.action}`}
+                    className={`border-b border-border/50 ${unsupported ? "bg-muted/20 opacity-50" : ""}`}
+                    title={unsupported ? r.unsupportedReason : undefined}
+                  >
+                    <td className="py-1.5 pr-3 font-mono">{r.action}</td>
+                    <td className="py-1.5 pr-3">
+                      {unsupported ? (
+                        <Badge variant="outline" className="text-muted-foreground border-muted-foreground/30 bg-muted/30 gap-1"><ShieldX className="h-3 w-3" />Not supported</Badge>
+                      ) : r.decision === "ALLOW" ? (
+                        <Badge variant="outline" className="text-green-600 border-green-300 bg-green-50 dark:bg-green-950 gap-1"><ShieldCheck className="h-3 w-3" />ALLOW</Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-muted-foreground gap-1"><ShieldX className="h-3 w-3" />DENY</Badge>
+                      )}
+                    </td>
+                    <td className="py-1.5 pr-3 text-xs text-muted-foreground">
+                      {!unsupported && r.decision === "ALLOW" ? (VIA_LABEL[r.via ?? "tuple"] ?? r.via ?? "tuple") : "—"}
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono text-xs text-muted-foreground">{r.debug.relation}</td>
+                    <td className="py-1.5 pr-3 font-mono text-xs text-muted-foreground break-all">{r.debug.checked[0]}</td>
+                    <td className="py-1.5">
+                      {unsupported ? (
+                        <span className="text-xs text-muted-foreground">Not supported</span>
+                      ) : r.decision === "DENY" ? (
+                        <Button type="button" variant="outline" size="sm" disabled={busyAction !== null} onClick={() => void grantRevoke(r.action, "grant")}>
+                          {busyAction === r.action ? <Loader2 className="h-3 w-3 animate-spin" /> : "Grant"}
+                        </Button>
+                      ) : r.via === "tuple" && r.directGrant?.revocable === true ? (
+                        <Button type="button" variant="outline" size="sm" disabled={busyAction !== null} onClick={() => void grantRevoke(r.action, "revoke")}>
+                          {busyAction === r.action ? <Loader2 className="h-3 w-3 animate-spin" /> : "Revoke"}
+                        </Button>
+                      ) : r.via === "tuple" ? (
+                        // assisted-by Codex Codex-sonnet-4-6
+                        <span
+                          className="text-xs text-muted-foreground"
+                          title={r.directGrant?.tuple ? `Allowed through another relationship; no direct ${r.directGrant.tuple} grant exists to revoke.` : undefined}
+                        >
+                          Inherited
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/admin/security/OpenFgaRebacTab.tsx
+++ b/ui/src/components/admin/security/OpenFgaRebacTab.tsx
@@ -1,73 +1,64 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
-import { Dialog,DialogContent,DialogDescription,DialogHeader,DialogTitle } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Tabs,TabsContent,TabsList,TabsTrigger } from "@/components/ui/tabs";
-import { cn } from "@/lib/utils";
-import type {
-UniversalRebacRelationship,
-UniversalRebacResourceAction,
-UniversalRebacResourceType,
-UniversalRebacResourceTypeDefinition,
-UniversalRebacSubjectRef,
-UniversalRebacSubjectType,
-} from "@/types/rbac-universal";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
-Background,
-BackgroundVariant,
-Handle,
-Panel,
-Position,
-ReactFlow,
-ReactFlowProvider,
-useEdgesState,
-useNodesState,
-useReactFlow,
-type Connection,
-type Edge,
-type Node,
-type NodeProps,
-type OnSelectionChangeParams,
+  AlertCircle,
+  Bot,
+  Database,
+  GitBranch,
+  Hash,
+  MessageSquare,
+  Shield,
+  CheckCircle2,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  RefreshCw,
+  Trash2,
+  User,
+  Users,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  Background,
+  BackgroundVariant,
+  Handle,
+  Panel,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+  type Connection,
+  type Edge,
+  type Node,
+  type NodeProps,
+  type OnSelectionChangeParams,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import {
-AlertCircle,
-Bot,
-CheckCircle2,
-Database,
-GitBranch,
-Hash,
-Loader2,
-Maximize2,
-MessageSquare,
-Minimize2,
-RefreshCw,
-Search,
-Shield,
-Trash2,
-User,
-Users,
-Wrench,
-type LucideIcon,
-} from "lucide-react";
-import { usePathname,useRouter,useSearchParams } from "next/navigation";
-import { memo,useCallback,useEffect,useMemo,useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import { BaselineFgaProfilePanel } from "../rebac/BaselineFgaProfilePanel";
 import { PolicyChangeSetDiff } from "../rebac/PolicyChangeSetDiff";
-import { RebacAccessChecker } from "../rebac/RebacAccessChecker";
-import { RebacGraphFilters,type RebacGraphUserOption } from "../rebac/RebacGraphFilters";
-import { UserBaselineDiagnosticsPanel } from "../rebac/UserBaselineDiagnosticsPanel";
+import { RebacGraphFilters, type RebacGraphUserOption } from "../rebac/RebacGraphFilters";
+import type {
+  UniversalRebacRelationship,
+  UniversalRebacResourceAction,
+  UniversalRebacResourceType,
+  UniversalRebacResourceTypeDefinition,
+} from "@/types/rbac-universal";
 
 type AccessResourceType = UniversalRebacResourceType;
 type GraphLayer = "tuples" | "effective" | "model";
-type AccessSubjectType = Extract<
-  UniversalRebacSubjectType,
-  "team" | "user" | "slack_channel" | "webex_space" | "external_group" | "service_account"
->;
 interface CatalogTeam {
   id: string;
   slug: string;
@@ -139,7 +130,7 @@ interface GraphEdge {
 const ALL_RELATIONSHIPS_SCOPE = "__all_relationships__";
 const DEFAULT_GRAPH_LAYER: GraphLayer = "tuples";
 const DEFAULT_OPENFGA_TAB = "tuples";
-const OPENFGA_TABS = new Set(["tuples", "graph", "access", "baseline", "diagnostics"]);
+const OPENFGA_TABS = new Set(["tuples", "graph", "baseline"]);
 const ACTION_TO_BASE_RELATION: Record<UniversalRebacResourceAction, string> = {
   discover: "reader",
   read: "reader",
@@ -186,24 +177,6 @@ const RELATION_TO_ACTION: Record<string, UniversalRebacResourceAction> = {
   can_use: "use",
   can_write: "write",
 };
-const ACTION_TO_CHECK_RELATION: Record<UniversalRebacResourceAction, string> = {
-  discover: "can_discover",
-  read: "can_read",
-  use: "can_use",
-  write: "can_write",
-  create: "can_manage",
-  delete: "can_delete",
-  manage: "can_manage",
-  administer: "can_admin",
-  audit: "can_audit",
-  approve: "can_approve",
-  share: "can_share",
-  call: "can_call",
-  invoke: "can_invoke",
-  map: "can_map",
-  ingest: "can_ingest",
-  "read-metadata": "can_read_metadata",
-};
 
 const ACCESS_RESOURCE_LABELS: Partial<Record<AccessResourceType, string>> = {
   organization: "Organization",
@@ -230,97 +203,6 @@ const ACCESS_RESOURCE_LABELS: Partial<Record<AccessResourceType, string>> = {
   secret_ref: "Secret reference",
   system_config: "System config",
 };
-
-const ACCESS_SUBJECT_LABELS: Record<AccessSubjectType, string> = {
-  team: "Team",
-  user: "User",
-  slack_channel: "Slack channel",
-  webex_space: "Webex space",
-  external_group: "External group",
-  service_account: "Service account",
-};
-
-const ACCESS_SUBJECT_TYPES: AccessSubjectType[] = [
-  "team",
-  "user",
-  "slack_channel",
-  "webex_space",
-  "external_group",
-  "service_account",
-];
-
-const BASE_RELATIONSHIP_CHEATSHEET = [
-  {
-    label: "Agent use",
-    tuple: "team:<slug>#member user agent:<id>",
-    meaning: "Team members can use or invoke agent.",
-  },
-  {
-    label: "Agent manage",
-    tuple: "team:<slug>#admin manager agent:<id>",
-    meaning: "Team admins can edit, delete, and administer agent.",
-  },
-  {
-    label: "Tool call",
-    tuple: "agent:<id> caller tool:<server>/<tool>",
-    meaning: "Agent may call that MCP tool through AgentGateway.",
-  },
-  {
-    label: "Knowledge base read",
-    tuple: "team:<slug>#member reader knowledge_base:<id>",
-    meaning: "Team members can search/read that datasource.",
-  },
-  {
-    label: "Knowledge base ingest",
-    tuple: "team:<slug>#member ingestor knowledge_base:<id>",
-    meaning: "Team members can ingest/update that datasource.",
-  },
-  {
-    label: "Admin surface",
-    tuple: "team:<slug>#member manager admin_surface:<name>",
-    meaning: "Team can administer a protected UI surface.",
-  },
-] as const;
-
-const DERIVED_PERMISSION_CHEATSHEET = [
-  ["can_discover", "show in lists and pickers"],
-  ["can_read", "read metadata or content"],
-  ["can_use", "use or invoke agent"],
-  ["can_write", "edit resource configuration"],
-  ["can_delete", "remove lifecycle-managed resource"],
-  ["can_manage", "administer resource"],
-  ["can_call", "call MCP gateway/tool"],
-] as const;
-
-const SUBJECT_CHEATSHEET = [
-  ["user:<sub>", "single Keycloak user"],
-  ["user:*", "all authenticated users for typed-wildcard grants"],
-  ["service_account:<id>", "machine principal"],
-  ["team:<slug>", "team object for membership tuples"],
-  ["team:<slug>#member", "all members of a team"],
-  ["team:<slug>#admin", "team owners/admins"],
-  ["external_group:<provider>/<id>#member", "synced IdP group members"],
-  ["slack_channel:<workspace>--<channel>", "Slack channel route principal"],
-  ["webex_space:<workspace>--<space>", "Webex space route principal"],
-] as const;
-
-const RESOURCE_OBJECT_CHEATSHEET = [
-  ["organization:<org>", "platform-wide organization scope"],
-  ["team:<slug>", "team membership container"],
-  ["agent:<id>", "Dynamic Agent config/runtime target"],
-  ["tool:<server>/<tool>", "specific MCP tool"],
-  ["tool:<server>/*", "all tools from an MCP server"],
-  ["mcp_gateway:<name>", "AgentGateway coarse MCP call gate"],
-  ["mcp_server:<id>", "MCP server discovery/sync target"],
-  ["knowledge_base:<id>", "RAG datasource or KB resource"],
-  ["conversation:<id>", "chat history and sharing target"],
-  ["skill:<id>", "skill catalog/runtime target"],
-  ["task:<id>", "task template or task execution target"],
-  ["admin_surface:<name>", "protected admin UI surface"],
-  ["system_config:<key>", "platform configuration key"],
-  ["slack_channel:<workspace>--<channel>", "Slack channel association target"],
-  ["webex_space:<workspace>--<space>", "Webex space association target"],
-] as const;
 
 interface RebacNodeData {
   label: string;
@@ -378,45 +260,11 @@ function actionOptions(catalog: CatalogResponse | null, type: AccessResourceType
   return catalog?.resource_types?.find((definition) => definition.type === type)?.actions.slice() ?? [];
 }
 
-function subjectOptions(catalog: CatalogResponse | null, type: AccessSubjectType): CatalogResource[] {
-  if (!catalog) return [];
-  if (type === "team") {
-    return catalog.teams.map((team) => ({
-      type: "team",
-      id: team.slug,
-      display_name: `${team.name} (${team.slug})`,
-      object: `team:${team.slug}`,
-    }));
-  }
-  return accessResources(catalog, type as AccessResourceType);
-}
 
 function accessResourceLabel(type: AccessResourceType): string {
   return ACCESS_RESOURCE_LABELS[type] ?? type.replaceAll("_", " ");
 }
 
-function accessSubjectLabel(type: AccessSubjectType): string {
-  return ACCESS_SUBJECT_LABELS[type];
-}
-
-function subjectRelations(type: AccessSubjectType): Array<NonNullable<UniversalRebacSubjectRef["relation"]>> {
-  if (type === "team") return ["member", "admin"];
-  if (type === "external_group") return ["member"];
-  return [];
-}
-
-function normalizeUserSearchResults(users: RebacGraphUserOption[]): CatalogResource[] {
-  return users.map((user) => {
-    const name = [user.firstName, user.lastName].filter(Boolean).join(" ").trim();
-    const primary = name || user.email || user.username || user.id;
-    return {
-      type: "user",
-      id: user.id,
-      display_name: primary === user.id ? `user:${user.id}` : `${primary} (${user.id})`,
-      object: `user:${user.id}`,
-    };
-  });
-}
 
 function statusBadge(catalog: CatalogResponse | null) {
   if (!catalog?.status.configured) {
@@ -426,95 +274,6 @@ function statusBadge(catalog: CatalogResponse | null) {
     return <Badge variant="secondary">Tuple writes available, team-save reconciliation disabled</Badge>;
   }
   return <Badge variant="default">OpenFGA reconciliation enabled</Badge>;
-}
-
-function OpenFgaPermissionCheatsheet() {
-  return (
-    <Card className="border-cyan-500/25 bg-cyan-500/[0.04]">
-      <CardHeader className="pb-3">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <CardTitle className="text-base">Access Manager Permission Cheatsheet</CardTitle>
-            <CardDescription>
-              Use this reference to connect selected actions to the base relationships that OpenFGA stores and the `can_*` permissions it checks at runtime.
-            </CardDescription>
-          </div>
-          <Badge variant="outline" className="border-cyan-500/40 text-cyan-700 dark:text-cyan-300">
-            Relationship reference
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
-          <div className="space-y-2">
-          <div className="text-sm font-medium">Base relationships you write</div>
-          <div className="grid gap-2">
-            {BASE_RELATIONSHIP_CHEATSHEET.map((item) => (
-              <div key={item.tuple} className="rounded-md border bg-background/70 p-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant="secondary">{item.label}</Badge>
-                  <code className="break-all text-xs">{item.tuple}</code>
-                </div>
-                <p className="mt-1 text-xs text-muted-foreground">{item.meaning}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-          <div className="space-y-2">
-          <div className="text-sm font-medium">Derived permissions OpenFGA checks</div>
-          <div className="rounded-md border bg-background/70 p-3">
-            <dl className="space-y-2">
-              {DERIVED_PERMISSION_CHEATSHEET.map(([permission, meaning]) => (
-                <div key={permission} className="grid grid-cols-[auto_1fr] gap-3 text-xs">
-                  <dt>
-                    <code>{permission}</code>
-                  </dt>
-                  <dd className="text-muted-foreground">{meaning}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Tip: tuple writes use relations like <code>user</code>, <code>manager</code>, <code>caller</code>,
-            <code> reader</code>, and <code>ingestor</code>. Avoid writing derived <code>can_*</code> relations directly.
-          </p>
-        </div>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <div className="space-y-2">
-            <div className="text-sm font-medium">Subjects and usersets</div>
-            <div className="rounded-md border bg-background/70 p-3">
-              <dl className="grid gap-2 sm:grid-cols-2">
-                {SUBJECT_CHEATSHEET.map(([subject, meaning]) => (
-                  <div key={subject} className="space-y-0.5">
-                    <dt>
-                      <code className="break-all text-xs">{subject}</code>
-                    </dt>
-                    <dd className="text-xs text-muted-foreground">{meaning}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          </div>
-          <div className="space-y-2">
-            <div className="text-sm font-medium">Resource objects</div>
-            <div className="rounded-md border bg-background/70 p-3">
-              <dl className="grid gap-2 sm:grid-cols-2">
-                {RESOURCE_OBJECT_CHEATSHEET.map(([resource, meaning]) => (
-                  <div key={resource} className="space-y-0.5">
-                    <dt>
-                      <code className="break-all text-xs">{resource}</code>
-                    </dt>
-                    <dd className="text-xs text-muted-foreground">{meaning}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
 }
 
 function tupleKey(tuple: TupleKey): string {
@@ -675,14 +434,6 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
   const [graphLayer, setGraphLayer] = useState<GraphLayer>(DEFAULT_GRAPH_LAYER);
   const [graphUser, setGraphUser] = useState<RebacGraphUserOption | null>(null);
   const [graphFullscreenOpen, setGraphFullscreenOpen] = useState(false);
-  const [accessSubjectType, setAccessSubjectType] = useState<AccessSubjectType>("team");
-  const [accessSubjectId, setAccessSubjectId] = useState("");
-  const [accessSubjectRelation, setAccessSubjectRelation] =
-    useState<NonNullable<UniversalRebacSubjectRef["relation"]>>("member");
-  const [accessResourceType, setAccessResourceType] = useState<AccessResourceType>("agent");
-  const [accessResourceId, setAccessResourceId] = useState("");
-  const [accessAction, setAccessAction] = useState<UniversalRebacResourceAction>("use");
-  const [checkResult, setCheckResult] = useState<boolean | null>(null);
   const [tupleFilter, setTupleFilter] = useState<Partial<TupleKey>>({});
   const [pendingGraphWrites, setPendingGraphWrites] = useState<TupleKey[]>([]);
   const [pendingGraphDeletes, setPendingGraphDeletes] = useState<TupleKey[]>([]);
@@ -692,41 +443,12 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
     return normalizeOpenFgaTab(tab);
   }, [searchParams]);
 
-  const selectedAccessRelationship: UniversalRebacRelationship | null = useMemo(() => {
-    if (!accessSubjectId || !accessResourceId || !accessAction) return null;
-    const allowedSubjectRelations = subjectRelations(accessSubjectType);
-    const subjectRelation = allowedSubjectRelations.includes(accessSubjectRelation)
-      ? accessSubjectRelation
-      : undefined;
-    return {
-      subject: {
-        type: accessSubjectType,
-        id: accessSubjectId,
-        ...(subjectRelation ? { relation: subjectRelation } : {}),
-      },
-      action: accessAction,
-      resource: {
-        type: accessResourceType,
-        id: accessResourceId,
-      },
-    };
-  }, [
-    accessAction,
-    accessResourceId,
-    accessResourceType,
-    accessSubjectId,
-    accessSubjectRelation,
-    accessSubjectType,
-  ]);
-
   const loadCatalog = useCallback(async () => {
     const res = await fetch("/api/admin/openfga/catalog");
     if (!res.ok) throw new Error(`Failed to load catalog: ${res.status}`);
     const payload = await res.json();
     const data = apiData<CatalogResponse>(payload);
     setCatalog(data);
-    setAccessSubjectId((prev) => prev || data.teams[0]?.slug || "");
-    setAccessResourceId((prev) => prev || accessResources(data, "agent")[0]?.id || "");
   }, []);
 
   const loadTuples = useCallback(async (filter: Partial<TupleKey> = {}) => {
@@ -776,22 +498,6 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
     }
   }, [loadTuples, tupleFilter]);
 
-  useEffect(() => {
-    const nextSubjects = subjectOptions(catalog, accessSubjectType);
-    setAccessSubjectId(nextSubjects[0]?.id || "");
-    const relations = subjectRelations(accessSubjectType);
-    setAccessSubjectRelation(relations[0] ?? "member");
-    setCheckResult(null);
-  }, [accessSubjectType, catalog]);
-
-  useEffect(() => {
-    const nextResources = accessResources(catalog, accessResourceType);
-    const nextActions = actionOptions(catalog, accessResourceType);
-    setAccessResourceId(nextResources[0]?.id || "");
-    setAccessAction(nextActions[0] ?? "read");
-    setCheckResult(null);
-  }, [accessResourceType, catalog]);
-
   const setActiveTab = useCallback(
     (tab: string) => {
       const nextTab = normalizeOpenFgaTab(tab);
@@ -835,81 +541,7 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
     if (!apply.ok) throw new Error(`Change-set apply failed: ${apply.status}`);
   }
 
-  async function checkAccess() {
-    if (!selectedAccessRelationship) {
-      setError("Select a subject, resource, and action to check effective access");
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    setCheckResult(null);
-    try {
-      const res = await fetch("/api/admin/rebac/check", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ relationship: selectedAccessRelationship }),
-      });
-      if (!res.ok) throw new Error(`ReBAC access check failed: ${res.status}`);
-      const payload = await res.json();
-      setCheckResult(Boolean(apiData<{ allowed: boolean }>(payload).allowed));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "ReBAC access check failed");
-    } finally {
-      setBusy(false);
-    }
-  }
 
-  async function grantSelectedAccess() {
-    if (!selectedAccessRelationship) {
-      setError("Select a subject, resource, and action before granting access");
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    setMessage(null);
-    try {
-      await applyChangeSet(
-        `Grant effective access ${selectedAccessRelationship.action} ${selectedAccessRelationship.resource.type}:${selectedAccessRelationship.resource.id}`,
-        [selectedAccessRelationship],
-        []
-      );
-      setMessage(
-        `Granted ${selectedAccessRelationship.action} on ${selectedAccessRelationship.resource.type}:${selectedAccessRelationship.resource.id}`
-      );
-      await Promise.all([loadTuples(tupleFilter), loadGraph()]);
-      await checkAccess();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Effective access grant failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function revokeSelectedAccess() {
-    if (!selectedAccessRelationship) {
-      setError("Select a subject, resource, and action before revoking access");
-      return;
-    }
-    setBusy(true);
-    setError(null);
-    setMessage(null);
-    try {
-      await applyChangeSet(
-        `Revoke effective access ${selectedAccessRelationship.action} ${selectedAccessRelationship.resource.type}:${selectedAccessRelationship.resource.id}`,
-        [],
-        [selectedAccessRelationship]
-      );
-      setMessage(
-        `Revoked ${selectedAccessRelationship.action} on ${selectedAccessRelationship.resource.type}:${selectedAccessRelationship.resource.id}`
-      );
-      await Promise.all([loadTuples(tupleFilter), loadGraph()]);
-      await checkAccess();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Effective access revoke failed");
-    } finally {
-      setBusy(false);
-    }
-  }
 
   async function deleteTuple(tuple: TupleKey) {
     const relationship = relationshipFromTuple(tuple);
@@ -1050,72 +682,11 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
         <TabsList>
           <TabsTrigger value="tuples" onClick={() => setActiveTab("tuples")}>OpenFGA Tuples</TabsTrigger>
           <TabsTrigger value="graph" onClick={() => setActiveTab("graph")}>Policy Graph</TabsTrigger>
-          <TabsTrigger value="access" onClick={() => setActiveTab("access")}>Access Manager</TabsTrigger>
           <TabsTrigger value="baseline" onClick={() => setActiveTab("baseline")}>Default FGA Grants</TabsTrigger>
-          <TabsTrigger value="diagnostics" onClick={() => setActiveTab("diagnostics")}>Diagnostics</TabsTrigger>
         </TabsList>
 
         <TabsContent value="baseline">
           <BaselineFgaProfilePanel isAdmin={isAdmin} />
-        </TabsContent>
-
-        <TabsContent value="diagnostics">
-          <Card>
-            <CardHeader>
-              <CardTitle>User Baseline Diagnostics</CardTitle>
-              <CardDescription>
-                Compare one user&apos;s actual OpenFGA decisions against the default member and admin baselines.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <UserBaselineDiagnosticsPanel />
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        <TabsContent value="access">
-          <Card>
-            <CardHeader>
-              <CardTitle>Access Manager</CardTitle>
-              <CardDescription>
-                Select any catalog-backed subject and resource, check the derived permission, then grant or revoke it through a validated change set.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <AccessCheckForm
-                catalog={catalog}
-                subjectType={accessSubjectType}
-                subjectId={accessSubjectId}
-                subjectRelation={accessSubjectRelation}
-                resourceType={accessResourceType}
-                resourceId={accessResourceId}
-                action={accessAction}
-                onSubjectType={setAccessSubjectType}
-                onSubjectId={setAccessSubjectId}
-                onSubjectRelation={setAccessSubjectRelation}
-                onResourceType={setAccessResourceType}
-                onResourceId={setAccessResourceId}
-                onAction={setAccessAction}
-              />
-              {selectedAccessRelationship && <AccessPreview relationship={selectedAccessRelationship} />}
-              <AccessChangeSetPreview
-                relationship={selectedAccessRelationship}
-                allowed={checkResult}
-                canMutate={isAdmin}
-              />
-              <RebacAccessChecker
-                relationship={selectedAccessRelationship}
-                allowed={checkResult}
-                busy={busy}
-                canGrant={isAdmin}
-                onCheck={checkAccess}
-                onGrant={grantSelectedAccess}
-                onRevoke={revokeSelectedAccess}
-              />
-              {!isAdmin && <p className="text-sm text-muted-foreground">You can inspect ReBAC, but only admins can mutate tuples.</p>}
-              <OpenFgaPermissionCheatsheet />
-            </CardContent>
-          </Card>
         </TabsContent>
 
         <TabsContent value="graph">
@@ -1295,260 +866,6 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
           </Card>
         </TabsContent>
       </Tabs>
-    </div>
-  );
-}
-
-function AccessCheckForm(props: {
-  catalog: CatalogResponse | null;
-  subjectType: AccessSubjectType;
-  subjectId: string;
-  subjectRelation: NonNullable<UniversalRebacSubjectRef["relation"]>;
-  resourceType: AccessResourceType;
-  resourceId: string;
-  action: UniversalRebacResourceAction;
-  onSubjectType: (value: AccessSubjectType) => void;
-  onSubjectId: (value: string) => void;
-  onSubjectRelation: (value: NonNullable<UniversalRebacSubjectRef["relation"]>) => void;
-  onResourceType: (value: AccessResourceType) => void;
-  onResourceId: (value: string) => void;
-  onAction: (value: UniversalRebacResourceAction) => void;
-}) {
-  const [subjectQuery, setSubjectQuery] = useState("");
-  const [subjectResults, setSubjectResults] = useState<CatalogResource[]>([]);
-  const [searchingSubjects, setSearchingSubjects] = useState(false);
-  const [subjectError, setSubjectError] = useState<string | null>(null);
-  const subjectCatalogOptions = subjectOptions(props.catalog, props.subjectType);
-  const availableResourceTypes = accessResourceTypes(props.catalog);
-  const resources = accessResources(props.catalog, props.resourceType);
-  const actions = actionOptions(props.catalog, props.resourceType);
-  const relations = subjectRelations(props.subjectType);
-  const normalizedQuery = subjectQuery.trim().toLowerCase();
-  const visibleSubjects = (subjectResults.length > 0 ? subjectResults : subjectCatalogOptions).filter((subject) => {
-    if (!normalizedQuery || subjectResults.length > 0) return true;
-    return `${resourceName(subject)} ${subject.id}`.toLowerCase().includes(normalizedQuery);
-  });
-  const showSubjectOptions = normalizedQuery.length > 0 || subjectResults.length > 0;
-
-  async function searchSubjects() {
-    if (props.subjectType !== "user") {
-      setSubjectResults([]);
-      return;
-    }
-    const query = subjectQuery.trim();
-    if (!query) {
-      setSubjectResults([]);
-      return;
-    }
-    setSearchingSubjects(true);
-    setSubjectError(null);
-    try {
-      const params = new URLSearchParams({ search: query, pageSize: "20" });
-      const response = await fetch(`/api/admin/users?${params.toString()}`);
-      if (!response.ok) throw new Error(`User search failed: ${response.status}`);
-      const payload = await response.json();
-      setSubjectResults(normalizeUserSearchResults(Array.isArray(payload.users) ? payload.users : []));
-    } catch (err) {
-      setSubjectError(err instanceof Error ? err.message : "Subject search failed");
-    } finally {
-      setSearchingSubjects(false);
-    }
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="grid gap-3 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.4fr)_minmax(0,0.8fr)]">
-        <div>
-          <Label htmlFor="rebac-access-subject-type">Subject type</Label>
-          <select
-            id="rebac-access-subject-type"
-            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            value={props.subjectType}
-            onChange={(event) => {
-              props.onSubjectType(event.target.value as AccessSubjectType);
-              setSubjectQuery("");
-              setSubjectResults([]);
-              setSubjectError(null);
-            }}
-          >
-            {ACCESS_SUBJECT_TYPES.map((type) => (
-              <option key={type} value={type}>
-                {accessSubjectLabel(type)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <Label htmlFor="rebac-access-subject">Subject</Label>
-          <div className="mt-1 flex gap-2">
-            <Input
-              id="rebac-access-subject"
-              autoComplete="off"
-              value={subjectQuery}
-              onChange={(event) => {
-                setSubjectQuery(event.target.value);
-                setSubjectResults([]);
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  void searchSubjects();
-                }
-              }}
-              placeholder={`Search ${accessSubjectLabel(props.subjectType).toLowerCase()} subjects`}
-            />
-            <Button type="button" variant="outline" className="gap-2" onClick={() => void searchSubjects()}>
-              <Search className="h-4 w-4" />
-              Search subjects
-            </Button>
-          </div>
-          {props.subjectId && (
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Selected <code>{props.subjectType}:{props.subjectId}</code>
-              {relations.length > 0 ? `#${props.subjectRelation}` : ""}
-            </p>
-          )}
-          {subjectError && <p className="mt-2 text-xs text-destructive">{subjectError}</p>}
-          {searchingSubjects && <p className="mt-2 text-xs text-muted-foreground">Searching subjects...</p>}
-          {showSubjectOptions && visibleSubjects.length > 0 && (
-            <div className="mt-2 max-h-44 overflow-auto rounded-md border bg-background">
-              {visibleSubjects.map((subject) => (
-                <button
-                  key={`${subject.type ?? props.subjectType}:${subject.id}`}
-                  type="button"
-                  className="block w-full border-b px-3 py-2 text-left text-xs last:border-b-0 hover:bg-muted"
-                  onClick={() => {
-                    props.onSubjectId(subject.id);
-                    setSubjectQuery(resourceName(subject));
-                    setSubjectResults([]);
-                  }}
-                >
-                  <span className="block font-medium">{resourceName(subject)}</span>
-                  <span className="block text-muted-foreground">
-                    {props.subjectType}:{subject.id}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-        {relations.length > 0 && (
-          <div>
-            <Label htmlFor="rebac-access-subject-relation">Subject relation</Label>
-            <select
-              id="rebac-access-subject-relation"
-              className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
-              value={props.subjectRelation}
-              onChange={(event) =>
-                props.onSubjectRelation(event.target.value as NonNullable<UniversalRebacSubjectRef["relation"]>)
-              }
-            >
-              {relations.map((relationValue) => (
-                <option key={relationValue} value={relationValue}>
-                  {relationValue}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
-      </div>
-      <div className="grid gap-3 md:grid-cols-3">
-        <div>
-          <Label htmlFor="rebac-access-resource-type">Resource type</Label>
-          <select
-            id="rebac-access-resource-type"
-            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            value={props.resourceType}
-            onChange={(event) => props.onResourceType(event.target.value as AccessResourceType)}
-          >
-            {availableResourceTypes.map((definition) => (
-              <option key={definition.type} value={definition.type}>
-                {accessResourceLabel(definition.type)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <Label htmlFor="rebac-access-resource">Resource</Label>
-          <select
-            id="rebac-access-resource"
-            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            value={props.resourceId}
-            onChange={(event) => props.onResourceId(event.target.value)}
-          >
-            {resources.map((resource) => (
-              <option key={resource.id} value={resource.id}>
-                {resourceName(resource)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <Label htmlFor="rebac-access-action">Action</Label>
-          <select
-            id="rebac-access-action"
-            className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            value={props.action}
-            onChange={(event) => props.onAction(event.target.value as UniversalRebacResourceAction)}
-          >
-            {actions.map((action) => (
-              <option key={action} value={action}>
-                {action}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function AccessPreview({ relationship }: { relationship: UniversalRebacRelationship }) {
-  const subject = `${relationship.subject.type}:${relationship.subject.id}${
-    relationship.subject.relation ? `#${relationship.subject.relation}` : ""
-  }`;
-  const object = `${relationship.resource.type}:${relationship.resource.id}`;
-  return (
-    <div className="rounded-md border bg-muted/30 p-3 text-sm">
-      <div className="font-medium">Check preview</div>
-      <code className="mt-1 block break-all">
-        {subject} <span className="text-muted-foreground">{ACTION_TO_CHECK_RELATION[relationship.action]}</span>{" "}
-        {object}
-      </code>
-    </div>
-  );
-}
-
-function AccessChangeSetPreview({
-  relationship,
-  allowed,
-  canMutate,
-}: {
-  relationship: UniversalRebacRelationship | null;
-  allowed: boolean | null;
-  canMutate: boolean;
-}) {
-  if (!relationship || allowed === null) {
-    return (
-      <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-        Run an access check to preview the grant or revoke change set for this relationship.
-      </div>
-    );
-  }
-
-  const grants = allowed ? [] : [relationship];
-  const revocations = allowed ? [relationship] : [];
-  return (
-    <div className="space-y-2">
-      <div>
-        <div className="text-sm font-medium">Policy change-set preview</div>
-        <p className="text-xs text-muted-foreground">
-          {canMutate
-            ? "The next mutation will be validated and applied through the ReBAC change-set API."
-            : "Only admins can apply this suggested policy change."}
-        </p>
-      </div>
-      <PolicyChangeSetDiff grants={grants} revocations={revocations} />
     </div>
   );
 }

--- a/ui/src/components/admin/security/PermissionDebuggerTab.tsx
+++ b/ui/src/components/admin/security/PermissionDebuggerTab.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+// assisted-by Cursor Auto
+
+import React, { useState } from "react";
+import { Bug, Loader2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+interface ExplainResponse {
+  decision: "ALLOW" | "DENY";
+  reason: string;
+  retriable: boolean;
+  debug?: {
+    engine: string;
+    relation: string;
+    checked: string[];
+    store: string;
+  };
+}
+
+export function PermissionDebuggerTab({ isAdmin }: { isAdmin: boolean }) {
+  const [subjectId, setSubjectId] = useState("");
+  const [resourceId, setResourceId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ExplainResponse | null>(null);
+
+  if (!isAdmin) {
+    return <p className="text-sm text-muted-foreground">Admin access required.</p>;
+  }
+
+  const canExplain = subjectId.trim().length > 0 && resourceId.trim().length > 0;
+
+  async function handleExplain() {
+    if (!canExplain) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/authz/v1/explain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subject: { type: "user", id: subjectId.trim() },
+          resource: { type: "agent", id: resourceId.trim() },
+          action: "use",
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(typeof body.error === "string" ? body.error : `HTTP ${res.status}`);
+      }
+      setResult(body as ExplainResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Explain request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bug className="h-5 w-5" />
+          Permission debugger
+        </CardTitle>
+        <CardDescription>
+          Explain a single agent-use decision through the Centralized Authorization Service.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Input
+            placeholder="Subject id"
+            value={subjectId}
+            onChange={(e) => setSubjectId(e.target.value)}
+          />
+          <Input
+            placeholder="Resource id"
+            value={resourceId}
+            onChange={(e) => setResourceId(e.target.value)}
+          />
+        </div>
+        <Button type="button" disabled={!canExplain || loading} onClick={() => void handleExplain()}>
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Explain
+        </Button>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {result && (
+          <div className="space-y-3 rounded-md border p-4">
+            <div className="flex items-center gap-2">
+              <Badge variant={result.decision === "ALLOW" ? "default" : "destructive"}>{result.decision}</Badge>
+              <span className="text-sm text-muted-foreground">{result.reason}</span>
+            </div>
+            {result.debug && (
+              <div className="space-y-1 text-sm font-mono">
+                <div>{result.debug.relation}</div>
+                {result.debug.checked.map((line) => (
+                  <div key={line}>{line}</div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/components/admin/security/UnifiedAuditTab.tsx
+++ b/ui/src/components/admin/security/UnifiedAuditTab.tsx
@@ -1,27 +1,35 @@
 "use client";
 
+// assisted-by Codex Codex-sonnet-4-6
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Popover,PopoverContent,PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip,TooltipContent,TooltipProvider,TooltipTrigger } from "@/components/ui/tooltip";
 import type { AuditEventType,UnifiedAuditEvent,UnifiedAuditOutcome } from "@/lib/rbac/types";
 import {
 ChevronDown,
 ChevronLeft,
 ChevronRight,
 ChevronUp,
+CircleHelp,
 Clock,
-GitBranch,
-Loader2,
-Network,
-RefreshCw,
-RotateCcw,
-Search,
-Shield,
-Wrench,
-X,
+Download,
+  GitBranch,
+  KeyRound,
+  Loader2,
+  Network,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  Shield,
+  UserPlus,
+  Wrench,
+  X,
 } from "lucide-react";
-import React,{ useCallback,useEffect,useRef,useState } from "react";
+import React,{ useCallback,useEffect,useMemo,useRef,useState } from "react";
 
 interface UnifiedAuditTabProps {
   isAdmin: boolean;
@@ -34,55 +42,231 @@ interface PaginatedResult {
   limit: number;
 }
 
-const TYPE_OPTIONS: { value: string; label: string }[] = [
-  { value: "", label: "All" },
-  { value: "auth", label: "Authorization" },
-  { value: "openfga_rebac", label: "OpenFGA ReBAC" },
-  { value: "tool_action", label: "Tool Action" },
-  { value: "agent_delegation", label: "Agent Delegation" },
+interface FilterOption {
+  value: string;
+  label: string;
+  description: string;
+}
+
+const TYPE_FILTER_GROUPS: {
+  label?: string;
+  options: FilterOption[];
+}[] = [
+  {
+    options: [
+      {
+        value: "",
+        label: "All event types",
+        description:
+          "Every audit record in this log — policy changes, access checks, ReBAC, tools, delegations, and login/API auth.",
+      },
+    ],
+  },
+  {
+    label: "Central authorization",
+    options: [
+      {
+        value: "cas_grant",
+        label: "Policy changes",
+        description:
+          "Grant and revoke attempts written by CAS (who changed access, for which grantee and resource, success or failure).",
+      },
+      {
+        value: "cas_decision",
+        label: "Access decisions",
+        description:
+          "Allow/deny results when the Centralized Authorization Service evaluates whether a subject may act on a resource.",
+      },
+    ],
+  },
+  {
+    label: "ReBAC",
+    options: [
+      {
+        value: "openfga_rebac",
+        label: "OpenFGA checks",
+        description:
+          "Relationship-based authorization checks from the OpenFGA authz bridge (tuple lookups, not grant/revoke writes).",
+      },
+    ],
+  },
+  {
+    label: "Runtime",
+    options: [
+      {
+        value: "tool_action",
+        label: "Tool invocations",
+        description:
+          "Audited MCP or agent tool calls — which tool ran, for whom, and whether authorization allowed it.",
+      },
+      {
+        value: "agent_delegation",
+        label: "Agent delegations",
+        description:
+          "When work or authority is delegated from one agent to another in a multi-agent flow.",
+      },
+      {
+        value: "auth",
+        label: "Login & API auth",
+        description:
+          "Session login and API authorization checks (for example admin tab gates and other BFF-protected routes).",
+      },
+    ],
+  },
 ];
 
-const OUTCOME_OPTIONS: { value: string; label: string }[] = [
-  { value: "", label: "All outcomes" },
-  { value: "allow", label: "Allow" },
-  { value: "deny", label: "Deny" },
-  { value: "success", label: "Success" },
-  { value: "error", label: "Error" },
+const OUTCOME_OPTIONS: FilterOption[] = [
+  {
+    value: "",
+    label: "All outcomes",
+    description: "No outcome filter — show allow, deny, success, and error events together.",
+  },
+  {
+    value: "allow",
+    label: "Allow",
+    description: "Access was granted for an authorization or access-decision check.",
+  },
+  {
+    value: "deny",
+    label: "Deny",
+    description: "Access was refused for an authorization or access-decision check.",
+  },
+  {
+    value: "success",
+    label: "Success",
+    description: "A policy change (grant/revoke) completed and was written to the PDP.",
+  },
+  {
+    value: "error",
+    label: "Error",
+    description:
+      "A policy change failed (for example missing manage capability or OpenFGA write error).",
+  },
 ];
+
+const AUDIT_TYPE_DESCRIPTIONS: Partial<Record<AuditEventType, string>> = Object.fromEntries(
+  TYPE_FILTER_GROUPS.flatMap((group) => group.options)
+    .filter((option) => option.value !== "")
+    .map((option) => [option.value, option.description]),
+) as Partial<Record<AuditEventType, string>>;
+
+function FilterDefinitionsHelp({
+  ariaLabel,
+  title,
+  groups,
+  flatOptions,
+}: {
+  ariaLabel: string;
+  title: string;
+  groups?: typeof TYPE_FILTER_GROUPS;
+  flatOptions?: FilterOption[];
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 shrink-0"
+          aria-label={ariaLabel}
+          title="View definitions for each option"
+        >
+          <CircleHelp className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-3" align="start">
+        <p className="text-sm font-medium mb-2">{title}</p>
+        <dl className="space-y-3 text-xs">
+          {groups
+            ? groups.flatMap((group) =>
+                group.options.map((option) => (
+                  <div key={option.value || "all"}>
+                    <dt className="font-medium text-foreground">{option.label}</dt>
+                    <dd className="text-muted-foreground mt-0.5">{option.description}</dd>
+                  </div>
+                )),
+              )
+            : (flatOptions ?? []).map((option) => (
+                <div key={option.value || "all"}>
+                  <dt className="font-medium text-foreground">{option.label}</dt>
+                  <dd className="text-muted-foreground mt-0.5">{option.description}</dd>
+                </div>
+              ))}
+        </dl>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 function TypeBadge({ type }: { type: AuditEventType }) {
+  let badge: React.ReactNode;
   switch (type) {
     case "auth":
-      return (
+      badge = (
         <Badge variant="outline" className="text-blue-600 border-blue-300 bg-blue-50 dark:bg-blue-950 dark:text-blue-400 dark:border-blue-800 gap-1">
           <Shield className="h-3 w-3" />
           Auth
         </Badge>
       );
+      break;
     case "tool_action":
-      return (
+      badge = (
         <Badge variant="outline" className="text-emerald-600 border-emerald-300 bg-emerald-50 dark:bg-emerald-950 dark:text-emerald-400 dark:border-emerald-800 gap-1">
           <Wrench className="h-3 w-3" />
           Tool
         </Badge>
       );
+      break;
     case "openfga_rebac":
-      return (
+      badge = (
         <Badge variant="outline" className="text-cyan-600 border-cyan-300 bg-cyan-50 dark:bg-cyan-950 dark:text-cyan-400 dark:border-cyan-800 gap-1">
           <Network className="h-3 w-3" />
           OpenFGA ReBAC
         </Badge>
       );
+      break;
+    case "cas_decision":
+      badge = (
+        <Badge variant="outline" className="text-indigo-600 border-indigo-300 bg-indigo-50 dark:bg-indigo-950 dark:text-indigo-400 dark:border-indigo-800 gap-1">
+          <KeyRound className="h-3 w-3" />
+          Access decision
+        </Badge>
+      );
+      break;
+    case "cas_grant":
+      badge = (
+        <Badge variant="outline" className="text-violet-600 border-violet-300 bg-violet-50 dark:bg-violet-950 dark:text-violet-400 dark:border-violet-800 gap-1">
+          <UserPlus className="h-3 w-3" />
+          Policy change
+        </Badge>
+      );
+      break;
     case "agent_delegation":
-      return (
+      badge = (
         <Badge variant="outline" className="text-purple-600 border-purple-300 bg-purple-50 dark:bg-purple-950 dark:text-purple-400 dark:border-purple-800 gap-1">
           <GitBranch className="h-3 w-3" />
           Delegation
         </Badge>
       );
+      break;
     default:
-      return <Badge variant="outline">{type}</Badge>;
+      badge = <Badge variant="outline">{type}</Badge>;
   }
+
+  const description = AUDIT_TYPE_DESCRIPTIONS[type];
+  if (!description) return badge;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">{badge}</span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs">
+        {description}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 function OutcomeBadge({ outcome }: { outcome: UnifiedAuditOutcome }) {
@@ -132,9 +316,116 @@ function displaySource(source?: string): string {
   return source || "—";
 }
 
+function humanizeToken(value?: string | null): string {
+  if (!value) return "unknown";
+  const normalized = value.replace(/[_#:-]+/g, " ").trim();
+  return normalized || value;
+}
+
+function sentenceCase(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function parseResourceRef(resourceRef?: string | null): { type?: string; id?: string } {
+  if (!resourceRef) return {};
+  const [type, ...rest] = resourceRef.split(":");
+  if (!type || rest.length === 0) return {};
+  return { type, id: rest.join(":") };
+}
+
+function resourceTypeLabel(type?: string): string {
+  if (type === "task") return "workflow config";
+  if (type === "mcp_tool") return "MCP tool";
+  return humanizeToken(type);
+}
+
+function getResourceParts(evt: UnifiedAuditEvent): { type?: string; id?: string; label: string } {
+  const parsed = parseResourceRef(evt.resource_ref);
+  const type = evt.resource_type || parsed.type;
+  const id = evt.resource_id || parsed.id;
+  if (type && id) {
+    return { type, id, label: `${resourceTypeLabel(type)} ${id}` };
+  }
+  if (evt.resource_ref) return { label: evt.resource_ref };
+  if (evt.agent_name) return { type: "agent", id: evt.agent_name, label: `agent ${evt.agent_name}` };
+  return { label: "resource" };
+}
+
+function actorLabel(evt: UnifiedAuditEvent): string {
+  const actor = evt.user_email || evt.caller_ref || evt.subject_hash;
+  if (!actor) return "Actor unknown";
+  if (actor.startsWith("sha256:")) return `Actor ${actor.slice(0, 23)}...`;
+  return `Actor ${actor}`;
+}
+
+function decisionPathLabel(evt: UnifiedAuditEvent): string {
+  const via = evt.decision_via;
+  if (via === "tuple") return "OpenFGA tuple";
+  if (via === "org_admin") return "Organization admin";
+  if (via === "workflow_run_owner") return "Workflow run owner";
+  if (via === "workflow_run_owner_mismatch") return "Workflow owner mismatch";
+  if (via === "workflow_delegation") return "Workflow delegation";
+  if (via) return sentenceCase(humanizeToken(via));
+  if (evt.pdp === "openfga") return "OpenFGA";
+  if (evt.pdp === "local") return "Local policy";
+  return "—";
+}
+
+function requestStory(evt: UnifiedAuditEvent): string {
+  const resource = getResourceParts(evt).label;
+  const action = humanizeToken(evt.action);
+  if (evt.type === "cas_grant") {
+    const op = evt.operation === "revoke" ? "Revoked" : "Granted";
+    return `${op} ${action} on ${resource}`;
+  }
+  const verb =
+    evt.outcome === "allow" || evt.outcome === "success"
+      ? "Allowed"
+      : evt.outcome === "deny"
+        ? "Denied"
+        : "Failed";
+  return `${verb} to ${action} ${resource}`;
+}
+
+function reasonPhrase(evt: UnifiedAuditEvent): string {
+  const reason = evt.reason_code ? humanizeToken(evt.reason_code) : "no reason code";
+  if (evt.type === "cas_decision") {
+    const service = evt.component === "cas" || evt.source === "cas" ? "CAS" : displaySource(evt.source);
+    const decision = evt.outcome === "allow" ? "allowed" : "denied";
+    const pdp = evt.pdp === "openfga" ? "OpenFGA" : evt.pdp ? sentenceCase(evt.pdp) : "the policy engine";
+    const via = evt.decision_via ? ` via ${decisionPathLabel(evt)}` : "";
+    return `${service} ${decision} this request because ${pdp} returned ${reason}${via}.`;
+  }
+  if (evt.type === "cas_grant") {
+    const op = evt.operation === "revoke" ? "revoke" : "grant";
+    return `CAS recorded a ${op} attempt with result ${evt.outcome}.`;
+  }
+  return `${sentenceCase(displaySource(evt.source))} recorded ${evt.outcome} with reason ${reason}.`;
+}
+
+function formatDownloadTimestamp(iso: string): string {
+  return iso.replace(/[:.]/g, "-");
+}
+
+function downloadJsonFile(filename: string, payload: unknown): void {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
 export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
   const [result, setResult] = useState<PaginatedResult | null>(null);
   const [loading, setLoading] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
 
@@ -149,19 +440,24 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const autoRefreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  const buildAuditParams = useCallback((p: number, limit: number) => {
+    const params = new URLSearchParams();
+    params.set("page", String(p));
+    params.set("limit", String(limit));
+    if (typeFilter) params.set("type", typeFilter);
+    if (outcomeFilter) params.set("outcome", outcomeFilter);
+    if (userEmail.trim()) params.set("user_email", userEmail.trim());
+    if (agentName.trim()) params.set("agent_name", agentName.trim());
+    if (dateFrom) params.set("from", new Date(dateFrom).toISOString());
+    if (dateTo) params.set("to", new Date(dateTo).toISOString());
+    return params;
+  }, [typeFilter, outcomeFilter, userEmail, agentName, dateFrom, dateTo]);
+
   const fetchEvents = useCallback(async (p = 1) => {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams();
-      params.set("page", String(p));
-      params.set("limit", "30");
-      if (typeFilter) params.set("type", typeFilter);
-      if (outcomeFilter) params.set("outcome", outcomeFilter);
-      if (userEmail.trim()) params.set("user_email", userEmail.trim());
-      if (agentName.trim()) params.set("agent_name", agentName.trim());
-      if (dateFrom) params.set("from", new Date(dateFrom).toISOString());
-      if (dateTo) params.set("to", new Date(dateTo).toISOString());
+      const params = buildAuditParams(p, 30);
 
       const res = await fetch(`/api/admin/audit-events?${params.toString()}`);
       if (!res.ok) {
@@ -176,7 +472,54 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
     } finally {
       setLoading(false);
     }
-  }, [typeFilter, outcomeFilter, userEmail, agentName, dateFrom, dateTo]);
+  }, [buildAuditParams]);
+
+  const downloadEvents = useCallback(async () => {
+    setExporting(true);
+    setError(null);
+    try {
+      const records: UnifiedAuditEvent[] = [];
+      let exportPage = 1;
+      let total = 0;
+
+      while (true) {
+        const params = buildAuditParams(exportPage, 200);
+        const res = await fetch(`/api/admin/audit-events?${params.toString()}`);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || body.message || `HTTP ${res.status}`);
+        }
+
+        const data: PaginatedResult = await res.json();
+        total = data.total;
+        records.push(...data.records);
+
+        if (records.length >= data.total || data.records.length === 0) break;
+        exportPage += 1;
+      }
+
+      const filters: Record<string, string> = {};
+      if (typeFilter) filters.type = typeFilter;
+      if (outcomeFilter) filters.outcome = outcomeFilter;
+      if (userEmail.trim()) filters.user_email = userEmail.trim();
+      if (agentName.trim()) filters.agent_name = agentName.trim();
+      if (dateFrom) filters.from = new Date(dateFrom).toISOString();
+      if (dateTo) filters.to = new Date(dateTo).toISOString();
+
+      const exportedAt = new Date().toISOString();
+      downloadJsonFile(`rbac-audit-log-${formatDownloadTimestamp(exportedAt)}.json`, {
+        exported_at: exportedAt,
+        filters,
+        total,
+        record_count: records.length,
+        records,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to download audit events");
+    } finally {
+      setExporting(false);
+    }
+  }, [buildAuditParams, typeFilter, outcomeFilter, userEmail, agentName, dateFrom, dateTo]);
 
   useEffect(() => {
     fetchEvents(1);
@@ -194,6 +537,13 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
   }, [autoRefresh, page, fetchEvents]);
 
   const totalPages = result ? Math.ceil(result.total / result.limit) : 0;
+
+  const selectedTypeHelp = useMemo(
+    () =>
+      TYPE_FILTER_GROUPS.flatMap((group) => group.options).find((option) => option.value === typeFilter)
+        ?.description,
+    [typeFilter],
+  );
 
   const handleReset = () => {
     setTypeFilter("");
@@ -218,16 +568,32 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
   }
 
   return (
+    <TooltipProvider delayDuration={200}>
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <div>
             <CardTitle className="text-lg">RBAC Audit Log</CardTitle>
             <CardDescription>
-              Unified view of authorization decisions, OpenFGA ReBAC checks, tool invocations, and agent delegations
+              Policy changes, access decisions, ReBAC checks, tool use, and delegations in one timeline
             </CardDescription>
           </div>
           <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={downloadEvents}
+              disabled={exporting}
+              aria-label="Download audit log"
+              className="gap-1.5"
+            >
+              {exporting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Download className="h-3.5 w-3.5" />
+              )}
+              Download
+            </Button>
             <Button
               variant={autoRefresh ? "default" : "outline"}
               size="sm"
@@ -247,24 +613,55 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
       <CardContent>
         {/* Filters */}
         <div className="flex flex-wrap gap-3 mb-4">
-          <select
-            value={typeFilter}
-            onChange={(e) => setTypeFilter(e.target.value)}
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-          >
-            {TYPE_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
-          <select
-            value={outcomeFilter}
-            onChange={(e) => setOutcomeFilter(e.target.value)}
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-          >
-            {OUTCOME_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
+          <div className="flex items-center gap-0.5">
+            <select
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm max-w-[220px]"
+              title={selectedTypeHelp}
+            >
+              {TYPE_FILTER_GROUPS.map((group) =>
+                group.label ? (
+                  <optgroup key={group.label} label={group.label}>
+                    {group.options.map((o) => (
+                      <option key={o.value} value={o.value} title={o.description}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ) : (
+                  group.options.map((o) => (
+                    <option key={o.value || "all"} value={o.value} title={o.description}>
+                      {o.label}
+                    </option>
+                  ))
+                ),
+              )}
+            </select>
+            <FilterDefinitionsHelp
+              ariaLabel="Event type definitions"
+              title="Event types"
+              groups={TYPE_FILTER_GROUPS}
+            />
+          </div>
+          <div className="flex items-center gap-0.5">
+            <select
+              value={outcomeFilter}
+              onChange={(e) => setOutcomeFilter(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              {OUTCOME_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value} title={o.description}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            <FilterDefinitionsHelp
+              ariaLabel="Outcome filter definitions"
+              title="Outcomes"
+              flatOptions={OUTCOME_OPTIONS}
+            />
+          </div>
           <Input
             placeholder="User email..."
             value={userEmail}
@@ -325,16 +722,16 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
               <table className="w-full text-sm">
                 <thead>
                   <tr className="bg-muted/50 text-left">
-                    <th className="px-3 py-2 font-medium w-8" />
-                    <th className="px-3 py-2 font-medium">Time</th>
-                    <th className="px-3 py-2 font-medium">Type</th>
-                    <th className="px-3 py-2 font-medium">Source</th>
-                    <th className="px-3 py-2 font-medium">Action</th>
-                    <th className="px-3 py-2 font-medium">Agent</th>
-                    <th className="px-3 py-2 font-medium">User</th>
-                    <th className="px-3 py-2 font-medium">Outcome</th>
-                    <th className="px-3 py-2 font-medium">Duration</th>
-                  </tr>
+	                    <th className="px-3 py-2 font-medium w-8" />
+	                    <th className="px-3 py-2 font-medium">Time</th>
+	                    <th className="px-3 py-2 font-medium">Event</th>
+	                    <th className="px-3 py-2 font-medium">Actor</th>
+	                    <th className="px-3 py-2 font-medium">Request</th>
+	                    <th className="px-3 py-2 font-medium">Path</th>
+	                    <th className="px-3 py-2 font-medium">Outcome</th>
+	                    <th className="px-3 py-2 font-medium">Source</th>
+	                    <th className="px-3 py-2 font-medium">Duration</th>
+	                  </tr>
                 </thead>
                 <tbody>
                   {result.records.length === 0 && (
@@ -344,11 +741,15 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
                       </td>
                     </tr>
                   )}
-                  {result.records.map((evt) => {
-                    const rowKey = `${evt.correlation_id}-${evt.ts}`;
-                    const isExpanded = expandedRow === rowKey;
-                    return (
-                      <React.Fragment key={rowKey}>
+	                  {result.records.map((evt) => {
+	                    const rowKey = `${evt.correlation_id}-${evt.ts}`;
+	                    const isExpanded = expandedRow === rowKey;
+	                    const resource = getResourceParts(evt);
+	                    const story = requestStory(evt);
+	                    const actor = actorLabel(evt);
+	                    const path = decisionPathLabel(evt);
+	                    return (
+	                      <React.Fragment key={rowKey}>
                         <tr
                           className="border-t hover:bg-muted/30 cursor-pointer transition-colors"
                           onClick={() => setExpandedRow(isExpanded ? null : rowKey)}
@@ -363,25 +764,29 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
                           <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
                             {formatTimestamp(evt.ts)}
                           </td>
-                          <td className="px-3 py-2">
-                            <TypeBadge type={evt.type} />
-                          </td>
-                          <td className="px-3 py-2 font-mono text-[11px] text-muted-foreground max-w-[160px] truncate" title={displaySource(evt.source)}>
-                            {displaySource(evt.source)}
-                          </td>
-                          <td className="px-3 py-2 font-mono text-xs max-w-[200px] truncate" title={evt.action}>
-                            {evt.action}
-                          </td>
-                          <td className="px-3 py-2 text-xs">
-                            {evt.agent_name || "—"}
-                          </td>
-                          <td className="px-3 py-2 text-xs max-w-[200px] truncate" title={evt.user_email || evt.subject_hash}>
-                            {evt.user_email || <span className="text-muted-foreground">{evt.subject_hash.slice(0, 16) + "…"}</span>}
-                          </td>
-                          <td className="px-3 py-2">
-                            <OutcomeBadge outcome={evt.outcome} />
-                          </td>
-                          <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
+	                          <td className="px-3 py-2">
+	                            <TypeBadge type={evt.type} />
+	                          </td>
+	                          <td className="px-3 py-2 text-xs max-w-[220px] truncate" title={evt.caller_ref || evt.user_email || evt.subject_hash}>
+	                            {actor}
+	                          </td>
+	                          <td className="px-3 py-2 min-w-[260px]" title={`${evt.action} ${evt.resource_ref || ""}`.trim()}>
+	                            <div className="font-medium text-sm">{story}</div>
+	                            <div className="text-[11px] text-muted-foreground mt-0.5">
+	                              {evt.workflow_run_id ? `Workflow run ${evt.workflow_run_id}` : `Resource ${resource.label}`}
+	                              {evt.action ? ` · Action ${evt.action}` : ""}
+	                            </div>
+	                          </td>
+	                          <td className="px-3 py-2 text-xs max-w-[180px] truncate" title={path}>
+	                            {path}
+	                          </td>
+	                          <td className="px-3 py-2">
+	                            <OutcomeBadge outcome={evt.outcome} />
+	                          </td>
+	                          <td className="px-3 py-2 font-mono text-[11px] text-muted-foreground max-w-[150px] truncate" title={displaySource(evt.source)}>
+	                            {displaySource(evt.source)}
+	                          </td>
+	                          <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
                             {evt.duration_ms != null && (
                               <span className="flex items-center gap-1">
                                 <Clock className="h-3 w-3" />
@@ -392,18 +797,34 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
                           </td>
                         </tr>
                         {isExpanded && (
-                          <tr className="border-t bg-muted/20">
-                            <td colSpan={9} className="px-6 py-4">
-                              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-xs">
-                                <DetailField label="Correlation ID" value={evt.correlation_id} />
-                                <DetailField label="Context ID" value={evt.context_id} />
-                                <DetailField label="Component" value={evt.component} />
+	                          <tr className="border-t bg-muted/20">
+	                            <td colSpan={9} className="px-6 py-4">
+	                              <div className="mb-4 rounded-md border border-border/60 bg-background/60 p-3">
+	                                <div className="text-xs text-muted-foreground mb-1">What happened:</div>
+	                                <div className="text-sm font-medium">{story}</div>
+	                                <div className="text-xs text-muted-foreground mt-1">{reasonPhrase(evt)}</div>
+	                              </div>
+	                              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-xs">
+	                                <DetailField label="Actor" value={actor} />
+	                                <DetailField label="Request" value={`${humanizeToken(evt.action)} ${resource.label}`} />
+	                                <DetailField label="Decision Path" value={path} />
+	                                <DetailField label="Correlation ID" value={evt.correlation_id} />
+	                                <DetailField label="Context ID" value={evt.context_id} />
+	                                <DetailField label="Component" value={evt.component} />
                                 <DetailField label="Source" value={displaySource(evt.source)} />
                                 <DetailField label="Tool" value={evt.tool_name} />
                                 <DetailField label="PDP" value={evt.pdp} />
                                 <DetailField label="Trace ID" value={evt.trace_id} mono />
                                 <DetailField label="Reason Code" value={evt.reason_code} />
                                 <DetailField label="Resource Ref" value={evt.resource_ref} />
+	                                <DetailField label="Resource Type" value={evt.resource_type} />
+	                                <DetailField label="Resource ID" value={evt.resource_id} />
+	                                <DetailField label="Workflow Run ID" value={evt.workflow_run_id} />
+	                                <DetailField label="Raw Decision Path" value={evt.decision_via} />
+                                <DetailField label="Operation" value={evt.operation} />
+                                <DetailField label="Caller" value={evt.caller_ref} />
+                                <DetailField label="Grantee" value={evt.grantee_ref} />
+                                <DetailField label="Actor Hash" value={evt.actor_hash} mono />
                                 <DetailField label="Subject Hash" value={evt.subject_hash} mono />
                                 <DetailField label="Tenant" value={evt.tenant_id} />
                               </div>
@@ -447,6 +868,7 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
         )}
       </CardContent>
     </Card>
+    </TooltipProvider>
   );
 }
 

--- a/ui/src/components/admin/security/__tests__/CasInsightsTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/CasInsightsTab.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CasInsightsTab } from "../CasInsightsTab";
+
+const ENGINE = { circuitState: "closed", cacheSize: 5, cacheHits: 8, cacheMisses: 2, cacheHitRatio: 0.8 };
+
+function mockStats(body: unknown, ok = true) {
+  (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({ ok, json: async () => body });
+}
+
+describe("CasInsightsTab", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows the admin-required message when not admin and does not fetch", () => {
+    (global.fetch as jest.Mock) = jest.fn();
+    render(<CasInsightsTab isAdmin={false} />);
+    expect(screen.getByText(/Admin access required/i)).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("renders the live engine snapshot and durable decision stats", async () => {
+    mockStats({
+      engine: ENGINE,
+      persistence: true,
+      window: "24h",
+      decisions: {
+        total: 10,
+        allow: 8,
+        deny: 2,
+        denyRate: 0.2,
+        byReason: [{ reason: "OK", count: 8 }, { reason: "NO_CAPABILITY", count: 2 }],
+        topDenied: [{ resource: "agent:pe", count: 2 }],
+      },
+    });
+    render(<CasInsightsTab isAdmin={true} />);
+
+    await waitFor(() => expect(screen.getByText(/Closed \(healthy\)/i)).toBeInTheDocument());
+    expect(screen.getByText("80.0%")).toBeInTheDocument(); // cache hit ratio
+    expect(screen.getByText(/20.0% deny rate/i)).toBeInTheDocument();
+    expect(screen.getByText("NO_CAPABILITY")).toBeInTheDocument();
+    expect(screen.getByText("agent:pe")).toBeInTheDocument();
+    expect(screen.getByText(/Centralized Authorization Service/i)).toBeInTheDocument();
+  });
+
+  it("explains when MongoDB is unconfigured (engine-only)", async () => {
+    mockStats({ engine: ENGINE, persistence: false, window: "24h", decisions: null });
+    render(<CasInsightsTab isAdmin={true} />);
+    await waitFor(() => expect(screen.getByText(/MongoDB is not configured/i)).toBeInTheDocument());
+  });
+
+  it("surfaces an error when the stats request fails", async () => {
+    mockStats({ error: "boom" }, false);
+    render(<CasInsightsTab isAdmin={true} />);
+    await waitFor(() => expect(screen.getByText("boom")).toBeInTheDocument());
+  });
+
+  it("refetches with the selected window", async () => {
+    mockStats({ engine: ENGINE, persistence: false, window: "24h", decisions: null });
+    render(<CasInsightsTab isAdmin={true} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "7d" } });
+    await waitFor(() =>
+      expect((global.fetch as jest.Mock).mock.calls.some((c) => String(c[0]).includes("window=7d"))).toBe(true),
+    );
+  });
+});

--- a/ui/src/components/admin/security/__tests__/CasInsightsTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/CasInsightsTab.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { CasInsightsTab } from "../CasInsightsTab";
+import { CasInsightsTab } from "../../CasInsightsTab";
 
 const ENGINE = { circuitState: "closed", cacheSize: 5, cacheHits: 8, cacheMisses: 2, cacheHitRatio: 0.8 };
 

--- a/ui/src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx
@@ -241,36 +241,6 @@ beforeEach(() => {
       rebacCheckAllowed = (lastChangeSetBody?.writes?.length ?? 0) > 0;
       return jsonResponse({ data: { applied: true } });
     }
-    if (url.startsWith("/api/admin/openfga/baseline-diagnostics")) {
-      return jsonResponse({
-        data: {
-          user_id: "alice-sub",
-          summary: { total: 2, matches_member: 2, matches_admin: 1, member_drift: 0, admin_drift: 1 },
-          checks: [
-            {
-              id: "baseline-metrics-read",
-              label: "Read-only metrics admin surface",
-              tuple: { user: "user:alice-sub", relation: "can_read", object: "admin_surface:metrics" },
-              actual: true,
-              expected_member: true,
-              expected_admin: true,
-              matches_member: true,
-              matches_admin: true,
-            },
-            {
-              id: "organization-manage",
-              label: "Organization manage",
-              tuple: { user: "user:alice-sub", relation: "can_manage", object: "organization:caipe" },
-              actual: false,
-              expected_member: false,
-              expected_admin: true,
-              matches_member: true,
-              matches_admin: false,
-            },
-          ],
-        },
-      });
-    }
     if (url === "/api/admin/slack/channels") {
       return jsonResponse({ data: { channels: [] } });
     }
@@ -323,7 +293,7 @@ function jsonResponse(payload: unknown): Response {
 it("does not expose the low-value Enforcement Status tab", async () => {
   render(<OpenFgaRebacTab isAdmin />);
 
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toBeInTheDocument();
+  expect(await screen.findByRole("tab", { name: "OpenFGA Tuples" })).toBeInTheDocument();
   expect(screen.queryByRole("tab", { name: "Enforcement Status" })).not.toBeInTheDocument();
 });
 
@@ -337,9 +307,7 @@ it("orders OpenFGA tabs by operational flow and defaults to tuples", async () =>
   expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
     "OpenFGA Tuples",
     "Policy Graph",
-    "Access Manager",
     "Default FGA Grants",
-    "Diagnostics",
   ]);
   expect(await screen.findByText("OpenFGA Tuple Store")).toBeInTheDocument();
 
@@ -361,17 +329,18 @@ it("falls back to tuples for integration-owned Slack/Webex query strings", async
   expect(screen.queryByRole("tab", { name: "Webex Spaces" })).not.toBeInTheDocument();
 });
 
-it("keeps OpenFGA focused on tuples, graph, access management, and diagnostics", async () => {
+it("keeps OpenFGA focused on tuples, graph, and default grants", async () => {
   currentSearchParams = new URLSearchParams("subtab=tuples");
 
   render(<OpenFgaRebacTab isAdmin />);
 
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toBeInTheDocument();
+  expect(await screen.findByRole("tab", { name: "OpenFGA Tuples" })).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "Policy Graph" })).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "Default FGA Grants" })).toBeInTheDocument();
+  expect(screen.queryByRole("tab", { name: "Access Manager" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("tab", { name: "Diagnostics" })).not.toBeInTheDocument();
   expect(screen.queryByRole("tab", { name: "Relationship Builder" })).not.toBeInTheDocument();
   expect(screen.queryByRole("tab", { name: "Effective Access" })).not.toBeInTheDocument();
-  expect(screen.getByRole("tab", { name: "Policy Graph" })).toBeInTheDocument();
-  expect(screen.getByRole("tab", { name: "OpenFGA Tuples" })).toBeInTheDocument();
-  expect(screen.getByRole("tab", { name: "Diagnostics" })).toBeInTheDocument();
   expect(screen.queryByRole("tab", { name: "RAG Team Access" })).not.toBeInTheDocument();
   expect(screen.queryByRole("tab", { name: "Slack Channels" })).not.toBeInTheDocument();
   expect(screen.queryByRole("tab", { name: "Webex Spaces" })).not.toBeInTheDocument();
@@ -401,47 +370,6 @@ it("only reloads tuple filters when Apply filters is clicked", async () => {
   ).toBe("/api/admin/openfga/tuples?relation=can&limit=100");
 });
 
-it("runs baseline diagnostics for an individual user", async () => {
-  const user = userEvent.setup();
-  currentSearchParams = new URLSearchParams("openfgaTab=diagnostics");
-
-  render(<OpenFgaRebacTab isAdmin />);
-
-  expect(await screen.findByRole("tab", { name: "Diagnostics" })).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
-  await user.type(screen.getByLabelText("User subject"), "alice-sub");
-  await user.click(screen.getByRole("button", { name: "Diagnose" }));
-
-  expect(await screen.findByText("Member baseline drift")).toBeInTheDocument();
-  expect(screen.getByText("Read-only metrics admin surface")).toBeInTheDocument();
-  expect(fetchMock).toHaveBeenCalledWith(
-    "/api/admin/openfga/baseline-diagnostics?userId=alice-sub"
-  );
-});
-
-it("maps legacy relationship builder links to the access manager", async () => {
-  currentSearchParams = new URLSearchParams("openfgaTab=builder");
-
-  render(<OpenFgaRebacTab isAdmin />);
-
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
-  expect(await screen.findByText("Access Manager Permission Cheatsheet")).toBeInTheDocument();
-  expect(screen.getByText("Base relationships you write")).toBeInTheDocument();
-  expect(screen.getByText("Derived permissions OpenFGA checks")).toBeInTheDocument();
-  expect(screen.getByText(/team:<slug>#member user agent:<id>/)).toBeInTheDocument();
-  expect(screen.getAllByText(/use or invoke agent/).length).toBeGreaterThan(0);
-  expect(screen.getByText("Subjects and usersets")).toBeInTheDocument();
-  expect(screen.getByText("Resource objects")).toBeInTheDocument();
-  expect(screen.getByText("user:<sub>")).toBeInTheDocument();
-  expect(screen.getByText("team:<slug>#member")).toBeInTheDocument();
-  expect(screen.getByText("conversation:<id>")).toBeInTheDocument();
-  expect(screen.getByText("system_config:<key>")).toBeInTheDocument();
-});
 
 it("starts the policy graph with a clean team workspace and selected resources only", async () => {
   const user = userEvent.setup();
@@ -735,139 +663,4 @@ it("shows the manual user subject controls inside the fullscreen graph", async (
   });
 });
 
-it("exposes catalog-backed universal resource types in the access manager", async () => {
-  currentSearchParams = new URLSearchParams("openfgaTab=access");
-
-  render(<OpenFgaRebacTab isAdmin />);
-
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
-
-  const resourceType = screen.getByLabelText("Resource type");
-  expect(within(resourceType).getByRole("option", { name: "Team" })).toBeInTheDocument();
-  expect(within(resourceType).getByRole("option", { name: "Slack channel" })).toBeInTheDocument();
-  expect(within(resourceType).getByRole("option", { name: "AgentGateway" })).toBeInTheDocument();
-  expect(within(resourceType).getByRole("option", { name: "MCP server" })).toBeInTheDocument();
-  expect(within(resourceType).getByRole("option", { name: "Tool" })).toBeInTheDocument();
-});
-
-it("checks effective access for a searched user subject", async () => {
-  const user = userEvent.setup();
-  currentSearchParams = new URLSearchParams("openfgaTab=access");
-
-  render(<OpenFgaRebacTab isAdmin />);
-
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
-
-  await user.selectOptions(screen.getByLabelText("Subject type"), "user");
-  await user.type(screen.getByLabelText("Subject"), "alice");
-  await user.click(screen.getByRole("button", { name: "Search subjects" }));
-  await user.click(await screen.findByRole("button", { name: /Alice Admin/ }));
-
-  await user.selectOptions(screen.getByLabelText("Resource type"), "agent");
-  await user.selectOptions(screen.getByLabelText("Resource"), "agent-1");
-  await user.selectOptions(screen.getByLabelText("Action"), "use");
-  await user.click(screen.getByRole("button", { name: "Explain effective access" }));
-
-  await waitFor(() => {
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/rebac/check",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          relationship: {
-            subject: { type: "user", id: "alice-sub" },
-            action: "use",
-            resource: { type: "agent", id: "agent-1" },
-          },
-        }),
-      })
-    );
-  });
-});
-
-it("lets admins grant the selected relationship when effective access is denied", async () => {
-  const user = userEvent.setup();
-  rebacCheckAllowed = false;
-  currentSearchParams = new URLSearchParams("openfgaTab=access");
-
-  render(<OpenFgaRebacTab isAdmin />);
-
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
-
-  await user.selectOptions(screen.getByLabelText("Action"), "use");
-  await user.click(screen.getByRole("button", { name: "Explain effective access" }));
-  expect(await screen.findByText("denied")).toBeInTheDocument();
-
-  await user.click(screen.getByRole("button", { name: "Grant this access" }));
-
-  await waitFor(() => {
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/rebac/change-sets",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          name: "Grant effective access use agent:agent-1",
-          writes: [
-            {
-              subject: { type: "team", id: "platform", relation: "member" },
-              action: "use",
-              resource: { type: "agent", id: "agent-1" },
-            },
-          ],
-          deletes: [],
-        }),
-      })
-    );
-  });
-  expect(await screen.findByText("allowed")).toBeInTheDocument();
-});
-
-it("lets admins revoke the selected relationship when effective access is allowed", async () => {
-  const user = userEvent.setup();
-  rebacCheckAllowed = true;
-  currentSearchParams = new URLSearchParams("openfgaTab=access");
-
-  render(<OpenFgaRebacTab isAdmin />);
-
-  expect(await screen.findByRole("tab", { name: "Access Manager" })).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
-
-  await user.selectOptions(screen.getByLabelText("Action"), "use");
-  await user.click(screen.getByRole("button", { name: "Explain effective access" }));
-  expect(await screen.findByText("allowed")).toBeInTheDocument();
-
-  await user.click(screen.getByRole("button", { name: "Revoke this access" }));
-
-  await waitFor(() => {
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/rebac/change-sets",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          name: "Revoke effective access use agent:agent-1",
-          writes: [],
-          deletes: [
-            {
-              subject: { type: "team", id: "platform", relation: "member" },
-              action: "use",
-              resource: { type: "agent", id: "agent-1" },
-            },
-          ],
-        }),
-      })
-    );
-  });
-  expect(await screen.findByText("denied")).toBeInTheDocument();
-});
 

--- a/ui/src/components/admin/security/__tests__/PermissionDebuggerTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/PermissionDebuggerTab.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PermissionDebuggerTab } from "../PermissionDebuggerTab";
+
+describe("PermissionDebuggerTab", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows the admin-required message when not admin", () => {
+    render(<PermissionDebuggerTab isAdmin={false} />);
+    expect(screen.getByText(/Admin access required/i)).toBeInTheDocument();
+  });
+
+  it("spells out the service name (no bare acronym) in the description", () => {
+    render(<PermissionDebuggerTab isAdmin={true} />);
+    expect(screen.getByText(/Centralized Authorization Service/i)).toBeInTheDocument();
+  });
+
+  it("disables Explain until subject and resource ids are filled", () => {
+    render(<PermissionDebuggerTab isAdmin={true} />);
+    const explain = screen.getByRole("button", { name: /Explain/i });
+    expect(explain).toBeDisabled();
+  });
+
+  it("submits an explain request and renders the decision + OpenFGA debug block", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        decision: "DENY",
+        reason: "NO_CAPABILITY",
+        retriable: false,
+        debug: { engine: "openfga", relation: "can_use", checked: ["user:bob can_use agent:pe"], store: "store-xyz" },
+      }),
+    });
+    render(<PermissionDebuggerTab isAdmin={true} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/subject id/i), { target: { value: "bob" } });
+    fireEvent.change(screen.getByPlaceholderText(/resource id/i), { target: { value: "pe" } });
+    fireEvent.click(screen.getByRole("button", { name: /Explain/i }));
+
+    await waitFor(() => expect(screen.getByText("DENY")).toBeInTheDocument());
+    expect(screen.getByText("can_use")).toBeInTheDocument();
+    expect(screen.getByText("user:bob can_use agent:pe")).toBeInTheDocument();
+
+    const sentBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(sentBody).toEqual({
+      subject: { type: "user", id: "bob" },
+      resource: { type: "agent", id: "pe" },
+      action: "use",
+    });
+  });
+
+  it("surfaces an error from a failed explain call", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({ ok: false, json: async () => ({ error: "nope" }) });
+    render(<PermissionDebuggerTab isAdmin={true} />);
+    fireEvent.change(screen.getByPlaceholderText(/subject id/i), { target: { value: "bob" } });
+    fireEvent.change(screen.getByPlaceholderText(/resource id/i), { target: { value: "pe" } });
+    fireEvent.click(screen.getByRole("button", { name: /Explain/i }));
+    await waitFor(() => expect(screen.getByText("nope")).toBeInTheDocument());
+  });
+});

--- a/ui/src/components/admin/security/__tests__/PermissionsToolTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/PermissionsToolTab.test.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PermissionsToolTab } from "../../PermissionsToolTab";
+
+const ok = (body: unknown) => Promise.resolve({ ok: true, json: async () => body } as Response);
+
+const MATRIX = {
+  results: [
+    { action: "use", decision: "ALLOW", reason: "OK", retriable: false, via: "org_admin", debug: { engine: "openfga", relation: "can_use", checked: ["user:bob-sub can_use agent:pe"], store: "s" } },
+    { action: "read", decision: "DENY", reason: "NO_CAPABILITY", retriable: false, debug: { engine: "openfga", relation: "can_read", checked: ["user:bob-sub can_read agent:pe"], store: "s" } },
+  ],
+};
+
+function routedFetch(opts: { explain?: unknown; explainOk?: boolean; resources?: { id: string }[] } = {}) {
+  const { explain = {}, explainOk = true, resources = [{ id: "pe" }, { id: "agent-sre-agent" }] } = opts;
+  return jest.fn((url: string) => {
+    const u = String(url);
+    if (u.includes("/api/admin/users")) return ok([{ id: "bob-sub", email: "bob@example.com" }]);
+    if (u.includes("/api/admin/authz/resources")) return ok({ resources });
+    if (u.includes("/api/admin/authz/explain")) return Promise.resolve({ ok: explainOk, json: async () => explain } as Response);
+    return ok({});
+  });
+}
+
+describe("PermissionsToolTab", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows the admin-required message when not admin", () => {
+    render(<PermissionsToolTab isAdmin={false} />);
+    expect(screen.getByText(/Admin access required/i)).toBeInTheDocument();
+  });
+
+  it("spells out the service name (no bare acronym)", () => {
+    (global.fetch as jest.Mock) = routedFetch();
+    render(<PermissionsToolTab isAdmin={true} />);
+    expect(screen.getByText(/Centralized Authorization Service/i)).toBeInTheDocument();
+  });
+
+  it("renders a pick dropdown AND an editable text field for subject and resource", async () => {
+    (global.fetch as jest.Mock) = routedFetch();
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "bob@example.com" }); // users loaded
+    await screen.findByRole("option", { name: "agent-sre-agent" }); // resources (OpenFGA) loaded
+    expect((screen.getByLabelText("Subject options") as HTMLElement).tagName).toBe("SELECT");
+    expect((screen.getByLabelText("Subject") as HTMLElement).tagName).toBe("INPUT");
+    expect((screen.getByLabelText("Resource options") as HTMLElement).tagName).toBe("SELECT");
+    expect((screen.getByLabelText("Resource") as HTMLElement).tagName).toBe("INPUT");
+  });
+
+  it("picking a resource from the dropdown fills the editable text field", async () => {
+    (global.fetch as jest.Mock) = routedFetch();
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "agent-sre-agent" });
+    fireEvent.change(screen.getByLabelText("Resource options"), { target: { value: "agent-sre-agent" } });
+    expect((screen.getByLabelText("Resource") as HTMLInputElement).value).toBe("agent-sre-agent");
+  });
+
+  it("evaluates the whole matrix and renders a row per action", async () => {
+    (global.fetch as jest.Mock) = routedFetch({ explain: MATRIX });
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "bob@example.com" });
+    fireEvent.change(screen.getByLabelText("Subject options"), { target: { value: "bob-sub" } });
+    fireEvent.change(screen.getByLabelText("Resource options"), { target: { value: "pe" } });
+    fireEvent.click(screen.getByRole("button", { name: /Explain all actions/i }));
+
+    await waitFor(() => expect(screen.getByText("Permission matrix")).toBeInTheDocument());
+    expect(screen.getByText("can_use")).toBeInTheDocument();
+    expect(screen.getByText("can_read")).toBeInTheDocument();
+    expect(screen.getByText("ALLOW")).toBeInTheDocument();
+    expect(screen.getByText("admin bypass")).toBeInTheDocument(); // via column for the org-admin ALLOW
+
+    const explainCall = (global.fetch as jest.Mock).mock.calls.find((c) => String(c[0]).includes("/explain"));
+    const sent = JSON.parse(explainCall[1].body);
+    expect(sent.subject).toEqual({ type: "user", id: "bob-sub" });
+    expect(sent.resource).toEqual({ type: "agent", id: "pe" });
+    expect(Array.isArray(sent.actions)).toBe(true);
+  });
+
+  it("shows a text-only field when no resources exist for the type", async () => {
+    (global.fetch as jest.Mock) = routedFetch({ resources: [] });
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "bob@example.com" });
+    await waitFor(() => expect(screen.queryByLabelText("Resource options")).not.toBeInTheDocument());
+    expect((screen.getByLabelText("Resource") as HTMLElement).tagName).toBe("INPUT");
+  });
+
+  it("refresh re-pulls the resource choices", async () => {
+    (global.fetch as jest.Mock) = routedFetch();
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "agent-sre-agent" });
+    const before = (global.fetch as jest.Mock).mock.calls.filter((c) => String(c[0]).includes("/resources")).length;
+    fireEvent.click(screen.getByRole("button", { name: /Refresh resource choices/i }));
+    await waitFor(() =>
+      expect((global.fetch as jest.Mock).mock.calls.filter((c) => String(c[0]).includes("/resources")).length).toBeGreaterThan(before),
+    );
+  });
+
+  it("surfaces an error from a failed explain call", async () => {
+    (global.fetch as jest.Mock) = routedFetch({ explain: { error: "nope" }, explainOk: false });
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "bob@example.com" });
+    fireEvent.change(screen.getByLabelText("Subject options"), { target: { value: "bob-sub" } });
+    fireEvent.change(screen.getByLabelText("Resource options"), { target: { value: "pe" } });
+    fireEvent.click(screen.getByRole("button", { name: /Explain all actions/i }));
+    await waitFor(() => expect(screen.getByText("nope")).toBeInTheDocument());
+  });
+
+  it("does not offer revoke when an ALLOW is inherited rather than a direct grant", async () => {
+    (global.fetch as jest.Mock) = routedFetch({
+      explain: {
+        results: [
+          {
+            action: "use",
+            decision: "ALLOW",
+            reason: "OK",
+            retriable: false,
+            via: "tuple",
+            directGrant: {
+              tuple: "user:bob-sub user agent:pe",
+              present: false,
+              revocable: false,
+            },
+            debug: {
+              engine: "openfga",
+              relation: "can_use",
+              checked: ["user:bob-sub can_use agent:pe"],
+              store: "s",
+            },
+          },
+        ],
+      },
+    });
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "bob@example.com" });
+    fireEvent.change(screen.getByLabelText("Subject options"), { target: { value: "bob-sub" } });
+    fireEvent.change(screen.getByLabelText("Resource options"), { target: { value: "pe" } });
+    fireEvent.click(screen.getByRole("button", { name: /Explain all actions/i }));
+
+    await waitFor(() => expect(screen.getByText("Permission matrix")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Revoke" })).not.toBeInTheDocument();
+    expect(screen.getByText("Inherited")).toBeInTheDocument();
+  });
+
+  it("greys out unsupported capabilities and does not offer grant actions", async () => {
+    (global.fetch as jest.Mock) = routedFetch({
+      explain: {
+        results: [
+          {
+            action: "ingest",
+            supported: false,
+            decision: "DENY",
+            reason: "INVALID_REQUEST",
+            unsupportedReason: "capability is not supported for this resource type",
+            retriable: false,
+            via: null,
+            debug: {
+              engine: "openfga",
+              relation: "can_ingest",
+              checked: ["user:bob-sub can_ingest agent:pe"],
+              store: "s",
+            },
+          },
+        ],
+      },
+    });
+    render(<PermissionsToolTab isAdmin={true} />);
+    await screen.findByRole("option", { name: "bob@example.com" });
+    fireEvent.change(screen.getByLabelText("Subject options"), { target: { value: "bob-sub" } });
+    fireEvent.change(screen.getByLabelText("Resource options"), { target: { value: "pe" } });
+    fireEvent.click(screen.getByRole("button", { name: /Explain all actions/i }));
+
+    const row = await screen.findByTestId("permission-row-ingest");
+    expect(row).toHaveClass("opacity-50");
+    expect(screen.getAllByText("Not supported")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "Grant" })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/admin/security/__tests__/UnifiedAuditTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/UnifiedAuditTab.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { UnifiedAuditTab } from '../UnifiedAuditTab';
 
+// assisted-by Codex Codex-sonnet-4-6
+
 describe('UnifiedAuditTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,7 +58,7 @@ describe('UnifiedAuditTab', () => {
     });
 
     expect(await screen.findByText(/RBAC Audit Log/i)).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /^All$/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /^All event types$/i })).toBeInTheDocument();
     expect(screen.queryByText(/Default view hides routine admin page-view checks/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /^All types$/i })).not.toBeInTheDocument();
     expect(screen.getByText(/admin_ui#view/i)).toBeInTheDocument();
@@ -96,7 +98,7 @@ describe('UnifiedAuditTab', () => {
   });
 
   it('blends bridge OpenFGA decisions into the audit table without rendering trace links', async () => {
-    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+    (global.fetch as jest.Mock).mockImplementation(() => {
       return Promise.resolve({
         ok: true,
         json: async () => ({
@@ -130,5 +132,247 @@ describe('UnifiedAuditTab', () => {
     expect(screen.getByText(/openfga_authz_bridge/i)).toBeInTheDocument();
     fireEvent.click(screen.getByText(/mcp#can_call/i));
     expect(screen.queryByText(/^Trace:/i)).not.toBeInTheDocument();
+  });
+
+  it('shows event type and outcome definition help', async () => {
+    render(<UnifiedAuditTab isAdmin />);
+
+    await screen.findByText(/RBAC Audit Log/i);
+
+    const typeHelp = screen.getByRole('button', { name: /event type definitions/i });
+    fireEvent.click(typeHelp);
+    expect(await screen.findByText(/Grant and revoke attempts written by CAS/i)).toBeInTheDocument();
+    expect(screen.getByText(/Allow\/deny results when the Centralized Authorization Service/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /outcome filter definitions/i }));
+    expect(await screen.findByText(/A policy change \(grant\/revoke\) completed/i)).toBeInTheDocument();
+  });
+
+  it('renders cas_grant policy-change events with caller and grantee context', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        records: [
+          {
+            ts: new Date().toISOString(),
+            type: 'cas_grant',
+            outcome: 'success',
+            action: 'use',
+            tenant_id: 'acme',
+            subject_hash: 'hash-caller',
+            correlation_id: 'grant-corr',
+            source: 'cas',
+            caller_ref: 'user:alice',
+            grantee_ref: 'team:eng',
+            operation: 'grant',
+            resource_ref: 'agent:platform-engineer',
+            component: 'cas',
+            pdp: 'openfga',
+          },
+          {
+            ts: new Date().toISOString(),
+            type: 'cas_grant',
+            outcome: 'error',
+            action: 'use',
+            tenant_id: 'acme',
+            subject_hash: 'hash-caller',
+            correlation_id: 'grant-deny-corr',
+            source: 'cas',
+            caller_ref: 'user:bob',
+            grantee_ref: 'team:eng',
+            operation: 'revoke',
+            reason_code: 'NO_CAPABILITY',
+            resource_ref: 'agent:platform-engineer',
+          },
+        ],
+        total: 2,
+        page: 1,
+        limit: 30,
+      }),
+    });
+
+    render(<UnifiedAuditTab isAdmin />);
+
+    expect(await screen.findByText(/user:alice/i)).toBeInTheDocument();
+    expect(screen.getByText(/user:bob/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Policy change/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('option', { name: /Policy changes/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/user:alice/i));
+    expect(await screen.findByText(/Grantee:/i)).toBeInTheDocument();
+    expect(screen.getByText(/team:eng/i)).toBeInTheDocument();
+    expect(screen.getByText(/Operation:/i)).toBeInTheDocument();
+    expect(screen.getByText(/^grant$/i)).toBeInTheDocument();
+  });
+
+  it('renders CAS decisions as readable authorization stories', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        records: [
+          {
+            ts: new Date('2026-06-11T22:05:36.000Z').toISOString(),
+            type: 'cas_decision',
+            outcome: 'allow',
+            action: 'manage',
+            tenant_id: 'default',
+            subject_hash: 'sha256:9accc8a00ffe8ae4451e81d95686e1f4',
+            user_email: 'sraradhy@cisco.com',
+            correlation_id: 'af9c0e92-3060-46de-bb16-db3e26c4f973',
+            source: 'cas',
+            component: 'cas',
+            pdp: 'openfga',
+            reason_code: 'OK',
+            resource_ref: 'organization:caipe',
+            resource_type: 'organization',
+            resource_id: 'caipe',
+            decision_via: 'tuple',
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 30,
+      }),
+    });
+
+    render(<UnifiedAuditTab isAdmin />);
+
+    expect(await screen.findByText(/Allowed to manage organization caipe/i)).toBeInTheDocument();
+    expect(screen.getByText(/Actor sraradhy@cisco.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/OpenFGA tuple/i)).toBeInTheDocument();
+    const headers = screen.getAllByRole('columnheader').map((header) => header.textContent?.trim());
+    expect(headers.indexOf('Actor')).toBeLessThan(headers.indexOf('Request'));
+
+    fireEvent.click(screen.getByText(/Allowed to manage organization caipe/i));
+    expect(await screen.findByText(/What happened:/i)).toBeInTheDocument();
+    expect(screen.getByText(/CAS allowed this request because OpenFGA returned OK/i)).toBeInTheDocument();
+  });
+
+  it('downloads all filtered audit events as JSON', async () => {
+    const exportedUrls: string[] = [];
+    const createObjectURL = jest.fn(() => {
+      exportedUrls.push(`blob:mock-${exportedUrls.length}`);
+      return exportedUrls[exportedUrls.length - 1];
+    });
+    const revokeObjectURL = jest.fn();
+    const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    const pageOneRecord = {
+      id: 'cas-1',
+      ts: new Date('2026-06-11T20:00:00.000Z').toISOString(),
+      type: 'cas_decision',
+      outcome: 'allow',
+      action: 'use',
+      tenant_id: 'default',
+      subject_hash: 'sha256:owner',
+      correlation_id: 'wfrun-20260611200000-abc',
+      source: 'cas',
+      resource_ref: 'agent:hello-world',
+      resource_type: 'agent',
+      resource_id: 'hello-world',
+      workflow_run_id: 'wfrun-20260611200000-abc',
+      decision_via: 'tuple',
+    };
+    const pageTwoRecord = {
+      ...pageOneRecord,
+      id: 'cas-2',
+      correlation_id: 'wfrun-20260611200000-def',
+      workflow_run_id: 'wfrun-20260611200000-def',
+    };
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          records: [],
+          total: 0,
+          page: 1,
+          limit: 30,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          records: [],
+          total: 0,
+          page: 1,
+          limit: 30,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          records: [pageOneRecord],
+          total: 2,
+          page: 1,
+          limit: 200,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          records: [pageTwoRecord],
+          total: 2,
+          page: 2,
+          limit: 200,
+        }),
+      });
+
+    render(<UnifiedAuditTab isAdmin />);
+
+    await screen.findByText(/RBAC Audit Log/i);
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: { value: 'cas_decision' },
+    });
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /download audit log/i }));
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+    });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('type=cas_decision'),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('limit=200'),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('page=2'),
+    );
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-0');
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const payloadText = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(blob);
+    });
+    const payload = JSON.parse(payloadText);
+    expect(payload).toMatchObject({
+      filters: { type: 'cas_decision' },
+      total: 2,
+      record_count: 2,
+    });
+    expect(payload.records).toEqual([pageOneRecord, pageTwoRecord]);
+
+    click.mockRestore();
   });
 });

--- a/ui/src/lib/__tests__/seed-config-default-agent.test.ts
+++ b/ui/src/lib/__tests__/seed-config-default-agent.test.ts
@@ -17,20 +17,30 @@
 
 const mockCollection = {
   countDocuments: jest.fn(),
+  findOne: jest.fn(),
   insertOne: jest.fn(),
+  updateOne: jest.fn(),
 };
+const mockReconcileAgentRelationships = jest.fn();
 
 jest.mock("@/lib/mongodb", () => ({
   isMongoDBConfigured: true,
   getCollection: jest.fn(async () => mockCollection),
+}));
+jest.mock("@/lib/rbac/openfga-agent-tools", () => ({
+  reconcileAgentRelationships: (...args: unknown[]) =>
+    mockReconcileAgentRelationships(...args),
 }));
 
 import {
   bootstrapDefaultDynamicAgentIfEmpty,
   bootstrapDefaultIdentityGroupSyncRuleIfEmpty,
   buildAutoCreateTeamsBootstrapRule,
+  buildHelloWorldAgentDoc,
+  reconcileHelloWorldBootstrapAgent,
   AUTO_CREATE_TEAMS_BOOTSTRAP_RULE_ID,
   HELLO_WORLD_AGENT_ID,
+  HELLO_WORLD_BOOTSTRAP_REVISION,
 } from "../seed-config";
 
 describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
@@ -56,7 +66,7 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
     // Bootstrap-provisioned, not config-driven — admins must be able to
     // edit/delete it through the UI.
     expect(inserted.config_driven).toBe(false);
-    // All four built-in tools enabled.
+    // Built-in tools enabled, including workflow HITL.
     expect(inserted.builtin_tools.fetch_url).toEqual({
       enabled: true,
       allowed_domains: "*",
@@ -67,10 +77,33 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
       enabled: true,
       max_seconds: 60,
     });
+    expect(inserted.builtin_tools.request_user_input).toEqual({
+      enabled: true,
+    });
+    expect(inserted.interrupt_on).toEqual({
+      builtin: { request_user_input: true },
+    });
+    expect(inserted.hello_world_bootstrap_revision).toBe(
+      HELLO_WORLD_BOOTSTRAP_REVISION,
+    );
     // Empty model is intentional — backend default is used.
     expect(inserted.model).toEqual({ id: "", provider: "" });
     expect(inserted.subagents).toEqual([]);
     expect(inserted.skills).toEqual([]);
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith({
+      agentId: HELLO_WORLD_AGENT_ID,
+      previousAllowedTools: {},
+      nextAllowedTools: inserted.allowed_tools,
+      ownerSubject: null,
+      organizationId: "caipe",
+      ownerTeamSlug: null,
+      previousOwnerTeamSlug: null,
+      nextSharedTeamSlugs: [],
+      previousSharedTeamSlugs: [],
+      globalUserAccess: true,
+      previousGlobalUserAccess: false,
+      failClosed: false,
+    });
   });
 
   it("is a no-op when any dynamic agent already exists", async () => {
@@ -99,6 +132,68 @@ describe("bootstrapDefaultDynamicAgentIfEmpty", () => {
     await expect(bootstrapDefaultDynamicAgentIfEmpty()).rejects.toThrow(
       "connection lost",
     );
+  });
+});
+
+describe("buildHelloWorldAgentDoc", () => {
+  it("includes request_user_input and workflow-oriented system prompt", () => {
+    const doc = buildHelloWorldAgentDoc("2026-01-01T00:00:00Z");
+    expect(doc.system_prompt).toContain("request_user_input");
+    expect(doc.system_prompt).toContain("write_file");
+  });
+});
+
+describe("reconcileHelloWorldBootstrapAgent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates system-owned hello-world when bootstrap revision is behind", async () => {
+    mockCollection.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+    const updated = await reconcileHelloWorldBootstrapAgent();
+
+    expect(updated).toBe(true);
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: HELLO_WORLD_AGENT_ID, owner_id: "system" }),
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          hello_world_bootstrap_revision: HELLO_WORLD_BOOTSTRAP_REVISION,
+          builtin_tools: expect.objectContaining({
+            request_user_input: { enabled: true },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("repairs OpenFGA relationships for current system-owned hello-world", async () => {
+    mockCollection.updateOne.mockResolvedValue({ modifiedCount: 0 });
+    mockCollection.findOne.mockResolvedValue(buildHelloWorldAgentDoc("2026-01-01T00:00:00Z"));
+
+    await expect(reconcileHelloWorldBootstrapAgent()).resolves.toBe(false);
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith({
+      agentId: HELLO_WORLD_AGENT_ID,
+      previousAllowedTools: {},
+      nextAllowedTools: {},
+      ownerSubject: null,
+      organizationId: "caipe",
+      ownerTeamSlug: null,
+      previousOwnerTeamSlug: null,
+      nextSharedTeamSlugs: [],
+      previousSharedTeamSlugs: [],
+      globalUserAccess: true,
+      previousGlobalUserAccess: true,
+      failClosed: false,
+    });
+  });
+
+  it("returns false when no document matched", async () => {
+    mockCollection.updateOne.mockResolvedValue({ modifiedCount: 0 });
+    mockCollection.findOne.mockResolvedValue(null);
+
+    await expect(reconcileHelloWorldBootstrapAgent()).resolves.toBe(false);
+    expect(mockReconcileAgentRelationships).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/lib/authz/__tests__/audit.test.ts
+++ b/ui/src/lib/authz/__tests__/audit.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment node
+ */
+
+const mockInsertOne = jest.fn();
+const mockGetCollection = jest.fn(async () => ({ insertOne: mockInsertOne }));
+let mongoConfigured = true;
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...a: unknown[]) => mockGetCollection(...a),
+  get isMongoDBConfigured() {
+    return mongoConfigured;
+  },
+}));
+
+import { buildDecisionEvent, buildGrantEvent, emitDecisionAudit, emitGrantAudit } from "../audit";
+
+const subject = { type: "user" as const, id: "alice" };
+const resource = { type: "agent" as const, id: "platform-engineer" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mongoConfigured = true;
+  mockInsertOne.mockResolvedValue({ acknowledged: true });
+});
+
+describe("buildDecisionEvent — UnifiedAuditEvent conformance", () => {
+  it("maps decision→outcome and builds resource_ref the tab renders", () => {
+    const e = buildDecisionEvent(subject, resource, "use", { decision: "DENY", reason: "NO_CAPABILITY", retriable: false });
+    expect(e).toMatchObject({
+      type: "cas_decision",
+      outcome: "deny", // tab reads `outcome`, not `decision`
+      action: "use",
+      resource_ref: "agent:platform-engineer", // tab reads `resource_ref`
+      resource_type: "agent",
+      resource_id: "platform-engineer",
+      reason_code: "NO_CAPABILITY",
+      pdp: "openfga",
+      source: "cas",
+      component: "cas",
+    });
+    expect(e.subject_hash).toMatch(/^sha256:/);
+    expect(e.subject_hash).not.toContain("alice"); // salted, not raw
+  });
+
+  it("maps ALLOW→allow and carries tenant + correlation + trace from context", () => {
+    const e = buildDecisionEvent(subject, resource, "use", { decision: "ALLOW", reason: "OK", retriable: false }, {
+      tenantId: "acme",
+      correlationId: "corr-1",
+      traceId: "t-1",
+      spanId: "s-1",
+    });
+    expect(e).toMatchObject({ outcome: "allow", tenant_id: "acme", correlation_id: "corr-1", trace_id: "t-1", span_id: "s-1" });
+  });
+
+  it("records decision path and trusted workflow run context when present", () => {
+    const e = buildDecisionEvent(
+      subject,
+      resource,
+      "use",
+      { decision: "ALLOW", reason: "OK", retriable: false, via: "tuple" },
+      { correlationId: "wfrun-20260611200000-abc" },
+      { workflowRunId: "wfrun-20260611200000-abc" },
+    );
+
+    expect(e).toMatchObject({
+      outcome: "allow",
+      decision_via: "tuple",
+      workflow_run_id: "wfrun-20260611200000-abc",
+    });
+  });
+
+  it("defaults tenant to 'default' and omits trace fields when absent", () => {
+    const e = buildDecisionEvent(subject, resource, "read", { decision: "ALLOW", reason: "OK", retriable: false });
+    expect(e.tenant_id).toBe("default");
+    expect(e.trace_id).toBeUndefined();
+    expect(e.span_id).toBeUndefined();
+  });
+});
+
+describe("emitDecisionAudit", () => {
+  it("inserts the event into audit_events when Mongo is configured", async () => {
+    emitDecisionAudit(subject, resource, "use", { decision: "ALLOW", reason: "OK", retriable: false });
+    await new Promise((r) => setImmediate(r)); // let the fire-and-forget settle
+    expect(mockGetCollection).toHaveBeenCalledWith("audit_events");
+    expect(mockInsertOne).toHaveBeenCalledTimes(1);
+    expect(mockInsertOne.mock.calls[0][0]).toMatchObject({ type: "cas_decision", outcome: "allow" });
+  });
+
+  it("is a no-op when Mongo is not configured", () => {
+    mongoConfigured = false;
+    emitDecisionAudit(subject, resource, "use", { decision: "ALLOW", reason: "OK", retriable: false });
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+
+  it("swallows insert failures (never throws into the decision path)", async () => {
+    mockInsertOne.mockRejectedValue(new Error("mongo down"));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => emitDecisionAudit(subject, resource, "use", { decision: "DENY", reason: "NO_CAPABILITY", retriable: false })).not.toThrow();
+    await new Promise((r) => setImmediate(r));
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+const grantIntent = {
+  resource: { type: "agent" as const, id: "platform-engineer" },
+  grantee: { type: "team" as const, id: "eng" },
+  capability: "use" as const,
+};
+const caller = { type: "user" as const, id: "alice" };
+
+describe("buildGrantEvent — policy-change audit conformance", () => {
+  it("records caller, grantee, resource, capability, operation, outcome, and context", () => {
+    const e = buildGrantEvent("grant", grantIntent, {
+      caller,
+      tenantId: "acme",
+      correlationId: "corr-grant-1",
+      traceId: "t-2",
+    });
+    expect(e).toMatchObject({
+      type: "cas_grant",
+      tenant_id: "acme",
+      correlation_id: "corr-grant-1",
+      caller_ref: "user:alice",
+      grantee_ref: "team:eng",
+      action: "use",
+      operation: "grant",
+      outcome: "success",
+      resource_ref: "agent:platform-engineer",
+      resource_type: "agent",
+      resource_id: "platform-engineer",
+      component: "cas",
+      pdp: "openfga",
+      source: "cas",
+      trace_id: "t-2",
+    });
+    expect(e.subject_hash).toMatch(/^sha256:/);
+    expect(e.actor_hash).toBe(e.subject_hash);
+    expect(e.subject_hash).not.toContain("alice");
+  });
+
+  it("maps everyone grantee to user:*", () => {
+    const e = buildGrantEvent("revoke", {
+      ...grantIntent,
+      grantee: { type: "everyone" },
+    }, { caller, correlationId: "c-1" });
+    expect(e).toMatchObject({ operation: "revoke", grantee_ref: "user:*", outcome: "success" });
+  });
+
+  it("records failed attempts with error outcome and reason_code", () => {
+    const e = buildGrantEvent("grant", grantIntent, { caller, tenantId: "acme" }, {
+      outcome: "error",
+      reasonCode: "NO_CAPABILITY",
+    });
+    expect(e).toMatchObject({
+      outcome: "error",
+      reason_code: "NO_CAPABILITY",
+      operation: "grant",
+      caller_ref: "user:alice",
+    });
+  });
+
+  it("requires ctx.caller", () => {
+    expect(() => buildGrantEvent("grant", grantIntent, {})).toThrow(/ctx\.caller/);
+  });
+});
+
+describe("emitGrantAudit", () => {
+  it("inserts cas_grant when Mongo is configured and caller is present", async () => {
+    await emitGrantAudit("grant", grantIntent, { caller, tenantId: "acme", correlationId: "c-1" });
+    expect(mockInsertOne).toHaveBeenCalledTimes(1);
+    expect(mockInsertOne.mock.calls[0][0]).toMatchObject({
+      type: "cas_grant",
+      caller_ref: "user:alice",
+      operation: "grant",
+      outcome: "success",
+    });
+  });
+
+  it("is a no-op without caller (never writes anonymous policy changes)", async () => {
+    await emitGrantAudit("grant", grantIntent, { tenantId: "acme" });
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when Mongo is not configured", async () => {
+    mongoConfigured = false;
+    await emitGrantAudit("grant", grantIntent, { caller });
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+
+  it("persists failed attempts when outcome is error", async () => {
+    mongoConfigured = true;
+    await emitGrantAudit("revoke", grantIntent, { caller }, { outcome: "error", reasonCode: "PDP_WRITE_FAILED" });
+    expect(mockInsertOne.mock.calls[0][0]).toMatchObject({
+      outcome: "error",
+      reason_code: "PDP_WRITE_FAILED",
+      operation: "revoke",
+    });
+  });
+
+  it("swallows insert failures (never throws into the grant path)", async () => {
+    mockInsertOne.mockRejectedValue(new Error("mongo down"));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      emitGrantAudit("grant", grantIntent, { caller }, { outcome: "error", reasonCode: "NO_CAPABILITY" }),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith("[cas/audit] Failed to persist grant event:", expect.any(Error));
+    warn.mockRestore();
+  });
+});

--- a/ui/src/lib/authz/__tests__/cache.test.ts
+++ b/ui/src/lib/authz/__tests__/cache.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { BoundedTtlCache } from "../cache";
+
+describe("BoundedTtlCache", () => {
+  let now = 1000;
+  beforeEach(() => {
+    now = 1000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it("returns a value within its TTL", () => {
+    const c = new BoundedTtlCache<string>(10, 100);
+    c.set("k", "v");
+    now = 1050;
+    expect(c.get("k")).toBe("v");
+  });
+
+  it("expires a value after its TTL", () => {
+    const c = new BoundedTtlCache<string>(10, 100);
+    c.set("k", "v");
+    now = 1101;
+    expect(c.get("k")).toBeUndefined();
+  });
+
+  it("honors a per-entry TTL override", () => {
+    const c = new BoundedTtlCache<string>(10, 10_000);
+    c.set("k", "v", 10);
+    now = 1011;
+    expect(c.get("k")).toBeUndefined();
+  });
+
+  it("evicts the oldest entry when over capacity", () => {
+    const c = new BoundedTtlCache<number>(2, 1000);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.set("c", 3); // evicts "a"
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBe(2);
+    expect(c.get("c")).toBe(3);
+  });
+
+  it("refreshes LRU order on get (recently-read survives eviction)", () => {
+    const c = new BoundedTtlCache<number>(2, 1000);
+    c.set("a", 1);
+    c.set("b", 2);
+    expect(c.get("a")).toBe(1); // "a" is now most-recently-used
+    c.set("c", 3); // evicts least-recently-used "b"
+    expect(c.get("b")).toBeUndefined();
+    expect(c.get("a")).toBe(1);
+    expect(c.get("c")).toBe(3);
+  });
+
+  it("clear() drops everything", () => {
+    const c = new BoundedTtlCache<number>(10, 1000);
+    c.set("a", 1);
+    c.clear();
+    expect(c.get("a")).toBeUndefined();
+  });
+
+  it("delete() removes a single entry", () => {
+    const c = new BoundedTtlCache<number>(10, 1000);
+    c.set("a", 1);
+    c.set("b", 2);
+    c.delete("a");
+    expect(c.get("a")).toBeUndefined();
+    expect(c.get("b")).toBe(2);
+  });
+
+  it("size reflects the number of entries", () => {
+    const c = new BoundedTtlCache<number>(10, 1000);
+    expect(c.size).toBe(0);
+    c.set("a", 1);
+    c.set("b", 2);
+    expect(c.size).toBe(2);
+    c.delete("a");
+    expect(c.size).toBe(1);
+  });
+});

--- a/ui/src/lib/authz/__tests__/compose.test.ts
+++ b/ui/src/lib/authz/__tests__/compose.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+import { compose } from "../compose";
+import type { PolicyEngine } from "../engine";
+import type { AuthorizeRequest, AuthorizeResult } from "../contract";
+
+function allow(): AuthorizeResult {
+  return { decision: "ALLOW", reason: "OK", retriable: false };
+}
+function deny(): AuthorizeResult {
+  return { decision: "DENY", reason: "NO_CAPABILITY", retriable: false };
+}
+
+function fakeEngine(): { engine: PolicyEngine; check: jest.Mock; batch: jest.Mock } {
+  const check = jest.fn().mockResolvedValue(deny());
+  const batch = jest.fn();
+  return {
+    engine: { check, batchCheck: batch },
+    check,
+    batch,
+  };
+}
+
+const req: AuthorizeRequest = { subject: { type: "user", id: "u" }, resource: { type: "agent", id: "a" }, action: "use" };
+
+describe("compose", () => {
+  it("passes through to the engine when there is no preCheck", async () => {
+    const { engine, check } = fakeEngine();
+    const composed = compose(engine);
+    await composed.check(req);
+    expect(check).toHaveBeenCalledWith(req);
+  });
+
+  it("short-circuits when preCheck returns a result", async () => {
+    const { engine, check } = fakeEngine();
+    const composed = compose(engine, { preCheck: async () => allow() });
+    const result = await composed.check(req);
+    expect(result.decision).toBe("ALLOW");
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the engine when preCheck returns null", async () => {
+    const { engine, check } = fakeEngine();
+    const composed = compose(engine, { preCheck: async () => null });
+    await composed.check(req);
+    expect(check).toHaveBeenCalledWith(req);
+  });
+
+  it("batchCheck without a preCheck delegates straight to the engine", async () => {
+    const { engine, batch } = fakeEngine();
+    batch.mockResolvedValue(new Map([["a", allow()]]));
+    const composed = compose(engine);
+    const r = await composed.batchCheck({ type: "user", id: "u" }, "discover", "agent", ["a"]);
+    expect(r.get("a")?.decision).toBe("ALLOW");
+    expect(batch).toHaveBeenCalledWith({ type: "user", id: "u" }, "discover", "agent", ["a"]);
+  });
+
+  it("batchCheck splits overrides from engine passthrough", async () => {
+    const { engine, batch } = fakeEngine();
+    batch.mockResolvedValue(new Map([["b", deny()]]));
+    const composed = compose(engine, {
+      preCheck: async (r) => (r.resource.id === "a" ? allow() : null),
+    });
+    const results = await composed.batchCheck({ type: "user", id: "u" }, "use", "agent", ["a", "b"]);
+    expect(results.get("a")?.decision).toBe("ALLOW"); // from preCheck
+    expect(results.get("b")?.decision).toBe("DENY"); // from engine
+    expect(batch).toHaveBeenCalledWith({ type: "user", id: "u" }, "use", "agent", ["b"]);
+  });
+});

--- a/ui/src/lib/authz/__tests__/http.test.ts
+++ b/ui/src/lib/authz/__tests__/http.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @jest-environment node
+ *
+ * Security-critical: these helpers enforce the CAS trust boundary. The
+ * binding rule must FAIL CLOSED.
+ */
+
+const mockAuthorize = jest.fn();
+const mockEmitGrantAudit = jest.fn();
+
+// assisted-by Codex Codex-sonnet-4-6
+
+jest.mock("../index", () => ({
+  authorize: (...args: unknown[]) => mockAuthorize(...args),
+}));
+jest.mock("../audit", () => ({
+  emitGrantAudit: (...args: unknown[]) => mockEmitGrantAudit(...args),
+}));
+
+import {
+  HttpAuthzError,
+  decisionContext,
+  enforceSubjectBinding,
+  isValidId,
+  parseAction,
+  parseGrantee,
+  parseGrantIntent,
+  parseResource,
+  parseResourceType,
+  parseSubject,
+  requireAuditCapability,
+  requireManage,
+  resolveCaller,
+  type Caller,
+} from "../http";
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("resolveCaller — fail closed", () => {
+  it("returns null when session is missing or not an object", () => {
+    expect(resolveCaller(null)).toBeNull();
+    expect(resolveCaller(undefined)).toBeNull();
+    expect(resolveCaller("nope")).toBeNull();
+  });
+
+  it("returns null when there is no stable sub (catalog-key / local-skills token)", () => {
+    expect(resolveCaller({ role: "user", catalogKey: "abc" })).toBeNull();
+    expect(resolveCaller({ sub: "" })).toBeNull();
+    expect(resolveCaller({ sub: "   " })).toBeNull();
+  });
+
+  it("resolves a user subject from a bearer/cookie session", () => {
+    expect(resolveCaller({ sub: "alice-sub" })).toEqual({ type: "user", id: "alice-sub" });
+  });
+
+  it("graphs an explicit service account under service_account:", () => {
+    expect(resolveCaller({ sub: "bot-sa", isServiceAccount: true })).toEqual({
+      type: "service_account",
+      id: "bot-sa",
+    });
+  });
+});
+
+describe("decisionContext", () => {
+  it("derives tenant from session.org and mints a correlation id", () => {
+    const ctx = decisionContext({ org: "acme" });
+    expect(ctx.tenantId).toBe("acme");
+    expect(typeof ctx.correlationId).toBe("string");
+  });
+  it("leaves tenant undefined when there is no org claim", () => {
+    expect(decisionContext({ sub: "x" }).tenantId).toBeUndefined();
+  });
+  it("threads caller and x-correlation-id from the request", () => {
+    const caller = { type: "user" as const, id: "alice" };
+    const req = new Request("http://localhost", { headers: { "x-correlation-id": "req-99" } });
+    const ctx = decisionContext({ org: "acme" }, caller, req);
+    expect(ctx).toMatchObject({
+      tenantId: "acme",
+      correlationId: "req-99",
+      caller: { type: "user", id: "alice" },
+    });
+  });
+});
+
+describe("isValidId — rejects OpenFGA structure and abuse", () => {
+  it("accepts UUIDs, emails, and resource ids", () => {
+    expect(isValidId("platform-engineer")).toBe(true);
+    expect(isValidId("3f1a-9b2c")).toBe(true);
+    expect(isValidId("alice@example.com")).toBe(true);
+  });
+  it("rejects wildcard, relation/type separators, and path traversal", () => {
+    expect(isValidId("*")).toBe(false);
+    expect(isValidId("agent:*")).toBe(false);
+    expect(isValidId("team:eng#member")).toBe(false);
+    expect(isValidId("../etc/passwd")).toBe(false);
+  });
+  it("rejects empty and overlong ids", () => {
+    expect(isValidId("")).toBe(false);
+    expect(isValidId("a".repeat(257))).toBe(false);
+  });
+});
+
+describe("parsers", () => {
+  it("parseSubject accepts valid and rejects bad type/id", () => {
+    expect(parseSubject({ type: "user", id: "x" })).toEqual({ type: "user", id: "x" });
+    expect(() => parseSubject({ type: "robot", id: "x" })).toThrow(HttpAuthzError);
+    expect(() => parseSubject({ type: "user", id: "a*b" })).toThrow(HttpAuthzError);
+    expect(() => parseSubject(null)).toThrow(HttpAuthzError);
+  });
+  it("parseResource validates type + id", () => {
+    expect(parseResource({ type: "agent", id: "pe" })).toEqual({ type: "agent", id: "pe" });
+    expect(() => parseResource({ type: "nope", id: "x" })).toThrow(HttpAuthzError);
+  });
+  it("parseResource rejects a missing object and an invalid id", () => {
+    expect(() => parseResource(null)).toThrow(HttpAuthzError);
+    expect(() => parseResource({ type: "agent", id: "a*b" })).toThrow(HttpAuthzError);
+  });
+  it("parseAction / parseResourceType validate membership", () => {
+    expect(parseAction("use")).toBe("use");
+    expect(() => parseAction("frobnicate")).toThrow(HttpAuthzError);
+    expect(parseResourceType("task")).toBe("task");
+    expect(() => parseResourceType("nope")).toThrow(HttpAuthzError);
+  });
+});
+
+describe("enforceSubjectBinding — the core control", () => {
+  const caller: Caller = { type: "user", id: "alice" };
+
+  it("allows a caller to evaluate its own subject without consulting the PDP", async () => {
+    await expect(
+      enforceSubjectBinding(caller, { type: "user", id: "alice" }, {}),
+    ).resolves.toBeUndefined();
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-subject evaluation without can_audit (403)", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+    await expect(
+      enforceSubjectBinding(caller, { type: "user", id: "bob" }, {}),
+    ).rejects.toMatchObject({ status: 403, code: "FORBIDDEN" });
+  });
+
+  it("permits cross-subject evaluation when the caller holds can_audit", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK" });
+    await expect(
+      enforceSubjectBinding(caller, { type: "user", id: "bob" }, {}),
+    ).resolves.toBeUndefined();
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "audit", resource: { type: "organization", id: "caipe" } }),
+      expect.anything(),
+    );
+  });
+
+  it("treats a type mismatch on the same id as cross-subject", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+    await expect(
+      enforceSubjectBinding(caller, { type: "service_account", id: "alice" }, {}),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("requireAuditCapability", () => {
+  it("throws 403 without can_audit", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+    await expect(requireAuditCapability({ type: "user", id: "x" }, {})).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+  it("passes with can_audit", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK" });
+    await expect(requireAuditCapability({ type: "user", id: "x" }, {})).resolves.toBeUndefined();
+  });
+});
+
+describe("grant parsing", () => {
+  it("parseGrantee accepts user/team/everyone and rejects bad types/ids", () => {
+    expect(parseGrantee({ type: "team", id: "eng" })).toEqual({ type: "team", id: "eng" });
+    expect(parseGrantee({ type: "everyone" })).toEqual({ type: "everyone" });
+    expect(parseGrantee({ type: "service_account", id: "bot" })).toEqual({ type: "service_account", id: "bot" });
+    expect(() => parseGrantee({ type: "nope", id: "x" })).toThrow(HttpAuthzError);
+    expect(() => parseGrantee({ type: "user", id: "a*b" })).toThrow(HttpAuthzError);
+    expect(() => parseGrantee(null)).toThrow(HttpAuthzError);
+  });
+  it("parseGrantIntent validates resource + grantee + capability", () => {
+    expect(parseGrantIntent({ resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" })).toEqual({
+      resource: { type: "agent", id: "pe" },
+      grantee: { type: "team", id: "eng" },
+      capability: "use",
+    });
+    expect(() => parseGrantIntent({ resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "frobnicate" })).toThrow(HttpAuthzError);
+    expect(() => parseGrantIntent(null)).toThrow(HttpAuthzError);
+  });
+
+  it("parseGrantIntent rejects valid actions that the resource type does not support", () => {
+    expect(() =>
+      parseGrantIntent({ resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "ingest" }),
+    ).toThrow(HttpAuthzError);
+  });
+
+  it("parseGrantIntent blocks high-risk everyone grants", () => {
+    expect(() =>
+      parseGrantIntent({ resource: { type: "agent", id: "pe" }, grantee: { type: "everyone" }, capability: "manage" }),
+    ).toThrow(HttpAuthzError);
+  });
+
+  it("parseGrantIntent blocks executable everyone use grants through the generic PAP", () => {
+    expect(() =>
+      parseGrantIntent({ resource: { type: "agent", id: "pe" }, grantee: { type: "everyone" }, capability: "use" }),
+    ).toThrow(HttpAuthzError);
+  });
+
+  it("parseGrantIntent allows explicitly low-risk everyone grants", () => {
+    expect(parseGrantIntent({ resource: { type: "agent", id: "pe" }, grantee: { type: "everyone" }, capability: "discover" })).toEqual({
+      resource: { type: "agent", id: "pe" },
+      grantee: { type: "everyone" },
+      capability: "discover",
+    });
+  });
+});
+
+describe("requireManage (grant meta-authz)", () => {
+  const caller: Caller = { type: "user", id: "admin" };
+  const ctx = { caller: { type: "user" as const, id: "admin" }, tenantId: "acme", correlationId: "c-1" };
+  const intent = {
+    resource: { type: "agent" as const, id: "pe" },
+    grantee: { type: "team" as const, id: "eng" },
+    capability: "use" as const,
+  };
+
+  it("passes when the caller can manage the resource", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "ALLOW", reason: "OK" });
+    await expect(requireManage(caller, { type: "agent", id: "pe" }, {})).resolves.toBeUndefined();
+    expect(mockAuthorize).toHaveBeenCalledWith(expect.objectContaining({ action: "manage", resource: { type: "agent", id: "pe" } }), expect.anything());
+    expect(mockEmitGrantAudit).not.toHaveBeenCalled();
+  });
+
+  it("passes when an organization admin lacks direct resource manage", async () => {
+    mockAuthorize
+      .mockResolvedValueOnce({ decision: "DENY", reason: "NO_CAPABILITY", retriable: false })
+      .mockResolvedValueOnce({ decision: "ALLOW", reason: "OK", retriable: false, via: "org_admin" });
+
+    await expect(requireManage(caller, { type: "agent", id: "pe" }, ctx)).resolves.toBeUndefined();
+
+    expect(mockAuthorize).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ action: "manage", resource: { type: "agent", id: "pe" } }),
+      ctx,
+    );
+    expect(mockAuthorize).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: "manage", resource: { type: "organization", id: "caipe" } }),
+      ctx,
+    );
+    expect(mockEmitGrantAudit).not.toHaveBeenCalled();
+  });
+
+  it("throws 403 when the caller cannot manage the resource", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+    await expect(requireManage(caller, { type: "agent", id: "pe" }, {})).rejects.toMatchObject({ status: 403, code: "FORBIDDEN" });
+    expect(mockEmitGrantAudit).not.toHaveBeenCalled();
+  });
+  it("throws 503 when the manage check is retriably unavailable", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true });
+    await expect(requireManage(caller, { type: "agent", id: "pe" }, {})).rejects.toMatchObject({
+      status: 503,
+      code: "AUTHZ_UNAVAILABLE",
+    });
+  });
+  it("audits failed grant attempts when meta-authz denies", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "NO_CAPABILITY" });
+    await expect(
+      requireManage(caller, intent.resource, ctx, { operation: "grant", intent }),
+    ).rejects.toMatchObject({ status: 403, code: "FORBIDDEN" });
+    expect(mockEmitGrantAudit).toHaveBeenCalledWith("grant", intent, ctx, {
+      outcome: "error",
+      reasonCode: "NO_CAPABILITY",
+    });
+  });
+});

--- a/ui/src/lib/authz/__tests__/index.test.ts
+++ b/ui/src/lib/authz/__tests__/index.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment node
+ */
+
+// The engine fns must be created INSIDE the factory: index.ts builds its
+// singleton engine at module load (before outer consts initialize), so the
+// factory cannot reference variables declared after the hoisted imports.
+jest.mock("../engines/openfga", () => {
+  const check = jest.fn();
+  const batchCheck = jest.fn();
+  const grant = jest.fn();
+  const revoke = jest.fn();
+  return {
+    __esModule: true,
+    createOpenFgaEngine: () => ({ check, batchCheck }),
+    createOpenFgaAdmin: () => ({ grant, revoke }),
+    describeFgaCheck: jest.fn(),
+    getEngineStats: jest.fn(() => ({ circuitState: "closed", cacheSize: 0, cacheHits: 0, cacheMisses: 0, cacheHitRatio: 0 })),
+    __mocks: { check, batchCheck, grant, revoke },
+  };
+});
+// Audit is a no-op in tests (Mongo unconfigured).
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn(), isMongoDBConfigured: false }));
+
+const mockEmitGrantAudit = jest.fn();
+jest.mock("../audit", () => {
+  const actual = jest.requireActual("../audit");
+  return {
+    ...actual,
+    emitDecisionAudit: jest.fn(),
+    emitGrantAudit: (...args: unknown[]) => mockEmitGrantAudit(...args),
+  };
+});
+
+import * as openfgaEngine from "../engines/openfga";
+const { check: mockCheck, batchCheck: mockBatch, grant: mockGrant, revoke: mockRevoke } = (
+  openfgaEngine as unknown as { __mocks: { check: jest.Mock; batchCheck: jest.Mock; grant: jest.Mock; revoke: jest.Mock } }
+).__mocks;
+
+import {
+  authorize,
+  authorizeMany,
+  authorizeOrThrow,
+  filterAccessible,
+  grant,
+  revoke,
+  AuthzDeniedError,
+  describeFgaCheck,
+  getEngineStats,
+  type AuthorizeResult,
+} from "../index";
+
+const ALLOW: AuthorizeResult = { decision: "ALLOW", reason: "OK", retriable: false };
+const DENY: AuthorizeResult = { decision: "DENY", reason: "NO_CAPABILITY", retriable: false };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("authorize", () => {
+  it("returns the engine's decision", async () => {
+    mockCheck.mockResolvedValue(ALLOW);
+    const r = await authorize({ subject: { type: "user", id: "u" }, resource: { type: "agent", id: "a" }, action: "use" });
+    expect(r.decision).toBe("ALLOW");
+  });
+});
+
+describe("authorizeOrThrow", () => {
+  it("resolves on ALLOW", async () => {
+    mockCheck.mockResolvedValue(ALLOW);
+    await expect(
+      authorizeOrThrow({ subject: { type: "user", id: "u" }, resource: { type: "agent", id: "a" }, action: "use" }),
+    ).resolves.toBeUndefined();
+  });
+  it("throws AuthzDeniedError on DENY", async () => {
+    mockCheck.mockResolvedValue(DENY);
+    await expect(
+      authorizeOrThrow({ subject: { type: "user", id: "u" }, resource: { type: "agent", id: "a" }, action: "use" }),
+    ).rejects.toBeInstanceOf(AuthzDeniedError);
+  });
+});
+
+describe("filterAccessible", () => {
+  it("returns only the ALLOWed ids", async () => {
+    mockBatch.mockResolvedValue(new Map([["a", ALLOW], ["b", DENY], ["c", ALLOW]]));
+    const out = await filterAccessible({ type: "user", id: "u" }, "discover", "agent", ["a", "b", "c"]);
+    expect(out).toEqual(["a", "c"]);
+  });
+  it("short-circuits an empty id list without calling the engine", async () => {
+    const out = await filterAccessible({ type: "user", id: "u" }, "discover", "agent", []);
+    expect(out).toEqual([]);
+    expect(mockBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("authorizeMany", () => {
+  it("delegates to the engine batch", async () => {
+    mockBatch.mockResolvedValue(new Map([["a", ALLOW]]));
+    const r = await authorizeMany({ type: "user", id: "u" }, "read", "task", ["a"]);
+    expect(r.get("a")?.decision).toBe("ALLOW");
+    expect(mockBatch).toHaveBeenCalledWith({ type: "user", id: "u" }, "read", "task", ["a"]);
+  });
+});
+
+describe("grant / revoke (PAP)", () => {
+  const ctx = { caller: { type: "user" as const, id: "alice" }, tenantId: "acme", correlationId: "c-1" };
+
+  beforeEach(() => {
+    mockEmitGrantAudit.mockClear();
+  });
+
+  it("grant delegates to the admin engine and emits audit", async () => {
+    const intent = { resource: { type: "agent" as const, id: "pe" }, grantee: { type: "team" as const, id: "eng" }, capability: "use" as const };
+    await grant(intent, ctx);
+    expect(mockGrant).toHaveBeenCalledWith(intent);
+    expect(mockEmitGrantAudit).toHaveBeenCalledWith("grant", intent, ctx, { outcome: "success" });
+  });
+  it("revoke delegates to the admin engine and emits audit", async () => {
+    const intent = { resource: { type: "agent" as const, id: "pe" }, grantee: { type: "everyone" as const }, capability: "use" as const };
+    await revoke(intent, ctx);
+    expect(mockRevoke).toHaveBeenCalledWith(intent);
+    expect(mockEmitGrantAudit).toHaveBeenCalledWith("revoke", intent, ctx, { outcome: "success" });
+  });
+  it("emits error audit when the PDP write fails", async () => {
+    const intent = { resource: { type: "agent" as const, id: "pe" }, grantee: { type: "team" as const, id: "eng" }, capability: "use" as const };
+    mockGrant.mockRejectedValueOnce(new Error("OpenFGA write failed"));
+    await expect(grant(intent, ctx)).rejects.toThrow("OpenFGA write failed");
+    expect(mockEmitGrantAudit).toHaveBeenCalledWith("grant", intent, ctx, {
+      outcome: "error",
+      reasonCode: "PDP_WRITE_FAILED",
+    });
+  });
+  it("emits error audit when revoke PDP write fails", async () => {
+    const intent = { resource: { type: "agent" as const, id: "pe" }, grantee: { type: "team" as const, id: "eng" }, capability: "use" as const };
+    mockRevoke.mockRejectedValueOnce(new Error("OpenFGA write failed"));
+    await expect(revoke(intent, ctx)).rejects.toThrow("OpenFGA write failed");
+    expect(mockEmitGrantAudit).toHaveBeenCalledWith("revoke", intent, ctx, {
+      outcome: "error",
+      reasonCode: "PDP_WRITE_FAILED",
+    });
+  });
+});
+
+describe("re-exports", () => {
+  it("surfaces describeFgaCheck and getEngineStats from the engine", () => {
+    expect(describeFgaCheck).toBeDefined();
+    expect(getEngineStats).toBeDefined();
+    expect(getEngineStats()).toMatchObject({ circuitState: "closed" });
+  });
+});

--- a/ui/src/lib/authz/__tests__/openfga-engine.test.ts
+++ b/ui/src/lib/authz/__tests__/openfga-engine.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @jest-environment node
+ */
+import { createOpenFgaAdmin, createOpenFgaEngine, describeFgaCheck, getEngineStats, __resetAdapterStateForTests } from "../engines/openfga";
+import type { AuthorizeRequest } from "../contract";
+
+const realFetch = global.fetch;
+
+function checkResponse(allowed: boolean): Response {
+  return { ok: true, status: 200, json: async () => ({ allowed }) } as unknown as Response;
+}
+function storesResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ stores: [{ id: "store-xyz", name: "caipe-openfga" }] }),
+  } as unknown as Response;
+}
+
+const req: AuthorizeRequest = {
+  subject: { type: "user", id: "alice" },
+  resource: { type: "agent", id: "pe" },
+  action: "use",
+};
+
+describe("OpenFGA engine adapter", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    process.env.OPENFGA_HTTP = "http://openfga:8080";
+    process.env.OPENFGA_STORE_ID = "store-xyz"; // skip discovery unless a test clears it
+    __resetAdapterStateForTests();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+    delete process.env.OPENFGA_STORE_ID;
+  });
+
+  it("maps allowed:true → ALLOW (via tuple)", async () => {
+    fetchMock.mockResolvedValue(checkResponse(true));
+    const r = await createOpenFgaEngine().check(req);
+    expect(r.decision).toBe("ALLOW");
+    expect(r.reason).toBe("OK");
+    expect(r.via).toBe("tuple");
+  });
+
+  it("maps allowed:false → DENY/NO_CAPABILITY", async () => {
+    fetchMock.mockResolvedValue(checkResponse(false));
+    const r = await createOpenFgaEngine().check(req);
+    expect(r).toMatchObject({ decision: "DENY", reason: "NO_CAPABILITY" });
+  });
+
+  it("fails closed to AUTHZ_UNAVAILABLE when OpenFGA errors", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const r = await createOpenFgaEngine().check(req);
+    expect(r).toMatchObject({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true });
+  });
+
+  it("caches a definitive decision (second identical check hits no fetch)", async () => {
+    fetchMock.mockResolvedValue(checkResponse(true));
+    const engine = createOpenFgaEngine();
+    await engine.check(req);
+    await engine.check(req);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches AUTHZ_UNAVAILABLE (retries on next call)", async () => {
+    fetchMock.mockRejectedValue(new Error("down"));
+    const engine = createOpenFgaEngine();
+    await engine.check(req);
+    await engine.check(req);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens the circuit after the failure threshold and stops calling OpenFGA", async () => {
+    fetchMock.mockRejectedValue(new Error("down"));
+    const engine = createOpenFgaEngine();
+    // 5 failures trip the breaker.
+    for (let i = 0; i < 5; i++) await engine.check(req);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    // 6th is short-circuited by the open breaker — no further fetch.
+    const r = await engine.check(req);
+    expect(r.reason).toBe("AUTHZ_UNAVAILABLE");
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("discovers and caches the store id when OPENFGA_STORE_ID is unset", async () => {
+    delete process.env.OPENFGA_STORE_ID;
+    __resetAdapterStateForTests();
+    fetchMock.mockImplementation(async (url: string) =>
+      url.endsWith("/stores") ? storesResponse() : checkResponse(true),
+    );
+    const engine = createOpenFgaEngine();
+    await engine.check(req); // /stores + /check
+    await engine.check({ ...req, resource: { type: "agent", id: "other" } }); // /check only (store cached)
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls.filter((u) => u.endsWith("/stores")).length).toBe(1);
+  });
+
+  it("batchCheck returns one decision per id", async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      return checkResponse(body.tuple_key.object === "agent:yes");
+    });
+    const results = await createOpenFgaEngine().batchCheck(
+      { type: "user", id: "alice" },
+      "use",
+      "agent",
+      ["yes", "no"],
+    );
+    expect(results.get("yes")?.decision).toBe("ALLOW");
+    expect(results.get("no")?.decision).toBe("DENY");
+  });
+
+  it("invalidates the cached store id and fails closed when a check returns 404", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) } as unknown as Response);
+    const r = await createOpenFgaEngine().check(req);
+    expect(r).toMatchObject({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE" });
+  });
+
+  it("fails closed to AUTHZ_UNAVAILABLE when store discovery returns non-ok", async () => {
+    delete process.env.OPENFGA_STORE_ID;
+    __resetAdapterStateForTests();
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as unknown as Response);
+    const r = await createOpenFgaEngine().check(req);
+    expect(r).toMatchObject({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE" });
+  });
+
+  it("getEngineStats tracks cache hits/misses and circuit state", async () => {
+    fetchMock.mockResolvedValue(checkResponse(true));
+    const engine = createOpenFgaEngine();
+    await engine.check(req); // miss → fetch
+    await engine.check(req); // hit
+    const s = getEngineStats();
+    expect(s.cacheMisses).toBe(1);
+    expect(s.cacheHits).toBe(1);
+    expect(s.cacheHitRatio).toBeCloseTo(0.5);
+    expect(s.circuitState).toBe("closed");
+    expect(s.cacheSize).toBeGreaterThanOrEqual(1);
+  });
+
+  describe("circuit breaker recovery", () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it("transitions open → half_open after cooldown, then closes on a successful probe", async () => {
+      let now = 1_000_000;
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      fetchMock.mockRejectedValue(new Error("down"));
+      const engine = createOpenFgaEngine();
+      for (let i = 0; i < 5; i++) await engine.check(req); // trip open
+      expect(getEngineStats().circuitState).toBe("open");
+
+      // Within cooldown: short-circuited, no new fetch.
+      const callsBefore = fetchMock.mock.calls.length;
+      expect((await engine.check(req)).reason).toBe("AUTHZ_UNAVAILABLE");
+      expect(fetchMock.mock.calls.length).toBe(callsBefore);
+
+      // After cooldown: half-open probe succeeds → closed.
+      now += 31_000;
+      fetchMock.mockResolvedValue(checkResponse(true));
+      const r = await engine.check(req);
+      expect(r.decision).toBe("ALLOW");
+      expect(getEngineStats().circuitState).toBe("closed");
+    });
+
+    it("re-opens if the half-open probe fails", async () => {
+      let now = 2_000_000;
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      fetchMock.mockRejectedValue(new Error("down"));
+      const engine = createOpenFgaEngine();
+      for (let i = 0; i < 5; i++) await engine.check(req);
+      now += 31_000;
+      await engine.check(req); // probe fails → re-open
+      expect(getEngineStats().circuitState).toBe("open");
+    });
+
+    it("admits only one probe while half-open (concurrent callers fail closed)", async () => {
+      let now = 3_000_000;
+      jest.spyOn(Date, "now").mockImplementation(() => now);
+      fetchMock.mockRejectedValue(new Error("down"));
+      const engine = createOpenFgaEngine();
+      for (let i = 0; i < 5; i++) await engine.check(req); // open
+      now += 31_000;
+
+      // Make the probe hang so a second concurrent caller observes probeInFlight.
+      let release: (v: Response) => void = () => {};
+      fetchMock.mockImplementation(() => new Promise<Response>((res) => { release = res; }));
+      const p1 = engine.check(req); // becomes the single probe
+      const p2 = engine.check(req); // denied — a probe is already in flight
+      expect((await p2).reason).toBe("AUTHZ_UNAVAILABLE");
+      release(checkResponse(true));
+      expect((await p1).decision).toBe("ALLOW");
+    });
+  });
+
+  describe("PolicyAdmin (grant/revoke)", () => {
+    function writeResponse(): Response {
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }
+
+    it("grant writes the base-relation tuple (team→use agent)", async () => {
+      fetchMock.mockResolvedValue(writeResponse());
+      await createOpenFgaAdmin().grant({ resource: { type: "agent", id: "pe" }, grantee: { type: "team", id: "eng" }, capability: "use" });
+      const writeCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/write"));
+      const body = JSON.parse((writeCall![1] as RequestInit).body as string);
+      expect(body.writes.tuple_keys[0]).toEqual({ user: "team:eng#member", relation: "user", object: "agent:pe" });
+      expect(body.deletes).toBeUndefined();
+    });
+
+    it("grant for 'everyone' writes a user:* wildcard tuple", async () => {
+      fetchMock.mockResolvedValue(writeResponse());
+      await createOpenFgaAdmin().grant({ resource: { type: "agent", id: "pe" }, grantee: { type: "everyone" }, capability: "use" });
+      const body = JSON.parse((fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/write"))![1] as RequestInit).body as string);
+      expect(body.writes.tuple_keys[0]).toEqual({ user: "user:*", relation: "user", object: "agent:pe" });
+    });
+
+  it("revoke deletes the tuple", async () => {
+    fetchMock.mockResolvedValue(writeResponse());
+    await createOpenFgaAdmin().revoke({ resource: { type: "knowledge_base", id: "kb1" }, grantee: { type: "user", id: "alice" }, capability: "read" });
+    const body = JSON.parse((fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/write"))![1] as RequestInit).body as string);
+    expect(body.deletes.tuple_keys[0]).toEqual({ user: "user:alice", relation: "reader", object: "knowledge_base:kb1" });
+    expect(body.writes).toBeUndefined();
+  });
+
+  it("is idempotent — a 'tuple already exists' 400 does not throw", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400, text: async () => '{"code":"write_failed_due_to_invalid_input","message":"cannot write a tuple which already exists"}' } as unknown as Response);
+    await expect(
+      createOpenFgaAdmin().grant({ resource: { type: "agent", id: "pe" }, grantee: { type: "user", id: "x" }, capability: "use" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not hide a grant failure just because the 400 body mentions a missing tuple", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400, text: async () => '{"message":"tuple does not exist"}' } as unknown as Response);
+    await expect(
+      createOpenFgaAdmin().grant({ resource: { type: "agent", id: "pe" }, grantee: { type: "user", id: "x" }, capability: "use" }),
+    ).rejects.toThrow(/write failed/i);
+  });
+
+  it("encodes OpenFGA-unsafe llm_model ids through the shared resource encoder", async () => {
+    fetchMock.mockResolvedValue(writeResponse());
+    await createOpenFgaAdmin().grant({
+      resource: { type: "llm_model", id: "global.anthropic.claude-haiku-4-5-20251001-v1:0" },
+      grantee: { type: "user", id: "alice" },
+      capability: "read",
+    });
+    const body = JSON.parse((fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/write"))![1] as RequestInit).body as string);
+    expect(body.writes.tuple_keys[0].object).toMatch(/^llm_model:b64_/);
+  });
+
+  it("throws on a real write failure", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => "boom" } as unknown as Response);
+    await expect(
+      createOpenFgaAdmin().grant({ resource: { type: "agent", id: "pe" }, grantee: { type: "user", id: "x" }, capability: "use" }),
+    ).rejects.toThrow(/write failed/i);
+  });
+  });
+
+  it("describeFgaCheck exposes the relation actually used (single source of truth)", () => {
+    expect(describeFgaCheck(req)).toMatchObject({
+      engine: "openfga",
+      relation: "can_use",
+      user: "user:alice",
+      object: "agent:pe",
+    });
+    // create maps to can_manage — explain reflects the real check
+    expect(describeFgaCheck({ ...req, action: "create" }).relation).toBe("can_manage");
+  });
+});

--- a/ui/src/lib/authz/audit.ts
+++ b/ui/src/lib/authz/audit.ts
@@ -1,0 +1,214 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// CAS decision audit. Writes ONE event per decision to the shared
+// `audit_events` collection, conforming to the UnifiedAuditEvent contract
+// that the admin audit tab (`UnifiedAuditTab`) renders — so CAS decisions
+// appear, typed and filterable, alongside existing auth/openfga_rebac events.
+//
+// Best-effort + fire-and-forget: a Mongo failure is logged but never blocks
+// or changes the decision (the decision is the authoritative output).
+
+import { createHash, randomUUID } from "crypto";
+
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
+
+import type {
+  Action,
+  AuthorizeResult,
+  DecisionContext,
+  GrantIntent,
+  Resource,
+  Subject,
+  TrustedAuthorizeContext,
+} from "./contract";
+
+const AUDIT_EVENTS = "audit_events";
+const SUBJECT_SALT = process.env.AUDIT_SUBJECT_SALT ?? "caipe-098-audit";
+
+/**
+ * Conforms to `AuditEventDocument` in the audit-events route. `outcome`
+ * (not `decision`) and `resource_ref` (not split fields) are what the tab
+ * reads; split resource fields, workflow context, and decision path are kept
+ * so exports can explain where workflow-scoped CAS decisions came from.
+ */
+export interface CasDecisionEvent {
+  audit_event_id: string;
+  ts: Date;
+  type: "cas_decision";
+  tenant_id: string;
+  subject_hash: string;
+  action: Action;
+  outcome: "allow" | "deny";
+  reason_code: AuthorizeResult["reason"];
+  correlation_id: string;
+  component: "cas";
+  resource_ref: string;
+  resource_type: string;
+  resource_id: string;
+  workflow_run_id?: string;
+  decision_via?: string;
+  pdp: "openfga";
+  source: "cas";
+  trace_id?: string;
+  span_id?: string;
+}
+
+function hashSubject(id: string): string {
+  return "sha256:" + createHash("sha256").update(`${SUBJECT_SALT}:${id}`).digest("hex");
+}
+
+export function buildDecisionEvent(
+  subject: Subject,
+  resource: Resource,
+  action: Action,
+  result: AuthorizeResult,
+  ctx: DecisionContext = {},
+  trustedContext: TrustedAuthorizeContext = {},
+): CasDecisionEvent {
+  return {
+    audit_event_id: randomUUID(),
+    ts: new Date(),
+    type: "cas_decision",
+    tenant_id: ctx.tenantId ?? process.env.TENANT_ID ?? "default",
+    subject_hash: hashSubject(subject.id),
+    action,
+    outcome: result.decision === "ALLOW" ? "allow" : "deny",
+    reason_code: result.reason,
+    correlation_id: ctx.correlationId ?? randomUUID(),
+    component: "cas",
+    resource_ref: `${resource.type}:${resource.id}`,
+    resource_type: resource.type,
+    resource_id: resource.id,
+    pdp: "openfga",
+    source: "cas",
+    ...(trustedContext.workflowRunId ? { workflow_run_id: trustedContext.workflowRunId } : {}),
+    ...(result.via ? { decision_via: result.via } : {}),
+    ...(ctx.traceId ? { trace_id: ctx.traceId } : {}),
+    ...(ctx.spanId ? { span_id: ctx.spanId } : {}),
+  };
+}
+
+export function emitDecisionAudit(
+  subject: Subject,
+  resource: Resource,
+  action: Action,
+  result: AuthorizeResult,
+  ctx: DecisionContext = {},
+  trustedContext: TrustedAuthorizeContext = {},
+): void {
+  if (!isMongoDBConfigured) return;
+
+  const event = buildDecisionEvent(subject, resource, action, result, ctx, trustedContext);
+
+  void (async () => {
+    try {
+      const coll = await getCollection<CasDecisionEvent>(AUDIT_EVENTS);
+      await coll.insertOne(event);
+    } catch (err) {
+      console.warn("[cas/audit] Failed to persist decision event:", err);
+    }
+  })();
+}
+
+export type GrantOperation = "grant" | "revoke";
+export type GrantAuditOutcome = "success" | "error";
+
+export interface GrantAuditOptions {
+  outcome?: GrantAuditOutcome;
+  /** Why the attempt failed (meta-authz deny, PDP error, etc.). */
+  reasonCode?: string;
+}
+
+function principalRef(type: string, id?: string): string {
+  if (type === "everyone") return "user:*";
+  return `${type}:${id ?? ""}`;
+}
+
+function granteeLabel(g: GrantIntent["grantee"]): string {
+  return principalRef(g.type, g.type === "everyone" ? undefined : g.id);
+}
+
+/**
+ * Durable audit record for a grant/revoke attempt (success or failure).
+ * Conforms to the unified audit tab — caller, grantee, resource, capability,
+ * operation, outcome, reason, and tenant/correlation context are explicit.
+ */
+export interface CasGrantEvent {
+  audit_event_id: string;
+  ts: Date;
+  type: "cas_grant";
+  tenant_id: string;
+  /** Hashed caller — who performed the policy change. */
+  subject_hash: string;
+  actor_hash: string;
+  caller_ref: string;
+  grantee_ref: string;
+  action: Action;
+  operation: GrantOperation;
+  outcome: GrantAuditOutcome;
+  reason_code?: string;
+  resource_ref: string;
+  resource_type: string;
+  resource_id: string;
+  correlation_id: string;
+  component: "cas";
+  pdp: "openfga";
+  source: "cas";
+  trace_id?: string;
+  span_id?: string;
+}
+
+export function buildGrantEvent(
+  operation: GrantOperation,
+  intent: GrantIntent,
+  ctx: DecisionContext = {},
+  options: GrantAuditOptions = {},
+): CasGrantEvent {
+  if (!ctx.caller) {
+    throw new Error("buildGrantEvent requires ctx.caller");
+  }
+  const outcome = options.outcome ?? "success";
+  const callerRef = principalRef(ctx.caller.type, ctx.caller.id);
+  return {
+    audit_event_id: randomUUID(),
+    ts: new Date(),
+    type: "cas_grant",
+    tenant_id: ctx.tenantId ?? process.env.TENANT_ID ?? "default",
+    subject_hash: hashSubject(ctx.caller.id),
+    actor_hash: hashSubject(ctx.caller.id),
+    caller_ref: callerRef,
+    grantee_ref: granteeLabel(intent.grantee),
+    action: intent.capability,
+    operation,
+    outcome,
+    resource_ref: `${intent.resource.type}:${intent.resource.id}`,
+    resource_type: intent.resource.type,
+    resource_id: intent.resource.id,
+    correlation_id: ctx.correlationId ?? randomUUID(),
+    component: "cas",
+    pdp: "openfga",
+    source: "cas",
+    ...(options.reasonCode ? { reason_code: options.reasonCode } : {}),
+    ...(ctx.traceId ? { trace_id: ctx.traceId } : {}),
+    ...(ctx.spanId ? { span_id: ctx.spanId } : {}),
+  };
+}
+
+/** One audit event per grant/revoke attempt → unified `audit_events`. */
+export async function emitGrantAudit(
+  operation: GrantOperation,
+  intent: GrantIntent,
+  ctx: DecisionContext = {},
+  options: GrantAuditOptions = {},
+): Promise<void> {
+  if (!isMongoDBConfigured || !ctx.caller) return;
+
+  const event = buildGrantEvent(operation, intent, ctx, options);
+
+  try {
+    const coll = await getCollection<CasGrantEvent>(AUDIT_EVENTS);
+    await coll.insertOne(event);
+  } catch (err) {
+    console.warn("[cas/audit] Failed to persist grant event:", err);
+  }
+}

--- a/ui/src/lib/authz/cache.ts
+++ b/ui/src/lib/authz/cache.ts
@@ -1,0 +1,50 @@
+// assisted-by claude code claude-sonnet-4-6
+
+interface CacheEntry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export class BoundedTtlCache<V> {
+  private readonly map = new Map<string, CacheEntry<V>>();
+
+  constructor(
+    private readonly maxSize: number,
+    private readonly defaultTtlMs: number,
+  ) {}
+
+  /** Current number of entries (may include not-yet-evicted expired ones). */
+  get size(): number {
+    return this.map.size;
+  }
+
+  get(key: string): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.map.delete(key);
+      return undefined;
+    }
+    // Refresh insertion order (LRU)
+    this.map.delete(key);
+    this.map.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: V, ttlMs?: number): void {
+    if (this.map.size >= this.maxSize) {
+      // Evict oldest (first insertion-order entry)
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) this.map.delete(oldest);
+    }
+    this.map.set(key, { value, expiresAt: Date.now() + (ttlMs ?? this.defaultTtlMs) });
+  }
+
+  delete(key: string): void {
+    this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}

--- a/ui/src/lib/authz/compose.ts
+++ b/ui/src/lib/authz/compose.ts
@@ -1,0 +1,61 @@
+// assisted-by claude code claude-sonnet-4-6
+//
+// compose() wraps a PolicyEngine with product policy that cannot live in
+// OpenFGA tuples (e.g. workflow-scoped delegation, channel visibility).
+// Returns a PolicyEngine — callers see no seam.
+
+import type { Action, AuthorizeRequest, AuthorizeResult, ResourceType, Subject } from "./contract";
+import type { PolicyEngine } from "./engine";
+
+export interface ProductPolicyOptions {
+  /**
+   * Called before the PDP for each check. Return a result to short-circuit
+   * (e.g. an org-admin bypass or a workflow-scoped delegation). Return null
+   * to fall through to the PDP.
+   */
+  preCheck?: (req: AuthorizeRequest) => Promise<AuthorizeResult | null>;
+}
+
+export function compose(engine: PolicyEngine, opts: ProductPolicyOptions = {}): PolicyEngine {
+  return {
+    async check(req: AuthorizeRequest): Promise<AuthorizeResult> {
+      if (opts.preCheck) {
+        const override = await opts.preCheck(req);
+        if (override) return override;
+      }
+      return engine.check(req);
+    },
+
+    async batchCheck(
+      subject: Subject,
+      action: Action,
+      resourceType: ResourceType,
+      ids: string[],
+    ): Promise<Map<string, AuthorizeResult>> {
+      if (!opts.preCheck) {
+        return engine.batchCheck(subject, action, resourceType, ids);
+      }
+      // Apply preCheck per-id; batch remaining to the engine.
+      const overrides = new Map<string, AuthorizeResult>();
+      const passthrough: string[] = [];
+
+      await Promise.all(
+        ids.map(async (id) => {
+          const req: AuthorizeRequest = { subject, action, resource: { type: resourceType, id } };
+          const override = await opts.preCheck!(req);
+          if (override) {
+            overrides.set(id, override);
+          } else {
+            passthrough.push(id);
+          }
+        }),
+      );
+
+      const engineResults = passthrough.length > 0
+        ? await engine.batchCheck(subject, action, resourceType, passthrough)
+        : new Map<string, AuthorizeResult>();
+
+      return new Map([...overrides, ...engineResults]);
+    },
+  };
+}

--- a/ui/src/lib/authz/contract.ts
+++ b/ui/src/lib/authz/contract.ts
@@ -1,0 +1,83 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import type { UniversalRebacResourceAction, UniversalRebacResourceType } from "@/types/rbac-universal";
+
+export type SubjectType = "user" | "service_account";
+
+export type ResourceType = UniversalRebacResourceType;
+
+export type Action = UniversalRebacResourceAction;
+
+export type DecisionValue = "ALLOW" | "DENY";
+
+export type ReasonCode =
+  | "OK"               // ALLOW
+  | "NO_CAPABILITY"    // DENY — no relationship
+  | "NOT_AUTHENTICATED"// caller token missing or invalid
+  | "AUTHZ_UNAVAILABLE"// PDP error, retriable
+  | "INVALID_REQUEST"; // bad id or malformed input
+
+export interface Subject {
+  type: SubjectType;
+  id: string;
+}
+
+export interface Resource {
+  type: ResourceType;
+  id: string;
+}
+
+export interface TrustedAuthorizeContext {
+  workflowRunId?: string;
+}
+
+export interface AuthorizeRequest {
+  subject: Subject;
+  resource: Resource;
+  action: Action;
+  /** Advisory only. May only NARROW a grant, never expand it. */
+  context?: Record<string, unknown>;
+  /**
+   * Internal-only context from trusted BFF callers. Never populated from the
+   * public /api/authz/v1 body.
+   */
+  trustedContext?: TrustedAuthorizeContext;
+}
+
+export interface AuthorizeResult {
+  decision: DecisionValue;
+  reason: ReasonCode;
+  retriable: boolean;
+  ttl_seconds?: number;
+  via?: string | null;
+}
+
+/**
+ * Per-request metadata threaded into the audit trail. Never affects the
+ * decision itself — only how it is recorded.
+ */
+export interface DecisionContext {
+  tenantId?: string;
+  correlationId?: string;
+  traceId?: string;
+  spanId?: string;
+  /** Principal performing a grant/revoke (PAP). Recorded in grant audit events. */
+  caller?: Subject;
+}
+
+// ─── Grant / Revoke (PAP) ─────────────────────────────────────────────────────
+
+export type GranteeType = "user" | "service_account" | "team" | "everyone";
+
+export type Grantee =
+  | { type: "user"; id: string }
+  | { type: "service_account"; id: string }
+  | { type: "team"; id: string }
+  | { type: "everyone" };
+
+export interface GrantIntent {
+  resource: Resource;
+  grantee: Grantee;
+  /** The capability to grant — must be a valid Action. */
+  capability: Action;
+}

--- a/ui/src/lib/authz/domains/workflow.ts
+++ b/ui/src/lib/authz/domains/workflow.ts
@@ -1,0 +1,48 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// Workflow-scoped delegation: a workflow may grant agent-use to the user
+// who started it, for the duration of that run. This prevents DA from
+// needing to read workflow_configs or teams from MongoDB.
+//
+// Currently a stub — wired at POST /api/workflow-runs in a future PR.
+
+import type { AuthorizeRequest, AuthorizeResult } from "../contract";
+
+export interface WorkflowRunContext {
+  workflowRunId: string;
+  /** Agent ids the workflow delegates can_use to the run owner. */
+  delegatedAgentIds: Set<string>;
+  /** The subject who started the run. */
+  ownerSubjectId: string;
+}
+
+/** In-memory run registry. Populated by POST /api/workflow-runs. */
+const activeRuns = new Map<string, WorkflowRunContext>();
+
+export function registerWorkflowRun(ctx: WorkflowRunContext): void {
+  activeRuns.set(ctx.workflowRunId, ctx);
+}
+
+export function unregisterWorkflowRun(workflowRunId: string): void {
+  activeRuns.delete(workflowRunId);
+}
+
+/**
+ * Returns ALLOW if the request is for an agent the active workflow run
+ * has delegated to the caller. Returns null otherwise (fall through to PDP).
+ */
+export function workflowDelegationPreCheck(
+  req: AuthorizeRequest,
+): AuthorizeResult | null {
+  if (req.resource.type !== "agent" || req.action !== "use") return null;
+
+  const runId = req.trustedContext?.workflowRunId;
+  if (typeof runId !== "string") return null;
+
+  const run = activeRuns.get(runId);
+  if (!run) return null;
+  if (run.ownerSubjectId !== req.subject.id) return null;
+  if (!run.delegatedAgentIds.has(req.resource.id)) return null;
+
+  return { decision: "ALLOW", reason: "OK", retriable: false, via: "workflow_delegation" };
+}

--- a/ui/src/lib/authz/engine.ts
+++ b/ui/src/lib/authz/engine.ts
@@ -1,0 +1,18 @@
+// assisted-by claude code claude-sonnet-4-6
+
+import type { Action, AuthorizeRequest, AuthorizeResult, GrantIntent, ResourceType, Subject } from "./contract";
+
+export interface PolicyEngine {
+  check(req: AuthorizeRequest): Promise<AuthorizeResult>;
+  batchCheck(
+    subject: Subject,
+    action: Action,
+    resourceType: ResourceType,
+    ids: string[],
+  ): Promise<Map<string, AuthorizeResult>>;
+}
+
+export interface PolicyAdmin {
+  grant(intent: GrantIntent): Promise<void>;
+  revoke(intent: GrantIntent): Promise<void>;
+}

--- a/ui/src/lib/authz/engines/openfga.ts
+++ b/ui/src/lib/authz/engines/openfga.ts
@@ -1,0 +1,355 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// Standalone OpenFGA adapter for CAS. Transport (HTTP client, store-id cache,
+// circuit breaker) is private to this silo. Vocabulary (action→relation maps)
+// is imported from lib/rbac/tuple-builders — the canonical source — so CAS
+// can never silently drift from the OpenFGA model used by the rest of the BFF.
+
+import type {
+  Action,
+  AuthorizeRequest,
+  AuthorizeResult,
+  Grantee,
+  GrantIntent,
+  Resource,
+  ResourceType,
+  Subject,
+} from "../contract";
+import type { PolicyAdmin, PolicyEngine } from "../engine";
+import { BoundedTtlCache } from "../cache";
+import { getReasonMeta } from "../reasons";
+import { openFgaRelation, openFgaCheckRelation } from "@/lib/rbac/tuple-builders";
+import { openFgaResourceObject } from "@/lib/rbac/openfga-resource-ids";
+
+// ─── Transport ────────────────────────────────────────────────────────────────
+
+const DEFAULT_STORE_NAME = "caipe-openfga";
+const BATCH_CONCURRENCY = 10;
+
+function baseUrl(): string {
+  const url = process.env.OPENFGA_HTTP?.trim()?.replace(/\/+$/, "");
+  if (!url) throw new Error("OPENFGA_HTTP is not set");
+  return url;
+}
+
+function fgaHeaders(): Record<string, string> {
+  return { "Content-Type": "application/json" };
+}
+
+// Module-level store-id cache: warm at first call, invalidated on 404.
+let cachedStoreId: string | null = null;
+
+async function resolveStoreId(): Promise<string> {
+  const explicit = process.env.OPENFGA_STORE_ID?.trim();
+  if (explicit) return explicit;
+  if (cachedStoreId) return cachedStoreId;
+
+  const res = await fetch(`${baseUrl()}/stores`, { headers: fgaHeaders() });
+  if (!res.ok) throw new Error(`OpenFGA store discovery failed: ${res.status}`);
+  const body = (await res.json()) as { stores?: Array<{ id?: string; name?: string }> };
+  const storeName = process.env.OPENFGA_STORE_NAME?.trim() || DEFAULT_STORE_NAME;
+  const store = body.stores?.find((s) => s.name === storeName);
+  if (!store?.id) throw new Error(`OpenFGA store "${storeName}" not found`);
+  cachedStoreId = store.id;
+  return cachedStoreId;
+}
+
+async function fgaCheck(storeId: string, user: string, relation: string, object: string): Promise<boolean> {
+  const res = await fetch(`${baseUrl()}/stores/${storeId}/check`, {
+    method: "POST",
+    headers: fgaHeaders(),
+    body: JSON.stringify({ tuple_key: { user, relation, object } }),
+  });
+  if (res.status === 404) {
+    cachedStoreId = null; // invalidate; next call re-resolves
+    throw new Error("OpenFGA store not found (404)");
+  }
+  if (!res.ok) throw new Error(`OpenFGA check failed: ${res.status}`);
+  const body = (await res.json()) as { allowed?: boolean };
+  return Boolean(body.allowed);
+}
+
+// ─── Circuit breaker (per replica) ───────────────────────────────────────────
+
+type CircuitState = "closed" | "open" | "half_open";
+
+const CIRCUIT_FAILURE_THRESHOLD = 5;
+const CIRCUIT_OPEN_DURATION_MS = 30_000;
+
+let circuitState: CircuitState = "closed";
+let failureCount = 0;
+let openSince = 0;
+let probeInFlight = false;
+
+/** Synchronous gate. In half_open, admits exactly one probe at a time. */
+function circuitAllows(): boolean {
+  if (circuitState === "closed") return true;
+  if (circuitState === "open") {
+    if (Date.now() - openSince < CIRCUIT_OPEN_DURATION_MS) return false; // still cooling down
+    circuitState = "half_open"; // cooldown elapsed — fall through to probe handling
+  }
+  // half_open: admit exactly one probe at a time
+  if (probeInFlight) return false;
+  probeInFlight = true;
+  return true;
+}
+
+function recordSuccess(): void {
+  failureCount = 0;
+  circuitState = "closed";
+  probeInFlight = false;
+}
+
+function recordFailure(): void {
+  probeInFlight = false;
+  if (circuitState === "half_open") {
+    circuitState = "open";
+    openSince = Date.now();
+    return;
+  }
+  failureCount++;
+  if (failureCount >= CIRCUIT_FAILURE_THRESHOLD) {
+    circuitState = "open";
+    openSince = Date.now();
+  }
+}
+
+/** Test-only reset of breaker + store-id state. */
+export function __resetAdapterStateForTests(): void {
+  circuitState = "closed";
+  failureCount = 0;
+  openSince = 0;
+  probeInFlight = false;
+  cachedStoreId = null;
+  cacheHits = 0;
+  cacheMisses = 0;
+  decisionCache.clear();
+}
+
+// ─── Decision cache ───────────────────────────────────────────────────────────
+
+const READ_TTL_MS = Number(process.env.AUTHZ_DECISION_CACHE_TTL_MS ?? 15_000);
+const WRITE_TTL_MS = Number(process.env.AUTHZ_DECISION_CACHE_WRITE_TTL_MS ?? 2_000);
+const WRITE_ACTIONS = new Set<Action>(["write", "create", "manage", "delete", "ingest"]);
+
+const decisionCache = new BoundedTtlCache<AuthorizeResult>(10_000, READ_TTL_MS);
+
+let cacheHits = 0;
+let cacheMisses = 0;
+
+function cacheKey(subject: Subject, resource: Resource, action: Action, context?: Record<string, unknown>): string {
+  const contextKey = context ? `|ctx:${stableContextKey(context)}` : "";
+  return `${subject.type}:${subject.id}|${resource.type}:${resource.id}|${action}${contextKey}`;
+}
+
+function stableContextKey(context: Record<string, unknown>): string {
+  return JSON.stringify(
+    Object.keys(context)
+      .sort()
+      .map((key) => [key, context[key]]),
+  );
+}
+
+/**
+ * Live, per-replica adapter snapshot for the CAS health panel. Reflects only
+ * the replica that serves the request (circuit + cache are module-local).
+ */
+export interface EngineStats {
+  circuitState: CircuitState;
+  cacheSize: number;
+  cacheHits: number;
+  cacheMisses: number;
+  cacheHitRatio: number;
+}
+
+export function getEngineStats(): EngineStats {
+  const total = cacheHits + cacheMisses;
+  return {
+    circuitState,
+    cacheSize: decisionCache.size,
+    cacheHits,
+    cacheMisses,
+    cacheHitRatio: total > 0 ? cacheHits / total : 0,
+  };
+}
+
+function ttlForAction(action: Action): number {
+  return WRITE_ACTIONS.has(action) ? WRITE_TTL_MS : READ_TTL_MS;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function boundedParallel<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const item = items[index++];
+      await fn(item);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+}
+
+function allow(): AuthorizeResult {
+  return { decision: "ALLOW", reason: "OK", retriable: getReasonMeta("OK").retriable, ttl_seconds: Math.floor(READ_TTL_MS / 1000), via: "tuple" };
+}
+
+function deny(reason: AuthorizeResult["reason"] = "NO_CAPABILITY"): AuthorizeResult {
+  return { decision: "DENY", reason, retriable: getReasonMeta(reason).retriable };
+}
+
+async function runCheck(req: AuthorizeRequest): Promise<AuthorizeResult> {
+  if (!circuitAllows()) return deny("AUTHZ_UNAVAILABLE");
+
+  const relation = openFgaCheckRelation(req.action);
+  const user = `${req.subject.type}:${req.subject.id}`;
+  const object = openFgaResourceObject(req.resource.type, req.resource.id);
+
+  try {
+    const storeId = await resolveStoreId();
+    const allowed = await fgaCheck(storeId, user, relation, object);
+    recordSuccess();
+    return allowed ? allow() : deny("NO_CAPABILITY");
+  } catch (err) {
+    recordFailure();
+    console.warn("[cas/openfga] check error:", err instanceof Error ? err.message : String(err));
+    return deny("AUTHZ_UNAVAILABLE");
+  }
+}
+
+async function checkWithCache(req: AuthorizeRequest): Promise<AuthorizeResult> {
+  const key = cacheKey(req.subject, req.resource, req.action, req.context);
+  const cached = decisionCache.get(key);
+  if (cached) {
+    cacheHits++;
+    return cached;
+  }
+  cacheMisses++;
+
+  const result = await runCheck(req);
+  // Only cache definitive outcomes — never cache transient unavailability.
+  if (result.reason !== "AUTHZ_UNAVAILABLE") {
+    decisionCache.set(key, result, ttlForAction(req.action));
+  }
+  return result;
+}
+
+// ─── PolicyEngine ─────────────────────────────────────────────────────────────
+
+export function createOpenFgaEngine(): PolicyEngine {
+  return {
+    check(req: AuthorizeRequest): Promise<AuthorizeResult> {
+      return checkWithCache(req);
+    },
+
+    async batchCheck(
+      subject: Subject,
+      action: Action,
+      resourceType: ResourceType,
+      ids: string[],
+    ): Promise<Map<string, AuthorizeResult>> {
+      const results = new Map<string, AuthorizeResult>();
+      await boundedParallel(ids, BATCH_CONCURRENCY, async (id) => {
+        const result = await checkWithCache({ subject, action, resource: { type: resourceType, id } });
+        results.set(id, result);
+      });
+      return results;
+    },
+  };
+}
+
+// ─── Admin / PAP (writes) ─────────────────────────────────────────────────────
+
+interface FgaTuple {
+  user: string;
+  relation: string;
+  object: string;
+}
+
+function granteeRef(g: Grantee): string {
+  switch (g.type) {
+    case "user":
+      return `user:${g.id}`;
+    case "service_account":
+      return `service_account:${g.id}`;
+    case "team":
+      return `team:${g.id}#member`;
+    case "everyone":
+      return "user:*";
+  }
+}
+
+function grantTuple(intent: GrantIntent): FgaTuple {
+  return {
+    user: granteeRef(intent.grantee),
+    relation: openFgaRelation(intent.capability),
+    object: openFgaResourceObject(intent.resource.type, intent.resource.id),
+  };
+}
+
+async function fgaWrite(storeId: string, writes: FgaTuple[], deletes: FgaTuple[]): Promise<void> {
+  const body = {
+    ...(writes.length ? { writes: { tuple_keys: writes } } : {}),
+    ...(deletes.length ? { deletes: { tuple_keys: deletes } } : {}),
+  };
+  const res = await fetch(`${baseUrl()}/stores/${storeId}/write`, {
+    method: "POST",
+    headers: fgaHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    // Idempotent: writing an existing tuple / deleting an absent one is a no-op.
+    if (isIdempotentWriteFailure(res.status, text, writes, deletes)) return;
+    throw new Error(`OpenFGA write failed: ${res.status} ${text.slice(0, 200)}`);
+  }
+}
+
+function isIdempotentWriteFailure(status: number, text: string, writes: FgaTuple[], deletes: FgaTuple[]): boolean {
+  if (status !== 400) return false;
+  const writeOnly = writes.length > 0 && deletes.length === 0;
+  const deleteOnly = deletes.length > 0 && writes.length === 0;
+  if (writeOnly) return /already exist|duplicate/i.test(text);
+  if (deleteOnly) return /does not exist|not found/i.test(text);
+  return false;
+}
+
+export function createOpenFgaAdmin(): PolicyAdmin {
+  return {
+    async grant(intent: GrantIntent): Promise<void> {
+      const storeId = await resolveStoreId();
+      await fgaWrite(storeId, [grantTuple(intent)], []);
+      decisionCache.clear(); // the graph changed — drop cached decisions
+    },
+    async revoke(intent: GrantIntent): Promise<void> {
+      const storeId = await resolveStoreId();
+      await fgaWrite(storeId, [], [grantTuple(intent)]);
+      decisionCache.clear();
+    },
+  };
+}
+
+/**
+ * Debug describe for the admin /explain endpoint — the ONLY place OpenFGA
+ * vocabulary (relation strings, store id, tuple shape) is exposed. Reuses
+ * the same maps as the live check so explain can never drift from reality.
+ */
+export function describeFgaCheck(req: AuthorizeRequest): {
+  engine: "openfga";
+  relation: string;
+  user: string;
+  object: string;
+  store: string;
+} {
+  return {
+    engine: "openfga",
+    relation: openFgaCheckRelation(req.action),
+    user: `${req.subject.type}:${req.subject.id}`,
+    object: openFgaResourceObject(req.resource.type, req.resource.id),
+    store: process.env.OPENFGA_STORE_ID?.trim() || cachedStoreId || "(resolved at boot)",
+  };
+}

--- a/ui/src/lib/authz/http.ts
+++ b/ui/src/lib/authz/http.ts
@@ -1,0 +1,329 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// Shared HTTP-layer helpers for the /api/authz/v1 routes: caller resolution,
+// input validation, and subject-binding. These enforce the trust boundary —
+// see spec §6 (threats 1–3). The rule of thumb: FAIL CLOSED. If we cannot
+// positively establish the caller's verified subject, we reject.
+
+import { randomUUID } from "crypto";
+import { NextResponse } from "next/server";
+
+import { emitGrantAudit, type GrantOperation } from "./audit";
+import { authorize } from "./index";
+import { isSupportedResourceAction, listResourceTypeDefinitions } from "@/lib/rbac/resource-model";
+import type {
+  Action,
+  AuthorizeResult,
+  DecisionContext,
+  Grantee,
+  GrantIntent,
+  Resource,
+  ResourceType,
+  Subject,
+  SubjectType,
+} from "./contract";
+
+const ORG_KEY = process.env.CAIPE_ORG_KEY ?? "caipe";
+const ID_MAX_LEN = 256;
+const RAW_ID_MAX_LEN = 512;
+
+// Safe id charset: alnum plus the characters that appear in Keycloak subs
+// (UUID), emails (`. _ % + - @`). Deliberately EXCLUDES:
+//   *  — wildcard (would let a caller probe `agent:*` public-share tuples)
+//   #  — OpenFGA relation separator
+//   :  — OpenFGA type separator
+//   /  — path traversal
+// so a caller can never smuggle OpenFGA structure through an id field.
+const ID_PATTERN = /^[A-Za-z0-9._%+\-@]+$/;
+const RESERVED_ADVISORY_CONTEXT_KEYS = new Set(["workflow_run_id"]);
+
+const SUBJECT_TYPES: ReadonlySet<string> = new Set<SubjectType>(["user", "service_account"]);
+const RESOURCE_DEFINITIONS = listResourceTypeDefinitions();
+const RESOURCE_TYPES: ReadonlySet<string> = new Set(RESOURCE_DEFINITIONS.map((definition) => definition.type));
+const ACTIONS: ReadonlySet<string> = new Set(RESOURCE_DEFINITIONS.flatMap((definition) => definition.actions));
+const PUBLIC_GRANTABLE_EVERYONE_RESOURCE_ACTIONS: ReadonlySet<string> = new Set([
+  "admin_surface:discover",
+  "agent:discover",
+  "audit_log:discover",
+  "conversation:discover",
+  "data_source:discover",
+  "document:discover",
+  "external_group:discover",
+  "knowledge_base:discover",
+  "llm_model:discover",
+  "mcp_server:discover",
+  "mcp_tool:discover",
+  "organization:discover",
+  "policy:discover",
+  "secret_ref:discover",
+  "skill:discover",
+  "slack_channel:discover",
+  "slack_workspace:discover",
+  "system_config:discover",
+  "task:discover",
+  "team:discover",
+  "tool:discover",
+  "user_profile:discover",
+  "webex_space:discover",
+  "webex_workspace:discover",
+]);
+
+// ─── Meta errors (HTTP-level failures, distinct from a DENY decision) ─────────
+
+export type MetaCode = "NOT_AUTHENTICATED" | "FORBIDDEN" | "INVALID_REQUEST" | "AUTHZ_UNAVAILABLE";
+
+export class HttpAuthzError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: MetaCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpAuthzError";
+  }
+}
+
+export function metaErrorResponse(err: HttpAuthzError): NextResponse {
+  return NextResponse.json(
+    { error: err.message, code: err.code, retriable: err.code === "AUTHZ_UNAVAILABLE" },
+    { status: err.status },
+  );
+}
+
+// ─── Caller resolution (fail-closed) ──────────────────────────────────────────
+
+export interface Caller {
+  type: SubjectType;
+  id: string;
+}
+
+/**
+ * Returns the verified caller identity, or null if no stable subject can be
+ * established (catalog-key / local-skills tokens carry no `sub`). Callers
+ * without a subject must be rejected with 401 — they are authenticated but
+ * cannot be bound to a subject, so they may not evaluate per-subject decisions.
+ */
+export function resolveCaller(session: unknown): Caller | null {
+  if (!session || typeof session !== "object") return null;
+  const s = session as { sub?: unknown; isServiceAccount?: unknown };
+  const sub = typeof s.sub === "string" ? s.sub.trim() : "";
+  if (!sub) return null;
+  return { type: s.isServiceAccount === true ? "service_account" : "user", id: sub };
+}
+
+export function decisionContext(session: unknown, caller?: Caller, request?: Request): DecisionContext {
+  let tenantId: string | undefined;
+  if (session && typeof session === "object") {
+    const org = (session as { org?: unknown }).org;
+    if (typeof org === "string" && org.trim()) tenantId = org.trim();
+  }
+  const headerCorrelation = request?.headers.get("x-correlation-id")?.trim();
+  return {
+    tenantId,
+    correlationId: headerCorrelation || randomUUID(),
+    ...(caller ? { caller: { type: caller.type, id: caller.id } } : {}),
+  };
+}
+
+// ─── Input validation ─────────────────────────────────────────────────────────
+
+export function isValidId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= ID_MAX_LEN &&
+    ID_PATTERN.test(value)
+  );
+}
+
+function isValidRawObjectId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= RAW_ID_MAX_LEN &&
+    !value.includes("*") &&
+    !value.includes("#") &&
+    !value.includes("\0")
+  );
+}
+
+export function isValidResourceId(type: ResourceType, value: unknown): value is string {
+  if (type === "llm_model") return isValidRawObjectId(value);
+  return isValidId(value);
+}
+
+export function sanitizeAdvisoryContext(raw: unknown): Record<string, unknown> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (RESERVED_ADVISORY_CONTEXT_KEYS.has(key)) continue;
+    out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function parseSubject(raw: unknown): Subject {
+  if (!raw || typeof raw !== "object") {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "subject is required");
+  }
+  const r = raw as Record<string, unknown>;
+  if (!SUBJECT_TYPES.has(r.type as string)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "subject.type must be 'user' or 'service_account'");
+  }
+  if (!isValidId(r.id)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "subject.id is missing or contains invalid characters");
+  }
+  return { type: r.type as SubjectType, id: r.id as string };
+}
+
+export function parseResource(raw: unknown): Resource {
+  if (!raw || typeof raw !== "object") {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "resource is required");
+  }
+  const r = raw as Record<string, unknown>;
+  const type = r.type as ResourceType;
+  if (!RESOURCE_TYPES.has(type)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "resource.type is not a recognized resource type");
+  }
+  if (!isValidResourceId(type, r.id)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "resource.id is missing or contains invalid characters");
+  }
+  return { type, id: r.id as string };
+}
+
+export function parseAction(raw: unknown): Action {
+  if (!ACTIONS.has(raw as string)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "action is not a recognized action");
+  }
+  return raw as Action;
+}
+
+export function parseResourceType(raw: unknown): ResourceType {
+  if (!RESOURCE_TYPES.has(raw as string)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "resource_type is not a recognized resource type");
+  }
+  return raw as ResourceType;
+}
+
+// ─── Subject-binding (the core trust-boundary control) ────────────────────────
+
+/**
+ * A caller may only evaluate decisions for its OWN subject. Cross-subject
+ * evaluation (one principal asking about another) requires `can_audit` on the
+ * organization — the admin/explain capability. This single rule closes both
+ * forged-subject (threat #1) and impersonation (threat #2): the OBO flow works
+ * naturally because a bot presents the *user's* token, so caller == subject.
+ */
+export async function enforceSubjectBinding(
+  caller: Caller,
+  subject: Subject,
+  ctx: DecisionContext,
+): Promise<void> {
+  if (subject.type === caller.type && subject.id === caller.id) return;
+
+  const audit = await authorize(
+    { subject: caller, resource: { type: "organization", id: ORG_KEY }, action: "audit" },
+    ctx,
+  );
+  if (audit.decision !== "ALLOW") {
+    throw new HttpAuthzError(403, "FORBIDDEN", "You may only evaluate decisions for your own subject");
+  }
+}
+
+/** Unconditional can_audit gate for the admin /explain endpoint. */
+export async function requireAuditCapability(caller: Caller, ctx: DecisionContext): Promise<void> {
+  const audit = await authorize(
+    { subject: caller, resource: { type: "organization", id: ORG_KEY }, action: "audit" },
+    ctx,
+  );
+  if (audit.decision !== "ALLOW") {
+    throw new HttpAuthzError(403, "FORBIDDEN", "can_audit permission is required to use /explain");
+  }
+}
+
+// ─── Grant / Revoke helpers ───────────────────────────────────────────────────
+
+const GRANTEE_TYPES_WITH_ID: ReadonlySet<string> = new Set(["user", "service_account", "team"]);
+
+export function parseGrantee(raw: unknown): Grantee {
+  if (!raw || typeof raw !== "object") {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "grantee is required");
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.type === "everyone") return { type: "everyone" };
+  if (!GRANTEE_TYPES_WITH_ID.has(r.type as string)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "grantee.type must be user, service_account, team, or everyone");
+  }
+  if (!isValidId(r.id)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "grantee.id is missing or contains invalid characters");
+  }
+  return { type: r.type as "user" | "service_account" | "team", id: r.id as string };
+}
+
+export function parseGrantIntent(raw: unknown): GrantIntent {
+  if (!raw || typeof raw !== "object") {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "request body must be an object");
+  }
+  const b = raw as Record<string, unknown>;
+  const resource = parseResource(b.resource);
+  const grantee = parseGrantee(b.grantee);
+  const capability = parseAction(b.capability);
+  if (!isSupportedResourceAction(resource.type, capability)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "capability is not supported for this resource type");
+  }
+  if (grantee.type === "everyone" && !isPublicEveryoneGrantable(resource, capability)) {
+    throw new HttpAuthzError(400, "INVALID_REQUEST", "everyone grants are limited to low-risk resource capabilities");
+  }
+  return { resource, grantee, capability };
+}
+
+function isPublicEveryoneGrantable(resource: Resource, capability: Action): boolean {
+  return PUBLIC_GRANTABLE_EVERYONE_RESOURCE_ACTIONS.has(`${resource.type}:${capability}`);
+}
+
+/** Optional grant/revoke audit context when meta-authz fails before the PAP write. */
+export interface GrantAuditRequest {
+  operation: GrantOperation;
+  intent: GrantIntent;
+}
+
+/** Per-resource meta-authz: the caller must hold `manage` on the resource to grant/revoke. */
+export async function requireManage(
+  caller: Caller,
+  resource: Resource,
+  ctx: DecisionContext,
+  audit?: GrantAuditRequest,
+): Promise<void> {
+  const check = await authorize({ subject: caller, resource, action: "manage" }, ctx);
+  if (check.decision === "ALLOW") return;
+  if (check.reason === "AUTHZ_UNAVAILABLE" || check.retriable) {
+    if (audit) {
+      await emitGrantAudit(audit.operation, audit.intent, ctx, {
+        outcome: "error",
+        reasonCode: check.reason,
+      });
+    }
+    throw metaAuthzDecisionError(check, "You must have manage permission on the resource to grant or revoke access");
+  }
+
+  const orgAdmin = await authorize(
+    { subject: caller, resource: { type: "organization", id: ORG_KEY }, action: "manage" },
+    ctx,
+  );
+  if (orgAdmin.decision === "ALLOW") return;
+
+  if (audit) {
+    await emitGrantAudit(audit.operation, audit.intent, ctx, {
+      outcome: "error",
+      reasonCode: orgAdmin.reason,
+    });
+  }
+  throw metaAuthzDecisionError(orgAdmin, "You must have manage permission on the resource to grant or revoke access");
+}
+
+function metaAuthzDecisionError(result: AuthorizeResult, forbiddenMessage: string): HttpAuthzError {
+  if (result.reason === "AUTHZ_UNAVAILABLE" || result.retriable) {
+    return new HttpAuthzError(503, "AUTHZ_UNAVAILABLE", "Authorization service temporarily unavailable");
+  }
+  return new HttpAuthzError(403, "FORBIDDEN", forbiddenMessage);
+}

--- a/ui/src/lib/authz/index.ts
+++ b/ui/src/lib/authz/index.ts
@@ -1,0 +1,141 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// Public API for the Centralized Authorization Service (CAS).
+// Everything inside the BFF imports from here — never from engines/,
+// compose.ts, or audit.ts directly. The ESLint boundary rule enforces this.
+
+import type {
+  Action,
+  AuthorizeRequest,
+  AuthorizeResult,
+  DecisionContext,
+  GrantIntent,
+  ResourceType,
+  Subject,
+} from "./contract";
+import { compose } from "./compose";
+import { emitDecisionAudit, emitGrantAudit } from "./audit";
+import { createOpenFgaEngine, createOpenFgaAdmin } from "./engines/openfga";
+import { workflowDelegationPreCheck } from "./domains/workflow";
+
+// ─── Singleton engine (module-level, reused across requests) ──────────────────
+
+const engine = compose(createOpenFgaEngine(), {
+  preCheck: async (req) => workflowDelegationPreCheck(req),
+});
+
+const admin = createOpenFgaAdmin();
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate a single authorization request. Never throws for DENY — returns
+ * the decision in the result. The decision is always audited.
+ */
+export async function authorize(
+  req: AuthorizeRequest,
+  ctx: DecisionContext = {},
+): Promise<AuthorizeResult> {
+  const result = await engine.check(req);
+  emitDecisionAudit(req.subject, req.resource, req.action, result, ctx, req.trustedContext);
+  return result;
+}
+
+/**
+ * Batch evaluation: same subject + action across multiple resource ids.
+ * Uses bounded-parallel checks internally. Each decision is audited.
+ */
+export async function authorizeMany(
+  subject: Subject,
+  action: Action,
+  resourceType: ResourceType,
+  ids: string[],
+  ctx: DecisionContext = {},
+): Promise<Map<string, AuthorizeResult>> {
+  const results = await engine.batchCheck(subject, action, resourceType, ids);
+  for (const [id, result] of results) {
+    emitDecisionAudit(subject, { type: resourceType, id }, action, result, ctx);
+  }
+  return results;
+}
+
+/**
+ * Guard variant. Throws {@link AuthzDeniedError} on DENY (including
+ * AUTHZ_UNAVAILABLE). Use inside BFF route handlers where a denial should
+ * stop the request.
+ */
+export async function authorizeOrThrow(
+  req: AuthorizeRequest,
+  ctx: DecisionContext = {},
+): Promise<void> {
+  const result = await authorize(req, ctx);
+  if (result.decision === "DENY") {
+    throw new AuthzDeniedError(result);
+  }
+}
+
+/** Returns only the ids from `ids` that the subject may access. */
+export async function filterAccessible(
+  subject: Subject,
+  action: Action,
+  resourceType: ResourceType,
+  ids: string[],
+  ctx: DecisionContext = {},
+): Promise<string[]> {
+  if (ids.length === 0) return [];
+  const results = await authorizeMany(subject, action, resourceType, ids, ctx);
+  return ids.filter((id) => results.get(id)?.decision === "ALLOW");
+}
+
+// ─── Grant / Revoke (PAP) ─────────────────────────────────────────────────────
+
+export async function grant(intent: GrantIntent, ctx: DecisionContext = {}): Promise<void> {
+  try {
+    await admin.grant(intent);
+    await emitGrantAudit("grant", intent, ctx, { outcome: "success" });
+  } catch (err) {
+    await emitGrantAudit("grant", intent, ctx, { outcome: "error", reasonCode: "PDP_WRITE_FAILED" });
+    throw err;
+  }
+}
+
+export async function revoke(intent: GrantIntent, ctx: DecisionContext = {}): Promise<void> {
+  try {
+    await admin.revoke(intent);
+    await emitGrantAudit("revoke", intent, ctx, { outcome: "success" });
+  } catch (err) {
+    await emitGrantAudit("revoke", intent, ctx, { outcome: "error", reasonCode: "PDP_WRITE_FAILED" });
+    throw err;
+  }
+}
+
+// ─── Error type ───────────────────────────────────────────────────────────────
+
+export class AuthzDeniedError extends Error {
+  readonly result: AuthorizeResult;
+  constructor(result: AuthorizeResult) {
+    super(`Authorization denied: ${result.reason}`);
+    this.name = "AuthzDeniedError";
+    this.result = result;
+  }
+}
+
+// ─── Re-exports ───────────────────────────────────────────────────────────────
+
+export { describeFgaCheck, getEngineStats } from "./engines/openfga";
+export type { EngineStats } from "./engines/openfga";
+
+export type {
+  Action,
+  AuthorizeRequest,
+  AuthorizeResult,
+  DecisionContext,
+  DecisionValue,
+  Grantee,
+  GrantIntent,
+  ReasonCode,
+  Resource,
+  ResourceType,
+  Subject,
+  SubjectType,
+} from "./contract";

--- a/ui/src/lib/authz/reasons.ts
+++ b/ui/src/lib/authz/reasons.ts
@@ -1,0 +1,21 @@
+// assisted-by claude code claude-sonnet-4-6
+
+import type { ReasonCode } from "./contract";
+
+export interface ReasonMeta {
+  retriable: boolean;
+  httpStatusHint: number;
+  userActionHint: string;
+}
+
+const REASON_META: Record<ReasonCode, ReasonMeta> = {
+  OK:               { retriable: false, httpStatusHint: 200, userActionHint: "" },
+  NO_CAPABILITY:    { retriable: false, httpStatusHint: 200, userActionHint: "contact_admin" },
+  NOT_AUTHENTICATED:{ retriable: false, httpStatusHint: 401, userActionHint: "sign_in" },
+  AUTHZ_UNAVAILABLE:{ retriable: true,  httpStatusHint: 503, userActionHint: "retry" },
+  INVALID_REQUEST:  { retriable: false, httpStatusHint: 400, userActionHint: "fix_request" },
+};
+
+export function getReasonMeta(code: ReasonCode): ReasonMeta {
+  return REASON_META[code];
+}

--- a/ui/src/lib/rbac/types.ts
+++ b/ui/src/lib/rbac/types.ts
@@ -122,7 +122,13 @@ export interface KeycloakAuthzConfig {
 }
 
 /** Unified audit event types (FR-037) */
-export type AuditEventType = "auth" | "tool_action" | "agent_delegation" | "openfga_rebac";
+export type AuditEventType =
+  | "auth"
+  | "tool_action"
+  | "agent_delegation"
+  | "openfga_rebac"
+  | "cas_decision"
+  | "cas_grant";
 
 /** Unified audit event outcome — superset of AuditOutcome for tool/delegation */
 export type UnifiedAuditOutcome = "allow" | "deny" | "success" | "error";
@@ -134,7 +140,8 @@ export type AuditEventSource =
   | "supervisor"
   | "slack"
   | "dynamic_agents"
-  | "openfga_authz_bridge";
+  | "openfga_authz_bridge"
+  | "cas";
 
 /** Unified audit event stored in the audit_events MongoDB collection (FR-037) */
 export interface UnifiedAuditEvent {
@@ -154,11 +161,23 @@ export interface UnifiedAuditEvent {
   context_id?: string;
   component?: string;
   resource_ref?: string;
+  resource_type?: string;
+  resource_id?: string;
+  workflow_run_id?: string;
+  decision_via?: string;
   pdp?: string;
   source: AuditEventSource;
   trace_id?: string;
   span_id?: string;
   trace_url?: string;
+  /** CAS grant/revoke: hashed caller principal. */
+  actor_hash?: string;
+  /** CAS grant/revoke: readable caller ref (e.g. user:sub). */
+  caller_ref?: string;
+  /** CAS grant/revoke: readable grantee ref (e.g. team:eng). */
+  grantee_ref?: string;
+  /** CAS grant/revoke: grant | revoke. */
+  operation?: "grant" | "revoke";
 }
 
 /** Admin dashboard tab keys for RBAC-based visibility */

--- a/ui/src/lib/rbac/workflow-config-rebac.ts
+++ b/ui/src/lib/rbac/workflow-config-rebac.ts
@@ -1,0 +1,410 @@
+/**
+ * OpenFGA projection for workflow_configs (stored as `task:<wf-id>`).
+ *
+ * Workflow configs historically only lived in MongoDB; runs enforced
+ * `task#read` in OpenFGA without ever writing tuples on create. This module
+ * reconciles visibility on write and applies Mongo visibility rules for run
+ * access (global = any signed-in user; team = shared team members; private = owner).
+ */
+
+import { getCollection } from "@/lib/mongodb";
+import { ApiError } from "@/lib/api-error";
+import type { OpenFgaReconcileResult } from "./openfga";
+import { reconcileShareableResource } from "./openfga-owned-resources";
+import { listUserTeamSlugs } from "./openfga-team-membership";
+import {
+  requireResourcePermission,
+  subjectFromSession,
+  type ResourceAuthzSession,
+} from "./resource-authz";
+import type { WorkflowConfigVisibility } from "@/types/workflow-config";
+
+export interface WorkflowConfigRebacSnapshot {
+  _id: string;
+  visibility?: WorkflowConfigVisibility | null;
+  shared_with_teams?: string[] | null;
+  owner_id: string;
+  config_driven?: boolean;
+}
+
+/**
+ * Resolve Mongo visibility for run/discover policy checks. Legacy rows may omit
+ * `visibility`; platform-seeded workflows (`owner_id: system`) default to global.
+ */
+export function effectiveWorkflowVisibility(
+  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "owner_id" | "config_driven">,
+): WorkflowConfigVisibility {
+  const raw =
+    typeof config.visibility === "string" ? config.visibility.trim().toLowerCase() : "";
+  if (raw === "global" || raw === "team" || raw === "private") {
+    return raw;
+  }
+  if (config.owner_id?.trim().toLowerCase() === "system" || config.config_driven) {
+    return "global";
+  }
+  return "private";
+}
+
+export function normalizeTeamSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+function normalizeTeamSlugs(slugs: string[] | null | undefined): string[] {
+  if (!slugs?.length) return [];
+  return [...new Set(slugs.map(normalizeTeamSlug).filter(Boolean))];
+}
+
+/** Maps team slug and Mongo `_id` string to canonical slug (lowercase). */
+export type TeamRefToSlugMap = Map<string, string>;
+
+export async function buildTeamRefToSlugMap(): Promise<TeamRefToSlugMap> {
+  const teams = await getCollection<{ _id: unknown; slug?: string }>("teams");
+  const rows = await teams.find({}).project({ slug: 1 }).toArray();
+  const map: TeamRefToSlugMap = new Map();
+  for (const row of rows) {
+    const slug = row.slug?.trim().toLowerCase();
+    if (!slug) continue;
+    map.set(slug, slug);
+    map.set(String(row._id), slug);
+  }
+  return map;
+}
+
+/** Resolve stored team refs (slug or legacy Mongo id) to slugs for FGA and visibility checks. */
+export function resolveSharedTeamSlugs(
+  refs: string[] | null | undefined,
+  teamRefToSlug?: TeamRefToSlugMap,
+): string[] {
+  if (!refs?.length) return [];
+  const resolved = refs.map((ref) => {
+    const trimmed = ref.trim();
+    if (!trimmed) return "";
+    const fromMap = teamRefToSlug?.get(trimmed) ?? teamRefToSlug?.get(normalizeTeamSlug(trimmed));
+    if (fromMap) return fromMap;
+    return normalizeTeamSlug(trimmed);
+  });
+  return normalizeTeamSlugs(resolved);
+}
+
+export async function normalizeSharedWithTeamSlugs(
+  refs: string[] | undefined,
+): Promise<string[] | undefined> {
+  if (!refs?.length) return undefined;
+  const map = await buildTeamRefToSlugMap();
+  const slugs = resolveSharedTeamSlugs(refs, map);
+  return slugs.length > 0 ? slugs : undefined;
+}
+
+/**
+ * Product policy: who may run (and discover) a workflow from Mongo visibility alone.
+ */
+export function agentListedInWorkflowSteps(
+  config: Pick<WorkflowConfigRebacSnapshot, "_id"> & {
+    steps?: Array<{ type?: string; agent_id?: string }>;
+  },
+  agentId: string,
+): boolean {
+  for (const step of config.steps ?? []) {
+    if (step?.type === "step" && step.agent_id === agentId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Agent use delegated from an in-flight workflow run the user may execute. */
+export function workflowDelegatesAgentUse(
+  config: WorkflowConfigRebacSnapshot & {
+    steps?: Array<{ type?: string; agent_id?: string }>;
+  },
+  agentId: string,
+  userEmail: string,
+  userTeamSlugs: string[],
+): boolean {
+  if (!agentListedInWorkflowSteps(config, agentId)) {
+    return false;
+  }
+  return workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs);
+}
+
+export function workflowRunAllowedByVisibility(
+  config: Pick<
+    WorkflowConfigRebacSnapshot,
+    "visibility" | "shared_with_teams" | "owner_id" | "config_driven"
+  >,
+  userEmail: string,
+  userTeamSlugs: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): boolean {
+  const visibility = effectiveWorkflowVisibility(config);
+
+  if (visibility === "global") {
+    return true;
+  }
+
+  if (visibility === "team") {
+    const shared = resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug);
+    if (shared.length === 0) {
+      return false;
+    }
+    const memberSlugs = new Set(normalizeTeamSlugs(userTeamSlugs));
+    return shared.some((slug) => memberSlugs.has(slug));
+  }
+
+  const owner = config.owner_id?.trim().toLowerCase();
+  return Boolean(owner && owner === userEmail.trim().toLowerCase());
+}
+
+export async function resolveUserTeamSlugsForWorkflow(
+  userEmail: string,
+  session: ResourceAuthzSession,
+): Promise<string[]> {
+  const subject = subjectFromSession(session);
+  if (subject) {
+    try {
+      const slugs = await listUserTeamSlugs({ subject });
+      if (slugs.length > 0) {
+        return slugs;
+      }
+    } catch {
+      // Fall through to Mongo membership lookup.
+    }
+  }
+
+  try {
+    const teams = await getCollection<{ slug?: string }>("teams");
+    const rows = await teams
+      .find({ "members.user_id": userEmail })
+      .project({ slug: 1 })
+      .toArray();
+    return rows.map((team) => team.slug?.trim()).filter((slug): slug is string => Boolean(slug));
+  } catch {
+    return [];
+  }
+}
+
+export function filterWorkflowConfigsByRunAccess<T extends WorkflowConfigRebacSnapshot>(
+  configs: T[],
+  userEmail: string,
+  userTeamSlugs: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): T[] {
+  return configs.filter((config) =>
+    workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs, teamRefToSlug),
+  );
+}
+
+export function mergeWorkflowConfigsById<T extends { _id: string }>(
+  ...groups: T[][]
+): T[] {
+  const byId = new Map<string, T>();
+  for (const group of groups) {
+    for (const config of group) {
+      byId.set(String(config._id), config);
+    }
+  }
+  return [...byId.values()];
+}
+
+export async function reconcileWorkflowConfigAccess(
+  session: ResourceAuthzSession,
+  config: Pick<WorkflowConfigRebacSnapshot, "_id" | "visibility" | "shared_with_teams">,
+  previous?: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams"> | null,
+): Promise<OpenFgaReconcileResult> {
+  const creatorSubject = subjectFromSession(session);
+  if (!creatorSubject) {
+    return { enabled: false, writes: 0, deletes: 0 };
+  }
+
+  const teamRefToSlug =
+    config.visibility === "team" || previous?.visibility === "team"
+      ? await buildTeamRefToSlugMap()
+      : undefined;
+
+  return reconcileShareableResource({
+    objectType: "task",
+    objectId: config._id,
+    creatorSubject,
+    ownerSubject: creatorSubject,
+    memberRelations: ["reader", "user"],
+    sharedWithOrg: config.visibility === "global",
+    previousSharedWithOrg: previous?.visibility === "global",
+    nextSharedTeamSlugs:
+      config.visibility === "team"
+        ? resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug)
+        : [],
+    previousSharedTeamSlugs:
+      previous?.visibility === "team"
+        ? resolveSharedTeamSlugs(previous.shared_with_teams, teamRefToSlug)
+        : [],
+  });
+}
+
+/** Who may edit/delete a workflow (stricter than run). */
+export function workflowWriteAllowedByVisibility(
+  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams" | "owner_id">,
+  userEmail: string,
+): boolean {
+  const owner = config.owner_id?.trim().toLowerCase();
+  const email = userEmail.trim().toLowerCase();
+  if (!owner || !email) {
+    return false;
+  }
+  // Seeded / platform workflows use a non-user owner id.
+  if (owner === "system") {
+    return false;
+  }
+  return owner === email;
+}
+
+/** Authorize updating or deleting a workflow config. */
+export async function requireWorkflowConfigWriteAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+): Promise<void> {
+  if (workflowWriteAllowedByVisibility(config, userEmail)) {
+    return;
+  }
+
+  try {
+    await requireResourcePermission(
+      session,
+      { type: "task", id: config._id, action: "write" },
+      { bypassForOrgAdmin: true },
+    );
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.statusCode === 403 &&
+      config.owner_id &&
+      config.owner_id.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Whether the caller may list or view workflow runs for a config (visibility +
+ * OpenFGA `task#read` or `task#use`). Matches the list-runs filter in
+ * `/api/workflow-runs`.
+ */
+export async function canViewWorkflowRunsForConfig(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): Promise<boolean> {
+  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  const map =
+    teamRefToSlug ??
+    (effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined);
+
+  if (workflowRunAllowedByVisibility(config, userEmail, slugs, map)) {
+    return true;
+  }
+
+  for (const action of ["read", "use"] as const) {
+    try {
+      await requireResourcePermission(
+        session,
+        { type: "task", id: config._id, action },
+        { bypassForOrgAdmin: true },
+      );
+      return true;
+    } catch {
+      // try next action
+    }
+  }
+  return false;
+}
+
+/** Authorize viewing or polling workflow runs for a config. */
+export async function requireWorkflowConfigRunViewAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<void> {
+  if (await canViewWorkflowRunsForConfig(session, config, userEmail, userTeamSlugs)) {
+    return;
+  }
+  throw new ApiError(
+    "You do not have permission to view workflow runs for this workflow.",
+    403,
+    "task#read",
+    "pdp_denied",
+    "contact_admin",
+  );
+}
+
+/** Authorize starting or viewing a workflow config (run / discover / read). */
+export async function requireWorkflowConfigRunAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<void> {
+  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  const teamRefToSlug =
+    effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined;
+
+  if (workflowRunAllowedByVisibility(config, userEmail, slugs, teamRefToSlug)) {
+    return;
+  }
+
+  try {
+    await requireResourcePermission(
+      session,
+      { type: "task", id: config._id, action: "use" },
+      { bypassForOrgAdmin: true },
+    );
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.statusCode === 403 &&
+      config.owner_id &&
+      config.owner_id.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * One-time style repair: rewrite `shared_with_teams` from legacy Mongo ids to slugs.
+ * Safe to run on UI startup after seed.
+ */
+export async function repairWorkflowConfigTeamSlugRefs(): Promise<number> {
+  const collection = await getCollection<WorkflowConfigRebacSnapshot>("workflow_configs");
+  const map = await buildTeamRefToSlugMap();
+  const teamConfigs = await collection.find({ visibility: "team" }).toArray();
+  let repaired = 0;
+
+  for (const config of teamConfigs) {
+    const resolved = resolveSharedTeamSlugs(config.shared_with_teams, map);
+    if (resolved.length === 0) continue;
+
+    const before = normalizeTeamSlugs(config.shared_with_teams);
+    const changed =
+      before.length !== resolved.length ||
+      before.some((slug, index) => slug !== resolved[index]);
+
+    if (!changed) continue;
+
+    await collection.updateOne(
+      { _id: config._id as unknown },
+      { $set: { shared_with_teams: resolved, updated_at: new Date() } },
+    );
+    repaired += 1;
+  }
+
+  return repaired;
+}
+
+/** @deprecated Use requireWorkflowConfigRunAccess */
+export const requireWorkflowConfigRead = requireWorkflowConfigRunAccess;

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -20,8 +20,13 @@ import { reconcileAgentRelationships } from "@/lib/rbac/openfga-agent-tools";
 import {
 reconcileConfigDrivenLlmModelRelationships,
 reconcileConfigDrivenMcpServerRelationships,
+reconcileShareableResource,
 } from "@/lib/rbac/openfga-owned-resources";
 import { caipeOrgKey } from "@/lib/rbac/organization";
+import {
+normalizeSharedWithTeamSlugs,
+repairWorkflowConfigTeamSlugRefs,
+} from "@/lib/rbac/workflow-config-rebac";
 import type {
 DynamicAgentConfig,
 MCPServerConfig,
@@ -149,6 +154,49 @@ function loadSeedConfig(configPath: string): SeedConfig {
 // Seeding functions
 // ═══════════════════════════════════════════════════════════════
 
+type AgentAllowedTools = DynamicAgentConfig["allowed_tools"];
+
+function normalizeStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+}
+
+async function reconcileSeededAgentRelationships(input: {
+  agentId: string;
+  previousAllowedTools?: AgentAllowedTools | null;
+  nextAllowedTools?: AgentAllowedTools | null;
+  ownerTeamSlug?: string | null;
+  previousOwnerTeamSlug?: string | null;
+  nextSharedTeamSlugs?: string[];
+  previousSharedTeamSlugs?: string[];
+  globalUserAccess?: boolean;
+  previousGlobalUserAccess?: boolean;
+  logContext: string;
+}): Promise<void> {
+  try {
+    // assisted-by Codex Codex-sonnet-4-6
+    await reconcileAgentRelationships({
+      agentId: input.agentId,
+      previousAllowedTools: input.previousAllowedTools ?? {},
+      nextAllowedTools: input.nextAllowedTools ?? {},
+      ownerSubject: null,
+      organizationId: caipeOrgKey(),
+      ownerTeamSlug: input.ownerTeamSlug ?? null,
+      previousOwnerTeamSlug: input.previousOwnerTeamSlug ?? null,
+      nextSharedTeamSlugs: input.nextSharedTeamSlugs ?? [],
+      previousSharedTeamSlugs: input.previousSharedTeamSlugs ?? [],
+      globalUserAccess: input.globalUserAccess === true,
+      previousGlobalUserAccess: input.previousGlobalUserAccess === true,
+      failClosed: false,
+    });
+  } catch (error) {
+    console.warn(
+      `[seed-config] Failed to reconcile OpenFGA relationships for agent ${input.agentId} (${input.logContext}):`,
+      error,
+    );
+  }
+}
+
 async function seedAgents(
   agents: Record<string, unknown>[],
 ): Promise<number> {
@@ -221,32 +269,20 @@ async function seedAgents(
 
     await collection.replaceOne({ _id: agentId }, doc, { upsert: true });
 
-    // Write the OpenFGA ownership/share tuples (team#member→can_use,
-    // team#admin→can_manage) so an owner/shared team can actually use the agent
-    // — including in Slack channels mapped to that team. Without this, a seeded
-    // agent's team grants live only in Mongo and the PDP denies. Mirrors what
-    // the agent editor (POST /api/dynamic-agents) does. Best-effort: a failure
-    // here shouldn't abort seeding the rest of the config.
-    if (ownerTeamSlug) {
-      try {
-        await reconcileAgentRelationships({
-          agentId,
-          previousAllowedTools: {},
-          nextAllowedTools: doc.allowed_tools,
-          ownerSubject: null,
-          organizationId: caipeOrgKey(),
-          ownerTeamSlug,
-          nextSharedTeamSlugs: sharedTeamSlugs,
-          previousSharedTeamSlugs: [],
-          failClosed: false,
-        });
-      } catch (error) {
-        console.warn(
-          `[seed-config] Failed to reconcile OpenFGA team grants for agent ${agentId}:`,
-          error,
-        );
-      }
-    }
+    // Write the OpenFGA ownership/share tuples so config-driven agents have
+    // the same PDP-visible policy as agents saved through the editor.
+    await reconcileSeededAgentRelationships({
+      agentId,
+      previousAllowedTools: existing?.allowed_tools,
+      nextAllowedTools: doc.allowed_tools,
+      ownerTeamSlug,
+      previousOwnerTeamSlug: existing?.owner_team_slug ?? null,
+      nextSharedTeamSlugs: sharedTeamSlugs,
+      previousSharedTeamSlugs: normalizeStringArray(existing?.shared_with_teams),
+      globalUserAccess: doc.visibility === "global",
+      previousGlobalUserAccess: existing?.visibility === "global",
+      logContext: "config seed",
+    });
 
     console.log(`[seed-config] Seeded agent: ${agentId}`);
     count++;
@@ -393,6 +429,11 @@ async function seedWorkflowConfigs(
 
     const visibility = ((cfgData.visibility as string) ?? "global") as WorkflowConfigVisibility;
     const steps = (cfgData.steps ?? []) as StepEntry[];
+    let sharedWithTeams =
+      visibility === "team" ? ((cfgData.shared_with_teams as string[]) ?? undefined) : undefined;
+    if (sharedWithTeams?.length) {
+      sharedWithTeams = await normalizeSharedWithTeamSlugs(sharedWithTeams);
+    }
 
     // Ensure each step has type: "step" (YAML may omit it)
     for (const step of steps) {
@@ -408,13 +449,30 @@ async function seedWorkflowConfigs(
       steps,
       owner_id: "system",
       visibility,
-      shared_with_teams: visibility === "team" ? (cfgData.shared_with_teams as string[]) : undefined,
+      shared_with_teams: sharedWithTeams,
       config_driven: true,
       created_at: createdAt,
       updated_at: now,
     };
 
     await collection.replaceOne({ _id: cfgId }, doc, { upsert: true });
+    try {
+      await reconcileShareableResource({
+        objectType: "task",
+        objectId: cfgId,
+        sharedWithOrg: visibility === "global",
+        previousSharedWithOrg: existing?.visibility === "global" && visibility !== "global",
+        memberRelations: ["reader", "user"],
+        nextSharedTeamSlugs: visibility === "team" ? (sharedWithTeams ?? []) : [],
+        previousSharedTeamSlugs:
+          existing?.visibility === "team" ? existing.shared_with_teams ?? [] : [],
+      });
+    } catch (err) {
+      console.warn(
+        `[seed-config] OpenFGA reconcile for workflow config ${cfgId} failed:`,
+        err,
+      );
+    }
     console.log(`[seed-config] Seeded workflow config: ${cfgId}`);
     count++;
   }
@@ -539,20 +597,28 @@ export async function cleanupStaleConfigDriven(
  * - `model: { id: "", provider: "" }` defers model selection to the
  *   dynamic-agents backend default. Hard-coding a model here would
  *   couple bootstrap behavior to a specific deployment.
- * - All four built-in tools enabled with conservative defaults
- *   (`fetch_url` allow-list `*`, `sleep.max_seconds: 60`). Lock-down
- *   environments can tighten these via the UI after first login.
+ * - Built-in tools enabled with conservative defaults (`fetch_url` allow-list
+ *   `*`, `sleep.max_seconds: 60`, `request_user_input` for workflow HITL).
+ *   Lock-down environments can tighten these via the UI after first login.
  */
 export const HELLO_WORLD_AGENT_ID = "hello-world";
 
-function buildHelloWorldAgentDoc(now: string): DynamicAgentConfig {
+/** Bump when bootstrap fields change so reconcile updates existing installs. */
+export const HELLO_WORLD_BOOTSTRAP_REVISION = 2;
+
+export function buildHelloWorldAgentDoc(now: string): DynamicAgentConfig {
   return {
     _id: HELLO_WORLD_AGENT_ID,
     name: "Hello World",
     description:
-      "Default starter agent provisioned automatically when no dynamic agents exist. Has all built-in tools enabled (fetch URL, current time, user info, sleep). Edit or delete via the Custom Agents UI.",
-    system_prompt:
-      "You are Hello World, a friendly default assistant for testing and validating CAIPE. You can fetch web content, tell the current time, look up the signed-in user, and pause briefly when asked. Be concise and helpful.",
+      "Default starter agent for testing CAIPE and demo workflows. Supports structured user input (forms), fetch URL, time, user info, and short waits. Edit or delete via the Custom Agents UI.",
+    system_prompt: `You are Hello World, a friendly default assistant for testing and validating CAIPE.
+
+When you need information from the user, always use the \`request_user_input\` tool with a clear prompt and structured fields. Do not ask questions in plain chat and wait for a reply — the user is not in the agent chat during workflow runs.
+
+When a workflow step asks you to save data for later steps, use \`write_file\` on the workflow filesystem (for example \`choices.txt\` or \`movie_title.txt\` at the root). After collecting input via \`request_user_input\`, write the answers into the required files before finishing the step.
+
+Be concise and helpful.`,
     allowed_tools: {},
     model: { id: "", provider: "" },
     visibility: "global",
@@ -563,7 +629,10 @@ function buildHelloWorldAgentDoc(now: string): DynamicAgentConfig {
       current_datetime: { enabled: true },
       user_info: { enabled: true },
       sleep: { enabled: true, max_seconds: 60 },
+      request_user_input: { enabled: true },
     },
+    interrupt_on: { builtin: { request_user_input: true } },
+    hello_world_bootstrap_revision: HELLO_WORLD_BOOTSTRAP_REVISION,
     enabled: true,
     owner_id: "system",
     is_system: false,
@@ -594,6 +663,18 @@ export async function bootstrapDefaultDynamicAgentIfEmpty(): Promise<boolean> {
   // key error would still be reported — that's the right signal.
   try {
     await collection.insertOne(doc);
+    await reconcileSeededAgentRelationships({
+      agentId: HELLO_WORLD_AGENT_ID,
+      previousAllowedTools: {},
+      nextAllowedTools: doc.allowed_tools,
+      ownerTeamSlug: null,
+      previousOwnerTeamSlug: null,
+      nextSharedTeamSlugs: [],
+      previousSharedTeamSlugs: [],
+      globalUserAccess: true,
+      previousGlobalUserAccess: false,
+      logContext: "bootstrap insert",
+    });
   } catch (err) {
     // Duplicate-key races are benign — another caller (or the YAML seed)
     // beat us to it. Anything else is worth surfacing.
@@ -610,6 +691,83 @@ export async function bootstrapDefaultDynamicAgentIfEmpty(): Promise<boolean> {
     `[seed-config] Provisioned default dynamic agent: ${HELLO_WORLD_AGENT_ID}`,
   );
   return true;
+}
+
+/**
+ * Refresh the bootstrap Hello World agent when it is still owned by `system`
+ * and its bootstrap revision is behind {@link HELLO_WORLD_BOOTSTRAP_REVISION}.
+ * Does not overwrite agents the operator re-owned or deleted.
+ */
+export async function reconcileHelloWorldBootstrapAgent(): Promise<boolean> {
+  if (!isMongoDBConfigured) return false;
+
+  const collection =
+    await getCollection<DynamicAgentConfig>("dynamic_agents");
+  const now = new Date().toISOString();
+  const doc = buildHelloWorldAgentDoc(now);
+
+  const result = await collection.updateOne(
+    {
+      _id: HELLO_WORLD_AGENT_ID,
+      owner_id: "system",
+      $or: [
+        { hello_world_bootstrap_revision: { $exists: false } },
+        {
+          hello_world_bootstrap_revision: {
+            $lt: HELLO_WORLD_BOOTSTRAP_REVISION,
+          },
+        },
+      ],
+    },
+    {
+      $set: {
+        description: doc.description,
+        system_prompt: doc.system_prompt,
+        builtin_tools: doc.builtin_tools,
+        interrupt_on: doc.interrupt_on,
+        hello_world_bootstrap_revision: HELLO_WORLD_BOOTSTRAP_REVISION,
+        updated_at: now,
+      },
+    },
+  );
+
+  if (result.modifiedCount > 0) {
+    await reconcileSeededAgentRelationships({
+      agentId: HELLO_WORLD_AGENT_ID,
+      previousAllowedTools: {},
+      nextAllowedTools: doc.allowed_tools,
+      ownerTeamSlug: null,
+      previousOwnerTeamSlug: null,
+      nextSharedTeamSlugs: [],
+      previousSharedTeamSlugs: [],
+      globalUserAccess: true,
+      previousGlobalUserAccess: false,
+      logContext: "bootstrap revision update",
+    });
+    console.log(
+      `[seed-config] Reconciled bootstrap agent ${HELLO_WORLD_AGENT_ID} to revision ${HELLO_WORLD_BOOTSTRAP_REVISION}`,
+    );
+    return true;
+  }
+  const existing = await collection.findOne({
+    _id: HELLO_WORLD_AGENT_ID,
+    owner_id: "system",
+  });
+  if (existing) {
+    await reconcileSeededAgentRelationships({
+      agentId: HELLO_WORLD_AGENT_ID,
+      previousAllowedTools: existing.allowed_tools,
+      nextAllowedTools: existing.allowed_tools ?? doc.allowed_tools,
+      ownerTeamSlug: existing.owner_team_slug ?? null,
+      previousOwnerTeamSlug: existing.owner_team_slug ?? null,
+      nextSharedTeamSlugs: normalizeStringArray(existing.shared_with_teams),
+      previousSharedTeamSlugs: normalizeStringArray(existing.shared_with_teams),
+      globalUserAccess: existing.visibility === "global",
+      previousGlobalUserAccess: existing.visibility === "global",
+      logContext: "bootstrap self-heal",
+    });
+  }
+  return false;
 }
 
 /**
@@ -864,6 +1022,12 @@ export async function applySeedConfig(): Promise<void> {
       await seedAgentGatewayAdminAccess();
       const agentCount = await seedAgents(config.agents);
       const workflowCount = await seedWorkflowConfigs(config.workflow_configs);
+      const workflowTeamSlugRepairs = await repairWorkflowConfigTeamSlugRefs();
+      if (workflowTeamSlugRepairs > 0) {
+        console.log(
+          `[seed-config] Repaired shared_with_teams slugs on ${workflowTeamSlugRepairs} team workflow(s)`,
+        );
+      }
 
       // Cleanup stale config-driven entities
       await cleanupStaleConfigDriven(
@@ -919,6 +1083,14 @@ export async function applySeedConfig(): Promise<void> {
     } catch (err) {
       console.error(
         "[seed-config] default dynamic agent bootstrap threw:",
+        err,
+      );
+    }
+    try {
+      await reconcileHelloWorldBootstrapAgent();
+    } catch (err) {
+      console.error(
+        "[seed-config] Hello World bootstrap reconcile threw:",
         err,
       );
     }

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { type ClassValue,clsx } from "clsx";
-import { formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow, isValid } from "date-fns";
 import { twMerge } from "tailwind-merge";
 
 // Default reload interval in seconds (24 hours) - matches backend DEFAULT_RELOAD_INTERVAL
@@ -93,6 +93,7 @@ export function formatRelativeTime(date: Date | string | number): string {
   } else {
     d = date;
   }
+  if (!isValid(d)) return "";
   return formatDistanceToNow(d, { addSuffix: true });
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.11.dev1"
+version = "0.5.11.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Introduces the **Centralized Authorization Service (CAS)** — one BFF-resident, PDP-agnostic decision core behind a versioned HTTP API — plus admin visualization and grant/revoke PAP surfaces.

**Rebuilt June 2026:** This branch was split out of a diverged local `feat/workflow-rbac-on-cas` checkpoint into a single clean commit on top of `main`. Workflow execution/read-path migration now lives exclusively in #1772.

Supersedes the docs-only #1769 (spec commits included here).

## Architecture

More diagrams (grant flow, migration posture) in `docs/docs/specs/2026-06-06-cas-implementation/architecture.md`.

## What's included

- **Core** `ui/src/lib/authz/`: decision core, PDP-agnostic contract, `PolicyEngine` + `PolicyAdmin`, compose product-policy layer, OpenFGA adapter (warm store-id, pooled client, decision cache, circuit breaker), audit.
- **HTTP Decision API**: `POST /api/authz/v1/decisions`, `:batch`, `explain` — JWKS caller verification + fail-closed subject-binding; DENY=`200` with body; meta-failures as `401/403/400/503`.
  - Batch response carries per-id `retriable` and top-level `degraded:true` when any result is `AUTHZ_UNAVAILABLE`.
- **Grant / Revoke (PAP)**:
  - `POST/DELETE /api/admin/authz/grants` — session auth + per-resource `can_manage` meta-authz.
  - `POST/DELETE /api/authz/v1/grants` — Bearer-or-session; same `can_manage` gate (Permissions Tool, future modals).
- **Grant audit**: durable `cas_grant` events on grant/revoke with caller/correlation metadata; surfaced in **RBAC Audit** (`UnifiedAuditTab`).
- **Vocabulary canonical import**: `openfga.ts` imports tuple builders from `lib/rbac/tuple-builders` (no local drift).
- **Silo boundary**: ESLint rule keeps `engines/openfga` private to `lib/authz`.
- **Admin UI**:
  - **Permissions Tool** (default Security & Policy landing tab)
  - **Authorization Insights** (`/api/admin/authz/stats`)
  - **Permission Debugger** / explain (`/api/admin/authz/explain`)
  - **RBAC Audit** tab with CAS grant + decision filters
  - OpenFGA ReBAC tab cleanup (dead Access Manager/Diagnostics removed)
  - User baseline diagnostics panel (from prior #1770 review branch)
- **Specs/docs**: `2026-06-05-centralized-bff-authz-pdp-agnostic/*`, `2026-06-06-cas-implementation/*`

## What's NOT included (by design)

- **Workflow RBAC** (configs/runs PDP, per-step gate, DA client, editor UX) → **#1772**
- **Agentgateway logging** → **#1825**
- DA / RAG / Slack / Webex are not migrated — per-surface follow-ups.
- `openfga-authz-bridge` stays data-plane; not routed through CAS.

## Test plan

- [ ] `cd ui && npm test -- --testPathPatterns="authz|UnifiedAudit|admin-page|audit-events|PermissionsTool|CasInsights|OpenFgaRebac"`
- [ ] `npm run lint` / `tsc --noEmit`
- [ ] Reviewer: Admin → Security & Policy → Permissions Tool (default tab)
- [ ] Reviewer: grant/revoke in Permissions Tool → `cas_grant` row in RBAC Audit
- [ ] Reviewer: `POST /api/authz/v1/decisions` returns `200` for ALLOW and DENY
- [ ] Reviewer: `POST /api/authz/v1/grants` + `DELETE` (requires `can_manage`)

## Related

Tracks #1742 · prerequisite #1455 · security driver #1730 · supersedes #1769 · stacked consumer #1772 · parallel #1825
