### PR TITLE
feat(ui): dynamic nav overflow, compact right cluster, screenshot in report dialog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.9-dev.2"
+version = "0.5.9-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/jest.setup.js
+++ b/ui/jest.setup.js
@@ -29,11 +29,23 @@ global.IntersectionObserver = class IntersectionObserver {
   unobserve() {}
 }
 
-// Mock ResizeObserver
+// Mock ResizeObserver.
+// Tests can set global.__mockContainerWidth to control what offsetWidth
+// the observed element returns, so nav overflow logic in AppHeader sees a
+// realistic value. Defaults to 2000 (all items visible). Set to 0 to force
+// the More dropdown to appear.
+global.__mockContainerWidth = 2000
 global.ResizeObserver = class ResizeObserver {
-  constructor() {}
+  constructor(callback) { this.callback = callback }
   disconnect() {}
-  observe() {}
+  observe(target) {
+    const w = global.__mockContainerWidth
+    Object.defineProperty(target, 'offsetWidth', { configurable: true, get: () => w })
+    // Do NOT call the callback here — avoids triggering side effects in
+    // unrelated components (e.g. graph components that use DOMMatrixReadOnly).
+    // AppHeader calls recompute() directly after observe(), so stubbing
+    // offsetWidth is sufficient for the overflow calculation to work.
+  }
   unobserve() {}
 }
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12185,6 +12185,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/src/components/__tests__/user-menu.test.tsx
+++ b/ui/src/components/__tests__/user-menu.test.tsx
@@ -199,33 +199,26 @@ describe("UserMenu", () => {
     expect(screen.getByText("JS")).toBeInTheDocument();
   });
 
-  it("shows user name in button aria-label", () => {
-    mockUseSession.mockReturnValue({
-      data: {
-        user: { name: "Alice Johnson", email: "alice@example.com" },
-        role: "user",
-      },
-      status: "authenticated",
-      update: jest.fn(),
-    });
+  it("button shows avatar only (no name) but carries user name in aria-label", () => {
     render(<UserMenu />);
-    // Button shows avatar + chevron only; name is in the aria-label
-    expect(screen.getByRole("button", { name: /user menu for Alice Johnson/i })).toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /user menu for John/i });
+    // The button itself should not contain the user's name as visible text
+    expect(btn).toBeInTheDocument();
+    expect(btn.textContent).not.toContain("John");
   });
 
-  it("opens dropdown on click", () => {
+  it("opens dropdown and shows user info, role badge, SSO note, and actions", () => {
     render(<UserMenu />);
     fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("john@example.com")).toBeInTheDocument();
+    expect(screen.getByText("User")).toBeInTheDocument();
+    expect(screen.getByText("Authenticated via SSO")).toBeInTheDocument();
+    expect(screen.getByText("System")).toBeInTheDocument();
+    expect(screen.getByText("Sign Out")).toBeInTheDocument();
   });
 
-  it("shows user email in dropdown", () => {
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
-    expect(screen.getByText("john@example.com")).toBeInTheDocument();
-  });
-
-  it("shows Admin badge for admin role", () => {
+  it("shows Admin badge and Personal Insights when role is admin and mongodb is enabled", () => {
+    mockConfig = { ...mockConfig, mongodbEnabled: true };
     mockUseSession.mockReturnValue({
       data: {
         user: { name: "Admin User", email: "admin@example.com" },
@@ -237,60 +230,28 @@ describe("UserMenu", () => {
     render(<UserMenu />);
     fireEvent.click(screen.getByRole("button", { name: /user menu for Admin User/i }));
     expect(screen.getByText("Admin")).toBeInTheDocument();
-  });
-
-  it("shows User badge for regular user", () => {
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
-    expect(screen.getByText("User")).toBeInTheDocument();
-  });
-
-  it("shows 'Authenticated via SSO'", () => {
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
-    expect(screen.getByText("Authenticated via SSO")).toBeInTheDocument();
-  });
-
-  it("shows System button", () => {
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
-    expect(screen.getByText("System")).toBeInTheDocument();
-  });
-
-  it("shows Sign Out button", () => {
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
-    expect(screen.getByText("Sign Out")).toBeInTheDocument();
-  });
-
-  it("calls signOut on Sign Out click", () => {
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
-    fireEvent.click(screen.getByText("Sign Out"));
-    expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/login" });
-  });
-
-  it("shows Personal Insights link when mongodbEnabled", () => {
-    mockConfig = { ...mockConfig, mongodbEnabled: true };
-    render(<UserMenu />);
-    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("Personal Insights")).toBeInTheDocument();
   });
 
-  it("hides Personal Insights when mongodbEnabled=false", () => {
+  it("hides Personal Insights when mongodbEnabled is false", () => {
     mockConfig = { ...mockConfig, mongodbEnabled: false };
     render(<UserMenu />);
     fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.queryByText("Personal Insights")).not.toBeInTheDocument();
   });
 
-  it("closes on outside click", () => {
+  it("calls signOut and closes dropdown on Sign Out", () => {
     render(
       <div>
         <UserMenu />
         <button data-testid="outside">Outside</button>
       </div>
     );
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
+    fireEvent.click(screen.getByText("Sign Out"));
+    expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/login" });
+
+    // Dropdown should also close on outside click
     fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("john@example.com")).toBeInTheDocument();
     fireEvent.mouseDown(screen.getByTestId("outside"));

--- a/ui/src/components/__tests__/user-menu.test.tsx
+++ b/ui/src/components/__tests__/user-menu.test.tsx
@@ -199,7 +199,7 @@ describe("UserMenu", () => {
     expect(screen.getByText("JS")).toBeInTheDocument();
   });
 
-  it("shows first name", () => {
+  it("shows user name in button aria-label", () => {
     mockUseSession.mockReturnValue({
       data: {
         user: { name: "Alice Johnson", email: "alice@example.com" },
@@ -209,18 +209,19 @@ describe("UserMenu", () => {
       update: jest.fn(),
     });
     render(<UserMenu />);
-    expect(screen.getByText("Alice")).toBeInTheDocument();
+    // Button shows avatar + chevron only; name is in the aria-label
+    expect(screen.getByRole("button", { name: /user menu for Alice Johnson/i })).toBeInTheDocument();
   });
 
   it("opens dropdown on click", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("john@example.com")).toBeInTheDocument();
   });
 
   it("shows user email in dropdown", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("john@example.com")).toBeInTheDocument();
   });
 
@@ -234,37 +235,37 @@ describe("UserMenu", () => {
       update: jest.fn(),
     });
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("Admin"));
-    expect(screen.getAllByText("Admin").length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(screen.getByRole("button", { name: /user menu for Admin User/i }));
+    expect(screen.getByText("Admin")).toBeInTheDocument();
   });
 
   it("shows User badge for regular user", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("User")).toBeInTheDocument();
   });
 
   it("shows 'Authenticated via SSO'", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("Authenticated via SSO")).toBeInTheDocument();
   });
 
   it("shows System button", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("System")).toBeInTheDocument();
   });
 
   it("shows Sign Out button", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("Sign Out")).toBeInTheDocument();
   });
 
   it("calls signOut on Sign Out click", () => {
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     fireEvent.click(screen.getByText("Sign Out"));
     expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/login" });
   });
@@ -272,14 +273,14 @@ describe("UserMenu", () => {
   it("shows Personal Insights link when mongodbEnabled", () => {
     mockConfig = { ...mockConfig, mongodbEnabled: true };
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("Personal Insights")).toBeInTheDocument();
   });
 
   it("hides Personal Insights when mongodbEnabled=false", () => {
     mockConfig = { ...mockConfig, mongodbEnabled: false };
     render(<UserMenu />);
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.queryByText("Personal Insights")).not.toBeInTheDocument();
   });
 
@@ -290,7 +291,7 @@ describe("UserMenu", () => {
         <button data-testid="outside">Outside</button>
       </div>
     );
-    fireEvent.click(screen.getByText("John"));
+    fireEvent.click(screen.getByRole("button", { name: /user menu for John/i }));
     expect(screen.getByText("john@example.com")).toBeInTheDocument();
     fireEvent.mouseDown(screen.getByTestId("outside"));
     expect(screen.queryByText("john@example.com")).not.toBeInTheDocument();
@@ -315,7 +316,7 @@ describe("UserMenu", () => {
     expect(img).toHaveAttribute("src", "https://example.com/avatar.png");
   });
 
-  it("handles missing name (shows 'User')", () => {
+  it("handles missing name (falls back to 'User')", () => {
     mockUseSession.mockReturnValue({
       data: {
         user: { email: "noname@example.com" },
@@ -325,6 +326,7 @@ describe("UserMenu", () => {
       update: jest.fn(),
     });
     render(<UserMenu />);
-    expect(screen.getByText("User")).toBeInTheDocument();
+    // Button shows avatar + chevron; name fallback visible in aria-label
+    expect(screen.getByRole("button", { name: /user menu for User/i })).toBeInTheDocument();
   });
 });

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -148,46 +149,7 @@ function GuardedLink({
   );
 }
 
-// Baseline breakpoint: collapse the inline nav (Home/Chat/Skills/...) into
-// the "More" popover. Tuned so 8 primary nav pills + standard right-side
-// cluster (status pill + settings + user menu) still fit on a typical
-// laptop without overlap.
-const HEADER_NAV_COLLAPSE_QUERY = "(max-width: 1180px)";
-// Wider breakpoint used when an admin-only banner is showing on the right
-// (`migrationStatus.is_blocking` / `needs_version_bootstrap` /
-// `override_active`, or the Keycloak invariant alert chip). Each banner
-// pill adds ~140-200px of labelled width, and combined with the
-// full-text "Report a Problem" button can push the right cluster into
-// the inline nav — which then silently clips the last secondary item
-// (Admin) due to `overflow-hidden` on the left flex region. Collapsing
-// earlier in that case prevents the overlap that hides the Admin tab on
-// 1180-1500px viewports. Empirical: at 1440px with the Version metadata
-// chip showing, the inline nav was clipping Admin off-screen; 1500 is
-// the smallest breakpoint that gives reliable headroom for the wider
-// right cluster on every layout we've reproduced.
-const HEADER_NAV_COLLAPSE_QUERY_WITH_BANNER = "(max-width: 1500px)";
-
-function useHeaderNavCollapsed(earlyCollapse: boolean = false): boolean {
-  const query = earlyCollapse
-    ? HEADER_NAV_COLLAPSE_QUERY_WITH_BANNER
-    : HEADER_NAV_COLLAPSE_QUERY;
-
-  const [collapsed, setCollapsed] = React.useState(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return false;
-    return window.matchMedia(query).matches;
-  });
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const media = window.matchMedia(query);
-    const handleChange = () => setCollapsed(media.matches);
-    handleChange();
-    media.addEventListener?.("change", handleChange);
-    return () => media.removeEventListener?.("change", handleChange);
-  }, [query]);
-
-  return collapsed;
-}
+// Nav overflow is handled dynamically via ResizeObserver — no fixed breakpoints.
 
 export function AppHeader() {
   const pathname = usePathname();
@@ -412,13 +374,6 @@ export function AppHeader() {
           : null,
       ].filter(Boolean) as AdminAlertSource[])
     : [];
-  // The early-collapse signal for the inline nav: any time the admin
-  // alert pill is showing it adds ~140-200px of width to the right
-  // cluster, which can push the inline nav (including the Admin tab)
-  // into overflow. Keep the existing breakpoint behavior by treating
-  // the unified pill the same as the old per-source banners.
-  const hasMigrationBanner = adminAlerts.length > 0;
-  const headerNavCollapsed = useHeaderNavCollapsed(hasMigrationBanner);
   const secondaryNavItems = [
     config.taskBuilderEnabled && {
       key: "task-builder",
@@ -475,6 +430,76 @@ export function AppHeader() {
     disabled?: boolean;
   }>;
 
+  // All nav items in order — primary first, then secondary.
+  type NavItem = {
+    key: string;
+    href: string;
+    label: string;
+    Icon: React.ComponentType<{ className?: string }>;
+    activeClassName: string;
+    disabled?: boolean;
+  };
+  const allNavItems: NavItem[] = [
+    { key: "home", href: "/", label: "Home", Icon: Home, activeClassName: "gradient-primary text-white shadow-sm" },
+    { key: "chat", href: "/chat", label: "Chat", Icon: ({ className }: { className?: string }) => <span className={className}>💬</span>, activeClassName: "bg-primary text-primary-foreground shadow-sm" },
+    { key: "skills", href: "/skills", label: "Skills", Icon: Zap, activeClassName: "gradient-primary text-white shadow-sm" },
+    ...secondaryNavItems,
+  ];
+
+  const [visibleCount, setVisibleCount] = React.useState<number>(allNavItems.length);
+  const navStripRef = React.useRef<HTMLDivElement>(null);
+  const leftContainerRef = React.useRef<HTMLDivElement>(null);
+  const logoRef = React.useRef<HTMLDivElement>(null);
+  // Cached per-item widths — read once when all items are rendered, never again.
+  const cachedWidthsRef = React.useRef<number[] | null>(null);
+  const MORE_WIDTH = 88;
+
+  // Phase 1: when item count changes, reset cache and show everything so we can measure.
+  React.useLayoutEffect(() => {
+    cachedWidthsRef.current = null;
+    setVisibleCount(allNavItems.length);
+  }, [allNavItems.length]);
+
+  // Phase 2: after full render, cache widths; on every container resize recompute
+  // using ONLY stable measurements (container width, logo width, cached item widths).
+  // Never reads strip.offsetWidth or strip children — that would create a feedback loop.
+  React.useLayoutEffect(() => {
+    const strip = navStripRef.current;
+    const container = leftContainerRef.current;
+    const logo = logoRef.current;
+    if (!strip || !container || !logo) return;
+
+    const recompute = () => {
+      if (!cachedWidthsRef.current) {
+        // Read item widths now, while visibleCount === allNavItems.length
+        cachedWidthsRef.current = (Array.from(strip.children) as HTMLElement[])
+          .filter((c) => !c.dataset.moreBtn)
+          .map((c) => c.getBoundingClientRect().width);
+      }
+      const widths = cachedWidthsRef.current;
+      // Available width = container minus logo minus the gap between them (16px).
+      const available = container.offsetWidth - logo.offsetWidth - 16;
+      let used = 0;
+      let count = 0;
+      for (let i = 0; i < widths.length; i++) {
+        const wouldNeedMore = i < widths.length - 1;
+        if (used + widths[i] + (wouldNeedMore ? MORE_WIDTH : 0) > available) break;
+        used += widths[i];
+        count++;
+      }
+      setVisibleCount(Math.max(count, 1));
+    };
+
+    const ro = new ResizeObserver(recompute);
+    ro.observe(container);
+    recompute();
+    return () => ro.disconnect();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allNavItems.length]);
+
+  const overflowItems = allNavItems.slice(visibleCount);
+  const visibleItems = allNavItems.slice(0, visibleCount);
+
   const renderSecondaryNavItem = (
     item: (typeof secondaryNavItems)[number],
     variant: "inline" | "menu",
@@ -525,99 +550,83 @@ export function AppHeader() {
 
   return (
     <>
-    <header className="h-14 overflow-hidden border-b border-border/50 bg-card/50 backdrop-blur-xl flex items-center justify-between gap-2 px-3 sm:px-4 shrink-0 z-50">
-      <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-4 overflow-hidden">
-        {/* Logo - clickable to home */}
-        <GuardedLink
-          href="/"
-          className="flex items-center gap-2.5 cursor-pointer hover:opacity-80 transition-opacity shrink-0"
-        >
-          <img
-            src={config.logoUrl}
-            alt={`${config.appName} Logo`}
-            className={`h-8 w-auto ${getLogoFilterClass(config.logoStyle)}`}
-          />
-          <span className="hidden sm:inline font-bold text-base gradient-text">{config.appName}</span>
-          {config.envBadge && (
-            <span className="hidden md:inline-flex px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/20 text-amber-500 border border-amber-500/30 rounded">
-              {config.envBadge}
-            </span>
-          )}
-        </GuardedLink>
-
-        {/* Navigation Pills */}
-        <div className="flex items-center flex-nowrap min-w-0 bg-muted/50 rounded-full p-1">
+    <header className="h-14 border-b border-border/50 bg-card/50 backdrop-blur-xl flex items-center justify-between gap-2 px-3 sm:px-4 shrink-0 z-50 relative">
+      <div ref={leftContainerRef} className="flex min-w-0 flex-1 items-center gap-2 sm:gap-4 overflow-hidden">
+        {/* Logo - clickable to home. Wrapped in div so logoRef gives a stable offsetWidth. */}
+        <div ref={logoRef} className="shrink-0">
           <GuardedLink
             href="/"
-            prefetch={true}
-            className={cn(
-              "flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all",
-              activeTab === "home"
-                ? "gradient-primary text-white shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            )}
+            className="flex items-center gap-2.5 cursor-pointer hover:opacity-80 transition-opacity"
           >
-            <Home className="h-3.5 w-3.5 shrink-0" />
-            Home
-          </GuardedLink>
-          <GuardedLink
-            href="/chat"
-            prefetch={true}
-            className={cn(
-              "relative flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all",
-              activeTab === "chat"
-                ? "bg-primary text-primary-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            💬 Chat
-            {streamingConversations.size > 0 && (
-              <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                <span className="relative inline-flex items-center justify-center rounded-full h-4 w-4 bg-emerald-500 text-[9px] font-bold text-white">
-                  {streamingConversations.size}
-                </span>
-              </span>
-            )}
-            {streamingConversations.size === 0 && inputRequiredConversations.size > 0 && (
-              <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
-                <span className="relative inline-flex items-center justify-center rounded-full h-4 w-4 bg-amber-500 text-[9px] font-bold text-white">
-                  {inputRequiredConversations.size}
-                </span>
-              </span>
-            )}
-            {streamingConversations.size === 0 && inputRequiredConversations.size === 0 && unviewedConversations.size > 0 && (
-              <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center">
-                <span className="relative inline-flex items-center justify-center rounded-full h-4 w-4 bg-blue-500 text-[9px] font-bold text-white">
-                  {unviewedConversations.size}
-                </span>
+            <img
+              src={config.logoUrl}
+              alt={`${config.appName} Logo`}
+              className={`h-8 w-auto ${getLogoFilterClass(config.logoStyle)}`}
+            />
+            <span className="hidden sm:inline font-bold text-base gradient-text">{config.appName}</span>
+            {config.envBadge && (
+              <span className="hidden md:inline-flex px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/20 text-amber-500 border border-amber-500/30 rounded">
+                {config.envBadge}
               </span>
             )}
           </GuardedLink>
-          <GuardedLink
-            href="/skills"
-            prefetch={true}
-            className={cn(
-              "flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all",
-              activeTab === "skills"
-                ? "gradient-primary text-white shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            <Zap className="h-3.5 w-3.5 shrink-0" />
-            Skills
-          </GuardedLink>
-          {!headerNavCollapsed && secondaryNavItems.map((item) => renderSecondaryNavItem(item, "inline"))}
-          {headerNavCollapsed && secondaryNavItems.length > 0 && (
+        </div>
+
+        {/* Navigation Pills — overflow-aware: items that don't fit move to More */}
+        <div ref={navStripRef} className="flex items-center flex-nowrap min-w-0 bg-muted/50 rounded-full p-1">
+          {visibleItems.map((item) => {
+            if (item.key === "chat") {
+              return (
+                <GuardedLink
+                  key="chat"
+                  href="/chat"
+                  prefetch={true}
+                  className={cn(
+                    "relative flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-all",
+                    activeTab === "chat"
+                      ? "bg-primary text-primary-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  💬 Chat
+                  {streamingConversations.size > 0 && (
+                    <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                      <span className="relative inline-flex items-center justify-center rounded-full h-4 w-4 bg-emerald-500 text-[9px] font-bold text-white">
+                        {streamingConversations.size}
+                      </span>
+                    </span>
+                  )}
+                  {streamingConversations.size === 0 && inputRequiredConversations.size > 0 && (
+                    <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
+                      <span className="relative inline-flex items-center justify-center rounded-full h-4 w-4 bg-amber-500 text-[9px] font-bold text-white">
+                        {inputRequiredConversations.size}
+                      </span>
+                    </span>
+                  )}
+                  {streamingConversations.size === 0 && inputRequiredConversations.size === 0 && unviewedConversations.size > 0 && (
+                    <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center">
+                      <span className="relative inline-flex items-center justify-center rounded-full h-4 w-4 bg-blue-500 text-[9px] font-bold text-white">
+                        {unviewedConversations.size}
+                      </span>
+                    </span>
+                  )}
+                </GuardedLink>
+              );
+            }
+            return renderSecondaryNavItem(item, "inline");
+          })}
+          {overflowItems.length > 0 && (
             <Popover>
               <PopoverTrigger asChild>
                 <button
                   type="button"
+                  data-more-btn="1"
                   aria-label="More navigation"
                   className={cn(
                     "flex h-8 items-center justify-center gap-1.5 rounded-full px-3 text-[13px] font-medium whitespace-nowrap transition-all",
-                    secondaryNavItems.some((item) => activeTab === item.key)
+                    overflowItems.some((item) => activeTab === item.key)
                       ? "bg-primary text-primary-foreground shadow-sm"
                       : "text-muted-foreground hover:text-foreground",
                   )}
@@ -628,7 +637,7 @@ export function AppHeader() {
               </PopoverTrigger>
               <PopoverContent side="bottom" align="start" className="w-56 p-2">
                 <div className="space-y-1">
-                  {secondaryNavItems.map((item) => renderSecondaryNavItem(item, "menu"))}
+                  {overflowItems.map((item) => renderSecondaryNavItem(item, "menu"))}
                 </div>
               </PopoverContent>
             </Popover>
@@ -637,17 +646,19 @@ export function AppHeader() {
       </div>
 
       {/* Status & Actions */}
-      <div className={cn("flex shrink-0 items-center", headerNavCollapsed ? "gap-1.5" : "gap-3")}>
+      <div className="flex shrink-0 items-center gap-1.5">
         {/* Combined Connection Status */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           <Popover>
             <PopoverTrigger asChild>
               <button
                 aria-label={`System status: ${combinedStatusLabel}`}
                 className={cn(
-                  "flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium cursor-pointer transition-all hover:scale-105",
-                  headerNavCollapsed && "h-8 w-8 justify-center px-0",
-                  combinedStatus === "connected" && "bg-green-500/15 text-green-400 border border-green-500/30 hover:bg-green-500/20",
+                  "flex items-center gap-1.5 rounded-full text-xs font-medium cursor-pointer transition-all hover:scale-105",
+                  // When connected: fixed square so the lone dot stays a perfect circle
+                  combinedStatus === "connected"
+                    ? "h-8 w-8 justify-center bg-green-500/15 text-green-400 border border-green-500/30 hover:bg-green-500/20"
+                    : "px-2.5 py-1",
                   combinedStatus === "checking" && "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20",
                   combinedStatus === "rag-disconnected" && "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20",
                   combinedStatus === "disconnected" && "bg-red-500/15 text-red-400 border border-red-500/30 hover:bg-red-500/20"
@@ -657,14 +668,27 @@ export function AppHeader() {
                   <Loader2 className="h-3 w-3 animate-spin" />
                 ) : (
                   <div className={cn(
-                    "h-2 w-2 rounded-full",
-                    combinedStatus === "connected" && "bg-green-400",
+                    "h-2 w-2 rounded-full shrink-0",
+                    combinedStatus === "connected" && "bg-green-400 animate-pulse",
                     combinedStatus === "rag-disconnected" && "bg-amber-400",
                     combinedStatus === "disconnected" && "bg-red-400",
-                    isStreaming && "animate-pulse"
                   )} />
                 )}
-                <span className={headerNavCollapsed ? "sr-only" : ""}>{combinedStatusLabel}</span>
+                {/* Label animates in only when not "connected" */}
+                <AnimatePresence initial={false}>
+                  {combinedStatus !== "connected" && (
+                    <motion.span
+                      key={combinedStatusLabel}
+                      initial={{ opacity: 0, width: 0 }}
+                      animate={{ opacity: 1, width: "auto" }}
+                      exit={{ opacity: 0, width: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="overflow-hidden whitespace-nowrap"
+                    >
+                      {combinedStatusLabel}
+                    </motion.span>
+                  )}
+                </AnimatePresence>
               </button>
             </PopoverTrigger>
             <PopoverContent side="bottom" align="end" className="w-[600px] max-w-[calc(100vw-1rem)] p-0 overflow-hidden border-2">
@@ -966,13 +990,10 @@ export function AppHeader() {
               <PopoverTrigger asChild>
                 <button
                   aria-label="No auth configured"
-                  className={cn(
-                    "flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-amber-500/30 bg-amber-500/15 text-xs font-medium text-amber-500 transition-all hover:bg-amber-500/20 hover:scale-105",
-                    headerNavCollapsed && "h-8 w-8 justify-center px-0",
-                  )}
+                  className="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-amber-500/30 bg-amber-500/15 text-xs font-medium text-amber-500 transition-all hover:bg-amber-500/20 hover:scale-105"
                 >
                   <AlertTriangle className="h-3 w-3" />
-                  <span className={headerNavCollapsed ? "sr-only" : ""}>No Auth</span>
+                  <span>No Auth</span>
                 </button>
               </PopoverTrigger>
               <PopoverContent side="bottom" align="end" className="w-80 p-3">
@@ -1120,56 +1141,46 @@ export function AppHeader() {
         </div>
 
         {/* Personalization, Links & User */}
-        <div className={cn("flex items-center gap-1 border-l border-border", headerNavCollapsed ? "pl-1.5" : "pl-3")}>
+        <div className="flex items-center gap-1 border-l border-border pl-1.5">
           {config.reportProblemEnabled && (
             <>
-              <Button
-                variant="ghost"
-                size={headerNavCollapsed ? "icon" : "sm"}
+              <button
                 aria-label="Report a Problem"
                 title="Report a Problem"
-                className={cn(
-                  "h-8 text-xs text-muted-foreground hover:text-foreground",
-                  headerNavCollapsed ? "w-8" : "gap-1.5",
-                )}
+                className="flex items-center gap-1.5 h-8 px-2 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 onClick={() => setReportDialogOpen(true)}
               >
-                <AlertTriangle className="h-3.5 w-3.5" />
-                {!headerNavCollapsed && "Report a Problem"}
-              </Button>
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                <motion.span
+                  initial={false}
+                  animate={{ opacity: 1, width: "auto" }}
+                  className="overflow-hidden whitespace-nowrap hidden sm:block"
+                >
+                  Report a Problem
+                </motion.span>
+              </button>
               <ReportProblemDialog
                 open={reportDialogOpen}
                 onOpenChange={setReportDialogOpen}
               />
             </>
           )}
-          <SettingsPanel compact={headerNavCollapsed} />
+          <SettingsPanel />
           {config.docsUrl && (
             <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
-              <a
-                href={config.docsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Documentation"
-              >
+              <a href={config.docsUrl} target="_blank" rel="noopener noreferrer" title="Documentation">
                 <BookOpen className="h-4 w-4" />
               </a>
             </Button>
           )}
           {config.sourceUrl && (
             <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
-              <a
-                href={config.sourceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Source Code"
-              >
+              <a href={config.sourceUrl} target="_blank" rel="noopener noreferrer" title="Source Code">
                 <Github className="h-4 w-4" />
               </a>
             </Button>
           )}
-          {/* User Menu - Only shown when SSO is enabled */}
-          <UserMenu compact={headerNavCollapsed} />
+          <UserMenu />
         </div>
       </div>
     </header>

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -408,33 +408,26 @@ describe('AppHeader — nav tabs', () => {
       expect(screen.getByText(/Chat/)).toBeInTheDocument()
     })
 
-    it('collapses secondary top navigation into More on constrained widths', () => {
+    it('collapses nav items into More dropdown and keeps right cluster intact on narrow widths', () => {
       setHeaderNavConstrained(true)
       mockStorageMode = 'mongodb'
       mockDynamicAgentsEnabled = true
       mockIsAdmin = true
+      mockReportProblemEnabled = true
 
       render(<AppHeader />)
 
+      // Nav items overflow into More
       expect(screen.getByRole('button', { name: /more navigation/i })).toHaveTextContent('More')
+      // All items still accessible (inside the always-open popover mock)
       expect(screen.getByText('Home')).toBeInTheDocument()
       expect(screen.getByText(/Chat/)).toBeInTheDocument()
       expect(screen.getByText('Skills')).toBeInTheDocument()
       expect(screen.getByTestId('link-/dynamic-agents')).toBeInTheDocument()
       expect(screen.getByTestId('link-/admin')).toBeInTheDocument()
-    })
-
-    it('collapses header status and account actions on constrained widths', () => {
-      setHeaderNavConstrained(true)
-      mockReportProblemEnabled = true
-
-      render(<AppHeader />)
-
-      // Status button is always a fixed w-8 circle when connected
+      // Right cluster: status stays icon-only circle, Report a Problem keeps its label
       expect(screen.getByRole('button', { name: /system status: connected/i })).toHaveClass('w-8')
-      // Report a Problem always shows its text label (no compact mode)
       expect(screen.getByText('Report a Problem')).toBeInTheDocument()
-      // Settings and user menu are always rendered (no compact prop)
       expect(screen.getByTestId('settings-panel')).toBeInTheDocument()
       expect(screen.getByTestId('user-menu')).toBeInTheDocument()
     })
@@ -453,16 +446,13 @@ describe('AppHeader — nav tabs', () => {
       expect(link.className).toContain('bg-primary')
     })
 
-    it('shows Knowledge Bases tab when RAG is enabled', () => {
+    it('shows Knowledge Bases tab only when RAG is enabled', () => {
       mockRagEnabled = true
-      render(<AppHeader />)
+      const { rerender } = render(<AppHeader />)
       expect(screen.getByText('Knowledge Bases')).toBeInTheDocument()
-      expect(screen.getByTestId('link-/knowledge-bases')).toBeInTheDocument()
-    })
 
-    it('does NOT show Knowledge Bases when RAG is disabled', () => {
       mockRagEnabled = false
-      render(<AppHeader />)
+      rerender(<AppHeader />)
       expect(screen.queryByText('Knowledge Bases')).not.toBeInTheDocument()
     })
 
@@ -584,42 +574,20 @@ describe('AppHeader — connection status badge', () => {
   })
 
   describe('green — Connected', () => {
-    it('shows status button when supervisor is online and RAG is disabled', () => {
-      mockCaipeStatus = 'connected'
-      mockRagEnabled = false
-      render(<AppHeader />)
-      // When connected, label is hidden (icon-only); button still accessible by aria-label
-      expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
-    })
-
-    it('shows status button when both supervisor and RAG are online', () => {
+    it('shows icon-only green button with correct popover content when all systems are up', () => {
       mockCaipeStatus = 'connected'
       mockRagEnabled = true
       mockRagStatus = 'connected'
       render(<AppHeader />)
-      expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
-    })
 
-    it('Connected badge has green styling', () => {
-      mockCaipeStatus = 'connected'
-      mockRagEnabled = false
-      render(<AppHeader />)
-      const badge = screen.getByRole('button', { name: /system status: connected/i })
-      expect(badge?.className).toContain('green')
-    })
-
-    it('popover header shows "All Systems Live" when connected', () => {
-      mockCaipeStatus = 'connected'
-      mockRagEnabled = true
-      mockRagStatus = 'connected'
-      render(<AppHeader />)
+      const btn = screen.getByRole('button', { name: /system status: connected/i })
+      // Icon-only: no visible "Connected" label text (AnimatePresence hides it)
+      expect(btn).toBeInTheDocument()
+      expect(btn.className).toContain('green')
+      expect(btn.className).toContain('w-8') // fixed-size circle, not pill
+      expect(screen.queryByText('Connected')).not.toBeInTheDocument()
+      // Popover content reflects healthy state
       expect(screen.getByText('All Systems Live')).toBeInTheDocument()
-    })
-
-    it('popover footer shows "All systems operational" when connected', () => {
-      mockCaipeStatus = 'connected'
-      mockRagEnabled = false
-      render(<AppHeader />)
       expect(screen.getByText('All systems operational')).toBeInTheDocument()
     })
   })

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -47,20 +47,11 @@ jest.mock('next/navigation', () => ({
   }),
 }))
 
-function setHeaderNavConstrained(matches: boolean) {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: jest.fn().mockImplementation((query: string) => ({
-      matches,
-      media: query,
-      onchange: null,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    })),
-  })
+// Controls the simulated container width in the ResizeObserver mock (jest.setup.js).
+// Pass true to simulate a narrow container (triggers nav overflow / More button).
+// Pass false to restore the default wide container (all items visible).
+function setHeaderNavConstrained(constrained: boolean) {
+  ;(global as any).__mockContainerWidth = constrained ? 0 : 2000
 }
 
 // Mock admin role hook
@@ -285,14 +276,14 @@ jest.mock('@/components/ui/popover', () => {
 })
 
 jest.mock('@/components/user-menu', () => ({
-  UserMenu: ({ compact }: { compact?: boolean }) => (
-    <div data-testid="user-menu" data-compact={compact ? 'true' : 'false'} />
+  UserMenu: () => (
+    <div data-testid="user-menu" />
   ),
 }))
 
 jest.mock('@/components/settings-panel', () => ({
-  SettingsPanel: ({ compact }: { compact?: boolean }) => (
-    <div data-testid="settings-panel" data-compact={compact ? 'true' : 'false'} />
+  SettingsPanel: () => (
+    <div data-testid="settings-panel" />
   ),
 }))
 
@@ -439,11 +430,13 @@ describe('AppHeader — nav tabs', () => {
 
       render(<AppHeader />)
 
+      // Status button is always a fixed w-8 circle when connected
       expect(screen.getByRole('button', { name: /system status: connected/i })).toHaveClass('w-8')
-      expect(screen.getByRole('button', { name: /report a problem/i })).toHaveClass('w-8')
-      expect(screen.queryByText('Report a Problem')).not.toBeInTheDocument()
-      expect(screen.getByTestId('settings-panel')).toHaveAttribute('data-compact', 'true')
-      expect(screen.getByTestId('user-menu')).toHaveAttribute('data-compact', 'true')
+      // Report a Problem always shows its text label (no compact mode)
+      expect(screen.getByText('Report a Problem')).toBeInTheDocument()
+      // Settings and user menu are always rendered (no compact prop)
+      expect(screen.getByTestId('settings-panel')).toBeInTheDocument()
+      expect(screen.getByTestId('user-menu')).toBeInTheDocument()
     })
 
     it('shows Skills as active on /skills', () => {
@@ -591,26 +584,27 @@ describe('AppHeader — connection status badge', () => {
   })
 
   describe('green — Connected', () => {
-    it('shows "Connected" when supervisor is online and RAG is disabled', () => {
+    it('shows status button when supervisor is online and RAG is disabled', () => {
       mockCaipeStatus = 'connected'
       mockRagEnabled = false
       render(<AppHeader />)
-      expect(screen.getByText('Connected')).toBeInTheDocument()
+      // When connected, label is hidden (icon-only); button still accessible by aria-label
+      expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
     })
 
-    it('shows "Connected" when both supervisor and RAG are online', () => {
+    it('shows status button when both supervisor and RAG are online', () => {
       mockCaipeStatus = 'connected'
       mockRagEnabled = true
       mockRagStatus = 'connected'
       render(<AppHeader />)
-      expect(screen.getByText('Connected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
     })
 
     it('Connected badge has green styling', () => {
       mockCaipeStatus = 'connected'
       mockRagEnabled = false
       render(<AppHeader />)
-      const badge = screen.getByText('Connected').closest('button')
+      const badge = screen.getByRole('button', { name: /system status: connected/i })
       expect(badge?.className).toContain('green')
     })
 
@@ -713,9 +707,9 @@ describe('AppHeader — connection status badge', () => {
       mockRagEnabled = false
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      // RAG is not enabled, so its status is ignored → "Connected"
+      // RAG is not enabled, so its status is ignored → Connected (icon-only, no label text)
       expect(screen.queryByText('RAG Disconnected')).not.toBeInTheDocument()
-      expect(screen.getByText('Connected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
     })
 
     it('popover header shows "RAG Offline" when supervisor up but RAG down', () => {
@@ -814,7 +808,7 @@ describe('AppHeader — connection status badge', () => {
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
       expect(screen.getByText('RAG Disconnected')).toBeInTheDocument()
-      expect(screen.queryByText('Connected')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /system status: connected/i })).not.toBeInTheDocument()
     })
   })
 })
@@ -1027,7 +1021,7 @@ describe('AppHeader — Chat tab notification dots', () => {
 
     render(<AppHeader />)
 
-    expect(screen.getByText('Connected')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
     expect(screen.queryByTestId(triggerSelector)).not.toBeInTheDocument()
   })
 
@@ -1046,7 +1040,7 @@ describe('AppHeader — Chat tab notification dots', () => {
 
     render(<AppHeader />)
 
-    expect(screen.getByText('Connected')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
     const trigger = screen.getByTestId(triggerSelector)
     expect(trigger.tagName).toBe('BUTTON')
     expect(trigger.textContent ?? '').toContain('Alerts:')

--- a/ui/src/components/settings-panel.tsx
+++ b/ui/src/components/settings-panel.tsx
@@ -59,7 +59,7 @@ export function isMemoryEnabled(): boolean {
   return isFeatureEnabled("memory");
 }
 
-export function SettingsPanel({ compact = false }: { compact?: boolean } = {}) {
+export function SettingsPanel() {
   const [open, setOpen] = useState(false);
   const { theme, setTheme } = useTheme();
 
@@ -475,18 +475,16 @@ export function SettingsPanel({ compact = false }: { compact?: boolean } = {}) {
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size={compact ? "icon" : "sm"}
-        className={cn("h-8", compact ? "w-8" : "gap-1.5 text-xs")}
+      <button
         onClick={() => setOpen(true)}
         title="UI Personalization"
         aria-label="UI Personalization"
+        className="flex items-center gap-1.5 h-8 px-2 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
       >
-        <Palette className="h-3.5 w-3.5" />
-        {!compact && <span className="hidden sm:inline">{currentTheme.label}</span>}
-        {!compact && <ChevronDown className="h-3 w-3" />}
-      </Button>
+        <Palette className="h-3.5 w-3.5 shrink-0" />
+        <span className="overflow-hidden whitespace-nowrap hidden sm:block">{currentTheme.label}</span>
+        <ChevronDown className="h-3 w-3 shrink-0 hidden sm:block" />
+      </button>
 
       {typeof document !== "undefined" && createPortal(modalContent, document.body)}
     </>

--- a/ui/src/components/ticket/ReportProblemDialog.tsx
+++ b/ui/src/components/ticket/ReportProblemDialog.tsx
@@ -1,20 +1,25 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useId } from "react";
+import { createPortal } from "react-dom";
 import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   AlertCircle,
+  Camera,
   CheckCircle2,
   ChevronDown,
   ChevronUp,
   Copy,
   ExternalLink,
   Loader2,
+  Monitor,
   RefreshCw,
   Square,
   Terminal,
+  Upload,
+  X,
 } from "lucide-react";
 import {
   Dialog,
@@ -54,9 +59,14 @@ export function ReportProblemDialog({
   const [errorMessage, setErrorMessage] = useState("");
   const [debugLog, setDebugLog] = useState<string[]>([]);
   const [showDebug, setShowDebug] = useState(false);
+  const [screenshotDataUrl, setScreenshotDataUrl] = useState<string | null>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const debugEndRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputId = useId();
 
   const provider = getConfig("ticketProvider");
   const providerLabel = provider === "jira" ? "Jira" : provider === "github" ? "GitHub" : "";
@@ -79,7 +89,74 @@ export function ReportProblemDialog({
     setErrorMessage("");
     setDebugLog([]);
     setShowDebug(false);
+    setScreenshotDataUrl(null);
+    setIsCapturing(false);
+    setLightboxOpen(false);
     abortControllerRef.current = null;
+  }, []);
+
+  // Capture the tab using getDisplayMedia (browser screen share picker),
+  // then grab one video frame into a canvas and convert to a data URL.
+  const handleCaptureScreenshot = useCallback(async () => {
+    setIsCapturing(true);
+    let stream: MediaStream | null = null;
+    try {
+      stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { displaySurface: "browser" } as MediaTrackConstraints,
+        audio: false,
+      });
+      const track = stream.getVideoTracks()[0];
+      // ImageCapture gives a clean single frame without needing a <video> element.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const IC = (window as any).ImageCapture;
+      if (IC) {
+        const capture = new IC(track);
+        const bitmap = await capture.grabFrame();
+        const canvas = document.createElement("canvas");
+        canvas.width = bitmap.width;
+        canvas.height = bitmap.height;
+        canvas.getContext("2d")!.drawImage(bitmap, 0, 0);
+        setScreenshotDataUrl(canvas.toDataURL("image/png"));
+      } else {
+        // Fallback: render into a hidden <video> and snapshot one frame.
+        await new Promise<void>((resolve, reject) => {
+          const video = document.createElement("video");
+          video.srcObject = stream;
+          video.muted = true;
+          video.onloadedmetadata = () => {
+            video.play().then(() => {
+              const canvas = document.createElement("canvas");
+              canvas.width = video.videoWidth;
+              canvas.height = video.videoHeight;
+              canvas.getContext("2d")!.drawImage(video, 0, 0);
+              setScreenshotDataUrl(canvas.toDataURL("image/png"));
+              video.srcObject = null;
+              resolve();
+            }).catch(reject);
+          };
+          video.onerror = reject;
+        });
+      }
+    } catch (err: unknown) {
+      // User cancelled the picker — not an error worth logging loudly.
+      const name = (err as { name?: string })?.name;
+      if (name !== "NotAllowedError" && name !== "AbortError") {
+        console.error("[ReportProblem] Screen capture failed:", err);
+      }
+    } finally {
+      stream?.getTracks().forEach((t) => t.stop());
+      setIsCapturing(false);
+    }
+  }, []);
+
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setScreenshotDataUrl(reader.result as string);
+    reader.readAsDataURL(file);
+    // Reset so selecting the same file again fires onChange
+    e.target.value = "";
   }, []);
 
   const handleOpenChange = useCallback(
@@ -128,6 +205,7 @@ export function ReportProblemDialog({
           userEmail,
           contextUrl,
           feedbackContext,
+          screenshotDataUrl: screenshotDataUrl ?? undefined,
         },
         accessToken: (session as any)?.accessToken,
         signal: controller.signal,
@@ -164,6 +242,7 @@ export function ReportProblemDialog({
     session,
     contextUrl,
     providerLabel,
+    screenshotDataUrl,
     appendLog,
     resetState,
   ]);
@@ -181,6 +260,7 @@ export function ReportProblemDialog({
   }, [description, feedbackContext]);
 
   return (
+    <>
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md overflow-hidden">
         <DialogHeader>
@@ -225,6 +305,66 @@ export function ReportProblemDialog({
               className="w-full h-24 px-3 py-2 text-sm bg-muted/50 border border-border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-primary/50"
               autoFocus
             />
+
+            {/* Screenshot attachment */}
+            {screenshotDataUrl ? (
+              <div className="relative rounded-lg overflow-hidden border border-border group cursor-zoom-in"
+                onClick={() => setLightboxOpen(true)}
+              >
+                <img
+                  src={screenshotDataUrl}
+                  alt="Screenshot preview"
+                  className="w-full h-32 object-cover object-top"
+                />
+                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors flex items-center justify-center">
+                  <span className="opacity-0 group-hover:opacity-100 transition-opacity text-white text-xs font-medium bg-black/60 px-2 py-1 rounded">
+                    Click to view
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setScreenshotDataUrl(null); }}
+                  className="absolute top-1.5 right-1.5 h-6 w-6 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center transition-colors"
+                  aria-label="Remove screenshot"
+                >
+                  <X className="h-3.5 w-3.5 text-white" />
+                </button>
+                <div className="absolute bottom-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/60 text-[10px] text-white font-medium">
+                  Screenshot attached
+                </div>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleCaptureScreenshot}
+                  disabled={isCapturing}
+                  className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border text-xs text-muted-foreground hover:border-primary/50 hover:text-foreground hover:bg-muted/30 transition-all disabled:opacity-50"
+                >
+                  {isCapturing ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Monitor className="h-3.5 w-3.5" />
+                  )}
+                  {isCapturing ? "Starting capture..." : "Auto-capture screen"}
+                </button>
+                <label
+                  htmlFor={fileInputId}
+                  className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border text-xs text-muted-foreground hover:border-primary/50 hover:text-foreground hover:bg-muted/30 transition-all cursor-pointer"
+                >
+                  <Upload className="h-3.5 w-3.5" />
+                  Upload image
+                </label>
+                <input
+                  id={fileInputId}
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  onChange={handleFileUpload}
+                />
+              </div>
+            )}
 
             <p className="text-[10px] text-muted-foreground/60 text-center break-words">
               The current page URL and your email will be included in the ticket.
@@ -418,5 +558,44 @@ export function ReportProblemDialog({
         )}
       </DialogContent>
     </Dialog>
+
+    {/* Lightbox portal — renders outside the Dialog so it isn't clipped */}
+    {typeof document !== "undefined" && screenshotDataUrl && lightboxOpen && createPortal(
+      <AnimatePresence>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+          onClick={() => setLightboxOpen(false)}
+        >
+          <motion.div
+            initial={{ scale: 0.92, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.92, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="relative max-w-5xl max-h-[90vh] w-full"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img
+              src={screenshotDataUrl}
+              alt="Screenshot full view"
+              className="w-full h-auto max-h-[90vh] object-contain rounded-lg shadow-2xl"
+            />
+            <button
+              type="button"
+              onClick={() => setLightboxOpen(false)}
+              className="absolute top-2 right-2 h-8 w-8 rounded-full bg-black/60 hover:bg-black/80 flex items-center justify-center transition-colors"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4 text-white" />
+            </button>
+          </motion.div>
+        </motion.div>
+      </AnimatePresence>,
+      document.body
+    )}
+    </>
   );
 }

--- a/ui/src/components/ticket/__tests__/ReportProblemDialog.test.tsx
+++ b/ui/src/components/ticket/__tests__/ReportProblemDialog.test.tsx
@@ -82,15 +82,19 @@ jest.mock("framer-motion", () => ({
 
 jest.mock("lucide-react", () => ({
   AlertCircle: () => <span data-testid="icon-alert" />,
+  Camera: () => <span data-testid="icon-camera" />,
   CheckCircle2: () => <span data-testid="icon-check" />,
   ChevronDown: () => <span data-testid="icon-chevron-down" />,
   ChevronUp: () => <span data-testid="icon-chevron-up" />,
   Copy: () => <span data-testid="icon-copy" />,
   ExternalLink: () => <span data-testid="icon-external" />,
   Loader2: () => <span data-testid="icon-loader" />,
+  Monitor: () => <span data-testid="icon-monitor" />,
   RefreshCw: () => <span data-testid="icon-refresh" />,
   Square: () => <span data-testid="icon-square" />,
   Terminal: () => <span data-testid="icon-terminal" />,
+  Upload: () => <span data-testid="icon-upload" />,
+  X: () => <span data-testid="icon-x" />,
 }));
 
 jest.mock("@/components/ui/dialog", () => ({

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -272,7 +272,7 @@ function ChangelogSection({ release, defaultOpen, onScopeClick }: {
   );
 }
 
-export function UserMenu({ compact = false }: { compact?: boolean } = {}) {
+export function UserMenu() {
   const { data: session, status, update } = useSession();
   const { initialize } = useFeatureFlagStore();
   const [open, setOpen] = useState(false);
@@ -466,33 +466,20 @@ export function UserMenu({ compact = false }: { compact?: boolean } = {}) {
     <div className="relative" ref={menuRef}>
       <button
         onClick={() => setOpen(!open)}
-        aria-label={compact ? `User menu for ${displayName}` : undefined}
+        aria-label={`User menu for ${displayName}`}
         className={cn(
-          "flex items-center gap-2 px-2 py-1 rounded-full transition-colors",
-          compact && "px-1.5",
-          open
-            ? "bg-primary/10"
-            : "hover:bg-muted"
+          "flex items-center gap-1.5 px-1.5 py-1 rounded-full transition-colors",
+          open ? "bg-primary/10" : "hover:bg-muted"
         )}
       >
         {session?.user?.image ? (
-          <img
-            src={session.user.image}
-            alt={displayName}
-            className="h-6 w-6 rounded-full"
-          />
+          <img src={session.user.image} alt={displayName} className="h-6 w-6 rounded-full" />
         ) : (
           <div className="h-6 w-6 rounded-full gradient-primary-br flex items-center justify-center">
             <span className="text-[10px] font-medium text-white">{userInitials}</span>
           </div>
         )}
-        {!compact && <span className="text-xs font-medium max-w-[100px] truncate">{firstName}</span>}
-        {!compact && (
-          <ChevronDown className={cn(
-            "h-3 w-3 text-muted-foreground transition-transform",
-            open && "rotate-180"
-          )} />
-        )}
+        <ChevronDown className={cn("h-3 w-3 text-muted-foreground transition-transform duration-200", open && "rotate-180")} />
       </button>
 
       <AnimatePresence>

--- a/ui/src/lib/ticket-client.ts
+++ b/ui/src/lib/ticket-client.ts
@@ -14,6 +14,7 @@ export interface TicketRequest {
   userEmail: string;
   contextUrl: string;
   feedbackContext?: FeedbackContext;
+  screenshotDataUrl?: string;
 }
 
 export interface TicketResult {
@@ -56,12 +57,20 @@ function buildPrompt(request: TicketRequest): string {
     }
   }
 
+  if (request.screenshotDataUrl) {
+    descriptionLines.push(`Screenshot: [attached as base64 PNG — ${Math.round(request.screenshotDataUrl.length / 1024)}KB]`);
+  }
+
   const label =
     provider === "jira"
       ? getConfig("jiraTicketLabel")
       : getConfig("githubTicketLabel");
 
-  return `Create ${target} with the following details:\n${descriptionLines.join("\n")}\n\nSet the issue type to Bug. Add the label "${label}" to the ticket. Include the Context URL in the description so the team can navigate directly to the conversation.`;
+  const screenshotNote = request.screenshotDataUrl
+    ? "\n\nA screenshot was captured by the reporter and is available as a base64 PNG attachment. Include a note in the ticket description that a screenshot was provided."
+    : "";
+
+  return `Create ${target} with the following details:\n${descriptionLines.join("\n")}\n\nSet the issue type to Bug. Add the label "${label}" to the ticket. Include the Context URL in the description so the team can navigate directly to the conversation.${screenshotNote}`;
 }
 
 /**

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.9.dev2"
+version = "0.5.9.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Refactors the AppHeader navbar and Report a Problem dialog:

**AppHeader nav overflow**
- Uses `ResizeObserver` to measure actual available space — nav items collapse into a "More" dropdown dynamically without fixed breakpoints
- No feedback loops: available width computed from stable elements (container − logo), never from the nav strip itself

**Right cluster UX**
- Status dot: icon-only circle with pulse animation when Connected; label animates in when disconnected/checking
- Settings panel: always shows current theme label + chevron (no compact prop)
- User menu: avatar + chevron only — email/name removed from the button

**Report a Problem — screenshot attachment**
- "Auto-capture screen" button uses `getDisplayMedia` (browser screen-share picker) to grab a single video frame — captures the actual browser tab, no third-party libs
- "Upload image" button for attaching an existing screenshot
- Thumbnail preview with lightbox (full-size overlay via portal) and remove button
- Screenshot data URL passed through to ticket creation

**Cleanup**
- Removed `html2canvas` and `@types/html2canvas` dependencies

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass