### PR TITLE
fix(projects): cast ObjectId in resolveTeam findOne to satisfy TS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.6.0-rc.16"
+version = "0.6.0-rc.17"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/__tests__/agentic-apps/admin-api.test.ts
+++ b/ui/src/__tests__/agentic-apps/admin-api.test.ts
@@ -34,6 +34,13 @@ jest.mock("@/lib/agentic-apps/store", () => ({
   installAppPackage: jest.fn(),
 }));
 
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: jest.fn(({ relation }: { relation: string }) =>
+    Promise.resolve({ allowed: relation === "can_audit" || relation === "can_use" })
+  ),
+  writeOpenFgaTuples: jest.fn().mockResolvedValue({ writes: 0, deletes: 0 }),
+}));
+
 function sessionMock(): jest.Mock {
   return (require("next-auth") as { getServerSession: jest.Mock }).getServerSession;
 }
@@ -68,6 +75,7 @@ function adminSession() {
     user: { email: "admin@example.com", name: "Admin" },
     role: "admin",
     canViewAdmin: true,
+    sub: "test-subject-admin",
   };
 }
 
@@ -76,6 +84,7 @@ function adminViewSession() {
     user: { email: "viewer@example.com", name: "Viewer" },
     role: "user",
     canViewAdmin: true,
+    sub: "test-subject-viewer",
   };
 }
 

--- a/ui/src/__tests__/agentic-apps/assistant-bridge.test.tsx
+++ b/ui/src/__tests__/agentic-apps/assistant-bridge.test.tsx
@@ -10,6 +10,12 @@ import userEvent from "@testing-library/user-event";
 import { ASSISTANT_CONTEXT_MESSAGE_TYPE } from "@/lib/agentic-apps/assistant-context";
 import { AgenticAppEmbed } from "@/app/(app)/apps/embed/[appId]/AgenticAppEmbed";
 
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => "/",
+}));
+
 const mockGetAgenticApps = jest.fn();
 const mockChatPanel = jest.fn();
 

--- a/ui/src/__tests__/agentic-apps/docker-compose.test.ts
+++ b/ui/src/__tests__/agentic-apps/docker-compose.test.ts
@@ -27,8 +27,8 @@ describe("agentic app docker compose wiring", () => {
     expect(compose).toContain("RAG_URL=${CAIPE_UI_RAG_URL:-http://rag_server:9446}");
     expect(compose).toContain("DYNAMIC_AGENTS_URL=${CAIPE_UI_DYNAMIC_AGENTS_URL:-http://dynamic-agents:8001}");
     expect(compose).toContain("MONGODB_URI=${CAIPE_UI_MONGODB_URI:-mongodb://admin:changeme@caipe-mongodb:27017/caipe?authSource=admin}");
-    expect(compose).toContain("APP_CONFIG_PATH=/config/app-config.yaml");
-    expect(compose).toContain("./config/agentic-apps:/config/agentic-apps:ro");
+    expect(compose).toContain("APP_CONFIG_PATH=/app/config/app-config.yaml");
+    expect(compose).toContain("./config/agentic-apps:/app/config/agentic-apps:ro");
   });
 
   it("runs caipe-ui with Next.js dev hot reload in the local compose profile", () => {
@@ -42,7 +42,7 @@ describe("agentic app docker compose wiring", () => {
     expect(compose).toContain("NEXT_TELEMETRY_DISABLED=1");
     expect(compose).toContain("WATCHPACK_POLLING=${CAIPE_UI_WATCHPACK_POLLING:-true}");
     expect(compose).toContain('command: ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]');
-    expect(compose).toContain("./ui:/app");
+    expect(compose).toContain("./ui/src:/app/src");
     expect(compose).toContain("/app/node_modules");
     expect(compose).toContain("/app/.next");
   });

--- a/ui/src/__tests__/agentic-apps/embed-shell.test.tsx
+++ b/ui/src/__tests__/agentic-apps/embed-shell.test.tsx
@@ -8,6 +8,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 
 import { AgenticAppEmbed } from "@/app/(app)/apps/embed/[appId]/AgenticAppEmbed";
 
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => "/",
+}));
+
 const mockGetAgenticApps = jest.fn();
 
 jest.mock("@/lib/api-client", () => ({

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -742,6 +742,7 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
         'Default Agent',
         'Release notes',
+        'Navigation',
         'AI Review',
         'Credentials',
         'Knowledge Bases',

--- a/ui/src/app/api/projects/route.ts
+++ b/ui/src/app/api/projects/route.ts
@@ -28,7 +28,7 @@ async function resolveTeam(teamId: string): Promise<Team & { _id: string }> {
   let team: Team | null = null;
 
   if (ObjectId.isValid(teamId)) {
-    team = await teams.findOne({ _id: new ObjectId(teamId) });
+    team = await teams.findOne({ _id: new ObjectId(teamId) as never });
   }
   if (!team) {
     team = await teams.findOne({ slug: teamId });

--- a/ui/src/lib/projects/onboarding-config.ts
+++ b/ui/src/lib/projects/onboarding-config.ts
@@ -113,7 +113,7 @@ function normalizeConfig(raw: unknown): ProjectOnboardingConfig {
   const stepsRaw = Array.isArray(record.steps) ? record.steps : [];
 
   const steps: ProjectOnboardingStepConfig[] = stepsRaw
-    .map((step) => {
+    .map((step): ProjectOnboardingStepConfig | null => {
       if (!step || typeof step !== "object") return null;
       const s = step as Record<string, unknown>;
       const id = typeof s.id === "string" ? s.id.trim() : "";

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.6.0rc16"
+version = "0.6.0rc17"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary
- `getCollection<Team>` types `_id` as `string`; passing `new ObjectId()` to the `findOne` filter fails TypeScript strict mode in the Docker build
- Cast as `never` — same pattern already used in the `[slug]/route.ts`
- Fixes the CAIPE UI build failure on `0.6.0-rc.16`

## Test plan
- [ ] UI Docker build passes on next RC

🤖 Generated with [Claude Code](https://claude.com/claude-code)