### PR TITLE
fix(rag-rbac): elevate OpenFGA org-admins to admin on ADMIN-gated endpoints

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/rbac.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/rbac.py
@@ -409,6 +409,16 @@ def require_role(required_role: str):
 
   async def role_checker(user: UserContext = Depends(require_authenticated_user)) -> UserContext:
     if not has_permission(user.role, required_role):
+      # Human users are always assigned READONLY at auth time. For ADMIN-gated
+      # endpoints, check OpenFGA org-admin as a fallback before rejecting.
+      if required_role == Role.ADMIN and await _openfga_check_org_admin(user):
+        logger.debug(f"OpenFGA org-admin grant elevated {user.email} to admin for this request")
+        return UserContext(
+          subject=user.subject,
+          email=user.email,
+          role=Role.ADMIN,
+          is_authenticated=True,
+        )
       logger.warning(f"Access denied for {user.email}: required {required_role}, has {user.role}")
       raise HTTPException(status_code=403, detail=(f"Insufficient permissions. This operation requires '{required_role}' role, but you have '{user.role}' role. Please contact your administrator to request the appropriate access level."))
     return user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.10-dev.2"
+version = "0.5.10-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.10.dev2"
+version = "0.5.10.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Human users are always assigned `READONLY` at JWT auth time — no admin signal comes from the token
- Admin-gated endpoints (`/v1/job/{id}/terminate`, `/v1/ingest/webloader/reload-all`, `DELETE /v1/ingestor/delete`, etc.) were unreachable for org-admins, even though they are correctly recorded in OpenFGA as `user:<sub> → admin → organization:caipe`
- `require_role(Role.ADMIN)` now falls back to `_openfga_check_org_admin` when the coarse role check fails, elevating org-admins to `ADMIN` for the duration of that request
- Service-account tokens (ingestor, bot client-credentials) are unaffected: they carry a coarse `INGESTONLY`/`ADMIN` role and have no OpenFGA subject to look up

## Root cause

```python
# rbac.py line 315 — always READONLY for every human user
role = Role.READONLY
```

OpenFGA is the authoritative source for human authorization. The coarse role is only meaningful for service accounts. The admin gate must consult OpenFGA for human callers.

## Test plan

- [ ] Log in as `admin@caipe.local` (has `user:<sub> → admin → organization:caipe` tuple in OpenFGA)
- [ ] Navigate to Knowledge Bases → Data Sources → an In Progress job → click **Stop** — should succeed
- [ ] Verify `DELETE /v1/ingestor/delete` and `POST /v1/ingest/webloader/reload-all` also succeed for org-admin
- [ ] Verify a non-admin user (`user@caipe.local`) still gets 403 on those endpoints
- [ ] Verify ingestor service-account token (client-credentials) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)