### PR TITLE
fix(supervisor): eager MCP init via A2A lifespan hook

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/protocol_bindings/a2a/main.py
@@ -10,6 +10,7 @@ Supports both single-node (all-in-one, in-process MCP tools) and distributed
 import logging
 import os
 import httpx
+from contextlib import asynccontextmanager
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -144,24 +145,24 @@ a2a_server = A2AStarletteApplication(
     http_handler=request_handler
 )
 
-app = a2a_server.build()
-
 ################################################################################
 # Eager initialisation — load MCP tools at startup, not on first request
 ################################################################################
 _binding = request_handler.agent_executor.agent
 
 
-async def _startup_initialize():
+@asynccontextmanager
+async def _supervisor_lifespan(_starlette_app):
     logger.info("Initialising agent (loading MCP tools)...")
     try:
         await _binding.ensure_initialized()
         logger.info("Agent initialised successfully")
     except Exception:
         logger.exception("Agent initialisation failed — will retry on first request")
+    yield
 
 
-app.add_event_handler("startup", _startup_initialize)
+app = a2a_server.build(lifespan=_supervisor_lifespan)
 
 ################################################################################
 # /tools endpoint – returns tool names per subagent from the running MAS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.11-dev.4"
+version = "0.5.11-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.11.dev4"
+version = "0.5.11.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Register supervisor startup through an `asynccontextmanager` lifespan passed to `a2a_server.build(lifespan=...)`
- MCP tools initialize at process start instead of on the first request

## Problem — Starlette 1.0 removed `add_event_handler`

`caipe-supervisor` was crashing on startup (exit code 1) after the Jun 10 dependabot bump moved **Starlette 0.50.0 → 1.0.1** (`9d601d3d0`).

The supervisor A2A entrypoint still used the pre-1.0 API:

```python
app = a2a_server.build()
app.add_event_handler("startup", _startup_initialize)
```

Starlette 1.0 dropped `add_event_handler` in favor of the **lifespan** context-manager API. Uvicorn fails while importing the module:

```
AttributeError: 'Starlette' object has no attribute 'add_event_handler'
```

This was a latent incompatibility: PR #1151 (Apr 10) added eager MCP init via `add_event_handler` when the lockfile still pinned Starlette 0.50.x. The dependency bump landed on `main` without updating `a2a/main.py`. A full `docker compose` rebuild of `caipe-supervisor` with the new lockfile surfaced the crash.

## Fix

Pass a lifespan hook into `A2AStarletteApplication.build()` (it forwards `**kwargs` to Starlette). Same pattern as `dynamic_agents/main.py`:

```python
@asynccontextmanager
async def _supervisor_lifespan(_starlette_app):
    await _binding.ensure_initialized()
    yield

app = a2a_server.build(lifespan=_supervisor_lifespan)
```

Initialization behavior is unchanged — MCP tools still load eagerly at startup, with the same log-and-continue fallback if init fails.

## Test plan

- [ ] `docker compose up caipe-supervisor` — container stays up; logs show `Initialising agent (loading MCP tools)...` / `Agent initialised successfully`
- [ ] `GET /tools` returns subagent tool names before the first chat request
- [ ] No regression in A2A streaming / agent routing

Made with [Cursor](https://cursor.com)