### PR TITLE
feat(slack): consolidate JIT shell-user provisioning into shared BFF endpoint

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_jit.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_jit.py
@@ -1,24 +1,33 @@
 # Copyright 2025 CNOE Contributors
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for ``create_user_from_slack`` (spec 103, FR-002 / FR-003 / FR-008).
+"""Tests for ``create_user_from_slack`` after issue #1781.
+
+Since #1781 ``create_user_from_slack`` no longer POSTs to the Keycloak Admin
+API directly — it calls the first-party BFF endpoint
+``POST /api/admin/users/provision-shell`` (the single canonical JIT
+create-or-resolve implementation, shared with the Okta directory sync).
 
 These tests pin:
 
-* The exact JSON body shape POSTed to ``/admin/realms/{realm}/users``
-  (no password, no required actions, ``emailVerified=true``, attributes
-  block with ``slack_user_id`` / ``created_by`` / ``created_at``).
-* The 401/403/5xx/network error paths each raise the *typed* JitError
-  subclass — callers downstream key off the ``error_kind`` attribute
-  for SIEM-friendly logging (FR-011).
-* The 409 race path re-queries by email and returns the surviving id,
-  rather than failing the user message (FR-008).
-* Happy-path UUID is parsed from the ``Location`` header AND the
-  fallback path (no Location header) re-queries by email.
+* The request the slack-bot makes to the BFF — URL, the
+  ``X-Client-Source: slack-bot`` header, the service-account bearer token,
+  and the ``{email, source, attributes:{slack_user_id}}`` body.
+* The HTTP-status → typed ``JitError`` mapping that ``identity_linker`` keys
+  off via the ``error_kind`` attribute (401→auth, 403→forbidden,
+  5xx/unexpected→server, network→network).
+* The happy path returns the ``sub`` from the BFF envelope
+  (``{"success": true, "data": {"sub", "created"}}``) for both the
+  newly-created and already-existing (``created: false``) cases.
+* An unconfigured BFF base URL surfaces as ``JitNetworkError`` so the caller
+  falls back to link-onboarding.
+
+The ``set_user_attribute`` test stays as-is: attribute writes were NOT in
+scope for #1781 and still go through the Keycloak Admin API.
 
 Mocking strategy: we monkeypatch ``httpx.AsyncClient`` inside
-``keycloak_admin`` to a fake async-context-manager that records calls
-and returns scripted responses. No respx/httpx_mock dependency to keep
-the test surface small.
+``keycloak_admin`` to a fake async-context-manager that records calls and
+returns scripted responses, and stub ``bff_client`` helpers so no real token
+or env is needed.
 """
 
 from __future__ import annotations
@@ -51,6 +60,8 @@ class _FakeResponse:
         self.headers = headers or {}
 
     def json(self) -> Any:
+        if isinstance(self._json, BaseException):
+            raise self._json
         return self._json
 
     def raise_for_status(self) -> None:
@@ -65,9 +76,9 @@ class _FakeResponse:
 class _FakeAsyncClient:
     """Async-context-manager stub for ``httpx.AsyncClient``.
 
-    ``script`` is a list of ``(predicate, response_or_exception)``
-    tuples. The first predicate that matches a method+url combo wins.
-    Predicates are simple callables: ``f(method, url, **kwargs) -> bool``.
+    ``script`` is a list of ``(predicate, response_or_exception)`` tuples.
+    The first predicate that matches a method+url combo wins. Predicates are
+    simple callables: ``f(method, url, **kwargs) -> bool``.
     """
 
     def __init__(self, script: list[tuple], calls: list[dict]) -> None:
@@ -107,8 +118,7 @@ def fake_client(monkeypatch: pytest.MonkeyPatch):
 
     Usage::
 
-        calls = []
-        install_fake([(predicate, response_or_exc)], calls)
+        calls = install_fake([(predicate, response_or_exc)])
     """
     calls: list[dict] = []
 
@@ -120,6 +130,141 @@ def fake_client(monkeypatch: pytest.MonkeyPatch):
         return calls
 
     return _install
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the BFF base URL + service-account token so create_user_from_slack
+    has somewhere to call and a token to send, without touching real env/OAuth."""
+    monkeypatch.setattr(ka, "resolve_bff_base_url", lambda *a, **k: "http://ui.test:3000")
+    monkeypatch.setattr(ka, "service_account_token", lambda: "sa-token")
+
+
+def _is_provision(method: str, url: str, **_: Any) -> bool:
+    return method == "POST" and url.endswith("/api/admin/users/provision-shell")
+
+
+def _ok(sub: str = "kc-uuid", created: bool = True) -> _FakeResponse:
+    return _FakeResponse(200, {"success": True, "data": {"sub": sub, "created": created}})
+
+
+# --------------------------------------------------------------------------- #
+# Request shape — URL, headers, body                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_create_user_from_slack_calls_bff_with_pinned_request(fake_client) -> None:
+    """The bot MUST call the BFF provision-shell endpoint with a lowercased
+    email, the ``slack-bot:jit`` source, the slack_user_id attribute, the
+    service-account bearer token, and the X-Client-Source header."""
+    calls = fake_client([(_is_provision, _ok(sub="abc-uuid", created=True))])
+
+    new_id = asyncio.run(ka.create_user_from_slack("U123", "Alice@Corp.COM"))
+
+    assert new_id == "abc-uuid"
+    call = next(c for c in calls if _is_provision(c["method"], c["url"]))
+    assert call["url"] == "http://ui.test:3000/api/admin/users/provision-shell"
+
+    body = call.get("json")
+    assert body == {
+        "email": "alice@corp.com",
+        "source": "slack-bot:jit",
+        "attributes": {"slack_user_id": ["U123"]},
+    }, "email must be lowercased; source + slack_user_id attribute pinned"
+
+    headers = call.get("headers", {})
+    assert headers.get("X-Client-Source") == "slack-bot"
+    assert headers.get("Authorization") == "Bearer sa-token"
+    assert headers.get("Content-Type") == "application/json"
+
+
+def test_create_user_from_slack_returns_sub_for_existing_user(fake_client) -> None:
+    """When the BFF resolves an existing user (created=false), the bot still
+    returns the sub — idempotent create-or-resolve preserved."""
+    fake_client([(_is_provision, _ok(sub="existing-uuid", created=False))])
+    new_id = asyncio.run(ka.create_user_from_slack("U1", "bob@corp.com"))
+    assert new_id == "existing-uuid"
+
+
+# --------------------------------------------------------------------------- #
+# Error paths — typed exceptions, stable error_kind                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_jit_401_raises_jit_auth_error(fake_client) -> None:
+    fake_client([(_is_provision, _FakeResponse(401))])
+    with pytest.raises(ka.JitAuthError) as exc_info:
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+    assert exc_info.value.error_kind == "auth_failure"
+
+
+def test_jit_403_raises_jit_forbidden_error(fake_client) -> None:
+    """403 is the load-bearing signal that the bot SA lacks the provisioning
+    grant. The error message must point at the OpenFGA fix."""
+    fake_client([(_is_provision, _FakeResponse(403))])
+    with pytest.raises(ka.JitForbiddenError) as exc_info:
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+    assert exc_info.value.error_kind == "forbidden"
+    assert "admin_surface:user_provisioning" in str(exc_info.value)
+
+
+def test_jit_5xx_raises_jit_server_error(fake_client) -> None:
+    fake_client([(_is_provision, _FakeResponse(503))])
+    with pytest.raises(ka.JitServerError) as exc_info:
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+    assert exc_info.value.error_kind == "server_error"
+
+
+def test_jit_unexpected_status_raises_jit_server_error(fake_client) -> None:
+    """A non-2xx, non-{401,403,5xx} status (e.g. 400 bad request) is a server
+    error from the bot's perspective — it cannot proceed."""
+    fake_client([(_is_provision, _FakeResponse(400))])
+    with pytest.raises(ka.JitServerError):
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+
+
+def test_jit_network_error_raises_jit_network_error(fake_client) -> None:
+    fake_client([(_is_provision, httpx.ConnectError("boom"))])
+    with pytest.raises(ka.JitNetworkError) as exc_info:
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+    assert exc_info.value.error_kind == "network_error"
+
+
+def test_jit_unconfigured_bff_raises_network_error(
+    fake_client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No BFF base URL configured ⇒ nowhere to provision. Surface as a
+    network-class failure so the caller falls back to link-onboarding."""
+    monkeypatch.setattr(ka, "resolve_bff_base_url", lambda *a, **k: "")
+    # No HTTP should be attempted; an empty script asserts that.
+    fake_client([])
+    with pytest.raises(ka.JitNetworkError):
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+
+
+# --------------------------------------------------------------------------- #
+# Malformed success envelope                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_jit_2xx_without_sub_raises_server_error(fake_client) -> None:
+    """A 200 whose envelope has no ``sub`` is a server-side inconsistency —
+    better to fail loudly than to return a bogus id."""
+    fake_client([(_is_provision, _FakeResponse(200, {"success": True, "data": {}}))])
+    with pytest.raises(ka.JitServerError):
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+
+
+def test_jit_2xx_non_json_raises_server_error(fake_client) -> None:
+    fake_client([(_is_provision, _FakeResponse(200, ValueError("not json")))])
+    with pytest.raises(ka.JitServerError):
+        asyncio.run(ka.create_user_from_slack("U1", "a@x.com"))
+
+
+# --------------------------------------------------------------------------- #
+# set_user_attribute round-trips Keycloak 26 user-profile-required fields     #
+# (unchanged by #1781 — attribute writes still use the Keycloak Admin API)    #
+# --------------------------------------------------------------------------- #
 
 
 @pytest.fixture
@@ -135,215 +280,8 @@ def _is_token(method: str, url: str, **_: Any) -> bool:
     return method == "POST" and url.endswith("/protocol/openid-connect/token")
 
 
-def _is_post_users(method: str, url: str, **_: Any) -> bool:
-    return method == "POST" and url.endswith("/admin/realms/caipe/users")
-
-
-def _is_get_users(method: str, url: str, **_: Any) -> bool:
-    return method == "GET" and url.endswith("/admin/realms/caipe/users")
-
-
 def _token_response() -> _FakeResponse:
     return _FakeResponse(200, {"access_token": "fake-admin-token"})
-
-
-# --------------------------------------------------------------------------- #
-# Body shape                                                                  #
-# --------------------------------------------------------------------------- #
-
-
-def test_create_user_from_slack_body_shape_pinned(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    """The POSTed body MUST match FR-003 exactly: no password, no required
-    actions, emailVerified=true, attributes block populated.
-
-    This is the single most security-critical assertion in JIT — a regression
-    here could re-introduce a password-bearing local account."""
-    calls = fake_client(
-        [
-            (_is_token, _token_response()),
-            (
-                _is_post_users,
-                _FakeResponse(
-                    201,
-                    headers={
-                        "Location": "http://kc.test:7080/admin/realms/caipe/users/abc-uuid"
-                    },
-                ),
-            ),
-        ]
-    )
-
-    new_id = asyncio.run(
-        ka.create_user_from_slack("U123", "Alice@Corp.COM", config=cfg)
-    )
-
-    assert new_id == "abc-uuid"
-
-    # First call is the token grant; second is the POST /users we care about.
-    post_call = next(c for c in calls if c["method"] == "POST" and "/users" in c["url"])
-    body = post_call.get("json")
-    assert body is not None
-    assert body["username"] == "alice@corp.com", "username MUST be lowercased email"
-    assert body["email"] == "alice@corp.com"
-    assert body["emailVerified"] is True
-    assert body["enabled"] is True
-    assert body["requiredActions"] == [], (
-        "JIT users MUST NOT carry required actions — they're federated-only"
-    )
-    assert "credentials" not in body, (
-        "JIT users MUST NOT have a password set"
-    )
-    attrs = body["attributes"]
-    assert attrs["slack_user_id"] == ["U123"]
-    assert attrs["created_by"] == ["slack-bot:jit"]
-    assert len(attrs["created_at"]) == 1
-    # RFC3339 second-precision UTC; loose check rather than time-pinning.
-    assert attrs["created_at"][0].endswith("Z")
-    assert "T" in attrs["created_at"][0]
-
-
-# --------------------------------------------------------------------------- #
-# Error paths — typed exceptions, stable error_kind                           #
-# --------------------------------------------------------------------------- #
-
-
-def test_jit_401_raises_jit_auth_error(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (_is_post_users, _FakeResponse(401)),
-        ]
-    )
-    with pytest.raises(ka.JitAuthError) as exc_info:
-        asyncio.run(ka.create_user_from_slack("U1", "a@x.com", config=cfg))
-    assert exc_info.value.error_kind == "auth_failure"
-
-
-def test_jit_403_raises_jit_forbidden_error(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    """403 is the load-bearing signal that the operator stripped manage-users
-    from caipe-platform. The error message must point at the fix."""
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (_is_post_users, _FakeResponse(403)),
-        ]
-    )
-    with pytest.raises(ka.JitForbiddenError) as exc_info:
-        asyncio.run(ka.create_user_from_slack("U1", "a@x.com", config=cfg))
-    assert exc_info.value.error_kind == "forbidden"
-    assert "manage-users" in str(exc_info.value)
-
-
-def test_jit_5xx_raises_jit_server_error(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (_is_post_users, _FakeResponse(503)),
-        ]
-    )
-    with pytest.raises(ka.JitServerError) as exc_info:
-        asyncio.run(ka.create_user_from_slack("U1", "a@x.com", config=cfg))
-    assert exc_info.value.error_kind == "server_error"
-
-
-def test_jit_network_error_raises_jit_network_error(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (
-                _is_post_users,
-                httpx.ConnectError("boom"),
-            ),
-        ]
-    )
-    with pytest.raises(ka.JitNetworkError) as exc_info:
-        asyncio.run(ka.create_user_from_slack("U1", "a@x.com", config=cfg))
-    assert exc_info.value.error_kind == "network_error"
-
-
-# --------------------------------------------------------------------------- #
-# 409 conflict — benign race resolution (FR-008)                              #
-# --------------------------------------------------------------------------- #
-
-
-def test_jit_409_resolves_to_existing_user(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    """If a parallel Slack message races us to the create, the loser MUST
-    NOT surface an error to the user — it should re-query by email and
-    return the survivor's id, exactly as if it had won the race."""
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (_is_post_users, _FakeResponse(409)),
-            # Token call for the inner get_user_by_email
-            (_is_token, _token_response()),
-            (_is_get_users, _FakeResponse(200, [{"id": "winner-uuid"}])),
-        ]
-    )
-    new_id = asyncio.run(
-        ka.create_user_from_slack("U1", "alice@corp.com", config=cfg)
-    )
-    assert new_id == "winner-uuid"
-
-
-def test_jit_409_with_no_followup_match_raises_server_error(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    """Pathological case: Keycloak says 409 but the follow-up GET returns
-    nothing. We treat that as a server-side inconsistency — better to fail
-    loudly than to return a bogus id."""
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (_is_post_users, _FakeResponse(409)),
-            (_is_token, _token_response()),
-            (_is_get_users, _FakeResponse(200, [])),
-        ]
-    )
-    with pytest.raises(ka.JitServerError):
-        asyncio.run(
-            ka.create_user_from_slack("U1", "alice@corp.com", config=cfg)
-        )
-
-
-# --------------------------------------------------------------------------- #
-# UUID parsing fallbacks                                                      #
-# --------------------------------------------------------------------------- #
-
-
-def test_jit_falls_back_to_email_lookup_when_no_location_header(
-    fake_client, cfg: ka.KeycloakAdminConfig
-) -> None:
-    """Some Keycloak proxies strip Location. The helper must still be able
-    to return a usable id by re-querying by email."""
-    fake_client(
-        [
-            (_is_token, _token_response()),
-            (_is_post_users, _FakeResponse(201, headers={})),
-            (_is_token, _token_response()),
-            (_is_get_users, _FakeResponse(200, [{"id": "recovered-uuid"}])),
-        ]
-    )
-    new_id = asyncio.run(
-        ka.create_user_from_slack("U1", "alice@corp.com", config=cfg)
-    )
-    assert new_id == "recovered-uuid"
-
-
-# --------------------------------------------------------------------------- #
-# set_user_attribute round-trips Keycloak 26 user-profile-required fields    #
-# --------------------------------------------------------------------------- #
 
 
 def test_set_user_attribute_roundtrips_user_profile_fields(
@@ -353,11 +291,7 @@ def test_set_user_attribute_roundtrips_user_profile_fields(
     omit user-profile-required fields (notably ``email``) with HTTP 400
     ``error-user-attribute-required``. ``set_user_attribute`` must therefore
     re-include the identity fields it pulled from the GET response in the
-    PUT body, not just ``{"attributes": ...}``.
-
-    This test pins the exact PUT body shape so the Keycloak 26 fix doesn't
-    silently regress to the old "attributes-only" shape.
-    """
+    PUT body, not just ``{"attributes": ...}``."""
     captured_put_bodies: list[dict] = []
 
     existing_user = {
@@ -404,9 +338,7 @@ def test_set_user_attribute_roundtrips_user_profile_fields(
         )
     )
 
-    assert len(captured_put_bodies) == 1, (
-        "expected exactly one PUT to /users/{id}"
-    )
+    assert len(captured_put_bodies) == 1, "expected exactly one PUT to /users/{id}"
     body = captured_put_bodies[0]
 
     # The new attribute must be set, and pre-existing attributes preserved.

--- a/ai_platform_engineering/integrations/slack_bot/utils/keycloak_admin.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/keycloak_admin.py
@@ -33,11 +33,12 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import httpx
+
+from .bff_client import bff_headers, resolve_bff_base_url, service_account_token
 
 logger = logging.getLogger("caipe.slack_bot.keycloak_admin")
 
@@ -49,24 +50,21 @@ logger = logging.getLogger("caipe.slack_bot.keycloak_admin")
 # JIT is the path that creates a Keycloak shell user the first time a Slack
 # user DMs the bot, when no Keycloak user with their email exists yet.
 #
-# Design choice (spec 103, FR-004 / FR-005): JIT reuses the *same*
-# ``KEYCLOAK_SLACK_BOT_ADMIN_*`` credentials as the lookup paths above —
-# i.e. it goes through the existing ``KeycloakAdminConfig``. We deliberately
-# did NOT introduce a separate ``caipe-slack-bot-provisioner`` client. The
-# trade-off (one secret can both read and create users) is documented in
-# ``docs/docs/specs/103-slack-jit-user-creation/plan.md`` R-8 and accepted
-# in exchange for operational simplicity (one Secret to manage, one rotation
-# procedure, one audit identity).
+# Since issue #1781, JIT does NOT touch the Keycloak Admin API from the
+# slack-bot. Instead ``create_user_from_slack`` calls the first-party BFF
+# endpoint ``POST /api/admin/users/provision-shell`` (Next.js UI), which is
+# the single canonical create-or-resolve implementation shared with the
+# Okta / IdP directory sync. This removes the layering smell of a bot
+# reaching Keycloak Admin directly and collapses two language-duplicated
+# spec-103 implementations into one.
 #
-# Compensating mitigations:
-# 1. The ``create_user_from_slack`` helper below is the ONLY function that
-#    POSTs to ``/users``; callers never get a generic "POST any user" surface.
-# 2. Any follow-up ``PUT /users/{id}`` performed inside this helper targets
-#    the just-returned UUID only — never an arbitrary id passed in.
-# 3. The Slack JIT path needs only {view-users, query-users, manage-users}.
-#    The default ``caipe-platform`` service account also holds the narrow
-#    client/authz roles required by the Web UI BFF's Keycloak RBAC migration;
-#    this helper still exposes only user lookup/create operations.
+# Auth: the call carries the bot's own service-account bearer token plus
+# ``X-Client-Source: slack-bot`` (see :mod:`bff_client`), and the BFF graphs
+# it as ``service_account:<sub>`` gated on ``admin_surface:user_provisioning``
+# in OpenFGA. The ``KEYCLOAK_SLACK_BOT_ADMIN_*`` credentials are still used by
+# the *lookup / attribute* helpers in this module (``get_user_by_*``,
+# ``set_user_attribute``), which were not in scope for #1781 — only user
+# *creation* moved behind the BFF.
 
 
 class JitError(Exception):
@@ -356,11 +354,14 @@ async def fetch_user_realm_role_names(
         return [str(r.get("name", "")) for r in raw if r.get("name")]
 
 
-def _rfc3339_now() -> str:
-    """RFC3339 timestamp in UTC with second precision (e.g.
-    ``2026-04-22T18:05:11Z``). Used as the value of the ``created_at``
-    user attribute (FR-003)."""
-    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+# Source tag recorded as the ``created_by`` attribute on JIT users the bot
+# provisions, so the origin of a shell account is auditable in Keycloak.
+_SLACK_JIT_SOURCE = "slack-bot:jit"
+
+# The BFF endpoint timeout. Generous relative to the ~10s used for direct
+# Keycloak calls because the BFF itself does a lookup + create round-trip to
+# Keycloak on a miss.
+_PROVISION_TIMEOUT_SECONDS = 15.0
 
 
 async def create_user_from_slack(
@@ -368,104 +369,96 @@ async def create_user_from_slack(
     email: str,
     config: KeycloakAdminConfig | None = None,
 ) -> str:
-    """Create a federated-only Keycloak shell user for a Slack identity.
+    """Create-or-resolve a federated-only Keycloak shell user for a Slack identity.
 
-    Implements spec 103 FR-002 / FR-003 / FR-008:
+    Since issue #1781 this calls the first-party BFF endpoint
+    ``POST /api/admin/users/provision-shell`` rather than the Keycloak Admin
+    API directly. The BFF owns the canonical spec-103 shape (lowercased email
+    as username+email, no password, no required actions, ``emailVerified=true``,
+    409 → re-query) and the ``created_by`` / ``created_at`` audit attributes;
+    this function supplies the ``slack_user_id`` attribute and the
+    ``slack-bot:jit`` source tag.
 
-    * ``POST /admin/realms/{realm}/users`` with the body shape pinned in
-      FR-003 (no password, no required actions, ``emailVerified=true``,
-      ``slack_user_id``/``created_by``/``created_at`` attributes).
-    * Parses the new user UUID from the ``Location`` header.
-    * On HTTP 409 ("conflict — user already exists"), re-queries by
-      email and returns the existing user's UUID, treating the race as
-      benign (FR-008).
-    * On 401/403/5xx/network error, raises a typed :class:`JitError`
-      subclass; callers log per FR-011 and fall through to the
-      link-based onboarding flow.
-    * Helper-shape mitigation (spec M1): this function is the only
-      Keycloak Admin write surface in slack-bot. Any future need to
-      mutate user records should add a separate, narrowly-scoped helper
-      rather than exposing a generic "PUT any user" call.
+    Behaviour preserved for callers (idempotency, attributes, returns the
+    Keycloak ``sub``). Error mapping → typed :class:`JitError` subclass so
+    ``identity_linker`` keeps keying off ``error_kind`` (FR-011):
 
-    The caller is expected to pass an *unvalidated* Slack profile email;
-    this helper does NOT enforce the optional
-    ``SLACK_JIT_ALLOWED_EMAIL_DOMAINS`` allowlist — that lives in
-    ``identity_linker.auto_bootstrap_slack_user`` so the gating decision
-    sits next to the JIT-on/off feature flag.
+    * 401 → :class:`JitAuthError`   (BFF rejected the bot's bearer token)
+    * 403 → :class:`JitForbiddenError` (bot SA lacks the provisioning grant)
+    * 5xx / unexpected status → :class:`JitServerError`
+    * network / unconfigured BFF → :class:`JitNetworkError`
+
+    ``config`` is accepted for signature compatibility with the old direct-Admin
+    implementation but is unused — auth now flows through the bot's
+    service-account token (see :mod:`bff_client`).
+
+    The caller passes an *unvalidated* Slack profile email; this helper does
+    NOT enforce the optional ``SLACK_JIT_ALLOWED_EMAIL_DOMAINS`` allowlist —
+    that lives in ``identity_linker.auto_bootstrap_slack_user`` so the gating
+    decision sits next to the JIT-on/off feature flag.
     """
-    cfg = config or _default_config
-    token = await _get_admin_token(cfg)
+    del config  # signature-compat only; see docstring.
 
     email_lower = email.strip().lower()
-    body = {
-        "username": email_lower,
-        "email": email_lower,
-        "emailVerified": True,
-        "enabled": True,
-        "requiredActions": [],
-        "attributes": {
-            "slack_user_id": [slack_user_id],
-            "created_by": ["slack-bot:jit"],
-            "created_at": [_rfc3339_now()],
-        },
-    }
 
-    users_url = f"{cfg.server_url}/admin/realms/{cfg.realm}/users"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
+    base_url = resolve_bff_base_url()
+    if not base_url:
+        # No BFF configured — there is nowhere to provision. Surface as a
+        # network-class failure so the caller falls back to link-onboarding.
+        raise JitNetworkError(
+            "No CAIPE BFF base URL configured (set CAIPE_UI_URL / CAIPE_API_URL); "
+            "cannot provision shell user"
+        )
+
+    url = f"{base_url}/api/admin/users/provision-shell"
+    payload = {
+        "email": email_lower,
+        "source": _SLACK_JIT_SOURCE,
+        "attributes": {"slack_user_id": [slack_user_id]},
     }
+    headers = bff_headers(bearer_token=service_account_token(), json_body=True)
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(users_url, json=body, headers=headers)
+        async with httpx.AsyncClient(timeout=_PROVISION_TIMEOUT_SECONDS) as client:
+            resp = await client.post(url, json=payload, headers=headers)
     except httpx.HTTPError as exc:
         raise JitNetworkError(str(exc)) from exc
 
     if resp.status_code == 401:
-        raise JitAuthError("Keycloak rejected admin token (401)")
+        raise JitAuthError("BFF rejected the bot service-account token (401)")
     if resp.status_code == 403:
         raise JitForbiddenError(
-            "Admin client lacks 'manage-users' role (403). "
-            "Check service-account-caipe-platform realm-management mappings."
-        )
-    if resp.status_code == 409:
-        # Race: another concurrent Slack request created this user
-        # between our lookup and POST. Re-query by email and return
-        # the surviving record (FR-008).
-        existing = await get_user_by_email(email_lower, config=cfg)
-        if existing and existing.get("id"):
-            kc_user_id = str(existing["id"])
-            logger.info(
-                "JIT 409 conflict resolved by re-query: slack=%s -> kc=%s",
-                slack_user_id,
-                kc_user_id,
-            )
-            return kc_user_id
-        # Conflict but re-query found nothing — treat as a server-side
-        # inconsistency rather than a happy-path resolution.
-        raise JitServerError(
-            "Keycloak returned 409 but follow-up email lookup found no user"
+            "BFF denied shell-user provisioning (403). The slack-bot service "
+            "account needs 'writer admin_surface:user_provisioning' in OpenFGA."
         )
     if 500 <= resp.status_code < 600:
-        raise JitServerError(f"Keycloak {resp.status_code} on POST /users")
+        raise JitServerError(
+            f"BFF {resp.status_code} on POST /api/admin/users/provision-shell"
+        )
     if resp.status_code not in (200, 201):
         raise JitServerError(
-            f"Unexpected Keycloak response {resp.status_code} on POST /users"
+            f"Unexpected BFF response {resp.status_code} on "
+            "POST /api/admin/users/provision-shell"
         )
 
-    # Happy path: parse the new user's UUID from the Location header.
-    location = resp.headers.get("Location") or resp.headers.get("location") or ""
-    new_id = location.rsplit("/", 1)[-1].strip()
-    if not new_id:
-        # Some Keycloak builds (and older proxy configurations) strip the
-        # Location header; fall back to a query-by-email so we still return
-        # a usable id.
-        existing = await get_user_by_email(email_lower, config=cfg)
-        if existing and existing.get("id"):
-            new_id = str(existing["id"])
-    if not new_id:
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        raise JitServerError(f"BFF provision-shell returned non-JSON body: {exc}") from exc
+
+    # Envelope is {"success": true, "data": {"sub": "...", "created": bool}}.
+    data = body.get("data") if isinstance(body, dict) else None
+    sub = data.get("sub") if isinstance(data, dict) else None
+    if not sub:
         raise JitServerError(
-            "POST /users succeeded but no user id could be resolved"
+            "BFF provision-shell succeeded but returned no 'sub'"
         )
-    return new_id
+
+    created = bool(data.get("created")) if isinstance(data, dict) else False
+    logger.info(
+        "JIT provisioned via BFF: event=jit_%s slack=%s keycloak=%s",
+        "created" if created else "resolved",
+        slack_user_id,
+        sub,
+    )
+    return str(sub)

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.5.10-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.10-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,36 +179,36 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.5.10-dev.1
+    version: 0.5.10-dev.2
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot
   # Webex Bot Integration (client, not an agent)
   - name: webex-bot
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - webex-bot
   # Keycloak Identity Provider for CAIPE RBAC/OIDC.
@@ -217,16 +217,16 @@ dependencies:
   # wiring. There is no upstream Keycloak chart that provides these CAIPE
   # bootstrap invariants without additional Jobs/templates.
   - name: keycloak
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - keycloak
   # OpenFGA relationship authorization service
   - name: openfga
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: openfga.enabled
   # AgentGateway ext_authz bridge backed by OpenFGA
   - name: openfga-authz-bridge
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: openfgaAuthzBridge.enabled
   # AgentGateway standalone proxy for RBAC-protected MCP routing.
   # Intentional local subchart for this release: this deploys the standalone
@@ -235,5 +235,5 @@ dependencies:
   # and remain the target for a later migration once we can preserve this
   # release's static MCP routing and authz bridge contract.
   - name: agentgateway
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: agentgateway.enabled

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.10-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.10-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/agentgateway/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agentgateway
 description: AgentGateway standalone proxy for CAIPE MCP traffic
 type: application
-version: 0.5.10-dev.1
-appVersion: 0.5.10-dev.1
+version: 0.5.10-dev.2
+appVersion: 0.5.10-dev.2

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.5.10-dev.1
-appVersion: "0.5.10-dev.1"
+version: 0.5.10-dev.2
+appVersion: "0.5.10-dev.2"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.10-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.10-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.5.10-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.10-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/keycloak/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
 description: Keycloak identity provider for CAIPE RBAC, token exchange, and identity federation
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.5.10-dev.1
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.5.10-dev.2
 type: application

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -561,18 +561,24 @@ fi
 # OpenFGA check. Nothing else grants the bots' service accounts those
 # relations, so we seed them here where each bot's SA user id is known.
 #
-# Currently one grant, applied to every bot SA: read access to
-# platform-wide settings (default agent, VictorOps agent) consumed via
-# `GET /api/admin/platform-config`. Add rows to SA_GRANTS as the bots take
-# on more service-to-service calls — each grant is applied to all bots in
-# BOT_SA_USER_IDS, so the Webex bot gets parity automatically.
+# Grants applied to every bot SA:
+#   - reader system_config:platform_settings — read platform-wide settings
+#     (default agent, VictorOps agent) via `GET /api/admin/platform-config`.
+#   - writer admin_surface:user_provisioning — JIT create-or-resolve a
+#     federated shell user via `POST /api/admin/users/provision-shell`
+#     (issue #1781), so a bot can provision a Keycloak account on first DM.
+# Add rows to SA_GRANTS as the bots take on more service-to-service calls —
+# each grant is applied to all bots in BOT_SA_USER_IDS, so the Webex bot gets
+# parity automatically.
 #
 # Idempotent (check-then-write). Best-effort: a missing store / unreachable
 # OpenFGA logs a warning and returns 0 so it never blocks token exchange —
 # the bots degrade to their env/YAML defaults until the grant lands.
 
-# "<relation> <object>" pairs to grant each bot's service account.
-SA_GRANTS="reader system_config:platform_settings"
+# Newline-separated "<relation> <object>" pairs to grant each bot's service
+# account (the seeding loop splits on newlines).
+SA_GRANTS="reader system_config:platform_settings
+writer admin_surface:user_provisioning"
 
 # resolve_openfga_store_id <openfga_base_url> <store_name> -> echoes store id
 resolve_openfga_store_id() {

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.10-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.10-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openfga-authz-bridge
 description: Envoy ext_authz bridge that adapts AgentGateway authorization checks to OpenFGA
 type: application
-version: 0.5.10-dev.1
-appVersion: 0.5.10-dev.1
+version: 0.5.10-dev.2
+appVersion: 0.5.10-dev.2

--- a/charts/ai-platform-engineering/charts/openfga/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openfga
 description: OpenFGA authorization service for CAIPE relationship-based access control
 type: application
-version: 0.5.10-dev.1
-appVersion: 0.5.10-dev.1
+version: 0.5.10-dev.2
+appVersion: 0.5.10-dev.2

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.10-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.10-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.5.10-dev.1
-appVersion: 0.5.10-dev.1
+version: 0.5.10-dev.2
+appVersion: 0.5.10-dev.2
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.10-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.10-dev.2 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/webex-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: webex-bot
 description: Webex bot integration for AI Platform Engineering using A2A protocol
-version: 0.5.10-dev.1
-appVersion: 0.5.10-dev.1
+version: 0.5.10-dev.2
+appVersion: 0.5.10-dev.2
 type: application

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.5.10-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.5.10-dev.2 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.10-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.5.10-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.10-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.10-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.10-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.5.10-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.5.10-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.10-dev.1" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.10-dev.2 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.10-dev.2" # Do NOT modify. It will be updated automatically using the release workflow

--- a/docs/docs/specs/2026-06-09-slack-bot-remove-direct-keycloak-admin/plan.md
+++ b/docs/docs/specs/2026-06-09-slack-bot-remove-direct-keycloak-admin/plan.md
@@ -339,7 +339,7 @@ grep -rln "KEYCLOAK_SLACK_BOT_ADMIN" --include="*.py" --include="*.ts" \
 - `docs/docs/specs/098-enterprise-rbac-slack-ui/{operator-guide,quickstart}.md`
   and `docs/docs/specs/103-slack-jit-user-creation/*` — these are historical
   spec docs. Add a short forward-reference note ("superseded by
-  <this spec / PR>; the bot no longer uses KEYCLOAK_SLACK_BOT_ADMIN_*") rather
+  `<this spec / PR>`; the bot no longer uses `KEYCLOAK_SLACK_BOT_ADMIN_*`") rather
   than rewriting history.
 - `docs/releases/2026-05-26-release-0-5-0.md` and
   `scripts/migrations/0.5.0/RUN.md` — historical; leave unless a maintainer wants

--- a/docs/docs/specs/2026-06-09-slack-bot-remove-direct-keycloak-admin/plan.md
+++ b/docs/docs/specs/2026-06-09-slack-bot-remove-direct-keycloak-admin/plan.md
@@ -1,0 +1,458 @@
+# Plan: Remove the Slack bot's direct Keycloak Admin credentials
+
+> **Status:** Ready to implement (fresh session).
+> **Author of plan:** drafted at the end of the #1781 work session.
+> **Tracking:** follow-up to #1781 (PR #1788). No GitHub issue yet — create one
+> (suggested title: *"Remove KEYCLOAK_SLACK_BOT_ADMIN_* — route all Slack bot
+> Keycloak access through the BFF"*) and reference it in the PR.
+
+---
+
+## 0. How to start (READ FIRST)
+
+**Base all changes off the branch `feat/1781-bff-provision-shell-user`** — NOT
+`main`. That branch (PR #1788) introduced the canonical `provisionShellUser`
+lib function, the `POST /api/admin/users/provision-shell` BFF endpoint, the
+`bff_client`-based Slack-bot call pattern, and the `admin_surface:user_provisioning`
+OpenFGA grant. This plan extends that exact pattern to the bot's remaining
+Keycloak Admin operations. If #1788 has merged to `main` by the time you start,
+branch off `main` instead and confirm those pieces are present.
+
+```bash
+# If #1788 is still open:
+git fetch origin
+git worktree add ../caipe-remove-slackbot-kc-admin -b feat/slack-bot-remove-direct-keycloak-admin origin/feat/1781-bff-provision-shell-user
+
+# If #1788 already merged:
+git worktree add ../caipe-remove-slackbot-kc-admin -b feat/slack-bot-remove-direct-keycloak-admin origin/main
+```
+
+Work in the new worktree. Reuse the #1781 implementation as the template for
+everything below — it is the reference for endpoint shape, auth gating, the
+Python `bff_client` call, error mapping, OpenFGA seeding, and test style.
+
+**Environment notes (from the #1781 session):**
+- Python venv lives at the repo root: use `/Users/kkantesa/ai-platform-engineering/.venv/bin/{python,pytest,ruff}`.
+  In a fresh worktree run pytest with `PYTHONPATH=<worktree-root>` so it loads the worktree copy.
+- The UI worktree has no `node_modules`. Symlink the main repo's to run jest/tsc/eslint:
+  `ln -s /Users/kkantesa/ai-platform-engineering/ui/node_modules <worktree>/ui/node_modules`
+  (verify `package.json` is identical first; remove the symlink before committing).
+- There are 9 pre-existing Slack-bot test failures/errors from a missing
+  `slack_sdk` module in the venv (`test_slack_route_no_silent_failure.py`,
+  `test_error_recovery.py`). These are **unrelated** — confirm they also fail on
+  `main` and ignore them.
+
+---
+
+## 1. Goal & motivation
+
+Today the Slack bot reaches Keycloak two different ways:
+
+1. **`caipe-slack-bot` service-account token** (via `ai_platform_engineering/integrations/slack_bot/utils/bff_client.py`)
+   → talks to the **BFF** (Next.js UI). Authentication is the SA JWT; the BFF
+   graphs it as `service_account:<sub>` and authorizes it with **OpenFGA grants**.
+   This is the correct, first-party path.
+2. **`KEYCLOAK_SLACK_BOT_ADMIN_*` credentials** (client `caipe-platform`, via
+   `keycloak_admin.py` → `_get_admin_token` / `KeycloakAdminConfig`) → talks to
+   the **Keycloak Admin REST API directly**. This is the layering smell #1781
+   called out: a bot holding realm-management credentials.
+
+#1781 moved user **creation** from path (2) to path (1). This plan moves the
+**remaining** Keycloak Admin operations (lookups + attribute read/write) onto
+path (1) as well, and then **deletes the `KEYCLOAK_SLACK_BOT_ADMIN_*` credentials
+from the Slack bot entirely** — code, env, chart, secrets, and docs.
+
+**Net effect:** the Slack bot holds exactly one Keycloak credential (its SA
+client-credentials token), and every capability it has is an explicit, auditable
+OpenFGA grant seeded in `init-token-exchange.sh`. The token does
+service-to-service auth; the grants are its RBAC.
+
+**Out of scope (do NOT touch):** the **Webex bot**. See §8.
+
+---
+
+## 2. Exact inventory of the Slack bot's direct-Keycloak-Admin surface
+
+`keycloak_admin.py` exports 8 functions that use the direct-Admin path
+(`_get_admin_token` + `KeycloakAdminConfig`). Their real usage:
+
+| Function | Live Slack-bot caller(s) | Disposition |
+|---|---|---|
+| `get_user_by_attribute(attr, value)` | `identity_linker.py` — resolve `slack_user_id`; read `slack_preauth_prompted` / `slack_preauth_prompted_at` | **Migrate** (read-by-attribute) |
+| `get_user_by_email(email)` | `identity_linker.py:177` (`auto_bootstrap_slack_user`) | **Migrate** (read-by-email) |
+| `get_user_attribute(user_id, attr)` | `channel_team_mapper.py:238` — read `caipe_default_team_id` | **Migrate** (read one attribute by id) |
+| `set_user_attribute(user_id, attr, value)` | `identity_linker.py` — write `slack_user_id`, `slack_preauth_prompted_at` | **Migrate** (write/merge one attribute by id) |
+| `create_user_from_slack(...)` | `identity_linker.py:215` | **Already migrated in #1781** (calls BFF) |
+| `remove_user_attribute(...)` | none | **Dead code — delete** |
+| `fetch_user_realm_role_names(...)` | none | **Dead code — delete** |
+| `get_user_by_id(user_id)` | none in Slack bot; **Webex bot only** (`webex_bot/utils/space_team_resolver.py:242`) | **Leave** (Webex out of scope; see §8) |
+
+So the live Slack surface to migrate is **4 functions → 3 logical operations**:
+- read user by attribute (exact)
+- read user by email (exact)
+- read a single attribute off a known user id
+- write/merge a single attribute onto a known user id
+
+The reads (by-attribute, by-email, single-attribute-by-id) all return "a user
+record (id + attributes + enabled)", so they collapse into **one resolve
+endpoint**. The write is **one attribute-merge endpoint**.
+
+### Verify the inventory before coding
+```bash
+# Confirm no NEW callers appeared since this plan was written:
+for fn in get_user_by_attribute get_user_by_email get_user_attribute set_user_attribute \
+          remove_user_attribute fetch_user_realm_role_names get_user_by_id; do
+  echo "=== $fn ==="
+  grep -rn "\b$fn\b" ai_platform_engineering/integrations/slack_bot --include="*.py" | grep -v "/tests/" | grep -v "def $fn"
+done
+```
+If `remove_user_attribute` / `fetch_user_realm_role_names` gained a caller, or
+`get_user_by_id` gained a *Slack* caller, adjust scope accordingly.
+
+---
+
+## 3. The authorization constraint that shapes the design (IMPORTANT)
+
+You **cannot** simply point the bot at existing user endpoints. Two reasons:
+
+1. **No lookup-by-attribute or lookup-by-email endpoint exists** anywhere under
+   `ui/src/app/api/`. They must be built.
+
+2. **`requireRbacPermission` hardcodes `user:${subject}`** (see
+   `ui/src/lib/api-middleware.ts` ~line 827) — it does **not** call
+   `subjectFromSession`, so a service-account token is graphed as `user:<sub>`
+   and can never match a `service_account:` OpenFGA grant. The same is true of
+   `requireUserProfileRead` in `ui/src/lib/rbac/require-openfga.ts` (uses
+   `user:${caller}`). The existing `GET`/`PUT /api/admin/users/[id]` routes use
+   these gates, so the bot's SA token would 403 there.
+
+   **Only `requireResourcePermission(session, {type, id, action})`
+   (`ui/src/lib/rbac/resource-authz.ts`) uses `subjectFromSession`, which graphs
+   `isServiceAccount` callers as `service_account:<sub>`.** This is the gate
+   #1781's provision-shell endpoint uses, and the one you must use here.
+
+**Therefore: new endpoints, gated with `requireResourcePermission` on an
+`admin_surface:*` object, authorized by a seeded SA grant.** This mirrors #1781
+exactly.
+
+---
+
+## 4. Design — two new BFF endpoints
+
+Use a single admin surface object for the bot's user-directory access. Suggested
+id: **`admin_surface:user_directory`** (distinct from #1781's
+`admin_surface:user_provisioning`, so read/lookup access is grantable separately
+from create access — least privilege). The `admin_surface` OpenFGA type already
+lists `service_account` as a valid `reader` and `writer` (confirmed in
+`deploy/openfga/model.fga` and `charts/.../openfga/authorization-model.json`), so
+**no model change is required** — these are just new object instances.
+
+> Naming decision to confirm with a maintainer: one surface
+> (`user_directory`) for both read and write, vs. reusing
+> `user_provisioning`. Recommendation: a dedicated `user_directory` surface,
+> `reader` for the lookups and `writer` for the attribute merge. Keep it one
+> object with two relations rather than two objects.
+
+### 4a. `GET /api/admin/users/resolve` — exact user lookup
+
+**File:** `ui/src/app/api/admin/users/resolve/route.ts`
+
+**Query contract (pick ONE locator):**
+- `?attribute=<name>&value=<v>` → exact attribute match (reuses lib
+  `findRealmUserIdByAttribute`, then `getRealmUserById` for the full record).
+- `?email=<addr>` → exact email match (reuses lib `findUserIdByEmail` +
+  `getRealmUserById`).
+- `?id=<sub>` → fetch by id (reuses lib `getRealmUserById`).
+
+**SECURITY — whitelist the attribute name.** Do not allow arbitrary attribute
+queries. Restrict `attribute` to an allowlist:
+`{"slack_user_id", "slack_preauth_prompted", "slack_preauth_prompted_at", "caipe_default_team_id"}`.
+Reject anything else with 400. (A generic "resolve any user by any attribute"
+surface for a bot SA is more powerful than provision-shell and should be
+explicitly bounded.)
+
+**Response:** `{ success, data: { sub, enabled, attributes } | null }`.
+Return `data: null` (200) for "no match", NOT 404 — the Python callers treat
+"not found" as a normal branch, and 404 would force awkward error handling.
+Include `enabled` (the bot drops disabled users) and `attributes` (the bot reads
+specific attribute values off the record).
+
+**Auth:**
+```ts
+const { session } = await getAuthFromBearerOrSession(request);
+await requireResourcePermission(
+  session,
+  { type: "admin_surface", id: "user_directory", action: "read" },
+  { bypassForOrgAdmin: true }
+);
+```
+
+### 4b. `PATCH /api/admin/users/[id]/attributes` — merge attributes
+
+**File:** `ui/src/app/api/admin/users/[id]/attributes/route.ts`
+
+**Body:** `{ attributes: Record<string, string[]> }`. Merge semantics (reuse the
+existing lib `mergeUserAttributes(userId, attrs)` — it already does the
+Keycloak-26 user-profile round-trip that the Python `set_user_attribute`
+replicates, so this is the natural server-side home for that logic).
+
+**SECURITY — whitelist writable attribute keys.** Restrict to
+`{"slack_user_id", "slack_preauth_prompted_at"}` (the only ones the bot writes).
+Reject other keys with 400 so the SA can't set arbitrary identity attributes.
+Also reject the server-owned `created_by` / `created_at` (consistent with
+provision-shell).
+
+**Response:** `{ success, data: { ok: true } }`.
+
+**Auth:** same as above but `action: "write"`.
+
+### 4c. Tests for both endpoints
+
+Mirror `ui/src/app/api/admin/users/provision-shell/__tests__/provision-shell-route.test.ts`:
+mock `next-auth`, `auth-config`, `config`, `jwt-validation` (return
+`{sub, email, name, isServiceAccount:true}`), `openfga`, `audit`, the
+`keycloak-admin` lib, and `mongodb`. Cover: SA authorized via the grant; org-admin
+bypass; denied without grant (403); the attribute whitelist (400 on disallowed
+name/key); "no match" → `data:null`/200 on resolve.
+
+---
+
+## 5. Python migration (`ai_platform_engineering/integrations/slack_bot/utils/keycloak_admin.py`)
+
+Follow the exact pattern `create_user_from_slack` now uses (post-#1781): build
+the URL from `resolve_bff_base_url()`, headers from
+`bff_headers(bearer_token=service_account_token(), json_body=...)`, call via
+`httpx.AsyncClient`, map non-2xx to typed errors, parse the `{success, data}`
+envelope.
+
+Rewrite these four functions to call the new endpoints (keep their **signatures
+identical** so `identity_linker.py` and `channel_team_mapper.py` are untouched):
+
+- `get_user_by_attribute(attr, value)` → `GET /api/admin/users/resolve?attribute=&value=`,
+  return `data` (the user dict) or `None`.
+- `get_user_by_email(email)` → `GET /api/admin/users/resolve?email=`, return `data` or `None`.
+- `get_user_attribute(user_id, attr)` → `GET /api/admin/users/resolve?id=`,
+  then pull `attributes[attr][0]` from `data`; return `None` if absent.
+- `set_user_attribute(user_id, attr, value)` → `PATCH /api/admin/users/{id}/attributes`
+  with `{attributes: {attr: [value]}}`.
+
+**Error handling:** these are not JIT paths, so they don't use `JitError`.
+Match the *current* behavior: the existing functions call `resp.raise_for_status()`
+and let `httpx.HTTPStatusError` propagate. Decide per call site whether callers
+want exceptions or graceful `None`:
+- `channel_team_mapper.get_effective_team` and `identity_linker` lookups already
+  treat `None` as "not found / fall through". For transport/HTTP errors, preserve
+  today's semantics (they currently bubble up from `raise_for_status`). Keep it
+  simple: raise on unexpected status, return `None` on a clean "no match"
+  (`data: null`).
+
+**Remove:**
+- `_get_admin_token`, `KeycloakAdminConfig`, `_default_config`,
+  `_user_profile_roundtrip`, `_USER_PROFILE_ROUNDTRIP_FIELDS` — once nothing in
+  the module uses the direct-Admin path anymore. (Double-check no remaining
+  function references them.)
+- `remove_user_attribute`, `fetch_user_realm_role_names` — dead code.
+- The `config: KeycloakAdminConfig | None = None` parameter on the migrated
+  functions (no longer meaningful). `create_user_from_slack` already accepts but
+  ignores `config` for signature-compat; you may drop the param there too since
+  this is an all-at-once change with no backwards-compat requirement (confirmed
+  by the user for #1781). **Update all call sites accordingly.**
+- The module docstring's `KEYCLOAK_SLACK_BOT_ADMIN_*` documentation block, and
+  the `KeycloakAdminConfig` env-var explanation. Replace with a note that all
+  Keycloak access now flows through the BFF via `bff_client`.
+
+> NOTE: after this migration, `keycloak_admin.py` may no longer warrant its name
+> (it's now a thin BFF client for user ops). Consider renaming to
+> `bff_user_client.py` or folding into an existing client — but that's optional
+> polish; do the functional migration first and rename only if cheap.
+
+---
+
+## 6. OpenFGA grant
+
+Add the directory grants to `SA_GRANTS` in **one** file (the deploy path is a
+symlink to the chart script — confirmed):
+`charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh`
+(`deploy/keycloak/init-token-exchange.sh` → symlink to it).
+
+The loop splits `SA_GRANTS` on newlines. After #1781 it reads:
+```sh
+SA_GRANTS="reader system_config:platform_settings
+writer admin_surface:user_provisioning"
+```
+Add:
+```sh
+SA_GRANTS="reader system_config:platform_settings
+writer admin_surface:user_provisioning
+reader admin_surface:user_directory
+writer admin_surface:user_directory"
+```
+Update the comment block above `SA_GRANTS` to document the two new grants
+(read = lookups, write = attribute merge). No OpenFGA model change needed.
+
+Verify the parse:
+```bash
+SA_GRANTS="reader system_config:platform_settings
+writer admin_surface:user_provisioning
+reader admin_surface:user_directory
+writer admin_surface:user_directory"
+echo "$SA_GRANTS" | while IFS= read -r g; do [ -z "$g" ] && continue; echo "rel=[${g%% *}] obj=[${g##* }]"; done
+```
+
+---
+
+## 7. Remove `KEYCLOAK_SLACK_BOT_ADMIN_*` everywhere (the payoff)
+
+Only after the code no longer reads these vars. Full reference list (captured
+2026-06-09 — re-grep to confirm before editing):
+
+```bash
+grep -rln "KEYCLOAK_SLACK_BOT_ADMIN" --include="*.py" --include="*.ts" \
+  --include="*.yaml" --include="*.yml" --include="*.md" --include="*.sh" \
+  --include="*.example" . | grep -v node_modules
+```
+
+**Code / config to update:**
+- `ai_platform_engineering/integrations/slack_bot/utils/keycloak_admin.py` — remove (see §5).
+- `setup-caipe.sh` — drop the var prompts/exports.
+- `docker-compose.dev.yaml` — remove the two env entries from the slack-bot service.
+- `charts/ai-platform-engineering/values.yaml` — remove the keys.
+- `charts/ai-platform-engineering/charts/slack-bot/values.yaml` — remove.
+- `charts/ai-platform-engineering/charts/slack-bot/templates/deployment.yaml` — remove the env wiring.
+
+**Tests:**
+- `ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_config.py`
+  — this entire file tests `KeycloakAdminConfig` env precedence. Once the config
+  class is gone, **delete this test file** (its subject no longer exists).
+- `ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_jit.py`
+  — #1781 already rewrote this to test the BFF call. Update the remaining
+  `set_user_attribute` test (currently still uses the direct-Admin
+  `KeycloakAdminConfig`/token mock) to instead assert the `PATCH .../attributes`
+  BFF call. Add tests for the migrated `get_user_by_*` / `get_user_attribute`
+  functions (assert URL, headers, query params, envelope parsing, `None` on
+  `data:null`).
+
+**Docs (update prose; these are not load-bearing for code):**
+- `docs/docs/security/rbac/{file-map,workflows,architecture}.md` — update any
+  description of the Slack bot calling Keycloak Admin directly; point to the BFF
+  endpoints + OpenFGA grants instead.
+- `docs/docs/specs/098-enterprise-rbac-slack-ui/{operator-guide,quickstart}.md`
+  and `docs/docs/specs/103-slack-jit-user-creation/*` — these are historical
+  spec docs. Add a short forward-reference note ("superseded by
+  <this spec / PR>; the bot no longer uses KEYCLOAK_SLACK_BOT_ADMIN_*") rather
+  than rewriting history.
+- `docs/releases/2026-05-26-release-0-5-0.md` and
+  `scripts/migrations/0.5.0/RUN.md` — historical; leave unless a maintainer wants
+  a migration note. Mention the removal in the **current** release notes / a new
+  migration note instead (a removed env var is an operator-facing change).
+
+**Operator migration note:** removing an env var that operators may have set is a
+deployment-facing change. Add a short note to the release/upgrade docs:
+"`KEYCLOAK_SLACK_BOT_ADMIN_CLIENT_ID/SECRET` are no longer used by the Slack bot
+and can be removed from values.yaml/.env; the bot now reaches Keycloak only
+through the BFF using its `caipe-slack-bot` service account." Use the
+`release-docs` / `update-docs` skills if appropriate.
+
+---
+
+## 8. Webex bot — EXPLICITLY OUT OF SCOPE
+
+Per the user: **do not include Webex.**
+
+- The Webex bot (`ai_platform_engineering/integrations/webex_bot/utils/space_team_resolver.py:242`)
+  is the **only** remaining caller of `get_user_by_id`, via its own
+  `webex_bot/utils/keycloak_admin.py` (a separate module from the Slack bot's).
+- This plan touches **only** the Slack bot's `keycloak_admin.py`. Leave the
+  Webex module and its credentials untouched.
+- **Guard rail:** do not remove `KEYCLOAK_SLACK_BOT_ADMIN_*` in a way that breaks
+  Webex. Confirm Webex uses its own creds (e.g. `KEYCLOAK_WEBEX_BOT_ADMIN_*` or a
+  separate config) and is unaffected. If Webex shares any removed var, STOP and
+  flag it — do not strand Webex.
+  ```bash
+  grep -rn "KEYCLOAK_.*ADMIN\|KeycloakAdminConfig\|_get_admin_token" \
+    ai_platform_engineering/integrations/webex_bot --include="*.py"
+  ```
+
+A parallel "migrate Webex to BFF endpoints" effort can reuse the `resolve`
+endpoint built here (it's bot-agnostic — `get_user_by_id` maps to
+`?id=`). Note that as a future opportunity; do not implement it.
+
+---
+
+## 9. Testing & quality gates (run all before PR)
+
+```bash
+# Python — migrated module + linker + mapper (NOT the dead config test, which is deleted)
+PYTHONPATH=<worktree> /Users/kkantesa/ai-platform-engineering/.venv/bin/pytest \
+  ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_jit.py \
+  ai_platform_engineering/integrations/slack_bot/tests/test_identity_linker_jit.py \
+  ai_platform_engineering/integrations/slack_bot/tests/ -q
+/Users/kkantesa/ai-platform-engineering/.venv/bin/ruff check ai_platform_engineering/integrations/slack_bot/
+
+# UI (symlink node_modules first)
+cd ui
+npx jest src/app/api/admin/users           # resolve + [id]/attributes + provision-shell
+npx tsc --noEmit -p tsconfig.json
+npx eslint src/app/api/admin/users/resolve/route.ts \
+           "src/app/api/admin/users/[id]/attributes/route.ts" \
+           src/lib/rbac/keycloak-admin.ts
+
+# RBAC matrix validator (resource-permission routes are NOT required in the matrix,
+# but run it to confirm nothing regressed)
+/Users/kkantesa/ai-platform-engineering/.venv/bin/python scripts/validate-rbac-matrix.py
+```
+
+Expected: all green except the 9 pre-existing `slack_sdk` failures (§0).
+Remember to **delete the node_modules symlink** before committing.
+
+---
+
+## 10. Risks & decisions to confirm with a maintainer
+
+1. **Attribute whitelist scope.** Recommended: lock both endpoints to the known
+   Slack attribute names (§4a/§4b). A generic query/write surface for a bot SA is
+   a larger attack surface. Confirm the allowlist is acceptable (it must include
+   `caipe_default_team_id` for the channel-team path).
+2. **Surface naming.** `admin_surface:user_directory` (new) vs. reusing
+   `admin_surface:user_provisioning`. Recommended: new, for least privilege.
+3. **`resolve` "not found" = 200 `data:null`** (not 404). Keeps the Python
+   callers' control flow clean. Confirm reviewers are OK with that convention.
+4. **Error semantics on transport failure.** The current direct-Admin functions
+   `raise_for_status()`. Preserve "raise on unexpected, `None` on clean no-match"
+   so callers behave identically. Watch `channel_team_mapper` (a failure there
+   should degrade gracefully, not crash team resolution).
+5. **Module rename** (`keycloak_admin.py` → BFF client) — optional; skip if not cheap.
+
+---
+
+## 11. File-by-file checklist
+
+**New:**
+- [ ] `ui/src/app/api/admin/users/resolve/route.ts`
+- [ ] `ui/src/app/api/admin/users/resolve/__tests__/resolve-route.test.ts`
+- [ ] `ui/src/app/api/admin/users/[id]/attributes/route.ts`
+- [ ] `ui/src/app/api/admin/users/[id]/attributes/__tests__/attributes-route.test.ts`
+
+**Modified:**
+- [ ] `ai_platform_engineering/integrations/slack_bot/utils/keycloak_admin.py` (migrate 4 fns, delete dead code + config/token plumbing + docstring)
+- [ ] `ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_jit.py` (update `set_user_attribute` test → BFF; add lookup tests)
+- [ ] `charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh` (two new `SA_GRANTS` rows + comment)
+- [ ] `setup-caipe.sh`, `docker-compose.dev.yaml`, `charts/.../values.yaml` (x2), `charts/.../slack-bot/templates/deployment.yaml` (drop env)
+- [ ] RBAC + release/migration docs (prose updates per §7)
+
+**Deleted:**
+- [ ] `ai_platform_engineering/integrations/slack_bot/tests/test_keycloak_admin_config.py`
+- [ ] `KEYCLOAK_SLACK_BOT_ADMIN_*` references everywhere they're set/consumed
+
+**Verify untouched:** `webex_bot/**`, Webex credentials.
+
+---
+
+## 12. Commit / PR
+
+- Conventional commit, e.g.
+  `refactor(slack): route all Slack-bot Keycloak access through the BFF; drop direct admin creds`.
+- DCO: `git commit -s` only after explicit human sign-off in the session (per
+  `CLAUDE.md`). Add `Assisted-by: Claude:<model>`. No `Co-Authored-By`.
+- Reference the new tracking issue and note it builds on #1788.
+- Use the `pr-caipe` skill to open the PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.10-dev.1"
+version = "0.5.10-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/identity-group-sync/directory-sync/trigger/route.ts
+++ b/ui/src/app/api/admin/identity-group-sync/directory-sync/trigger/route.ts
@@ -17,7 +17,7 @@ listRunningIdpSyncRuns,
 reapStaleIdpSyncRuns,
 updateIdpSyncRun,
 } from "@/lib/rbac/idp-sync-store";
-import { resolveOrProvisionUserSub } from "@/lib/rbac/keycloak-admin";
+import { provisionShellUser } from "@/lib/rbac/keycloak-admin";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
 import { withIdentityGroupSyncAdminAuth } from "../../_lib";
@@ -99,8 +99,13 @@ async function executeSyncRun(runId: string, provider: string, actor: string): P
         if (!member.active || !email) continue;
         if (!subCache.has(email)) {
           try {
-            const { sub } = await resolveOrProvisionUserSub(email, {
-              created_by: [`idp-sync:${provider}`],
+            // Shares the canonical JIT provisioning logic with the BFF
+            // `POST /api/admin/users/provision-shell` endpoint the bots call
+            // (issue #1781) — in-process, so no self-network hop. This route's
+            // own RBAC gate has already authorized the admin action.
+            const { sub } = await provisionShellUser({
+              email,
+              source: `idp-sync:${provider}`,
             });
             subCache.set(email, sub);
           } catch (err) {

--- a/ui/src/app/api/admin/users/provision-shell/__tests__/provision-shell-route.test.ts
+++ b/ui/src/app/api/admin/users/provision-shell/__tests__/provision-shell-route.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for POST /api/admin/users/provision-shell (issue #1781) — the
+ * canonical JIT shell-user provisioning endpoint the Slack bot calls.
+ *
+ * Covers:
+ *  - the bot service account (graphed `service_account:<sub>`) is authorized
+ *    via `writer admin_surface:user_provisioning` and provisions a user;
+ *  - an org admin passes via the bypass;
+ *  - a caller with no grant is denied 403;
+ *  - request validation (missing/invalid email, missing source);
+ *  - server-owned attributes (`created_by`/`created_at`) cannot be forged;
+ *  - the response echoes {sub, created} from the canonical lib function.
+ */
+
+import { NextRequest } from "next/server";
+
+const mockCheckOpenFgaTuple = jest.fn();
+const mockProvisionShellUser = jest.fn();
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn(async () => null),
+}));
+
+jest.mock("@/lib/auth-config", () => ({
+  authOptions: {},
+  isBootstrapAdmin: jest.fn().mockReturnValue(false),
+  REQUIRED_ADMIN_GROUP: "",
+}));
+
+jest.mock("@/lib/config", () => ({
+  getConfig: (key: string) => key === "ssoEnabled",
+}));
+
+jest.mock("@/lib/jwt-validation", () => ({
+  validateLocalSkillsJWT: jest.fn(async () => null),
+  validateBearerJWT: jest.fn(async () => ({
+    sub: "slack-bot-sub",
+    email: "service-account-slack-bot@local",
+    name: "Slack Bot Service Account",
+    isServiceAccount: true,
+  })),
+}));
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
+jest.mock("@/lib/rbac/audit", () => ({
+  logAuthzDecision: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/keycloak-admin", () => ({
+  provisionShellUser: (...args: unknown[]) => mockProvisionShellUser(...args),
+}));
+
+function request(body: unknown): NextRequest {
+  return new NextRequest(new URL("/api/admin/users/provision-shell", "http://localhost:3000"), {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+      "X-Client-Source": "slack-bot",
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: deny everything; individual tests grant what they need.
+  mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
+  mockProvisionShellUser.mockResolvedValue({ sub: "new-kc-uuid", created: true });
+});
+
+describe("POST /api/admin/users/provision-shell", () => {
+  it("provisions for the bot SA with writer admin_surface:user_provisioning", async () => {
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { user: string; relation: string; object: string }) => ({
+      allowed:
+        tuple.user === "service_account:slack-bot-sub" &&
+        tuple.relation === "can_write" &&
+        tuple.object === "admin_surface:user_provisioning",
+    }));
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      request({ email: "Alice@Corp.COM", source: "slack-bot:jit", attributes: { slack_user_id: ["U123"] } })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { sub: "new-kc-uuid", created: true } });
+    expect(mockProvisionShellUser).toHaveBeenCalledWith({
+      email: "alice@corp.com",
+      source: "slack-bot:jit",
+      attributes: { slack_user_id: ["U123"] },
+    });
+  });
+
+  it("allows an org admin via the can_manage bypass", async () => {
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { relation: string; object: string }) => ({
+      allowed: tuple.relation === "can_manage" && tuple.object === "organization:caipe",
+    }));
+
+    const { POST } = await import("../route");
+    const response = await POST(request({ email: "bob@corp.com", source: "admin-ui" }));
+
+    expect(response.status).toBe(200);
+    expect(mockProvisionShellUser).toHaveBeenCalledWith({
+      email: "bob@corp.com",
+      source: "admin-ui",
+      attributes: undefined,
+    });
+  });
+
+  it("denies a caller without the provisioning grant", async () => {
+    const { POST } = await import("../route");
+    const response = await POST(request({ email: "alice@corp.com", source: "slack-bot:jit" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.code).toBe("admin_surface#write");
+    expect(mockProvisionShellUser).not.toHaveBeenCalled();
+  });
+
+  describe("request validation (after auth)", () => {
+    beforeEach(() => {
+      mockCheckOpenFgaTuple.mockImplementation(async (tuple: { user: string; relation: string; object: string }) => ({
+        allowed:
+          tuple.user === "service_account:slack-bot-sub" &&
+          tuple.relation === "can_write" &&
+          tuple.object === "admin_surface:user_provisioning",
+      }));
+    });
+
+    it("rejects a missing email", async () => {
+      const { POST } = await import("../route");
+      const response = await POST(request({ source: "slack-bot:jit" }));
+      expect(response.status).toBe(400);
+      expect(mockProvisionShellUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid email", async () => {
+      const { POST } = await import("../route");
+      const response = await POST(request({ email: "not-an-email", source: "slack-bot:jit" }));
+      expect(response.status).toBe(400);
+      expect(mockProvisionShellUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing source", async () => {
+      const { POST } = await import("../route");
+      const response = await POST(request({ email: "alice@corp.com" }));
+      expect(response.status).toBe(400);
+      expect(mockProvisionShellUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-object body", async () => {
+      const { POST } = await import("../route");
+      const response = await POST(request("not json"));
+      expect(response.status).toBe(400);
+      expect(mockProvisionShellUser).not.toHaveBeenCalled();
+    });
+
+    it("strips caller-supplied created_by / created_at (server-owned)", async () => {
+      const { POST } = await import("../route");
+      const response = await POST(
+        request({
+          email: "alice@corp.com",
+          source: "slack-bot:jit",
+          attributes: {
+            slack_user_id: ["U1"],
+            created_by: ["attacker"],
+            created_at: ["1999-01-01T00:00:00Z"],
+          },
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockProvisionShellUser).toHaveBeenCalledWith({
+        email: "alice@corp.com",
+        source: "slack-bot:jit",
+        attributes: { slack_user_id: ["U1"] },
+      });
+    });
+
+    it("rejects non-string-array attribute values", async () => {
+      const { POST } = await import("../route");
+      const response = await POST(
+        request({ email: "alice@corp.com", source: "slack-bot:jit", attributes: { slack_user_id: "U1" } })
+      );
+      expect(response.status).toBe(400);
+      expect(mockProvisionShellUser).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/src/app/api/admin/users/provision-shell/route.ts
+++ b/ui/src/app/api/admin/users/provision-shell/route.ts
@@ -1,0 +1,117 @@
+// POST /api/admin/users/provision-shell
+//
+// Canonical JIT "create-or-resolve a federated shell user" endpoint (issue
+// #1781). Resolves an email to a Keycloak `sub`, provisioning a federated-only
+// shell user (spec-103 shape) when none exists yet, so RBAC can be granted to
+// people who have not logged into CAIPE.
+//
+// This is the single first-party surface bots use for JIT provisioning. The
+// Slack bot (and any future bot, e.g. Webex) calls it with its own
+// service-account token + `X-Client-Source`. The in-process Okta / IdP
+// directory sync does NOT call this HTTP route — it shares the same
+// `provisionShellUser` lib function directly (no self-network hop).
+
+import { NextRequest } from "next/server";
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { provisionShellUser } from "@/lib/rbac/keycloak-admin";
+import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+
+// Gate on the user-provisioning admin surface. The OpenFGA `admin_surface`
+// type lists `service_account` as a valid `writer` subject, so the Slack bot's
+// client-credentials caller (graphed as `service_account:<sub>`) can be granted
+// `writer admin_surface:user_provisioning` by the realm init seed. Org admins
+// pass via the bypass.
+const PROVISIONING_SURFACE_ID = "user_provisioning";
+
+// Conservative upper bound; a Keycloak username/email is realistically far
+// shorter. Guards against absurd payloads before we touch Keycloak.
+const MAX_EMAIL_LENGTH = 320;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseEmail(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new ApiError("email is required and must be a string", 400, "INVALID_EMAIL");
+  }
+  const email = value.trim().toLowerCase();
+  if (!email) {
+    throw new ApiError("email must not be empty", 400, "INVALID_EMAIL");
+  }
+  if (email.length > MAX_EMAIL_LENGTH) {
+    throw new ApiError("email is too long", 400, "INVALID_EMAIL");
+  }
+  // Loose shape check — Keycloak is the real validator. We only reject the
+  // obviously-not-an-email so a typo cannot create a junk shell user.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new ApiError("email is not a valid address", 400, "INVALID_EMAIL");
+  }
+  return email;
+}
+
+function parseSource(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new ApiError("source is required and must be a string", 400, "INVALID_SOURCE");
+  }
+  const source = value.trim();
+  if (!source) {
+    throw new ApiError("source must not be empty", 400, "INVALID_SOURCE");
+  }
+  if (source.length > 128) {
+    throw new ApiError("source is too long", 400, "INVALID_SOURCE");
+  }
+  return source;
+}
+
+function parseAttributes(value: unknown): Record<string, string[]> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) {
+    throw new ApiError("attributes must be an object of string arrays", 400, "INVALID_ATTRIBUTES");
+  }
+  const out: Record<string, string[]> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    // `created_by` / `created_at` are owned by the server (audit provenance);
+    // a caller must not be able to forge them via the attributes bag.
+    if (key === "created_by" || key === "created_at") continue;
+    if (!Array.isArray(raw) || !raw.every((v) => typeof v === "string")) {
+      throw new ApiError(
+        `attribute "${key}" must be an array of strings`,
+        400,
+        "INVALID_ATTRIBUTES"
+      );
+    }
+    out[key] = raw;
+  }
+  return out;
+}
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const { session } = await getAuthFromBearerOrSession(request);
+
+  // First-party admin surface: the bot service account is granted
+  // `writer admin_surface:user_provisioning`; org admins pass via the bypass.
+  await requireResourcePermission(
+    session,
+    { type: "admin_surface", id: PROVISIONING_SURFACE_ID, action: "write" },
+    { bypassForOrgAdmin: true }
+  );
+
+  const rawBody = await request.json().catch(() => null);
+  if (!isRecord(rawBody)) {
+    throw new ApiError("Request body must be a JSON object", 400, "INVALID_BODY");
+  }
+
+  const email = parseEmail(rawBody.email);
+  const source = parseSource(rawBody.source);
+  const attributes = parseAttributes(rawBody.attributes);
+
+  const { sub, created } = await provisionShellUser({ email, source, attributes });
+  return successResponse({ sub, created });
+});

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -684,9 +684,9 @@ function parseUserIdFromLocation(location: string | null): string | null {
  * account (Keycloak matches by email). Idempotent: a 409 (already exists) falls
  * back to resolving the existing user by email.
  *
- * NOTE: the canonical JIT implementation will eventually live behind a shared
- * BFF endpoint that both this sync and the Slack bot call (tracked separately);
- * this is the in-process seed of that shared logic.
+ * Most callers should prefer {@link provisionShellUser}, which stamps the
+ * canonical `created_by` / `created_at` audit attributes; this lower-level
+ * helper is the create primitive it (and the bootstrap paths) build on.
  */
 export async function createFederatedShellUser(
   email: string,
@@ -731,6 +731,64 @@ export async function resolveOrProvisionUserSub(
   if (existing) return { sub: existing, created: false };
   const sub = await createFederatedShellUser(email, attributes);
   return { sub, created: true };
+}
+
+export interface ProvisionShellUserInput {
+  /** Email to resolve / provision. Lowercased before any Keycloak call. */
+  email: string;
+  /**
+   * Who is asking. Recorded verbatim as the `created_by` user attribute on a
+   * freshly-provisioned shell user so the origin of a JIT account is auditable
+   * (e.g. `slack-bot:jit`, `idp-sync:okta`). Ignored when the user already
+   * exists. Required so every provisioning surface is attributable.
+   */
+  source: string;
+  /**
+   * Extra user attributes to stamp on a newly-created shell user (e.g.
+   * `{ slack_user_id: ["U123"] }`). Merged with the canonical `created_by` /
+   * `created_at` attributes. Ignored when the user already exists.
+   */
+  attributes?: Record<string, string[]>;
+}
+
+export interface ProvisionShellUserResult {
+  sub: string;
+  created: boolean;
+}
+
+/**
+ * Canonical JIT "create-or-resolve a federated shell user" entry point
+ * (issue #1781). This is the single implementation every provisioning
+ * surface converges on:
+ *
+ * * the BFF endpoint `POST /api/admin/users/provision-shell` (called by the
+ *   Slack bot, and any future bot) is a thin wrapper over this function;
+ * * the in-process Okta / IdP directory sync calls it directly.
+ *
+ * It owns the spec-103 attribute contract: a newly-provisioned user is
+ * stamped with `created_by: [source]` and an RFC3339 `created_at`, plus any
+ * caller-supplied `attributes`. Resolution of an existing user never mutates
+ * attributes (idempotent). The federated-shell shape (no password, no required
+ * actions, `emailVerified: true`, 409 → re-query) is inherited from
+ * {@link createFederatedShellUser} via {@link resolveOrProvisionUserSub}.
+ */
+export async function provisionShellUser(
+  input: ProvisionShellUserInput
+): Promise<ProvisionShellUserResult> {
+  const email = input.email.trim().toLowerCase();
+  if (!email) {
+    throw new Error("provisionShellUser: email is required");
+  }
+  const source = input.source.trim();
+  if (!source) {
+    throw new Error("provisionShellUser: source is required");
+  }
+  const attributes: Record<string, string[]> = {
+    ...(input.attributes ?? {}),
+    created_by: [source],
+    created_at: [new Date().toISOString().replace(/\.\d{3}Z$/, "Z")],
+  };
+  return resolveOrProvisionUserSub(email, attributes);
 }
 
 function exactEmailUserId(email: string, users: Array<Record<string, unknown>>): string | null {

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.10.dev1"
+version = "0.5.10.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Closes #1781.

Consolidates the two duplicated, language-divergent JIT "create-or-resolve a federated shell user" implementations into a single canonical path behind the BFF, and removes the Slack bot's direct Keycloak Admin call for user creation.

**What changed:**

- **Canonical lib function** `provisionShellUser({email, source, attributes})` → `{sub, created}` in `ui/src/lib/rbac/keycloak-admin.ts`. Owns the spec-103 attribute contract (`created_by` = source, RFC3339 `created_at`) and delegates to the existing `resolveOrProvisionUserSub`. This is the single implementation both surfaces converge on.
- **New BFF endpoint** `POST /api/admin/users/provision-shell`. Gated via `requireResourcePermission(admin_surface:user_provisioning, write)` with org-admin bypass, so the Slack bot's service-account caller (graphed `service_account:<sub>`) is authorized by an OpenFGA grant. Validates input and strips caller-forged `created_by`/`created_at`.
- **Okta / IdP directory sync** (in-process in the UI) now calls `provisionShellUser(...)` directly — no self-network hop; the route's own RBAC gate already authorizes the admin action.
- **Slack bot** `create_user_from_slack` rewritten to call the new BFF endpoint via `bff_client` (service-account token + `X-Client-Source: slack-bot`) instead of reaching Keycloak Admin directly. Python signature preserved, so `identity_linker` is unchanged; HTTP status → typed `JitError` mapping (401/403/5xx/network) preserved.
- **OpenFGA seed**: adds `writer admin_surface:user_provisioning` to the bot service-account grants in `init-token-exchange.sh` (applies to all bot SAs, so Webex gets parity automatically). No model change needed — `admin_surface` already permits `service_account` as `writer`.
- **Tests**: Python JIT tests rewritten to assert the BFF call (URL, headers, body, status→error mapping); new Jest route test (auth, validation, attribute-forgery guard). `set_user_attribute` Keycloak-26 round-trip test retained.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass