### PR TITLE
fix(setup-caipe): complete Ollama k8s deployment

### DIFF
--- a/deploy/kind/ollama.yaml
+++ b/deploy/kind/ollama.yaml
@@ -1,7 +1,8 @@
 ---
 # Persistent storage for Ollama model weights.
 # local-path provisioner writes to /var/local-path-provisioner on the kind node.
-# 10Gi comfortably holds mistral Q4_K_M (4.1 GB) plus headroom for additional models.
+# 20Gi holds a typical LLM (gemma3 = 3.3 GB) + embedding model (nomic-embed-text = 274 MB)
+# plus headroom for swapping to a larger model without reprovisioning.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,7 +14,7 @@ spec:
   storageClassName: standard
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
 
 ---
 apiVersion: apps/v1
@@ -42,7 +43,7 @@ spec:
         # Runs as a separate init container so the pull completes before the
         # main container's readiness probe starts.
         - name: pull-model
-          image: ollama/ollama:0.30.0
+          image: ollama/ollama:latest
           command:
             - sh
             - -c
@@ -85,10 +86,10 @@ spec:
           resources:
             requests:
               cpu: "250m"
-              memory: 256Mi
+              memory: 1Gi
             limits:
-              cpu: "1"
-              memory: 512Mi
+              cpu: "2"
+              memory: 4Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -96,7 +97,7 @@ spec:
 
       containers:
         - name: ollama
-          image: ollama/ollama:0.30.0
+          image: ollama/ollama:latest
           ports:
             - containerPort: 11434
               name: http

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -147,7 +147,7 @@ LITELLM_ROUTE_EMBEDDINGS=false
 LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-caipe-litellm}"
 VLLM_MODEL="${VLLM_MODEL:-openai/gpt-oss-20b}"
 VLLM_GPU_COUNT="${VLLM_GPU_COUNT:-1}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-llama2}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-gemma3}"
 OLLAMA_PORT=11434
 # Base URL the RAG server uses for Ollama embeddings. The EmbeddingsFactory
 # default (http://localhost:11434) is the pod's own loopback and cannot reach
@@ -1028,7 +1028,7 @@ collect_credentials() {
       echo -e "    ${BOLD}2)${NC} AWS Bedrock       ${DIM}(Claude on Bedrock, cross-region inference)${NC}"
       echo -e "    ${BOLD}3)${NC} OpenAI            ${DIM}(gpt-5.2, gpt-4.1, etc.)${NC}"
       echo -e "    ${BOLD}4)${NC} LiteLLM Proxy     ${DIM}(gpt-oss-20B or any OpenAI-compatible endpoint)${NC}"
-      echo -e "    ${BOLD}5)${NC} Ollama            ${DIM}(local models: llama2, mistral, neural-chat, etc.)${NC}"
+      echo -e "    ${BOLD}5)${NC} Ollama            ${DIM}(in-cluster: gemma3, llama3.2, mistral, phi4, etc.)${NC}"
       echo ""
       prompt "Select provider ${CYAN}[1]${NC}${BOLD}: "
       tty_read -r provider_choice
@@ -1477,7 +1477,7 @@ _collect_vllm_credentials() {
 _collect_ollama_config() {
   if ! $NON_INTERACTIVE; then
     echo ""
-    echo -e "  ${DIM}Available Ollama models: llama2, mistral, neural-chat, dolphin-mixtral, vicuna${NC}"
+    echo -e "  ${DIM}Available Ollama models: gemma3, llama3.2, llama3.2:1b, mistral, phi4-mini, qwen2.5${NC}"
     prompt "Ollama model to use ${CYAN}[${OLLAMA_MODEL}]${NC}${BOLD}: "
     tty_read -r input
     OLLAMA_MODEL="${input:-$OLLAMA_MODEL}"
@@ -1491,8 +1491,15 @@ _collect_ollama_config() {
   OPENAI_MODEL_NAME="${OLLAMA_MODEL}"
 
   EMBEDDINGS_PROVIDER="ollama"
+  # Default to nomic-embed-text when no embeddings model is set — gemma3 and
+  # most chat models lack the /api/embed capability Ollama embeddings require.
+  # nomic-embed-text is a small (274 MB), purpose-built embedding model that
+  # the Ollama init container will pull alongside the chat model.
+  if [[ -z "${EMBEDDINGS_MODEL:-}" || "${EMBEDDINGS_MODEL}" == "text-embedding-3-large" ]]; then
+    EMBEDDINGS_MODEL="nomic-embed-text"
+  fi
 
-  log "Provider: openai (via in-cluster Ollama)  Model: ${OLLAMA_MODEL}"
+  log "Provider: openai (via in-cluster Ollama)  Model: ${OLLAMA_MODEL}  Embeddings: ${EMBEDDINGS_MODEL}"
 }
 
 _collect_openai_embeddings_key() {
@@ -7306,7 +7313,12 @@ cmd_cleanup() {
   # Ollama (deployed via kubectl, not Helm)
   if kubectl get deployment ollama -n caipe &>/dev/null; then
     if ask_yn "Delete Ollama resources?" "y"; then
-      kubectl delete -f "${SCRIPT_DIR}/deploy/kind/ollama.yaml" 2>/dev/null || true
+      local _ollama_yaml="${SCRIPT_DIR}/deploy/kind/ollama.yaml"
+      if [[ -f "$_ollama_yaml" ]]; then
+        kubectl delete -f "$_ollama_yaml" 2>/dev/null || true
+      else
+        kubectl delete deployment,svc,pvc -l app=ollama -n caipe 2>/dev/null || true
+      fi
       log "Ollama deleted"
     fi
   fi
@@ -7871,7 +7883,14 @@ BANNER
     # against a missing LLM endpoint. The init container pulls the model
     # (potentially several GB), so allow up to 10 minutes on first run.
     step "Deploying in-cluster Ollama"
-    kubectl apply -f "${SCRIPT_DIR}/deploy/kind/ollama.yaml" 2>&1 \
+    local _ollama_yaml="${SCRIPT_DIR}/deploy/kind/ollama.yaml"
+    if [[ ! -f "$_ollama_yaml" ]]; then
+      err "deploy/kind/ollama.yaml not found at ${_ollama_yaml}."
+      err "When running via 'curl | bash', clone the repo and run setup-caipe.sh directly:"
+      err "  git clone https://github.com/cnoe-io/ai-platform-engineering && cd ai-platform-engineering && bash setup-caipe.sh"
+      exit 1
+    fi
+    kubectl apply -f "$_ollama_yaml" 2>&1 \
       | grep -v "^$" | while IFS= read -r line; do log "$line"; done
     log "Waiting for Ollama to be ready (model pull may take several minutes on first run)..."
     kubectl rollout status deployment/ollama -n caipe --timeout=10m 2>&1 \


### PR DESCRIPTION
## Summary

Builds on #1695 (sibu's in-cluster Ollama work) with remaining gaps discovered during testing on `caipe-rbac.outshift.io`:

- **Default model**: `llama2` → `gemma3` (llama2 unavailable on current Ollama releases)
- **Model hints**: update stale list to `gemma3, llama3.2, phi4-mini, qwen2.5`
- **Embeddings default**: auto-set `EMBEDDINGS_MODEL=nomic-embed-text` when `ENABLE_OLLAMA=true` — gemma3 and most chat models have completion-only capability; without this, non-interactive deploys silently fall back to `text-embedding-3-large` (requires OpenAI key) and the RAG server fails init tests
- **Init container memory**: `512Mi` → `4Gi` — gemma3 alone is 3.3 GB; 512Mi causes OOMKilled during model pull
- **Image pin**: `ollama/ollama:0.30.0` → `latest`
- **PVC size**: `10Gi` → `20Gi` — chat model + embedding model + headroom for model swaps
- **`curl | bash` guard**: fail fast with clear `git clone` instruction when `deploy/kind/ollama.yaml` is missing
- **Cleanup fallback**: label-based delete when yaml is unavailable

## Test plan

- [x] Deployed on `caipe-rbac.outshift.io` with `ENABLE_OLLAMA=true OLLAMA_MODEL=gemma3 EMBEDDINGS_MODEL=nomic-embed-text`
- [x] RAG server init tests passed (Ollama embeddings via nomic-embed-text, Milvus vector search verified)
- [x] Supervisor and UI healthy at https://caipe-rbac.outshift.io
- [ ] Re-run (upgrade) path with existing Ollama deployment
- [ ] Interactive mode model selection

cc @sibuthomasmathew — meant to complement #1695, not replace it. Happy to co-author or fold these into your branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
