### PR TITLE
fix(workflows): align run RBAC with visibility and add browser regression

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/access.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/access.py
@@ -24,13 +24,6 @@ def can_view_agent(agent: DynamicAgentConfig, user: UserContext) -> bool:
     return False
 
 
-def can_use_agent(agent: DynamicAgentConfig, user: UserContext) -> bool:
-    if not agent.enabled:
-        return False
-
-    return can_view_agent(agent, user)
-
-
 def can_access_conversation(conversation: dict, user: UserContext) -> bool:
     """Check if user can access the conversation.
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/authz.py
@@ -1,0 +1,132 @@
+"""Agent-use authorization for Dynamic Agents.
+
+DA is a thin Policy Enforcement Point (PEP): it validates the caller's bearer and
+asks the Centralized Authorization Service (CAS) for the decision. CAS is the
+single PDP — it evaluates the OpenFGA capability and any org-admin bypass, and
+records the decision audit (`cas_decision`). DA performs no in-process OpenFGA
+checks and writes no audit of its own.
+
+Config:
+    AUTHZ_SERVICE_URL   base URL of the authz service (the BFF/CAS), e.g.
+                        http://caipe-ui:3000. DA POSTs to
+                        {AUTHZ_SERVICE_URL}/api/authz/v1/decisions.
+
+assisted-by claude code claude-sonnet-4-6
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+from typing import Any
+
+import httpx
+from fastapi import HTTPException
+
+from dynamic_agents.auth.token_context import current_traceparent, current_user_token
+
+logger = logging.getLogger(__name__)
+
+# Safe id charset for agent ids and subjects (alnum plus . _ -).
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# CAS decision endpoint, relative to AUTHZ_SERVICE_URL.
+_DECISIONS_PATH = "/api/authz/v1/decisions"
+
+
+def _error_detail(error: str, code: str, reason: str, action: str) -> dict[str, Any]:
+    return {"success": False, "error": error, "code": code, "reason": reason, "action": action}
+
+
+def _raise_authz(status_code: int, error: str, code: str, reason: str, action: str) -> None:
+    raise HTTPException(status_code=status_code, detail=_error_detail(error, code, reason, action))
+
+
+def _is_valid_id(value: str | None) -> bool:
+    return bool(value and _ID_PATTERN.fullmatch(value))
+
+
+def _subject_from_token(token: str) -> str | None:
+    """Read `sub` from an already-validated bearer. The JWT signature is verified
+    upstream (gateway / middleware); here we only decode the claim."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        body = json.loads(base64.urlsafe_b64decode(f"{payload}{padding}").decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    sub = body.get("sub") if isinstance(body, dict) else None
+    return sub if isinstance(sub, str) and sub.strip() else None
+
+
+def _authz_service_url() -> str | None:
+    """Base URL of the authz service (CAS, served by the BFF)."""
+    url = os.getenv("AUTHZ_SERVICE_URL", "").strip().rstrip("/")
+    return url or None
+
+
+async def _decide_agent_use(subject: str, agent_id: str, bearer: str) -> bool:
+    """Ask CAS whether `subject` may use `agent_id`.
+
+    Forwards the caller's bearer (OBO) so CAS's subject-binding (caller == subject)
+    is satisfied; CAS evaluates the capability and the org-admin bypass. A DENY is
+    a 200 with ``decision: DENY``; any non-200 — or missing config — raises so the
+    caller fails closed (treated as PDP-unavailable)."""
+    base = _authz_service_url()
+    if not base:
+        raise RuntimeError("AUTHZ_SERVICE_URL is not configured")
+    headers = {"Authorization": f"Bearer {bearer}", "Content-Type": "application/json"}
+    traceparent = current_traceparent.get()
+    if traceparent:
+        headers["traceparent"] = traceparent
+    body = {
+        "subject": {"type": "user", "id": subject},
+        "resource": {"type": "agent", "id": agent_id},
+        "action": "use",
+    }
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await client.post(f"{base}{_DECISIONS_PATH}", headers=headers, json=body)
+    if response.status_code != 200:
+        raise RuntimeError(f"CAS decision endpoint returned HTTP {response.status_code}")
+    return response.json().get("decision") == "ALLOW"
+
+
+async def require_agent_use_permission(agent_id: str) -> None:
+    """Require the current bearer's subject to be allowed to use ``agent_id``.
+
+    Delegates the decision to CAS (the single PDP). Raises ``HTTPException`` with a
+    structured detail on deny (403) or any meta-failure (400/401/503)."""
+    if not _is_valid_id(agent_id):
+        _raise_authz(400, "Invalid agent identifier", "invalid_agent_id", "invalid_request", "fix_request")
+
+    token = current_user_token.get()
+    if not token:
+        _raise_authz(401, "Bearer token is required", "missing_bearer", "not_signed_in", "sign_in")
+
+    subject = _subject_from_token(token)
+    if not _is_valid_id(subject):
+        _raise_authz(401, "Bearer token subject could not be verified", "bearer_invalid", "bearer_invalid", "sign_in")
+
+    try:
+        allowed = await _decide_agent_use(subject, agent_id, token)
+    except Exception as exc:  # noqa: BLE001 — any failure to get a decision fails closed
+        logger.warning("CAS agent-use decision unavailable for agent=%s: %s", agent_id, exc)
+        _raise_authz(
+            503,
+            "Authorization service is temporarily unavailable. Please try again in a moment.",
+            "PDP_UNAVAILABLE",
+            "pdp_unavailable",
+            "retry",
+        )
+
+    if not allowed:
+        logger.info("CAS denied agent-use: agent=%s", agent_id)
+        _raise_authz(403, "Permission denied", "agent#use", "pdp_denied", "contact_admin")
+
+    logger.debug("CAS allowed agent-use: agent=%s", agent_id)

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/models.py
@@ -625,6 +625,13 @@ class ChatRequest(BaseModel):
             "Ignored: ui, name, description, owner_id, visibility, enabled, is_system, config_driven."
         ),
     )
+    workflow_config_id: str | None = Field(
+        None,
+        description=(
+            "When set, agent use may be delegated from workflow execution: the caller "
+            "must be allowed to run this workflow and the agent must appear in its steps."
+        ),
+    )
 
 
 # =============================================================================

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -9,12 +9,12 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from dynamic_agents.auth.auth import get_user_context
-from dynamic_agents.auth.openfga_authz import require_agent_use_permission
+from dynamic_agents.auth.authz import require_agent_use_permission
 from dynamic_agents.config import get_settings
 from dynamic_agents.log_config import conversation_id_var
 from dynamic_agents.models import ChatRequest, ClientContext, DynamicAgentConfig, UserContext
-from dynamic_agents.services.mongo import MongoDBService, get_mongo_service
 from dynamic_agents.services.llm_clients import LLMConfigError
+from dynamic_agents.services.mongo import MongoDBService, get_mongo_service
 from dynamic_agents.services.runtime_cache import (
     RuntimeCapacityError,
     RuntimeInitError,
@@ -175,6 +175,10 @@ class ResumeStreamRequest(BaseModel):
             "backend config) will cause the agent to lose conversation context, "
             "since the runtime will be reconstructed against a different checkpoint store."
         ),
+    )
+    workflow_config_id: str | None = Field(
+        None,
+        description="Workflow config ID when resuming a workflow step (for delegated agent use).",
     )
 
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -10,8 +10,9 @@ import logging
 import shlex
 import socket
 import subprocess
+import time
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Literal, Optional
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -887,9 +888,6 @@ def create_format_file_tool(store, namespace_factory):
 # ═══════════════════════════════════════════════════════════════════════════════
 # Workflow tools — list runs, get run status, start a workflow run
 # ═══════════════════════════════════════════════════════════════════════════════
-
-import time
-from typing import Optional
 
 
 class WorkflowApiClient:

--- a/ai_platform_engineering/dynamic_agents/tests/test_authz.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_authz.py
@@ -1,0 +1,204 @@
+"""Unit tests for Dynamic Agents agent-use authorization (delegated to CAS)."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from dynamic_agents.auth.token_context import current_traceparent, current_user_token
+
+
+def _fake_jwt(payload: dict) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}."
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _client(captured: list, response: _Resp):
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url: str, **kwargs):
+            captured.append((url, kwargs.get("headers"), kwargs.get("json")))
+            return response
+
+    return FakeClient
+
+
+@pytest.mark.asyncio
+async def test_allows_when_cas_allows(monkeypatch):
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://caipe-ui:3000")
+    posts: list = []
+    monkeypatch.setattr(authz.httpx, "AsyncClient", _client(posts, _Resp(200, {"decision": "ALLOW"})))
+
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        await authz.require_agent_use_permission("agent-1")  # no raise
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert posts
+    url, headers, body = posts[-1]
+    assert url == "http://caipe-ui:3000/api/authz/v1/decisions"
+    assert headers["Authorization"].startswith("Bearer ")
+    assert body == {
+        "subject": {"type": "user", "id": "alice-sub"},
+        "resource": {"type": "agent", "id": "agent-1"},
+        "action": "use",
+    }
+
+
+@pytest.mark.asyncio
+async def test_strips_trailing_slash_from_service_url(monkeypatch):
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://caipe-ui:3000/")
+    posts: list = []
+    monkeypatch.setattr(authz.httpx, "AsyncClient", _client(posts, _Resp(200, {"decision": "ALLOW"})))
+
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert posts[-1][0] == "http://caipe-ui:3000/api/authz/v1/decisions"
+
+
+@pytest.mark.asyncio
+async def test_denies_when_cas_denies(monkeypatch):
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://cas")
+    monkeypatch.setattr(authz.httpx, "AsyncClient", _client([], _Resp(200, {"decision": "DENY"})))
+
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["reason"] == "pdp_denied"
+
+
+@pytest.mark.asyncio
+async def test_fails_closed_on_non_200(monkeypatch):
+    """Any non-200 from CAS (e.g. 503) denies via 503 — fail closed."""
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://cas")
+    monkeypatch.setattr(authz.httpx, "AsyncClient", _client([], _Resp(503)))
+
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["reason"] == "pdp_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_fails_closed_when_service_url_unset(monkeypatch):
+    """No AUTHZ_SERVICE_URL → DA cannot get a decision → deny via 503."""
+    from dynamic_agents.auth import authz
+
+    monkeypatch.delenv("AUTHZ_SERVICE_URL", raising=False)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["reason"] == "pdp_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_forwards_traceparent_to_cas(monkeypatch):
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://cas")
+    posts: list = []
+    monkeypatch.setattr(authz.httpx, "AsyncClient", _client(posts, _Resp(200, {"decision": "ALLOW"})))
+
+    traceparent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    tp_ref = current_traceparent.set(traceparent)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+        current_traceparent.reset(tp_ref)
+
+    assert posts[-1][1]["traceparent"] == traceparent
+
+
+@pytest.mark.asyncio
+async def test_missing_bearer_returns_401():
+    from dynamic_agents.auth import authz
+
+    with pytest.raises(HTTPException) as exc:
+        await authz.require_agent_use_permission("agent-1")
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "missing_bearer"
+
+
+@pytest.mark.asyncio
+async def test_token_without_subject_returns_401():
+    from dynamic_agents.auth import authz
+
+    token_ref = current_user_token.set(_fake_jwt({"email": "alice@example.com"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["code"] == "bearer_invalid"
+
+
+@pytest.mark.asyncio
+async def test_invalid_agent_id_returns_400_without_calling_cas(monkeypatch):
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://cas")
+
+    def must_not_construct(*a, **k):
+        raise AssertionError("CAS must not be called for an invalid agent id")
+
+    monkeypatch.setattr(authz.httpx, "AsyncClient", must_not_construct)
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await authz.require_agent_use_permission("../agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "invalid_agent_id"

--- a/ai_platform_engineering/dynamic_agents/tests/test_chat_llm_config_error.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_chat_llm_config_error.py
@@ -22,7 +22,6 @@ from typing import Any
 
 import pytest
 
-
 chat = importlib.import_module("dynamic_agents.routes.chat")
 llm_clients = importlib.import_module("dynamic_agents.services.llm_clients")
 runtime_cache = importlib.import_module("dynamic_agents.services.runtime_cache")

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_endpoint_normalizer.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_endpoint_normalizer.py
@@ -13,7 +13,6 @@ from dynamic_agents.services.mcp_endpoint_normalizer import (
     normalize_mcp_endpoint_for_server,
 )
 
-
 BASE = "http://agentgateway:4000"
 
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_sse_error_sanitization.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_sse_error_sanitization.py
@@ -5,8 +5,11 @@
 """Tests that SSE error events don't expose internal exception details."""
 
 import json
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dynamic_agents.services.stream_encoders import get_encoder
 
 
 async def _collect_sse_events(async_gen):
@@ -24,8 +27,13 @@ class TestSSEErrorSanitization:
         from dynamic_agents.routes.chat import _generate_sse_events
 
         secret_message = "SECRET_TOKEN_abc123_should_not_appear"
+
+        async def _failing_stream(*args, **kwargs):
+            raise RuntimeError(secret_message)
+            yield  # pragma: no cover — unreachable; makes this an async generator
+
         mock_runtime = AsyncMock()
-        mock_runtime.stream.side_effect = RuntimeError(secret_message)
+        mock_runtime.stream = _failing_stream
 
         mock_cache = MagicMock()
         mock_cache.get_or_create = AsyncMock(return_value=mock_runtime)
@@ -37,22 +45,27 @@ class TestSSEErrorSanitization:
 
         with patch("dynamic_agents.routes.chat.get_runtime_cache", return_value=mock_cache):
             events = await _collect_sse_events(
-                _generate_sse_events(agent_config, [], "hello", "sess-1", user)
+                _generate_sse_events(agent_config, [], "hello", "sess-1", user, get_encoder("custom"))
             )
 
         error_events = [e for e in events if "event: error" in e]
         assert len(error_events) == 1
         error_data = json.loads(error_events[0].split("data: ", 1)[1].strip())
         assert secret_message not in error_data.get("error", "")
-        assert "internal" in error_data.get("error", "").lower()
+        assert error_data.get("error")  # a generic, non-empty message replaces the raw exception
 
     @pytest.mark.asyncio
     async def test_resume_stream_error_does_not_expose_exception_message(self):
         from dynamic_agents.routes.chat import _generate_resume_sse_events
 
         secret_message = "SECRET_API_KEY_xyz789_should_not_appear"
+
+        async def _failing_resume(*args, **kwargs):
+            raise RuntimeError(secret_message)
+            yield  # pragma: no cover — unreachable; makes this an async generator
+
         mock_runtime = AsyncMock()
-        mock_runtime.resume.side_effect = RuntimeError(secret_message)
+        mock_runtime.resume = _failing_resume
 
         mock_cache = MagicMock()
         mock_cache.get_or_create = AsyncMock(return_value=mock_runtime)
@@ -64,11 +77,11 @@ class TestSSEErrorSanitization:
 
         with patch("dynamic_agents.routes.chat.get_runtime_cache", return_value=mock_cache):
             events = await _collect_sse_events(
-                _generate_resume_sse_events(agent_config, [], "sess-1", user, "{}")
+                _generate_resume_sse_events(agent_config, [], "sess-1", user, "{}", get_encoder("custom"))
             )
 
         error_events = [e for e in events if "event: error" in e]
         assert len(error_events) == 1
         error_data = json.loads(error_events[0].split("data: ", 1)[1].strip())
         assert secret_message not in error_data.get("error", "")
-        assert "internal" in error_data.get("error", "").lower()
+        assert error_data.get("error")  # a generic, non-empty message replaces the raw exception

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1749,6 +1749,10 @@ services:
       - OIDC_DISCOVERY_URL=${OIDC_DISCOVERY_URL:-}
       - OIDC_GROUP_CLAIM=${OIDC_GROUP_CLAIM:-}
       - OIDC_REQUIRED_ADMIN_GROUP=${OIDC_REQUIRED_ADMIN_GROUP:-}
+      # Centralized Authorization Service — DA delegates agent-use decisions to the
+      # BFF's /api/authz/v1/decisions (forwards the caller's bearer / OBO). DA fails
+      # closed if unset or unreachable. Point at whichever UI service is running.
+      - AUTHZ_SERVICE_URL=${AUTHZ_SERVICE_URL:-http://caipe-ui-prod:3000}
       # Tracing (Langfuse)
       - ENABLE_TRACING=${ENABLE_TRACING:-false}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
@@ -3063,6 +3067,7 @@ services:
       AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH: /bootstrap/config.yaml
       AGENTGATEWAY_ADMIN_CONFIG_URL: http://agentgateway:15000/config
       AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS: ${AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS:-5}
+      AGENTGATEWAY_LOG_LEVEL: ${AGENTGATEWAY_LOG_LEVEL:-info}
       LOG_LEVEL: ${AGENTGATEWAY_CONFIG_BRIDGE_LOG_LEVEL:-INFO}
     volumes:
       - agentgateway_config:/generated

--- a/docs/docs/specs/2026-06-07-workflow-rbac-on-cas/tasks.md
+++ b/docs/docs/specs/2026-06-07-workflow-rbac-on-cas/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Workflow RBAC on CAS (re-implementation of #1751)
+
+**Date:** 2026-06-07
+**Stacked on:** PR #1770 (CAS foundation) — branch `feat/centralized-authz-service`
+**Supersedes:** PR #1751
+**Companions:** [`../2026-06-06-cas-implementation/spec.md`](../2026-06-06-cas-implementation/spec.md) · [`architecture.md`](../2026-06-06-cas-implementation/architecture.md) · [`research.md`](../2026-06-06-cas-implementation/research.md)
+
+## Goal
+
+Re-implement #1751 (workflow RBAC: visibility, run access, team sharing, execution authz, editor UX) on top of CAS — and resolve the #1751 review feedback.
+
+## Status — 2026-06-07
+
+Implemented on local branch `feat/workflow-rbac-on-cas` (to be split → #1770 CAS core + #1771 workflow).
+
+- **Phase 1 (PAP)** — `PolicyAdmin` + grant/revoke shipped in CAS core; grants exposed at `/api/admin/authz/grants` (admin-gated + meta-authz "caller manages the resource"), `cas_grant` audit. *Path differs from the planned `/api/authz/v1/grants`.*
+- **Phase 2 (read/use)** — data model from the #1751 merge; `workflow-runs` (read/delete/start) and `workflow-configs` **read-path** re-pointed onto CAS via `filterAccessible` + org-admin bypass. ⚠️ **PUT/DELETE configs stay on the owner/visibility model** — CAS write/delete grants aren't modeled yet.
+- **Phase 3 (per-step gate)** — `authorize(user, step.agent_id, use)` runs in the shared `executeSteps()` loop (covers start **and** resume); DENY fails the step. Tested.
+- **Phase 4 (DA)** — `workflow_execution_authz.py` **and** `openfga_authz.py` deleted. DA is now a thin PEP: `auth/authz.py` delegates every agent-use decision to CAS (`{AUTHZ_SERVICE_URL}/api/authz/v1/decisions`, OBO). No in-process OpenFGA, no bypass mirror, no DA-side Mongo audit — CAS is the single PDP. Fails closed if CAS is unreachable. Tested.
+- **Phase 6 (editor UX)** — landed via the #1751 merge.
+- **Phase 7** — `domains/workflow.ts` stub dropped; Access Manager/Diagnostics dead code removed; missing tests added (Phase 3/4 + bearer fallback).
+
+**Remaining:** Phase 5 (modal → grant API, cosmetic); split branch → PRs #1770/#1771 + DCO sign-off; reply to #1751 threads.
+
+## Addresses #1751 review comments
+
+| Comment | Resolution here |
+|---|---|
+| **@subbaksh** on `workflow_execution_authz.py` — *"Workflows are a UI-server concept; RBAC for invocation should be in the UI server, not DA."* | Per-step agent-use gate moves into the BFF `executeSteps()`; **`workflow_execution_authz.py` is deleted**. DA reads no `workflow_configs`. |
+| **@subbaksh** on `workflow-da-auth.ts` — *"Why send user/email in a header and have DA trust it?"* | Workflow authz no longer depends on `X-User-Context`. Header survives only for `get_user_context()` email; cleanup tracked in **#1753**. |
+| **code-quality bot** — unused import in `workflow-run-access.ts` | File is replaced by CAS `authorize` / `filterAccessible`. |
+
+## Architecture note
+
+The BFF `executeSteps()` **orchestrates the workflow and invokes agents one step at a time** (`/api/v1/chat/stream/start` per step). So the per-step CAS gate runs **in-process in the BFF** — no DA→CAS cross-process delegation, no decision tokens, no shared run registry. Direct agent chat still migrates DA's `openfga_authz.py` → CAS HTTP check.
+
+## Decisions (locked)
+
+- **Standing grants** — sharing writes `team→agent` tuples; global workflows write a `user:* can_use agent` wildcard.
+- **CAS owns grants** via an intent-based PAP (`PolicyAdmin`); meta-authz: caller must **manage the agent** being granted.
+- **Full #1751 parity** (including editor UX).
+- **Drop** the `domains/workflow.ts` delegation stub.
+
+## Phases
+
+### Phase 1 — CAS grant API (PAP)
+- [ ] `PolicyAdmin` interface + `OpenFgaPolicyAdmin` (tuple write/delete transport)
+- [ ] `grant()` / `revoke()` in `lib/authz`; `GrantIntent` contract type
+- [ ] `POST` / `DELETE /api/authz/v1/grants` — JWKS verify + meta-authz (caller manages resource)
+- [ ] `cas_grant` audit event
+- [ ] unit + contract tests
+
+### Phase 2 — Workflow data model + BFF read/use
+- [x] `visibility` / `shared_with_teams` / `owner_id` on workflow config (via #1751 merge)
+- [x] `workflow-configs` **read-path** → CAS; runs read/delete/start → CAS *(PUT/DELETE configs stay on owner/visibility)*
+- [x] list filtering via `filterAccessible`
+
+### Phase 3 — BFF per-step execution gate (addresses @subbaksh #3)
+- [x] `authorize({user, step.agent_id, use})` in `executeSteps()` before `chat/stream/start`
+- [x] same gate covers resume (shared `executeSteps()` loop)
+- [x] DENY → fail step with a clean reason; audit
+
+### Phase 4 — DA cleanup (addresses @subbaksh #3 + #2)
+- [x] delete `workflow_execution_authz.py` + its test
+- [x] **`openfga_authz.py` removed entirely** → replaced by a thin `auth/authz.py` that delegates every agent-use decision to CAS (`POST {AUTHZ_SERVICE_URL}/api/authz/v1/decisions`, OBO bearer). No in-process OpenFGA check, no org-admin-bypass mirror, no DA-side Mongo audit — CAS is the single PDP and records `cas_decision`. Fails closed (503) when CAS is unreachable or `AUTHZ_SERVICE_URL` is unset.
+- [ ] `X-User-Context` reduced to email-only; link #1753
+
+### Phase 5 — Share / modal via CAS grant API
+- [ ] `WorkflowAgentAccessModal` → `POST /api/authz/v1/grants` (team→agent, global→`user:*`)
+- [ ] remove direct OpenFGA admin writes from the modal path
+
+### Phase 6 — Editor UX parity
+- [ ] unsaved-changes badge + discard dialog
+- [ ] `WorkflowCanvas` / `WorkflowSidebar` / `WorkflowStepSidebar` / `WorkflowToolbar`
+
+### Phase 7 — Cleanup + verify
+- [x] drop `domains/workflow.ts` stub
+- [x] fix unused import (bot comment) + remove Access Manager/Diagnostics dead code
+- [x] Phase 3/4 + bearer-fallback tests added; targeted suites green *(full-suite coverage pass pending)*
+- [ ] reply to #1751 threads; mark #1751 superseded by this PR
+
+<!-- assisted-by claude code claude-opus-4-8 -->

--- a/ui/e2e/rbac/README.md
+++ b/ui/e2e/rbac/README.md
@@ -10,6 +10,7 @@ CAIPE + Keycloak stack:
 | `expired-session.spec.ts` | An expired NextAuth cookie surfaces the standardized 401 toast (Spec 102 Phase 7) instead of a generic 500. |
 | `missing-role.spec.ts` | A user without `chat_user` gets a 403 toast on chat submit. |
 | `pdp-down.spec.ts` | When Keycloak is unreachable, the UI shows a 503 toast (no silent allow). |
+| `workflow-agent-access.spec.ts` | Mocked browser regression for workflow run access and denied agent-access grants. |
 
 ## Skip-by-default
 
@@ -46,6 +47,15 @@ each spec hits `test.skip()` immediately, so:
        RBAC_NOACCESS_USER_EMAIL=e2e-rbac-noaccess-user@caipe.local \
        RBAC_NOACCESS_USER_PASSWORD=changeme \
        npx playwright test --config=playwright.rbac.config.ts
+
+## Workflow agent-access regression
+
+`workflow-agent-access.spec.ts` uses the real Workflows UI in Chromium but
+intercepts the BFF APIs it needs. It does not require Keycloak fixture users:
+
+       RUN_WORKFLOW_E2E=1 \
+       CAIPE_UI_BASE_URL=http://localhost:3000 \
+       npx playwright test e2e/rbac/workflow-agent-access.spec.ts --config=playwright.rbac.config.ts
 
 ## PDP-down spec
 

--- a/ui/e2e/rbac/_mocked-rbac.ts
+++ b/ui/e2e/rbac/_mocked-rbac.ts
@@ -1,0 +1,157 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import { type Page, type Route } from "@playwright/test";
+
+export const MOCK_RBAC_EMAIL = "non-manager@caipe.local";
+
+export type MockRouteContext = {
+  route: Route;
+  url: URL;
+  path: string;
+  method: string;
+};
+
+export type MockRouteHandler = (context: MockRouteContext) => boolean | Promise<boolean>;
+
+type SessionOverrides = {
+  email?: string;
+  name?: string;
+  role?: "admin" | "user";
+  canViewAdmin?: boolean;
+};
+
+type MockedRbacOptions = {
+  isAdmin?: boolean;
+  session?: SessionOverrides;
+  handlers?: MockRouteHandler[];
+};
+
+export function mockedRbacEnabled() {
+  return (
+    process.env.RUN_RBAC_REGRESSION === "1" ||
+    process.env.RUN_WORKFLOW_E2E === "1" ||
+    process.env.RUN_RBAC_E2E === "1"
+  );
+}
+
+export function mockSessionBody(options: MockedRbacOptions = {}) {
+  const isAdmin = options.isAdmin ?? false;
+  const role = options.session?.role ?? (isAdmin ? "admin" : "user");
+  const email = options.session?.email ?? MOCK_RBAC_EMAIL;
+
+  return {
+    user: {
+      name: options.session?.name ?? (isAdmin ? "RBAC Admin" : "Non Manager"),
+      email,
+    },
+    role,
+    isAuthorized: true,
+    canViewAdmin: options.session?.canViewAdmin ?? isAdmin,
+    canAccessDynamicAgents: true,
+    accessToken: "playwright-access-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    expires: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}
+
+export async function postJson(route: Route) {
+  try {
+    return route.request().postDataJSON();
+  } catch {
+    return null;
+  }
+}
+
+export async function fulfillJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function installMockedRbacApp(page: Page, options: MockedRbacOptions = {}) {
+  const isAdmin = options.isAdmin ?? false;
+  const session = mockSessionBody({ ...options, isAdmin });
+  const handlers = options.handlers ?? [];
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+    const path = url.pathname;
+    const context = { route, url, path, method };
+
+    for (const handler of handlers) {
+      if (await handler(context)) {
+        return;
+      }
+    }
+
+    if (path === "/api/auth/session") {
+      await fulfillJson(route, session);
+      return;
+    }
+
+    if (path === "/api/auth/role") {
+      await fulfillJson(route, { role: session.role });
+      return;
+    }
+
+    if (path === "/api/users/me") {
+      await fulfillJson(route, {
+        id: session.user.email,
+        email: session.user.email,
+        name: session.user.name,
+        role: session.role,
+      });
+      return;
+    }
+
+    if (path === "/api/admin/platform-config") {
+      await fulfillJson(route, { data: { release_notes: { enabled: false } } });
+      return;
+    }
+
+    if (path === "/api/settings") {
+      await fulfillJson(route, { data: { preferences: {} } });
+      return;
+    }
+
+    if (path === "/api/changelog") {
+      await fulfillJson(route, { releases: [] });
+      return;
+    }
+
+    if (path === "/api/version") {
+      await fulfillJson(route, {
+        version: "playwright",
+        gitCommit: "e2e",
+        buildDate: "2026-06-12T16:00:00.000Z",
+      });
+      return;
+    }
+
+    if (path === "/api/dynamic-agents/available" || path === "/api/dynamic-agents") {
+      await fulfillJson(route, { data: [] });
+      return;
+    }
+
+    if (path === "/api/dynamic-agents/teams") {
+      await fulfillJson(route, { success: true, data: [] });
+      return;
+    }
+
+    if (path === "/api/dynamic-agents/health") {
+      await fulfillJson(route, { status: "healthy" });
+      return;
+    }
+
+    if (path.startsWith("/api/a2a/")) {
+      await fulfillJson(route, { name: "playwright-supervisor", skills: [] });
+      return;
+    }
+
+    await fulfillJson(route, { success: true });
+  });
+}

--- a/ui/e2e/rbac/workflow-agent-access.spec.ts
+++ b/ui/e2e/rbac/workflow-agent-access.spec.ts
@@ -1,0 +1,271 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  fulfillJson,
+  installMockedRbacApp,
+  MOCK_RBAC_EMAIL,
+  mockedRbacEnabled,
+  postJson,
+} from "./_mocked-rbac";
+
+const GLOBAL_ACCESS_LABEL = "(all users)";
+
+type WorkflowScenario = {
+  name: string;
+  workflowId: string;
+  workflowName: string;
+  visibility: "global" | "team";
+  sharedWithTeams?: string[];
+  gapTarget: string;
+  expectedGrant: {
+    resource: { type: "agent"; id: string };
+    grantee: { type: "everyone" } | { type: "team"; id: string };
+    capability: "use";
+  };
+};
+
+type InstalledMocks = {
+  grantRequests: unknown[];
+  saveRequests: unknown[];
+  runRequests: unknown[];
+};
+
+const agent = {
+  _id: "agent-private",
+  id: "agent-private",
+  name: "Private agent",
+  description: "A private test agent",
+};
+
+const team = {
+  _id: "team-platform",
+  slug: "platform",
+  name: "Platform Team",
+};
+
+function workflowFixture(scenario: WorkflowScenario) {
+  return {
+    _id: scenario.workflowId,
+    name: scenario.workflowName,
+    description: "Playwright RBAC fixture",
+    owner_id: MOCK_RBAC_EMAIL,
+    visibility: scenario.visibility,
+    shared_with_teams: scenario.sharedWithTeams ?? null,
+    config_driven: false,
+    created_at: "2026-06-12T16:00:00.000Z",
+    updated_at: "2026-06-12T16:00:00.000Z",
+    steps: [
+      {
+        type: "step",
+        display_text: "Use private agent",
+        agent_id: agent.id,
+        prompt: "Run the private agent",
+        on_error: "abort",
+        retry: null,
+        config_override: null,
+      },
+    ],
+  };
+}
+
+async function installWorkflowMocks(
+  page: Page,
+  scenario: WorkflowScenario,
+  options: { denyGrants?: boolean } = {},
+): Promise<InstalledMocks> {
+  const grantRequests: unknown[] = [];
+  const saveRequests: unknown[] = [];
+  const runRequests: unknown[] = [];
+  const workflow = workflowFixture(scenario);
+
+  await installMockedRbacApp(page, {
+    isAdmin: false,
+    handlers: [
+      async ({ route, url, path, method }) => {
+        if (path === "/api/dynamic-agents/available" || path === "/api/dynamic-agents") {
+          await fulfillJson(route, { data: [agent] });
+          return true;
+        }
+
+        if (path === "/api/dynamic-agents/teams") {
+          await fulfillJson(route, { success: true, data: [team] });
+          return true;
+        }
+
+        if (path === "/api/workflow-configs/check-agent-access" && method === "POST") {
+          await fulfillJson(route, {
+            gaps: [
+              {
+                agentId: agent.id,
+                agentName: agent.name,
+                teamsWithoutAccess: [scenario.gapTarget],
+              },
+            ],
+          });
+          return true;
+        }
+
+        if (path === "/api/authz/v1/grants" && method === "POST") {
+          grantRequests.push(await postJson(route));
+          if (options.denyGrants) {
+            await fulfillJson(
+              route,
+              {
+                error: `Non-manager ${MOCK_RBAC_EMAIL} cannot manage ${agent.id}`,
+              },
+              403,
+            );
+            return true;
+          }
+
+          await fulfillJson(route, { success: true });
+          return true;
+        }
+
+        if (path === "/api/workflow-configs" && method === "GET") {
+          await fulfillJson(route, { data: [workflow] });
+          return true;
+        }
+
+        if (path === "/api/workflow-configs" && (method === "PUT" || method === "POST")) {
+          saveRequests.push(await postJson(route));
+          await fulfillJson(route, { data: { id: workflow._id }, success: true });
+          return true;
+        }
+
+        if (path === "/api/workflow-runs" && method === "GET") {
+          await fulfillJson(route, []);
+          return true;
+        }
+
+        if (path === "/api/workflow-runs" && method === "POST") {
+          runRequests.push(await postJson(route));
+          await fulfillJson(route, { run_id: "wfrun-playwright-rbac" });
+          return true;
+        }
+
+        if (path === "/api/workflow-runs" && url.searchParams.get("run_id")) {
+          await fulfillJson(route, {
+            _id: "wfrun-playwright-rbac",
+            workflow_config_id: workflow._id,
+            status: "running",
+            steps: [],
+          });
+          return true;
+        }
+
+        return false;
+      },
+    ],
+  });
+
+  return { grantRequests, saveRequests, runRequests };
+}
+
+async function openWorkflowEditor(page: Page, scenario: WorkflowScenario) {
+  await page.goto("/workflows", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText(scenario.workflowName)).toBeVisible();
+  await page.getByText(scenario.workflowName).click();
+  await expect(page.locator('input[placeholder="Workflow name..."]')).toHaveValue(
+    scenario.workflowName,
+  );
+}
+
+async function expectDeniedGrantBlocksSave(
+  page: Page,
+  scenario: WorkflowScenario,
+  mocks: InstalledMocks,
+) {
+  await page.getByRole("button", { name: /^Save$/ }).click();
+
+  const dialog = page.getByRole("dialog", { name: /agent access required/i });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(agent.name);
+  await expect(dialog).toContainText(scenario.gapTarget);
+
+  await page.getByRole("button", { name: /grant access and save/i }).click();
+
+  await expect(dialog).toBeVisible();
+  await expect(page.getByText(/cannot manage agent-private/i)).toBeVisible();
+  await expect.poll(() => mocks.grantRequests.length).toBe(1);
+  await expect.poll(() => mocks.saveRequests.length).toBe(0);
+  expect(mocks.grantRequests[0]).toMatchObject(scenario.expectedGrant);
+}
+
+test.describe("workflow agent access grant modal", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run the mocked RBAC browser regression.",
+    );
+  });
+
+  const deniedGrantScenarios: WorkflowScenario[] = [
+    {
+      name: "global workflow",
+      workflowId: "wf-playwright-global",
+      workflowName: "Global workflow needing private agent",
+      visibility: "global",
+      gapTarget: GLOBAL_ACCESS_LABEL,
+      expectedGrant: {
+        resource: { type: "agent", id: agent.id },
+        grantee: { type: "everyone" },
+        capability: "use",
+      },
+    },
+    {
+      name: "team workflow",
+      workflowId: "wf-playwright-team",
+      workflowName: "Team workflow needing private agent",
+      visibility: "team",
+      sharedWithTeams: [team.slug],
+      gapTarget: team.slug,
+      expectedGrant: {
+        resource: { type: "agent", id: agent.id },
+        grantee: { type: "team", id: team.slug },
+        capability: "use",
+      },
+    },
+  ];
+
+  for (const scenario of deniedGrantScenarios) {
+    test(`keeps the modal open and blocks save when a non-manager cannot grant ${scenario.name} agent access`, async ({
+      page,
+    }) => {
+      const mocks = await installWorkflowMocks(page, scenario, { denyGrants: true });
+
+      await openWorkflowEditor(page, scenario);
+      await expectDeniedGrantBlocksSave(page, scenario, mocks);
+    });
+  }
+
+  test("runs a visible workflow without requiring a direct legacy CAS read grant", async ({
+    page,
+  }) => {
+    const scenario: WorkflowScenario = {
+      name: "run access",
+      workflowId: "wf-playwright-run",
+      workflowName: "Visible workflow can run",
+      visibility: "global",
+      gapTarget: GLOBAL_ACCESS_LABEL,
+      expectedGrant: {
+        resource: { type: "agent", id: agent.id },
+        grantee: { type: "everyone" },
+        capability: "use",
+      },
+    };
+    const mocks = await installWorkflowMocks(page, scenario);
+
+    await openWorkflowEditor(page, scenario);
+    await page.getByText("Run", { exact: true }).click();
+
+    await expect.poll(() => mocks.runRequests.length).toBe(1);
+    expect(mocks.runRequests[0]).toMatchObject({
+      workflow_config_id: scenario.workflowId,
+      trigger_info: { triggered_by: "webui" },
+    });
+    await expect(page).toHaveURL(/\/workflows\/run\/wfrun-playwright-rbac$/);
+  });
+});

--- a/ui/src/app/(app)/workflows/page.tsx
+++ b/ui/src/app/(app)/workflows/page.tsx
@@ -23,8 +23,9 @@ export default function WorkflowsPage() {
         setAgentCount(list.length);
       })
       .catch(() => setAgentCount(null));
+    loadConfigs();
     loadRuns();
-  }, [loadRuns]);
+  }, [loadConfigs, loadRuns]);
 
   const selectedConfig = useMemo(
     () => (selectedConfigId ? configs.find((c) => c._id === selectedConfigId) : undefined),

--- a/ui/src/app/api/__tests__/authz-v1-grants.test.ts
+++ b/ui/src/app/api/__tests__/authz-v1-grants.test.ts
@@ -131,6 +131,15 @@ it("returns 400 for high-risk everyone grants", async () => {
   expect(mockGrant).not.toHaveBeenCalled();
 });
 
+it("allows everyone grants for agent use so global workflows can run their agents", async () => {
+  const res = await POST(req({ ...validGrant, grantee: { type: "everyone" }, capability: "use" }));
+  expect(res.status).toBe(200);
+  expect(mockGrant).toHaveBeenCalledWith(
+    { resource: { type: "agent", id: "pe" }, grantee: { type: "everyone" }, capability: "use" },
+    expect.objectContaining({ caller: { type: "user", id: "alice" } }),
+  );
+});
+
 it("returns 400 for malformed JSON", async () => {
   const r = new NextRequest(new URL("/api/authz/v1/grants", "http://localhost:3000"), { method: "POST", body: "{bad" });
   expect((await POST(r)).status).toBe(400);

--- a/ui/src/app/api/__tests__/task-workflow-rbac.test.ts
+++ b/ui/src/app/api/__tests__/task-workflow-rbac.test.ts
@@ -51,6 +51,11 @@ jest.mock("@/lib/api-middleware", () => {
 jest.mock("@/lib/rbac/resource-authz", () => ({
   filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
   requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  subjectFromSession: () => "alice-sub",
+}));
+
+jest.mock("@/lib/rbac/openfga-team-membership", () => ({
+  listUserTeamSlugs: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/lib/rbac/keycloak-resource-sync", () => ({
@@ -95,15 +100,24 @@ describe("task/workflow config RBAC cutover", () => {
     expect(body).toEqual([expect.objectContaining({ id: "task-openfga" })]);
   });
 
-  it("loads workflow configs through OpenFGA task discover instead of legacy team visibility", async () => {
+  it("lists global workflows for non-admins via visibility and merges OpenFGA read grants", async () => {
     const configs = [
       { _id: "wf-openfga", name: "OpenFGA Workflow", visibility: "private", owner_id: "bob@example.com" },
-      { _id: "wf-denied", name: "Denied Workflow", visibility: "global" },
+      { _id: "wf-global", name: "Global Workflow", visibility: "global", owner_id: "system" },
     ];
     mockFilterResourcesByPermission.mockResolvedValue([configs[0]]);
     const sort = jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue(configs) });
     const find = jest.fn().mockReturnValue({ sort });
-    mockGetCollection.mockResolvedValue({ find });
+    const teamsCollection = {
+      find: jest.fn().mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "teams" ? teamsCollection : { find },
+    );
     const { GET } = await import("../workflow-configs/route");
 
     const response = await GET(request("/api/workflow-configs"));
@@ -115,8 +129,15 @@ describe("task/workflow config RBAC cutover", () => {
     expect(mockFilterResourcesByPermission).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
       configs,
-      { type: "task", action: "discover", id: expect.any(Function) },
+      { type: "task", action: "read", id: expect.any(Function) },
+      { bypassForOrgAdmin: true },
     );
-    expect(body).toEqual([expect.objectContaining({ _id: "wf-openfga" })]);
+    expect(body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "wf-openfga" }),
+        expect.objectContaining({ _id: "wf-global" }),
+      ]),
+    );
+    expect(body).toHaveLength(2);
   });
 });

--- a/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
+++ b/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
@@ -10,6 +10,12 @@ const mockRequireWorkflowAccess = jest.fn();
 const mockWorkflowAccessAllowed = jest.fn();
 const mockFilterAccessibleWorkflowConfigs = jest.fn();
 const mockRequireWorkflowRunAccess = jest.fn();
+const mockRequireWorkflowConfigRunAccess = jest.fn();
+const mockRequireWorkflowConfigRunViewAccess = jest.fn();
+const mockResolveUserTeamSlugsForWorkflow = jest.fn();
+const mockBuildTeamRefToSlugMap = jest.fn();
+const mockFilterWorkflowConfigsByRunAccess = jest.fn();
+const mockMergeWorkflowConfigsById = jest.fn();
 const mockStartWorkflowRun = jest.fn();
 const mockGetAuth = jest.fn();
 const mockAuthUser = { email: "alice@example.com", role: "user", name: "Alice" };
@@ -65,6 +71,15 @@ jest.mock("@/lib/server/workflow-engine", () => ({
   startWorkflowRun: (...args: unknown[]) => mockStartWorkflowRun(...args),
 }));
 
+jest.mock("@/lib/rbac/workflow-config-rebac", () => ({
+  buildTeamRefToSlugMap: (...args: unknown[]) => mockBuildTeamRefToSlugMap(...args),
+  filterWorkflowConfigsByRunAccess: (...args: unknown[]) => mockFilterWorkflowConfigsByRunAccess(...args),
+  mergeWorkflowConfigsById: (...args: unknown[]) => mockMergeWorkflowConfigsById(...args),
+  requireWorkflowConfigRunAccess: (...args: unknown[]) => mockRequireWorkflowConfigRunAccess(...args),
+  requireWorkflowConfigRunViewAccess: (...args: unknown[]) => mockRequireWorkflowConfigRunViewAccess(...args),
+  resolveUserTeamSlugsForWorkflow: (...args: unknown[]) => mockResolveUserTeamSlugsForWorkflow(...args),
+}));
+
 jest.mock("@/lib/server/event-store", () => ({
   deleteEventsByRun: jest.fn(),
   readEventsByRun: jest.fn().mockResolvedValue(new Map()),
@@ -88,9 +103,23 @@ describe("workflow runs OpenFGA config access", () => {
     mockRequireWorkflowAccess.mockResolvedValue(undefined);
     mockRequireWorkflowRunAccess.mockResolvedValue(undefined);
     mockWorkflowAccessAllowed.mockResolvedValue(true);
+    mockRequireWorkflowConfigRunAccess.mockResolvedValue(undefined);
+    mockRequireWorkflowConfigRunViewAccess.mockResolvedValue(undefined);
+    mockResolveUserTeamSlugsForWorkflow.mockResolvedValue(["eng"]);
+    mockBuildTeamRefToSlugMap.mockResolvedValue(new Map([["eng", "eng"]]));
+    mockFilterWorkflowConfigsByRunAccess.mockImplementation((configs) =>
+      configs.filter((config: { _id?: string }) => config._id === "wf-global"),
+    );
     mockFilterAccessibleWorkflowConfigs.mockImplementation(async (_session, resources) =>
       resources.filter((resource: { _id?: string }) => resource._id === "wf-visible"),
     );
+    mockMergeWorkflowConfigsById.mockImplementation((...groups) => {
+      const byId = new Map<string, unknown>();
+      for (const group of groups) {
+        for (const item of group as Array<{ _id: string }>) byId.set(item._id, item);
+      }
+      return [...byId.values()];
+    });
     mockStartWorkflowRun.mockResolvedValue("run-new");
     mockGetAuth.mockResolvedValue({ user: mockAuthUser, session: mockAuthSession });
   });
@@ -125,11 +154,17 @@ describe("workflow runs OpenFGA config access", () => {
   });
 
   it("surfaces CAS outage when listing runs for a specific workflow config", async () => {
+    const config = { _id: "wf-visible", visibility: "private", owner_id: "bob@example.com" };
     const runCollection = {
       deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
     };
-    mockGetCollection.mockResolvedValue(runCollection);
-    mockRequireWorkflowAccess.mockRejectedValueOnce(
+    const configCollection = {
+      findOne: jest.fn().mockResolvedValue(config),
+    };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "workflow_runs" ? runCollection : configCollection,
+    );
+    mockRequireWorkflowConfigRunViewAccess.mockRejectedValueOnce(
       Object.assign(new Error("Authorization service temporarily unavailable."), { statusCode: 503 }),
     );
     const { GET } = await import("../workflow-runs/route");
@@ -141,7 +176,72 @@ describe("workflow runs OpenFGA config access", () => {
     expect(body).toMatchObject({ success: false, error: "Authorization service temporarily unavailable." });
   });
 
-  it("requires OpenFGA read permission before starting a workflow run", async () => {
+  it("lists runs for a workflow config allowed by Mongo visibility even without a direct CAS read grant", async () => {
+    const config = { _id: "wf-global", visibility: "global", owner_id: "system" };
+    const runCollection = {
+      deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+      find: jest.fn().mockReturnValue(cursor([{ _id: "run-global", workflow_config_id: "wf-global" }])),
+    };
+    const configCollection = {
+      findOne: jest.fn().mockResolvedValue(config),
+    };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "workflow_runs" ? runCollection : configCollection,
+    );
+    mockRequireWorkflowAccess.mockRejectedValueOnce(Object.assign(new Error("forbidden"), { statusCode: 403 }));
+    const { GET } = await import("../workflow-runs/route");
+
+    const response = await GET(request("/api/workflow-runs?workflow_config_id=wf-global"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockRequireWorkflowConfigRunViewAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: "alice-sub" }),
+      config,
+      "alice@example.com",
+      ["eng"],
+    );
+    expect(body).toEqual([{ _id: "run-global", workflow_config_id: "wf-global" }]);
+  });
+
+  it("merges Mongo-visible workflow configs into the all-runs list", async () => {
+    const configCandidates = [
+      { _id: "wf-global", visibility: "global", owner_id: "system" },
+      { _id: "wf-visible", visibility: "private", owner_id: "bob@example.com" },
+    ];
+    const runCollection = {
+      deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+      find: jest.fn().mockReturnValue(cursor([
+        { _id: "run-global", workflow_config_id: "wf-global" },
+        { _id: "run-fga", workflow_config_id: "wf-visible" },
+      ])),
+    };
+    const configCollection = { find: jest.fn().mockReturnValue(cursor(configCandidates)) };
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "workflow_runs" ? runCollection : configCollection,
+    );
+    mockFilterWorkflowConfigsByRunAccess.mockReturnValue([configCandidates[0]]);
+    mockFilterAccessibleWorkflowConfigs.mockResolvedValue([configCandidates[1]]);
+    const { GET } = await import("../workflow-runs/route");
+
+    const response = await GET(request("/api/workflow-runs"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockFilterWorkflowConfigsByRunAccess).toHaveBeenCalledWith(
+      configCandidates,
+      "alice@example.com",
+      ["eng"],
+      expect.any(Map),
+    );
+    expect(runCollection.find).toHaveBeenCalledWith({ workflow_config_id: { $in: ["wf-global", "wf-visible"] } });
+    expect(body).toEqual([
+      { _id: "run-global", workflow_config_id: "wf-global" },
+      { _id: "run-fga", workflow_config_id: "wf-visible" },
+    ]);
+  });
+
+  it("requires workflow run access before starting a workflow run", async () => {
     const config = { _id: "wf-visible", name: "Workflow" };
     const configCollection = { findOne: jest.fn().mockResolvedValue(config) };
     mockGetCollection.mockResolvedValue(configCollection);
@@ -156,10 +256,11 @@ describe("workflow runs OpenFGA config access", () => {
 
     expect(response.status).toBe(201);
     expect(mockGetUserTeamIds).not.toHaveBeenCalled();
-    expect(mockRequireWorkflowAccess).toHaveBeenCalledWith(
+    expect(mockRequireWorkflowConfigRunAccess).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
-      "wf-visible",
-      "read",
+      expect.objectContaining({ _id: "wf-visible" }),
+      "alice@example.com",
+      ["eng"],
     );
     expect(mockStartWorkflowRun).toHaveBeenCalledWith(
       config,
@@ -168,6 +269,30 @@ describe("workflow runs OpenFGA config access", () => {
       expect.objectContaining({ user: { email: "alice@example.com", name: "Alice" } }),
       { type: "user", id: "alice-sub" },
     );
+  });
+
+  it("starts a workflow config allowed by Mongo visibility even without a direct CAS read grant", async () => {
+    const config = { _id: "wf-global", name: "Global Workflow", visibility: "global", owner_id: "system" };
+    const configCollection = { findOne: jest.fn().mockResolvedValue(config) };
+    mockGetCollection.mockResolvedValue(configCollection);
+    mockRequireWorkflowAccess.mockRejectedValueOnce(Object.assign(new Error("forbidden"), { statusCode: 403 }));
+    const { POST } = await import("../workflow-runs/route");
+
+    const response = await POST(
+      request("/api/workflow-runs", {
+        method: "POST",
+        body: JSON.stringify({ workflow_config_id: "wf-global" }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockRequireWorkflowConfigRunAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: "alice-sub" }),
+      expect.objectContaining({ _id: "wf-global", owner_id: "system", visibility: "global" }),
+      "alice@example.com",
+      ["eng"],
+    );
+    expect(mockStartWorkflowRun).toHaveBeenCalled();
   });
 
   it("forwards the incoming Bearer to the DA call when present", async () => {

--- a/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
+++ b/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
@@ -6,9 +6,14 @@ import { NextRequest } from "next/server";
 
 const mockGetCollection = jest.fn();
 const mockGetUserTeamIds = jest.fn();
-const mockRequireResourcePermission = jest.fn();
-const mockFilterResourcesByPermission = jest.fn();
+const mockRequireWorkflowAccess = jest.fn();
+const mockWorkflowAccessAllowed = jest.fn();
+const mockFilterAccessibleWorkflowConfigs = jest.fn();
+const mockRequireWorkflowRunAccess = jest.fn();
 const mockStartWorkflowRun = jest.fn();
+const mockGetAuth = jest.fn();
+const mockAuthUser = { email: "alice@example.com", role: "user", name: "Alice" };
+const mockAuthSession: Record<string, unknown> = { sub: "alice-sub", role: "user" };
 
 jest.mock("@/lib/mongodb", () => ({
   getCollection: (...args: unknown[]) => mockGetCollection(...args),
@@ -24,15 +29,13 @@ jest.mock("@/lib/api-middleware", () => {
       super(message);
     }
   }
-  const user = { email: "alice@example.com", role: "user", name: "Alice" };
-  const session = { sub: "alice-sub", role: "user" };
   return {
     ApiError,
-    getAuthFromBearerOrSession: async () => ({ user, session }),
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuth(...args),
     getUserTeamIds: (...args: unknown[]) => mockGetUserTeamIds(...args),
     successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
     withAuth: async (_request: NextRequest, handler: (...args: unknown[]) => Promise<Response>) =>
-      handler(_request, user, session),
+      handler(_request, mockAuthUser, mockAuthSession),
     withErrorHandler:
       <T,>(handler: (...args: unknown[]) => Promise<T>) =>
       async (...args: unknown[]) => {
@@ -48,9 +51,13 @@ jest.mock("@/lib/api-middleware", () => {
   };
 });
 
-jest.mock("@/lib/rbac/resource-authz", () => ({
-  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
-  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+jest.mock("@/lib/server/workflow-cas-authz", () => ({
+  filterAccessibleWorkflowConfigs: (...args: unknown[]) => mockFilterAccessibleWorkflowConfigs(...args),
+  requireWorkflowAccess: (...args: unknown[]) => mockRequireWorkflowAccess(...args),
+  requireWorkflowRunAccess: (...args: unknown[]) => mockRequireWorkflowRunAccess(...args),
+  workflowAccessAllowed: (...args: unknown[]) => mockWorkflowAccessAllowed(...args),
+  workflowSubjectFromSession: (session: { sub?: string; isServiceAccount?: boolean }) =>
+    session.sub ? { type: session.isServiceAccount === true ? "service_account" : "user", id: session.sub } : null,
 }));
 
 jest.mock("@/lib/server/workflow-engine", () => ({
@@ -78,11 +85,14 @@ describe("workflow runs OpenFGA config access", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetUserTeamIds.mockResolvedValue(["legacy-team"]);
-    mockRequireResourcePermission.mockResolvedValue(undefined);
-    mockFilterResourcesByPermission.mockImplementation(async (_session, resources) =>
+    mockRequireWorkflowAccess.mockResolvedValue(undefined);
+    mockRequireWorkflowRunAccess.mockResolvedValue(undefined);
+    mockWorkflowAccessAllowed.mockResolvedValue(true);
+    mockFilterAccessibleWorkflowConfigs.mockImplementation(async (_session, resources) =>
       resources.filter((resource: { _id?: string }) => resource._id === "wf-visible"),
     );
     mockStartWorkflowRun.mockResolvedValue("run-new");
+    mockGetAuth.mockResolvedValue({ user: mockAuthUser, session: mockAuthSession });
   });
 
   it("lists runs for OpenFGA-readable workflow configs without legacy team prefiltering", async () => {
@@ -104,14 +114,31 @@ describe("workflow runs OpenFGA config access", () => {
     expect(response.status).toBe(200);
     expect(mockGetUserTeamIds).not.toHaveBeenCalled();
     expect(configCollection.find).toHaveBeenCalledWith({});
-    expect(mockFilterResourcesByPermission).toHaveBeenCalledWith(
+    expect(mockFilterAccessibleWorkflowConfigs).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
       [{ _id: "wf-visible" }, { _id: "wf-hidden" }],
-      { type: "task", action: "read", id: expect.any(Function) },
-      { bypassForOrgAdmin: true },
+      expect.any(Function),
+      "read",
     );
     expect(runCollection.find).toHaveBeenCalledWith({ workflow_config_id: { $in: ["wf-visible"] } });
     expect(body).toEqual([{ _id: "run-1", workflow_config_id: "wf-visible" }]);
+  });
+
+  it("surfaces CAS outage when listing runs for a specific workflow config", async () => {
+    const runCollection = {
+      deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+    };
+    mockGetCollection.mockResolvedValue(runCollection);
+    mockRequireWorkflowAccess.mockRejectedValueOnce(
+      Object.assign(new Error("Authorization service temporarily unavailable."), { statusCode: 503 }),
+    );
+    const { GET } = await import("../workflow-runs/route");
+
+    const response = await GET(request("/api/workflow-runs?workflow_config_id=wf-visible"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({ success: false, error: "Authorization service temporarily unavailable." });
   });
 
   it("requires OpenFGA read permission before starting a workflow run", async () => {
@@ -129,16 +156,66 @@ describe("workflow runs OpenFGA config access", () => {
 
     expect(response.status).toBe(201);
     expect(mockGetUserTeamIds).not.toHaveBeenCalled();
-    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
+    expect(mockRequireWorkflowAccess).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
-      { type: "task", id: "wf-visible", action: "read" },
-      { bypassForOrgAdmin: true },
+      "wf-visible",
+      "read",
     );
     expect(mockStartWorkflowRun).toHaveBeenCalledWith(
       config,
       null,
       expect.any(Object),
       expect.objectContaining({ user: { email: "alice@example.com", name: "Alice" } }),
+      { type: "user", id: "alice-sub" },
+    );
+  });
+
+  it("forwards the incoming Bearer to the DA call when present", async () => {
+    const config = { _id: "wf-visible", name: "Workflow" };
+    mockGetCollection.mockResolvedValue({ findOne: jest.fn().mockResolvedValue(config) });
+    const { POST } = await import("../workflow-runs/route");
+
+    await POST(
+      request("/api/workflow-runs", {
+        method: "POST",
+        headers: { Authorization: "Bearer incoming-tok" },
+        body: JSON.stringify({ workflow_config_id: "wf-visible" }),
+      }),
+    );
+
+    expect(mockStartWorkflowRun).toHaveBeenCalledWith(
+      config,
+      null,
+      expect.objectContaining({ Authorization: "Bearer incoming-tok" }),
+      expect.any(Object),
+      { type: "user", id: "alice-sub" },
+    );
+  });
+
+  it("falls back to the session accessToken when no Bearer is forwarded (cookie session)", async () => {
+    // The regression: cookie-session starts sent no Authorization header, so the
+    // DA call 401'd with missing_bearer. The route now forwards session.accessToken.
+    mockGetAuth.mockResolvedValueOnce({
+      user: mockAuthUser,
+      session: { ...mockAuthSession, accessToken: "sess-tok" },
+    });
+    const config = { _id: "wf-visible", name: "Workflow" };
+    mockGetCollection.mockResolvedValue({ findOne: jest.fn().mockResolvedValue(config) });
+    const { POST } = await import("../workflow-runs/route");
+
+    await POST(
+      request("/api/workflow-runs", {
+        method: "POST",
+        body: JSON.stringify({ workflow_config_id: "wf-visible" }),
+      }),
+    );
+
+    expect(mockStartWorkflowRun).toHaveBeenCalledWith(
+      config,
+      null,
+      expect.objectContaining({ Authorization: "Bearer sess-tok" }),
+      expect.any(Object),
+      { type: "user", id: "alice-sub" },
     );
   });
 });

--- a/ui/src/app/api/workflow-configs/check-agent-access/route.ts
+++ b/ui/src/app/api/workflow-configs/check-agent-access/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-middleware";
+import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
+import { getCollection } from "@/lib/mongodb";
+
+interface StepEntry {
+  type?: string;
+  agent_id?: string;
+}
+
+interface CheckBody {
+  steps: StepEntry[];
+  visibility: "private" | "team" | "global";
+  shared_with_teams?: string[];
+}
+
+export interface AgentAccessGap {
+  agentId: string;
+  agentName: string;
+  teamsWithoutAccess: string[];
+}
+
+export interface CheckAgentAccessResponse {
+  gaps: AgentAccessGap[];
+}
+
+// Deduplicate agent IDs from workflow steps.
+function agentIdsFromSteps(steps: StepEntry[]): string[] {
+  const seen = new Set<string>();
+  for (const step of steps) {
+    if (step?.type === "step" && typeof step.agent_id === "string" && step.agent_id.trim()) {
+      seen.add(step.agent_id.trim());
+    }
+  }
+  return [...seen];
+}
+
+async function resolveAgentNames(agentIds: string[]): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  try {
+    const col = await getCollection<{ _id: string; name?: string }>("dynamic_agents");
+    const docs = await col
+      .find({ _id: { $in: agentIds } }, { projection: { name: 1 } })
+      .toArray();
+    for (const doc of docs) {
+      names.set(String(doc._id), doc.name ?? String(doc._id));
+    }
+  } catch {
+    // Non-fatal — fall back to using the ID as the name.
+  }
+  for (const id of agentIds) {
+    if (!names.has(id)) names.set(id, id);
+  }
+  return names;
+}
+
+// Check whether team:{slug}#member has the `user` relation on agent:{agentId}.
+async function teamHasAgentAccess(teamSlug: string, agentId: string): Promise<boolean> {
+  try {
+    const result = await checkOpenFgaTuple({
+      user: `team:${teamSlug}#member`,
+      relation: "user",
+      object: `agent:${agentId}`,
+    });
+    return result.allowed;
+  } catch {
+    // Treat check errors conservatively — surface the gap.
+    return false;
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return withAuth(request, async () => {
+    let body: CheckBody;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const { steps = [], visibility, shared_with_teams = [] } = body;
+
+    // Only team-scoped workflows need per-team agent access checks.
+    // Global workflows are accessible to all users — surface a gap only when
+    // the agent itself is not globally accessible (user:* → user → agent:id).
+    const teamsToCheck =
+      visibility === "team"
+        ? shared_with_teams.filter((s) => typeof s === "string" && s.trim())
+        : [];
+
+    if (teamsToCheck.length === 0 && visibility !== "global") {
+      return NextResponse.json<CheckAgentAccessResponse>({ gaps: [] });
+    }
+
+    const agentIds = agentIdsFromSteps(steps);
+    if (agentIds.length === 0) {
+      return NextResponse.json<CheckAgentAccessResponse>({ gaps: [] });
+    }
+
+    const agentNames = await resolveAgentNames(agentIds);
+    const gaps: AgentAccessGap[] = [];
+
+    if (visibility === "global") {
+      // For global workflows check whether user:* has access to each agent.
+      for (const agentId of agentIds) {
+        try {
+          const result = await checkOpenFgaTuple({
+            user: "user:*",
+            relation: "user",
+            object: `agent:${agentId}`,
+          });
+          if (!result.allowed) {
+            gaps.push({
+              agentId,
+              agentName: agentNames.get(agentId) ?? agentId,
+              teamsWithoutAccess: ["(all users)"],
+            });
+          }
+        } catch {
+          gaps.push({
+            agentId,
+            agentName: agentNames.get(agentId) ?? agentId,
+            teamsWithoutAccess: ["(all users)"],
+          });
+        }
+      }
+    } else {
+      // team visibility — check each (agent, team) pair in parallel.
+      await Promise.all(
+        agentIds.map(async (agentId) => {
+          const missing = (
+            await Promise.all(
+              teamsToCheck.map(async (slug) => ({
+                slug,
+                ok: await teamHasAgentAccess(slug, agentId),
+              })),
+            )
+          )
+            .filter((r) => !r.ok)
+            .map((r) => r.slug);
+
+          if (missing.length > 0) {
+            gaps.push({
+              agentId,
+              agentName: agentNames.get(agentId) ?? agentId,
+              teamsWithoutAccess: missing,
+            });
+          }
+        }),
+      );
+    }
+
+    return NextResponse.json<CheckAgentAccessResponse>({ gaps });
+  });
+}

--- a/ui/src/app/api/workflow-configs/route.ts
+++ b/ui/src/app/api/workflow-configs/route.ts
@@ -6,9 +6,19 @@ withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import {
-filterResourcesByPermission,
-requireResourcePermission,
-} from "@/lib/rbac/resource-authz";
+filterAccessibleWorkflowConfigs,
+workflowAccessAllowed,
+} from "@/lib/server/workflow-cas-authz";
+import {
+buildTeamRefToSlugMap,
+filterWorkflowConfigsByRunAccess,
+mergeWorkflowConfigsById,
+normalizeSharedWithTeamSlugs,
+reconcileWorkflowConfigAccess,
+requireWorkflowConfigRunAccess,
+requireWorkflowConfigWriteAccess,
+resolveUserTeamSlugsForWorkflow,
+} from "@/lib/rbac/workflow-config-rebac";
 import type {
 CreateWorkflowConfigInput,
 StepEntry,
@@ -125,21 +135,50 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       return NextResponse.json(configs) as NextResponse;
     }
 
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+
     if (id) {
       const config = await getVisibleConfigById(id, user.email);
       if (!config) {
         throw new ApiError("Workflow config not found", 404);
       }
-      await requireResourcePermission(session, { type: "task", id, action: "read" });
+      // Additive CAS read (Phase 2) — mirrors the list's "visibility ∪ FGA read"
+      // semantics: if CAS grants task#read (org-admin bypass included) serve it;
+      // otherwise fall back to the legacy visibility check unchanged.
+      if (!(await workflowAccessAllowed(session, String(config._id), "read"))) {
+        await requireWorkflowConfigRunAccess(
+          session,
+          {
+            _id: String(config._id),
+            owner_id: config.owner_id,
+            visibility: config.visibility,
+            shared_with_teams: config.shared_with_teams,
+          },
+          user.email,
+          userTeamSlugs,
+        );
+      }
       return NextResponse.json(config) as NextResponse;
     }
 
     const configs = await getVisibleConfigs(user.email);
-    const visibleConfigs = await filterResourcesByPermission(session, configs, {
-      type: "task",
-      action: "discover",
-      id: (config) => String(config._id),
-    });
+    const teamRefToSlug = await buildTeamRefToSlugMap();
+    const byVisibility = filterWorkflowConfigsByRunAccess(
+      configs,
+      user.email,
+      userTeamSlugs,
+      teamRefToSlug,
+    );
+    // Match workflow-runs list: org-wide global workflows use Mongo visibility;
+    // CAS `task#read` supplements legacy per-user/team grants (org-admin bypass
+    // included). This is the PDP call re-pointed onto CAS (Phase 2).
+    const byFga = await filterAccessibleWorkflowConfigs(
+      session,
+      configs,
+      (config) => String(config._id),
+      "read",
+    );
+    const visibleConfigs = mergeWorkflowConfigsById(byVisibility, byFga);
     return NextResponse.json(visibleConfigs) as NextResponse;
   });
 });
@@ -162,7 +201,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 
     validateSteps(body.steps);
     const visibility: WorkflowConfigVisibility = body.visibility || "global";
-    validateVisibility(visibility, body.shared_with_teams);
+    const sharedWithTeams =
+      visibility === "team"
+        ? await normalizeSharedWithTeamSlugs(body.shared_with_teams)
+        : undefined;
+    validateVisibility(visibility, sharedWithTeams);
 
     const id = `wf-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date();
@@ -174,13 +217,15 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       steps: body.steps,
       owner_id: user.email,
       visibility,
-      shared_with_teams: visibility === "team" ? body.shared_with_teams : undefined,
+      shared_with_teams: sharedWithTeams,
       created_at: now,
       updated_at: now,
     };
 
     const collection = await getCollection("workflow_configs");
     await collection.insertOne(config as any);
+
+    await reconcileWorkflowConfigAccess(session, config);
 
     return successResponse({ id, message: "Workflow config created successfully" }, 201);
   });
@@ -214,11 +259,21 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     if (!existing) {
       throw new ApiError("Workflow config not found", 404);
     }
-    if (user.role !== "admin") {
-      await requireResourcePermission(session, { type: "task", id, action: "write" });
-    }
     if ((existing as any).config_driven) {
       throw new ApiError("Cannot modify a config-driven workflow. Edit app-config.yaml instead.", 403);
+    }
+
+    if (user.role !== "admin") {
+      await requireWorkflowConfigWriteAccess(
+        session,
+        {
+          _id: id,
+          owner_id: existing.owner_id,
+          visibility: existing.visibility,
+          shared_with_teams: existing.shared_with_teams,
+        },
+        user.email,
+      );
     }
 
     if (body.steps) {
@@ -230,11 +285,47 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
         body.shared_with_teams = undefined;
       }
     }
+    if (body.shared_with_teams?.length) {
+      body.shared_with_teams = await normalizeSharedWithTeamSlugs(body.shared_with_teams);
+    }
 
-    await collection.updateOne(
-      { _id: id as any },
-      { $set: { ...body, updated_at: new Date() } }
-    );
+    const mergedVisibility = body.visibility ?? existing.visibility;
+    let mergedSharedWithTeams =
+      mergedVisibility === "team"
+        ? body.shared_with_teams ?? existing.shared_with_teams
+        : mergedVisibility !== undefined
+          ? undefined
+          : existing.shared_with_teams;
+
+    if (mergedVisibility === "team" && mergedSharedWithTeams?.length) {
+      mergedSharedWithTeams =
+        (await normalizeSharedWithTeamSlugs(mergedSharedWithTeams)) ?? undefined;
+    }
+
+    const updateFields: Record<string, unknown> = {
+      ...body,
+      updated_at: new Date(),
+    };
+    if (mergedVisibility === "team") {
+      updateFields.shared_with_teams = mergedSharedWithTeams;
+    } else if (
+      body.visibility !== undefined &&
+      (mergedVisibility === "private" || mergedVisibility === "global")
+    ) {
+      updateFields.shared_with_teams = undefined;
+    }
+
+    await collection.updateOne({ _id: id as any }, { $set: updateFields });
+
+    const merged = {
+      ...existing,
+      ...body,
+      _id: id,
+      visibility: mergedVisibility,
+      shared_with_teams: mergedSharedWithTeams,
+    };
+
+    await reconcileWorkflowConfigAccess(session, merged, existing);
 
     return successResponse({ id, message: "Workflow config updated successfully" });
   });
@@ -262,11 +353,21 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
     if (!existing) {
       throw new ApiError("Workflow config not found", 404);
     }
-    if (user.role !== "admin") {
-      await requireResourcePermission(session, { type: "task", id, action: "delete" });
-    }
     if ((existing as any).config_driven) {
       throw new ApiError("Cannot delete a config-driven workflow. Remove it from app-config.yaml instead.", 403);
+    }
+
+    if (user.role !== "admin") {
+      await requireWorkflowConfigWriteAccess(
+        session,
+        {
+          _id: id,
+          owner_id: existing.owner_id,
+          visibility: existing.visibility,
+          shared_with_teams: existing.shared_with_teams,
+        },
+        user.email,
+      );
     }
 
     await collection.deleteOne({ _id: id as any });

--- a/ui/src/app/api/workflow-runs/[id]/cancel/route.ts
+++ b/ui/src/app/api/workflow-runs/[id]/cancel/route.ts
@@ -2,9 +2,9 @@
  * POST /api/workflow-runs/[id]/cancel — Cancel a running workflow
  */
 
-import { ApiError,getAuthFromBearerOrSession,withErrorHandler } from "@/lib/api-middleware";
+import { ApiError,withAuth,withErrorHandler } from "@/lib/api-middleware";
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
-import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import { requireWorkflowRunAccess } from "@/lib/server/workflow-cas-authz";
 import { cancelWorkflowRun,type WorkflowRunDocument } from "@/lib/server/workflow-engine";
 import { NextRequest,NextResponse } from "next/server";
 
@@ -17,22 +17,18 @@ export const POST = withErrorHandler(async (
   }
 
   const { id } = await params;
-  const { session } = await getAuthFromBearerOrSession(request);
 
-  // Load run to check config access
-  const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
-  const run = await runCol.findOne({ _id: id });
-  if (!run) {
-    throw new ApiError("Workflow run not found", 404);
-  }
+  return await withAuth(request, async (_req, _user, session) => {
+    const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
+    const run = await runCol.findOne({ _id: id });
+    if (!run) {
+      throw new ApiError("Workflow run not found", 404);
+    }
 
-  await requireResourcePermission(
-    session,
-    { type: "task", id: run.workflow_config_id, action: "write" },
-    { bypassForOrgAdmin: true },
-  );
+    await requireWorkflowRunAccess(session, run, "cancel");
 
-  await cancelWorkflowRun(id);
+    await cancelWorkflowRun(id);
 
-  return NextResponse.json({ status: "cancelled" }) as NextResponse;
+    return NextResponse.json({ status: "cancelled" }) as NextResponse;
+  });
 });

--- a/ui/src/app/api/workflow-runs/[id]/resume/route.ts
+++ b/ui/src/app/api/workflow-runs/[id]/resume/route.ts
@@ -2,9 +2,10 @@
  * POST /api/workflow-runs/[id]/resume — Resume a workflow run waiting for input
  */
 
-import { ApiError,getAuthFromBearerOrSession,withErrorHandler } from "@/lib/api-middleware";
+import { ApiError,withAuth,withErrorHandler } from "@/lib/api-middleware";
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
-import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import { buildWorkflowDaAuthHeaders } from "@/lib/server/workflow-da-auth";
+import { requireWorkflowRunAccess } from "@/lib/server/workflow-cas-authz";
 import { resumeWorkflowRun,type WorkflowRunDocument } from "@/lib/server/workflow-engine";
 import { NextRequest,NextResponse } from "next/server";
 
@@ -17,39 +18,27 @@ export const POST = withErrorHandler(async (
   }
 
   const { id } = await params;
-  const { user, session } = await getAuthFromBearerOrSession(request);
-  const body = await request.json();
-  const { step_index, resume_data } = body;
 
-  if (step_index === undefined || resume_data === undefined) {
-    throw new ApiError("step_index and resume_data are required", 400);
-  }
+  return await withAuth(request, async (req, user, session) => {
+    const body = await req.json();
+    const { step_index, resume_data } = body;
 
-  // Load run to check config access
-  const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
-  const run = await runCol.findOne({ _id: id });
-  if (!run) {
-    throw new ApiError("Workflow run not found", 404);
-  }
+    if (step_index === undefined || resume_data === undefined) {
+      throw new ApiError("step_index and resume_data are required", 400);
+    }
 
-  await requireResourcePermission(
-    session,
-    { type: "task", id: run.workflow_config_id, action: "write" },
-    { bypassForOrgAdmin: true },
-  );
+    const runCol = await getCollection<WorkflowRunDocument>("workflow_runs");
+    const run = await runCol.findOne({ _id: id });
+    if (!run) {
+      throw new ApiError("Workflow run not found", 404);
+    }
 
-  // Build auth headers
-  const authHeaders: Record<string, string> = {};
-  const authHeader = request.headers.get("Authorization");
-  if (authHeader) {
-    authHeaders["Authorization"] = authHeader;
-  }
-  authHeaders["X-User-Context"] = Buffer.from(JSON.stringify({
-    email: user.email,
-    name: user.name,
-  })).toString("base64");
+    await requireWorkflowRunAccess(session, run, "resume");
 
-  await resumeWorkflowRun(id, step_index, resume_data, authHeaders);
+    const authHeaders = buildWorkflowDaAuthHeaders(req, user, session);
 
-  return NextResponse.json({ status: "resumed" }) as NextResponse;
+    await resumeWorkflowRun(id, step_index, resume_data, authHeaders);
+
+    return NextResponse.json({ status: "resumed" }) as NextResponse;
+  });
 });

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -24,11 +24,19 @@ type WorkflowRunDocument,
 import { deleteEventsByRun,readEventsByRun } from "@/lib/server/event-store";
 import {
 filterAccessibleWorkflowConfigs,
-requireWorkflowAccess,
 requireWorkflowRunAccess,
 workflowSubjectFromSession,
 type WorkflowAuthzSession,
 } from "@/lib/server/workflow-cas-authz";
+import {
+buildTeamRefToSlugMap,
+filterWorkflowConfigsByRunAccess,
+mergeWorkflowConfigsById,
+requireWorkflowConfigRunAccess,
+requireWorkflowConfigRunViewAccess,
+resolveUserTeamSlugsForWorkflow,
+type WorkflowConfigRebacSnapshot,
+} from "@/lib/rbac/workflow-config-rebac";
 import type { WorkflowConfig } from "@/types/workflow-config";
 import { NextRequest,NextResponse } from "next/server";
 
@@ -49,6 +57,16 @@ function ownerMatchesSession(run: WorkflowRunDocument, session: WorkflowAuthzSes
 
 function filterRunsForOwner<T extends WorkflowRunDocument>(runs: T[], session: WorkflowAuthzSession): T[] {
   return runs.filter((run) => !run.owner_subject || ownerMatchesSession(run, session));
+}
+
+function workflowRunAccessConfig(config: WorkflowConfig): WorkflowConfigRebacSnapshot {
+  return {
+    _id: String(config._id),
+    owner_id: config.owner_id,
+    visibility: config.visibility,
+    shared_with_teams: config.shared_with_teams,
+    config_driven: config.config_driven,
+  };
 }
 
 /**
@@ -133,8 +151,16 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError(`Workflow config ${workflow_config_id} not found`, 404);
   }
 
-  // Verify user has access to this workflow config (via CAS)
-  await requireWorkflowAccess(session, workflow_config_id, "read");
+  // Start uses the same visibility ∪ authorization semantics as workflow config
+  // reads, so global/team/owner-visible workflows remain runnable before every
+  // legacy row has been projected into OpenFGA.
+  const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+  await requireWorkflowConfigRunAccess(
+    session,
+    workflowRunAccessConfig(config),
+    user.email,
+    userTeamSlugs,
+  );
 
   // Build auth headers for DA server calls. Prefer the incoming Bearer; fall
   // back to the session's OIDC access token so browser (cookie) sessions still
@@ -182,7 +208,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError("MongoDB is required for workflow runs", 503);
   }
 
-  const { session } = await getAuthFromBearerOrSession(request);
+  const { user, session } = await getAuthFromBearerOrSession(request);
 
   const { searchParams } = new URL(request.url);
   const runId = searchParams.get("run_id");
@@ -228,11 +254,21 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const workflowConfigId = searchParams.get("workflow_config_id");
 
   if (workflowConfigId) {
-    // Filter by specific config — check access once
+    const configCol = await getCollection<WorkflowConfig>("workflow_configs");
+    const config = await configCol.findOne({ _id: workflowConfigId });
+    if (!config) {
+      return NextResponse.json([]) as NextResponse;
+    }
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
     try {
-      await requireWorkflowAccess(session, workflowConfigId, "read");
+      await requireWorkflowConfigRunViewAccess(
+        session,
+        workflowRunAccessConfig(config),
+        user.email,
+        userTeamSlugs,
+      );
     } catch (err) {
-      if (err instanceof ApiError && err.statusCode === 403) {
+      if ((err as { statusCode?: number }).statusCode === 403) {
         return NextResponse.json([]) as NextResponse;
       }
       throw err;
@@ -247,13 +283,25 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
   // List all runs — filter to only those whose configs the user can read.
   const configCol = await getCollection<WorkflowConfig>("workflow_configs");
-  const configCandidates = await configCol.find({}).project({ _id: 1 }).toArray();
-  const accessibleConfigs = await filterAccessibleWorkflowConfigs(
+  const configCandidates = await configCol
+    .find({})
+    .project({ _id: 1, owner_id: 1, visibility: 1, shared_with_teams: 1, config_driven: 1 })
+    .toArray();
+  const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+  const teamRefToSlug = await buildTeamRefToSlugMap();
+  const byVisibility = filterWorkflowConfigsByRunAccess(
+    configCandidates,
+    user.email,
+    userTeamSlugs,
+    teamRefToSlug,
+  );
+  const byFga = await filterAccessibleWorkflowConfigs(
     session,
     configCandidates,
     (config) => config._id as string,
     "read",
   );
+  const accessibleConfigs = mergeWorkflowConfigsById(byVisibility, byFga);
 
   const accessibleIds = accessibleConfigs.map((c) => c._id);
   if (accessibleIds.length === 0) {

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -17,16 +17,18 @@ withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import {
-filterResourcesByPermission,
-requireResourcePermission,
-type ResourceAuthzSession,
-} from "@/lib/rbac/resource-authz";
-import { deleteEventsByRun,readEventsByRun } from "@/lib/server/event-store";
-import {
 detectStaleRun,
 startWorkflowRun,
 type WorkflowRunDocument,
 } from "@/lib/server/workflow-engine";
+import { deleteEventsByRun,readEventsByRun } from "@/lib/server/event-store";
+import {
+filterAccessibleWorkflowConfigs,
+requireWorkflowAccess,
+requireWorkflowRunAccess,
+workflowSubjectFromSession,
+type WorkflowAuthzSession,
+} from "@/lib/server/workflow-cas-authz";
 import type { WorkflowConfig } from "@/types/workflow-config";
 import { NextRequest,NextResponse } from "next/server";
 
@@ -39,41 +41,14 @@ const RETENTION_DAYS = parseInt(process.env.WORKFLOW_RUN_RETENTION_DAYS ?? "7", 
 let lastCleanupAt = 0;
 const CLEANUP_INTERVAL_MS = 30 * 60 * 1000;
 
-// ---------------------------------------------------------------------------
-// Access control helper — checks if user can access a workflow config
-// ---------------------------------------------------------------------------
-
-async function userCanAccessConfig(
-  configId: string,
-  session: ResourceAuthzSession,
-): Promise<boolean> {
-  try {
-    await requireResourcePermission(
-      session,
-      { type: "task", id: configId, action: "read" },
-      { bypassForOrgAdmin: true },
-    );
-    return true;
-  } catch {
-    return false;
-  }
+function ownerMatchesSession(run: WorkflowRunDocument, session: WorkflowAuthzSession): boolean {
+  const subject = workflowSubjectFromSession(session);
+  if (!subject) return false;
+  return run.owner_subject?.type === subject.type && run.owner_subject.id === subject.id;
 }
 
-/** Check if user can delete runs for the workflow config. */
-async function userCanDeleteConfigRuns(
-  configId: string,
-  session: ResourceAuthzSession,
-): Promise<boolean> {
-  try {
-    await requireResourcePermission(
-      session,
-      { type: "task", id: configId, action: "delete" },
-      { bypassForOrgAdmin: true },
-    );
-    return true;
-  } catch {
-    return false;
-  }
+function filterRunsForOwner<T extends WorkflowRunDocument>(runs: T[], session: WorkflowAuthzSession): T[] {
+  return runs.filter((run) => !run.owner_subject || ownerMatchesSession(run, session));
 }
 
 /**
@@ -158,18 +133,22 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError(`Workflow config ${workflow_config_id} not found`, 404);
   }
 
-  // Verify user has access to this workflow config
-  await requireResourcePermission(
-    session,
-    { type: "task", id: workflow_config_id, action: "read" },
-    { bypassForOrgAdmin: true },
-  );
+  // Verify user has access to this workflow config (via CAS)
+  await requireWorkflowAccess(session, workflow_config_id, "read");
 
-  // Build auth headers for DA server calls
+  // Build auth headers for DA server calls. Prefer the incoming Bearer; fall
+  // back to the session's OIDC access token so browser (cookie) sessions still
+  // forward a valid bearer — DA + the BFF per-step CAS gate both need the
+  // run-owner's token.
   const authHeaders: Record<string, string> = {};
-  const authHeader = request.headers.get("Authorization");
-  if (authHeader) {
-    authHeaders["Authorization"] = authHeader;
+  const incomingAuth = request.headers.get("Authorization");
+  const sessionAccessToken = typeof (session as { accessToken?: unknown }).accessToken === "string"
+    ? (session as { accessToken?: string }).accessToken
+    : undefined;
+  if (incomingAuth) {
+    authHeaders["Authorization"] = incomingAuth;
+  } else if (sessionAccessToken) {
+    authHeaders["Authorization"] = `Bearer ${sessionAccessToken}`;
   }
   authHeaders["X-User-Context"] = Buffer.from(JSON.stringify({
     email: user.email,
@@ -183,7 +162,13 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     user: { email: user.email, name: user.name },
   };
 
-  const runId = await startWorkflowRun(config, user_context || null, authHeaders, enrichedTriggerInfo);
+  const runId = await startWorkflowRun(
+    config,
+    user_context || null,
+    authHeaders,
+    enrichedTriggerInfo,
+    workflowSubjectFromSession(session),
+  );
 
   return NextResponse.json({ run_id: runId, status: "running" }, { status: 201 });
 });
@@ -197,7 +182,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     throw new ApiError("MongoDB is required for workflow runs", 503);
   }
 
-  const { user, session } = await getAuthFromBearerOrSession(request);
+  const { session } = await getAuthFromBearerOrSession(request);
 
   const { searchParams } = new URL(request.url);
   const runId = searchParams.get("run_id");
@@ -210,10 +195,13 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError(`Run ${runId} not found`, 404);
     }
 
-    // Verify user has access to the parent workflow config
-    const hasAccess = await userCanAccessConfig(run.workflow_config_id, session);
-    if (!hasAccess) {
-      throw new ApiError(`Run ${runId} not found`, 404);
+    try {
+      await requireWorkflowRunAccess(session, run, "read");
+    } catch (err) {
+      if (err instanceof ApiError && err.statusCode === 403) {
+        throw new ApiError(`Run ${runId} not found`, 404);
+      }
+      throw err;
     }
 
     // Detect stale runs
@@ -241,26 +229,30 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
   if (workflowConfigId) {
     // Filter by specific config — check access once
-    const hasAccess = await userCanAccessConfig(workflowConfigId, session);
-    if (!hasAccess) {
-      return NextResponse.json([]) as NextResponse;
+    try {
+      await requireWorkflowAccess(session, workflowConfigId, "read");
+    } catch (err) {
+      if (err instanceof ApiError && err.statusCode === 403) {
+        return NextResponse.json([]) as NextResponse;
+      }
+      throw err;
     }
     const runs = await col
       .find({ workflow_config_id: workflowConfigId })
       .sort({ started_at: -1 })
       .limit(100)
       .toArray();
-    return NextResponse.json(runs) as NextResponse;
+    return NextResponse.json(filterRunsForOwner(runs, session)) as NextResponse;
   }
 
   // List all runs — filter to only those whose configs the user can read.
   const configCol = await getCollection<WorkflowConfig>("workflow_configs");
   const configCandidates = await configCol.find({}).project({ _id: 1 }).toArray();
-  const accessibleConfigs = await filterResourcesByPermission(
+  const accessibleConfigs = await filterAccessibleWorkflowConfigs(
     session,
     configCandidates,
-    { type: "task", action: "read", id: (config) => config._id },
-    { bypassForOrgAdmin: true },
+    (config) => config._id as string,
+    "read",
   );
 
   const accessibleIds = accessibleConfigs.map((c) => c._id);
@@ -273,7 +265,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     .sort({ started_at: -1 })
     .limit(100)
     .toArray();
-  return NextResponse.json(runs) as NextResponse;
+  return NextResponse.json(filterRunsForOwner(runs, session)) as NextResponse;
 });
 
 // ═══════════════════════════════════════════════════════════════
@@ -303,11 +295,7 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError("Workflow run not found", 404);
     }
 
-    // Verify user has access to the parent workflow config
-    const hasAccess = await userCanAccessConfig(run.workflow_config_id, session);
-    if (!hasAccess) {
-      throw new ApiError("Workflow run not found", 404);
-    }
+    await requireWorkflowRunAccess(session, run, "write");
 
     await col.updateOne({ _id: id }, { $set: body });
 
@@ -339,11 +327,7 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError("Workflow run not found", 404);
     }
 
-    // Deleting runs requires OpenFGA delete on the workflow config (or admin).
-    const canDelete = await userCanDeleteConfigRuns(run.workflow_config_id, session);
-    if (!canDelete) {
-      throw new ApiError("You don't have permission to delete this workflow run", 403);
-    }
+    await requireWorkflowRunAccess(session, run, "delete");
 
     // Clean up GridFS files via backend
     try {

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -90,7 +90,6 @@ const EDITOR_ROUTES_WITH_OWN_DISCARD_DIALOG = [
  */
 const EDITOR_ROUTES_WITH_HEADER_DIALOG = [
   "/task-builder",
-  "/workflows",
   "/dynamic-agents",
 ];
 

--- a/ui/src/components/workflows/WorkflowAgentAccessModal.tsx
+++ b/ui/src/components/workflows/WorkflowAgentAccessModal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React, { useState } from "react";
+import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-access/route";
+
+interface WorkflowAgentAccessModalProps {
+  gaps: AgentAccessGap[];
+  onGrantAndSave: () => Promise<void>;
+  onCancel: () => void;
+}
+
+export function WorkflowAgentAccessModal({
+  gaps,
+  onGrantAndSave,
+  onCancel,
+}: WorkflowAgentAccessModalProps) {
+  const [isGranting, setIsGranting] = useState(false);
+
+  const handleGrant = async () => {
+    setIsGranting(true);
+    try {
+      await onGrantAndSave();
+    } finally {
+      setIsGranting(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Agent access required
+          </DialogTitle>
+          <DialogDescription>
+            The following agents are not accessible to all teams this workflow is shared with.
+            Grant access to let those teams run this workflow.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2 max-h-64 overflow-y-auto">
+          {gaps.map((gap) => (
+            <div key={gap.agentId} className="rounded-md border px-3 py-2 text-sm">
+              <p className="font-medium">{gap.agentName}</p>
+              <p className="text-muted-foreground mt-0.5">
+                Not accessible to:{" "}
+                <span className="font-mono">{gap.teamsWithoutAccess.join(", ")}</span>
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={isGranting}>
+            Cancel
+          </Button>
+          <Button onClick={handleGrant} disabled={isGranting} className="gap-2">
+            <ShieldCheck className="h-4 w-4" />
+            {isGranting ? "Granting access…" : "Grant access and save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/workflows/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/WorkflowCanvas.tsx
@@ -40,6 +40,7 @@ import { WorkflowStepSidebar } from "./WorkflowStepSidebar";
 import { WorkflowToolbar } from "./WorkflowToolbar";
 import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-access/route";
 import { WorkflowAgentAccessModal } from "./WorkflowAgentAccessModal";
+import { grantAgentAccessGaps } from "./agent-access-grants";
 
 // ---------------------------------------------------------------------------
 // Node types — defined outside component to avoid re-renders
@@ -664,30 +665,18 @@ function WorkflowCanvasInner({
   }, [doSave, visibility, steps, sharedWithTeams]);
 
   const handleGrantAndSave = useCallback(async () => {
-    // assisted-by claude code claude-sonnet-4-6
-    // Route grants through the Centralized Authorization Service PAP so CAS owns
-    // grants (audit + meta-authz: caller must manage the agent). This writes the
-    // same `team:<slug>#member user agent:<id>` tuple the direct OpenFGA write did.
-    for (const gap of agentAccessGaps) {
-      for (const teamSlug of gap.teamsWithoutAccess) {
-        if (teamSlug === "(all users)") continue;
-        try {
-          await fetch("/api/admin/authz/grants", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              resource: { type: "agent", id: gap.agentId },
-              grantee: { type: "team", id: teamSlug },
-              capability: "use",
-            }),
-          });
-        } catch { /* best-effort */ }
-      }
+    try {
+      await grantAgentAccessGaps(agentAccessGaps);
+      setShowAccessModal(false);
+      setAgentAccessGaps([]);
+      await doSave("Agent access granted and workflow saved");
+    } catch (error) {
+      toast(
+        error instanceof Error ? error.message : "Failed to grant agent access",
+        "error",
+      );
     }
-    setShowAccessModal(false);
-    setAgentAccessGaps([]);
-    await doSave("Agent access granted and workflow saved");
-  }, [agentAccessGaps, doSave]);
+  }, [agentAccessGaps, doSave, toast]);
 
   // -----------------------------------------------------------------------
   // Run workflow

--- a/ui/src/components/workflows/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/WorkflowCanvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AgentAvatarAgent } from "@/components/dynamic-agents/AgentAvatar";
+import { UnsavedChangesDialog } from "@/components/task-builder/UnsavedChangesDialog";
 import { useToast } from "@/components/ui/toast";
 import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import { useWorkflowConfigStore } from "@/store/workflow-config-store";
@@ -24,6 +25,8 @@ type Node,
 type NodeMouseHandler,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { Lock } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useCallback,useEffect,useMemo,useRef,useState } from "react";
 import YAML from "yaml";
@@ -35,6 +38,8 @@ type WorkflowStepNodeData,
 } from "./WorkflowStepNode";
 import { WorkflowStepSidebar } from "./WorkflowStepSidebar";
 import { WorkflowToolbar } from "./WorkflowToolbar";
+import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-access/route";
+import { WorkflowAgentAccessModal } from "./WorkflowAgentAccessModal";
 
 // ---------------------------------------------------------------------------
 // Node types — defined outside component to avoid re-renders
@@ -282,10 +287,19 @@ function WorkflowCanvasInner({
   initialSteps,
   onBack,
 }: WorkflowCanvasProps) {
-  const { createConfig, updateConfig, deleteConfig, closeEditor, loadConfigs } = useWorkflowConfigStore();
+  const { createConfig, updateConfig, deleteConfig, closeEditor, loadConfigs, openEditor } =
+    useWorkflowConfigStore();
+  const { data: authSession } = useSession();
   const { executeWorkflow } = useWorkflowExecStore();
-  const { setUnsaved, pendingNavigationHref, cancelNavigation, confirmNavigation } =
-    useUnsavedChangesStore();
+  const {
+    hasUnsavedChanges,
+    setUnsaved,
+    pendingNavigationHref,
+    pendingDeferredAction,
+    cancelNavigation,
+    confirmNavigation,
+    confirmDeferredAction,
+  } = useUnsavedChangesStore();
   const { agents, loading: agentsLoading } = useDynamicAgents();
   const router = useRouter();
   const { toast } = useToast();
@@ -307,6 +321,8 @@ function WorkflowCanvasInner({
     existingConfig?.description || initialDescription || "",
   );
   const [isSaving, setIsSaving] = useState(false);
+  const [agentAccessGaps, setAgentAccessGaps] = useState<AgentAccessGap[]>([]);
+  const [showAccessModal, setShowAccessModal] = useState(false);
   const [selectedStepIndex, setSelectedStepIndex] = useState<number>(-1);
 
   // Visibility & sharing
@@ -316,16 +332,42 @@ function WorkflowCanvasInner({
   const [sharedWithTeams, setSharedWithTeams] = useState<string[]>(
     existingConfig?.shared_with_teams || [],
   );
-  const [availableTeams, setAvailableTeams] = useState<{ _id: string; name: string }[]>([]);
+  const [availableTeams, setAvailableTeams] = useState<
+    { _id: string; slug: string; name: string }[]
+  >([]);
 
   useEffect(() => {
     fetch("/api/dynamic-agents/teams")
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
-        if (data?.success && Array.isArray(data.data)) setAvailableTeams(data.data);
+        if (data?.success && Array.isArray(data.data)) {
+          setAvailableTeams(
+            data.data.filter(
+              (team: { slug?: string }) => typeof team.slug === "string" && team.slug.length > 0,
+            ),
+          );
+        }
       })
       .catch(() => {});
   }, []);
+
+  // Legacy workflows stored Mongo team _id in shared_with_teams; normalize to slug in UI.
+  useEffect(() => {
+    if (!existingConfig?.shared_with_teams?.length || availableTeams.length === 0) return;
+    setSharedWithTeams((current) => {
+      const normalized = existingConfig.shared_with_teams!.map((ref) => {
+        const refLower = ref.trim().toLowerCase();
+        const bySlug = availableTeams.find((t) => t.slug.toLowerCase() === refLower);
+        if (bySlug) return bySlug.slug;
+        const byId = availableTeams.find((t) => t._id === ref);
+        return byId?.slug ?? refLower;
+      });
+      const same =
+        current.length === normalized.length &&
+        current.every((slug, i) => slug === normalized[i]);
+      return same ? current : normalized;
+    });
+  }, [existingConfig?._id, existingConfig?.shared_with_teams, availableTeams]);
 
   const isDirtyRef = useRef(false);
 
@@ -345,7 +387,38 @@ function WorkflowCanvasInner({
   // Node click handler — handles both step selection and "+" button clicks
   // -----------------------------------------------------------------------
 
-  const isReadOnly = !!existingConfig?.config_driven;
+  const isConfigDriven = !!existingConfig?.config_driven;
+
+  const { isReadOnly, readOnlyHint } = useMemo(() => {
+    if (!existingConfig) {
+      return { isReadOnly: false, readOnlyHint: undefined };
+    }
+    if (existingConfig.config_driven) {
+      return {
+        isReadOnly: true,
+        readOnlyHint:
+          "This workflow is seeded from config/app-config.yaml and cannot be overwritten. " +
+          "Edit steps here, then use Save as copy or Run (which saves a copy first).",
+      };
+    }
+    const userEmail = authSession?.user?.email?.trim().toLowerCase();
+    const ownerId = existingConfig.owner_id?.trim().toLowerCase();
+    if (ownerId === "system") {
+      return {
+        isReadOnly: true,
+        readOnlyHint:
+          "This is a platform workflow (owner: system). Use Clone to edit to create your own editable copy.",
+      };
+    }
+    if (userEmail && ownerId && ownerId !== userEmail) {
+      return {
+        isReadOnly: true,
+        readOnlyHint:
+          "You can run this workflow, but only the owner can change it. Use Clone to edit to create your own copy.",
+      };
+    }
+    return { isReadOnly: false, readOnlyHint: undefined };
+  }, [existingConfig, authSession?.user?.email]);
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
@@ -422,30 +495,8 @@ function WorkflowCanvasInner({
     return () => setUnsaved(false);
   }, [setUnsaved]);
 
-  useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
-      if (isDirtyRef.current) e.preventDefault();
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, []);
-
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const pendingActionRef = useRef<(() => void) | null>(null);
-
-  useEffect(() => {
-    if (pendingNavigationHref && isDirtyRef.current) {
-      setShowUnsavedDialog(true);
-      pendingActionRef.current = () => {
-        const href = confirmNavigation();
-        if (href) {
-          setUnsaved(false);
-          isDirtyRef.current = false;
-          window.location.href = href;
-        }
-      };
-    }
-  }, [pendingNavigationHref, confirmNavigation, setUnsaved]);
 
   const guardAction = useCallback((action: () => void) => {
     if (isDirtyRef.current) {
@@ -456,9 +507,45 @@ function WorkflowCanvasInner({
     }
   }, []);
 
+  useEffect(() => {
+    if (!isDirtyRef.current) return;
+
+    if (pendingNavigationHref) {
+      setShowUnsavedDialog(true);
+      pendingActionRef.current = () => {
+        const href = confirmNavigation();
+        if (href) {
+          isDirtyRef.current = false;
+          setUnsaved(false);
+          window.location.href = href;
+        }
+      };
+      return;
+    }
+
+    if (pendingDeferredAction) {
+      setShowUnsavedDialog(true);
+      pendingActionRef.current = () => {
+        confirmDeferredAction();
+        isDirtyRef.current = false;
+      };
+    }
+  }, [
+    pendingNavigationHref,
+    pendingDeferredAction,
+    confirmNavigation,
+    confirmDeferredAction,
+    setUnsaved,
+  ]);
+
   const handleBack = useCallback(() => {
     guardAction(onBack);
   }, [onBack, guardAction]);
+
+  const handleCloneToEdit = useCallback(() => {
+    if (!existingConfig) return;
+    guardAction(() => openEditor("clone", existingConfig._id));
+  }, [existingConfig, openEditor, guardAction]);
 
   const handleNameChange = useCallback(
     (v: string) => { markDirty(); setName(v); },
@@ -474,40 +561,133 @@ function WorkflowCanvasInner({
   // Save
   // -----------------------------------------------------------------------
 
-  const handleSave = useCallback(async () => {
-    if (!name || steps.length === 0) return;
-    setIsSaving(true);
+  const persistWorkflow = useCallback(async (): Promise<string | null> => {
+    if (!name || steps.length === 0) {
+      toast("Workflow name and at least one step are required", "error");
+      return null;
+    }
 
+    if (existingConfig?.config_driven) {
+      const input: CreateWorkflowConfigInput = {
+        name: `${name.trim()} (editable)`,
+        description: description.trim() || undefined,
+        steps,
+        visibility,
+        shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+      };
+      const newId = await createConfig(input);
+      openEditor("edit", newId);
+      return newId;
+    }
+
+    if (existingConfig) {
+      const updates: UpdateWorkflowConfigInput = {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        steps,
+        visibility,
+        shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+      };
+      await updateConfig(existingConfig._id, updates);
+      return existingConfig._id;
+    }
+
+    const input: CreateWorkflowConfigInput = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      steps,
+      visibility,
+      shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+    };
+    const newId = await createConfig(input);
+    openEditor("edit", newId);
+    return newId;
+  }, [
+    name,
+    description,
+    steps,
+    visibility,
+    sharedWithTeams,
+    existingConfig,
+    createConfig,
+    updateConfig,
+    openEditor,
+    toast,
+  ]);
+
+  const doSave = useCallback(async (successMsg?: string) => {
+    setIsSaving(true);
     try {
-      if (existingConfig) {
-        const updates: UpdateWorkflowConfigInput = {
-          name: name.trim(),
-          description: description.trim() || undefined,
-          steps,
-          visibility,
-          shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
-        };
-        await updateConfig(existingConfig._id, updates);
-      } else {
-        const input: CreateWorkflowConfigInput = {
-          name: name.trim(),
-          description: description.trim() || undefined,
-          steps,
-          visibility,
-          shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
-        };
-        await createConfig(input);
-      }
+      const savedId = await persistWorkflow();
+      if (!savedId) return;
       isDirtyRef.current = false;
       setUnsaved(false);
-      toast("Workflow saved", "success");
+      toast(
+        successMsg ??
+          (existingConfig?.config_driven
+            ? "Saved as a new editable workflow"
+            : "Workflow saved"),
+        "success",
+      );
     } catch (error) {
       console.error("Failed to save workflow config:", error);
-      toast("Failed to save workflow", "error");
+      toast(
+        error instanceof Error ? error.message : "Failed to save workflow",
+        "error",
+      );
     } finally {
       setIsSaving(false);
     }
-  }, [name, description, steps, visibility, sharedWithTeams, existingConfig, createConfig, updateConfig, setUnsaved, toast]);
+  }, [persistWorkflow, existingConfig?.config_driven, setUnsaved, toast]);
+
+  const handleSave = useCallback(async () => {
+    if (visibility !== "private") {
+      let gaps: AgentAccessGap[] = [];
+      try {
+        const res = await fetch("/api/workflow-configs/check-agent-access", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ steps, visibility, shared_with_teams: sharedWithTeams }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          gaps = data.gaps ?? [];
+        }
+      } catch { /* non-fatal — proceed to save */ }
+      if (gaps.length > 0) {
+        setAgentAccessGaps(gaps);
+        setShowAccessModal(true);
+        return;
+      }
+    }
+    await doSave();
+  }, [doSave, visibility, steps, sharedWithTeams]);
+
+  const handleGrantAndSave = useCallback(async () => {
+    // assisted-by claude code claude-sonnet-4-6
+    // Route grants through the Centralized Authorization Service PAP so CAS owns
+    // grants (audit + meta-authz: caller must manage the agent). This writes the
+    // same `team:<slug>#member user agent:<id>` tuple the direct OpenFGA write did.
+    for (const gap of agentAccessGaps) {
+      for (const teamSlug of gap.teamsWithoutAccess) {
+        if (teamSlug === "(all users)") continue;
+        try {
+          await fetch("/api/admin/authz/grants", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              resource: { type: "agent", id: gap.agentId },
+              grantee: { type: "team", id: teamSlug },
+              capability: "use",
+            }),
+          });
+        } catch { /* best-effort */ }
+      }
+    }
+    setShowAccessModal(false);
+    setAgentAccessGaps([]);
+    await doSave("Agent access granted and workflow saved");
+  }, [agentAccessGaps, doSave]);
 
   // -----------------------------------------------------------------------
   // Run workflow
@@ -515,17 +695,48 @@ function WorkflowCanvasInner({
 
   const handleRun = useCallback(async () => {
     if (!existingConfig) return;
+
+    if (isReadOnly && isDirtyRef.current) {
+      toast(
+        "Unsaved changes cannot be applied to a config-driven workflow. Click Save to create an editable copy, or Clone to edit, then run that copy.",
+        "error",
+      );
+      return;
+    }
+
+    setIsSaving(true);
+    let configId = existingConfig._id;
     try {
-      const runId = await executeWorkflow(existingConfig._id);
-      isDirtyRef.current = false;
-      setUnsaved(false);
+      if (isDirtyRef.current) {
+        const savedId = await persistWorkflow();
+        if (!savedId) return;
+        configId = savedId;
+        isDirtyRef.current = false;
+        setUnsaved(false);
+      }
+
+      const runId = await executeWorkflow(configId);
       closeEditor();
-      // Navigate directly to the new run
       router.push(`/workflows/run/${runId}`);
     } catch (error) {
       console.error("Failed to execute workflow:", error);
+      toast(
+        error instanceof Error ? error.message : "Failed to start workflow",
+        "error",
+      );
+    } finally {
+      setIsSaving(false);
     }
-  }, [existingConfig, executeWorkflow, setUnsaved, closeEditor, router]);
+  }, [
+    existingConfig,
+    isReadOnly,
+    persistWorkflow,
+    executeWorkflow,
+    setUnsaved,
+    closeEditor,
+    router,
+    toast,
+  ]);
 
   // -----------------------------------------------------------------------
   // Delete workflow
@@ -585,14 +796,24 @@ function WorkflowCanvasInner({
         setVisibility(obj.visibility);
       }
       if (Array.isArray(obj.shared_with_teams)) {
-        setSharedWithTeams(obj.shared_with_teams as string[]);
+        const refs = (obj.shared_with_teams as string[]).map((ref) => ref.trim().toLowerCase());
+        setSharedWithTeams(
+          refs
+            .map((ref) => {
+              const bySlug = availableTeams.find((t) => t.slug.toLowerCase() === ref);
+              if (bySlug) return bySlug.slug;
+              const byId = availableTeams.find((t) => t._id === ref);
+              return byId?.slug ?? ref;
+            })
+            .filter(Boolean),
+        );
       }
       if (Array.isArray(obj.steps)) {
         setSteps(obj.steps as WorkflowStep[]);
       }
       markDirty();
     },
-    [markDirty],
+    [availableTeams, markDirty],
   );
 
   // Agent objects for the sidebar (with _id, name, description, ui)
@@ -614,7 +835,7 @@ function WorkflowCanvasInner({
     cancelNavigation();
   }, [setUnsaved, cancelNavigation]);
 
-  const handleCancelDialog = useCallback(() => {
+  const handleCancelUnsavedDialog = useCallback(() => {
     setShowUnsavedDialog(false);
     pendingActionRef.current = null;
     cancelNavigation();
@@ -647,14 +868,25 @@ function WorkflowCanvasInner({
         onImport={handleImport}
         isSaving={isSaving}
         isEditing={!!existingConfig}
+        hasUnsavedChanges={hasUnsavedChanges}
         stepCount={steps.length}
-        readOnly={existingConfig?.config_driven}
+        readOnly={isReadOnly}
+        saveAsCopy={isConfigDriven}
+        readOnlyHint={readOnlyHint}
+        onCloneToEdit={existingConfig ? handleCloneToEdit : undefined}
         visibility={visibility}
         onVisibilityChange={(v) => { setVisibility(v); markDirty(); }}
         sharedWithTeams={sharedWithTeams}
         onSharedWithTeamsChange={(t) => { setSharedWithTeams(t); markDirty(); }}
         teams={availableTeams}
       />
+
+      {isReadOnly && readOnlyHint && (
+        <div className="px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/20 flex items-start gap-2 shrink-0">
+          <Lock className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-700 dark:text-amber-300 leading-relaxed">{readOnlyHint}</p>
+        </div>
+      )}
 
       <div className="flex flex-1 overflow-hidden">
         <div className="flex-1">
@@ -695,34 +927,24 @@ function WorkflowCanvasInner({
           }}
           agents={sidebarAgents}
           agentsLoading={agentsLoading}
-          readOnly={existingConfig?.config_driven}
+          readOnly={isReadOnly}
+          readOnlyHint={readOnlyHint}
         />
       </div>
 
-      {/* Unsaved changes dialog */}
-      {showUnsavedDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card border border-border rounded-lg p-6 shadow-xl max-w-sm mx-4">
-            <h3 className="text-sm font-bold text-foreground mb-2">Unsaved changes</h3>
-            <p className="text-sm text-muted-foreground mb-4">
-              You have unsaved changes. Discard them?
-            </p>
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={handleCancelDialog}
-                className="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleDiscardChanges}
-                className="px-3 py-1.5 text-sm rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
-              >
-                Discard
-              </button>
-            </div>
-          </div>
-        </div>
+      <UnsavedChangesDialog
+        open={showUnsavedDialog}
+        onDiscard={handleDiscardChanges}
+        onCancel={handleCancelUnsavedDialog}
+        description="You have unsaved changes in this workflow. They will be lost if you leave without saving."
+      />
+
+      {showAccessModal && agentAccessGaps.length > 0 && (
+        <WorkflowAgentAccessModal
+          gaps={agentAccessGaps}
+          onGrantAndSave={handleGrantAndSave}
+          onCancel={() => { setShowAccessModal(false); setAgentAccessGaps([]); }}
+        />
       )}
 
       {/* Delete confirmation dialog */}

--- a/ui/src/components/workflows/WorkflowSidebar.tsx
+++ b/ui/src/components/workflows/WorkflowSidebar.tsx
@@ -22,7 +22,9 @@ TooltipContent,
 TooltipProvider,
 TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useToast } from "@/components/ui/toast";
 import { cn,formatRelativeTime } from "@/lib/utils";
+import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import { useWorkflowConfigStore } from "@/store/workflow-config-store";
 import {
 useWorkflowExecStore,
@@ -161,6 +163,7 @@ export function WorkflowSidebar({
   onCollapse,
 }: WorkflowSidebarProps) {
   const router = useRouter();
+  const { toast } = useToast();
   const params = useParams();
   const activeRunId = params?.id as string | undefined;
 
@@ -169,12 +172,14 @@ export function WorkflowSidebar({
   const {
     configs,
     isLoading: isLoadingConfigs,
+    error: configsError,
     loadConfigs,
     deleteConfig,
     openEditor,
     editMode,
     selectedConfigId,
   } = useWorkflowConfigStore();
+  const requestDeferredAction = useUnsavedChangesStore((s) => s.requestDeferredAction);
 
   const [activeTab, setActiveTab] = useState<SidebarTab>("workflows");
   const [tabDirection, setTabDirection] = useState(0); // -1 = left, 1 = right
@@ -208,7 +213,7 @@ export function WorkflowSidebar({
   const hasActiveFilters = statusFilter.size > 0 || configFilter !== null || searchQuery.length > 0;
 
   const filteredRuns = useMemo(() => {
-    let result = runs;
+    let result = Array.isArray(runs) ? runs : [];
     if (statusFilter.size > 0) {
       result = result.filter((r) => statusFilter.has(r.status));
     }
@@ -240,10 +245,17 @@ export function WorkflowSidebar({
   const switchTab = useCallback(
     (tab: SidebarTab) => {
       if (tab === activeTab) return;
-      setTabDirection(tab === "runs" ? 1 : -1);
-      setActiveTab(tab);
+      const doSwitch = () => {
+        setTabDirection(tab === "runs" ? 1 : -1);
+        setActiveTab(tab);
+      };
+      if (editMode) {
+        requestDeferredAction(doSwitch);
+        return;
+      }
+      doSwitch();
     },
-    [activeTab]
+    [activeTab, editMode, requestDeferredAction],
   );
 
   const handleRefresh = useCallback(async () => {
@@ -257,22 +269,29 @@ export function WorkflowSidebar({
   }, [activeTab, loadConfigs, loadRuns]);
 
   const handleSelectRun = (runId: string) => {
-    router.push(`/workflows/run/${runId}`);
+    requestDeferredAction(() => router.push(`/workflows/run/${runId}`));
   };
 
   const handleEditConfig = (config: WorkflowConfig) => {
-    openEditor("edit", config._id);
-    router.push("/workflows");
+    if (editMode === "edit" && selectedConfigId === config._id) return;
+    requestDeferredAction(() => {
+      openEditor("edit", config._id);
+      router.push("/workflows");
+    });
   };
 
   const handleCloneConfig = (config: WorkflowConfig) => {
-    openEditor("clone", config._id);
-    router.push("/workflows");
+    requestDeferredAction(() => {
+      openEditor("clone", config._id);
+      router.push("/workflows");
+    });
   };
 
   const handleNewConfig = () => {
-    openEditor("new");
-    router.push("/workflows");
+    requestDeferredAction(() => {
+      openEditor("new");
+      router.push("/workflows");
+    });
   };
 
   const handleDeleteConfig = async (config: WorkflowConfig) => {
@@ -304,7 +323,7 @@ export function WorkflowSidebar({
       switchTab("runs");
       router.push(`/workflows/run/${runId}`);
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to start workflow");
+      toast(err instanceof Error ? err.message : "Failed to start workflow", "error");
     }
   };
 
@@ -660,6 +679,7 @@ export function WorkflowSidebar({
                       <WorkflowsTab
                         configs={configs}
                         isLoading={isLoadingConfigs}
+                        error={configsError}
                         selectedConfigId={editMode ? selectedConfigId : null}
                         searchQuery={workflowSearchQuery}
                         onEdit={handleEditConfig}
@@ -742,6 +762,7 @@ export function WorkflowSidebar({
 function WorkflowsTab({
   configs,
   isLoading,
+  error,
   selectedConfigId,
   searchQuery,
   onEdit,
@@ -751,6 +772,7 @@ function WorkflowsTab({
 }: {
   configs: WorkflowConfig[];
   isLoading: boolean;
+  error: string | null;
   selectedConfigId: string | null;
   searchQuery: string;
   onEdit: (config: WorkflowConfig) => void;
@@ -762,6 +784,16 @@ function WorkflowsTab({
     return (
       <div className="flex items-center justify-center py-10">
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error && configs.length === 0) {
+    return (
+      <div className="text-center py-10 px-4">
+        <XCircle className="h-8 w-8 text-destructive/70 mx-auto mb-3" />
+        <p className="text-sm text-foreground font-medium">Could not load workflows</p>
+        <p className="text-xs text-muted-foreground mt-1">{error}</p>
       </div>
     );
   }
@@ -796,7 +828,7 @@ function WorkflowsTab({
     <div className="py-1">
       {filtered.map((config) => {
         const isActive = config._id === selectedConfigId;
-        const stepCount = config.steps.length;
+        const stepCount = config.steps?.length ?? 0;
 
         return (
           <div
@@ -1022,7 +1054,8 @@ function RunsTab({
         const isActive = run._id === activeRunId;
         const configName =
           configNameMap[run.workflow_config_id] || run.workflow_config_id;
-        const completedSteps = run.steps.filter(
+        const runSteps = run.steps ?? [];
+        const completedSteps = runSteps.filter(
           (s) => s.status === "completed"
         ).length;
 
@@ -1044,7 +1077,7 @@ function RunsTab({
               </div>
               <div className="flex items-center justify-between text-[11px] text-muted-foreground pl-5">
                 <span>
-                  {completedSteps}/{run.steps.length} steps
+                  {completedSteps}/{runSteps.length} steps
                 </span>
                 {run.started_at && <span>{formatRelativeTime(run.started_at)}</span>}
               </div>

--- a/ui/src/components/workflows/WorkflowStepSidebar.tsx
+++ b/ui/src/components/workflows/WorkflowStepSidebar.tsx
@@ -50,6 +50,7 @@ interface WorkflowStepSidebarProps {
   agentsLoading: boolean;
 
   readOnly?: boolean;
+  readOnlyHint?: string;
 }
 
 
@@ -66,6 +67,7 @@ export function WorkflowStepSidebar({
   agents,
   agentsLoading,
   readOnly,
+  readOnlyHint,
 }: WorkflowStepSidebarProps) {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [configOverrideJson, setConfigOverrideJson] = useState(
@@ -168,11 +170,24 @@ export function WorkflowStepSidebar({
     // Steps exist but none selected
     return (
       <div className="w-[624px] border-l border-border bg-card/50 flex items-center justify-center">
-        <div className="text-center px-6">
-          <MousePointerClick className="h-8 w-8 text-muted-foreground/30 mx-auto mb-3" />
-          <p className="text-sm text-muted-foreground">
-            Select a step on the canvas to edit its properties
-          </p>
+        <div className="text-center px-6 max-w-sm">
+          {readOnly ? (
+            <>
+              <Lock className="h-8 w-8 text-amber-500/60 mx-auto mb-3" />
+              <p className="text-sm text-foreground font-medium mb-1">View only</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                {readOnlyHint ??
+                  "This workflow cannot be edited here. Use Clone to edit to create your own copy."}
+              </p>
+            </>
+          ) : (
+            <>
+              <MousePointerClick className="h-8 w-8 text-muted-foreground/30 mx-auto mb-3" />
+              <p className="text-sm text-muted-foreground">
+                Select a step on the canvas to edit its properties
+              </p>
+            </>
+          )}
         </div>
       </div>
     );
@@ -205,7 +220,8 @@ export function WorkflowStepSidebar({
         <div className="px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/20 flex items-center gap-2 shrink-0">
           <Lock className="h-3.5 w-3.5 text-amber-500 shrink-0" />
           <p className="text-xs text-amber-600 dark:text-amber-400">
-            This workflow is seeded from config and is not editable.
+            {readOnlyHint ??
+              "This workflow is seeded from config and is not editable."}
           </p>
         </div>
       )}

--- a/ui/src/components/workflows/WorkflowToolbar.tsx
+++ b/ui/src/components/workflows/WorkflowToolbar.tsx
@@ -2,14 +2,16 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { TeamMultiPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 import { cn } from "@/lib/utils";
 import type { WorkflowConfigVisibility } from "@/types/workflow-config";
-import { ArrowLeft,Download,Globe,Lock,Play,Save,Trash2,Upload,Users } from "lucide-react";
-import React,{ useEffect,useRef,useState } from "react";
+import { ArrowLeft,Copy,Download,Globe,Lock,Play,Save,Trash2,Upload,Users } from "lucide-react";
+import React,{ useEffect,useMemo,useRef,useState } from "react";
 import YAML from "yaml";
 
 interface Team {
   _id: string;
+  slug: string;
   name: string;
 }
 
@@ -26,8 +28,14 @@ interface WorkflowToolbarProps {
   onImport?: (config: unknown) => void;
   isSaving: boolean;
   isEditing: boolean;
+  hasUnsavedChanges?: boolean;
   stepCount: number;
   readOnly?: boolean;
+  /** When true, Save creates a new editable workflow instead of updating in place */
+  saveAsCopy?: boolean;
+  /** Shown when readOnly — explains why Save is disabled */
+  readOnlyHint?: string;
+  onCloneToEdit?: () => void;
   visibility: WorkflowConfigVisibility;
   onVisibilityChange: (v: WorkflowConfigVisibility) => void;
   sharedWithTeams: string[];
@@ -93,6 +101,18 @@ function VisibilityPopover({
 
   const config = VISIBILITY_CONFIG[visibility];
 
+  const teamOptions = useMemo<TeamPickerOption[]>(
+    () =>
+      teams
+        .filter((team): team is Team & { slug: string } => Boolean(team.slug))
+        .map((team) => ({
+          slug: team.slug,
+          name: team.name,
+          _id: team._id,
+        })),
+    [teams],
+  );
+
   return (
     <div className="relative" ref={ref}>
       <button
@@ -113,7 +133,7 @@ function VisibilityPopover({
 
       {open && (
         <div
-          className="absolute top-full left-0 mt-1 z-[100] w-64 rounded-lg border border-border bg-card shadow-lg p-2"
+          className="absolute top-full left-0 mt-1 z-[100] w-72 rounded-lg border border-border bg-card shadow-lg p-2"
           onPointerDown={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => e.stopPropagation()}
@@ -144,39 +164,25 @@ function VisibilityPopover({
             );
           })}
 
-          {/* Team selector */}
           {visibility === "team" && (
-            <div className="mt-2 pt-2 border-t border-border">
-              <div className="text-[10px] font-medium text-muted-foreground mb-1.5 px-1">
-                Share with teams
-              </div>
-              {teams.length === 0 ? (
+            <div className="mt-2 pt-2 border-t border-border px-0.5">
+              {teamOptions.length === 0 ? (
                 <p className="text-[10px] text-muted-foreground italic px-1">
                   No teams available.
                 </p>
               ) : (
-                <div className="space-y-1 max-h-32 overflow-y-auto">
-                  {teams.map((team) => (
-                    <label
-                      key={team._id}
-                      className="flex items-center gap-2 px-1 py-0.5 rounded hover:bg-muted/50 cursor-pointer"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={sharedWithTeams.includes(team._id)}
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            onSharedWithTeamsChange([...sharedWithTeams, team._id]);
-                          } else {
-                            onSharedWithTeamsChange(sharedWithTeams.filter((id) => id !== team._id));
-                          }
-                        }}
-                        className="rounded border-muted h-3 w-3"
-                      />
-                      <span className="text-xs">{team.name}</span>
-                    </label>
-                  ))}
-                </div>
+                <TeamMultiPicker
+                  options={teamOptions}
+                  selected={sharedWithTeams}
+                  onChange={onSharedWithTeamsChange}
+                  disabled={disabled}
+                  ariaLabel="Share workflow with teams"
+                  placeholder="Share with teams…"
+                  searchPlaceholder="Search teams…"
+                  emptyLabel="No teams match"
+                  triggerChipCap={1}
+                  contentClassName="z-[110]"
+                />
               )}
             </div>
           )}
@@ -199,8 +205,12 @@ export function WorkflowToolbar({
   onImport,
   isSaving,
   isEditing,
+  hasUnsavedChanges = false,
   stepCount,
   readOnly,
+  saveAsCopy,
+  readOnlyHint,
+  onCloneToEdit,
   visibility,
   onVisibilityChange,
   sharedWithTeams,
@@ -277,6 +287,15 @@ export function WorkflowToolbar({
           {stepCount} step{stepCount !== 1 ? "s" : ""}
         </span>
 
+        {hasUnsavedChanges && (
+          <span
+            className="text-xs font-medium shrink-0 px-2 py-0.5 rounded border border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+            title="Save your workflow before leaving the editor"
+          >
+            Unsaved
+          </span>
+        )}
+
         {/* Visibility button */}
         <VisibilityPopover
           visibility={visibility}
@@ -350,14 +369,27 @@ export function WorkflowToolbar({
             </Button>
           )}
 
+          {readOnly && onCloneToEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onCloneToEdit}
+              className="gap-1.5 h-8 text-xs px-3 border-primary/30 text-primary hover:bg-primary/10"
+            >
+              <Copy className="h-3.5 w-3.5" />
+              Clone to edit
+            </Button>
+          )}
+
           <Button
             size="sm"
             onClick={onSave}
-            disabled={isSaving || !name || stepCount === 0 || readOnly}
-            className="gap-1.5 h-8 text-xs px-4 gradient-primary text-white"
+            disabled={isSaving || !name || stepCount === 0 || (readOnly && !saveAsCopy)}
+            title={readOnly && !saveAsCopy ? readOnlyHint : undefined}
+            className="gap-1.5 h-8 text-xs px-4 gradient-primary text-white disabled:opacity-40"
           >
             <Save className="h-3.5 w-3.5" />
-            {isSaving ? "Saving..." : "Save"}
+            {isSaving ? "Saving..." : saveAsCopy ? "Save as copy" : "Save"}
           </Button>
         </div>
       </div>

--- a/ui/src/components/workflows/__tests__/agent-access-grants.test.ts
+++ b/ui/src/components/workflows/__tests__/agent-access-grants.test.ts
@@ -1,0 +1,58 @@
+import { grantAgentAccessGaps } from "../agent-access-grants";
+
+const ok = { ok: true, json: async () => ({ granted: true }) } as Response;
+
+describe("grantAgentAccessGaps", () => {
+  it("writes everyone grants for global workflow gaps and team grants for team gaps", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(ok);
+
+    await grantAgentAccessGaps(
+      [
+        { agentId: "hello-world", agentName: "Hello World", teamsWithoutAccess: ["(all users)"] },
+        { agentId: "platform-engineer", agentName: "Platform Engineer", teamsWithoutAccess: ["eng"] },
+      ],
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      "/api/authz/v1/grants",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          resource: { type: "agent", id: "hello-world" },
+          grantee: { type: "everyone" },
+          capability: "use",
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      "/api/authz/v1/grants",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          resource: { type: "agent", id: "platform-engineer" },
+          grantee: { type: "team", id: "eng" },
+          capability: "use",
+        }),
+      }),
+    );
+  });
+
+  it("throws on non-2xx grant responses so save can stay blocked", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "You must have manage permission" }),
+    } as Response);
+
+    await expect(
+      grantAgentAccessGaps(
+        [{ agentId: "hello-world", agentName: "Hello World", teamsWithoutAccess: ["(all users)"] }],
+        fetchImpl,
+      ),
+    ).rejects.toThrow("You must have manage permission");
+  });
+});

--- a/ui/src/components/workflows/agent-access-grants.ts
+++ b/ui/src/components/workflows/agent-access-grants.ts
@@ -1,0 +1,44 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-access/route";
+
+const GLOBAL_ACCESS_LABEL = "(all users)";
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function grantBodyForGapTarget(gap: AgentAccessGap, target: string) {
+  return {
+    resource: { type: "agent", id: gap.agentId },
+    grantee: target === GLOBAL_ACCESS_LABEL ? { type: "everyone" } : { type: "team", id: target },
+    capability: "use",
+  };
+}
+
+async function grantErrorMessage(response: Response, gap: AgentAccessGap, target: string): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: unknown; message?: unknown };
+    const detail = typeof body.error === "string" ? body.error : typeof body.message === "string" ? body.message : "";
+    if (detail) return detail;
+  } catch {
+    // Fall through to a stable generic message.
+  }
+  return `Failed to grant ${gap.agentName || gap.agentId} access to ${target} (${response.status})`;
+}
+
+export async function grantAgentAccessGaps(
+  gaps: AgentAccessGap[],
+  fetchImpl: FetchLike = fetch,
+): Promise<void> {
+  for (const gap of gaps) {
+    for (const target of gap.teamsWithoutAccess) {
+      const response = await fetchImpl("/api/authz/v1/grants", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(grantBodyForGapTarget(gap, target)),
+      });
+      if (!response.ok) {
+        throw new Error(await grantErrorMessage(response, gap, target));
+      }
+    }
+  }
+}

--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -1170,6 +1170,9 @@ describe('withAuth', () => {
     });
 
     it.each([
+      ['/api/workflow-configs', 'GET', 'can_use', 'dynamic_agent#view'],
+      ['/api/workflow-configs', 'POST', 'can_manage', 'dynamic_agent#manage'],
+      ['/api/workflow-runs', 'GET', 'can_use', 'dynamic_agent#view'],
       ['/api/unclassified-feature', 'GET', 'can_audit', 'admin_ui#view'],
       ['/api/unclassified-feature', 'POST', 'can_manage', 'admin_ui#manage'],
     ])('maps fallback route %s %s to explicit %s capability', async (

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -342,6 +342,11 @@ function resolveLegacyWithAuthRbacPolicy(request: NextRequest): RouteRbacPolicy 
       ? { resource: 'dynamic_agent', scope: 'view' }
       : { resource: 'dynamic_agent', scope: 'manage' };
   }
+  if (pathname.startsWith('/api/workflow-configs')) {
+    return method === 'GET'
+      ? { resource: 'dynamic_agent', scope: 'view' }
+      : { resource: 'dynamic_agent', scope: 'manage' };
+  }
   if (pathname.startsWith('/api/workflow-runs')) {
     return method === 'GET'
       ? { resource: 'dynamic_agent', scope: 'view' }

--- a/ui/src/lib/authz/domains/workflow.ts
+++ b/ui/src/lib/authz/domains/workflow.ts
@@ -1,0 +1,48 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// Workflow-scoped delegation: a workflow may grant agent-use to the user
+// who started it, for the duration of that run. This prevents DA from
+// needing to read workflow_configs or teams from MongoDB.
+//
+// Currently a stub — wired at POST /api/workflow-runs in a future PR.
+
+import type { AuthorizeRequest, AuthorizeResult } from "../contract";
+
+export interface WorkflowRunContext {
+  workflowRunId: string;
+  /** Agent ids the workflow delegates can_use to the run owner. */
+  delegatedAgentIds: Set<string>;
+  /** The subject who started the run. */
+  ownerSubjectId: string;
+}
+
+/** In-memory run registry. Populated by POST /api/workflow-runs. */
+const activeRuns = new Map<string, WorkflowRunContext>();
+
+export function registerWorkflowRun(ctx: WorkflowRunContext): void {
+  activeRuns.set(ctx.workflowRunId, ctx);
+}
+
+export function unregisterWorkflowRun(workflowRunId: string): void {
+  activeRuns.delete(workflowRunId);
+}
+
+/**
+ * Returns ALLOW if the request is for an agent the active workflow run
+ * has delegated to the caller. Returns null otherwise (fall through to PDP).
+ */
+export function workflowDelegationPreCheck(
+  req: AuthorizeRequest,
+): AuthorizeResult | null {
+  if (req.resource.type !== "agent" || req.action !== "use") return null;
+
+  const runId = req.trustedContext?.workflowRunId;
+  if (typeof runId !== "string") return null;
+
+  const run = activeRuns.get(runId);
+  if (!run) return null;
+  if (run.ownerSubjectId !== req.subject.id) return null;
+  if (!run.delegatedAgentIds.has(req.resource.id)) return null;
+
+  return { decision: "ALLOW", reason: "OK", retriable: false, via: "workflow_delegation" };
+}

--- a/ui/src/lib/authz/http.ts
+++ b/ui/src/lib/authz/http.ts
@@ -44,6 +44,7 @@ const ACTIONS: ReadonlySet<string> = new Set(RESOURCE_DEFINITIONS.flatMap((defin
 const PUBLIC_GRANTABLE_EVERYONE_RESOURCE_ACTIONS: ReadonlySet<string> = new Set([
   "admin_surface:discover",
   "agent:discover",
+  "agent:use",
   "audit_log:discover",
   "conversation:discover",
   "data_source:discover",

--- a/ui/src/lib/rbac/__tests__/workflow-config-rebac.test.ts
+++ b/ui/src/lib/rbac/__tests__/workflow-config-rebac.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @jest-environment node
+ */
+
+import { ApiError } from "@/lib/api-error";
+
+const mockRequireResourcePermission = jest.fn();
+const mockReconcileShareableResource = jest.fn();
+const mockListUserTeamSlugs = jest.fn();
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  subjectFromSession: () => "alice-sub",
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources", () => ({
+  reconcileShareableResource: (...args: unknown[]) => mockReconcileShareableResource(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga-team-membership", () => ({
+  listUserTeamSlugs: (...args: unknown[]) => mockListUserTeamSlugs(...args),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+import {
+  effectiveWorkflowVisibility,
+  filterWorkflowConfigsByRunAccess,
+  reconcileWorkflowConfigAccess,
+  requireWorkflowConfigRunAccess,
+  workflowRunAllowedByVisibility,
+  workflowWriteAllowedByVisibility,
+} from "@/lib/rbac/workflow-config-rebac";
+
+describe("workflow-config-rebac", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReconcileShareableResource.mockResolvedValue({ enabled: true, writes: 2, deletes: 0 });
+    mockListUserTeamSlugs.mockResolvedValue(["platform-eng"]);
+  });
+
+  it("reconciles workflow configs as task resources with creator owner", async () => {
+    await reconcileWorkflowConfigAccess(
+      { sub: "alice-sub" },
+      { _id: "wf-1", visibility: "global", shared_with_teams: null },
+    );
+
+    expect(mockReconcileShareableResource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectType: "task",
+        objectId: "wf-1",
+        creatorSubject: "alice-sub",
+        ownerSubject: "alice-sub",
+        sharedWithOrg: true,
+      }),
+    );
+  });
+
+  describe("effectiveWorkflowVisibility", () => {
+    it("defaults system-owned and config-driven workflows to global when visibility is missing", () => {
+      expect(
+        effectiveWorkflowVisibility({
+          visibility: undefined,
+          owner_id: "system",
+          config_driven: true,
+        }),
+      ).toBe("global");
+    });
+
+    it("treats missing visibility on user-owned workflows as private", () => {
+      expect(
+        effectiveWorkflowVisibility({
+          visibility: null,
+          owner_id: "alice@example.com",
+        }),
+      ).toBe("private");
+    });
+  });
+
+  describe("workflowRunAllowedByVisibility", () => {
+    it("allows any user for global workflows", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: "global", shared_with_teams: null, owner_id: "owner@example.com" },
+          "bob@example.com",
+          [],
+        ),
+      ).toBe(true);
+    });
+
+    it("allows any user for system-seeded workflows without a visibility field", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: undefined, shared_with_teams: null, owner_id: "system", config_driven: true },
+          "bob@example.com",
+          [],
+        ),
+      ).toBe(true);
+    });
+
+    it("allows team members when workflow is shared with their team", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          {
+            visibility: "team",
+            shared_with_teams: ["Platform-Eng"],
+            owner_id: "owner@example.com",
+          },
+          "bob@example.com",
+          ["platform-eng"],
+        ),
+      ).toBe(true);
+    });
+
+    it("denies team workflows when user is not on a shared team", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          {
+            visibility: "team",
+            shared_with_teams: ["other-team"],
+            owner_id: "owner@example.com",
+          },
+          "bob@example.com",
+          ["platform-eng"],
+        ),
+      ).toBe(false);
+    });
+
+    it("resolves legacy Mongo team _id refs via teamRefToSlug map", () => {
+      const teamRefToSlug = new Map<string, string>([
+        ["507f1f77bcf86cd799439011", "platform-eng"],
+        ["platform-eng", "platform-eng"],
+      ]);
+      expect(
+        workflowRunAllowedByVisibility(
+          {
+            visibility: "team",
+            shared_with_teams: ["507f1f77bcf86cd799439011"],
+            owner_id: "owner@example.com",
+          },
+          "bob@example.com",
+          ["platform-eng"],
+          teamRefToSlug,
+        ),
+      ).toBe(true);
+    });
+
+    it("allows only the owner for private workflows", () => {
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: "private", shared_with_teams: null, owner_id: "alice@example.com" },
+          "alice@example.com",
+          [],
+        ),
+      ).toBe(true);
+      expect(
+        workflowRunAllowedByVisibility(
+          { visibility: "private", shared_with_teams: null, owner_id: "alice@example.com" },
+          "bob@example.com",
+          [],
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it("skips OpenFGA when global visibility allows run", async () => {
+    await expect(
+      requireWorkflowConfigRunAccess(
+        { sub: "alice-sub" },
+        {
+          _id: "wf-global",
+          owner_id: "owner@example.com",
+          visibility: "global",
+          shared_with_teams: null,
+        },
+        "bob@example.com",
+        [],
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("allows the documented owner when OpenFGA use is denied", async () => {
+    mockRequireResourcePermission.mockRejectedValue(new ApiError("denied", 403));
+
+    await expect(
+      requireWorkflowConfigRunAccess(
+        { sub: "alice-sub" },
+        {
+          _id: "wf-legacy",
+          owner_id: "alice@example.com",
+          visibility: "private",
+          shared_with_teams: null,
+        },
+        "alice@example.com",
+        [],
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("allows write only for the workflow owner (not system-owned)", () => {
+    expect(
+      workflowWriteAllowedByVisibility(
+        { visibility: "global", shared_with_teams: null, owner_id: "alice@example.com" },
+        "alice@example.com",
+      ),
+    ).toBe(true);
+    expect(
+      workflowWriteAllowedByVisibility(
+        { visibility: "global", shared_with_teams: null, owner_id: "system" },
+        "alice@example.com",
+      ),
+    ).toBe(false);
+    expect(
+      workflowWriteAllowedByVisibility(
+        { visibility: "global", shared_with_teams: null, owner_id: "other@example.com" },
+        "alice@example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("filters configs by visibility for list endpoints", () => {
+    const configs = [
+      {
+        _id: "wf-global",
+        visibility: "global" as const,
+        shared_with_teams: null,
+        owner_id: "a@example.com",
+      },
+      {
+        _id: "wf-team",
+        visibility: "team" as const,
+        shared_with_teams: ["platform-eng"],
+        owner_id: "a@example.com",
+      },
+      {
+        _id: "wf-private",
+        visibility: "private" as const,
+        shared_with_teams: null,
+        owner_id: "a@example.com",
+      },
+    ];
+
+    const visible = filterWorkflowConfigsByRunAccess(configs, "bob@example.com", ["platform-eng"]);
+    expect(visible.map((c) => c._id)).toEqual(["wf-global", "wf-team"]);
+  });
+});

--- a/ui/src/lib/rbac/workflow-config-rebac.ts
+++ b/ui/src/lib/rbac/workflow-config-rebac.ts
@@ -1,0 +1,410 @@
+/**
+ * OpenFGA projection for workflow_configs (stored as `task:<wf-id>`).
+ *
+ * Workflow configs historically only lived in MongoDB; runs enforced
+ * `task#read` in OpenFGA without ever writing tuples on create. This module
+ * reconciles visibility on write and applies Mongo visibility rules for run
+ * access (global = any signed-in user; team = shared team members; private = owner).
+ */
+
+import { getCollection } from "@/lib/mongodb";
+import { ApiError } from "@/lib/api-error";
+import type { OpenFgaReconcileResult } from "./openfga";
+import { reconcileShareableResource } from "./openfga-owned-resources";
+import { listUserTeamSlugs } from "./openfga-team-membership";
+import {
+  requireResourcePermission,
+  subjectFromSession,
+  type ResourceAuthzSession,
+} from "./resource-authz";
+import type { WorkflowConfigVisibility } from "@/types/workflow-config";
+
+export interface WorkflowConfigRebacSnapshot {
+  _id: string;
+  visibility?: WorkflowConfigVisibility | null;
+  shared_with_teams?: string[] | null;
+  owner_id: string;
+  config_driven?: boolean;
+}
+
+/**
+ * Resolve Mongo visibility for run/discover policy checks. Legacy rows may omit
+ * `visibility`; platform-seeded workflows (`owner_id: system`) default to global.
+ */
+export function effectiveWorkflowVisibility(
+  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "owner_id" | "config_driven">,
+): WorkflowConfigVisibility {
+  const raw =
+    typeof config.visibility === "string" ? config.visibility.trim().toLowerCase() : "";
+  if (raw === "global" || raw === "team" || raw === "private") {
+    return raw;
+  }
+  if (config.owner_id?.trim().toLowerCase() === "system" || config.config_driven) {
+    return "global";
+  }
+  return "private";
+}
+
+export function normalizeTeamSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+function normalizeTeamSlugs(slugs: string[] | null | undefined): string[] {
+  if (!slugs?.length) return [];
+  return [...new Set(slugs.map(normalizeTeamSlug).filter(Boolean))];
+}
+
+/** Maps team slug and Mongo `_id` string to canonical slug (lowercase). */
+export type TeamRefToSlugMap = Map<string, string>;
+
+export async function buildTeamRefToSlugMap(): Promise<TeamRefToSlugMap> {
+  const teams = await getCollection<{ _id: unknown; slug?: string }>("teams");
+  const rows = await teams.find({}).project({ slug: 1 }).toArray();
+  const map: TeamRefToSlugMap = new Map();
+  for (const row of rows) {
+    const slug = row.slug?.trim().toLowerCase();
+    if (!slug) continue;
+    map.set(slug, slug);
+    map.set(String(row._id), slug);
+  }
+  return map;
+}
+
+/** Resolve stored team refs (slug or legacy Mongo id) to slugs for FGA and visibility checks. */
+export function resolveSharedTeamSlugs(
+  refs: string[] | null | undefined,
+  teamRefToSlug?: TeamRefToSlugMap,
+): string[] {
+  if (!refs?.length) return [];
+  const resolved = refs.map((ref) => {
+    const trimmed = ref.trim();
+    if (!trimmed) return "";
+    const fromMap = teamRefToSlug?.get(trimmed) ?? teamRefToSlug?.get(normalizeTeamSlug(trimmed));
+    if (fromMap) return fromMap;
+    return normalizeTeamSlug(trimmed);
+  });
+  return normalizeTeamSlugs(resolved);
+}
+
+export async function normalizeSharedWithTeamSlugs(
+  refs: string[] | undefined,
+): Promise<string[] | undefined> {
+  if (!refs?.length) return undefined;
+  const map = await buildTeamRefToSlugMap();
+  const slugs = resolveSharedTeamSlugs(refs, map);
+  return slugs.length > 0 ? slugs : undefined;
+}
+
+/**
+ * Product policy: who may run (and discover) a workflow from Mongo visibility alone.
+ */
+export function agentListedInWorkflowSteps(
+  config: Pick<WorkflowConfigRebacSnapshot, "_id"> & {
+    steps?: Array<{ type?: string; agent_id?: string }>;
+  },
+  agentId: string,
+): boolean {
+  for (const step of config.steps ?? []) {
+    if (step?.type === "step" && step.agent_id === agentId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Agent use delegated from an in-flight workflow run the user may execute. */
+export function workflowDelegatesAgentUse(
+  config: WorkflowConfigRebacSnapshot & {
+    steps?: Array<{ type?: string; agent_id?: string }>;
+  },
+  agentId: string,
+  userEmail: string,
+  userTeamSlugs: string[],
+): boolean {
+  if (!agentListedInWorkflowSteps(config, agentId)) {
+    return false;
+  }
+  return workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs);
+}
+
+export function workflowRunAllowedByVisibility(
+  config: Pick<
+    WorkflowConfigRebacSnapshot,
+    "visibility" | "shared_with_teams" | "owner_id" | "config_driven"
+  >,
+  userEmail: string,
+  userTeamSlugs: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): boolean {
+  const visibility = effectiveWorkflowVisibility(config);
+
+  if (visibility === "global") {
+    return true;
+  }
+
+  if (visibility === "team") {
+    const shared = resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug);
+    if (shared.length === 0) {
+      return false;
+    }
+    const memberSlugs = new Set(normalizeTeamSlugs(userTeamSlugs));
+    return shared.some((slug) => memberSlugs.has(slug));
+  }
+
+  const owner = config.owner_id?.trim().toLowerCase();
+  return Boolean(owner && owner === userEmail.trim().toLowerCase());
+}
+
+export async function resolveUserTeamSlugsForWorkflow(
+  userEmail: string,
+  session: ResourceAuthzSession,
+): Promise<string[]> {
+  const subject = subjectFromSession(session);
+  if (subject) {
+    try {
+      const slugs = await listUserTeamSlugs({ subject });
+      if (slugs.length > 0) {
+        return slugs;
+      }
+    } catch {
+      // Fall through to Mongo membership lookup.
+    }
+  }
+
+  try {
+    const teams = await getCollection<{ slug?: string }>("teams");
+    const rows = await teams
+      .find({ "members.user_id": userEmail })
+      .project({ slug: 1 })
+      .toArray();
+    return rows.map((team) => team.slug?.trim()).filter((slug): slug is string => Boolean(slug));
+  } catch {
+    return [];
+  }
+}
+
+export function filterWorkflowConfigsByRunAccess<T extends WorkflowConfigRebacSnapshot>(
+  configs: T[],
+  userEmail: string,
+  userTeamSlugs: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): T[] {
+  return configs.filter((config) =>
+    workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs, teamRefToSlug),
+  );
+}
+
+export function mergeWorkflowConfigsById<T extends { _id: string }>(
+  ...groups: T[][]
+): T[] {
+  const byId = new Map<string, T>();
+  for (const group of groups) {
+    for (const config of group) {
+      byId.set(String(config._id), config);
+    }
+  }
+  return [...byId.values()];
+}
+
+export async function reconcileWorkflowConfigAccess(
+  session: ResourceAuthzSession,
+  config: Pick<WorkflowConfigRebacSnapshot, "_id" | "visibility" | "shared_with_teams">,
+  previous?: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams"> | null,
+): Promise<OpenFgaReconcileResult> {
+  const creatorSubject = subjectFromSession(session);
+  if (!creatorSubject) {
+    return { enabled: false, writes: 0, deletes: 0 };
+  }
+
+  const teamRefToSlug =
+    config.visibility === "team" || previous?.visibility === "team"
+      ? await buildTeamRefToSlugMap()
+      : undefined;
+
+  return reconcileShareableResource({
+    objectType: "task",
+    objectId: config._id,
+    creatorSubject,
+    ownerSubject: creatorSubject,
+    memberRelations: ["reader", "user"],
+    sharedWithOrg: config.visibility === "global",
+    previousSharedWithOrg: previous?.visibility === "global",
+    nextSharedTeamSlugs:
+      config.visibility === "team"
+        ? resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug)
+        : [],
+    previousSharedTeamSlugs:
+      previous?.visibility === "team"
+        ? resolveSharedTeamSlugs(previous.shared_with_teams, teamRefToSlug)
+        : [],
+  });
+}
+
+/** Who may edit/delete a workflow (stricter than run). */
+export function workflowWriteAllowedByVisibility(
+  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams" | "owner_id">,
+  userEmail: string,
+): boolean {
+  const owner = config.owner_id?.trim().toLowerCase();
+  const email = userEmail.trim().toLowerCase();
+  if (!owner || !email) {
+    return false;
+  }
+  // Seeded / platform workflows use a non-user owner id.
+  if (owner === "system") {
+    return false;
+  }
+  return owner === email;
+}
+
+/** Authorize updating or deleting a workflow config. */
+export async function requireWorkflowConfigWriteAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+): Promise<void> {
+  if (workflowWriteAllowedByVisibility(config, userEmail)) {
+    return;
+  }
+
+  try {
+    await requireResourcePermission(
+      session,
+      { type: "task", id: config._id, action: "write" },
+      { bypassForOrgAdmin: true },
+    );
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.statusCode === 403 &&
+      config.owner_id &&
+      config.owner_id.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Whether the caller may list or view workflow runs for a config (visibility +
+ * OpenFGA `task#read` or `task#use`). Matches the list-runs filter in
+ * `/api/workflow-runs`.
+ */
+export async function canViewWorkflowRunsForConfig(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+  teamRefToSlug?: TeamRefToSlugMap,
+): Promise<boolean> {
+  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  const map =
+    teamRefToSlug ??
+    (effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined);
+
+  if (workflowRunAllowedByVisibility(config, userEmail, slugs, map)) {
+    return true;
+  }
+
+  for (const action of ["read", "use"] as const) {
+    try {
+      await requireResourcePermission(
+        session,
+        { type: "task", id: config._id, action },
+        { bypassForOrgAdmin: true },
+      );
+      return true;
+    } catch {
+      // try next action
+    }
+  }
+  return false;
+}
+
+/** Authorize viewing or polling workflow runs for a config. */
+export async function requireWorkflowConfigRunViewAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<void> {
+  if (await canViewWorkflowRunsForConfig(session, config, userEmail, userTeamSlugs)) {
+    return;
+  }
+  throw new ApiError(
+    "You do not have permission to view workflow runs for this workflow.",
+    403,
+    "task#read",
+    "pdp_denied",
+    "contact_admin",
+  );
+}
+
+/** Authorize starting or viewing a workflow config (run / discover / read). */
+export async function requireWorkflowConfigRunAccess(
+  session: ResourceAuthzSession,
+  config: WorkflowConfigRebacSnapshot,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<void> {
+  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  const teamRefToSlug =
+    effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined;
+
+  if (workflowRunAllowedByVisibility(config, userEmail, slugs, teamRefToSlug)) {
+    return;
+  }
+
+  try {
+    await requireResourcePermission(
+      session,
+      { type: "task", id: config._id, action: "use" },
+      { bypassForOrgAdmin: true },
+    );
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.statusCode === 403 &&
+      config.owner_id &&
+      config.owner_id.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * One-time style repair: rewrite `shared_with_teams` from legacy Mongo ids to slugs.
+ * Safe to run on UI startup after seed.
+ */
+export async function repairWorkflowConfigTeamSlugRefs(): Promise<number> {
+  const collection = await getCollection<WorkflowConfigRebacSnapshot>("workflow_configs");
+  const map = await buildTeamRefToSlugMap();
+  const teamConfigs = await collection.find({ visibility: "team" }).toArray();
+  let repaired = 0;
+
+  for (const config of teamConfigs) {
+    const resolved = resolveSharedTeamSlugs(config.shared_with_teams, map);
+    if (resolved.length === 0) continue;
+
+    const before = normalizeTeamSlugs(config.shared_with_teams);
+    const changed =
+      before.length !== resolved.length ||
+      before.some((slug, index) => slug !== resolved[index]);
+
+    if (!changed) continue;
+
+    await collection.updateOne(
+      { _id: config._id as unknown },
+      { $set: { shared_with_teams: resolved, updated_at: new Date() } },
+    );
+    repaired += 1;
+  }
+
+  return repaired;
+}
+
+/** @deprecated Use requireWorkflowConfigRunAccess */
+export const requireWorkflowConfigRead = requireWorkflowConfigRunAccess;

--- a/ui/src/lib/rbac/workflow-run-access.ts
+++ b/ui/src/lib/rbac/workflow-run-access.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared workflow run access helpers (list, poll, resume, cancel).
+ */
+
+import { getCollection } from "@/lib/mongodb";
+import { ApiError } from "@/lib/api-error";
+import type { ResourceAuthzSession } from "./resource-authz";
+import {
+  canViewWorkflowRunsForConfig,
+  requireWorkflowConfigRunAccess,
+  requireWorkflowConfigRunViewAccess,
+  type WorkflowConfigRebacSnapshot,
+} from "./workflow-config-rebac";
+import type { WorkflowConfig } from "@/types/workflow-config";
+
+export function workflowConfigAccessSnapshot(
+  config: Pick<
+    WorkflowConfig,
+    "_id" | "owner_id" | "visibility" | "shared_with_teams" | "config_driven"
+  >,
+): WorkflowConfigRebacSnapshot {
+  return {
+    _id: String(config._id),
+    owner_id: config.owner_id,
+    visibility: config.visibility,
+    shared_with_teams: config.shared_with_teams,
+    config_driven: config.config_driven,
+  };
+}
+
+export async function loadWorkflowConfigForRunAccess(
+  configId: string,
+): Promise<WorkflowConfig | null> {
+  const configCol = await getCollection<WorkflowConfig>("workflow_configs");
+  return configCol.findOne({ _id: configId as WorkflowConfig["_id"] });
+}
+
+export async function assertCanViewWorkflowRunsForConfigId(
+  session: ResourceAuthzSession,
+  configId: string,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<WorkflowConfig> {
+  const config = await loadWorkflowConfigForRunAccess(configId);
+  if (!config) {
+    throw new ApiError(`Workflow config ${configId} not found`, 404);
+  }
+  await requireWorkflowConfigRunViewAccess(
+    session,
+    workflowConfigAccessSnapshot(config),
+    userEmail,
+    userTeamSlugs,
+  );
+  return config;
+}
+
+export async function assertCanExecuteWorkflowRunsForConfigId(
+  session: ResourceAuthzSession,
+  configId: string,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<WorkflowConfig> {
+  const config = await loadWorkflowConfigForRunAccess(configId);
+  if (!config) {
+    throw new ApiError(`Workflow config ${configId} not found`, 404);
+  }
+  await requireWorkflowConfigRunAccess(
+    session,
+    workflowConfigAccessSnapshot(config),
+    userEmail,
+    userTeamSlugs,
+  );
+  return config;
+}
+
+export async function canViewWorkflowRunsForConfigId(
+  session: ResourceAuthzSession,
+  configId: string,
+  userEmail: string,
+  userTeamSlugs?: string[],
+): Promise<boolean> {
+  const config = await loadWorkflowConfigForRunAccess(configId);
+  if (!config) {
+    return false;
+  }
+  return canViewWorkflowRunsForConfig(
+    session,
+    workflowConfigAccessSnapshot(config),
+    userEmail,
+    userTeamSlugs,
+  );
+}

--- a/ui/src/lib/server/__tests__/workflow-cas-authz.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-cas-authz.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @jest-environment node
+ */
+
+const mockAuthorize = jest.fn();
+const mockAuthorizeMany = jest.fn();
+const mockEmitDecisionAudit = jest.fn();
+
+jest.mock("@/lib/authz", () => ({
+  authorize: (...a: unknown[]) => mockAuthorize(...a),
+  authorizeMany: (...a: unknown[]) => mockAuthorizeMany(...a),
+}));
+
+jest.mock("@/lib/authz/audit", () => ({
+  emitDecisionAudit: (...a: unknown[]) => mockEmitDecisionAudit(...a),
+}));
+
+import {
+  filterAccessibleWorkflowConfigs,
+  requireWorkflowAccess,
+  requireWorkflowRunAccess,
+  workflowSubjectFromSession,
+  workflowAccessAllowed,
+} from "../workflow-cas-authz";
+
+const ALLOW = { decision: "ALLOW", reason: "OK", retriable: false };
+const DENY = { decision: "DENY", reason: "NO_CAPABILITY", retriable: false };
+const session = { sub: "alice", org: "acme" };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("workflowAccessAllowed", () => {
+  it("returns false (no PDP call) when there is no subject", async () => {
+    expect(await workflowAccessAllowed({}, "wf-1", "read")).toBe(false);
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  it("allows org admins without a per-workflow check", async () => {
+    mockAuthorize.mockResolvedValueOnce(ALLOW); // org-admin check
+    expect(await workflowAccessAllowed(session, "wf-1", "read")).toBe(true);
+    expect(mockAuthorize).toHaveBeenCalledTimes(1);
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.objectContaining({ resource: { type: "organization", id: "caipe" }, action: "manage" }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the per-workflow task check for non-admins", async () => {
+    mockAuthorize
+      .mockResolvedValueOnce(DENY) // not org admin
+      .mockResolvedValueOnce(ALLOW); // task#read allowed
+    expect(await workflowAccessAllowed(session, "wf-1", "read")).toBe(true);
+    expect(mockAuthorize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ resource: { type: "task", id: "wf-1" }, action: "read" }),
+      expect.anything(),
+    );
+  });
+
+  it("returns false when both org-admin and task checks deny", async () => {
+    mockAuthorize.mockResolvedValue(DENY);
+    expect(await workflowAccessAllowed(session, "wf-1", "delete")).toBe(false);
+  });
+
+  it("graphs a service-account caller and tolerates a missing org", async () => {
+    mockAuthorize.mockResolvedValueOnce(DENY).mockResolvedValueOnce(ALLOW);
+    expect(await workflowAccessAllowed({ sub: "bot", isServiceAccount: true }, "wf-1", "read")).toBe(true);
+    expect(mockAuthorize).toHaveBeenCalledWith(
+      expect.objectContaining({ subject: { type: "service_account", id: "bot" } }),
+      expect.anything(),
+    );
+  });
+});
+
+describe("requireWorkflowAccess", () => {
+  it("throws 401 (NO_SUBJECT) when subject is missing", async () => {
+    await expect(requireWorkflowAccess({}, "wf-1", "read")).rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it("throws 403 with a clean code (no task#read leak) on deny", async () => {
+    mockAuthorize.mockResolvedValue(DENY);
+    await expect(requireWorkflowAccess(session, "wf-1", "read")).rejects.toMatchObject({
+      statusCode: 403,
+      code: "WORKFLOW_FORBIDDEN",
+      reason: "forbidden",
+    });
+  });
+
+  it("resolves when access is allowed", async () => {
+    mockAuthorize.mockResolvedValueOnce(DENY).mockResolvedValueOnce(ALLOW);
+    await expect(requireWorkflowAccess(session, "wf-1", "read")).resolves.toBeUndefined();
+  });
+
+  it("throws 503 instead of 403 when CAS is unavailable", async () => {
+    mockAuthorize.mockResolvedValue({ decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true });
+    await expect(requireWorkflowAccess(session, "wf-1", "read")).rejects.toMatchObject({
+      statusCode: 503,
+      code: "AUTHZ_UNAVAILABLE",
+    });
+  });
+});
+
+describe("filterAccessibleWorkflowConfigs", () => {
+  const configs = [{ _id: "wf-a" }, { _id: "wf-b" }, { _id: "wf-c" }];
+  const getId = (c: { _id: string }) => c._id;
+
+  it("returns everything for org admins (one batched call avoided)", async () => {
+    mockAuthorize.mockResolvedValueOnce(ALLOW); // org admin
+    const out = await filterAccessibleWorkflowConfigs(session, configs, getId, "read");
+    expect(out).toEqual(configs);
+    expect(mockAuthorizeMany).not.toHaveBeenCalled();
+  });
+
+  it("filters non-admins to the accessible subset via one batch call", async () => {
+    mockAuthorize.mockResolvedValueOnce(DENY); // not admin
+    mockAuthorizeMany.mockResolvedValue(
+      new Map([
+        ["wf-a", ALLOW],
+        ["wf-b", DENY],
+        ["wf-c", ALLOW],
+      ]),
+    );
+    const out = await filterAccessibleWorkflowConfigs(session, configs, getId, "read");
+    expect(out).toEqual([{ _id: "wf-a" }, { _id: "wf-c" }]);
+    expect(mockAuthorizeMany).toHaveBeenCalledWith(
+      { type: "user", id: "alice" },
+      "read",
+      "task",
+      ["wf-a", "wf-b", "wf-c"],
+      expect.anything(),
+    );
+  });
+
+  it("throws 503 when any batch decision is unavailable", async () => {
+    mockAuthorize.mockResolvedValueOnce(DENY); // not admin
+    mockAuthorizeMany.mockResolvedValue(
+      new Map([
+        ["wf-a", ALLOW],
+        ["wf-b", { decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true }],
+      ]),
+    );
+    await expect(filterAccessibleWorkflowConfigs(session, configs, getId, "read")).rejects.toMatchObject({
+      statusCode: 503,
+      code: "AUTHZ_UNAVAILABLE",
+    });
+  });
+
+  it("returns [] when there is no subject", async () => {
+    expect(await filterAccessibleWorkflowConfigs({}, configs, getId)).toEqual([]);
+  });
+
+  it("returns [] for an empty config list without consulting the PDP", async () => {
+    expect(await filterAccessibleWorkflowConfigs(session, [], getId)).toEqual([]);
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireWorkflowRunAccess", () => {
+  const ownedRun = {
+    _id: "run-1",
+    workflow_config_id: "wf-1",
+    owner_subject: { type: "user" as const, id: "alice" },
+  };
+  const otherRun = {
+    _id: "run-2",
+    workflow_config_id: "wf-2",
+    owner_subject: { type: "user" as const, id: "bob" },
+  };
+
+  it("allows the persisted run owner without a config-level check", async () => {
+    await expect(requireWorkflowRunAccess(session, ownedRun, "resume")).resolves.toBeUndefined();
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  it("audits owner-scoped workflow run reads that bypass config-level CAS", async () => {
+    await expect(requireWorkflowRunAccess(session, ownedRun, "read")).resolves.toBeUndefined();
+
+    expect(mockAuthorize).not.toHaveBeenCalled();
+    expect(mockEmitDecisionAudit).toHaveBeenCalledWith(
+      { type: "user", id: "alice" },
+      { type: "task", id: "wf-1" },
+      "read",
+      { decision: "ALLOW", reason: "OK", retriable: false, via: "workflow_run_owner" },
+      { tenantId: "acme" },
+      { workflowRunId: "run-1" },
+    );
+  });
+
+  it("denies non-owner access to owner-scoped runs without falling back to workflow access", async () => {
+    mockAuthorize.mockResolvedValueOnce(DENY).mockResolvedValueOnce(ALLOW);
+    await expect(requireWorkflowRunAccess(session, otherRun, "read")).rejects.toMatchObject({
+      statusCode: 403,
+      code: "WORKFLOW_RUN_FORBIDDEN",
+    });
+    expect(mockAuthorize).not.toHaveBeenCalled();
+  });
+
+  it("audits non-owner denials for owner-scoped workflow runs", async () => {
+    await expect(requireWorkflowRunAccess(session, otherRun, "read")).rejects.toMatchObject({
+      statusCode: 403,
+      code: "WORKFLOW_RUN_FORBIDDEN",
+    });
+
+    expect(mockEmitDecisionAudit).toHaveBeenCalledWith(
+      { type: "user", id: "alice" },
+      { type: "task", id: "wf-2" },
+      "read",
+      {
+        decision: "DENY",
+        reason: "NO_CAPABILITY",
+        retriable: false,
+        via: "workflow_run_owner_mismatch",
+      },
+      { tenantId: "acme" },
+      { workflowRunId: "run-2" },
+    );
+  });
+
+  it("maps legacy run reads to workflow read when no owner subject was stored", async () => {
+    const legacyRun = { _id: "run-legacy", workflow_config_id: "wf-2" };
+    mockAuthorize.mockResolvedValueOnce(DENY).mockResolvedValueOnce(ALLOW);
+    await expect(requireWorkflowRunAccess(session, legacyRun, "read")).resolves.toBeUndefined();
+    expect(mockAuthorize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ resource: { type: "task", id: "wf-2" }, action: "read" }),
+      expect.anything(),
+    );
+  });
+
+  it("maps legacy resume/cancel/update checks to workflow write", async () => {
+    const legacyRun = { _id: "run-legacy", workflow_config_id: "wf-2" };
+    mockAuthorize.mockResolvedValueOnce(DENY).mockResolvedValueOnce(ALLOW);
+    await expect(requireWorkflowRunAccess(session, legacyRun, "cancel")).resolves.toBeUndefined();
+    expect(mockAuthorize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ resource: { type: "task", id: "wf-2" }, action: "write" }),
+      expect.anything(),
+    );
+  });
+
+  it("maps legacy run deletion to workflow delete", async () => {
+    const legacyRun = { _id: "run-legacy", workflow_config_id: "wf-2" };
+    mockAuthorize.mockResolvedValueOnce(DENY).mockResolvedValueOnce(ALLOW);
+    await expect(requireWorkflowRunAccess(session, legacyRun, "delete")).resolves.toBeUndefined();
+    expect(mockAuthorize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ resource: { type: "task", id: "wf-2" }, action: "delete" }),
+      expect.anything(),
+    );
+  });
+});
+
+describe("workflowSubjectFromSession", () => {
+  it("extracts the stable owner subject persisted on workflow runs", () => {
+    expect(workflowSubjectFromSession({ sub: "alice", isServiceAccount: false })).toEqual({
+      type: "user",
+      id: "alice",
+    });
+    expect(workflowSubjectFromSession({ sub: "bot", isServiceAccount: true })).toEqual({
+      type: "service_account",
+      id: "bot",
+    });
+  });
+});

--- a/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for runOwnerSubject — the Phase 3 helper that extracts the workflow
+ * run owner's `sub` from the forwarded Bearer token so executeSteps can run the
+ * per-step CAS agent-use gate. Pure function; the heavy workflow-engine imports
+ * are mocked to no-ops so the module loads in isolation.
+ */
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn() }));
+jest.mock("@/lib/streaming/clients/server-agui-consumer", () => ({ consumeAgentStream: jest.fn() }));
+jest.mock("@/lib/server/event-store", () => ({ readEvents: jest.fn() }));
+jest.mock("@/lib/authz", () => ({ authorize: jest.fn() }));
+
+import { runOwnerSubject } from "../workflow-engine";
+
+/** Build a JWT (`header.payload.signature`) with a base64url-encoded payload. */
+function jwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${b64url({ alg: "none" })}.${b64url(payload)}.sig`;
+}
+
+describe("runOwnerSubject", () => {
+  it("returns the sub from a valid Bearer JWT", () => {
+    expect(runOwnerSubject({ Authorization: `Bearer ${jwt({ sub: "alice-sub" })}` })).toBe("alice-sub");
+  });
+
+  it("reads a lowercase `authorization` header too", () => {
+    expect(runOwnerSubject({ authorization: `Bearer ${jwt({ sub: "bob-sub" })}` })).toBe("bob-sub");
+  });
+
+  it("trims surrounding whitespace on the sub", () => {
+    expect(runOwnerSubject({ Authorization: `Bearer ${jwt({ sub: "  carol-sub  " })}` })).toBe("carol-sub");
+  });
+
+  it("returns null when there is no Authorization header (system run)", () => {
+    expect(runOwnerSubject({})).toBeNull();
+  });
+
+  it("returns null for a non-Bearer scheme", () => {
+    expect(runOwnerSubject({ Authorization: "Basic dXNlcjpwYXNz" })).toBeNull();
+  });
+
+  it("returns null when the token has fewer than two segments", () => {
+    expect(runOwnerSubject({ Authorization: "Bearer not-a-jwt" })).toBeNull();
+  });
+
+  it("returns null when the payload is not valid base64/JSON", () => {
+    expect(runOwnerSubject({ Authorization: "Bearer aaa.@@@notbase64@@@.sig" })).toBeNull();
+  });
+
+  it("returns null when the JWT carries no sub", () => {
+    expect(runOwnerSubject({ Authorization: `Bearer ${jwt({ email: "x@y.com" })}` })).toBeNull();
+  });
+
+  it("returns null when the sub is whitespace-only", () => {
+    expect(runOwnerSubject({ Authorization: `Bearer ${jwt({ sub: "   " })}` })).toBeNull();
+  });
+
+  it("returns null when the sub is non-string", () => {
+    expect(runOwnerSubject({ Authorization: `Bearer ${jwt({ sub: 12345 })}` })).toBeNull();
+  });
+});

--- a/ui/src/lib/server/workflow-cas-authz.ts
+++ b/ui/src/lib/server/workflow-cas-authz.ts
@@ -1,0 +1,228 @@
+// assisted-by Codex Codex-sonnet-4-6
+//
+// Workflow PEP (Policy Enforcement Point) backed by the Centralized
+// Authorization Service. This is the FIRST surface migrated onto CAS — it
+// replaces the workflow-runs route's direct `requireResourcePermission` /
+// `filterResourcesByPermission` calls (which leaked `task#read` / `pdp_denied`
+// in error bodies) with CAS `authorize` / `authorizeMany`.
+//
+// Behavior preserved from the legacy path:
+//   - org-admin bypass (mirrors `{ bypassForOrgAdmin: true }`)
+//   - service_account vs user subject namespacing
+//   - 401 on missing subject, 403 on deny
+// What improves: clean reason codes (no OpenFGA vocabulary in responses) and
+// one shared decision core + cache + audit.
+
+import { ApiError } from "@/lib/api-error";
+import { authorize, authorizeMany, type AuthorizeResult, type DecisionContext, type Subject } from "@/lib/authz";
+import { emitDecisionAudit } from "@/lib/authz/audit";
+
+const ORG_KEY = process.env.CAIPE_ORG_KEY ?? "caipe";
+
+/** Workflow configs are modeled as the `task` resource type in OpenFGA. */
+type WorkflowAction = "read" | "write" | "delete";
+
+/** Structural subset of the session needed to resolve a subject. */
+export interface WorkflowAuthzSession {
+  sub?: string;
+  isServiceAccount?: boolean;
+  org?: string;
+}
+
+export function workflowSubjectFromSession(session: WorkflowAuthzSession): Subject | null {
+  const sub = typeof session.sub === "string" ? session.sub.trim() : "";
+  if (!sub) return null;
+  return { type: session.isServiceAccount === true ? "service_account" : "user", id: sub };
+}
+
+function ctxFromSession(session: WorkflowAuthzSession): DecisionContext {
+  return { tenantId: typeof session.org === "string" && session.org.trim() ? session.org.trim() : undefined };
+}
+
+async function workflowAccessDecision(
+  session: WorkflowAuthzSession,
+  configId: string,
+  action: WorkflowAction,
+): Promise<AuthorizeResult> {
+  const subject = workflowSubjectFromSession(session);
+  if (!subject) return { decision: "DENY", reason: "NOT_AUTHENTICATED", retriable: false };
+  const ctx = ctxFromSession(session);
+  const orgAdmin = await authorize(
+    { subject, resource: { type: "organization", id: ORG_KEY }, action: "manage" },
+    ctx,
+  );
+  if (orgAdmin.decision === "ALLOW") return orgAdmin;
+  if (orgAdmin.reason === "AUTHZ_UNAVAILABLE") return orgAdmin;
+  return authorize({ subject, resource: { type: "task", id: configId }, action }, ctx);
+}
+
+function unavailableError(): ApiError {
+  return new ApiError(
+    "Authorization service temporarily unavailable.",
+    503,
+    "AUTHZ_UNAVAILABLE",
+    "pdp_unavailable",
+    "retry",
+  );
+}
+
+function workflowRunForbiddenError(): ApiError {
+  return new ApiError(
+    "You do not have permission to access this workflow run.",
+    403,
+    "WORKFLOW_RUN_FORBIDDEN",
+    "forbidden",
+    "contact_admin",
+  );
+}
+
+function ownerMatches(run: WorkflowRunAccessDocument, subject: Subject): boolean {
+  return run.owner_subject?.type === subject.type && run.owner_subject.id === subject.id;
+}
+
+function workflowActionForRunAction(
+  action: "read" | "write" | "delete" | "resume" | "cancel",
+): WorkflowAction {
+  return action === "read" ? "read" : action === "delete" ? "delete" : "write";
+}
+
+function auditWorkflowRunDecision(
+  session: WorkflowAuthzSession,
+  subject: Subject,
+  run: WorkflowRunAccessDocument,
+  action: WorkflowAction,
+  result: AuthorizeResult,
+): void {
+  emitDecisionAudit(
+    subject,
+    { type: "task", id: run.workflow_config_id },
+    action,
+    result,
+    ctxFromSession(session),
+    { workflowRunId: run._id },
+  );
+}
+
+export interface WorkflowRunAccessDocument {
+  _id: string;
+  workflow_config_id: string;
+  owner_subject?: Subject | null;
+}
+
+/**
+ * Boolean access check for a single workflow config. Org admins are allowed
+ * unconditionally. Returns false (never throws) for missing subject or deny —
+ * matching the legacy `userCanAccessConfig` try/catch idiom.
+ */
+export async function workflowAccessAllowed(
+  session: WorkflowAuthzSession,
+  configId: string,
+  action: WorkflowAction,
+): Promise<boolean> {
+  const r = await workflowAccessDecision(session, configId, action);
+  return r.decision === "ALLOW";
+}
+
+/**
+ * Throwing access check. 401 on missing subject, 403 on deny — with clean
+ * reason codes (no OpenFGA relation strings leaked).
+ */
+export async function requireWorkflowAccess(
+  session: WorkflowAuthzSession,
+  configId: string,
+  action: WorkflowAction,
+): Promise<void> {
+  const result = await workflowAccessDecision(session, configId, action);
+  if (result.reason === "NOT_AUTHENTICATED") {
+    throw new ApiError(
+      "A stable user subject is required for this workflow authorization check.",
+      401,
+      "NO_SUBJECT",
+      "session_expired",
+      "sign_in",
+    );
+  }
+  if (result.reason === "AUTHZ_UNAVAILABLE" || result.retriable) {
+    throw unavailableError();
+  }
+  if (result.decision !== "ALLOW") {
+    throw new ApiError(
+      "You do not have permission to access this workflow.",
+      403,
+      "WORKFLOW_FORBIDDEN",
+      "forbidden",
+      "contact_admin",
+    );
+  }
+}
+
+export async function requireWorkflowRunAccess(
+  session: WorkflowAuthzSession,
+  run: WorkflowRunAccessDocument,
+  action: "read" | "write" | "delete" | "resume" | "cancel",
+): Promise<void> {
+  const subject = workflowSubjectFromSession(session);
+  if (!subject) {
+    throw new ApiError(
+      "A stable user subject is required for this workflow run authorization check.",
+      401,
+      "NO_SUBJECT",
+      "session_expired",
+      "sign_in",
+    );
+  }
+  const configAction = workflowActionForRunAction(action);
+  if (ownerMatches(run, subject)) {
+    auditWorkflowRunDecision(session, subject, run, configAction, {
+      decision: "ALLOW",
+      reason: "OK",
+      retriable: false,
+      via: "workflow_run_owner",
+    });
+    return;
+  }
+  if (run.owner_subject) {
+    auditWorkflowRunDecision(session, subject, run, configAction, {
+      decision: "DENY",
+      reason: "NO_CAPABILITY",
+      retriable: false,
+      via: "workflow_run_owner_mismatch",
+    });
+    throw workflowRunForbiddenError();
+  }
+
+  await requireWorkflowAccess(session, run.workflow_config_id, configAction);
+}
+
+/**
+ * Filters a list of workflow configs to those the subject may access.
+ * Org admins see all. Uses one batched CAS call for the rest.
+ */
+export async function filterAccessibleWorkflowConfigs<T>(
+  session: WorkflowAuthzSession,
+  configs: T[],
+  getId: (config: T) => string,
+  action: WorkflowAction = "read",
+): Promise<T[]> {
+  const subject = workflowSubjectFromSession(session);
+  if (!subject) return [];
+  if (configs.length === 0) return [];
+  const ctx = ctxFromSession(session);
+  const orgAdmin = await authorize(
+    { subject, resource: { type: "organization", id: ORG_KEY }, action: "manage" },
+    ctx,
+  );
+  if (orgAdmin.decision === "ALLOW") return configs;
+  if (orgAdmin.reason === "AUTHZ_UNAVAILABLE" || orgAdmin.retriable) {
+    throw unavailableError();
+  }
+
+  const ids = configs.map(getId);
+  const results = await authorizeMany(subject, action, "task", ids, ctx);
+  for (const result of results.values()) {
+    if (result.reason === "AUTHZ_UNAVAILABLE" || result.retriable) {
+      throw unavailableError();
+    }
+  }
+  return configs.filter((config) => results.get(getId(config))?.decision === "ALLOW");
+}

--- a/ui/src/lib/server/workflow-da-auth.ts
+++ b/ui/src/lib/server/workflow-da-auth.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+
+import type { ResourceAuthzSession } from "@/lib/rbac/resource-authz";
+
+/**
+ * Headers for server-side workflow engine calls into Dynamic Agents.
+ * Prefer the caller's Bearer token; fall back to the OIDC access token on the session.
+ */
+export function buildWorkflowDaAuthHeaders(
+  request: NextRequest,
+  user: { email: string; name?: string | null },
+  session: ResourceAuthzSession,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const incomingAuth = request.headers.get("Authorization")?.trim();
+  const sessionRecord = session as Record<string, unknown>;
+  const accessToken =
+    typeof sessionRecord.accessToken === "string" ? sessionRecord.accessToken.trim() : "";
+
+  if (incomingAuth) {
+    headers.Authorization = incomingAuth;
+  } else if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  headers["X-User-Context"] = Buffer.from(
+    JSON.stringify({
+      email: user.email,
+      name: user.name ?? null,
+    }),
+  ).toString("base64");
+
+  return headers;
+}

--- a/ui/src/lib/server/workflow-engine.ts
+++ b/ui/src/lib/server/workflow-engine.ts
@@ -16,7 +16,31 @@ import { consumeAgentStream,type ConsumeResult } from "@/lib/streaming/clients/s
 import { isToolStartData } from "@/lib/streaming/types";
 import type { WorkflowConfig,WorkflowStep } from "@/types/workflow-config";
 import { flattenStepEntries } from "@/types/workflow-config";
+import { authorize, type Subject } from "@/lib/authz";
 import { buildTemplateContext,renderPrompt,type StepContext } from "./workflow-templating";
+
+/**
+ * Decode the run owner's subject from the forwarded Bearer token. Per-step
+ * agent-use is authorized in the UI server (this engine) via CAS — workflow
+ * RBAC is a UI-server concept (the engine invokes agents one step at a time),
+ * so DA no longer needs workflow_execution_authz. Returns null for system /
+ * config-driven runs with no user token (already authorized at run start).
+ */
+// Exported for unit testing — extracts the run owner's `sub` from the forwarded
+// Bearer so executeSteps can authorize per-step agent use against CAS.
+export function runOwnerSubject(authHeaders: Record<string, string>): string | null {
+  const auth = authHeaders["Authorization"] ?? authHeaders["authorization"];
+  if (!auth?.startsWith("Bearer ")) return null;
+  const parts = auth.slice(7).split(".");
+  if (parts.length < 2) return null;
+  try {
+    const json = Buffer.from(parts[1].replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    const sub = (JSON.parse(json) as { sub?: unknown }).sub;
+    return typeof sub === "string" && sub.trim() ? sub.trim() : null;
+  } catch {
+    return null;
+  }
+}
 
 // ═══════════════════════════════════════════════════════════════
 // Configuration
@@ -66,6 +90,7 @@ export interface WorkflowRunTriggerInfo {
 export interface WorkflowRunDocument {
   _id: string;
   workflow_config_id: string;
+  owner_subject?: Subject | null;
   status: WorkflowRunStatus;
   steps: WorkflowStepRun[];
   current_step_index: number;
@@ -98,9 +123,11 @@ export async function startWorkflowRun(
   userContext: string | null,
   authHeaders: Record<string, string>,
   triggerInfo?: WorkflowRunTriggerInfo | null,
+  ownerSubject?: Subject | null,
 ): Promise<string> {
   const runId = generateRunId();
   const flatSteps = flattenStepEntries(config.steps);
+  const runOwner = ownerSubject ?? ownerSubjectFromAuthHeaders(authHeaders);
 
   const stepRuns: WorkflowStepRun[] = flatSteps.map(({ index, step }) => ({
     type: "step",
@@ -120,6 +147,7 @@ export async function startWorkflowRun(
   const runDoc: WorkflowRunDocument = {
     _id: runId,
     workflow_config_id: config._id,
+    owner_subject: runOwner,
     status: "running",
     steps: stepRuns,
     current_step_index: 0,
@@ -134,7 +162,7 @@ export async function startWorkflowRun(
 
   // Fire-and-forget
   const flatWorkflowSteps = flatSteps.map(({ step }) => step);
-  executeSteps(runId, config._id, config.name, config.description, flatWorkflowSteps, userContext, authHeaders, 0).catch((err) => {
+  executeSteps(runId, config._id, config.name, config.description, flatWorkflowSteps, userContext, authHeaders, 0, runOwner).catch((err) => {
     console.error(`[WorkflowEngine] Unhandled error in run ${runId}:`, err);
   });
 
@@ -170,7 +198,7 @@ export async function resumeWorkflowRun(
   const flatSteps = flattenStepEntries(config.steps).map(({ step: s }) => s);
 
   // Fire-and-forget: resume current step then continue
-  resumeAndContinue(runId, run.workflow_config_id, config.name, config.description, stepIndex, resumeData, flatSteps, run.user_context, authHeaders).catch(
+  resumeAndContinue(runId, run.workflow_config_id, config.name, config.description, stepIndex, resumeData, flatSteps, run.user_context, authHeaders, run.owner_subject ?? null).catch(
     (err) => {
       console.error(`[WorkflowEngine] Resume error in run ${runId}:`, err);
     },
@@ -233,6 +261,7 @@ async function executeSteps(
   userContext: string | null,
   authHeaders: Record<string, string>,
   startFrom: number,
+  ownerSubject: Subject | null,
 ): Promise<void> {
   const col = await getCollection<WorkflowRunDocument>(RUNS_COLLECTION);
   const completedSteps: StepContext[] = [];
@@ -257,6 +286,31 @@ async function executeSteps(
 
   for (let i = startFrom; i < steps.length; i++) {
     const step = steps[i];
+
+    // Per-step authorization gate (CAS) — the @subbaksh fix: workflow agent-use
+    // is decided here in the UI server, not in DA. Org-admin bypass + standing
+    // team/global grants apply via CAS. System runs (no owner token) skip this.
+    //
+    // Per-step agent-use is authorized here in the UI server via CAS. Standing
+    // grants come from the share/agent-access modal (team→agent tuples) and
+    // global wildcards; org admins pass via the CAS bypass. Set
+    // WORKFLOW_CAS_STEP_GATE=false to fall back to DA-only gating.
+    if (ownerSubject && process.env.WORKFLOW_CAS_STEP_GATE !== "false") {
+      const decision = await authorize(
+        {
+          subject: ownerSubject,
+          resource: { type: "agent", id: step.agent_id },
+          action: "use",
+          trustedContext: { workflowRunId: runId },
+        },
+        { correlationId: runId },
+      );
+      if (decision.decision !== "ALLOW") {
+        await markStepFailed(col, runId, i, `Not authorized to use agent "${step.agent_id}" (${decision.reason})`);
+        await markRunFailed(col, runId);
+        return;
+      }
+    }
 
     // Mark step running
     await col.updateOne(
@@ -346,6 +400,7 @@ async function executeSteps(
           message: attemptPrompt,
           conversation_id: conversationId,
           agent_id: step.agent_id,
+          workflow_config_id: workflowConfigId,
           protocol: "agui",
           config_override: {
             backend: {
@@ -497,6 +552,7 @@ async function resumeAndContinue(
   steps: WorkflowStep[],
   userContext: string | null,
   authHeaders: Record<string, string>,
+  ownerSubject: Subject | null,
 ): Promise<void> {
   const col = await getCollection<WorkflowRunDocument>(RUNS_COLLECTION);
   const step = steps[stepIndex];
@@ -525,6 +581,7 @@ async function resumeAndContinue(
     body: {
       conversation_id: conversationId,
       agent_id: step.agent_id,
+      workflow_config_id: workflowConfigId,
       resume_data: resumeData,
       protocol: "agui",
       config_override: {
@@ -608,7 +665,12 @@ async function resumeAndContinue(
   }
 
   // Continue with remaining steps
-  await executeSteps(runId, workflowConfigId, workflowName, workflowDescription, steps, userContext, authHeaders, stepIndex + 1);
+  await executeSteps(runId, workflowConfigId, workflowName, workflowDescription, steps, userContext, authHeaders, stepIndex + 1, ownerSubject);
+}
+
+function ownerSubjectFromAuthHeaders(authHeaders: Record<string, string>): Subject | null {
+  const sub = runOwnerSubject(authHeaders);
+  return sub ? { type: "user", id: sub } : null;
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -718,8 +780,9 @@ function buildWorkflowContextPrefix(
 
   // --- Critical: User interaction ---
   ctx += "## Critical: User Interaction\n";
-  ctx += "The user does NOT have access to this chat. All interaction with the user must happen through the `require_user_input` tool.\n";
-  ctx += "If that tool is not available and you cannot proceed without user input, state the reason and stop.\n\n";
+  ctx += "The user does NOT have access to this chat. All interaction with the user must happen through the `request_user_input` tool.\n";
+  ctx += "When a step must pass data to later steps, call `request_user_input` if needed, then persist outputs with `write_file` (for example `choices.txt` at the filesystem root).\n";
+  ctx += "If that tool is not available and you cannot proceed without user input, write the reason to error.txt and stop.\n\n";
 
   // --- Critical: Reporting failure ---
   ctx += "## Critical: Reporting Failure\n";

--- a/ui/src/lib/server/workflow-step-agents.ts
+++ b/ui/src/lib/server/workflow-step-agents.ts
@@ -1,0 +1,38 @@
+import { ApiError } from "@/lib/api-middleware";
+import { getCollection } from "@/lib/mongodb";
+import type { WorkflowConfig, WorkflowStep } from "@/types/workflow-config";
+
+/**
+ * Fail fast when a workflow references dynamic agent IDs that are not in MongoDB.
+ */
+export async function assertWorkflowStepAgentsExist(config: WorkflowConfig): Promise<void> {
+  const agentIds = [
+    ...new Set(
+      (config.steps ?? [])
+        .filter((entry): entry is WorkflowStep => entry.type === "step")
+        .map((step) => step.agent_id)
+        .filter((id): id is string => Boolean(id?.trim())),
+    ),
+  ];
+
+  if (agentIds.length === 0) {
+    return;
+  }
+
+  const agentCol = await getCollection<{ _id: string }>("dynamic_agents");
+  const found = await agentCol
+    .find({ _id: { $in: agentIds } })
+    .project({ _id: 1 })
+    .toArray();
+  const foundIds = new Set(found.map((doc) => String(doc._id)));
+  const missing = agentIds.filter((id) => !foundIds.has(id));
+
+  if (missing.length > 0) {
+    throw new ApiError(
+      `This workflow references agent(s) that do not exist: ${missing.join(", ")}. ` +
+        "Open the workflow in the editor, select each step, and choose an agent from the catalog " +
+        "(or update config/app-config.yaml for config-driven workflows and restart the UI).",
+      400,
+    );
+  }
+}

--- a/ui/src/store/__tests__/unsaved-changes-store.test.ts
+++ b/ui/src/store/__tests__/unsaved-changes-store.test.ts
@@ -21,6 +21,7 @@ function resetStore() {
   useUnsavedChangesStore.setState({
     hasUnsavedChanges: false,
     pendingNavigationHref: null,
+    pendingDeferredAction: null,
   });
 }
 
@@ -110,6 +111,56 @@ describe("unsaved-changes-store", () => {
         href = useUnsavedChangesStore.getState().confirmNavigation();
       });
       expect(href).toBeNull();
+    });
+  });
+
+  describe("requestDeferredAction", () => {
+    it("runs immediately when there are no unsaved changes", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+      });
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBeNull();
+    });
+
+    it("queues the action when there are unsaved changes", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().setUnsaved(true);
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+      });
+      expect(action).not.toHaveBeenCalled();
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBe(action);
+    });
+  });
+
+  describe("confirmDeferredAction", () => {
+    it("runs the queued action and clears dirty state", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().setUnsaved(true);
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+      });
+      act(() => {
+        useUnsavedChangesStore.getState().confirmDeferredAction();
+      });
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(useUnsavedChangesStore.getState().hasUnsavedChanges).toBe(false);
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBeNull();
+    });
+  });
+
+  describe("cancelNavigation", () => {
+    it("clears pendingDeferredAction", () => {
+      const action = jest.fn();
+      act(() => {
+        useUnsavedChangesStore.getState().setUnsaved(true);
+        useUnsavedChangesStore.getState().requestDeferredAction(action);
+        useUnsavedChangesStore.getState().cancelNavigation();
+      });
+      expect(useUnsavedChangesStore.getState().pendingDeferredAction).toBeNull();
+      expect(action).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/store/unsaved-changes-store.ts
+++ b/ui/src/store/unsaved-changes-store.ts
@@ -3,26 +3,54 @@ import { create } from "zustand";
 interface UnsavedChangesState {
   hasUnsavedChanges: boolean;
   pendingNavigationHref: string | null;
+  /** In-app action blocked until the user discards edits (e.g. switch workflow). */
+  pendingDeferredAction: (() => void) | null;
 
   setUnsaved: (dirty: boolean) => void;
   requestNavigation: (href: string) => void;
+  requestDeferredAction: (action: () => void) => void;
   cancelNavigation: () => void;
   confirmNavigation: () => string | null;
+  confirmDeferredAction: () => void;
 }
 
 export const useUnsavedChangesStore = create<UnsavedChangesState>()((set, get) => ({
   hasUnsavedChanges: false,
   pendingNavigationHref: null,
+  pendingDeferredAction: null,
 
   setUnsaved: (dirty) => set({ hasUnsavedChanges: dirty }),
 
   requestNavigation: (href) => set({ pendingNavigationHref: href }),
 
-  cancelNavigation: () => set({ pendingNavigationHref: null }),
+  requestDeferredAction: (action) => {
+    if (get().hasUnsavedChanges) {
+      set({ pendingDeferredAction: action });
+      return;
+    }
+    action();
+  },
+
+  cancelNavigation: () =>
+    set({ pendingNavigationHref: null, pendingDeferredAction: null }),
 
   confirmNavigation: () => {
     const href = get().pendingNavigationHref;
-    set({ hasUnsavedChanges: false, pendingNavigationHref: null });
+    set({
+      hasUnsavedChanges: false,
+      pendingNavigationHref: null,
+      pendingDeferredAction: null,
+    });
     return href;
+  },
+
+  confirmDeferredAction: () => {
+    const action = get().pendingDeferredAction;
+    set({
+      hasUnsavedChanges: false,
+      pendingNavigationHref: null,
+      pendingDeferredAction: null,
+    });
+    action?.();
   },
 }));

--- a/ui/src/store/workflow-config-store.ts
+++ b/ui/src/store/workflow-config-store.ts
@@ -35,11 +35,26 @@ interface WorkflowConfigState {
 }
 
 function transformConfig(config: Record<string, unknown>): WorkflowConfig {
+  const raw = config as unknown as WorkflowConfig;
   return {
-    ...(config as unknown as WorkflowConfig),
+    ...raw,
+    steps: Array.isArray(raw.steps) ? raw.steps : [],
     created_at: new Date(config.created_at as string),
     updated_at: new Date(config.updated_at as string),
   };
+}
+
+function parseWorkflowConfigList(data: unknown): WorkflowConfig[] {
+  if (Array.isArray(data)) {
+    return data.map((item) => transformConfig(item as Record<string, unknown>));
+  }
+  if (data && typeof data === "object") {
+    const wrapped = (data as { data?: unknown }).data;
+    if (Array.isArray(wrapped)) {
+      return wrapped.map((item) => transformConfig(item as Record<string, unknown>));
+    }
+  }
+  return [];
 }
 
 export const useWorkflowConfigStore = create<WorkflowConfigState>()((set, get) => ({
@@ -50,7 +65,6 @@ export const useWorkflowConfigStore = create<WorkflowConfigState>()((set, get) =
   editMode: null,
 
   loadConfigs: async () => {
-    if (get().isLoading) return;
     set({ isLoading: true, error: null });
 
     try {
@@ -58,17 +72,24 @@ export const useWorkflowConfigStore = create<WorkflowConfigState>()((set, get) =
 
       // Handle 503 (MongoDB not configured) — not an error, just not available
       if (response.status === 503) {
-        set({ configs: [], isLoading: false });
+        set({ configs: [], isLoading: false, error: null });
         return;
       }
 
       if (!response.ok) {
-        throw new Error(`Failed to load workflow configs: ${response.status}`);
+        const message = await response.text().catch(() => "");
+        let detail = `Failed to load workflow configs (${response.status})`;
+        try {
+          const json = JSON.parse(message) as { error?: string; message?: string };
+          detail = json.error || json.message || detail;
+        } catch {
+          if (message.trim()) detail = message.trim();
+        }
+        throw new Error(detail);
       }
 
       const data = await response.json();
-      const configs = Array.isArray(data) ? data.map(transformConfig) : [];
-      set({ configs, isLoading: false });
+      set({ configs: parseWorkflowConfigList(data), isLoading: false, error: null });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to load workflow configs";
       set({ error: message, isLoading: false });

--- a/ui/src/store/workflow-exec-store.ts
+++ b/ui/src/store/workflow-exec-store.ts
@@ -11,6 +11,22 @@ import { create } from "zustand";
  */
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readWorkflowApiError(res: Response): Promise<string> {
+  const text = await res.text();
+  try {
+    const json = JSON.parse(text) as { error?: string; message?: string };
+    if (typeof json.error === "string" && json.error.trim()) return json.error;
+    if (typeof json.message === "string" && json.message.trim()) return json.message;
+  } catch {
+    // fall through
+  }
+  return text.trim() || `Request failed (${res.status})`;
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -137,7 +153,13 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       const res = await fetch("/api/workflow-runs");
       if (!res.ok) throw new Error("Failed to load runs");
       const data = await res.json();
-      set({ runs: data as WfRunSummary[], isLoadingRuns: false });
+      const runs = Array.isArray(data)
+        ? data.map((run) => ({
+            ...run,
+            steps: Array.isArray(run?.steps) ? run.steps : [],
+          }))
+        : [];
+      set({ runs, isLoadingRuns: false });
     } catch {
       set({ isLoadingRuns: false });
     }
@@ -159,8 +181,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Execute failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       const data = await res.json();
@@ -245,8 +266,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Resume failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       // Resume polling
@@ -266,8 +286,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Cancel failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       get().stopPolling();
@@ -287,8 +306,7 @@ export const useWorkflowExecStore = create<WorkflowExecState>()((set, get) => ({
       });
 
       if (!res.ok) {
-        const err = await res.text();
-        throw new Error(err || `Delete failed: ${res.status}`);
+        throw new Error(await readWorkflowApiError(res));
       }
 
       // Remove from sidebar list


### PR DESCRIPTION
## Summary

Corrected branch based on the `/private/tmp/caipe-pr1772` split worktree.

Includes the workflow RBAC blocker fix plus a mocked Chromium regression for the browser behaviors that caught it.

## What changed

- Aligns workflow run start/list/read access with workflow-config visibility/CAS union semantics.
- Ensures workflow agent-access grant failures block save instead of reporting false success.
- Adds a mocked Playwright workflow regression covering:
  - global workflow `(all users)` grant failure keeps the modal open and blocks save,
  - team workflow grant failure keeps the modal open and blocks save,
  - visible workflow can start without requiring a direct legacy CAS `read` tuple.
- Documents the workflow browser regression command in `ui/e2e/rbac/README.md`.

## Test plan

- [x] `RUN_WORKFLOW_E2E=1 CAIPE_UI_BASE_URL=http://localhost:3000 npx playwright test e2e/rbac/workflow-agent-access.spec.ts --config=playwright.rbac.config.ts`
- [x] `npx eslint e2e/rbac/_mocked-rbac.ts e2e/rbac/workflow-agent-access.spec.ts`
- [x] `git diff --check`