### PR TITLE
fix(setup): auto-install kind during prerequisites check

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -731,7 +731,13 @@ check_prerequisites() {
   _check_docker_access
 
   if ! command -v kind &>/dev/null; then
-    warn "kind not found — Kind cluster options will be unavailable"
+    if [[ "$(uname -s)" == "Linux" ]]; then
+      _install_kind_linux
+    elif [[ "$(uname -s)" == "Darwin" ]]; then
+      _install_kind_macos
+    else
+      warn "kind not found — install it manually: https://kind.sigs.k8s.io/docs/user/quick-start/"
+    fi
   fi
 
   # k9s — optional but strongly recommended; auto-install if missing
@@ -767,7 +773,7 @@ check_prerequisites() {
     fi
   fi
 
-  log "Prerequisites checked (docker, kubectl, helm, openssl, curl, jq, k9s)"
+  log "Prerequisites checked (docker, kubectl, helm, kind, openssl, curl, jq, k9s)"
 }
 
 choose_cluster() {


### PR DESCRIPTION
## Summary

- `kind` was silently skipped during prerequisites with a misleading warning ("Kind cluster options will be unavailable") even though option 3 "Create a new Kind cluster" was still shown in the menu
- Moves kind install to `check_prerequisites` alongside kubectl/helm — `_install_kind_linux` already has a `$HOME/.local/bin` fallback so no sudo is required
- Adds `kind` to the prerequisites success log line

## Test plan

- [ ] Run `setup-caipe.sh` on a fresh Ubuntu box without `kind` — verify it installs automatically before the cluster menu appears
- [ ] Select "Create a new Kind cluster" — verify no double-install attempt since kind is already present
- [ ] Run with `kind` already installed — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)