### PR TITLE
chore(agentgateway): structured authz logging in config bridge

### DIFF
--- a/deploy/agentgateway/config.caipe-rbac.yaml
+++ b/deploy/agentgateway/config.caipe-rbac.yaml
@@ -184,5 +184,5 @@ binds:
 config:
   adminAddr: 0.0.0.0:15000
   logging:
-    level: debug
+    level: info
     format: json

--- a/deploy/agentgateway/config.yaml
+++ b/deploy/agentgateway/config.yaml
@@ -202,5 +202,5 @@ config:
   # Default is localhost-only; use 0.0.0.0 so Docker can publish :15000 to the host.
   adminAddr: 0.0.0.0:15000
   logging:
-    level: debug
+    level: info
     format: json

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -32,6 +32,8 @@ import yaml
 LOGGER = logging.getLogger("agentgateway-config-bridge")
 SAFE_TARGET_ID = re.compile(r"^[A-Za-z0-9._-]+$")
 PUBLISHED_CONFIG_MODE = 0o644
+_VALID_AGENTGATEWAY_LOG_LEVELS = frozenset({"trace", "debug", "info", "warn", "error"})
+DEFAULT_AGENTGATEWAY_LOG_LEVEL = "info"
 
 DEFAULT_MCP_ROUTE_POLICIES: dict[str, Any] = {
     "extAuthz": {
@@ -409,6 +411,28 @@ def _ensure_published_config_mode(path: Path) -> bool:
     return True
 
 
+def resolve_agentgateway_log_level() -> str:
+    """Return the AgentGateway proxy log level from ``AGENTGATEWAY_LOG_LEVEL``."""
+
+    level = os.getenv("AGENTGATEWAY_LOG_LEVEL", DEFAULT_AGENTGATEWAY_LOG_LEVEL).strip().lower()
+    if level not in _VALID_AGENTGATEWAY_LOG_LEVELS:
+        LOGGER.warning(
+            "Invalid AGENTGATEWAY_LOG_LEVEL %r; using %s",
+            level,
+            DEFAULT_AGENTGATEWAY_LOG_LEVEL,
+        )
+        return DEFAULT_AGENTGATEWAY_LOG_LEVEL
+    return level
+
+
+def apply_agentgateway_logging(config: dict[str, Any]) -> None:
+    """Pin proxy logging on every published config so live admin state cannot revert it."""
+
+    logging_config = config.setdefault("config", {}).setdefault("logging", {})
+    logging_config["level"] = resolve_agentgateway_log_level()
+    logging_config.setdefault("format", "json")
+
+
 def write_config_atomically(path: Path, config: dict[str, Any]) -> bool:
     """Write config as JSON/YAML-compatible content; return true when changed."""
 
@@ -487,7 +511,10 @@ def _minimal_config() -> dict[str, Any]:
         ],
         "config": {
             "adminAddr": os.getenv("AGENTGATEWAY_ADMIN_ADDR", "0.0.0.0:15000"),
-            "logging": {"level": os.getenv("LOG_LEVEL", "info"), "format": "json"},
+            "logging": {
+                "level": resolve_agentgateway_log_level(),
+                "format": "json",
+            },
         },
     }
 
@@ -534,6 +561,7 @@ def reconcile_once(
     )
     builtin_routes = load_builtin_mcp_routes(bootstrap_path)
     rendered = merge_agentgateway_mcp_routes(baseline, targets, builtin_routes=builtin_routes)
+    apply_agentgateway_logging(rendered)
     changed = write_config_atomically(config_path, rendered)
     result = {
         "targets": [target.id for target in targets],

--- a/deploy/agentgateway/tests/test_config_bridge.py
+++ b/deploy/agentgateway/tests/test_config_bridge.py
@@ -11,6 +11,8 @@ import sys
 import urllib.error
 from pathlib import Path
 
+import yaml
+
 
 BRIDGE_PATH = Path(__file__).resolve().parents[1] / "config_bridge.py"
 spec = importlib.util.spec_from_file_location("agentgateway_config_bridge", BRIDGE_PATH)
@@ -474,3 +476,40 @@ def test_reconcile_keeps_existing_config_when_admin_config_is_unavailable(
         raise AssertionError("reconcile should wait for the live config instead of overwriting")
 
     assert config_path.read_text(encoding="utf-8") == existing_config
+
+
+def test_apply_agentgateway_logging_defaults_to_info() -> None:
+    config = _baseline_config()
+    assert config["config"]["logging"]["level"] == "debug"
+
+    bridge.apply_agentgateway_logging(config)
+
+    assert config["config"]["logging"]["level"] == "info"
+    assert config["config"]["logging"]["format"] == "json"
+
+
+def test_apply_agentgateway_logging_honors_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENTGATEWAY_LOG_LEVEL", "warn")
+    config = _baseline_config()
+
+    bridge.apply_agentgateway_logging(config)
+
+    assert config["config"]["logging"]["level"] == "warn"
+
+
+def test_reconcile_once_enforces_logging_level(tmp_path: Path, monkeypatch) -> None:
+    config_path = tmp_path / "generated" / "config.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text("binds: []\n", encoding="utf-8")
+
+    monkeypatch.setattr(bridge, "_load_targets_from_mongo", lambda: [])
+    monkeypatch.setattr(
+        bridge,
+        "fetch_agentgateway_config",
+        lambda _admin_config_url: _baseline_config(),
+    )
+
+    bridge.reconcile_once(config_path=config_path, admin_config_url="http://agentgateway:15000/config")
+
+    rendered = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert rendered["config"]["logging"]["level"] == "info"


### PR DESCRIPTION
## Summary

Adds structured request logging to the agentgateway **config bridge** to make authz-related bootstrap/poll failures easier to diagnose in local and dev deployments.

Split out of local `feat/workflow-rbac-on-cas` work as an independent PR (parallel to #1770 / #1772).

## What's included

- `deploy/agentgateway/config_bridge.py` — structured logging for config fetch/apply cycles
- `deploy/agentgateway/config.yaml` + `config.caipe-rbac.yaml` — template tweaks supporting the bridge
- `deploy/agentgateway/tests/test_config_bridge.py` — unit coverage for logging paths

## What's NOT included

- CAS BFF library / HTTP API → **#1770**
- Workflow RBAC / DA `AUTHZ_SERVICE_URL` compose wiring → **#1772**
- `docker-compose.dev.yaml` `AGENTGATEWAY_LOG_LEVEL` env (left in #1772 compose diff to avoid cross-PR compose churn)

## Test plan

- [x] `uv run pytest deploy/agentgateway/tests/test_config_bridge.py`

## Related

Parallel to #1770 · #1772
