### PR TITLE
fix(webex): replace static agent route mappings

### DIFF
--- a/ai_platform_engineering/integrations/webex_bot/tests/test_webex_admin_api.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_webex_admin_api.py
@@ -19,6 +19,7 @@ from ai_platform_engineering.integrations.webex_bot.utils.webex_admin_api import
     WebexAdminTokenValidator,
     WebexBotAdminService,
     _WebexAdminRequestHandler,
+    load_webex_bot_config,
     webex_admin_jwt_audience,
 )
 from ai_platform_engineering.integrations.webex_bot.utils.webex_config_models import (
@@ -30,6 +31,8 @@ from ai_platform_engineering.integrations.webex_bot.utils.webex_config_models im
 class _RoutesCollection:
     def __init__(self) -> None:
         self.update_calls: list[tuple[dict[str, object], dict[str, object], bool]] = []
+        self.update_many_calls: list[tuple[dict[str, object], dict[str, object]]] = []
+        self.delete_calls: list[dict[str, object]] = []
 
     def update_one(
         self,
@@ -38,6 +41,12 @@ class _RoutesCollection:
         upsert: bool = False,
     ) -> None:
         self.update_calls.append((filter_query, update, upsert))
+
+    def update_many(self, filter_query: dict[str, object], update: dict[str, object]) -> None:
+        self.update_many_calls.append((filter_query, update))
+
+    def delete_one(self, filter_query: dict[str, object]) -> None:
+        self.delete_calls.append(filter_query)
 
 
 class _Resolver:
@@ -165,6 +174,45 @@ def test_sync_from_config_upserts_routes_writes_openfga_and_invalidates_cache() 
     assert resolver.invalidated == [("CAIPE-WEBEX", "space-abc")]
 
 
+def test_sync_from_config_replaces_existing_agent_metadata_without_touching_others() -> None:
+    config = WebexBotConfig(
+        spaces={
+            "space-abc": SpaceConfig(
+                name="Platform Space",
+                agents=[
+                    AgentBinding(
+                        agent_id="incident-agent",
+                        users=UsersConfig(enabled=True, listen="message"),
+                    )
+                ],
+            )
+        }
+    )
+    routes = _RoutesCollection()
+    service = WebexBotAdminService(
+        config=config,
+        resolver=_Resolver(),
+        collection_factory=lambda _name: routes,
+        openfga_writer=lambda _tuple_key: None,
+    )
+
+    summary = service.sync_from_config(workspace_id="CAIPE-WEBEX", dry_run=False)
+
+    assert summary["routes_upserted"] == 1
+    assert len(routes.update_calls) == 1
+    filter_query, update, upsert = routes.update_calls[0]
+    assert upsert is True
+    assert filter_query == {
+        "workspace_id": "CAIPE-WEBEX",
+        "space_id": "space-abc",
+        "agent_id": "incident-agent",
+    }
+    assert update["$set"]["users"]["listen"] == "message"  # type: ignore[index]
+    assert update["$unset"] == {"bots": "", "escalation": ""}
+    assert routes.update_many_calls == []
+    assert routes.delete_calls == []
+
+
 def test_sync_from_config_canonicalizes_public_webex_room_ids() -> None:
     config = WebexBotConfig(
         spaces={
@@ -191,6 +239,73 @@ def test_sync_from_config_canonicalizes_public_webex_room_ids() -> None:
         "webex_space:CAIPE-WEBEX--6f91b070-531a-11f1-926d-6fd3c20dfdc4"
     )
     assert resolver.invalidated == [("CAIPE-WEBEX", "6f91b070-531a-11f1-926d-6fd3c20dfdc4")]
+
+
+def test_load_webex_bot_config_from_inline_yaml(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "WEBEX_INTEGRATION_BOT_CONFIG",
+        """
+space-abc:
+  name: Platform Space
+  agents:
+    - agent_id: incident-agent
+      users:
+        enabled: true
+        listen: all
+""",
+    )
+
+    config = load_webex_bot_config()
+
+    assert list(config.spaces) == ["space-abc"]
+    assert config.spaces["space-abc"].agents[0].agent_id == "incident-agent"
+    assert config.spaces["space-abc"].agents[0].users is not None
+    assert config.spaces["space-abc"].agents[0].users.listen == "all"
+
+
+def test_load_webex_bot_config_from_file_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    config_path = tmp_path / "webex-bot.yaml"
+    config_path.write_text(
+        """
+spaces:
+  space-from-file:
+    name: File Space
+    agents:
+      - agent_id: file-agent
+        users:
+          enabled: true
+          listen: mention
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("WEBEX_INTEGRATION_BOT_CONFIG", str(config_path))
+
+    config = load_webex_bot_config()
+
+    assert config.spaces["space-from-file"].name == "File Space"
+    assert config.spaces["space-from-file"].agents[0].agent_id == "file-agent"
+
+
+def test_load_webex_bot_config_supports_legacy_agent_id_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "WEBEX_INTEGRATION_BOT_CONFIG",
+        """
+space-legacy:
+  agent_id: legacy-agent
+""",
+    )
+
+    config = load_webex_bot_config()
+
+    route = config.spaces["space-legacy"].agents[0]
+    assert config.spaces["space-legacy"].name == "space-legacy"
+    assert route.agent_id == "legacy-agent"
+    assert route.users is not None
+    assert route.users.listen == "all"
 
 
 def test_validator_default_audience_is_webex_admin() -> None:

--- a/ai_platform_engineering/integrations/webex_bot/utils/webex_admin_api.py
+++ b/ai_platform_engineering/integrations/webex_bot/utils/webex_admin_api.py
@@ -34,6 +34,7 @@ from .webex_ids import canonicalize_webex_space_id
 logger = logging.getLogger("caipe.webex_bot.webex_admin_api")
 
 MAX_ADMIN_REQUEST_BODY_BYTES = 64 * 1024
+ROUTE_METADATA_FIELDS = ("users", "bots", "escalation")
 
 CollectionFactory = Callable[[str], Optional[Collection[Any]]]
 OpenFgaWriter = Callable[[dict[str, str]], None]
@@ -256,19 +257,7 @@ class WebexBotAdminService:
                         "space_id": route["space_id"],
                         "agent_id": route["agent_id"],
                     },
-                    {
-                        "$set": {
-                            **route,
-                            "source_type": "config_sync",
-                            "status": "active",
-                            "updated_by": "webex_admin_sync",
-                            "updated_at": now,
-                        },
-                        "$setOnInsert": {
-                            "created_by": "webex_admin_sync",
-                            "created_at": now,
-                        },
-                    },
+                    _route_upsert_update(route, now),
                     upsert=True,
                 )
                 summary["routes_upserted"] += 1
@@ -344,6 +333,26 @@ def _route_from_agent_binding(
     if agent.escalation is not None:
         route["escalation"] = agent.escalation.model_dump(exclude_none=True)
     return route
+
+
+def _route_upsert_update(route: dict[str, Any], now: str) -> dict[str, Any]:
+    unset = {field: "" for field in ROUTE_METADATA_FIELDS if field not in route}
+    update: dict[str, Any] = {
+        "$set": {
+            **route,
+            "source_type": "config_sync",
+            "status": "active",
+            "updated_by": "webex_admin_sync",
+            "updated_at": now,
+        },
+        "$setOnInsert": {
+            "created_by": "webex_admin_sync",
+            "created_at": now,
+        },
+    }
+    if unset:
+        update["$unset"] = unset
+    return update
 
 
 def _openfga_store_id(base_url: str) -> str:
@@ -455,7 +464,7 @@ def _optional_string(value: object) -> str | None:
 def load_webex_bot_config() -> WebexBotConfig:
     """Load optional static Webex routing config (empty when unset)."""
 
-    return WebexBotConfig()
+    return WebexBotConfig.from_env()
 
 
 def start_webex_admin_api_server(

--- a/ai_platform_engineering/integrations/webex_bot/utils/webex_config_models.py
+++ b/ai_platform_engineering/integrations/webex_bot/utils/webex_config_models.py
@@ -4,9 +4,19 @@
 
 from __future__ import annotations
 
+import logging
+import os
+from typing import Any
+
 from pydantic import BaseModel, Field
 
-from ai_platform_engineering.integrations.slack_bot.utils.config_models import AgentBinding
+from ai_platform_engineering.integrations.slack_bot.utils.config_models import (
+    AgentBinding,
+    UsersConfig,
+)
+
+logger = logging.getLogger("caipe.webex_bot.webex_config_models")
+DEFAULT_BOT_CONFIG_PATH = "/etc/caipe/bot-config.yaml"
 
 
 class SpaceConfig(BaseModel):
@@ -20,3 +30,57 @@ class WebexBotConfig(BaseModel):
     """Deployment static Webex space routing config."""
 
     spaces: dict[str, SpaceConfig] = Field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls) -> "WebexBotConfig":
+        """Load static Webex routing config from file or inline YAML."""
+
+        import yaml
+
+        raw_config: dict[str, Any]
+        config_source = os.environ.get("WEBEX_INTEGRATION_BOT_CONFIG", "").strip()
+        if config_source:
+            if os.path.isfile(config_source):
+                logger.info("Loading Webex bot config from file: %s", config_source)
+                with open(config_source, encoding="utf-8") as config_file:
+                    loaded = yaml.safe_load(config_file) or {}
+            else:
+                logger.info("Loading Webex bot config from inline YAML")
+                loaded = yaml.safe_load(config_source) or {}
+        elif os.path.isfile(DEFAULT_BOT_CONFIG_PATH):
+            logger.info("Loading Webex bot config from %s", DEFAULT_BOT_CONFIG_PATH)
+            with open(DEFAULT_BOT_CONFIG_PATH, encoding="utf-8") as config_file:
+                loaded = yaml.safe_load(config_file) or {}
+        else:
+            logger.info("No Webex bot config found; starting with no static space routes")
+            loaded = {}
+
+        if not isinstance(loaded, dict):
+            raise ValueError("Webex bot config must be a mapping")
+
+        raw_config = loaded
+        raw_spaces = raw_config.get("spaces") if isinstance(raw_config.get("spaces"), dict) else raw_config
+        return cls(
+            spaces={
+                str(space_id): _space_config_from_raw(str(space_id), space_data)
+                for space_id, space_data in raw_spaces.items()
+            }
+        )
+
+
+def _space_config_from_raw(space_id: str, value: Any) -> SpaceConfig:
+    if not isinstance(value, dict):
+        raise ValueError(f"Webex space config for {space_id!r} must be a mapping")
+
+    data = dict(value)
+    if "agents" not in data:
+        agent_id = data.get("agent_id")
+        if isinstance(agent_id, str) and agent_id.strip():
+            data["agents"] = [
+                AgentBinding(
+                    agent_id=agent_id.strip(),
+                    users=UsersConfig(enabled=True, listen="all"),
+                )
+            ]
+    data.setdefault("name", space_id)
+    return SpaceConfig(**data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.12-dev.1"
+version = "0.5.12-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.12.dev1"
+version = "0.5.12.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Fixes #1806.

This updates Webex static route config sync so an existing `(workspace_id, space_id, agent_id)` mapping is replaced with the new static config instead of keeping stale optional route metadata. It also wires `WEBEX_INTEGRATION_BOT_CONFIG` loading so Helm-mounted `webex-bot.botConfig` can be read by the Webex admin sync path.

Grounded behavior changes:
- Config sync still uses upsert semantics keyed by `workspace_id + space_id + agent_id`.
- Omitted optional route metadata (`users`, `bots`, `escalation`) is unset during an override.
- Routes for agents not present in the new static config are left untouched.
- Webex bot config can now load from an inline YAML env var, an env-var file path, or `/etc/caipe/bot-config.yaml`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `uv run --group unittest pytest tests/test_webex_admin_api.py tests/test_webex_agent_routes.py` -> 36 passed
- `uv run ruff check ai_platform_engineering/integrations/webex_bot/utils/webex_admin_api.py ai_platform_engineering/integrations/webex_bot/utils/webex_config_models.py ai_platform_engineering/integrations/webex_bot/tests/test_webex_admin_api.py` -> passed