### PR TITLE
fix(openfga): add organization#member to skill type restrictions

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga/authorization-model.json
+++ b/charts/ai-platform-engineering/charts/openfga/authorization-model.json
@@ -3357,6 +3357,10 @@
                 "relation": "member"
               },
               {
+                "type": "organization",
+                "relation": "member"
+              },
+              {
                 "type": "slack_channel"
               },
               {
@@ -3382,6 +3386,10 @@
               },
               {
                 "type": "external_group",
+                "relation": "member"
+              },
+              {
+                "type": "organization",
                 "relation": "member"
               },
               {


### PR DESCRIPTION
## Summary

- Adds `{"type": "organization", "relation": "member"}` to `skill#reader` and `skill#user` `directly_related_user_types` in `authorization-model.json`
- Fixes the `agent_skills` v1→v2 migration failure: `organization#member is not an allowed type restriction for skill#user`
- Root cause: `deploy/openfga/model.fga` (source of truth) already had `organization#member` in `skill reader`/`user`, but the compiled JSON chart artifact was never updated when `mcp_server` received this entry in commit `f77dcfe18` by Sri Aradhyula

## Test plan

- [ ] Deploy to dev and re-run the `agent_skills` v1→v2 migration from the Admin → Migrations panel
- [ ] Confirm migration applies without OpenFGA 400 validation errors
- [ ] Verify globally-visible skills are accessible org-wide after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)