### PR TITLE
feat(ui): ephemeral file preview in agents and workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.11-dev.4"
+version = "0.5.11-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/workflows/run/[id]/page.tsx
+++ b/ui/src/app/(app)/workflows/run/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { WorkflowProgressMap } from "@/components/workflows/WorkflowProgressMap";
 import { WorkflowRunTimeline } from "@/components/workflows/WorkflowRunTimeline";
 import { cn,formatRelativeTime } from "@/lib/utils";
+import { fetchEphemeralFileContent } from "@/lib/ephemeral-files";
 import type { WfRunStatus } from "@/store/workflow-exec-store";
 import { useWorkflowExecStore } from "@/store/workflow-exec-store";
 import { Ban,CheckCircle2,Clock,FolderOpen,Info,Loader2,MessageSquare,XCircle } from "lucide-react";
@@ -90,6 +91,12 @@ export default function WorkflowRunPage() {
     } catch {
       // ignore
     }
+  }, [run, runId]);
+
+  const handleGetFileContent = useCallback(async (path: string): Promise<string | null> => {
+    if (!run || !runId) return null;
+    const fsNamespace = JSON.stringify([run.workflow_config_id, runId, "filesystem"]);
+    return fetchEphemeralFileContent(fsNamespace, path);
   }, [run, runId]);
 
   const handleResume = async (stepIndex: number, data: string) => {
@@ -183,6 +190,7 @@ export default function WorkflowRunPage() {
               stepEvents={stepEvents}
               workflowFiles={showFiles ? workflowFiles : undefined}
               onFileDownload={handleFileDownload}
+              getFileContent={handleGetFileContent}
               onResume={run.status !== "failed" && run.status !== "cancelled" ? handleResume : undefined}
             />
           )}

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -11,6 +11,7 @@ import { useAgentTimeline } from "@/hooks/useDynamicAgentTimeline";
 import { APIClientError } from "@/lib/api-client";
 import { authErrorToastTitle,type AuthError } from "@/lib/auth-error";
 import { getConfig } from "@/lib/config";
+import { fetchEphemeralFileContent } from "@/lib/ephemeral-files";
 import { createStreamAdapter,StreamError,type StreamCallbacks } from "@/lib/streaming";
 import { createStreamEvent,FILE_TOOL_NAMES,TODO_TOOL_NAME,type StreamEvent } from "@/lib/streaming/types";
 import { cn,deduplicateByKey } from "@/lib/utils";
@@ -526,6 +527,15 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
       }
     },
     [conversationId, agentId, isDownloadingFile]
+  );
+
+  const handleGetFileContent = useCallback(
+    async (path: string): Promise<string | null> => {
+      if (!conversationId || !agentId) return null;
+      const fsNamespace = JSON.stringify([agentId, conversationId, "filesystem"]);
+      return fetchEphemeralFileContent(fsNamespace, path);
+    },
+    [conversationId, agentId],
   );
 
   // Handle file delete
@@ -1680,6 +1690,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
                           timelineFiles={timelineFiles}
                           timelineTasks={timelineTasks}
                           onFileDownload={handleTimelineFileDownload}
+                          getFileContent={handleGetFileContent}
                           onFileDelete={handleTimelineFileDelete}
                           isDownloadingFile={isDownloadingFile}
                           downloadingFilePath={downloadingFilePath}
@@ -2067,6 +2078,7 @@ interface ChatMessageProps {
   timelineFiles?: string[];
   timelineTasks?: TaskItem[];
   onFileDownload?: (path: string) => void;
+  getFileContent?: (path: string) => Promise<string | null>;
   onFileDelete?: (path: string) => void;
   isDownloadingFile?: boolean;
   downloadingFilePath?: string;
@@ -2099,6 +2111,7 @@ const ChatMessage = React.memo(function ChatMessage({
   timelineFiles = [],
   timelineTasks = [],
   onFileDownload,
+  getFileContent,
   onFileDelete,
   isDownloadingFile,
   downloadingFilePath,
@@ -2314,6 +2327,7 @@ const ChatMessage = React.memo(function ChatMessage({
                 tasks={isLatestAnswer ? timelineTasks : []}
                 isLatestMessage={isLatestAnswer}
                 onFileDownload={onFileDownload}
+                getFileContent={getFileContent}
                 onFileDelete={onFileDelete}
                 isDownloadingFile={isDownloadingFile}
                 downloadingFilePath={downloadingFilePath}

--- a/ui/src/components/chat/DynamicAgentTimeline.tsx
+++ b/ui/src/components/chat/DynamicAgentTimeline.tsx
@@ -165,8 +165,9 @@ interface AgentTimelineProps {
   /** Function to look up subagent info by name (for avatar gradient) */
   getSubagentInfo?: SubagentLookupFn;
 
-  // ─── File operations (only active when isLatestMessage=true) ─
+  // ─── File operations ─────────────────────────────────────────
   onFileDownload?: (path: string) => void;
+  getFileContent?: (path: string) => Promise<string | null>;
   onFileDelete?: (path: string) => void;
   isDownloadingFile?: boolean;
   downloadingFilePath?: string;
@@ -189,6 +190,7 @@ export function AgentTimeline({
   isLatestMessage,
   getSubagentInfo,
   onFileDownload,
+  getFileContent,
   onFileDelete,
   isDownloadingFile,
   downloadingFilePath,
@@ -373,6 +375,7 @@ export function AgentTimeline({
             turnEnded={turnEnded}
             isStreaming={isStreaming}
             onFileDownload={onFileDownload}
+            getFileContent={getFileContent}
             onFileDelete={onFileDelete}
             isDownloading={isDownloadingFile}
             downloadingPath={downloadingFilePath}
@@ -1212,6 +1215,7 @@ function FileSection({
   turnEnded = false,
   isStreaming = false,
   onFileDownload,
+  getFileContent,
   onFileDelete,
   isDownloading,
   downloadingPath,
@@ -1223,6 +1227,7 @@ function FileSection({
   turnEnded?: boolean;
   isStreaming?: boolean;
   onFileDownload?: (path: string) => void;
+  getFileContent?: (path: string) => Promise<string | null>;
   onFileDelete?: (path: string) => void;
   isDownloading?: boolean;
   downloadingPath?: string;
@@ -1239,7 +1244,8 @@ function FileSection({
     >
       <FileTree
         files={files}
-        onFileClick={readonly ? undefined : onFileDownload}
+        getFileContent={getFileContent}
+        onFileClick={onFileDownload}
         onFileDelete={readonly ? undefined : onFileDelete}
         isDownloading={isDownloading}
         downloadingPath={downloadingPath}

--- a/ui/src/components/dynamic-agents/DynamicAgentContext.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentContext.tsx
@@ -5,6 +5,7 @@ import { FileTree } from "@/components/dynamic-agents/FileTree";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { fetchEphemeralFileContent } from "@/lib/ephemeral-files";
 import { useChatStore } from "@/store/chat-store";
 import type { DynamicAgentConfig } from "@/types/dynamic-agent";
 import { motion } from "framer-motion";
@@ -148,6 +149,12 @@ export function DynamicAgentContext({
     } catch {
       // ignore
     }
+  }, [agentId, conversationId]);
+
+  const handleGetFileContent = useCallback(async (path: string): Promise<string | null> => {
+    if (!agentId || !conversationId) return null;
+    const fsNamespace = JSON.stringify([agentId, conversationId, "filesystem"]);
+    return fetchEphemeralFileContent(fsNamespace, path);
   }, [agentId, conversationId]);
 
   // Download chat handler
@@ -319,6 +326,7 @@ export function DynamicAgentContext({
               isLoadingFiles={isLoadingFiles}
               onToggleFiles={handleToggleFiles}
               onFileDownload={handleFileDownload}
+              getFileContent={handleGetFileContent}
             />
           </div>
         </ScrollArea>
@@ -372,6 +380,7 @@ interface AgentInfoContentProps {
   isLoadingFiles?: boolean;
   onToggleFiles?: () => void;
   onFileDownload?: (path: string) => void;
+  getFileContent?: (path: string) => Promise<string | null>;
 }
 
 function AgentInfoContent({
@@ -389,6 +398,7 @@ function AgentInfoContent({
   isLoadingFiles,
   onToggleFiles,
   onFileDownload,
+  getFileContent,
 }: AgentInfoContentProps) {
   // Count total tools across all MCP servers
   const toolCount = agent?.allowed_tools
@@ -637,6 +647,7 @@ function AgentInfoContent({
               ) : (
                 <FileTree
                   files={files}
+                  getFileContent={getFileContent}
                   onFileClick={onFileDownload}
                 />
               )}

--- a/ui/src/components/dynamic-agents/EphemeralFilePreview.tsx
+++ b/ui/src/components/dynamic-agents/EphemeralFilePreview.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { MarkdownRenderer } from "@/components/shared/timeline/MarkdownRenderer";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { isPreviewableEphemeralFile } from "@/lib/ephemeral-files";
+import { Download,Loader2,Maximize2,X } from "lucide-react";
+import { useState } from "react";
+
+interface EphemeralFilePreviewProps {
+  path: string;
+  content: string | null;
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onDownload?: (path: string) => void;
+  className?: string;
+}
+
+function FilePreviewBody({
+  path,
+  content,
+  isLoading,
+  error,
+  expanded = false,
+}: {
+  path: string;
+  content: string | null;
+  isLoading: boolean;
+  error: string | null;
+  expanded?: boolean;
+}) {
+  const isMarkdown = isPreviewableEphemeralFile(path) && path.toLowerCase().endsWith(".md");
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
+        <Loader2 className="h-5 w-5 animate-spin" />
+        Loading preview…
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-500 py-2">{error}</p>;
+  }
+
+  if (content === null) {
+    return null;
+  }
+
+  if (isMarkdown) {
+    return (
+      <div
+        className={cn(
+          "prose dark:prose-invert max-w-none",
+          expanded ? "prose-base" : "prose-sm text-sm",
+        )}
+      >
+        <MarkdownRenderer content={content} />
+      </div>
+    );
+  }
+
+  return (
+    <pre
+      className={cn(
+        "font-mono whitespace-pre-wrap break-words text-foreground/90 leading-relaxed",
+        expanded ? "text-sm" : "text-xs",
+      )}
+    >
+      {content}
+    </pre>
+  );
+}
+
+export function EphemeralFilePreview({
+  path,
+  content,
+  isLoading,
+  error,
+  onClose,
+  onDownload,
+  className,
+}: EphemeralFilePreviewProps) {
+  const [fullscreenOpen, setFullscreenOpen] = useState(false);
+  const filename = path.split("/").pop() || path;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex flex-col rounded-lg border border-border/60 bg-background/80 overflow-hidden min-h-[16rem]",
+          className,
+        )}
+      >
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border/40 bg-muted/40 shrink-0">
+          <span className="text-xs font-medium truncate flex-1" title={path}>
+            {filename}
+          </span>
+          <button
+            type="button"
+            onClick={() => setFullscreenOpen(true)}
+            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            title="Open fullscreen preview"
+          >
+            <Maximize2 className="h-3.5 w-3.5" />
+          </button>
+          {onDownload && (
+            <button
+              type="button"
+              onClick={() => onDownload(path)}
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              title="Download file"
+            >
+              <Download className="h-3.5 w-3.5" />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            title="Close preview"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto px-3 py-3">
+          <FilePreviewBody
+            path={path}
+            content={content}
+            isLoading={isLoading}
+            error={error}
+          />
+        </div>
+      </div>
+
+      <Dialog open={fullscreenOpen} onOpenChange={setFullscreenOpen}>
+        <DialogContent className="flex h-[92vh] max-h-[92vh] min-w-0 w-[96vw] max-w-[96vw] flex-col gap-0 overflow-hidden p-0">
+          <DialogHeader className="shrink-0 border-b border-border/50 px-5 py-4 pr-12">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <DialogTitle className="truncate">{filename}</DialogTitle>
+                <DialogDescription className="truncate font-mono text-xs mt-1">
+                  {path}
+                </DialogDescription>
+              </div>
+              {onDownload && (
+                <button
+                  type="button"
+                  onClick={() => onDownload(path)}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+                  title="Download file"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  Download
+                </button>
+              )}
+            </div>
+          </DialogHeader>
+
+          <div className="flex-1 min-h-0 overflow-y-auto px-5 py-4">
+            <FilePreviewBody
+              path={path}
+              content={content}
+              isLoading={isLoading}
+              error={error}
+              expanded
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/ui/src/components/dynamic-agents/FileTree.tsx
+++ b/ui/src/components/dynamic-agents/FileTree.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import { EphemeralFilePreview } from "@/components/dynamic-agents/EphemeralFilePreview";
 import { cn } from "@/lib/utils";
+import { isPreviewableEphemeralFile } from "@/lib/ephemeral-files";
 import { AnimatePresence,motion } from "framer-motion";
-import { Download,FileText,Folder,Loader2,Trash2 } from "lucide-react";
-import React,{ useCallback,useMemo } from "react";
+import { Download,Eye,FileText,Folder,Loader2,Trash2 } from "lucide-react";
+import React,{ useCallback,useMemo,useState } from "react";
 
 interface FileTreeProps {
   /** List of file paths from the agent's in-memory filesystem */
   files: string[];
-  /** Callback when a file is clicked (for download) */
+  /** Fetch file text for inline preview (.md, .txt) */
+  getFileContent?: (path: string) => Promise<string | null>;
+  /** Callback when a non-previewable file is clicked, or download is requested */
   onFileClick?: (path: string) => void;
   /** Callback when delete is clicked */
   onFileDelete?: (path: string) => void;
@@ -32,10 +36,11 @@ interface TreeNode {
 /**
  * FileTree component displays files from the agent's in-memory filesystem.
  * Files are shown in a tree structure with folders expanded.
- * Clicking a file triggers a download.
+ * .md and .txt files open an inline preview when getFileContent is provided.
  */
 export function FileTree({
   files,
+  getFileContent,
   onFileClick,
   onFileDelete,
   isDownloading = false,
@@ -43,6 +48,57 @@ export function FileTree({
   isDeleting = false,
   deletingPath,
 }: FileTreeProps) {
+  const [previewPath, setPreviewPath] = useState<string | null>(null);
+  const [previewContent, setPreviewContent] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const loadPreview = useCallback(
+    async (path: string) => {
+      if (!getFileContent) return;
+      setPreviewPath(path);
+      setPreviewLoading(true);
+      setPreviewError(null);
+      setPreviewContent(null);
+      try {
+        const content = await getFileContent(path);
+        if (content === null) {
+          setPreviewError("Failed to load file preview.");
+        } else {
+          setPreviewContent(content);
+        }
+      } catch {
+        setPreviewError("Failed to load file preview.");
+      } finally {
+        setPreviewLoading(false);
+      }
+    },
+    [getFileContent],
+  );
+
+  const handleFileActivate = useCallback(
+    async (path: string) => {
+      if (getFileContent && isPreviewableEphemeralFile(path)) {
+        if (previewPath === path) {
+          setPreviewPath(null);
+          setPreviewContent(null);
+          setPreviewError(null);
+          return;
+        }
+        await loadPreview(path);
+        return;
+      }
+      onFileClick?.(path);
+    },
+    [getFileContent, loadPreview, onFileClick, previewPath],
+  );
+
+  const closePreview = useCallback(() => {
+    setPreviewPath(null);
+    setPreviewContent(null);
+    setPreviewError(null);
+  }, []);
+
   // Build tree structure from flat file paths
   const tree = useMemo(() => buildTree(files), [files]);
 
@@ -59,23 +115,50 @@ export function FileTree({
       </div>
       <p className="text-[10px] text-muted-foreground/60 italic">Ephemeral — files may be deleted automatically.</p>
 
-      <div className="rounded-lg border border-border/50 bg-muted/30 p-2">
-        <AnimatePresence mode="popLayout">
-          {tree.map((node, idx) => (
-            <TreeNodeItem
-              key={node.path}
-              node={node}
-              depth={0}
-              index={idx}
-              onFileClick={onFileClick}
-              onFileDelete={onFileDelete}
-              isDownloading={isDownloading}
-              downloadingPath={downloadingPath}
-              isDeleting={isDeleting}
-              deletingPath={deletingPath}
-            />
-          ))}
-        </AnimatePresence>
+      <div
+        className={cn(
+          "flex gap-3 items-stretch min-h-[16rem]",
+          previewPath && getFileContent ? "flex-row" : "flex-col",
+        )}
+      >
+        <div
+          className={cn(
+            "rounded-lg border border-border/50 bg-muted/30 p-2 min-h-0",
+            previewPath && getFileContent ? "w-[38%] max-w-xs shrink-0 overflow-y-auto" : "flex-1",
+          )}
+        >
+          <AnimatePresence mode="popLayout">
+            {tree.map((node, idx) => (
+              <TreeNodeItem
+                key={node.path}
+                node={node}
+                depth={0}
+                index={idx}
+                previewPath={previewPath}
+                canPreview={!!getFileContent}
+                onFileActivate={handleFileActivate}
+                onFileDownload={onFileClick}
+                onFileDelete={onFileDelete}
+                isDownloading={isDownloading}
+                downloadingPath={downloadingPath}
+                isDeleting={isDeleting}
+                deletingPath={deletingPath}
+              />
+            ))}
+          </AnimatePresence>
+        </div>
+
+        {previewPath && getFileContent && (
+          <EphemeralFilePreview
+            path={previewPath}
+            content={previewContent}
+            isLoading={previewLoading}
+            error={previewError}
+            onClose={closePreview}
+            onDownload={onFileClick}
+            className="flex-1 min-w-0"
+          />
+        )}
       </div>
     </div>
   );
@@ -85,7 +168,10 @@ interface TreeNodeItemProps {
   node: TreeNode;
   depth: number;
   index: number;
-  onFileClick?: (path: string) => void;
+  previewPath: string | null;
+  canPreview: boolean;
+  onFileActivate?: (path: string) => void;
+  onFileDownload?: (path: string) => void;
   onFileDelete?: (path: string) => void;
   isDownloading?: boolean;
   downloadingPath?: string;
@@ -97,7 +183,10 @@ function TreeNodeItem({
   node,
   depth,
   index,
-  onFileClick,
+  previewPath,
+  canPreview,
+  onFileActivate,
+  onFileDownload,
   onFileDelete,
   isDownloading,
   downloadingPath,
@@ -106,12 +195,24 @@ function TreeNodeItem({
 }: TreeNodeItemProps) {
   const isCurrentlyDownloading = isDownloading && downloadingPath === node.path;
   const isCurrentlyDeleting = isDeleting && deletingPath === node.path;
+  const isPreviewable = canPreview && isPreviewableEphemeralFile(node.path);
+  const isPreviewOpen = previewPath === node.path;
 
   const handleClick = useCallback(() => {
-    if (!node.isDirectory && onFileClick) {
-      onFileClick(node.path);
+    if (!node.isDirectory && onFileActivate) {
+      onFileActivate(node.path);
     }
-  }, [node.isDirectory, node.path, onFileClick]);
+  }, [node.isDirectory, node.path, onFileActivate]);
+
+  const handleDownload = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!node.isDirectory && onFileDownload) {
+        onFileDownload(node.path);
+      }
+    },
+    [node.isDirectory, node.path, onFileDownload],
+  );
 
   const handleDelete = useCallback(
     (e: React.MouseEvent) => {
@@ -134,7 +235,8 @@ function TreeNodeItem({
           "flex items-center gap-1.5 py-1 px-1 rounded text-xs",
           !node.isDirectory && "hover:bg-muted cursor-pointer group",
           !node.isDirectory && isCurrentlyDownloading && "bg-blue-500/10",
-          !node.isDirectory && isCurrentlyDeleting && "bg-red-500/10"
+          !node.isDirectory && isCurrentlyDeleting && "bg-red-500/10",
+          isPreviewOpen && "bg-primary/10 ring-1 ring-primary/20",
         )}
         style={{ paddingLeft: `${depth * 12 + 4}px` }}
         onClick={handleClick}
@@ -167,7 +269,21 @@ function TreeNodeItem({
         </span>
         {!node.isDirectory && !isCurrentlyDownloading && !isCurrentlyDeleting && (
           <>
-            <Download className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+            {isPreviewable ? (
+              <Eye className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+            ) : (
+              <Download className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+            )}
+            {onFileDownload && isPreviewable && (
+              <button
+                type="button"
+                onClick={handleDownload}
+                className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground transition-all shrink-0"
+                title="Download file"
+              >
+                <Download className="h-3 w-3" />
+              </button>
+            )}
             {onFileDelete && (
               <button
                 onClick={handleDelete}
@@ -190,7 +306,10 @@ function TreeNodeItem({
               node={child}
               depth={depth + 1}
               index={idx}
-              onFileClick={onFileClick}
+              previewPath={previewPath}
+              canPreview={canPreview}
+              onFileActivate={onFileActivate}
+              onFileDownload={onFileDownload}
               onFileDelete={onFileDelete}
               isDownloading={isDownloading}
               downloadingPath={downloadingPath}

--- a/ui/src/components/workflows/WorkflowRunTimeline.tsx
+++ b/ui/src/components/workflows/WorkflowRunTimeline.tsx
@@ -21,6 +21,8 @@ interface WorkflowRunTimelineProps {
   workflowFiles?: string[];
   /** Callback for file download */
   onFileDownload?: (path: string) => void;
+  /** Fetch file text for inline preview */
+  getFileContent?: (path: string) => Promise<string | null>;
   onResume: (stepIndex: number, resumeData: string) => Promise<void>;
 }
 
@@ -29,6 +31,7 @@ export function WorkflowRunTimeline({
   stepEvents,
   workflowFiles,
   onFileDownload,
+  getFileContent,
   onResume,
 }: WorkflowRunTimelineProps) {
 
@@ -142,6 +145,7 @@ export function WorkflowRunTimeline({
           {workflowFiles.length > 0 ? (
             <FileTree
               files={workflowFiles}
+              getFileContent={getFileContent}
               onFileClick={onFileDownload}
             />
           ) : (

--- a/ui/src/lib/__tests__/ephemeral-files.test.ts
+++ b/ui/src/lib/__tests__/ephemeral-files.test.ts
@@ -1,0 +1,11 @@
+import { isPreviewableEphemeralFile,PREVIEWABLE_FILE_EXTENSIONS } from "../ephemeral-files";
+
+describe("ephemeral-files", () => {
+  it("marks .md and .txt as previewable", () => {
+    expect(PREVIEWABLE_FILE_EXTENSIONS).toEqual([".md", ".txt"]);
+    expect(isPreviewableEphemeralFile("workflow-state/meraki-docs-networking.md")).toBe(true);
+    expect(isPreviewableEphemeralFile("output.txt")).toBe(true);
+    expect(isPreviewableEphemeralFile("data.json")).toBe(false);
+    expect(isPreviewableEphemeralFile("archive.tar.gz")).toBe(false);
+  });
+});

--- a/ui/src/lib/ephemeral-files.ts
+++ b/ui/src/lib/ephemeral-files.ts
@@ -1,0 +1,19 @@
+/** Extensions that can be previewed inline instead of forcing a download. */
+export const PREVIEWABLE_FILE_EXTENSIONS = [".md", ".txt"] as const;
+
+export function isPreviewableEphemeralFile(path: string): boolean {
+  const lower = path.toLowerCase();
+  return PREVIEWABLE_FILE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+export async function fetchEphemeralFileContent(
+  fsNamespace: string,
+  path: string,
+): Promise<string | null> {
+  const response = await fetch(
+    `/api/files/content?fs_namespace=${encodeURIComponent(fsNamespace)}&path=${encodeURIComponent(path)}`,
+  );
+  if (!response.ok) return null;
+  const data = (await response.json()) as { content?: unknown };
+  return typeof data.content === "string" ? data.content : "";
+}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.11.dev4"
+version = "0.5.11.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Adds inline preview for ephemeral agent/workflow files (`.md`, `.txt`) so users can read generated artifacts without downloading them first.

### Motivation

Dynamic agents and workflows write short-lived files to an in-memory filesystem (`fs_namespace`). Before this change, every file click triggered a download — awkward for markdown reports, logs, and notes the agent produced during a run.

### What's new

| Layer | Change |
|-------|--------|
| **`ephemeral-files.ts`** | Shared helpers: `isPreviewableEphemeralFile()`, `fetchEphemeralFileContent()` via existing `/api/files/content` BFF |
| **`EphemeralFilePreview.tsx`** | Inline panel + fullscreen dialog; markdown rendered with `MarkdownRenderer`, plain text in monospace; download/close controls |
| **`FileTree.tsx`** | Split-pane layout when preview is open; eye icon for previewable files; toggle preview on second click |
| **Dynamic agent surfaces** | `DynamicAgentContext` (editor sidebar) and `DynamicAgentChatPanel` → `DynamicAgentTimeline` pass `getFileContent` into `FileTree` |
| **Workflow surfaces** | `workflows/run/[id]/page.tsx` → `WorkflowRunTimeline` pass `getFileContent` for run artifacts |

### Preview behavior

- **Previewable:** `.md` (rendered markdown), `.txt` (plain text)
- **Not previewable:** everything else — still downloads via existing `onFileClick` / `onFileDownload` handlers
- **Namespace:** `[agentId, conversationId, "filesystem"]` for agent runs; `[workflow_config_id, runId, "filesystem"]` for workflow runs
- **UX:** inline preview beside the tree; maximize opens a fullscreen dialog; ephemeral disclaimer retained

### Files changed (9 UI + version bump)

```
ui/src/lib/ephemeral-files.ts                          (new)
ui/src/lib/__tests__/ephemeral-files.test.ts           (new)
ui/src/components/dynamic-agents/EphemeralFilePreview.tsx (new)
ui/src/components/dynamic-agents/FileTree.tsx
ui/src/components/dynamic-agents/DynamicAgentContext.tsx
ui/src/components/chat/DynamicAgentChatPanel.tsx
ui/src/components/chat/DynamicAgentTimeline.tsx
ui/src/components/workflows/WorkflowRunTimeline.tsx
ui/src/app/(app)/workflows/run/[id]/page.tsx
```

No new API routes — reuses `/api/files/content`.

## Test plan

- [ ] `cd ui && npm test -- --testPathPattern=ephemeral-files` passes
- [ ] **Dynamic agent chat:** run an agent that writes a `.md` file → open Files section → click file → inline preview renders; maximize opens dialog; download still works
- [ ] **Dynamic agent editor:** same preview from context sidebar `FileTree`
- [ ] **Workflow run:** open a run with ephemeral files → preview from timeline file panel
- [ ] **Non-previewable:** `.json` / binary still downloads on click (no preview panel)

## Related

Split from [#1819](https://github.com/cnoe-io/ai-platform-engineering/pull/1819) (MCP OpenFGA work) for independent review.

Made with [Cursor](https://cursor.com)
