### PR TITLE
feat(slack): derive slash-command prefix from APP_NAME, enforce DM-only on all commands

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -157,8 +157,8 @@ if RBAC_ENABLED:
                     # surfaces (commands return ephemeral replies). We
                     # mark the surface so downstream handlers can
                     # decide whether the body of the command requires
-                    # a channel mapping (it never does for /caipe-help
-                    # or /caipe-list).
+                    # a channel mapping (it never does for /{cmd}-help
+                    # or /{cmd}-list).
                     context["surface_kind"] = "dm"
                     logger.info(
                         "Channel={} has no team mapping; allowing surface_kind=dm "
@@ -642,97 +642,111 @@ def _ack_ephemeral(ack, result: SlashCommandResult) -> None:
     logger.warning("Failed to ack slash command (code={}): {}", result.code, exc)
 
 
-@app.command("/caipe-help")
-def slash_caipe_help(ack, body, context=None):
-  """``/caipe-help`` — list available commands (FR-030)."""
-  user_id = body.get("user_id") or ""
-  result = handle_help_command(
-      user_key=user_id,
-      rate_limiter=_command_rate_limiter(),
-  )
-  _ack_ephemeral(ack, result)
+def _register_slash_commands() -> None:
+  """Register /{cmd}-help, /{cmd}-list, /{cmd}-use with the Bolt app.
 
+  The command prefix is derived from APP_NAME at startup time so that
+  ``APP_NAME=Forge`` registers ``/forge-help`` etc.
+  """
+  from utils.slash_commands import _cmd_prefix  # local import to avoid circular refs
+  cmd = _cmd_prefix()
 
-@app.command("/caipe-list")
-def slash_caipe_list(ack, body, context=None):
-  """``/caipe-list`` — show user's accessible agents (FR-028, FR-036)."""
-  user_id = body.get("user_id") or ""
-  bearer_token = _obo_token_from_context(context) or ""
-  if not bearer_token:
-    _ack_ephemeral(
-        ack,
-        SlashCommandResult(
-            text=(
-                "I couldn't verify your identity for this command. "
-                "Please re-link your account and try again."
-            ),
-            code="no_bearer",
-        ),
+  @app.command(f"/{cmd}-help")
+  def slash_help(ack, body, context=None):
+    channel_id = body.get("channel_id") or ""
+    is_dm = bool(channel_id) and channel_id.startswith("D")
+    user_id = body.get("user_id") or ""
+    result = handle_help_command(
+        user_key=user_id,
+        is_dm=is_dm,
+        rate_limiter=_command_rate_limiter(),
     )
-    return
-  result = handle_list_command(
-      user_key=user_id,
-      bearer_token=bearer_token,
-      accessible_agents_client=_accessible_agents_client(),
-      rate_limiter=_command_rate_limiter(),
-  )
-  _ack_ephemeral(ack, result)
+    _ack_ephemeral(ack, result)
 
-
-@app.command("/caipe-use")
-def slash_caipe_use(ack, body, context=None):
-  """``/caipe-use <agent>|default`` — set DM thread override or clear preferences."""
-  user_id = body.get("user_id") or ""
-  bearer_token = _obo_token_from_context(context) or ""
-  if not bearer_token:
-    _ack_ephemeral(
-        ack,
-        SlashCommandResult(
-            text=(
-                "I couldn't verify your identity for this command. "
-                "Please re-link your account and try again."
-            ),
-            code="no_bearer",
-        ),
-    )
-    return
-
-  raw_text = body.get("text") or ""
-  channel_id = body.get("channel_id") or ""
-  workspace_id = (context or {}).get("slack_workspace_id") or body.get("team_id") or ""
-  # Slack slash commands fire against a single channel; for DM threads
-  # the "thread" identity is the channel itself (Slack DMs don't carry
-  # a thread_ts in the command body). This matches the override key the
-  # DM message handler builds below for root messages.
-  thread_ts = channel_id  # one thread-key per DM channel for command-level overrides
-
-  # Slack DM channel ids start with "D" — this is a stable Slack
-  # convention, so it works regardless of whether RBAC enrichment ran.
-  is_dm = bool(channel_id) and channel_id.startswith("D")
-  override_key = (
-      _override_key_for_dm(
-          workspace_id=workspace_id,
-          channel_id=channel_id,
-          user_id=user_id,
-          thread_ts=thread_ts,
+  @app.command(f"/{cmd}-list")
+  def slash_list(ack, body, context=None):
+    channel_id = body.get("channel_id") or ""
+    is_dm = bool(channel_id) and channel_id.startswith("D")
+    user_id = body.get("user_id") or ""
+    bearer_token = _obo_token_from_context(context) or ""
+    if not bearer_token:
+      _ack_ephemeral(
+          ack,
+          SlashCommandResult(
+              text=(
+                  "I couldn't verify your identity for this command. "
+                  "Please re-link your account and try again."
+              ),
+              code="no_bearer",
+          ),
       )
-      if is_dm
-      else None
-  )
+      return
+    result = handle_list_command(
+        user_key=user_id,
+        bearer_token=bearer_token,
+        accessible_agents_client=_accessible_agents_client(),
+        is_dm=is_dm,
+        rate_limiter=_command_rate_limiter(),
+    )
+    _ack_ephemeral(ack, result)
 
-  result = handle_use_command(
-      user_key=user_id,
-      raw_text=raw_text,
-      bearer_token=bearer_token,
-      is_dm=is_dm,
-      override_key=override_key,
-      override_store=get_default_override_store(),
-      dm_authz_client=_dm_authz_client(),
-      user_preferences_client=_user_preferences_client(),
-      accessible_agents_client=_accessible_agents_client(),
-      rate_limiter=_command_rate_limiter(),
-  )
-  _ack_ephemeral(ack, result)
+
+  @app.command(f"/{cmd}-use")
+  def slash_use(ack, body, context=None):
+    user_id = body.get("user_id") or ""
+    bearer_token = _obo_token_from_context(context) or ""
+    if not bearer_token:
+      _ack_ephemeral(
+          ack,
+          SlashCommandResult(
+              text=(
+                  "I couldn't verify your identity for this command. "
+                  "Please re-link your account and try again."
+              ),
+              code="no_bearer",
+          ),
+      )
+      return
+
+    raw_text = body.get("text") or ""
+    channel_id = body.get("channel_id") or ""
+    workspace_id = (context or {}).get("slack_workspace_id") or body.get("team_id") or ""
+    # Slack slash commands fire against a single channel; for DM threads
+    # the "thread" identity is the channel itself (Slack DMs don't carry
+    # a thread_ts in the command body). This matches the override key the
+    # DM message handler builds below for root messages.
+    thread_ts = channel_id  # one thread-key per DM channel for command-level overrides
+
+    # Slack DM channel ids start with "D" — this is a stable Slack
+    # convention, so it works regardless of whether RBAC enrichment ran.
+    is_dm = bool(channel_id) and channel_id.startswith("D")
+    override_key = (
+        _override_key_for_dm(
+            workspace_id=workspace_id,
+            channel_id=channel_id,
+            user_id=user_id,
+            thread_ts=thread_ts,
+        )
+        if is_dm
+        else None
+    )
+
+    result = handle_use_command(
+        user_key=user_id,
+        raw_text=raw_text,
+        bearer_token=bearer_token,
+        is_dm=is_dm,
+        override_key=override_key,
+        override_store=get_default_override_store(),
+        dm_authz_client=_dm_authz_client(),
+        user_preferences_client=_user_preferences_client(),
+        accessible_agents_client=_accessible_agents_client(),
+        rate_limiter=_command_rate_limiter(),
+    )
+    _ack_ephemeral(ack, result)
+
+
+_register_slash_commands()
 
 
 def _resolve_conversation_id(thread_ts: str, channel_id: str, agent_id: str = "", owner_id: str = "") -> str:
@@ -946,7 +960,7 @@ def rbac_global_middleware(body, context, next, logger):
     # run regardless of channel mapping — the command itself decides whether
     # its semantics require DM context. So we treat both like mentions for the
     # mapping requirement and the command handlers enforce DM-only semantics
-    # for `/caipe-use <agent>` themselves.
+    # for `/{cmd}-use <agent>` themselves.
     is_mention = event.get("type") == "app_mention"
     is_command = bool(body.get("command"))
 
@@ -1565,7 +1579,7 @@ def handle_dm_message(event, say, client, context=None):
         say(
             text=(
                 "You don't have access to any agents that can answer this "
-                "DM. Use `/caipe-list` to see what's available, or ask "
+                f"DM. Use `/{APP_NAME.lower()}-list` to see what's available, or ask "
                 "your admin for a grant."
             ),
             thread_ts=thread_ts,

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slash_commands.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slash_commands.py
@@ -1,4 +1,4 @@
-"""Tests for the /caipe-list, /caipe-use, /caipe-help slash command handlers."""
+"""Tests for the /{cmd}-list, /{cmd}-use, /{cmd}-help slash command handlers."""
 
 from __future__ import annotations
 
@@ -20,19 +20,20 @@ from ai_platform_engineering.integrations.slack_bot.utils.dm_thread_overrides im
     OverrideStore,
 )
 from ai_platform_engineering.integrations.slack_bot.utils.slash_commands import (
-    HELP_MESSAGE,
-    LIST_EMPTY_MESSAGE,
-    LIST_HEADER,
     LIST_UNAVAILABLE_MESSAGE,
+    LIST_EMPTY_MESSAGE,
     PDP_UNAVAILABLE_MESSAGE,
     RATE_LIMITED_MESSAGE,
     USE_DEFAULT_OK_MESSAGE,
     USE_DEFAULT_PARTIAL_OK_MESSAGE,
-    USE_DENIED_MESSAGE,
-    USE_DM_ONLY_MESSAGE,
-    USE_MISSING_ARG_MESSAGE,
     USE_OK_MESSAGE,
-    USE_UNKNOWN_AGENT_MESSAGE,
+    dm_only_message,
+    help_message,
+    list_header,
+    use_denied_message,
+    use_dm_only_message,
+    use_missing_arg_message,
+    use_unknown_agent_message,
     handle_help_command,
     handle_list_command,
     handle_use_command,
@@ -129,9 +130,15 @@ def _override_key() -> OverrideKey:
 
 
 def test_help_returns_help_text() -> None:
-    result = handle_help_command(user_key="U1")
+    result = handle_help_command(user_key="U1", is_dm=True)
     assert result.code == "help"
-    assert result.text == HELP_MESSAGE
+    assert result.text == help_message()
+
+
+def test_help_outside_dm_returns_dm_only() -> None:
+    result = handle_help_command(user_key="U1", is_dm=False)
+    assert result.code == "dm_only"
+    assert result.text == dm_only_message("help")
 
 
 def test_help_is_rate_limited() -> None:
@@ -139,8 +146,8 @@ def test_help_is_rate_limited() -> None:
     limiter = CommandRateLimiter(
         max_per_window=1, window_seconds=10.0, time_source=clock
     )
-    first = handle_help_command(user_key="U1", rate_limiter=limiter)
-    second = handle_help_command(user_key="U1", rate_limiter=limiter)
+    first = handle_help_command(user_key="U1", is_dm=True, rate_limiter=limiter)
+    second = handle_help_command(user_key="U1", is_dm=True, rate_limiter=limiter)
     assert first.code == "help"
     assert second.code == "rate_limited"
     assert second.text == RATE_LIMITED_MESSAGE
@@ -163,12 +170,31 @@ def test_list_returns_formatted_agents() -> None:
         user_key="U1",
         bearer_token="tok",
         accessible_agents_client=fake_client,
+        is_dm=True,
     )
     assert result.code == "list_ok"
-    assert LIST_HEADER.format(count=2).splitlines()[0] in result.text
+    assert list_header(2) in result.text
     assert "`github`" in result.text
     assert "Git ops" in result.text
     assert "`jira`" in result.text
+
+
+def test_list_outside_dm_returns_dm_only() -> None:
+    fake_client = _FakeAccessibleAgentsClient(
+        result=AccessibleAgentsResult(
+            agents=[AccessibleAgent(id="x", name="X", description="")],
+            available=True,
+        )
+    )
+    result = handle_list_command(
+        user_key="U1",
+        bearer_token="tok",
+        accessible_agents_client=fake_client,
+        is_dm=False,
+    )
+    assert result.code == "dm_only"
+    assert result.text == dm_only_message("list")
+    assert fake_client.calls == 0
 
 
 def test_list_handles_empty_list() -> None:
@@ -179,6 +205,7 @@ def test_list_handles_empty_list() -> None:
         user_key="U1",
         bearer_token="tok",
         accessible_agents_client=fake_client,
+        is_dm=True,
     )
     assert result.code == "list_empty"
     assert result.text == LIST_EMPTY_MESSAGE
@@ -192,6 +219,7 @@ def test_list_unavailable_is_friendly() -> None:
         user_key="U1",
         bearer_token="tok",
         accessible_agents_client=fake_client,
+        is_dm=True,
     )
     assert result.code == "list_unavailable"
     assert result.text == LIST_UNAVAILABLE_MESSAGE
@@ -212,12 +240,14 @@ def test_list_respects_rate_limit() -> None:
         user_key="U1",
         bearer_token="tok",
         accessible_agents_client=fake_client,
+        is_dm=True,
         rate_limiter=limiter,
     )
     second = handle_list_command(
         user_key="U1",
         bearer_token="tok",
         accessible_agents_client=fake_client,
+        is_dm=True,
         rate_limiter=limiter,
     )
     assert first.code == "list_ok"
@@ -241,7 +271,7 @@ def test_use_missing_arg() -> None:
         user_preferences_client=_FakeUserPreferencesClient(),
     )
     assert result.code == "use_missing_arg"
-    assert result.text == USE_MISSING_ARG_MESSAGE
+    assert result.text == use_missing_arg_message()
 
 
 def test_use_outside_dm_is_refused() -> None:
@@ -257,7 +287,7 @@ def test_use_outside_dm_is_refused() -> None:
         user_preferences_client=_FakeUserPreferencesClient(),
     )
     assert result.code == "use_dm_only"
-    assert result.text == USE_DM_ONLY_MESSAGE
+    assert result.text == use_dm_only_message()
 
 
 def test_use_allowed_sets_override() -> None:
@@ -299,7 +329,7 @@ def test_use_denied_known_agent() -> None:
         accessible_agents_client=fake_list,
     )
     assert result.code == "use_denied"
-    assert result.text == USE_DENIED_MESSAGE.format(agent_id="github")
+    assert result.text == use_denied_message("github")
     assert store.get(key) is None
 
 
@@ -324,7 +354,7 @@ def test_use_denied_unknown_agent_is_friendly() -> None:
         accessible_agents_client=fake_list,
     )
     assert result.code == "use_unknown"
-    assert result.text == USE_UNKNOWN_AGENT_MESSAGE.format(agent_id="github-agent")
+    assert result.text == use_unknown_agent_message("github-agent")
 
 
 def test_use_pdp_unavailable() -> None:

--- a/ai_platform_engineering/integrations/slack_bot/utils/accessible_agents_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/accessible_agents_client.py
@@ -1,7 +1,7 @@
 """BFF client for ``GET /api/user/accessible-agents``.
 
 Phase 2 of spec 2026-05-24-derive-team-from-channel. Used by the
-``/caipe-list`` slash command (Slack) and the ``list`` text command
+``/{cmd}-list`` slash command (Slack) and the ``list`` text command
 (Webex) to show the signed-in user which agents they can dispatch to.
 
 The BFF route is paginated (default 25, max 100); the bot only ever

--- a/ai_platform_engineering/integrations/slack_bot/utils/command_rate_limiter.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/command_rate_limiter.py
@@ -8,7 +8,7 @@ user, with timestamps stored in a ``deque``. We expire timestamps on
 read so memory cost is proportional to the active set of users
 in the last ``window_seconds``.
 
-Used by both ``/caipe-list``, ``/caipe-use``, and ``/caipe-help``
+Used by the ``/{cmd}-list``, ``/{cmd}-use``, and ``/{cmd}-help``
 slash command handlers in Slack (and corresponding text commands in
 Webex via a separate, identical-shaped twin).
 """

--- a/ai_platform_engineering/integrations/slack_bot/utils/slash_commands.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slash_commands.py
@@ -1,4 +1,14 @@
-"""Slack slash-command handlers for /caipe-list, /caipe-use, /caipe-help.
+"""Slack slash-command handlers for /{cmd}-list, /{cmd}-use, /{cmd}-help.
+
+The command prefix (``cmd``) is derived from the ``APP_NAME`` /
+``SLACK_INTEGRATION_APP_NAME`` environment variable at runtime
+(default: ``caipe``).  When ``APP_NAME=Forge`` the commands become
+``/forge-list``, ``/forge-use``, and ``/forge-help``.
+
+All three commands are DM-only.  Invoking them in a public channel
+returns an ephemeral error pointing the user to a DM.  The one
+exception is ``/forge-use default``, which clears a saved preference
+and is intentionally allowed anywhere.
 
 Phase 2 of spec ``2026-05-24-derive-team-from-channel``. These
 handlers implement FR-028 / FR-029 / FR-029a / FR-030 / FR-033 /
@@ -13,15 +23,14 @@ Design:
   fakes. We don't import Bolt here.
 * Return type is :class:`SlashCommandResult` — a structured value
   with the ephemeral text the bot should post back to Slack.
-* All user-visible copy is centralized here so spec FR-037 (use
-  ``user_messages.py`` templating, not ad-hoc strings) stays
-  satisfied for the slash-command surface. The other user-message
-  constants live in ``user_messages.py``; the command-specific copy
-  lives here next to its single call site.
+* User-visible copy that references command names is generated via
+  module-level helper functions so the prefix stays consistent with
+  the environment-configured app name.
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Optional, Protocol
 
@@ -31,6 +40,20 @@ from .dm_authz_client import DmAuthzClient
 from .dm_thread_overrides import OverrideKey
 from .user_preferences_client import UserPreferencesClient
 
+
+def _cmd_prefix() -> str:
+    """Return the slash-command prefix derived from APP_NAME (e.g. ``forge``)."""
+    name = (
+        os.environ.get("SLACK_INTEGRATION_APP_NAME")
+        or os.environ.get("APP_NAME")
+        or "caipe"
+    )
+    return name.lower()
+
+
+# ---------------------------------------------------------------------------
+# Static messages (no command-name references)
+# ---------------------------------------------------------------------------
 
 RATE_LIMITED_MESSAGE = (
     "You're sending commands too fast. Wait a few seconds and try again."
@@ -42,32 +65,7 @@ LIST_UNAVAILABLE_MESSAGE = (
 
 LIST_EMPTY_MESSAGE = (
     "You don't have access to any agents yet. Ask your admin to grant you "
-    "agent access in CAIPE."
-)
-
-LIST_HEADER = (
-    "Agents you can use ({count} total). Use `/caipe-use <agent>` to override "
-    "for this thread."
-)
-
-USE_MISSING_ARG_MESSAGE = (
-    "Usage: `/caipe-use <agent-id>` (or `/caipe-use default` to clear your "
-    "saved preference and revert to the deployment default)."
-)
-
-USE_DENIED_MESSAGE = (
-    "You don't have access to agent `{agent_id}`. Your existing preference "
-    "is unchanged. Use `/caipe-list` to see what you can use."
-)
-
-USE_UNKNOWN_AGENT_MESSAGE = (
-    "I don't recognize an agent called `{agent_id}`. Use `/caipe-list` to "
-    "see what's available."
-)
-
-USE_DM_ONLY_MESSAGE = (
-    "`/caipe-use` only applies in direct messages — it sets a per-thread "
-    "agent override for your DM with the bot."
+    "agent access."
 )
 
 USE_OK_MESSAGE = (
@@ -82,24 +80,84 @@ USE_DEFAULT_OK_MESSAGE = (
 
 USE_DEFAULT_PARTIAL_OK_MESSAGE = (
     "Cleared the thread override. I couldn't update your saved preference "
-    "right now — try again later, or set it in the CAIPE Settings UI."
+    "right now — try again later, or set it in the Settings UI."
 )
 
 PDP_UNAVAILABLE_MESSAGE = (
     "I can't verify agent access right now. Try again in a moment."
 )
 
-HELP_MESSAGE = (
-    "*CAIPE bot commands*\n"
-    "• `/caipe-list` — show the agents you can use\n"
-    "• `/caipe-use <agent>` — route this DM thread to a specific agent "
-    "(use `/caipe-use default` to clear your saved preference)\n"
-    "• `/caipe-help` — show this message\n"
-    "\n"
-    "Direct messages dispatch via: thread override → your saved default → "
-    "the deployment default."
-)
 
+# ---------------------------------------------------------------------------
+# Dynamic messages (reference the command prefix)
+# ---------------------------------------------------------------------------
+
+def help_message() -> str:
+    cmd = _cmd_prefix()
+    return (
+        f"*Bot commands*\n"
+        f"• `/{cmd}-list` — show the agents you can use\n"
+        f"• `/{cmd}-use <agent>` — route this DM thread to a specific agent "
+        f"(use `/{cmd}-use default` to clear your saved preference)\n"
+        f"• `/{cmd}-help` — show this message\n"
+        "\n"
+        "Direct messages dispatch via: thread override → your saved default → "
+        "the deployment default."
+    )
+
+
+def list_header(count: int) -> str:
+    cmd = _cmd_prefix()
+    return (
+        f"Agents you can use ({count} total). "
+        f"Use `/{cmd}-use <agent>` to override for this thread."
+    )
+
+
+def use_missing_arg_message() -> str:
+    cmd = _cmd_prefix()
+    return (
+        f"Usage: `/{cmd}-use <agent-id>` (or `/{cmd}-use default` to clear your "
+        "saved preference and revert to the deployment default)."
+    )
+
+
+def use_denied_message(agent_id: str) -> str:
+    cmd = _cmd_prefix()
+    return (
+        f"You don't have access to agent `{agent_id}`. Your existing preference "
+        f"is unchanged. Use `/{cmd}-list` to see what you can use."
+    )
+
+
+def use_unknown_agent_message(agent_id: str) -> str:
+    cmd = _cmd_prefix()
+    return (
+        f"I don't recognize an agent called `{agent_id}`. Use `/{cmd}-list` to "
+        "see what's available."
+    )
+
+
+def use_dm_only_message() -> str:
+    cmd = _cmd_prefix()
+    return (
+        f"`/{cmd}-use` only applies in direct messages — it sets a per-thread "
+        "agent override for your DM with the bot."
+    )
+
+
+def dm_only_message(command: str) -> str:
+    """Ephemeral shown when a DM-only command is invoked outside a DM."""
+    cmd = _cmd_prefix()
+    return (
+        f"`/{cmd}-{command}` only works in direct messages with the bot. "
+        f"Open a DM and try again."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core types
+# ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
 class SlashCommandResult:
@@ -131,15 +189,25 @@ def _rate_limited(
     return not rate_limiter.check_and_consume(user_key)
 
 
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
 def handle_help_command(
     *,
     user_key: str,
+    is_dm: bool = True,
     rate_limiter: Optional[CommandRateLimiter] = None,
 ) -> SlashCommandResult:
-    """Return the help text (FR-030, FR-037)."""
+    """Return the help text (FR-030, FR-037).
+
+    DM-only.  Returns a ``dm_only`` error when invoked in a channel.
+    """
+    if not is_dm:
+        return SlashCommandResult(text=dm_only_message("help"), code="dm_only")
     if _rate_limited(rate_limiter, user_key):
         return SlashCommandResult(text=RATE_LIMITED_MESSAGE, code="rate_limited")
-    return SlashCommandResult(text=HELP_MESSAGE, code="help")
+    return SlashCommandResult(text=help_message(), code="help")
 
 
 def handle_list_command(
@@ -147,9 +215,15 @@ def handle_list_command(
     user_key: str,
     bearer_token: str,
     accessible_agents_client: AccessibleAgentsClient,
+    is_dm: bool = True,
     rate_limiter: Optional[CommandRateLimiter] = None,
 ) -> SlashCommandResult:
-    """Return the user's accessible agents (FR-028, FR-036)."""
+    """Return the user's accessible agents (FR-028, FR-036).
+
+    DM-only.  Returns a ``dm_only`` error when invoked in a channel.
+    """
+    if not is_dm:
+        return SlashCommandResult(text=dm_only_message("list"), code="dm_only")
     if _rate_limited(rate_limiter, user_key):
         return SlashCommandResult(text=RATE_LIMITED_MESSAGE, code="rate_limited")
 
@@ -161,7 +235,7 @@ def handle_list_command(
     if not result.agents:
         return SlashCommandResult(text=LIST_EMPTY_MESSAGE, code="list_empty")
 
-    lines = [LIST_HEADER.format(count=len(result.agents))]
+    lines = [list_header(len(result.agents))]
     for agent in result.agents:
         if agent.description:
             lines.append(f"• `{agent.id}` — {agent.name}: {agent.description}")
@@ -192,7 +266,9 @@ def handle_use_command(
         bearer_token: User's OBO/session bearer for downstream PDP +
             preferences calls.
         is_dm: Whether the command was issued in a DM channel.
-            ``/caipe-use`` is DM-only (per FR-029 dispatch chain).
+            The ``<agent>`` form is DM-only (per FR-029 dispatch chain).
+            The ``default`` form is allowed anywhere (clears your own
+            saved preference).
         override_key: Identity for the override store. ``None`` is
             allowed for the ``default`` argument when ``is_dm`` is
             False (we still clear the saved preference; but for
@@ -214,7 +290,7 @@ def handle_use_command(
     argument = (raw_text or "").strip()
     if not argument:
         return SlashCommandResult(
-            text=USE_MISSING_ARG_MESSAGE, code="use_missing_arg"
+            text=use_missing_arg_message(), code="use_missing_arg"
         )
 
     if argument.lower() == "default":
@@ -227,7 +303,7 @@ def handle_use_command(
 
     if not is_dm or override_key is None:
         return SlashCommandResult(
-            text=USE_DM_ONLY_MESSAGE, code="use_dm_only"
+            text=use_dm_only_message(), code="use_dm_only"
         )
 
     decision = dm_authz_client.check_agent_access(
@@ -253,7 +329,7 @@ def _handle_use_default(
     override_store: _OverrideStoreProto,
     user_preferences_client: UserPreferencesClient,
 ) -> SlashCommandResult:
-    """``/caipe-use default`` — FR-029a.
+    """``/{cmd}-use default`` — FR-029a.
 
     Always succeeds at clearing the user's local state. If clearing
     the saved preference in the BFF fails (network/5xx), we still
@@ -292,19 +368,19 @@ def _denied_use_response(
     """
     if accessible_agents_client is None:
         return SlashCommandResult(
-            text=USE_DENIED_MESSAGE.format(agent_id=agent_id), code="use_denied"
+            text=use_denied_message(agent_id), code="use_denied"
         )
     listing = accessible_agents_client.list_agents(bearer_token=bearer_token)
     if not listing.available:
         return SlashCommandResult(
-            text=USE_DENIED_MESSAGE.format(agent_id=agent_id), code="use_denied"
+            text=use_denied_message(agent_id), code="use_denied"
         )
     known_ids = {agent.id for agent in listing.agents}
     if agent_id in known_ids:
         return SlashCommandResult(
-            text=USE_DENIED_MESSAGE.format(agent_id=agent_id), code="use_denied"
+            text=use_denied_message(agent_id), code="use_denied"
         )
     return SlashCommandResult(
-        text=USE_UNKNOWN_AGENT_MESSAGE.format(agent_id=agent_id),
+        text=use_unknown_agent_message(agent_id),
         code="use_unknown",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.9-dev.3"
+version = "0.5.9-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.9.dev3"
+version = "0.5.9.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Slack slash commands were hard-coded as `/caipe-help`, `/caipe-list`, and `/caipe-use`. This change derives the command prefix from the `APP_NAME` / `SLACK_INTEGRATION_APP_NAME` environment variable at startup, so deployments with `APP_NAME=Forge` automatically register `/forge-help`, `/forge-list`, and `/forge-use`.

Also enforces DM-only access on `/help` and `/list` — previously only `/use <agent>` was gated. All three now return an ephemeral error when invoked in a public channel:
> `` `/forge-help` only works in direct messages with the bot. Open a DM and try again. ``

The one intentional exception is preserved: `/{cmd}-use default` works anywhere since it only clears the user's own saved preference.

**Changed files:**
- `slack_bot/utils/slash_commands.py` — replaced hard-coded `/caipe-*` string constants with `_cmd_prefix()`-driven helper functions; added `is_dm` parameter to `handle_help_command` and `handle_list_command`
- `slack_bot/app.py` — replaced three top-level `@app.command` decorators with `_register_slash_commands()` called at startup; updated stray `/caipe-list` user-facing string
- `slack_bot/tests/test_slash_commands.py` — updated imports to use new functions; added `test_help_outside_dm_returns_dm_only` and `test_list_outside_dm_returns_dm_only`
- Minor docstring cleanups in `accessible_agents_client.py` and `command_rate_limiter.py`

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass