### PR TITLE
feat(service-accounts): credential passthrough (provider tokens) for service accounts

### DIFF
--- a/ui/src/app/(app)/credentials/__tests__/page.test.tsx
+++ b/ui/src/app/(app)/credentials/__tests__/page.test.tsx
@@ -23,6 +23,7 @@ jest.mock("@/lib/auth-config", () => ({
 
 jest.mock("@/lib/feature-flags/credentials", () => ({
   getCredentialFeatureConfig: jest.fn(() => ({ enabled: true })),
+  isUserConnectionsEnabled: jest.fn(() => true),
 }));
 
 jest.mock("@/components/credentials/CredentialsWorkspace", () => ({

--- a/ui/src/app/(app)/credentials/page.tsx
+++ b/ui/src/app/(app)/credentials/page.tsx
@@ -3,12 +3,15 @@ import { notFound,redirect } from "next/navigation";
 
 import { CredentialsWorkspace } from "@/components/credentials/CredentialsWorkspace";
 import { authOptions } from "@/lib/auth-config";
-import { getCredentialFeatureConfig } from "@/lib/feature-flags/credentials";
+import { isUserConnectionsEnabled } from "@/lib/feature-flags/credentials";
 import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
 import { organizationObjectId } from "@/lib/rbac/organization";
 
 export default async function CredentialsPage() {
-  if (!getCredentialFeatureConfig().enabled) {
+  // Gated on the user-facing Connections surface flag (independent of the SA
+  // token surface). False when CAIPE_USER_CONNECTIONS_ENABLED=false even if the
+  // credential subsystem is on for service-account tokens.
+  if (!isUserConnectionsEnabled()) {
     notFound();
   }
 

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/__tests__/route.test.ts
@@ -67,10 +67,11 @@ jest.mock("@/lib/mongodb", () => ({
   }),
 }));
 
-// Feature-flag mock — enabled by default, toggled in specific tests
+// Feature-flag mock — enabled by default, toggled in specific tests. The route
+// gates on the SA Tokens surface flag (isServiceAccountTokensEnabled).
 const mockIsEnabled = jest.fn().mockReturnValue(true);
 jest.mock("@/lib/feature-flags/credentials", () => ({
-  getCredentialFeatureConfig: () => ({ enabled: mockIsEnabled() }),
+  isServiceAccountTokensEnabled: () => mockIsEnabled(),
 }));
 
 import { GET, POST, DELETE } from "../route";

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/__tests__/route.test.ts
@@ -1,0 +1,337 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for GET/POST/DELETE /api/admin/service-accounts/[id]/credentials
+ *
+ * Covers:
+ * - Happy paths for all three verbs
+ * - 401 when unauthenticated
+ * - 404 when caller is not a can_manage member (non-member, revoked SA)
+ * - POST: provider validation (unknown provider → 400)
+ * - DELETE: cross-owner guard (connection belongs to a different SA → 404)
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
+
+const mockCheckOpenFgaTuple = jest.fn();
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
+const mockGetBySub = jest.fn();
+jest.mock("@/lib/service-accounts", () => ({
+  getBySub: (...args: unknown[]) => mockGetBySub(...args),
+}));
+
+const mockListConnections = jest.fn();
+const mockRegisterStaticToken = jest.fn();
+const mockGetConnection = jest.fn();
+jest.mock("@/lib/credentials/oauth-service-factory", () => ({
+  getProviderConnectionService: jest.fn(async () => ({
+    listConnections: mockListConnections,
+    registerStaticToken: mockRegisterStaticToken,
+    getConnection: mockGetConnection,
+  })),
+}));
+
+// Mongo collection mock — supports deleteOne
+const mockConnectionsDeleteOne = jest.fn();
+const mockPayloadsDeleteOne = jest.fn();
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: jest.fn(async (name: string) => {
+    if (name === "provider_connections") {
+      return { deleteOne: mockConnectionsDeleteOne };
+    }
+    if (name === "credential_encrypted_payloads") {
+      return { deleteOne: mockPayloadsDeleteOne };
+    }
+    return {};
+  }),
+}));
+
+import { GET, POST, DELETE } from "../route";
+
+const SESSION = { sub: "mgr-sub", user: { email: "mgr@example.com" } };
+const SA_ID = "sa-abc";
+const SA_SUB = "sa-abc"; // sa_sub === id in these tests
+const DOC = {
+  sa_sub: SA_SUB,
+  client_id: "caipe-sa-bot",
+  client_uuid: "kc-uuid-1",
+  name: "bot",
+  owning_team_id: "team-eng",
+  created_by: "creator-sub",
+  status: "active" as const,
+};
+
+const CONN = {
+  id: "conn-1",
+  connectorId: "connector-gitlab",
+  provider: "gitlab",
+  owner: { type: "service_account", id: SA_SUB },
+  status: "connected" as const,
+  updatedAt: new Date("2025-01-01"),
+  requestedScopes: ["api"],
+};
+
+function makeRequest(
+  method: string,
+  body?: unknown,
+  queryConnectionId?: string,
+): NextRequest {
+  const url = queryConnectionId
+    ? `http://localhost/api/admin/service-accounts/${SA_ID}/credentials?connection_id=${queryConnectionId}`
+    : `http://localhost/api/admin/service-accounts/${SA_ID}/credentials`;
+  if (body !== undefined) {
+    return new NextRequest(url, {
+      method,
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new NextRequest(url, { method });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ id: SA_ID }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue(SESSION);
+  mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
+  mockGetBySub.mockResolvedValue(DOC);
+  mockListConnections.mockResolvedValue([CONN]);
+  mockRegisterStaticToken.mockResolvedValue(CONN);
+  mockGetConnection.mockResolvedValue(CONN);
+  mockConnectionsDeleteOne.mockResolvedValue({ deletedCount: 1 });
+  mockPayloadsDeleteOne.mockResolvedValue({ deletedCount: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe("GET .../[id]/credentials", () => {
+  it("returns connection metadata for the SA, no token material", async () => {
+    const res = await GET(makeRequest("GET"), ctx());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    const item = body.data[0];
+    expect(item.id).toBe("conn-1");
+    expect(item.provider).toBe("gitlab");
+    expect(item.status).toBe("connected");
+    // Must NOT contain any token field
+    expect(item).not.toHaveProperty("accessToken");
+    expect(item).not.toHaveProperty("access_token");
+    expect(item).not.toHaveProperty("accessTokenRef");
+    expect(item).not.toHaveProperty("refreshTokenRef");
+    expect(mockListConnections).toHaveBeenCalledWith({
+      type: "service_account",
+      id: SA_SUB,
+    });
+  });
+
+  it("401 when unauthenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest("GET"), ctx());
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when caller is not can_manage member", async () => {
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
+    const res = await GET(makeRequest("GET"), ctx());
+    expect(res.status).toBe(404);
+    expect(mockListConnections).not.toHaveBeenCalled();
+  });
+
+  it("404 when SA is revoked", async () => {
+    mockGetBySub.mockResolvedValue({ ...DOC, status: "revoked" });
+    const res = await GET(makeRequest("GET"), ctx());
+    expect(res.status).toBe(404);
+    expect(mockListConnections).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST
+// ---------------------------------------------------------------------------
+
+describe("POST .../[id]/credentials", () => {
+  it("registers a static token and returns connection metadata (no token)", async () => {
+    const res = await POST(
+      makeRequest("POST", { provider: "gitlab", token: "glpat-abc123" }),
+      ctx(),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.provider).toBe("gitlab");
+    expect(body.data.id).toBe("conn-1");
+    // No token material
+    expect(body.data).not.toHaveProperty("accessToken");
+    expect(body.data).not.toHaveProperty("access_token");
+    expect(mockRegisterStaticToken).toHaveBeenCalledWith({
+      providerKey: "gitlab",
+      owner: { type: "service_account", id: SA_SUB },
+      accessToken: "glpat-abc123",
+      requestedScopes: undefined,
+    });
+  });
+
+  it("forwards requestedScopes when provided", async () => {
+    await POST(
+      makeRequest("POST", { provider: "github", token: "ghp-token", requestedScopes: ["repo"] }),
+      ctx(),
+    );
+    expect(mockRegisterStaticToken).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedScopes: ["repo"] }),
+    );
+  });
+
+  it("400 when provider is unknown", async () => {
+    const res = await POST(
+      makeRequest("POST", { provider: "unknown-provider", token: "tok" }),
+      ctx(),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/provider must be one of/);
+    expect(mockRegisterStaticToken).not.toHaveBeenCalled();
+  });
+
+  it("400 when token is missing", async () => {
+    const res = await POST(makeRequest("POST", { provider: "gitlab" }), ctx());
+    expect(res.status).toBe(400);
+    expect(mockRegisterStaticToken).not.toHaveBeenCalled();
+  });
+
+  it("400 when provider is missing", async () => {
+    const res = await POST(makeRequest("POST", { token: "tok" }), ctx());
+    expect(res.status).toBe(400);
+    expect(mockRegisterStaticToken).not.toHaveBeenCalled();
+  });
+
+  it("401 when unauthenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest("POST", { provider: "gitlab", token: "tok" }),
+      ctx(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when caller is not can_manage member", async () => {
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
+    const res = await POST(
+      makeRequest("POST", { provider: "gitlab", token: "tok" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+    expect(mockRegisterStaticToken).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe("DELETE .../[id]/credentials", () => {
+  it("deletes the connection when owner matches (body connection_id)", async () => {
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({ id: "conn-1", deleted: true });
+    expect(mockConnectionsDeleteOne).toHaveBeenCalledWith({ id: "conn-1" });
+  });
+
+  it("deletes the connection when owner matches (query connection_id)", async () => {
+    const res = await DELETE(makeRequest("DELETE", undefined, "conn-1"), ctx());
+    expect(res.status).toBe(200);
+    expect(mockConnectionsDeleteOne).toHaveBeenCalledWith({ id: "conn-1" });
+  });
+
+  it("404 via cross-owner guard — connection belongs to a different SA", async () => {
+    // Connection is owned by a DIFFERENT service account
+    mockGetConnection.mockResolvedValue({
+      ...CONN,
+      owner: { type: "service_account", id: "OTHER-SA-sub" },
+    });
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+    expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
+  });
+
+  it("404 via cross-owner guard — connection belongs to a user, not an SA", async () => {
+    mockGetConnection.mockResolvedValue({
+      ...CONN,
+      owner: { type: "user", id: SA_SUB },
+    });
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+    expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
+  });
+
+  it("404 when connection not found", async () => {
+    mockGetConnection.mockRejectedValue(new Error("not found"));
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "nonexistent" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("400 when connection_id is missing", async () => {
+    const res = await DELETE(makeRequest("DELETE", {}), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("401 when unauthenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when caller is not can_manage member", async () => {
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+    expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
+  });
+
+  it("best-effort: payload cleanup failure does not fail the request", async () => {
+    mockPayloadsDeleteOne.mockRejectedValue(new Error("payload store unavailable"));
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    // Still succeeds despite payload cleanup failure
+    expect(res.status).toBe(200);
+    expect(mockConnectionsDeleteOne).toHaveBeenCalledWith({ id: "conn-1" });
+  });
+});

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/__tests__/route.test.ts
@@ -8,8 +8,13 @@
  * - Happy paths for all three verbs
  * - 401 when unauthenticated
  * - 404 when caller is not a can_manage member (non-member, revoked SA)
+ * - 404 when credential feature flag is disabled
  * - POST: provider validation (unknown provider → 400)
+ * - POST: duplicate provider → 409
  * - DELETE: cross-owner guard (connection belongs to a different SA → 404)
+ * - DELETE: deletes encrypted payload by deterministic key
+ * - DELETE: only 404 on genuine not-found, propagates infra errors
+ * - Audit events emitted on POST and DELETE success
  */
 
 import { NextRequest } from "next/server";
@@ -23,6 +28,12 @@ jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
 const mockCheckOpenFgaTuple = jest.fn();
 jest.mock("@/lib/rbac/openfga", () => ({
   checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
+const mockLogOpenFgaRebacAuditEvent = jest.fn();
+jest.mock("@/lib/rbac/audit", () => ({
+  logOpenFgaRebacAuditEvent: (...args: unknown[]) =>
+    mockLogOpenFgaRebacAuditEvent(...args),
 }));
 
 const mockGetBySub = jest.fn();
@@ -54,6 +65,12 @@ jest.mock("@/lib/mongodb", () => ({
     }
     return {};
   }),
+}));
+
+// Feature-flag mock — enabled by default, toggled in specific tests
+const mockIsEnabled = jest.fn().mockReturnValue(true);
+jest.mock("@/lib/feature-flags/credentials", () => ({
+  getCredentialFeatureConfig: () => ({ enabled: mockIsEnabled() }),
 }));
 
 import { GET, POST, DELETE } from "../route";
@@ -105,6 +122,7 @@ function ctx() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsEnabled.mockReturnValue(true);
   mockGetServerSession.mockResolvedValue(SESSION);
   mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
   mockGetBySub.mockResolvedValue(DOC);
@@ -113,6 +131,46 @@ beforeEach(() => {
   mockGetConnection.mockResolvedValue(CONN);
   mockConnectionsDeleteOne.mockResolvedValue({ deletedCount: 1 });
   mockPayloadsDeleteOne.mockResolvedValue({ deletedCount: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// Feature-flag guard — all verbs
+// ---------------------------------------------------------------------------
+
+describe("feature-flag disabled", () => {
+  beforeEach(() => {
+    mockIsEnabled.mockReturnValue(false);
+  });
+
+  it("GET returns 404 CREDENTIALS_DISABLED", async () => {
+    const res = await GET(makeRequest("GET"), ctx());
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("CREDENTIALS_DISABLED");
+    expect(mockListConnections).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 404 CREDENTIALS_DISABLED", async () => {
+    const res = await POST(
+      makeRequest("POST", { provider: "gitlab", token: "tok" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("CREDENTIALS_DISABLED");
+    expect(mockRegisterStaticToken).not.toHaveBeenCalled();
+  });
+
+  it("DELETE returns 404 CREDENTIALS_DISABLED", async () => {
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("CREDENTIALS_DISABLED");
+    expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -168,6 +226,8 @@ describe("GET .../[id]/credentials", () => {
 
 describe("POST .../[id]/credentials", () => {
   it("registers a static token and returns connection metadata (no token)", async () => {
+    // No existing connections for this provider
+    mockListConnections.mockResolvedValue([]);
     const res = await POST(
       makeRequest("POST", { provider: "gitlab", token: "glpat-abc123" }),
       ctx(),
@@ -189,6 +249,7 @@ describe("POST .../[id]/credentials", () => {
   });
 
   it("forwards requestedScopes when provided", async () => {
+    mockListConnections.mockResolvedValue([]);
     await POST(
       makeRequest("POST", { provider: "github", token: "ghp-token", requestedScopes: ["repo"] }),
       ctx(),
@@ -196,6 +257,48 @@ describe("POST .../[id]/credentials", () => {
     expect(mockRegisterStaticToken).toHaveBeenCalledWith(
       expect.objectContaining({ requestedScopes: ["repo"] }),
     );
+  });
+
+  it("emits audit event on success", async () => {
+    mockListConnections.mockResolvedValue([]);
+    await POST(
+      makeRequest("POST", { provider: "gitlab", token: "glpat-abc123" }),
+      ctx(),
+    );
+    expect(mockLogOpenFgaRebacAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sub: SESSION.sub,
+        operation: "service_account.credential.add",
+        scope: "admin",
+        resourceRef: `service_account:${SA_ID}`,
+        email: SESSION.user.email,
+      }),
+    );
+  });
+
+  it("409 when a connected credential for the same provider already exists", async () => {
+    // CONN is provider=gitlab, status=connected — same provider as the request
+    mockListConnections.mockResolvedValue([CONN]);
+    const res = await POST(
+      makeRequest("POST", { provider: "gitlab", token: "glpat-new" }),
+      ctx(),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/already exists/);
+    expect(mockRegisterStaticToken).not.toHaveBeenCalled();
+  });
+
+  it("allows POST when existing connection for same provider is NOT connected", async () => {
+    // Existing is "disconnected" — not a blocker
+    mockListConnections.mockResolvedValue([{ ...CONN, status: "disconnected" }]);
+    const res = await POST(
+      makeRequest("POST", { provider: "gitlab", token: "glpat-new" }),
+      ctx(),
+    );
+    expect(res.status).toBe(201);
+    expect(mockRegisterStaticToken).toHaveBeenCalled();
   });
 
   it("400 when provider is unknown", async () => {
@@ -264,6 +367,26 @@ describe("DELETE .../[id]/credentials", () => {
     expect(mockConnectionsDeleteOne).toHaveBeenCalledWith({ id: "conn-1" });
   });
 
+  it("deletes encrypted payload by deterministic key", async () => {
+    await DELETE(makeRequest("DELETE", { connection_id: "conn-1" }), ctx());
+    expect(mockPayloadsDeleteOne).toHaveBeenCalledWith({
+      secretRefId: "provider_connection:conn-1:access_token",
+    });
+  });
+
+  it("emits audit event on success", async () => {
+    await DELETE(makeRequest("DELETE", { connection_id: "conn-1" }), ctx());
+    expect(mockLogOpenFgaRebacAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sub: SESSION.sub,
+        operation: "service_account.credential.remove",
+        scope: "admin",
+        resourceRef: `service_account:${SA_ID}`,
+        email: SESSION.user.email,
+      }),
+    );
+  });
+
   it("404 via cross-owner guard — connection belongs to a different SA", async () => {
     // Connection is owned by a DIFFERENT service account
     mockGetConnection.mockResolvedValue({
@@ -291,13 +414,28 @@ describe("DELETE .../[id]/credentials", () => {
     expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
   });
 
-  it("404 when connection not found", async () => {
-    mockGetConnection.mockRejectedValue(new Error("not found"));
+  it("404 when connection genuinely not found (ApiError 404)", async () => {
+    const { ApiError } = jest.requireActual<{ ApiError: new (msg: string, status: number, code?: string) => Error & { statusCode: number } }>(
+      "@/lib/api-error",
+    );
+    mockGetConnection.mockRejectedValue(new ApiError("not found", 404, "CREDENTIAL_NOT_FOUND"));
     const res = await DELETE(
       makeRequest("DELETE", { connection_id: "nonexistent" }),
       ctx(),
     );
     expect(res.status).toBe(404);
+    expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
+  });
+
+  it("503 when getConnection throws a non-404 infra error (not swallowed as 404)", async () => {
+    mockGetConnection.mockRejectedValue(new Error("DB timeout"));
+    const res = await DELETE(
+      makeRequest("DELETE", { connection_id: "conn-1" }),
+      ctx(),
+    );
+    // Must propagate to outer handler → 503, NOT 404
+    expect(res.status).toBe(503);
+    expect(mockConnectionsDeleteOne).not.toHaveBeenCalled();
   });
 
   it("400 when connection_id is missing", async () => {

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
@@ -2,11 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-config";
 import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
+import { logOpenFgaRebacAuditEvent } from "@/lib/rbac/audit";
 import { getBySub } from "@/lib/service-accounts";
 import { getProviderConnectionService } from "@/lib/credentials/oauth-service-factory";
 import { BUILT_IN_OAUTH_CONNECTORS } from "@/lib/credentials/built-in-oauth-connectors";
 import { getCollection } from "@/lib/mongodb";
 import { CREDENTIAL_COLLECTIONS } from "@/lib/credentials/collections";
+import { getCredentialFeatureConfig } from "@/lib/feature-flags/credentials";
+import { ApiError } from "@/lib/api-error";
 import type { ProviderConnectionDocument } from "@/lib/credentials/oauth-service";
 
 /**
@@ -22,19 +25,31 @@ import type { ProviderConnectionDocument } from "@/lib/credentials/oauth-service
  *         metadata; NEVER returns token material (FR-005).
  * POST — register a pasted access token for a provider. Body: { provider,
  *         token, requestedScopes? }. Provider must be one of the 5
- *         built-in connectors.
+ *         built-in connectors. Returns 409 if a connected credential for
+ *         that provider already exists.
  * DELETE — remove a connection. Body (or query): { connection_id }. The
  *           cross-owner guard verifies the connection belongs to this SA
  *           before deleting, so a caller cannot delete another principal's
  *           connection by guessing an id.
  */
 
-const BUILT_IN_PROVIDER_KEYS = new Set(
-  BUILT_IN_OAUTH_CONNECTORS.map((c) => c.provider as string),
+const BUILT_IN_PROVIDER_KEYS = new Set<string>(
+  BUILT_IN_OAUTH_CONNECTORS.map((c) => c.provider),
 );
 
 interface RouteContext {
   params: Promise<{ id: string }>;
+}
+
+/** Return 404 when credential features are disabled (mirrors connections/route.ts). */
+function assertFeatureEnabled(): NextResponse | null {
+  if (!getCredentialFeatureConfig().enabled) {
+    return NextResponse.json(
+      { success: false, error: "Credential features are disabled", code: "CREDENTIALS_DISABLED" },
+      { status: 404 },
+    );
+  }
+  return null;
 }
 
 /** Resolve the SA and gate by can_manage. Returns [sa_sub, 403/404 response | null]. */
@@ -92,6 +107,9 @@ function safeConnectionShape(conn: {
 }
 
 export async function GET(_request: NextRequest, context: RouteContext) {
+  const featureGuard = assertFeatureEnabled();
+  if (featureGuard) return featureGuard;
+
   const session = (await getServerSession(authOptions)) as {
     sub?: string;
     user?: { email?: string | null };
@@ -131,6 +149,9 @@ export async function GET(_request: NextRequest, context: RouteContext) {
 }
 
 export async function POST(request: NextRequest, context: RouteContext) {
+  const featureGuard = assertFeatureEnabled();
+  if (featureGuard) return featureGuard;
+
   const session = (await getServerSession(authOptions)) as {
     sub?: string;
     user?: { email?: string | null };
@@ -197,11 +218,37 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const { sa_sub } = result;
 
     const service = await getProviderConnectionService();
+
+    // Duplicate-provider guard: reject if a connected credential for this
+    // provider already exists on the SA (prevents non-deterministic exchange).
+    const existing = await service.listConnections({ type: "service_account", id: sa_sub });
+    const duplicate = existing.find(
+      (c) => c.provider === provider && c.status === "connected",
+    );
+    if (duplicate) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `A connected credential for provider "${provider}" already exists (id: ${duplicate.id}). Delete it first or rotate it.`,
+        },
+        { status: 409 },
+      );
+    }
+
     const connection = await service.registerStaticToken({
       providerKey: provider,
       owner: { type: "service_account", id: sa_sub },
       accessToken: token,
       requestedScopes,
+    });
+
+    logOpenFgaRebacAuditEvent({
+      sub: session.sub,
+      operation: "service_account.credential.add",
+      scope: "admin",
+      resourceRef: `service_account:${id}`,
+      email: session.user.email ?? undefined,
+      correlationId: `service_account.credential.add:${id}:${provider}:${connection.id}`,
     });
 
     return NextResponse.json(
@@ -232,6 +279,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
 }
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
+  const featureGuard = assertFeatureEnabled();
+  if (featureGuard) return featureGuard;
+
   const session = (await getServerSession(authOptions)) as {
     sub?: string;
     user?: { email?: string | null };
@@ -281,15 +331,20 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
     const { sa_sub } = result;
 
     // Fetch the connection to verify cross-owner guard.
+    // Only return 404 for genuine not-found (ApiError with statusCode 404);
+    // let infra errors (DB timeout, etc.) propagate to the outer handler.
     const service = await getProviderConnectionService();
     let connection;
     try {
       connection = await service.getConnection(connectionId);
-    } catch {
-      return NextResponse.json(
-        { success: false, error: "Provider connection not found" },
-        { status: 404 },
-      );
+    } catch (err) {
+      if (err instanceof ApiError && err.statusCode === 404) {
+        return NextResponse.json(
+          { success: false, error: "Provider connection not found" },
+          { status: 404 },
+        );
+      }
+      throw err;
     }
 
     // Cross-owner guard: only delete if the connection belongs to this SA.
@@ -316,16 +371,27 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
     }).deleteOne({ id: connectionId });
 
     // Best-effort: purge the encrypted payload for the access token secret.
+    // The key is deterministic: provider_connection:<connectionId>:access_token
+    // (matches oauth-service.ts registerStaticToken line 460).
     try {
       const payloadsCollection = await getCollection(
         CREDENTIAL_COLLECTIONS.encryptedPayloads,
       );
       await (payloadsCollection as unknown as {
         deleteOne(query: Record<string, unknown>): Promise<unknown>;
-      }).deleteOne({ secretRefId: (connection as { accessTokenRef?: string }).accessTokenRef ?? "" });
+      }).deleteOne({ secretRefId: `provider_connection:${connectionId}:access_token` });
     } catch {
       // Non-fatal — the token is inaccessible once the connection doc is gone.
     }
+
+    logOpenFgaRebacAuditEvent({
+      sub: session.sub,
+      operation: "service_account.credential.remove",
+      scope: "admin",
+      resourceRef: `service_account:${id}`,
+      email: session.user.email ?? undefined,
+      correlationId: `service_account.credential.remove:${id}:${connectionId}`,
+    });
 
     return NextResponse.json({ success: true, data: { id: connectionId, deleted: true } });
   } catch (error) {

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
@@ -370,16 +370,22 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       deleteOne(query: Record<string, unknown>): Promise<unknown>;
     }).deleteOne({ id: connectionId });
 
-    // Best-effort: purge the encrypted payload for the access token secret.
-    // The key is deterministic: provider_connection:<connectionId>:access_token
-    // (matches oauth-service.ts registerStaticToken line 460).
+    // Best-effort: purge the encrypted payloads for this connection's secrets.
+    // Keys are deterministic: provider_connection:<connectionId>:{access,refresh}_token
+    // (matches oauth-service.ts). Static tokens have no refresh secret (the
+    // refresh delete is a harmless no-op), but purge both so an OAuth-shaped
+    // connection doesn't leave its refresh token orphaned in the payload store.
     try {
       const payloadsCollection = await getCollection(
         CREDENTIAL_COLLECTIONS.encryptedPayloads,
       );
-      await (payloadsCollection as unknown as {
+      const deletePayload = (payloadsCollection as unknown as {
         deleteOne(query: Record<string, unknown>): Promise<unknown>;
-      }).deleteOne({ secretRefId: `provider_connection:${connectionId}:access_token` });
+      }).deleteOne.bind(payloadsCollection);
+      await Promise.all([
+        deletePayload({ secretRefId: `provider_connection:${connectionId}:access_token` }),
+        deletePayload({ secretRefId: `provider_connection:${connectionId}:refresh_token` }),
+      ]);
     } catch {
       // Non-fatal — the token is inaccessible once the connection doc is gone.
     }

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
@@ -1,0 +1,338 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-config";
+import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
+import { getBySub } from "@/lib/service-accounts";
+import { getProviderConnectionService } from "@/lib/credentials/oauth-service-factory";
+import { BUILT_IN_OAUTH_CONNECTORS } from "@/lib/credentials/built-in-oauth-connectors";
+import { getCollection } from "@/lib/mongodb";
+import { CREDENTIAL_COLLECTIONS } from "@/lib/credentials/collections";
+import type { ProviderConnectionDocument } from "@/lib/credentials/oauth-service";
+
+/**
+ * GET/POST/DELETE /api/admin/service-accounts/[id]/credentials
+ *
+ * Manage provider credentials (pasted static tokens) owned by a service
+ * account. `[id]` is the SA's OpenFGA subject id (`sa_sub`). All three
+ * verbs are gated by the SAME `can_manage` check used elsewhere in the SA
+ * admin API (owning-team member). Non-members get 404 (do not reveal
+ * existence — FR-022).
+ *
+ * GET  — list provider connections owned by this SA. Returns connection
+ *         metadata; NEVER returns token material (FR-005).
+ * POST — register a pasted access token for a provider. Body: { provider,
+ *         token, requestedScopes? }. Provider must be one of the 5
+ *         built-in connectors.
+ * DELETE — remove a connection. Body (or query): { connection_id }. The
+ *           cross-owner guard verifies the connection belongs to this SA
+ *           before deleting, so a caller cannot delete another principal's
+ *           connection by guessing an id.
+ */
+
+const BUILT_IN_PROVIDER_KEYS = new Set(
+  BUILT_IN_OAUTH_CONNECTORS.map((c) => c.provider as string),
+);
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+/** Resolve the SA and gate by can_manage. Returns [sa_sub, 403/404 response | null]. */
+async function resolveAndGate(
+  callerSub: string,
+  id: string,
+): Promise<
+  | { sa_sub: string; error?: never }
+  | { sa_sub?: never; error: NextResponse }
+> {
+  const decision = await checkOpenFgaTuple({
+    user: `user:${callerSub}`,
+    relation: "can_manage",
+    object: `service_account:${id}`,
+  });
+  if (!decision.allowed) {
+    return {
+      error: NextResponse.json(
+        { success: false, error: "Service account not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  const doc = await getBySub(id);
+  if (!doc || doc.status === "revoked") {
+    return {
+      error: NextResponse.json(
+        { success: false, error: "Service account not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  return { sa_sub: doc.sa_sub };
+}
+
+/** Strip secret fields from connection metadata for safe external response. */
+function safeConnectionShape(conn: {
+  id: string;
+  provider: string;
+  status: string;
+  updatedAt?: Date;
+  requestedScopes?: string[];
+  connectorId: string;
+}) {
+  return {
+    id: conn.id,
+    provider: conn.provider,
+    status: conn.status,
+    connectedAt: conn.updatedAt ?? null,
+    requestedScopes: conn.requestedScopes ?? [],
+    connectorId: conn.connectorId,
+  };
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const session = (await getServerSession(authOptions)) as {
+    sub?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email || !session.sub) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json(
+      { success: false, error: "Missing service account id" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await resolveAndGate(session.sub, id);
+    if (result.error) return result.error;
+    const { sa_sub } = result;
+
+    const service = await getProviderConnectionService();
+    const connections = await service.listConnections({ type: "service_account", id: sa_sub });
+
+    return NextResponse.json({
+      success: true,
+      data: connections.map(safeConnectionShape),
+    });
+  } catch (error) {
+    console.error("[service-accounts:credentials:list] failed:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to list credentials" },
+      { status: 503 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = (await getServerSession(authOptions)) as {
+    sub?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email || !session.sub) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json(
+      { success: false, error: "Missing service account id" },
+      { status: 400 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const provider =
+    typeof body.provider === "string" ? body.provider.trim() : "";
+  const token =
+    typeof body.token === "string" ? body.token.trim() : "";
+
+  if (!provider) {
+    return NextResponse.json(
+      { success: false, error: "provider is required" },
+      { status: 400 },
+    );
+  }
+  if (!BUILT_IN_PROVIDER_KEYS.has(provider)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `provider must be one of: ${[...BUILT_IN_PROVIDER_KEYS].join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+  if (!token) {
+    return NextResponse.json(
+      { success: false, error: "token is required" },
+      { status: 400 },
+    );
+  }
+
+  const requestedScopes =
+    Array.isArray(body.requestedScopes) &&
+    body.requestedScopes.every((s) => typeof s === "string")
+      ? (body.requestedScopes as string[])
+      : undefined;
+
+  try {
+    const result = await resolveAndGate(session.sub, id);
+    if (result.error) return result.error;
+    const { sa_sub } = result;
+
+    const service = await getProviderConnectionService();
+    const connection = await service.registerStaticToken({
+      providerKey: provider,
+      owner: { type: "service_account", id: sa_sub },
+      accessToken: token,
+      requestedScopes,
+    });
+
+    return NextResponse.json(
+      { success: true, data: safeConnectionShape(connection) },
+      { status: 201 },
+    );
+  } catch (error) {
+    // Let validation errors (from the service — e.g. bad scopes, unknown
+    // connector) surface as 400.
+    if (
+      error !== null &&
+      typeof error === "object" &&
+      typeof (error as { statusCode?: unknown }).statusCode === "number" &&
+      (error as { statusCode: number }).statusCode < 500
+    ) {
+      const apiErr = error as { message: string; statusCode: number };
+      return NextResponse.json(
+        { success: false, error: apiErr.message },
+        { status: apiErr.statusCode },
+      );
+    }
+    console.error("[service-accounts:credentials:add] failed:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to register credential" },
+      { status: 503 },
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = (await getServerSession(authOptions)) as {
+    sub?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email || !session.sub) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json(
+      { success: false, error: "Missing service account id" },
+      { status: 400 },
+    );
+  }
+
+  // Accept connection_id from body OR query param.
+  let connectionId: string;
+  const queryConnectionId = new URL(request.url).searchParams.get("connection_id") ?? "";
+  if (queryConnectionId) {
+    connectionId = queryConnectionId.trim();
+  } else {
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json(
+        { success: false, error: "connection_id is required (body or query)" },
+        { status: 400 },
+      );
+    }
+    connectionId =
+      typeof body.connection_id === "string" ? body.connection_id.trim() : "";
+  }
+
+  if (!connectionId) {
+    return NextResponse.json(
+      { success: false, error: "connection_id is required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await resolveAndGate(session.sub, id);
+    if (result.error) return result.error;
+    const { sa_sub } = result;
+
+    // Fetch the connection to verify cross-owner guard.
+    const service = await getProviderConnectionService();
+    let connection;
+    try {
+      connection = await service.getConnection(connectionId);
+    } catch {
+      return NextResponse.json(
+        { success: false, error: "Provider connection not found" },
+        { status: 404 },
+      );
+    }
+
+    // Cross-owner guard: only delete if the connection belongs to this SA.
+    if (
+      connection.owner.type !== "service_account" ||
+      connection.owner.id !== sa_sub
+    ) {
+      return NextResponse.json(
+        { success: false, error: "Provider connection not found" },
+        { status: 404 },
+      );
+    }
+
+    // Delete the connection document directly from the Mongo collection.
+    // There is no service-level delete method today; follow the same pattern
+    // as lib/service-accounts.ts (direct getCollection). Best-effort cleanup
+    // of the encrypted payload secret is attempted but does not fail the
+    // request if the payload is already gone.
+    const connectionsCollection = await getCollection<ProviderConnectionDocument>(
+      CREDENTIAL_COLLECTIONS.providerConnections,
+    );
+    await (connectionsCollection as unknown as {
+      deleteOne(query: Record<string, unknown>): Promise<unknown>;
+    }).deleteOne({ id: connectionId });
+
+    // Best-effort: purge the encrypted payload for the access token secret.
+    try {
+      const payloadsCollection = await getCollection(
+        CREDENTIAL_COLLECTIONS.encryptedPayloads,
+      );
+      await (payloadsCollection as unknown as {
+        deleteOne(query: Record<string, unknown>): Promise<unknown>;
+      }).deleteOne({ secretRefId: (connection as { accessTokenRef?: string }).accessTokenRef ?? "" });
+    } catch {
+      // Non-fatal — the token is inaccessible once the connection doc is gone.
+    }
+
+    return NextResponse.json({ success: true, data: { id: connectionId, deleted: true } });
+  } catch (error) {
+    console.error("[service-accounts:credentials:delete] failed:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to delete credential" },
+      { status: 503 },
+    );
+  }
+}

--- a/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/credentials/route.ts
@@ -8,7 +8,7 @@ import { getProviderConnectionService } from "@/lib/credentials/oauth-service-fa
 import { BUILT_IN_OAUTH_CONNECTORS } from "@/lib/credentials/built-in-oauth-connectors";
 import { getCollection } from "@/lib/mongodb";
 import { CREDENTIAL_COLLECTIONS } from "@/lib/credentials/collections";
-import { getCredentialFeatureConfig } from "@/lib/feature-flags/credentials";
+import { isServiceAccountTokensEnabled } from "@/lib/feature-flags/credentials";
 import { ApiError } from "@/lib/api-error";
 import type { ProviderConnectionDocument } from "@/lib/credentials/oauth-service";
 
@@ -41,11 +41,11 @@ interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
-/** Return 404 when credential features are disabled (mirrors connections/route.ts). */
+/** Return 404 when the service-account Tokens surface is disabled. */
 function assertFeatureEnabled(): NextResponse | null {
-  if (!getCredentialFeatureConfig().enabled) {
+  if (!isServiceAccountTokensEnabled()) {
     return NextResponse.json(
-      { success: false, error: "Credential features are disabled", code: "CREDENTIALS_DISABLED" },
+      { success: false, error: "Service account tokens are disabled", code: "CREDENTIALS_DISABLED" },
       { status: 404 },
     );
   }

--- a/ui/src/app/api/admin/service-accounts/__tests__/token-providers.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/token-providers.test.ts
@@ -28,6 +28,11 @@ jest.mock("@/lib/feature-flags/credentials", () => ({
     mockIsServiceAccountTokensEnabled(...args),
 }));
 
+const mockListOpenFgaObjects = jest.fn();
+jest.mock("@/lib/rbac/openfga", () => ({
+  listOpenFgaObjects: (...args: unknown[]) => mockListOpenFgaObjects(...args),
+}));
+
 import { GET } from "../token-providers/route";
 
 const SESSION = { sub: "caller-sub", user: { email: "caller@example.com" } };
@@ -42,6 +47,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockGetServerSession.mockResolvedValue(SESSION);
   mockIsServiceAccountTokensEnabled.mockReturnValue(true);
+  // Caller is a member of at least one team by default (membership gate).
+  mockListOpenFgaObjects.mockResolvedValue({ objects: ["team:platform-eng"] });
 });
 
 describe("GET /api/admin/service-accounts/token-providers", () => {
@@ -139,7 +146,28 @@ describe("GET /api/admin/service-accounts/token-providers", () => {
     expect(body.data).toEqual([{ provider: "gitlab", name: "GitLab" }]);
   });
 
-  it("returns 404 when the service-account tokens feature is disabled", async () => {
+  it("excludes providers not in the built-in set (POST would reject them)", async () => {
+    mockServers([
+      {
+        _id: "gitlab",
+        enabled: true,
+        credential_sources: [{ kind: "provider_connection", provider: "gitlab", target: "header", name: "X" }],
+      },
+      {
+        _id: "custom",
+        enabled: true,
+        // a provider invented in an MCP config that isn't a built-in connector
+        credential_sources: [{ kind: "provider_connection", provider: "made-up-provider", target: "header", name: "X" }],
+      },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data).toEqual([{ provider: "gitlab", name: "GitLab" }]);
+  });
+
+  it("returns 404 (with code) when the service-account tokens feature is disabled", async () => {
     mockIsServiceAccountTokensEnabled.mockReturnValue(false);
 
     const res = await GET();
@@ -147,6 +175,7 @@ describe("GET /api/admin/service-accounts/token-providers", () => {
 
     expect(res.status).toBe(404);
     expect(body.success).toBe(false);
+    expect(body.code).toBe("CREDENTIALS_DISABLED");
     expect(mockGetCollection).not.toHaveBeenCalled();
   });
 
@@ -158,5 +187,17 @@ describe("GET /api/admin/service-accounts/token-providers", () => {
 
     expect(res.status).toBe(401);
     expect(body.success).toBe(false);
+  });
+
+  it("returns 403 when the caller is a member of no team", async () => {
+    mockListOpenFgaObjects.mockResolvedValue({ objects: [] });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.success).toBe(false);
+    // Must not reach the mcp_servers query for an un-teamed caller.
+    expect(mockGetCollection).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/api/admin/service-accounts/__tests__/token-providers.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/token-providers.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * GET /api/admin/service-accounts/token-providers.
+ *
+ * The token-provider list is derived from ENABLED mcp_servers that declare a
+ * `provider_connection` credential source. It powers the SA "Add a token"
+ * dropdown — enabling only the GitLab MCP must yield only GitLab. It must NOT
+ * leak disabled servers or non-provider_connection sources, and must be gated
+ * by the credential feature flag + an authenticated session.
+ */
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+jest.mock("@/lib/auth-config", () => ({ authOptions: {} }));
+
+const mockGetCollection = jest.fn();
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+const mockIsServiceAccountTokensEnabled = jest.fn();
+jest.mock("@/lib/feature-flags/credentials", () => ({
+  isServiceAccountTokensEnabled: (...args: unknown[]) =>
+    mockIsServiceAccountTokensEnabled(...args),
+}));
+
+import { GET } from "../token-providers/route";
+
+const SESSION = { sub: "caller-sub", user: { email: "caller@example.com" } };
+
+function mockServers(docs: unknown[]) {
+  mockGetCollection.mockResolvedValue({
+    find: () => ({ toArray: async () => docs }),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue(SESSION);
+  mockIsServiceAccountTokensEnabled.mockReturnValue(true);
+});
+
+describe("GET /api/admin/service-accounts/token-providers", () => {
+  it("returns distinct providers from enabled provider_connection sources", async () => {
+    mockServers([
+      {
+        _id: "gitlab",
+        enabled: true,
+        credential_sources: [
+          { kind: "provider_connection", provider: "gitlab", target: "header", name: "X-CAIPE-Provider-Token" },
+        ],
+      },
+      {
+        _id: "github",
+        enabled: true,
+        credential_sources: [
+          { kind: "provider_connection", provider: "github", target: "header", name: "X-CAIPE-Provider-Token" },
+        ],
+      },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    // Sorted by display name: GitHub then GitLab.
+    expect(body.data).toEqual([
+      { provider: "github", name: "GitHub" },
+      { provider: "gitlab", name: "GitLab" },
+    ]);
+  });
+
+  it("excludes disabled servers (only the query returns enabled, but guard the shape)", async () => {
+    // The route queries { enabled: true } — simulate Mongo honoring it by only
+    // returning the enabled doc.
+    mockServers([
+      {
+        _id: "gitlab",
+        enabled: true,
+        credential_sources: [
+          { kind: "provider_connection", provider: "gitlab", target: "header", name: "X-CAIPE-Provider-Token" },
+        ],
+      },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data).toEqual([{ provider: "gitlab", name: "GitLab" }]);
+  });
+
+  it("ignores credential sources that are not provider_connection or lack a provider", async () => {
+    mockServers([
+      {
+        _id: "knowledge-base",
+        enabled: true,
+        credential_sources: [{ kind: "caller_token", target: "header", name: "X-CAIPE-Provider-Token" }],
+      },
+      {
+        _id: "weird",
+        enabled: true,
+        credential_sources: [{ kind: "provider_connection", target: "header", name: "X" }], // no provider
+      },
+      {
+        _id: "argocd",
+        enabled: true,
+        // no credential_sources at all
+      },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data).toEqual([]);
+  });
+
+  it("dedupes a provider declared by multiple servers", async () => {
+    mockServers([
+      {
+        _id: "gitlab",
+        enabled: true,
+        credential_sources: [{ kind: "provider_connection", provider: "gitlab", target: "header", name: "X" }],
+      },
+      {
+        _id: "gitlab-mirror",
+        enabled: true,
+        credential_sources: [{ kind: "provider_connection", provider: "gitlab", target: "header", name: "X" }],
+      },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data).toEqual([{ provider: "gitlab", name: "GitLab" }]);
+  });
+
+  it("returns 404 when the service-account tokens feature is disabled", async () => {
+    mockIsServiceAccountTokensEnabled.mockReturnValue(false);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.success).toBe(false);
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when there is no authenticated session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.success).toBe(false);
+  });
+});

--- a/ui/src/app/api/admin/service-accounts/token-providers/route.ts
+++ b/ui/src/app/api/admin/service-accounts/token-providers/route.ts
@@ -4,7 +4,16 @@ import { authOptions } from "@/lib/auth-config";
 import { getCollection } from "@/lib/mongodb";
 import { isServiceAccountTokensEnabled } from "@/lib/feature-flags/credentials";
 import { getProviderDisplayName } from "@/lib/credentials/provider-display-names";
+import { BUILT_IN_OAUTH_CONNECTORS } from "@/lib/credentials/built-in-oauth-connectors";
+import { listOpenFgaObjects } from "@/lib/rbac/openfga";
 import type { MCPServerConfig } from "@/types/dynamic-agent";
+
+// Providers a token can actually be added for — the POST /[id]/credentials route
+// validates `provider` against this same set, so don't surface a provider in the
+// picker that the add call would reject.
+const BUILT_IN_PROVIDER_KEYS = new Set<string>(
+  BUILT_IN_OAUTH_CONNECTORS.map((c) => c.provider),
+);
 
 /**
  * GET /api/admin/service-accounts/token-providers
@@ -31,7 +40,7 @@ interface TokenProvider {
 export async function GET() {
   if (!isServiceAccountTokensEnabled()) {
     return NextResponse.json(
-      { success: false, error: "Service account tokens are disabled" },
+      { success: false, error: "Service account tokens are disabled", code: "CREDENTIALS_DISABLED" },
       { status: 404 },
     );
   }
@@ -48,6 +57,23 @@ export async function GET() {
     );
   }
 
+  // Gate on team membership, matching the rest of the SA admin surface (a
+  // service account is always owned by a team, and only owning-team members
+  // manage it). A caller who belongs to no team can't manage any SA, so they
+  // have no reason to enumerate token-capable providers either. 403 rather than
+  // expose the platform's enabled-integration topology to any logged-in user.
+  const callerTeams = await listOpenFgaObjects({
+    user: `user:${session.sub}`,
+    relation: "member",
+    type: "team",
+  });
+  if (callerTeams.objects.length === 0) {
+    return NextResponse.json(
+      { success: false, error: "Forbidden" },
+      { status: 403 },
+    );
+  }
+
   try {
     const collection = await getCollection<MCPServerConfig>("mcp_servers");
     const servers = await collection.find({ enabled: true }).toArray();
@@ -55,10 +81,16 @@ export async function GET() {
     // Collect distinct provider keys from enabled servers' provider_connection
     // credential sources. A server may declare more than one source; only the
     // provider_connection kind (with a non-empty provider) is token-capable.
+    // Filter to BUILT_IN_PROVIDER_KEYS so we never surface a provider the
+    // add-token POST would reject (it validates against the same set).
     const providers = new Set<string>();
     for (const server of servers) {
       for (const source of server.credential_sources ?? []) {
-        if (source.kind === "provider_connection" && source.provider) {
+        if (
+          source.kind === "provider_connection" &&
+          source.provider &&
+          BUILT_IN_PROVIDER_KEYS.has(source.provider)
+        ) {
           providers.add(source.provider);
         }
       }

--- a/ui/src/app/api/admin/service-accounts/token-providers/route.ts
+++ b/ui/src/app/api/admin/service-accounts/token-providers/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-config";
+import { getCollection } from "@/lib/mongodb";
+import { isServiceAccountTokensEnabled } from "@/lib/feature-flags/credentials";
+import { getProviderDisplayName } from "@/lib/credentials/provider-display-names";
+import type { MCPServerConfig } from "@/types/dynamic-agent";
+
+/**
+ * GET /api/admin/service-accounts/token-providers
+ *
+ * Returns the providers a service account can add a TOKEN (PAT) for. The set is
+ * derived from the platform's *enabled* MCP servers that declare a
+ * `provider_connection` credential source — i.e. servers wired for per-principal
+ * token passthrough. Enable only the GitLab MCP and only GitLab is offered.
+ *
+ * Why not /api/credentials/oauth-connectors? That endpoint lists OAuth
+ * *connectors*, which only become "enabled" once a registered OAuth app
+ * (clientId/secret/redirect) is bootstrapped. PATs need no OAuth app, so the
+ * connector list is the wrong source — it would (incorrectly) hide GitLab when
+ * we have no GitLab OAuth app but DO support GitLab PATs.
+ *
+ * Response: { success, data: [{ provider, name }] } — never any token material.
+ */
+
+interface TokenProvider {
+  provider: string;
+  name: string;
+}
+
+export async function GET() {
+  if (!isServiceAccountTokensEnabled()) {
+    return NextResponse.json(
+      { success: false, error: "Service account tokens are disabled" },
+      { status: 404 },
+    );
+  }
+
+  const session = (await getServerSession(authOptions)) as {
+    sub?: string;
+    user?: { email?: string | null };
+  } | null;
+
+  if (!session?.user?.email || !session.sub) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const collection = await getCollection<MCPServerConfig>("mcp_servers");
+    const servers = await collection.find({ enabled: true }).toArray();
+
+    // Collect distinct provider keys from enabled servers' provider_connection
+    // credential sources. A server may declare more than one source; only the
+    // provider_connection kind (with a non-empty provider) is token-capable.
+    const providers = new Set<string>();
+    for (const server of servers) {
+      for (const source of server.credential_sources ?? []) {
+        if (source.kind === "provider_connection" && source.provider) {
+          providers.add(source.provider);
+        }
+      }
+    }
+
+    const data: TokenProvider[] = Array.from(providers)
+      .map((provider) => ({ provider, name: getProviderDisplayName(provider) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error("[service-accounts/token-providers] failed:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to list token providers" },
+      { status: 503 },
+    );
+  }
+}

--- a/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/__tests__/channel-delete-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/__tests__/channel-delete-route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * DELETE /api/admin/slack/channels/[workspaceId]/[channelId].
+ *
+ * Hard-deletes a channel: sweeps every OpenFGA tuple referencing the channel
+ * (both directions) and purges its Mongo metadata. The OpenFGA sweep is the
+ * piece under test — `listChannelTuples` must:
+ *   - read the channel-as-object direction with `{ object: <channelRef> }`,
+ *   - read the channel-as-user direction once PER usable object type
+ *     (`{ object: "<type>:", user: <channelRef> }`) — OpenFGA /read rejects a
+ *     user-only filter, so a single combined read is impossible,
+ *   - union + dedup the results before deleting,
+ *   - abort (502) if the OpenFGA delete fails, leaving Mongo untouched.
+ */
+
+import { NextRequest } from "next/server";
+
+const mockReadOpenFgaTuples = jest.fn();
+const mockDeleteExactOpenFgaTuples = jest.fn();
+const mockDeleteSlackChannelAgentRoutes = jest.fn();
+const mockDeleteSlackChannelGrants = jest.fn();
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  readOpenFgaTuples: (...args: unknown[]) => mockReadOpenFgaTuples(...args),
+  deleteExactOpenFgaTuples: (...args: unknown[]) => mockDeleteExactOpenFgaTuples(...args),
+}));
+
+jest.mock("@/lib/rbac/slack-channel-grant-store", () => ({
+  deleteSlackChannelGrants: (...args: unknown[]) => mockDeleteSlackChannelGrants(...args),
+  slackChannelSubjectId: (ws: string, ch: string) => `${ws}--${ch}`,
+  slackWorkspaceRef: (ws: string) => ws,
+}));
+
+jest.mock("@/lib/rbac/slack-channel-route-store", () => ({
+  deleteSlackChannelAgentRoutes: (...args: unknown[]) => mockDeleteSlackChannelAgentRoutes(...args),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+// Auth wrapper: pass through to the handler (authorization is exercised
+// elsewhere; here we focus on the delete/sweep behavior).
+jest.mock("../../../_lib", () => ({
+  withSlackChannelRebacManageAuth: (
+    _request: unknown,
+    handler: () => Promise<unknown>,
+  ) => handler(),
+}));
+
+import { DELETE } from "../route";
+
+const WS = "T123";
+const CH = "C456";
+const CHANNEL_REF = `slack_channel:${WS}--${CH}`;
+const CHANNEL_USABLE_OBJECT_TYPES = ["agent", "mcp_server", "tool", "knowledge_base", "document", "skill"];
+
+function ctx() {
+  return { params: Promise.resolve({ workspaceId: WS, channelId: CH }) };
+}
+function req() {
+  return new NextRequest(new URL(`/api/admin/slack/channels/${WS}/${CH}`, "http://localhost:3000"), {
+    method: "DELETE",
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockReadOpenFgaTuples.mockResolvedValue({ tuples: [], continuationToken: undefined });
+  mockDeleteExactOpenFgaTuples.mockResolvedValue({ enabled: true, deletes: 0 });
+  mockDeleteSlackChannelAgentRoutes.mockResolvedValue(0);
+  mockDeleteSlackChannelGrants.mockResolvedValue(0);
+  mockGetCollection.mockResolvedValue({
+    deleteMany: jest.fn(async () => ({ deletedCount: 1 })),
+  });
+});
+
+describe("DELETE channel", () => {
+  it("reads channel-as-object once plus channel-as-user once per usable object type", async () => {
+    const res = await DELETE(req(), ctx());
+    expect(res.status).toBe(200);
+
+    // 1 channel-as-object read + one per usable type = 1 + N.
+    const tuples = mockReadOpenFgaTuples.mock.calls.map((c) => (c[0] as { tuple: unknown }).tuple);
+    expect(mockReadOpenFgaTuples).toHaveBeenCalledTimes(1 + CHANNEL_USABLE_OBJECT_TYPES.length);
+    // channel-as-object direction
+    expect(tuples).toContainEqual({ object: CHANNEL_REF });
+    // channel-as-user direction, one typed read each
+    for (const type of CHANNEL_USABLE_OBJECT_TYPES) {
+      expect(tuples).toContainEqual({ object: `${type}:`, user: CHANNEL_REF });
+    }
+  });
+
+  it("unions + dedupes tuples across reads before deleting", async () => {
+    const agentTuple = { user: CHANNEL_REF, relation: "user", object: "agent:incident" };
+    const teamTuple = { user: "team:eng#member", relation: "user", object: CHANNEL_REF };
+    // Same agentTuple returned by two different reads → must be deduped to one.
+    mockReadOpenFgaTuples.mockImplementation(async (opts: { tuple?: Record<string, string> }) => {
+      const t = opts.tuple ?? {};
+      if (t.object === CHANNEL_REF) return { tuples: [{ key: teamTuple }], continuationToken: undefined };
+      if (t.object === "agent:") return { tuples: [{ key: agentTuple }], continuationToken: undefined };
+      if (t.object === "tool:") return { tuples: [{ key: agentTuple }], continuationToken: undefined }; // dup
+      return { tuples: [], continuationToken: undefined };
+    });
+
+    await DELETE(req(), ctx());
+
+    expect(mockDeleteExactOpenFgaTuples).toHaveBeenCalledTimes(1);
+    const deleted = mockDeleteExactOpenFgaTuples.mock.calls[0][0] as unknown[];
+    expect(deleted).toHaveLength(2); // teamTuple + one agentTuple (dup removed)
+    expect(deleted).toContainEqual(agentTuple);
+    expect(deleted).toContainEqual(teamTuple);
+  });
+
+  it("aborts with 502 if the OpenFGA delete fails, before touching Mongo", async () => {
+    mockDeleteExactOpenFgaTuples.mockRejectedValue(new Error("openfga down"));
+    const deleteMany = jest.fn(async () => ({ deletedCount: 1 }));
+    mockGetCollection.mockResolvedValue({ deleteMany });
+
+    const res = await DELETE(req(), ctx());
+
+    expect(res.status).toBe(502);
+    expect(deleteMany).not.toHaveBeenCalled();
+    expect(mockDeleteSlackChannelAgentRoutes).not.toHaveBeenCalled();
+    expect(mockDeleteSlackChannelGrants).not.toHaveBeenCalled();
+  });
+
+  it("purges Mongo metadata (mappings, routes, grants) after a successful OpenFGA delete", async () => {
+    const deleteMany = jest.fn(async () => ({ deletedCount: 1 }));
+    mockGetCollection.mockResolvedValue({ deleteMany });
+
+    const res = await DELETE(req(), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(deleteMany).toHaveBeenCalled(); // channel_team_mappings purge
+    expect(mockDeleteSlackChannelAgentRoutes).toHaveBeenCalledWith(WS, CH);
+    expect(mockDeleteSlackChannelGrants).toHaveBeenCalledWith(WS, CH);
+    expect(body.data.deleted.channel_id).toBe(CH);
+  });
+});

--- a/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/route.ts
+++ b/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/route.ts
@@ -33,18 +33,21 @@ async function readAllTuples(filter: Partial<OpenFgaTupleKey>): Promise<OpenFgaT
 }
 
 // Every tuple touching a channel encodes it as `slack_channel:<ws>--<ch>` —
-// either in the `user` field (channel→resource grants, e.g. the channel may
-// `use` agent:x) or in the `object` field (team→channel visibility, e.g.
-// team:<slug>#member is a `user` of the channel). Two server-side filtered
-// reads (by user, by object) scope the scan to this channel's tuples instead
-// of paging the whole store; we union and dedup the two directions.
+// either in the `object` field (team→channel visibility, e.g. team:<slug>#member
+// is a `user` of the channel) or in the `user` field (channel→resource grants,
+// e.g. the channel may `use` agent:x). To enumerate ALL of a channel's tuples
+// we issue: one read filtered by `{ object: <channelRef> }` (channel-as-object),
+// plus one read per usable object type filtered by `{ object: "<type>:", user:
+// <channelRef> }` (channel-as-user). OpenFGA's /read requires an object TYPE in
+// the filter — a user-only filter 400s ("object type field is required") — which
+// is why the channel-as-user direction fans out per type. Results are unioned
+// and deduped.
+//
 // Object types a slack_channel can be granted access to (i.e. types where the
 // channel appears as the tuple `user`). Derived from the authorization model's
-// directly_related_user_types that reference slack_channel. OpenFGA's /read
-// requires an object TYPE in the filter, so to find "tuples where this channel
-// is the user" we must scope each read to a specific object type — a user-only
-// filter 400s ("object type field is required"). Keep this in sync with the
-// model if a new resource type starts granting slack_channel subjects.
+// directly_related_user_types that reference slack_channel; a drift test
+// (slack-channel-usable-types-drift.test.ts) asserts this list matches the model
+// so a newly-grantable type can't be silently missed by the channel-delete sweep.
 const CHANNEL_USABLE_OBJECT_TYPES = [
   "agent",
   "mcp_server",
@@ -53,6 +56,8 @@ const CHANNEL_USABLE_OBJECT_TYPES = [
   "document",
   "skill",
 ] as const;
+
+export { CHANNEL_USABLE_OBJECT_TYPES };
 
 async function listChannelTuples(workspaceId: string, channelId: string): Promise<OpenFgaTupleKey[]> {
   const channelRef = `slack_channel:${slackChannelSubjectId(workspaceId, channelId)}`;

--- a/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/route.ts
+++ b/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/route.ts
@@ -38,15 +38,37 @@ async function readAllTuples(filter: Partial<OpenFgaTupleKey>): Promise<OpenFgaT
 // team:<slug>#member is a `user` of the channel). Two server-side filtered
 // reads (by user, by object) scope the scan to this channel's tuples instead
 // of paging the whole store; we union and dedup the two directions.
+// Object types a slack_channel can be granted access to (i.e. types where the
+// channel appears as the tuple `user`). Derived from the authorization model's
+// directly_related_user_types that reference slack_channel. OpenFGA's /read
+// requires an object TYPE in the filter, so to find "tuples where this channel
+// is the user" we must scope each read to a specific object type — a user-only
+// filter 400s ("object type field is required"). Keep this in sync with the
+// model if a new resource type starts granting slack_channel subjects.
+const CHANNEL_USABLE_OBJECT_TYPES = [
+  "agent",
+  "mcp_server",
+  "tool",
+  "knowledge_base",
+  "document",
+  "skill",
+] as const;
+
 async function listChannelTuples(workspaceId: string, channelId: string): Promise<OpenFgaTupleKey[]> {
   const channelRef = `slack_channel:${slackChannelSubjectId(workspaceId, channelId)}`;
-  const [asUser, asObject] = await Promise.all([
-    readAllTuples({ user: channelRef }),
+  const reads = await Promise.all([
+    // Channel-as-object: team→channel visibility tuples (channel is the object).
+    // A bare object filter is valid because channelRef carries its type.
     readAllTuples({ object: channelRef }),
+    // Channel-as-user: channel→resource grants, one read per usable object type
+    // (OpenFGA needs the object type; `<type>:` + user returns all such tuples).
+    ...CHANNEL_USABLE_OBJECT_TYPES.map((type) =>
+      readAllTuples({ object: `${type}:`, user: channelRef }),
+    ),
   ]);
   const seen = new Set<string>();
   const matches: OpenFgaTupleKey[] = [];
-  for (const key of [...asUser, ...asObject]) {
+  for (const key of reads.flat()) {
     const dedup = `${key.user}\n${key.relation}\n${key.object}`;
     if (seen.has(dedup)) continue;
     seen.add(dedup);

--- a/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/routes/route.ts
+++ b/ui/src/app/api/admin/slack/channels/[workspaceId]/[channelId]/routes/route.ts
@@ -93,8 +93,15 @@ async function listOpenFgaChannelAgentIds(workspaceId: string, channelId: string
   const seen = new Set<string>();
   let continuationToken: string | undefined;
   do {
+    // OpenFGA's /read requires an OBJECT TYPE in the tuple_key filter — a
+    // user-only (or user+relation) filter 400s with "object type field is
+    // required". We only want agents this channel can use, so scope the read to
+    // the `agent:` object type with the channel as `user`. OpenFGA accepts an
+    // object type prefix with an empty id (`agent:`) plus a user, returning all
+    // agent tuples for that subject. (The earlier `{ user, relation: "user" }`
+    // and `{ user }` forms were both rejected by this OpenFGA version.)
     const result = await readOpenFgaTuples({
-      tuple: { user: subject, relation: "user" },
+      tuple: { object: "agent:", user: subject },
       pageSize: 100,
       ...(continuationToken ? { continuationToken } : {}),
     });

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -512,9 +512,12 @@ describe("Slack channel ReBAC APIs", () => {
     ]);
     expect(mockReadOpenFgaTuples).toHaveBeenCalledWith({
       pageSize: 100,
-      // SEC-6: the read is now scoped to the channel subject server-side
-      // instead of fetching all tuples and filtering in JS.
-      tuple: { user: `slack_channel:${workspaceAlias}--${channelId}`, relation: "user" },
+      // SEC-6: the read is scoped server-side instead of fetching all tuples and
+      // filtering in JS. OpenFGA /read requires an object TYPE in the filter (a
+      // user-only or user+relation filter 400s with "object type field is
+      // required"), so we scope to the `agent:` object type with the channel as
+      // `user`; the agent id is recovered in-memory via agentIdFromObject.
+      tuple: { object: "agent:", user: `slack_channel:${workspaceAlias}--${channelId}` },
     });
   });
 

--- a/ui/src/app/api/admin/slack/channels/__tests__/slack-channel-usable-types-drift.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/slack-channel-usable-types-drift.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Drift guard for CHANNEL_USABLE_OBJECT_TYPES.
+ *
+ * The channel-delete handler (`[workspaceId]/[channelId]/route.ts`) sweeps every
+ * OpenFGA tuple where a slack_channel is the `user` (channel→resource grants) so
+ * deleting a channel fully cleans up its grants. OpenFGA's /read requires an
+ * object TYPE in the filter, so that sweep fans out one read per type in
+ * CHANNEL_USABLE_OBJECT_TYPES. If a new resource type starts granting
+ * slack_channel subjects in the model but isn't added to that list, channel
+ * delete would silently orphan those tuples.
+ *
+ * This test derives the authoritative set from the deployed chart model
+ * (authorization-model.json — the one the running stack imports) by collecting
+ * every type whose metadata lists `slack_channel` as a directly-related user
+ * type, and asserts it matches CHANNEL_USABLE_OBJECT_TYPES exactly.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { CHANNEL_USABLE_OBJECT_TYPES } from "../[workspaceId]/[channelId]/route";
+
+// __dirname = ui/src/app/api/admin/slack/channels/__tests__ → 8 levels to repo root.
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..", "..", "..", "..", "..");
+const CHART_JSON = join(
+  REPO_ROOT,
+  "charts",
+  "ai-platform-engineering",
+  "charts",
+  "openfga",
+  "authorization-model.json",
+);
+
+interface ModelRelationMeta {
+  directly_related_user_types?: Array<{ type?: string; relation?: string; wildcard?: unknown }>;
+}
+interface ModelTypeDef {
+  type: string;
+  metadata?: { relations?: Record<string, ModelRelationMeta> };
+}
+
+function typesGrantingSlackChannel(): string[] {
+  const model = JSON.parse(readFileSync(CHART_JSON, "utf8")) as {
+    type_definitions?: ModelTypeDef[];
+    authorization_model?: { type_definitions?: ModelTypeDef[] };
+  };
+  const defs = model.type_definitions ?? model.authorization_model?.type_definitions ?? [];
+  const types = new Set<string>();
+  for (const def of defs) {
+    const relations = def.metadata?.relations ?? {};
+    for (const meta of Object.values(relations)) {
+      for (const dut of meta.directly_related_user_types ?? []) {
+        if (dut.type === "slack_channel") {
+          types.add(def.type);
+        }
+      }
+    }
+  }
+  return Array.from(types);
+}
+
+describe("CHANNEL_USABLE_OBJECT_TYPES drift", () => {
+  it("matches every model type that grants slack_channel as a subject", () => {
+    const fromModel = typesGrantingSlackChannel().sort();
+    const fromCode = [...CHANNEL_USABLE_OBJECT_TYPES].sort();
+    expect(fromCode).toEqual(fromModel);
+  });
+
+  it("is non-empty (sanity: the model still grants slack_channel somewhere)", () => {
+    expect(typesGrantingSlackChannel().length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/app/api/credentials/exchange/__tests__/service-account.test.ts
+++ b/ui/src/app/api/credentials/exchange/__tests__/service-account.test.ts
@@ -141,7 +141,7 @@ describe("/api/credentials/exchange — service account caller", () => {
     });
   });
 
-  it("calls requireResourcePermission when SA fetches another principal's connection by id", async () => {
+  it("calls requireResourcePermission with isServiceAccount:true when SA fetches another principal's connection by id", async () => {
     // Connection belongs to a different service account
     mockGetConnection.mockResolvedValue({
       ...SA_CONN,
@@ -156,10 +156,47 @@ describe("/api/credentials/exchange — service account caller", () => {
       ),
     );
 
+    // Must forward isServiceAccount:true so subjectFromSession graphs the caller
+    // as `service_account:<sub>` — matching the OpenFGA tuple — not `user:<sub>`.
     expect(mockRequireResourcePermission).toHaveBeenCalledWith(
-      { sub: SA_SUB, user: { email: expect.any(String) } },
+      { sub: SA_SUB, user: { email: expect.any(String) }, isServiceAccount: true },
       { type: "secret_ref", id: "provider_connection:sa-conn-1", action: "use" },
     );
+  });
+
+  it("SA WITH a service_account secret_ref#use grant is allowed to fetch another principal's connection", async () => {
+    // Connection belongs to a user, not the SA
+    mockGetConnection.mockResolvedValue({
+      ...SA_CONN,
+      id: "user-conn-99",
+      owner: { type: "user", id: "human-user-sub" },
+    });
+    // OpenFGA has granted service_account:<SA_SUB> can_use secret_ref:provider_connection:user-conn-99
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockRefreshConnection.mockResolvedValue({ accessToken: "delegated-token", expiresIn: 3600 });
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      request(
+        { provider_connection_id: "user-conn-99", intended_use: "mcp_server" },
+        SERVICE_HEADERS,
+      ),
+    );
+
+    // requireResourcePermission must be called with isServiceAccount:true so the
+    // correct service_account:<sub> subject is used in the OpenFGA check.
+    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: SA_SUB, isServiceAccount: true }),
+      { type: "secret_ref", id: "provider_connection:user-conn-99", action: "use" },
+    );
+    // With the grant resolving, the request must succeed and return the token.
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        provider_connection_id: "user-conn-99",
+        access_token: "delegated-token",
+      },
+    });
   });
 
   it("404 when no connected SA-owned connection exists for the provider", async () => {
@@ -201,5 +238,38 @@ describe("/api/credentials/exchange — service account caller", () => {
       id: "user-sub-42",
     });
     expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("user caller fetching a cross-principal connection passes isServiceAccount:false (not true)", async () => {
+    // User identity
+    mockValidateBearerJWT.mockResolvedValue({
+      sub: "user-sub-42",
+      email: "alice@example.test",
+      isServiceAccount: false,
+    });
+    // Connection belongs to a different user
+    mockGetConnection.mockResolvedValue({
+      id: "other-user-conn-5",
+      connectorId: "connector-github",
+      provider: "github",
+      owner: { type: "user", id: "other-user-sub" },
+      status: "connected",
+    });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockRefreshConnection.mockResolvedValue({ accessToken: "cross-token", expiresIn: 3600 });
+
+    const { POST } = await import("../route");
+    await POST(
+      request(
+        { provider_connection_id: "other-user-conn-5", intended_use: "mcp_server" },
+        SERVICE_HEADERS,
+      ),
+    );
+
+    // isServiceAccount must NOT be true — caller is a user, not a service account.
+    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ isServiceAccount: true }),
+      { type: "secret_ref", id: "provider_connection:other-user-conn-5", action: "use" },
+    );
   });
 });

--- a/ui/src/app/api/credentials/exchange/__tests__/service-account.test.ts
+++ b/ui/src/app/api/credentials/exchange/__tests__/service-account.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for the SA-caller path of POST /api/credentials/exchange.
+ *
+ * Verifies that a Keycloak service-account token (identity.isServiceAccount=true)
+ * resolves connections keyed by owner.type="service_account" and passes the
+ * cross-owner guard without requiring an explicit `use` permission when the
+ * connection belongs to the calling subject.
+ */
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    statusCode: number;
+    code?: string;
+    constructor(message: string, statusCode = 500, code?: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+    }
+  }
+  return {
+    ApiError,
+    successResponse: (data: unknown, status = 200) => ({
+      status,
+      json: async () => ({ success: true, data }),
+    }),
+    withErrorHandler: (handler: unknown) => handler,
+  };
+});
+
+const mockRefreshConnection = jest.fn();
+const mockGetConnection = jest.fn();
+const mockListConnections = jest.fn();
+const mockValidateBearerJWT = jest.fn();
+const mockRequireResourcePermission = jest.fn();
+
+jest.mock("@/lib/credentials/oauth-service-factory", () => ({
+  getProviderConnectionService: jest.fn(async () => ({
+    getConnection: mockGetConnection,
+    listConnections: mockListConnections,
+    refreshConnection: mockRefreshConnection,
+  })),
+}));
+
+jest.mock("@/lib/jwt-validation", () => ({
+  validateBearerJWT: (...args: unknown[]) => mockValidateBearerJWT(...args),
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+}));
+
+const SA_SUB = "sa-bot-sub-123";
+
+const SA_CONN = {
+  id: "sa-conn-1",
+  connectorId: "connector-gitlab",
+  provider: "gitlab",
+  owner: { type: "service_account", id: SA_SUB },
+  status: "connected",
+};
+
+function request(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    headers: new Headers(headers),
+    json: async () => body,
+    url: "http://localhost/api/credentials/exchange",
+  } as never;
+}
+
+const SERVICE_HEADERS = {
+  authorization: "Bearer sa-token",
+  "x-caipe-credential-caller": "dynamic_agent",
+  "x-caipe-credential-audience": "caipe-credential-service",
+};
+
+describe("/api/credentials/exchange — service account caller", () => {
+  beforeEach(() => {
+    process.env.CAIPE_CREDENTIALS_ENABLED = "true";
+    jest.clearAllMocks();
+    // Identity is an SA (isServiceAccount: true)
+    mockValidateBearerJWT.mockResolvedValue({
+      sub: SA_SUB,
+      email: `service-account-bot@keycloak.local`,
+      isServiceAccount: true,
+    });
+    mockRefreshConnection.mockResolvedValue({ accessToken: "sa-fresh-token", expiresIn: 3600 });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+  });
+
+  it("resolves connection by provider using service_account owner type", async () => {
+    mockListConnections.mockResolvedValue([SA_CONN]);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      request(
+        { provider: "gitlab", intended_use: "mcp_server" },
+        SERVICE_HEADERS,
+      ),
+    );
+
+    // Must list by service_account owner, not user
+    expect(mockListConnections).toHaveBeenCalledWith({
+      type: "service_account",
+      id: SA_SUB,
+    });
+    expect(mockRefreshConnection).toHaveBeenCalledWith("sa-conn-1");
+    // Must NOT require extra permission (SA owns its own connection)
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        provider: "gitlab",
+        provider_connection_id: "sa-conn-1",
+        access_token: "sa-fresh-token",
+        expires_in: 3600,
+      },
+    });
+  });
+
+  it("resolves connection by provider_connection_id for an SA caller", async () => {
+    mockGetConnection.mockResolvedValue(SA_CONN);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      request(
+        { provider_connection_id: "sa-conn-1", intended_use: "mcp_server" },
+        SERVICE_HEADERS,
+      ),
+    );
+
+    expect(mockGetConnection).toHaveBeenCalledWith("sa-conn-1");
+    expect(mockListConnections).not.toHaveBeenCalled();
+    // SA is the owner → no requireResourcePermission
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { provider_connection_id: "sa-conn-1", access_token: "sa-fresh-token" },
+    });
+  });
+
+  it("calls requireResourcePermission when SA fetches another principal's connection by id", async () => {
+    // Connection belongs to a different service account
+    mockGetConnection.mockResolvedValue({
+      ...SA_CONN,
+      owner: { type: "service_account", id: "other-sa-sub" },
+    });
+
+    const { POST } = await import("../route");
+    await POST(
+      request(
+        { provider_connection_id: "sa-conn-1", intended_use: "mcp_server" },
+        SERVICE_HEADERS,
+      ),
+    );
+
+    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
+      { sub: SA_SUB, user: { email: expect.any(String) } },
+      { type: "secret_ref", id: "provider_connection:sa-conn-1", action: "use" },
+    );
+  });
+
+  it("404 when no connected SA-owned connection exists for the provider", async () => {
+    mockListConnections.mockResolvedValue([]); // No connection found
+
+    const { POST } = await import("../route");
+    await expect(
+      POST(
+        request({ provider: "gitlab", intended_use: "mcp_server" }, SERVICE_HEADERS),
+      ),
+    ).rejects.toMatchObject({ statusCode: 404, code: "CREDENTIAL_NOT_FOUND" });
+  });
+
+  it("user caller still uses user owner type (regression guard)", async () => {
+    // A regular user identity (not an SA)
+    mockValidateBearerJWT.mockResolvedValue({
+      sub: "user-sub-42",
+      email: "alice@example.test",
+      isServiceAccount: false,
+    });
+    mockListConnections.mockResolvedValue([
+      {
+        id: "user-conn-1",
+        connectorId: "connector-github",
+        provider: "github",
+        owner: { type: "user", id: "user-sub-42" },
+        status: "connected",
+      },
+    ]);
+    mockRefreshConnection.mockResolvedValue({ accessToken: "user-token", expiresIn: 3600 });
+
+    const { POST } = await import("../route");
+    await POST(
+      request({ provider: "github", intended_use: "mcp_server" }, SERVICE_HEADERS),
+    );
+
+    expect(mockListConnections).toHaveBeenCalledWith({
+      type: "user",
+      id: "user-sub-42",
+    });
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/credentials/exchange/route.ts
+++ b/ui/src/app/api/credentials/exchange/route.ts
@@ -30,16 +30,27 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError("provider_connection_id or provider is required", 400, "VALIDATION_ERROR");
   }
 
+  // Determine the owner type for subject-keyed lookup: Keycloak service-account
+  // tokens carry `preferred_username = "service-account-<clientId>"` and have
+  // identity.isServiceAccount === true (see jwt-validation.ts:247).
+  const ownerType = identity.isServiceAccount === true ? "service_account" : "user";
+
   const service = await getProviderConnectionService();
   const connection = providerConnectionId
     ? await service.getConnection(providerConnectionId)
-    : (await service.listConnections({ type: "user", id: identity.sub })).find(
+    : (await service.listConnections({ type: ownerType, id: identity.sub })).find(
         (candidate) => candidate.provider === provider && candidate.status === "connected",
       );
   if (!connection) {
     throw new ApiError("Provider connection was not found", 404, "CREDENTIAL_NOT_FOUND");
   }
-  if (connection.owner.type !== "user" || connection.owner.id !== identity.sub) {
+  // Owner guard: the connection must belong to the calling subject. An SA caller
+  // must own a service_account-typed connection; a user caller must own a
+  // user-typed connection. If the types/ids differ the caller is fetching
+  // another principal's connection — require explicit `use` permission instead.
+  const callerOwnsConnection =
+    connection.owner.type === ownerType && connection.owner.id === identity.sub;
+  if (!callerOwnsConnection) {
     await requireResourcePermission(
       { sub: identity.sub, user: { email: identity.email } },
       { type: "secret_ref", id: `provider_connection:${connection.id}`, action: "use" },

--- a/ui/src/app/api/credentials/exchange/route.ts
+++ b/ui/src/app/api/credentials/exchange/route.ts
@@ -52,7 +52,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     connection.owner.type === ownerType && connection.owner.id === identity.sub;
   if (!callerOwnsConnection) {
     await requireResourcePermission(
-      { sub: identity.sub, user: { email: identity.email } },
+      { sub: identity.sub, user: { email: identity.email }, isServiceAccount: identity.isServiceAccount },
       { type: "secret_ref", id: `provider_connection:${connection.id}`, action: "use" },
     );
   }

--- a/ui/src/components/admin/ServiceAccountsTab.tsx
+++ b/ui/src/components/admin/ServiceAccountsTab.tsx
@@ -9,11 +9,10 @@
 // their teams, scoped only to agents/tools they themselves hold, and reveals
 // the credential EXACTLY ONCE (FR-005 — never re-fetchable).
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Bot,
   KeyRound,
-  Link2,
   Loader2,
   Plus,
   RefreshCw,
@@ -34,12 +33,10 @@ import {
 } from "@/components/ui/dialog";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
+import { ProviderSelect, type ProviderOption } from "@/components/ui/provider-select";
 import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
-import {
-  PROVIDER_DISPLAY_LIST,
-  getProviderDisplayName,
-} from "@/lib/credentials/provider-display-names";
+import { getProviderDisplayName } from "@/lib/credentials/provider-display-names";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types (mirror the BFF contract; never include secret material on list/detail)
@@ -107,11 +104,6 @@ interface ServiceAccountCredential {
   connectorId?: string;
 }
 
-// Use the shared provider-display-names module (ui/src/lib/credentials/provider-display-names.ts)
-// as the single source of truth for the 5 built-in providers and their display names.
-// That module is plain-data with no browser or next/server imports, so it is safe
-// for "use client" components.
-const BUILT_IN_PROVIDERS = PROVIDER_DISPLAY_LIST;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Component
@@ -637,14 +629,26 @@ function ManageServiceAccountDialog({
   const [addAgents, setAddAgents] = useState<string[]>([]);
   const [addTools, setAddTools] = useState<string[]>([]);
 
-  // ── Credentials section state ──────────────────────────────────────────────
+  // ── Tokens section state ───────────────────────────────────────────────────
   const [credentials, setCredentials] = useState<ServiceAccountCredential[]>([]);
   const [credLoading, setCredLoading] = useState(false);
   const [credBusy, setCredBusy] = useState(false);
   const [credError, setCredError] = useState<string | null>(null);
   const [pendingRemoveCred, setPendingRemoveCred] = useState<string | null>(null);
-  const [addCredProvider, setAddCredProvider] = useState<string>(BUILT_IN_PROVIDERS[0].provider);
+  // The selectable providers are the platform's *enabled, token-capable* MCP
+  // servers (#3) — fetched from /api/admin/service-accounts/token-providers,
+  // which derives the list from enabled mcp_servers that declare a
+  // provider_connection credential source. Enable only the GitLab MCP and only
+  // GitLab shows up. (Deliberately NOT the OAuth-connector list — PATs need no
+  // OAuth app, so a missing GitLab OAuth app must not hide GitLab here.)
+  const [providerOptions, setProviderOptions] = useState<ProviderOption[]>([]);
+  const [addCredProvider, setAddCredProvider] = useState<string>("");
   const [addCredToken, setAddCredToken] = useState("");
+  // Whether the SA Tokens surface is enabled at all. The token-providers route
+  // returns 404 when CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED is off; in that case
+  // we hide the entire Tokens section rather than show an empty one. Defaults
+  // to true (optimistic) so the section renders while loading.
+  const [tokensEnabled, setTokensEnabled] = useState(true);
 
   const refreshCredentials = useCallback(async () => {
     if (!saId) return;
@@ -654,15 +658,62 @@ function ManageServiceAccountDialog({
     // fetch, so a successful refresh wipes the error too.
     setCredError(null);
     try {
-      const res = await fetch(
-        `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
-      ).then((r) => r.json()).catch(() => ({ success: false }));
-      if (res.success) setCredentials(res.data as ServiceAccountCredential[]);
-      else setCredError(res.error || "Failed to load credentials");
+      // Load the SA's existing tokens and the token-capable provider list in
+      // parallel. The provider list drives the Add-token dropdown (#3).
+      const [credRes, providerRes] = await Promise.all([
+        fetch(
+          `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
+        ).then((r) => r.json()).catch(() => ({ success: false })),
+        fetch("/api/admin/service-accounts/token-providers")
+          .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({ success: false })) }))
+          .catch(() => ({ status: 0, body: { success: false } })),
+      ]);
+      // A 404 from token-providers means the SA Tokens feature is disabled —
+      // hide the whole section. Any other failure leaves the section visible.
+      if (providerRes.status === 404) {
+        setTokensEnabled(false);
+        return;
+      }
+      setTokensEnabled(true);
+      if (credRes.success) setCredentials(credRes.data as ServiceAccountCredential[]);
+      else setCredError(credRes.error || "Failed to load tokens");
+      if (providerRes.body.success && Array.isArray(providerRes.body.data)) {
+        const opts: ProviderOption[] = (
+          providerRes.body.data as Array<{ provider: string; name: string }>
+        ).map((c) => ({ provider: c.provider, name: c.name }));
+        setProviderOptions(opts);
+        // The picker's default/valid selection is maintained by the
+        // availableProviders effect below (which also excludes already-used
+        // providers), so we don't set addCredProvider here.
+      }
     } finally {
       setCredLoading(false);
     }
   }, [saId]);
+
+  // Only offer providers that don't already have a token on this SA — a single
+  // SA holds at most one token per provider (the backend also rejects a second
+  // with 409), so a provider already in the list is removed from the dropdown,
+  // mirroring how the scope section hides already-granted scopes.
+  const usedProviders = useMemo(
+    () => new Set(credentials.map((c) => c.provider)),
+    [credentials],
+  );
+  const availableProviders = useMemo(
+    () => providerOptions.filter((p) => !usedProviders.has(p.provider)),
+    [providerOptions, usedProviders],
+  );
+  // Keep the picker selection valid: if the chosen provider just got a token (or
+  // isn't selectable), fall back to the first still-available provider.
+  useEffect(() => {
+    if (availableProviders.length === 0) {
+      if (addCredProvider !== "") setAddCredProvider("");
+      return;
+    }
+    if (!availableProviders.some((p) => p.provider === addCredProvider)) {
+      setAddCredProvider(availableProviders[0].provider);
+    }
+  }, [availableProviders, addCredProvider]);
 
   const refresh = useCallback(async () => {
     if (!saId) return;
@@ -1054,26 +1105,31 @@ function ManageServiceAccountDialog({
               </div>
             )}
 
-            {/* ── Provider credentials ─────────────────────────────────────── */}
+            {/* ── Tokens ───────────────────────────────────────────────────── */}
+            {/* Hidden entirely when the SA Tokens surface is disabled
+                (CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED=false → token-providers 404). */}
+            {tokensEnabled && (
             <div className="space-y-2 border-t pt-3">
               <div className="flex items-center gap-1.5">
-                <Link2 className="h-4 w-4 text-muted-foreground" />
-                <span className="text-sm font-medium">Provider credentials</span>
+                <KeyRound className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Tokens</span>
               </div>
               <p className="text-xs text-muted-foreground">
-                Paste a provider access token to let this service account use its own
-                credential for that provider. If no credential is set, the shared org
-                token is used as a fallback — the same behaviour as for user accounts.
+                Add a personal/project access token so this service account uses its
+                own token when an agent calls that provider&apos;s tools. If no token
+                is set for a provider, the platform falls back to the shared org token
+                (if one is configured) — the same behaviour as for user accounts.
               </p>
 
-              {/* Current credentials list */}
+              {/* Current tokens list */}
               {credLoading ? (
                 <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading credentials…
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading tokens…
                 </div>
               ) : credentials.length === 0 ? (
                 <p className="text-sm text-muted-foreground">
-                  No provider credentials — org fallback will be used for all providers.
+                  No tokens added — this service account uses the shared org token
+                  (if configured) for every provider.
                 </p>
               ) : (
                 <ul className="space-y-1">
@@ -1145,51 +1201,68 @@ function ManageServiceAccountDialog({
                 </ul>
               )}
 
-              {/* Add credential form */}
+              {/* Add token form */}
               <div className="space-y-2 rounded-md border border-dashed border-input p-3">
-                <span className="text-sm font-medium">Add a credential</span>
+                <span className="text-sm font-medium">Add a token</span>
                 <p className="text-xs text-muted-foreground">
                   The token is stored encrypted and is <span className="font-semibold">never shown again</span> after
                   submission.
                 </p>
-                <div className="flex gap-2">
-                  <select
-                    aria-label="Provider"
-                    value={addCredProvider}
-                    onChange={(e) => setAddCredProvider(e.target.value)}
-                    className="h-9 rounded-md border border-input bg-background px-2 text-sm"
-                  >
-                    {BUILT_IN_PROVIDERS.map((p) => (
-                      <option key={p.provider} value={p.provider}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </select>
-                  {/* autoComplete="new-password" is intentional: suppresses
-                      password-manager autofill for this pasted external token
-                      field — we do not want saved login credentials injected. */}
-                  <input
-                    type="password"
-                    aria-label="Access token"
-                    value={addCredToken}
-                    onChange={(e) => setAddCredToken(e.target.value)}
-                    placeholder="Paste access token…"
-                    autoComplete="new-password"
-                    className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm"
-                  />
-                  <Button
-                    onClick={addCredential}
-                    disabled={credBusy || !addCredToken.trim()}
-                    className="gap-1.5"
-                  >
-                    {credBusy ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Plus className="h-4 w-4" />
-                    )}
-                    Add
-                  </Button>
-                </div>
+                {providerOptions.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No token-capable integrations are enabled on this platform. Ask
+                    an admin to enable an MCP server that supports token passthrough
+                    (e.g. GitLab) before adding a token.
+                  </p>
+                ) : availableProviders.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    A token has been added for every available provider. Remove one
+                    above to replace it.
+                  </p>
+                ) : (
+                  <div className="flex gap-2">
+                    <ProviderSelect
+                      options={availableProviders}
+                      value={addCredProvider}
+                      onChange={setAddCredProvider}
+                      disabled={credBusy}
+                    />
+                    {/* This is a pasted external token — we want NO browser
+                        autocomplete/autofill of any kind (no saved-password
+                        injection, no "save password" prompt, no generation).
+                        autoComplete="off" is the primary signal; the extra
+                        attrs defeat heuristic autofill in browsers that ignore
+                        "off" on password-type inputs:
+                          - data-1p-ignore / data-lpignore: 1Password / LastPass
+                          - data-form-type="other": Dashlane
+                          - name="" so there's no field name to match a saved entry. */}
+                    <input
+                      type="password"
+                      name=""
+                      aria-label="Access token"
+                      value={addCredToken}
+                      onChange={(e) => setAddCredToken(e.target.value)}
+                      placeholder="Paste access token…"
+                      autoComplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
+                      data-form-type="other"
+                      className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                    />
+                    <Button
+                      onClick={addCredential}
+                      disabled={credBusy || !addCredToken.trim() || !addCredProvider}
+                      className="gap-1.5"
+                    >
+                      {credBusy ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Plus className="h-4 w-4" />
+                      )}
+                      Add
+                    </Button>
+                  </div>
+                )}
               </div>
 
               {credError && (
@@ -1198,6 +1271,7 @@ function ManageServiceAccountDialog({
                 </div>
               )}
             </div>
+            )}
 
             {/* Credential lifecycle (rotate / revoke). Both are destructive and
                 spec'd "with confirm" (T032) / "delete-confirm" (T028), so each

--- a/ui/src/components/admin/ServiceAccountsTab.tsx
+++ b/ui/src/components/admin/ServiceAccountsTab.tsx
@@ -36,6 +36,10 @@ import { MultiSelect } from "@/components/ui/multi-select";
 import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
+import {
+  PROVIDER_DISPLAY_LIST,
+  getProviderDisplayName,
+} from "@/lib/credentials/provider-display-names";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types (mirror the BFF contract; never include secret material on list/detail)
@@ -103,15 +107,11 @@ interface ServiceAccountCredential {
   connectorId?: string;
 }
 
-// The 5 built-in providers (kept local to avoid importing the lib file from a client component
-// that lives outside app/ — this avoids a cross-boundary import warning from Next.js).
-const BUILT_IN_PROVIDERS: { provider: string; name: string }[] = [
-  { provider: "github", name: "GitHub" },
-  { provider: "gitlab", name: "GitLab" },
-  { provider: "atlassian", name: "Atlassian Cloud" },
-  { provider: "webex", name: "Webex" },
-  { provider: "pagerduty", name: "PagerDuty" },
-];
+// Use the shared provider-display-names module (ui/src/lib/credentials/provider-display-names.ts)
+// as the single source of truth for the 5 built-in providers and their display names.
+// That module is plain-data with no browser or next/server imports, so it is safe
+// for "use client" components.
+const BUILT_IN_PROVIDERS = PROVIDER_DISPLAY_LIST;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Component
@@ -643,12 +643,16 @@ function ManageServiceAccountDialog({
   const [credBusy, setCredBusy] = useState(false);
   const [credError, setCredError] = useState<string | null>(null);
   const [pendingRemoveCred, setPendingRemoveCred] = useState<string | null>(null);
-  const [addCredProvider, setAddCredProvider] = useState(BUILT_IN_PROVIDERS[0].provider);
+  const [addCredProvider, setAddCredProvider] = useState<string>(BUILT_IN_PROVIDERS[0].provider);
   const [addCredToken, setAddCredToken] = useState("");
 
   const refreshCredentials = useCallback(async () => {
     if (!saId) return;
     setCredLoading(true);
+    // M-2: clear any stale error banner on a successful (re)load — mirrors how
+    // addCredential/removeCredential already call setCredError(null) before their
+    // fetch, so a successful refresh wipes the error too.
+    setCredError(null);
     try {
       const res = await fetch(
         `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
@@ -818,24 +822,38 @@ function ManageServiceAccountDialog({
     if (!saId || !addCredToken.trim()) return;
     setCredBusy(true);
     setCredError(null);
+    // M-1: snapshot the token BEFORE any await so the request body is stable
+    // regardless of when React flushes state. The token is cleared from state
+    // ONLY on success (after refreshCredentials) — clearing on entry would wipe
+    // the pasted value if the request fails and force a re-paste. Matches the
+    // pattern in SecretsManager.tsx (handleCreate).
     const tokenSnapshot = addCredToken;
-    // Drop the token from state immediately — it must not persist in memory
-    // after the request is sent (shown-once safety).
-    setAddCredToken("");
     try {
-      const res = await fetch(
-        `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ provider: addCredProvider, token: tokenSnapshot }),
-        },
-      );
-      const body = await res.json();
+      let res: Response;
+      try {
+        res = await fetch(
+          `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ provider: addCredProvider, token: tokenSnapshot }),
+          },
+        );
+      } catch (networkErr) {
+        // Network-level failure (no response) — surface as a credError instead
+        // of an unhandled rejection.
+        setCredError(
+          networkErr instanceof Error ? networkErr.message : "Network error — please retry",
+        );
+        return;
+      }
+      const body = (await res.json()) as { success: boolean; error?: string };
       if (!res.ok || !body.success) {
         setCredError(body.error || "Failed to add credential");
         return;
       }
+      // Success — safe to clear the token from state now.
+      setAddCredToken("");
       await refreshCredentials();
     } finally {
       setCredBusy(false);
@@ -903,7 +921,9 @@ function ManageServiceAccountDialog({
             </div>
           </div>
         ) : (
-          <div className="space-y-4">
+          // Dialog scroll: cap height and let content scroll vertically so the
+          // dialog doesn't overflow the viewport when credentials + scopes stack up.
+          <div className="max-h-[65vh] overflow-y-auto space-y-4 pr-1">
             {/* Current scopes */}
             <div className="space-y-2">
               <span className="text-sm font-medium">Current scopes</span>
@@ -1058,9 +1078,7 @@ function ManageServiceAccountDialog({
               ) : (
                 <ul className="space-y-1">
                   {credentials.map((cred) => {
-                    const providerLabel =
-                      BUILT_IN_PROVIDERS.find((p) => p.provider === cred.provider)?.name ??
-                      cred.provider;
+                    const providerLabel = getProviderDisplayName(cred.provider);
                     const isPendingRemove = pendingRemoveCred === cred.id;
                     return (
                       <li
@@ -1136,6 +1154,7 @@ function ManageServiceAccountDialog({
                 </p>
                 <div className="flex gap-2">
                   <select
+                    aria-label="Provider"
                     value={addCredProvider}
                     onChange={(e) => setAddCredProvider(e.target.value)}
                     className="h-9 rounded-md border border-input bg-background px-2 text-sm"
@@ -1146,8 +1165,12 @@ function ManageServiceAccountDialog({
                       </option>
                     ))}
                   </select>
+                  {/* autoComplete="new-password" is intentional: suppresses
+                      password-manager autofill for this pasted external token
+                      field — we do not want saved login credentials injected. */}
                   <input
                     type="password"
+                    aria-label="Access token"
                     value={addCredToken}
                     onChange={(e) => setAddCredToken(e.target.value)}
                     placeholder="Paste access token…"

--- a/ui/src/components/admin/ServiceAccountsTab.tsx
+++ b/ui/src/components/admin/ServiceAccountsTab.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import {
   Bot,
   KeyRound,
+  Link2,
   Loader2,
   Plus,
   RefreshCw,
@@ -90,6 +91,27 @@ interface MyTeam {
   slug: string; // the canonical `team:<slug>` OpenFGA subject — use this as owning_team_id (#48).
   name: string;
 }
+
+// ─── SA credential types (mirrors GET /api/admin/service-accounts/[id]/credentials) ───
+
+interface ServiceAccountCredential {
+  id: string;
+  provider: string;
+  status: string;
+  connectedAt?: string;
+  requestedScopes?: string[];
+  connectorId?: string;
+}
+
+// The 5 built-in providers (kept local to avoid importing the lib file from a client component
+// that lives outside app/ — this avoids a cross-boundary import warning from Next.js).
+const BUILT_IN_PROVIDERS: { provider: string; name: string }[] = [
+  { provider: "github", name: "GitHub" },
+  { provider: "gitlab", name: "GitLab" },
+  { provider: "atlassian", name: "Atlassian Cloud" },
+  { provider: "webex", name: "Webex" },
+  { provider: "pagerduty", name: "PagerDuty" },
+];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Component
@@ -615,6 +637,29 @@ function ManageServiceAccountDialog({
   const [addAgents, setAddAgents] = useState<string[]>([]);
   const [addTools, setAddTools] = useState<string[]>([]);
 
+  // ── Credentials section state ──────────────────────────────────────────────
+  const [credentials, setCredentials] = useState<ServiceAccountCredential[]>([]);
+  const [credLoading, setCredLoading] = useState(false);
+  const [credBusy, setCredBusy] = useState(false);
+  const [credError, setCredError] = useState<string | null>(null);
+  const [pendingRemoveCred, setPendingRemoveCred] = useState<string | null>(null);
+  const [addCredProvider, setAddCredProvider] = useState(BUILT_IN_PROVIDERS[0].provider);
+  const [addCredToken, setAddCredToken] = useState("");
+
+  const refreshCredentials = useCallback(async () => {
+    if (!saId) return;
+    setCredLoading(true);
+    try {
+      const res = await fetch(
+        `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
+      ).then((r) => r.json()).catch(() => ({ success: false }));
+      if (res.success) setCredentials(res.data as ServiceAccountCredential[]);
+      else setCredError(res.error || "Failed to load credentials");
+    } finally {
+      setCredLoading(false);
+    }
+  }, [saId]);
+
   const refresh = useCallback(async () => {
     if (!saId) return;
     setLoading(true);
@@ -639,8 +684,11 @@ function ManageServiceAccountDialog({
   }, [saId]);
 
   useEffect(() => {
-    if (saId) void refresh();
-  }, [saId, refresh]);
+    if (saId) {
+      void refresh();
+      void refreshCredentials();
+    }
+  }, [saId, refresh, refreshCredentials]);
 
   // Held refs available to ADD (exclude ones the SA already has), per type.
   const existingRefs = new Set((detail?.scopes ?? []).map((s) => `${s.type}:${s.ref}`));
@@ -763,6 +811,64 @@ function ManageServiceAccountDialog({
       setBusy(false);
     }
   }, [saId, onClose, onMutated]);
+
+  // ── Credentials section callbacks ──────────────────────────────────────────
+
+  const addCredential = useCallback(async () => {
+    if (!saId || !addCredToken.trim()) return;
+    setCredBusy(true);
+    setCredError(null);
+    const tokenSnapshot = addCredToken;
+    // Drop the token from state immediately — it must not persist in memory
+    // after the request is sent (shown-once safety).
+    setAddCredToken("");
+    try {
+      const res = await fetch(
+        `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ provider: addCredProvider, token: tokenSnapshot }),
+        },
+      );
+      const body = await res.json();
+      if (!res.ok || !body.success) {
+        setCredError(body.error || "Failed to add credential");
+        return;
+      }
+      await refreshCredentials();
+    } finally {
+      setCredBusy(false);
+    }
+  }, [saId, addCredProvider, addCredToken, refreshCredentials]);
+
+  const removeCredential = useCallback(
+    async (connectionId: string) => {
+      if (!saId) return;
+      setCredBusy(true);
+      setCredError(null);
+      try {
+        const res = await fetch(
+          `/api/admin/service-accounts/${encodeURIComponent(saId)}/credentials`,
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ connection_id: connectionId }),
+          },
+        );
+        const body = await res.json();
+        if (!res.ok || !body.success) {
+          setCredError(body.error || "Failed to remove credential");
+          return;
+        }
+        setPendingRemoveCred(null);
+        await refreshCredentials();
+      } finally {
+        setCredBusy(false);
+      }
+    },
+    [saId, refreshCredentials],
+  );
 
   return (
     <Dialog open={Boolean(saId)} onOpenChange={(o) => { if (!o) onClose(); }}>
@@ -927,6 +1033,148 @@ function ManageServiceAccountDialog({
                 {error}
               </div>
             )}
+
+            {/* ── Provider credentials ─────────────────────────────────────── */}
+            <div className="space-y-2 border-t pt-3">
+              <div className="flex items-center gap-1.5">
+                <Link2 className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Provider credentials</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Paste a provider access token to let this service account use its own
+                credential for that provider. If no credential is set, the shared org
+                token is used as a fallback — the same behaviour as for user accounts.
+              </p>
+
+              {/* Current credentials list */}
+              {credLoading ? (
+                <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading credentials…
+                </div>
+              ) : credentials.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No provider credentials — org fallback will be used for all providers.
+                </p>
+              ) : (
+                <ul className="space-y-1">
+                  {credentials.map((cred) => {
+                    const providerLabel =
+                      BUILT_IN_PROVIDERS.find((p) => p.provider === cred.provider)?.name ??
+                      cred.provider;
+                    const isPendingRemove = pendingRemoveCred === cred.id;
+                    return (
+                      <li
+                        key={cred.id}
+                        className="flex items-center justify-between gap-2 rounded-md border border-input px-2.5 py-1.5"
+                      >
+                        <span className="inline-flex items-center gap-1.5 text-sm">
+                          <KeyRound className="h-3.5 w-3.5 text-muted-foreground" />
+                          <span className="font-medium">{providerLabel}</span>
+                          <span
+                            className={cn(
+                              "rounded-full px-1.5 py-0.5 text-xs font-medium",
+                              cred.status === "connected"
+                                ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+                                : "bg-muted text-muted-foreground",
+                            )}
+                          >
+                            {cred.status}
+                          </span>
+                          {cred.connectedAt && (
+                            <span className="text-xs text-muted-foreground">
+                              {new Date(cred.connectedAt).toLocaleDateString()}
+                            </span>
+                          )}
+                        </span>
+                        {isPendingRemove ? (
+                          <span className="inline-flex items-center gap-1.5">
+                            <span className="text-xs text-muted-foreground">Remove?</span>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              className="h-7 gap-1.5"
+                              disabled={credBusy}
+                              onClick={() => removeCredential(cred.id)}
+                            >
+                              {credBusy && <Loader2 className="h-3 w-3 animate-spin" />}
+                              Confirm
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="h-7"
+                              disabled={credBusy}
+                              onClick={() => setPendingRemoveCred(null)}
+                            >
+                              Cancel
+                            </Button>
+                          </span>
+                        ) : (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-7 w-7 text-destructive hover:text-destructive"
+                            aria-label={`Remove ${providerLabel} credential`}
+                            disabled={credBusy}
+                            onClick={() => setPendingRemoveCred(cred.id)}
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              {/* Add credential form */}
+              <div className="space-y-2 rounded-md border border-dashed border-input p-3">
+                <span className="text-sm font-medium">Add a credential</span>
+                <p className="text-xs text-muted-foreground">
+                  The token is stored encrypted and is <span className="font-semibold">never shown again</span> after
+                  submission.
+                </p>
+                <div className="flex gap-2">
+                  <select
+                    value={addCredProvider}
+                    onChange={(e) => setAddCredProvider(e.target.value)}
+                    className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+                  >
+                    {BUILT_IN_PROVIDERS.map((p) => (
+                      <option key={p.provider} value={p.provider}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="password"
+                    value={addCredToken}
+                    onChange={(e) => setAddCredToken(e.target.value)}
+                    placeholder="Paste access token…"
+                    autoComplete="new-password"
+                    className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                  />
+                  <Button
+                    onClick={addCredential}
+                    disabled={credBusy || !addCredToken.trim()}
+                    className="gap-1.5"
+                  >
+                    {credBusy ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Plus className="h-4 w-4" />
+                    )}
+                    Add
+                  </Button>
+                </div>
+              </div>
+
+              {credError && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+                  {credError}
+                </div>
+              )}
+            </div>
 
             {/* Credential lifecycle (rotate / revoke). Both are destructive and
                 spec'd "with confirm" (T032) / "delete-confirm" (T028), so each

--- a/ui/src/components/admin/ServiceAccountsTab.tsx
+++ b/ui/src/components/admin/ServiceAccountsTab.tsx
@@ -646,9 +646,10 @@ function ManageServiceAccountDialog({
   const [addCredToken, setAddCredToken] = useState("");
   // Whether the SA Tokens surface is enabled at all. The token-providers route
   // returns 404 when CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED is off; in that case
-  // we hide the entire Tokens section rather than show an empty one. Defaults
-  // to true (optimistic) so the section renders while loading.
-  const [tokensEnabled, setTokensEnabled] = useState(true);
+  // we hide the entire Tokens section. Starts `null` (unknown) and the section
+  // renders only once we've confirmed `true` — so a flag-off deployment never
+  // flashes the section before the fetch resolves.
+  const [tokensEnabled, setTokensEnabled] = useState<boolean | null>(null);
 
   const refreshCredentials = useCallback(async () => {
     if (!saId) return;
@@ -1106,9 +1107,11 @@ function ManageServiceAccountDialog({
             )}
 
             {/* ── Tokens ───────────────────────────────────────────────────── */}
-            {/* Hidden entirely when the SA Tokens surface is disabled
+            {/* Rendered only once confirmed enabled (=== true). null = unknown
+                (still loading) and false = disabled both hide the section, so a
+                flag-off deployment never flashes it
                 (CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED=false → token-providers 404). */}
-            {tokensEnabled && (
+            {tokensEnabled === true && (
             <div className="space-y-2 border-t pt-3">
               <div className="flex items-center gap-1.5">
                 <KeyRound className="h-4 w-4 text-muted-foreground" />
@@ -1208,7 +1211,14 @@ function ManageServiceAccountDialog({
                   The token is stored encrypted and is <span className="font-semibold">never shown again</span> after
                   submission.
                 </p>
-                {providerOptions.length === 0 ? (
+                {credLoading ? (
+                  // Don't render the "no integrations" message until the provider
+                  // list has actually loaded — otherwise the empty initial state
+                  // flashes a false "ask an admin to enable an MCP" claim.
+                  <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading providers…
+                  </div>
+                ) : providerOptions.length === 0 ? (
                   <p className="text-xs text-muted-foreground">
                     No token-capable integrations are enabled on this platform. Ask
                     an admin to enable an MCP server that supports token passthrough
@@ -1226,6 +1236,7 @@ function ManageServiceAccountDialog({
                       value={addCredProvider}
                       onChange={setAddCredProvider}
                       disabled={credBusy}
+                      ariaLabel="Token provider"
                     />
                     {/* This is a pasted external token — we want NO browser
                         autocomplete/autofill of any kind (no saved-password
@@ -1242,6 +1253,18 @@ function ManageServiceAccountDialog({
                       aria-label="Access token"
                       value={addCredToken}
                       onChange={(e) => setAddCredToken(e.target.value)}
+                      onKeyDown={(e) => {
+                        // Enter submits, matching the Add button's enabled guard.
+                        if (
+                          e.key === "Enter" &&
+                          !credBusy &&
+                          addCredToken.trim() &&
+                          addCredProvider
+                        ) {
+                          e.preventDefault();
+                          void addCredential();
+                        }
+                      }}
                       placeholder="Paste access token…"
                       autoComplete="off"
                       data-1p-ignore

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -402,7 +402,7 @@ export function AppHeader() {
       Icon: Bot,
       activeClassName: "bg-purple-500 text-white shadow-sm",
     },
-    storageMode === "mongodb" && config.credentialsEnabled && {
+    storageMode === "mongodb" && config.userConnectionsEnabled && {
       key: "credentials",
       href: "/credentials",
       label: "Connections",

--- a/ui/src/components/ui/provider-select.tsx
+++ b/ui/src/components/ui/provider-select.tsx
@@ -1,0 +1,105 @@
+// Styled single-select for credential providers (GitHub, GitLab, …).
+//
+// Mirrors the platform's Popover-based picker idiom (see team-picker.tsx) so the
+// SA Credentials "Add a credential" form matches the rest of the admin UI rather
+// than rendering a bare native <select>. Single-select, controlled: the parent
+// owns the selected provider key and receives changes via onChange. Options are
+// expected to be the *enabled* connectors only (the caller filters); this
+// component just renders whatever it's given.
+"use client";
+
+import * as React from "react";
+import { Check, ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export interface ProviderOption {
+  /** Provider key — the value persisted/sent to the API (e.g. "gitlab"). */
+  provider: string;
+  /** Human label rendered in the trigger and list (e.g. "GitLab"). */
+  name: string;
+}
+
+interface ProviderSelectProps {
+  options: ProviderOption[];
+  value: string;
+  onChange: (provider: string) => void;
+  disabled?: boolean;
+  /** Accessible name for the trigger (defaults to "Provider"). */
+  ariaLabel?: string;
+  placeholder?: string;
+  className?: string;
+}
+
+export function ProviderSelect({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  ariaLabel = "Provider",
+  placeholder = "Select a provider…",
+  className,
+}: ProviderSelectProps) {
+  const [open, setOpen] = React.useState(false);
+  const selected = options.find((o) => o.provider === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            "flex h-9 min-w-[10rem] items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            disabled && "cursor-not-allowed opacity-50",
+            className,
+          )}
+        >
+          <span className={cn("truncate", !selected && "text-muted-foreground")}>
+            {selected ? selected.name : placeholder}
+          </span>
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="min-w-[12rem] p-1" align="start">
+        <ul role="listbox" className="max-h-64 overflow-y-auto">
+          {options.length === 0 ? (
+            <li className="px-2 py-1.5 text-sm text-muted-foreground">
+              No providers available
+            </li>
+          ) : (
+            options.map((option) => {
+              const isSelected = option.provider === value;
+              return (
+                <li key={option.provider}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                      "hover:bg-accent hover:text-accent-foreground",
+                      isSelected && "bg-accent/50",
+                    )}
+                    onClick={() => {
+                      onChange(option.provider);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="truncate">{option.name}</span>
+                    {isSelected && <Check className="h-3.5 w-3.5 shrink-0" />}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/src/components/ui/provider-select.tsx
+++ b/ui/src/components/ui/provider-select.tsx
@@ -42,6 +42,7 @@ export function ProviderSelect({
   className,
 }: ProviderSelectProps) {
   const [open, setOpen] = React.useState(false);
+  const listboxId = React.useId();
   const selected = options.find((o) => o.provider === value);
 
   return (
@@ -51,6 +52,7 @@ export function ProviderSelect({
           type="button"
           aria-label={ariaLabel}
           aria-haspopup="listbox"
+          aria-controls={listboxId}
           aria-expanded={open}
           disabled={disabled}
           className={cn(
@@ -67,16 +69,18 @@ export function ProviderSelect({
         </button>
       </PopoverTrigger>
       <PopoverContent className="min-w-[12rem] p-1" align="start">
-        <ul role="listbox" className="max-h-64 overflow-y-auto">
+        <ul id={listboxId} role="listbox" className="max-h-64 overflow-y-auto">
           {options.length === 0 ? (
-            <li className="px-2 py-1.5 text-sm text-muted-foreground">
+            <li role="none" className="px-2 py-1.5 text-sm text-muted-foreground">
               No providers available
             </li>
           ) : (
             options.map((option) => {
               const isSelected = option.provider === value;
               return (
-                <li key={option.provider}>
+                // role="none" strips the implicit listitem role so the inner
+                // button's role="option" is owned directly by the listbox.
+                <li key={option.provider} role="none">
                   <button
                     type="button"
                     role="option"

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -141,7 +141,7 @@ describe('getServerConfig', () => {
       const expectedKeys: (keyof Config)[] = [
         'agentProtocol',
         'caipeUrl', 'ragUrl', 'isDev', 'isProd', 'ssoEnabled',
-        'ragEnabled', 'mongodbEnabled', 'credentialsEnabled',
+        'ragEnabled', 'mongodbEnabled', 'credentialsEnabled', 'userConnectionsEnabled',
         'tagline', 'description', 'appName', 'logoUrl', 'envBadge',
         'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
         'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled', 'unsafeRbacBypassEnabled',
@@ -938,7 +938,7 @@ describe('getClientConfigScript (XSS safety)', () => {
     const expectedKeys: (keyof Config)[] = [
       'agentProtocol',
       'caipeUrl', 'ragUrl', 'isDev', 'isProd', 'ssoEnabled',
-      'ragEnabled', 'mongodbEnabled', 'credentialsEnabled',
+      'ragEnabled', 'mongodbEnabled', 'credentialsEnabled', 'userConnectionsEnabled',
       'tagline', 'description', 'appName', 'logoUrl', 'envBadge',
       'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
       'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled', 'unsafeRbacBypassEnabled',

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -46,8 +46,10 @@ export interface Config {
   ragEnabled: boolean;
   /** Whether MongoDB persistence is enabled */
   mongodbEnabled: boolean;
-  /** Whether Connections & Secrets credential management is enabled */
+  /** Whether the credential subsystem (master switch) is enabled */
   credentialsEnabled: boolean;
+  /** Whether the user-facing Connections & Secrets surface (nav + /credentials page) is enabled */
+  userConnectionsEnabled: boolean;
   /** Main tagline displayed throughout the UI */
   tagline: string;
   /** Description text displayed throughout the UI */
@@ -232,6 +234,7 @@ const DEFAULT_CONFIG: Config = {
   ragEnabled: true,
   mongodbEnabled: false,
   credentialsEnabled: false,
+  userConnectionsEnabled: false,
   tagline: DEFAULT_TAGLINE,
   description: DEFAULT_DESCRIPTION,
   appName: DEFAULT_APP_NAME,
@@ -383,6 +386,15 @@ export function getServerConfig(): Config {
   const actionAuditEnabled = env('ACTION_AUDIT_ENABLED') !== 'false';
   const dynamicAgentsEnabled = env('DYNAMIC_AGENTS_ENABLED') === 'true';
   const credentialsEnabled = env('CAIPE_CREDENTIALS_ENABLED') === 'true';
+  // The user-facing Connections surface is gated independently of the SA token
+  // surface. It defaults to the master flag (backward-compatible) and can be
+  // explicitly turned off with CAIPE_USER_CONNECTIONS_ENABLED=false. Mirrors
+  // subFeatureEnabled() in feature-flags/credentials.ts (kept inline here so
+  // config.ts stays free of server-only imports for the client bundle).
+  const userConnectionsRaw = env('CAIPE_USER_CONNECTIONS_ENABLED');
+  const userConnectionsEnabled =
+    credentialsEnabled &&
+    (userConnectionsRaw === undefined ? true : userConnectionsRaw === 'true');
   const userInfoToolEnabled = env('ENABLE_USER_INFO_TOOL') === 'true';
 
   // Enabled when an org URL is set AND we have credentials in EITHER mode:
@@ -426,6 +438,7 @@ export function getServerConfig(): Config {
     ragEnabled,
     mongodbEnabled,
     credentialsEnabled,
+    userConnectionsEnabled,
     tagline: env('TAGLINE') || DEFAULT_TAGLINE,
     description: env('DESCRIPTION') || DEFAULT_DESCRIPTION,
     appName: env('APP_NAME') || DEFAULT_APP_NAME,

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -391,7 +391,9 @@ export function getServerConfig(): Config {
   // explicitly turned off with CAIPE_USER_CONNECTIONS_ENABLED=false. Mirrors
   // subFeatureEnabled() in feature-flags/credentials.ts (kept inline here so
   // config.ts stays free of server-only imports for the client bundle).
-  const userConnectionsRaw = env('CAIPE_USER_CONNECTIONS_ENABLED');
+  // Match subFeatureEnabled's parsing exactly — trim + lowercase, so a value
+  // like " true" doesn't diverge between the two sources of truth.
+  const userConnectionsRaw = env('CAIPE_USER_CONNECTIONS_ENABLED')?.trim().toLowerCase();
   const userConnectionsEnabled =
     credentialsEnabled &&
     (userConnectionsRaw === undefined ? true : userConnectionsRaw === 'true');

--- a/ui/src/lib/credentials/__tests__/indexes.test.ts
+++ b/ui/src/lib/credentials/__tests__/indexes.test.ts
@@ -22,11 +22,25 @@ describe("credential MongoDB indexes", () => {
         },
         {
           collection: CREDENTIAL_COLLECTIONS.providerConnections,
-          keys: { connectorKey: 1, subject: 1 },
-          options: { name: "provider_connections_connector_subject_unique", unique: true },
+          keys: { "owner.type": 1, "owner.id": 1, updatedAt: -1 },
+          options: { name: "provider_connections_owner_updated_at" },
+        },
+        {
+          collection: CREDENTIAL_COLLECTIONS.providerConnections,
+          keys: { "owner.type": 1, "owner.id": 1, provider: 1 },
+          options: {
+            name: "provider_connections_owner_provider_connected_unique",
+            unique: true,
+            partialFilterExpression: { status: "connected" },
+          },
         },
       ]),
     );
+  });
+
+  it("no longer ships the stale connectorKey/subject index (fields removed from the doc shape)", () => {
+    const names = buildCredentialIndexSpecs().map((s) => s.options?.name);
+    expect(names).not.toContain("provider_connections_connector_subject_unique");
   });
 
   it("adds audit and cleanup indexes without storing raw credential values", () => {

--- a/ui/src/lib/credentials/__tests__/oauth-service.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-service.test.ts
@@ -912,7 +912,9 @@ describe("ProviderConnectionService", () => {
       const doc = connections.docs[0];
       expect(doc).toMatchObject({
         id: "static-conn-1",
-        connectorId: "connector-1",
+        // Synthetic connectorId — a PAT has no OAuth connector. Derived from the
+        // provider key, never used to resolve anything downstream.
+        connectorId: "static:gitlab",
         provider: "gitlab",
         owner: { type: "service_account", id: "sa-sub-abc" },
         status: "connected",
@@ -941,41 +943,50 @@ describe("ProviderConnectionService", () => {
       expect(result.status).toBe("connected");
     });
 
-    it("bounds requestedScopes to the connector's allowed set", async () => {
+    it("stores requestedScopes verbatim (a PAT carries its own scopes; no bounding)", async () => {
       const connectors = new MemoryCollection<OAuthConnectorDocument>();
       const connections = new MemoryCollection<ProviderConnectionDocument>();
-      connectors.docs.push(makeConnector());
       const service = makeService(connectors, connections);
 
       const result = await service.registerStaticToken({
         providerKey: "gitlab",
         owner: { type: "service_account", id: "sa-sub-abc" },
         accessToken: "glpat-mysecrettoken",
-        requestedScopes: ["api"],
+        requestedScopes: ["api", "read_repository"],
       });
 
-      expect(result.requestedScopes).toEqual(["api"]);
+      // Not bounded to any connector scope list — stored as provided.
+      expect(result.requestedScopes).toEqual(["api", "read_repository"]);
     });
 
-    it("rejects a scope outside the connector's allowed set", async () => {
-      const connectors = new MemoryCollection<OAuthConnectorDocument>();
-      connectors.docs.push(makeConnector());
-      const service = makeService(connectors, new MemoryCollection<ProviderConnectionDocument>());
+    it("does NOT require an OAuth connector to exist (PATs need no OAuth app)", async () => {
+      // Empty connector collection — the previous implementation 404'd here
+      // ("OAuth connector was not found"); a PAT must succeed regardless.
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      const service = makeService(
+        new MemoryCollection<OAuthConnectorDocument>(),
+        connections,
+      );
 
-      await expect(
-        service.registerStaticToken({
-          providerKey: "gitlab",
-          owner: { type: "service_account", id: "sa-sub-abc" },
-          accessToken: "glpat-mysecrettoken",
-          requestedScopes: ["admin"],
-        }),
-      ).rejects.toMatchObject({ statusCode: 400 });
+      const result = await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        accessToken: "glpat-mysecrettoken",
+      });
+
+      expect(result).toMatchObject({
+        provider: "gitlab",
+        status: "connected",
+        connectorId: "static:gitlab",
+      });
+      expect(connections.docs).toHaveLength(1);
     });
 
     it("rejects an empty or blank accessToken", async () => {
-      const connectors = new MemoryCollection<OAuthConnectorDocument>();
-      connectors.docs.push(makeConnector());
-      const service = makeService(connectors, new MemoryCollection<ProviderConnectionDocument>());
+      const service = makeService(
+        new MemoryCollection<OAuthConnectorDocument>(),
+        new MemoryCollection<ProviderConnectionDocument>(),
+      );
 
       await expect(
         service.registerStaticToken({
@@ -986,7 +997,7 @@ describe("ProviderConnectionService", () => {
       ).rejects.toMatchObject({ statusCode: 400 });
     });
 
-    it("rejects when no enabled connector matches the providerKey", async () => {
+    it("rejects an empty or blank providerKey", async () => {
       const service = makeService(
         new MemoryCollection<OAuthConnectorDocument>(),
         new MemoryCollection<ProviderConnectionDocument>(),
@@ -994,11 +1005,11 @@ describe("ProviderConnectionService", () => {
 
       await expect(
         service.registerStaticToken({
-          providerKey: "nonexistent",
+          providerKey: "  ",
           owner: { type: "service_account", id: "sa-sub-abc" },
           accessToken: "some-token",
         }),
-      ).rejects.toMatchObject({ statusCode: 404 });
+      ).rejects.toMatchObject({ statusCode: 400 });
     });
 
     it("does not call tokenClient (no OAuth exchange for static tokens)", async () => {

--- a/ui/src/lib/credentials/__tests__/oauth-service.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-service.test.ts
@@ -436,6 +436,74 @@ describe("ProviderConnectionService", () => {
     expect(payloadStore.putSecret).not.toHaveBeenCalled();
   });
 
+  it("refreshConnection returns the stored token for a static: connection WITHOUT querying the connector store", async () => {
+    const providerConnections = new MemoryCollection<ProviderConnectionDocument>();
+    providerConnections.docs.push({
+      id: "conn-static",
+      connectorId: "static:gitlab", // static token — no OAuth connector exists
+      provider: "gitlab",
+      owner: { type: "service_account", id: "sa-sub-abc" },
+      status: "connected",
+      refreshTokenRef: "",
+      accessTokenRef: "provider_connection:conn-static:access_token",
+    });
+    const connectors = new MemoryCollection<OAuthConnectorDocument>(); // empty
+    const findOneSpy = jest.spyOn(connectors, "findOne");
+    const payloadStore = {
+      getSecret: jest.fn(async (ref: string) => {
+        if (!ref) throw new Error("Credential payload was not found");
+        return `${ref}:value`;
+      }),
+      putSecret: mockPutSecret(),
+    };
+    const tokenClient = mockTokenClient({ access_token: "should-not-be-used" });
+    const service = new ProviderConnectionService({
+      providerConnectionsCollection: providerConnections,
+      connectorsCollection: connectors,
+      payloadStore,
+      tokenClient,
+    });
+
+    const token = await service.refreshConnection("conn-static");
+
+    expect(token.accessToken).toBe("provider_connection:conn-static:access_token:value");
+    // The static: short-circuit must NOT hit the connector store (which would
+    // 404 and break every static-token exchange).
+    expect(findOneSpy).not.toHaveBeenCalled();
+    expect(tokenClient).not.toHaveBeenCalled();
+  });
+
+  it("refreshConnection reuses the stored token when a non-static OAuth connector was deleted", async () => {
+    const providerConnections = new MemoryCollection<ProviderConnectionDocument>();
+    providerConnections.docs.push({
+      id: "conn-orphan",
+      connectorId: "connector-deleted", // non-static, but no matching connector row
+      provider: "github",
+      owner: { type: "user", id: "alice-sub" },
+      status: "connected",
+      refreshTokenRef: "provider_connection:conn-orphan:refresh_token",
+      accessTokenRef: "provider_connection:conn-orphan:access_token",
+    });
+    const connectors = new MemoryCollection<OAuthConnectorDocument>(); // connector deleted
+    const payloadStore = {
+      getSecret: jest.fn(async (ref: string) => `${ref}:value`),
+      putSecret: mockPutSecret(),
+    };
+    const tokenClient = mockTokenClient({ access_token: "should-not-be-used" });
+    const service = new ProviderConnectionService({
+      providerConnectionsCollection: providerConnections,
+      connectorsCollection: connectors,
+      payloadStore,
+      tokenClient,
+    });
+
+    const token = await service.refreshConnection("conn-orphan");
+
+    // Graceful degradation: reuse the stored token instead of 404'ing.
+    expect(token.accessToken).toBe("provider_connection:conn-orphan:access_token:value");
+    expect(tokenClient).not.toHaveBeenCalled();
+  });
+
   it("reuses the stored access token when the provider rejects the refresh grant", async () => {
     const providerConnections = new MemoryCollection<ProviderConnectionDocument>();
     providerConnections.docs.push({

--- a/ui/src/lib/credentials/__tests__/oauth-service.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-service.test.ts
@@ -6,6 +6,7 @@ import {
   type OAuthConnectorDocument,
   ProviderConnectionService,
   type ProviderConnectionDocument,
+  type ProviderConnectionServiceOptions,
 } from "../oauth-service";
 
 class MemoryCollection<T extends object> {
@@ -797,6 +798,224 @@ describe("ProviderConnectionService", () => {
     expect(payloadStore.putSecret).not.toHaveBeenCalledWith(
       expect.objectContaining({ secretRefId: "provider_connection:provider-connection-1:refresh_token" }),
     );
+  });
+
+  describe("registerStaticToken", () => {
+    function makeConnector(overrides?: Partial<OAuthConnectorDocument>): OAuthConnectorDocument {
+      return {
+        id: "connector-1",
+        name: "GitLab",
+        provider: "gitlab",
+        clientId: "client-id",
+        clientSecretRef: "oauth_connector:connector-1:client_secret",
+        authorizationUrl: "https://gitlab.example.com/oauth/authorize",
+        tokenUrl: "https://gitlab.example.com/oauth/token",
+        scopes: ["api", "read_repository"],
+        redirectUri: "https://caipe.example.com/api/credentials/oauth/gitlab/callback",
+        enabled: true,
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+        ...overrides,
+      };
+    }
+
+    function makeService(
+      connectors: MemoryCollection<OAuthConnectorDocument>,
+      connections: MemoryCollection<ProviderConnectionDocument>,
+      overrides?: Partial<ProviderConnectionServiceOptions>,
+    ) {
+      return new ProviderConnectionService({
+        providerConnectionsCollection: connections,
+        connectorsCollection: connectors,
+        payloadStore: {
+          getSecret: jest.fn(async () => "secret"),
+          putSecret: mockPutSecret(),
+        },
+        tokenClient: mockTokenClient({ access_token: "should-not-be-used" }),
+        idGenerator: () => "static-conn-1",
+        now: () => new Date("2026-06-08T00:00:00.000Z"),
+        ...overrides,
+      });
+    }
+
+    it("creates a connected, refresh-less connection for a service_account owner", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      connectors.docs.push(makeConnector());
+      const putSecret = mockPutSecret();
+      const service = makeService(connectors, connections, {
+        payloadStore: {
+          getSecret: jest.fn(async () => "secret"),
+          putSecret,
+        },
+      });
+
+      const result = await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        accessToken: "glpat-mysecrettoken",
+      });
+
+      expect(result).toMatchObject({
+        id: "static-conn-1",
+        provider: "gitlab",
+        status: "connected",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+      });
+      // No token material in the returned metadata
+      expect(JSON.stringify(result)).not.toContain("glpat-mysecrettoken");
+      // No expiresAt on a static token
+      expect(result.expiresAt).toBeUndefined();
+    });
+
+    it("stores the access token secret but writes no refresh token secret", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      connectors.docs.push(makeConnector());
+      const putSecret = mockPutSecret();
+      const service = makeService(connectors, connections, {
+        payloadStore: {
+          getSecret: jest.fn(async () => "secret"),
+          putSecret,
+        },
+      });
+
+      await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        accessToken: "glpat-mysecrettoken",
+      });
+
+      expect(putSecret).toHaveBeenCalledTimes(1);
+      expect(putSecret).toHaveBeenCalledWith({
+        secretRefId: "provider_connection:static-conn-1:access_token",
+        plaintext: "glpat-mysecrettoken",
+      });
+      // Confirm no refresh_token secret was written
+      const calls = putSecret.mock.calls as Array<[{ secretRefId: string; plaintext: string }]>;
+      expect(calls.every(([{ secretRefId }]) => !secretRefId.includes("refresh_token"))).toBe(true);
+    });
+
+    it("persists the document with the correct shape (no refresh token ref set)", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      connectors.docs.push(makeConnector());
+      const service = makeService(connectors, connections);
+
+      await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        accessToken: "glpat-mysecrettoken",
+      });
+
+      expect(connections.docs).toHaveLength(1);
+      const doc = connections.docs[0];
+      expect(doc).toMatchObject({
+        id: "static-conn-1",
+        connectorId: "connector-1",
+        provider: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        status: "connected",
+        accessTokenRef: "provider_connection:static-conn-1:access_token",
+      });
+      // refreshTokenRef is set to empty string (not a real secret ref)
+      expect(doc.refreshTokenRef).toBe("");
+      expect(doc.expiresAt).toBeUndefined();
+      // Raw token must never appear in the stored document
+      expect(JSON.stringify(doc)).not.toContain("glpat-mysecrettoken");
+    });
+
+    it("accepts a user owner (owner-agnostic)", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      connectors.docs.push(makeConnector());
+      const service = makeService(connectors, connections);
+
+      const result = await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "user", id: "alice-sub" },
+        accessToken: "glpat-usertok",
+      });
+
+      expect(result.owner).toEqual({ type: "user", id: "alice-sub" });
+      expect(result.status).toBe("connected");
+    });
+
+    it("bounds requestedScopes to the connector's allowed set", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      connectors.docs.push(makeConnector());
+      const service = makeService(connectors, connections);
+
+      const result = await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        accessToken: "glpat-mysecrettoken",
+        requestedScopes: ["api"],
+      });
+
+      expect(result.requestedScopes).toEqual(["api"]);
+    });
+
+    it("rejects a scope outside the connector's allowed set", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      connectors.docs.push(makeConnector());
+      const service = makeService(connectors, new MemoryCollection<ProviderConnectionDocument>());
+
+      await expect(
+        service.registerStaticToken({
+          providerKey: "gitlab",
+          owner: { type: "service_account", id: "sa-sub-abc" },
+          accessToken: "glpat-mysecrettoken",
+          requestedScopes: ["admin"],
+        }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("rejects an empty or blank accessToken", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      connectors.docs.push(makeConnector());
+      const service = makeService(connectors, new MemoryCollection<ProviderConnectionDocument>());
+
+      await expect(
+        service.registerStaticToken({
+          providerKey: "gitlab",
+          owner: { type: "service_account", id: "sa-sub-abc" },
+          accessToken: "   ",
+        }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("rejects when no enabled connector matches the providerKey", async () => {
+      const service = makeService(
+        new MemoryCollection<OAuthConnectorDocument>(),
+        new MemoryCollection<ProviderConnectionDocument>(),
+      );
+
+      await expect(
+        service.registerStaticToken({
+          providerKey: "nonexistent",
+          owner: { type: "service_account", id: "sa-sub-abc" },
+          accessToken: "some-token",
+        }),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it("does not call tokenClient (no OAuth exchange for static tokens)", async () => {
+      const connectors = new MemoryCollection<OAuthConnectorDocument>();
+      const connections = new MemoryCollection<ProviderConnectionDocument>();
+      connectors.docs.push(makeConnector());
+      const tokenClient = mockTokenClient({ access_token: "should-not-be-used" });
+      const service = makeService(connectors, connections, { tokenClient });
+
+      await service.registerStaticToken({
+        providerKey: "gitlab",
+        owner: { type: "service_account", id: "sa-sub-abc" },
+        accessToken: "glpat-mysecrettoken",
+      });
+
+      expect(tokenClient).not.toHaveBeenCalled();
+    });
   });
 
   it("lists provider connection metadata for an owner without token refs", async () => {

--- a/ui/src/lib/credentials/indexes.ts
+++ b/ui/src/lib/credentials/indexes.ts
@@ -8,6 +8,7 @@ export interface CredentialIndexSpec {
     name: string;
     sparse?: boolean;
     unique?: boolean;
+    partialFilterExpression?: Record<string, unknown>;
   };
 }
 
@@ -34,9 +35,27 @@ export function buildCredentialIndexSpecs(): CredentialIndexSpec[] {
       options: { name: "oauth_connectors_key_unique", unique: true },
     },
     {
+      // Owner-keyed lookup index. listConnections filters by
+      // { "owner.type", "owner.id" }; without this the read scans the whole
+      // collection. (Replaces the old connectorKey/subject index, which
+      // referenced fields that no longer exist on ProviderConnectionDocument
+      // — connectorId/owner — and so was never used.)
       collection: CREDENTIAL_COLLECTIONS.providerConnections,
-      keys: { connectorKey: 1, subject: 1 },
-      options: { name: "provider_connections_connector_subject_unique", unique: true },
+      keys: { "owner.type": 1, "owner.id": 1, updatedAt: -1 },
+      options: { name: "provider_connections_owner_updated_at" },
+    },
+    {
+      // At most one CONNECTED connection per (owner, provider). Closes the
+      // check-then-act race in the add-token POST: two concurrent inserts for
+      // the same SA+provider now collide at the DB (E11000) instead of both
+      // landing. Partial so revoked/disabled rows don't block re-adding.
+      collection: CREDENTIAL_COLLECTIONS.providerConnections,
+      keys: { "owner.type": 1, "owner.id": 1, provider: 1 },
+      options: {
+        name: "provider_connections_owner_provider_connected_unique",
+        unique: true,
+        partialFilterExpression: { status: "connected" },
+      },
     },
     {
       collection: CREDENTIAL_COLLECTIONS.providerConnections,

--- a/ui/src/lib/credentials/oauth-service.ts
+++ b/ui/src/lib/credentials/oauth-service.ts
@@ -450,10 +450,20 @@ export class ProviderConnectionService {
     accessToken: string;
     requestedScopes?: string[];
   }): Promise<ProviderConnectionMetadata> {
-    const connector = await this.findEnabledConnector(nonEmpty(input.providerKey, "providerKey"));
+    // A pasted token (PAT / project access token) does NOT require a registered
+    // OAuth connector — there is no authorization-code flow, no client app, and
+    // no client secret. Earlier this called findEnabledConnector, which 404'd
+    // ("OAuth connector was not found") for providers like GitLab where we have
+    // no OAuth app but DO support PATs. The connector was only used for two
+    // non-essential things: its id (stored, never used to resolve anything) and
+    // its scope list (to bound requestedScopes). We don't need either here:
+    //   - connectorId is synthesised as `static:<provider>` purely for display.
+    //   - the PAT carries its own scopes intrinsically, so we store the caller's
+    //     requestedScopes verbatim (informational) rather than bounding them.
+    const provider = nonEmpty(input.providerKey, "providerKey");
     const requestedScopes =
-      input.requestedScopes !== undefined
-        ? boundScopes(connector.scopes, input.requestedScopes)
+      input.requestedScopes && input.requestedScopes.length > 0
+        ? input.requestedScopes
         : undefined;
 
     const id = this.idGenerator();
@@ -466,8 +476,8 @@ export class ProviderConnectionService {
     const now = this.now();
     const doc: ProviderConnectionDocument = {
       id,
-      connectorId: connector.id,
-      provider: connector.provider,
+      connectorId: `static:${provider}`,
+      provider,
       owner: input.owner,
       status: "connected",
       accessTokenRef,

--- a/ui/src/lib/credentials/oauth-service.ts
+++ b/ui/src/lib/credentials/oauth-service.ts
@@ -515,10 +515,6 @@ export class ProviderConnectionService {
     if (!connection) {
       throw new ApiError("Provider connection was not found", 404, "CREDENTIAL_NOT_FOUND");
     }
-    const connector = await this.connectorsCollection.findOne({ id: connection.connectorId });
-    if (!connector) {
-      throw new ApiError("OAuth connector was not found", 404, "CREDENTIAL_NOT_FOUND");
-    }
 
     // The stored access token is the source of truth. Long-lived tokens such as
     // GitHub OAuth-App tokens never expire and are not issued with a refresh
@@ -554,6 +550,20 @@ export class ProviderConnectionService {
         : undefined;
       return { accessToken: storedAccessToken, expiresIn };
     };
+
+    // A pasted static token (PAT / project access token) has NO OAuth connector
+    // — registerStaticToken stores connectorId as `static:<provider>`. It also
+    // has no refresh token and can't be refreshed via an authorization-code
+    // grant. Reuse the stored token directly; looking up an OAuth connector here
+    // would 404 ("OAuth connector was not found") and break the exchange for
+    // every static token (the symptom that blocked GitLab PAT passthrough for
+    // both users and service accounts).
+    const connector = connection.connectorId.startsWith("static:")
+      ? null
+      : await this.connectorsCollection.findOne({ id: connection.connectorId });
+    if (!connector) {
+      return reuseStoredToken();
+    }
 
     // No usable refresh token (e.g. GitHub never issued one): reuse the stored
     // access token instead of attempting a doomed refresh grant.

--- a/ui/src/lib/credentials/oauth-service.ts
+++ b/ui/src/lib/credentials/oauth-service.ts
@@ -551,13 +551,21 @@ export class ProviderConnectionService {
       return { accessToken: storedAccessToken, expiresIn };
     };
 
-    // A pasted static token (PAT / project access token) has NO OAuth connector
-    // — registerStaticToken stores connectorId as `static:<provider>`. It also
-    // has no refresh token and can't be refreshed via an authorization-code
-    // grant. Reuse the stored token directly; looking up an OAuth connector here
-    // would 404 ("OAuth connector was not found") and break the exchange for
-    // every static token (the symptom that blocked GitLab PAT passthrough for
-    // both users and service accounts).
+    // `connector` is intentionally null in two distinct cases, BOTH of which
+    // reuse the stored access token rather than attempting an OAuth refresh:
+    //
+    //   1. Static token: a pasted PAT / project access token has NO OAuth
+    //      connector — registerStaticToken stores connectorId as
+    //      `static:<provider>` and writes no refresh token. We skip the
+    //      connector lookup entirely. Looking one up would 404 ("OAuth
+    //      connector was not found") and break the exchange for every static
+    //      token (the symptom that blocked GitLab PAT passthrough for both
+    //      users and service accounts).
+    //   2. Deleted connector: an OAuth connection whose connector row was
+    //      removed after the connection was created. Rather than 404 the
+    //      exchange (the prior behavior), we gracefully degrade to the last
+    //      known-good stored access token; the caller can re-connect/rotate if
+    //      it has gone stale.
     const connector = connection.connectorId.startsWith("static:")
       ? null
       : await this.connectorsCollection.findOne({ id: connection.connectorId });

--- a/ui/src/lib/credentials/oauth-service.ts
+++ b/ui/src/lib/credentials/oauth-service.ts
@@ -430,6 +430,58 @@ export class ProviderConnectionService {
     return toProviderConnectionMetadata(doc);
   }
 
+  /**
+   * Register a pasted static access token as a provider connection.
+   *
+   * This is the paste-token analogue of {@link completeConnection}: instead of
+   * exchanging an OAuth authorization code, the caller supplies a long-lived
+   * token (e.g. a GitLab project access token or a GitHub personal access token)
+   * that was obtained out-of-band. The resulting `ProviderConnectionDocument`
+   * has `status: "connected"`, no `refreshTokenRef` secret, and no `expiresAt` —
+   * matching the shape that {@link refreshConnection} already handles correctly
+   * for refresh-less connections (lines 496-499: reuse stored access token).
+   *
+   * The method is owner-agnostic: `input.owner.type` may be `"user"`,
+   * `"service_account"`, `"team"`, or `"organization"`.
+   */
+  async registerStaticToken(input: {
+    providerKey: string;
+    owner: CredentialOwnerRef;
+    accessToken: string;
+    requestedScopes?: string[];
+  }): Promise<ProviderConnectionMetadata> {
+    const connector = await this.findEnabledConnector(nonEmpty(input.providerKey, "providerKey"));
+    const requestedScopes =
+      input.requestedScopes !== undefined
+        ? boundScopes(connector.scopes, input.requestedScopes)
+        : undefined;
+
+    const id = this.idGenerator();
+    const accessTokenRef = `provider_connection:${id}:access_token`;
+    await this.payloadStore.putSecret({
+      secretRefId: accessTokenRef,
+      plaintext: nonEmpty(input.accessToken, "accessToken"),
+    });
+
+    const now = this.now();
+    const doc: ProviderConnectionDocument = {
+      id,
+      connectorId: connector.id,
+      provider: connector.provider,
+      owner: input.owner,
+      status: "connected",
+      accessTokenRef,
+      // No refresh token — static tokens are long-lived and not rotated via
+      // an OAuth refresh grant. refreshConnection already handles this case.
+      refreshTokenRef: "",
+      // No expiresAt — caller manages token lifecycle out-of-band.
+      updatedAt: now,
+      ...(requestedScopes ? { requestedScopes } : {}),
+    };
+    await this.providerConnectionsCollection.insertOne(doc);
+    return toProviderConnectionMetadata(doc);
+  }
+
   async listConnections(owner: CredentialOwnerRef): Promise<ProviderConnectionMetadata[]> {
     if (!this.providerConnectionsCollection.find) {
       return [];

--- a/ui/src/lib/credentials/provider-display-names.ts
+++ b/ui/src/lib/credentials/provider-display-names.ts
@@ -1,0 +1,34 @@
+// Plain-data module — NO browser APIs, NO next/server imports.
+// Safe to import from both client components and server-side code.
+//
+// Source of truth: ui/src/lib/credentials/built-in-oauth-connectors.ts
+// This module derives the human-readable display names from the same 5 providers
+// defined there, without importing the full OAuth descriptor (which carries
+// authorizationUrl, tokenUrl, scopes, etc. not needed in UI display contexts).
+//
+// Keep this list in sync with BUILT_IN_OAUTH_CONNECTORS whenever a provider is
+// added or renamed.
+
+export type BuiltInProviderKey = "github" | "gitlab" | "atlassian" | "webex" | "pagerduty";
+
+/** Ordered list of the 5 built-in providers with their display names. */
+export const PROVIDER_DISPLAY_LIST: { provider: BuiltInProviderKey; name: string }[] = [
+  { provider: "github", name: "GitHub" },
+  { provider: "gitlab", name: "GitLab" },
+  { provider: "atlassian", name: "Atlassian Cloud" },
+  { provider: "webex", name: "Webex" },
+  { provider: "pagerduty", name: "PagerDuty" },
+];
+
+/** Map from provider key → display name for O(1) lookup. */
+export const PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.fromEntries(
+  PROVIDER_DISPLAY_LIST.map(({ provider, name }) => [provider, name]),
+);
+
+/**
+ * Returns the display name for a provider key, falling back to the raw key
+ * for unknown/future providers.
+ */
+export function getProviderDisplayName(provider: string): string {
+  return PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+}

--- a/ui/src/lib/credentials/types.ts
+++ b/ui/src/lib/credentials/types.ts
@@ -1,4 +1,4 @@
-export type CredentialOwnerType = "organization" | "team" | "user";
+export type CredentialOwnerType = "organization" | "team" | "user" | "service_account";
 export type CredentialSecretType = "api_key" | "basic_auth" | "bearer_token" | "custom";
 export type ProviderConnectionStatus =
   | "connected"

--- a/ui/src/lib/feature-flags/__tests__/credentials.test.ts
+++ b/ui/src/lib/feature-flags/__tests__/credentials.test.ts
@@ -3,6 +3,8 @@ import { afterAll, beforeEach, describe, expect, it } from "@jest/globals";
 import {
   getCredentialFeatureConfig,
   isCredentialFeatureEnabled,
+  isServiceAccountTokensEnabled,
+  isUserConnectionsEnabled,
 } from "../credentials";
 
 const ORIGINAL_ENV = process.env;
@@ -15,6 +17,8 @@ function resetEnv(overrides: Record<string, string | undefined> = {}): void {
   delete process.env.CREDENTIAL_KMS_CMK_ID;
   delete process.env.CREDENTIAL_KMS_REGION;
   delete process.env.CREDENTIAL_SERVICE_AUDIENCE;
+  delete process.env.CAIPE_USER_CONNECTIONS_ENABLED;
+  delete process.env.CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED;
 
   for (const [key, value] of Object.entries(overrides)) {
     if (value === undefined) {
@@ -72,5 +76,51 @@ describe("credential feature flags", () => {
       kmsRegion: "us-west-2",
       serviceAudience: "caipe-credential-service-local",
     });
+  });
+});
+
+describe("credential sub-surface flags (Connections vs SA Tokens)", () => {
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  beforeEach(() => {
+    resetEnv();
+  });
+
+  it("both sub-surfaces are off when the master flag is off, regardless of sub-flag", () => {
+    resetEnv({
+      CAIPE_CREDENTIALS_ENABLED: "false",
+      CAIPE_USER_CONNECTIONS_ENABLED: "true",
+      CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED: "true",
+    });
+    // A sub-flag can never be on when the subsystem master is off.
+    expect(isUserConnectionsEnabled()).toBe(false);
+    expect(isServiceAccountTokensEnabled()).toBe(false);
+  });
+
+  it("both sub-surfaces inherit the master flag when their sub-flags are unset", () => {
+    resetEnv({ CAIPE_CREDENTIALS_ENABLED: "true" });
+    expect(isUserConnectionsEnabled()).toBe(true);
+    expect(isServiceAccountTokensEnabled()).toBe(true);
+  });
+
+  it("hides user Connections independently while keeping SA Tokens on", () => {
+    resetEnv({
+      CAIPE_CREDENTIALS_ENABLED: "true",
+      CAIPE_USER_CONNECTIONS_ENABLED: "false",
+      // SA tokens flag unset → inherits master (on)
+    });
+    expect(isUserConnectionsEnabled()).toBe(false);
+    expect(isServiceAccountTokensEnabled()).toBe(true);
+  });
+
+  it("hides SA Tokens independently while keeping user Connections on", () => {
+    resetEnv({
+      CAIPE_CREDENTIALS_ENABLED: "true",
+      CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED: "false",
+    });
+    expect(isServiceAccountTokensEnabled()).toBe(false);
+    expect(isUserConnectionsEnabled()).toBe(true);
   });
 });

--- a/ui/src/lib/feature-flags/credentials.ts
+++ b/ui/src/lib/feature-flags/credentials.ts
@@ -39,6 +39,43 @@ export function isCredentialFeatureEnabled(): boolean {
   return envBoolean("CAIPE_CREDENTIALS_ENABLED");
 }
 
+/**
+ * Read an optional boolean sub-flag that defaults to the value of the master
+ * credential flag when unset. This lets a deployment turn the whole credential
+ * subsystem on/off with CAIPE_CREDENTIALS_ENABLED, while still being able to
+ * independently hide one surface (e.g. user Connections) by explicitly setting
+ * its sub-flag to "false". A sub-flag can never be on when the master is off —
+ * the subsystem (store, key wrapper, routes) must be enabled for either surface
+ * to function.
+ */
+function subFeatureEnabled(name: string): boolean {
+  if (!isCredentialFeatureEnabled()) return false;
+  const raw = env(name)?.toLowerCase();
+  if (raw === undefined) return true; // inherit master (backward-compatible)
+  return raw === "true";
+}
+
+/**
+ * Whether the user-facing "Connections & Secrets" surface (the /credentials
+ * page + the "Connections" nav link) is enabled. Independent of the
+ * service-account token surface so a deployment without registered OAuth apps
+ * can hide user Connections while still letting service accounts hold PATs.
+ * Env: CAIPE_USER_CONNECTIONS_ENABLED (defaults to the master flag).
+ */
+export function isUserConnectionsEnabled(): boolean {
+  return subFeatureEnabled("CAIPE_USER_CONNECTIONS_ENABLED");
+}
+
+/**
+ * Whether the service-account Tokens surface (the SA Tokens section + its
+ * token-providers / [id]/credentials routes) is enabled. Independent of the
+ * user Connections surface.
+ * Env: CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED (defaults to the master flag).
+ */
+export function isServiceAccountTokensEnabled(): boolean {
+  return subFeatureEnabled("CAIPE_SERVICE_ACCOUNT_TOKENS_ENABLED");
+}
+
 export function getCredentialFeatureConfig(): CredentialFeatureConfig {
   return {
     enabled: isCredentialFeatureEnabled(),


### PR DESCRIPTION
# Description

Lets a **service account hold platform credentials (personal/project access tokens)** that are passed through to MCP tool calls, mirroring the existing per-user credential passthrough — just with the service account as the principal instead of a human user.

Today a user can add a provider token (e.g. for GitLab) and, when an agent invokes that provider's MCP tools on their behalf, their token is injected into the tool call. This PR extends the same mechanism to service accounts: add a token to a service account, and when that service account drives an agent that calls a provider tool, the service account's own token is used.

> Reparented after #1784 merged — base branch is now `main`. Review only the credential passthrough commits in this PR's diff.

## What's included

**Token storage (provider-shaped, no OAuth app required)**
- Adds a `service_account` credential owner type; a service account's token is stored as a provider connection owned by the service account.
- Pasted tokens are stored directly (no authorization-code/OAuth-app dependency). The static-token path is decoupled from OAuth connectors so storing **and** exchanging a token works without a registered OAuth client.

**Runtime passthrough (largely reuses the existing path)**
- The credential exchange resolves a connection for the calling subject (user *or* service account) and injects the token into the MCP tool call. No new runtime branch — the existing subject-keyed resolution handles both.

**Management UI**
- A "Tokens" section in the service-account management dialog: list, add (styled provider picker), and remove tokens.
- The provider list is derived from **enabled, token-capable MCP servers** (servers that declare a provider-connection credential source), so only providers the platform actually supports for passthrough are offered.
- Token input has autocomplete/autofill fully disabled; token values are never echoed back after submission and never returned by the API.

**Feature flags (two independent surfaces under one master switch)**
- A master switch enables the credential subsystem.
- One flag gates the user-facing Connections surface; a separate flag gates the service-account Tokens surface. Each defaults to the master flag, so a deployment can enable service-account tokens without exposing the user Connections UI (or vice versa).

**Authorization**
- Managing a service account's tokens uses the same ownership check as the rest of service-account management (owning-team membership).
- Adding an agent/tool scope remains permission-bounded: a caller can only grant scopes they themselves hold.

**Incidental fixes surfaced during integration**
- Credential exchange for static tokens no longer fails by requiring an OAuth connector that doesn't exist for pasted tokens.
- Two Slack channel admin routes built an OpenFGA read filter that the PDP rejects (a relation/user filter without an object type); scoped those reads to an object type instead.

## Type of Change

- [x] New Feature
- [x] Bugfix

## Checklist

- [x] Functionality is documented
- [x] All code style checks pass (lint)
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass