### PR TITLE
fix(ui): refresh mcp server list

### DIFF
--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -103,6 +103,15 @@ async function installTeamResourceMocks(page: Page): Promise<InstalledTeamMocks>
 type InstalledMcpMocks = {
   createRequests: Array<Record<string, unknown>>;
   listRequests: number;
+  addExternalServer: (server: {
+    _id: string;
+    name: string;
+    description?: string;
+    transport?: string;
+    endpoint?: string;
+    enabled?: boolean;
+    config_driven?: boolean;
+  }) => void;
 };
 
 type InstalledRagFileMocks = {
@@ -115,17 +124,16 @@ type InstalledRagFileMocks = {
 async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
   const createRequests: Array<Record<string, unknown>> = [];
   let listRequests = 0;
-  let createdServer:
-    | {
-        _id: string;
-        name: string;
-        description: string;
-        transport: string;
-        endpoint: string;
-        enabled: boolean;
-        config_driven: boolean;
-      }
-    | null = null;
+  type BrowserMcpServer = {
+    _id: string;
+    name: string;
+    description: string;
+    transport: string;
+    endpoint: string;
+    enabled: boolean;
+    config_driven: boolean;
+  };
+  let servers: BrowserMcpServer[] = [];
 
   await installMockedRbacApp(page, {
     isAdmin: true,
@@ -139,12 +147,11 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
 
         if (path === "/api/mcp-servers" && method === "GET") {
           listRequests += 1;
-          const items = createdServer ? [createdServer] : [];
           await fulfillJson(route, {
             success: true,
             data: {
-              items,
-              total: items.length,
+              items: servers,
+              total: servers.length,
               page: 1,
               page_size: 100,
               has_more: false,
@@ -160,16 +167,18 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
             typeof body.id === "string" && body.id.startsWith("mcp-")
               ? body.id
               : `mcp-${String(body.id ?? "ops-tools")}`;
-          createdServer = {
-            _id: serverId,
-            name: String(body.name ?? "Ops Tools"),
-            description: String(body.description ?? ""),
-            transport: String(body.transport ?? "sse"),
-            endpoint: String(body.endpoint ?? ""),
-            enabled: true,
-            config_driven: false,
-          };
-          await fulfillJson(route, { success: true, data: createdServer }, 201);
+          servers = [
+            {
+              _id: serverId,
+              name: String(body.name ?? "Ops Tools"),
+              description: String(body.description ?? ""),
+              transport: String(body.transport ?? "sse"),
+              endpoint: String(body.endpoint ?? ""),
+              enabled: true,
+              config_driven: false,
+            },
+          ];
+          await fulfillJson(route, { success: true, data: servers[0] }, 201);
           return true;
         }
 
@@ -184,6 +193,20 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
     },
     get listRequests() {
       return listRequests;
+    },
+    addExternalServer(server) {
+      servers = [
+        ...servers,
+        {
+          _id: server._id,
+          name: server.name,
+          description: server.description ?? "",
+          transport: server.transport ?? "sse",
+          endpoint: server.endpoint ?? "",
+          enabled: server.enabled ?? true,
+          config_driven: server.config_driven ?? false,
+        },
+      ];
     },
   };
 }
@@ -390,6 +413,27 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
 
     await expect(page.getByText("Ops Tools")).toBeVisible();
     await expect.poll(() => mocks.listRequests).toBeGreaterThanOrEqual(2);
+    await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
+  });
+
+  test("mounted MCP server list refreshes when servers change outside the tab", async ({ page }) => {
+    const mocks = await installMcpServerMocks(page);
+
+    await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("No MCP Servers Yet")).toBeVisible();
+    const initialListRequests = mocks.listRequests;
+
+    mocks.addExternalServer({
+      _id: "mcp-incident-tools",
+      name: "Incident Tools",
+      endpoint: "https://mcp.example.test/incidents",
+    });
+
+    await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+    await expect(page.getByText("Incident Tools")).toBeVisible();
+    await expect(page.getByText("mcp-incident-tools")).toBeVisible();
+    await expect.poll(() => mocks.listRequests).toBeGreaterThan(initialListRequests);
     await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
   });
 

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -24,6 +24,10 @@ Zap,
 import React from "react";
 import { MCPServerEditor } from "./MCPServerEditor";
 
+// assisted-by Codex Codex-sonnet-4-6
+export const MCP_SERVERS_REFRESH_INTERVAL_MS = 10_000;
+const MCP_SERVERS_LIST_URL = "/api/mcp-servers?page_size=100";
+
 interface ProbeResult {
   server_id: string;
   loading: boolean;
@@ -37,6 +41,15 @@ interface AgentGatewayMigrationWarning {
   target_endpoint?: string;
   existing_endpoint?: string;
   message: string;
+}
+
+interface FetchServersOptions {
+  showLoading?: boolean;
+  preserveListOnError?: boolean;
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
 }
 
 export function MCPServersTab() {
@@ -53,26 +66,63 @@ export function MCPServersTab() {
   const [agentGatewayMessage, setAgentGatewayMessage] = React.useState<string | null>(null);
   const [agentGatewayError, setAgentGatewayError] = React.useState<string | null>(null);
 
-  const fetchServers = React.useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const fetchServers = React.useCallback(async ({
+    showLoading = true,
+    preserveListOnError = false,
+  }: FetchServersOptions = {}) => {
+    if (showLoading) {
+      setLoading(true);
+    }
+    if (!preserveListOnError) {
+      setError(null);
+    }
     try {
-      const response = await fetch("/api/mcp-servers?page_size=100");
+      const response = await fetch(MCP_SERVERS_LIST_URL, { cache: "no-store" });
       const data = await response.json();
       if (data.success) {
         setServers(data.data.items || []);
+        setError(null);
       } else {
-        setError(data.error || "Failed to fetch servers");
+        if (!preserveListOnError) {
+          setError(data.error || "Failed to fetch servers");
+        }
       }
-    } catch (err: any) {
-      setError(err.message || "Failed to fetch servers");
+    } catch (err: unknown) {
+      if (!preserveListOnError) {
+        setError(errorMessage(err, "Failed to fetch servers"));
+      }
     } finally {
-      setLoading(false);
+      if (showLoading) {
+        setLoading(false);
+      }
     }
   }, []);
 
   React.useEffect(() => {
     fetchServers();
+  }, [fetchServers]);
+
+  React.useEffect(() => {
+    const refreshFromBackend = () => {
+      void fetchServers({ showLoading: false, preserveListOnError: true });
+    };
+
+    const intervalId = window.setInterval(refreshFromBackend, MCP_SERVERS_REFRESH_INTERVAL_MS);
+
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "visible") {
+        refreshFromBackend();
+      }
+    };
+
+    window.addEventListener("focus", refreshFromBackend);
+    document.addEventListener("visibilitychange", refreshWhenVisible);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshFromBackend);
+      document.removeEventListener("visibilitychange", refreshWhenVisible);
+    };
   }, [fetchServers]);
 
   const handleDelete = async (serverId: string) => {
@@ -88,8 +138,8 @@ export function MCPServersTab() {
       } else {
         alert(data.error || "Failed to delete server");
       }
-    } catch (err: any) {
-      alert(err.message || "Failed to delete server");
+    } catch (err: unknown) {
+      alert(errorMessage(err, "Failed to delete server"));
     }
   };
 
@@ -106,8 +156,8 @@ export function MCPServersTab() {
       } else {
         alert(data.error || "Failed to update server");
       }
-    } catch (err: any) {
-      alert(err.message || "Failed to update server");
+    } catch (err: unknown) {
+      alert(errorMessage(err, "Failed to update server"));
     }
   };
 
@@ -159,13 +209,13 @@ export function MCPServersTab() {
           },
         }));
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       setProbeResults((prev) => ({
         ...prev,
         [serverId]: {
           server_id: serverId,
           loading: false,
-          error: err.message || "Probe failed",
+          error: errorMessage(err, "Probe failed"),
         },
       }));
     }
@@ -196,8 +246,8 @@ export function MCPServersTab() {
       );
       setAgentGatewayMigrationWarnings(data.data.migration_warnings || []);
       await fetchServers();
-    } catch (err: any) {
-      setAgentGatewayError(err.message || "Failed to sync AgentGateway MCP servers");
+    } catch (err: unknown) {
+      setAgentGatewayError(errorMessage(err, "Failed to sync AgentGateway MCP servers"));
     } finally {
       setAgentGatewaySyncing(false);
     }
@@ -299,7 +349,7 @@ export function MCPServersTab() {
               )}
               Sync with AgentGateway
             </Button>
-            <Button variant="outline" size="sm" onClick={fetchServers} disabled={loading}>
+            <Button variant="outline" size="sm" onClick={() => fetchServers()} disabled={loading}>
               <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
               Refresh
             </Button>
@@ -368,7 +418,7 @@ export function MCPServersTab() {
         ) : error ? (
           <div className="text-center py-12">
             <p className="text-destructive">{error}</p>
-            <Button variant="outline" className="mt-4" onClick={fetchServers}>
+            <Button variant="outline" className="mt-4" onClick={() => fetchServers()}>
               Retry
             </Button>
           </div>

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MCPServersTab } from "../MCPServersTab";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MCP_SERVERS_REFRESH_INTERVAL_MS, MCPServersTab } from "../MCPServersTab";
+
+// assisted-by Codex Codex-sonnet-4-6
 
 const jiraServer = {
   _id: "jira",
@@ -107,5 +109,63 @@ describe("MCPServersTab AgentGateway sync", () => {
 
     expect(screen.getByText("AgentGateway")).toBeInTheDocument();
     expect(screen.getByText(/Target: http:\/\/rag-server:9446\/mcp/i)).toBeInTheDocument();
+  });
+
+  it("refreshes the mounted list when servers are added outside the tab", async () => {
+    jest.useFakeTimers();
+    const { unmount } = render(<MCPServersTab />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Jira")).toBeInTheDocument();
+    expect(screen.queryByText("RAG")).not.toBeInTheDocument();
+
+    serverItems = [jiraServer, agentGatewayRagServer];
+
+    await act(async () => {
+      jest.advanceTimersByTime(MCP_SERVERS_REFRESH_INTERVAL_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("RAG")).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/mcp-servers?page_size=100",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+
+    unmount();
+    jest.useRealTimers();
+  });
+
+  it("refreshes the mounted list when servers are removed outside the tab", async () => {
+    jest.useFakeTimers();
+    serverItems = [jiraServer, agentGatewayRagServer];
+    const { unmount } = render(<MCPServersTab />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Jira")).toBeInTheDocument();
+    expect(screen.getByText("RAG")).toBeInTheDocument();
+
+    serverItems = [jiraServer];
+
+    await act(async () => {
+      jest.advanceTimersByTime(MCP_SERVERS_REFRESH_INTERVAL_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Jira")).toBeInTheDocument();
+    expect(screen.queryByText("RAG")).not.toBeInTheDocument();
+
+    unmount();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
# Description

Fixes #1809.

The MCP Servers tab kept a local snapshot after mount. When MCP servers were added or removed through config or API paths outside the tab, the backend state could be correct while the mounted UI kept showing stale data until a manual refresh or remount.

This change makes the tab refetch `/api/mcp-servers` with `cache: "no-store"`, refreshes the mounted list in the background, and also refreshes on focus/visibility changes. Background refresh failures preserve the currently displayed list so transient backend errors do not blank the UI.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- [x] `cd ui && CI=1 npm test -- MCPServersTab.test.tsx --runInBand`
- [x] `cd ui && npx eslint src/components/dynamic-agents/MCPServersTab.tsx src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx`
- [x] `cd ui && npm run build`
- [x] `cd ui && npm run lint` exits 0; existing repo-wide warnings remain
- [x] `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3100 npx playwright test e2e/rbac/mcp-openfga-tuples.spec.ts --config=playwright.rbac.config.ts`

## Test Coverage

- Added a regression test for MCP servers added outside the mounted tab.
- Added a regression test for MCP servers removed outside the mounted tab.
- Added a Playwright regression proving the mounted MCP Servers tab refreshes when backend state changes outside the tab.
- Existing AgentGateway sync/label tests continue to pass.

## Checklist

- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] New code contribution is covered by automated tests
- [x] All code style checks pass
- [x] All new and existing relevant tests pass
