### PR TITLE
fix(rbac): write org-admin connector tuple for super-admins team on bootstrap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.6.0-rc.14"
+version = "0.6.0-rc.15"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/rbac/super-admins-team.ts
+++ b/ui/src/lib/rbac/super-admins-team.ts
@@ -24,12 +24,38 @@ import {
   writeTeamMembershipTuples,
   mongoRoleToOpenFgaRelations,
 } from "@/lib/rbac/team-membership-sync";
+import { writeOpenFgaTuples } from "@/lib/rbac/openfga";
+import { organizationObjectId } from "@/lib/rbac/organization";
 import { upsertTeamMembershipSource } from "@/lib/rbac/team-membership-source-store";
 import { loadActiveTeamMembers } from "@/lib/rbac/team-membership-store";
 import type { TeamMembershipSource } from "@/types/identity-group-sync";
 
 export const SUPER_ADMINS_TEAM_SLUG = "super-admins";
 export const SUPER_ADMINS_TEAM_NAME = "Super Admins";
+
+/**
+ * Write the connector tuple `team:super-admins#admin admin organization:<key>`.
+ * This makes anyone with the `admin` relation on the super-admins team an org
+ * admin, so BOOTSTRAP_ADMIN_EMAILS is only needed for break-glass access before
+ * this tuple is seeded. Safe to call multiple times (OpenFGA write is idempotent).
+ */
+async function ensureSuperAdminsOrgAdminTuple(warnings: string[]): Promise<void> {
+  try {
+    await writeOpenFgaTuples({
+      writes: [
+        {
+          user: `team:${SUPER_ADMINS_TEAM_SLUG}#admin`,
+          relation: "admin",
+          object: organizationObjectId(),
+        },
+      ],
+      deletes: [],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`super-admins org connector tuple: ${message}`);
+  }
+}
 
 export interface SuperAdminsBootstrapMember {
   email: string;
@@ -219,6 +245,7 @@ export async function ensureSuperAdminsTeam(
         warnings.push(`${member.email}: failed to record membership source: ${message}`);
       }
     }
+    await ensureSuperAdminsOrgAdminTuple(warnings);
     return {
       status: "created",
       team_slug: SUPER_ADMINS_TEAM_SLUG,
@@ -316,6 +343,7 @@ export async function ensureSuperAdminsTeam(
   };
   await teams.updateOne({ slug: SUPER_ADMINS_TEAM_SLUG }, { $set: setOps });
 
+  await ensureSuperAdminsOrgAdminTuple(warnings);
   return {
     status: newMemberCount > 0 ? "updated" : "noop",
     team_slug: SUPER_ADMINS_TEAM_SLUG,

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.6.0rc14"
+version = "0.6.0rc15"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- `ensureSuperAdminsTeam()` now idempotently writes `team:super-admins#admin admin organization:<key>` on every bootstrap run
- Without this tuple, team membership granted `user:<sub> admin team:super-admins` but was not connected to `organization:caipe`, so `admin_ui#view` checks failed with `DENY_NO_CAPABILITY` for team members
- Adding a user to the super-admins team via the admin UI is now sufficient to grant org admin access; `BOOTSTRAP_ADMIN_EMAILS` remains as break-glass

## Test plan
- [ ] Add a user to the super-admins team, verify they can access the admin UI without being in `BOOTSTRAP_ADMIN_EMAILS`
- [ ] DCO passes (single clean commit with `Signed-off-by`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)