### PR TITLE
fix(docs): repair MDX breakage in FGA module-api contract page

### DIFF
--- a/docs/docs/specs/2026-06-04-fga-projected-team-shares/contracts/module-api.md
+++ b/docs/docs/specs/2026-06-04-fga-projected-team-shares/contracts/module-api.md
@@ -47,9 +47,11 @@ export async function readSharedTeamSlugsFromOpenFga(
 - If `!isOpenFgaReconciliationEnabled()` → `[]`.
 - Paginate FGA tuples for the resource object:
 
-  ```ts
-  readOpenFgaTuples({ tuple: { object: `${objectType}:${objectId}` } })
-  ```
+```ts
+readOpenFgaTuples({
+  tuple: { object: objectType + ':' + objectId },
+})
+```
 
 - Collect slugs via `extractTeamSlugsFromTuples`.
 - Sort/dedupe stable for tests.
@@ -95,24 +97,24 @@ export async function reconcileProjectedTeamShares(
 2. If `visibility` present:
    - `next !== "team"` → `nextTeamRefs` treated as `[]` for team shares.
    - `sharedWithOrg` / `previousSharedWithOrg` from `global` visibility (same as `reconcileSkillTeamShares` today).
-3. Call `reconcileShareableResource` with the descriptor fields:
-
-   ```ts
-   reconcileShareableResource({
-     objectType,
-     objectId,
-     creatorSubject: ownerSubject,
-     ownerSubject,
-     ownerTeamSlug,
-     previousOwnerTeamSlug,
-     nextSharedTeamSlugs,
-     previousSharedTeamSlugs,
-     memberRelations: descriptor.memberRelations,
-     sharedWithOrg,
-     previousSharedWithOrg,
-   })
-   ```
+3. Call `reconcileShareableResource` with the descriptor fields (example below).
 4. Never persist to Mongo.
+
+```ts
+reconcileShareableResource({
+  objectType: descriptor.objectType,
+  objectId,
+  creatorSubject: ownerSubject,
+  ownerSubject,
+  ownerTeamSlug,
+  previousOwnerTeamSlug,
+  nextSharedTeamSlugs,
+  previousSharedTeamSlugs,
+  memberRelations: descriptor.memberRelations,
+  sharedWithOrg,
+  previousSharedWithOrg,
+})
+```
 
 ## P4. Mongo hygiene
 

--- a/docs/scripts/generate-versioned-docs.js
+++ b/docs/scripts/generate-versioned-docs.js
@@ -123,11 +123,86 @@ function sanitizeVersionLinks(versionDir, tag) {
           path.dirname(relWithinVersion).split(path.sep).join('/')
         );
         if (sanitizeFileLinks(abs, fileDirRepoRel, tag)) count += 1;
+        if (sanitizeMdxBreakingPatterns(abs)) count += 1;
       }
     }
   };
   walk(versionDir);
   return count;
+}
+
+// ---------------------------------------------------------------------------
+// MDX sanitizer
+//
+// Frozen tag snapshots can contain markdown that compiled fine as plain MD but
+// breaks under MDX (e.g. nested backticks leaking `{objectType}` expressions).
+// Patch known offenders in-place after the version tree is copied.
+// ---------------------------------------------------------------------------
+
+const MDX_MODULE_API_P2_BLOCK = `- Paginate FGA tuples for the resource object:
+
+\`\`\`ts
+readOpenFgaTuples({
+  tuple: { object: objectType + ':' + objectId },
+})
+\`\`\`
+
+- Collect slugs via \`extractTeamSlugsFromTuples\`.`;
+
+const MDX_MODULE_API_P3_BLOCK = `3. Call \`reconcileShareableResource\` with the descriptor fields (example below).
+4. Never persist to Mongo.
+
+\`\`\`ts
+reconcileShareableResource({
+  objectType: descriptor.objectType,
+  objectId,
+  creatorSubject: ownerSubject,
+  ownerSubject,
+  ownerTeamSlug,
+  previousOwnerTeamSlug,
+  nextSharedTeamSlugs,
+  previousSharedTeamSlugs,
+  memberRelations: descriptor.memberRelations,
+  sharedWithOrg,
+  previousSharedWithOrg,
+})
+\`\`\``;
+
+function sanitizeMdxBreakingPatterns(absFile) {
+  if (!absFile.endsWith('specs/2026-06-04-fga-projected-team-shares/contracts/module-api.md')) {
+    return false;
+  }
+
+  let content = fs.readFileSync(absFile, 'utf8');
+  const original = content;
+
+  // 0.5.9: nested backticks in a list item leak \`{objectType}\` into MDX.
+  content = content.replace(
+    /- Paginate `readOpenFgaTuples\(\{ tuple: \{ object: `\$\{objectType\}:\$\{objectId\}` \} \}\)`\.\r?\n- Collect slugs via `extractTeamSlugsFromTuples`\./,
+    MDX_MODULE_API_P2_BLOCK
+  );
+
+  // 0.5.10+: indented fenced block inside a list item is not always treated as code.
+  content = content.replace(
+    /- Paginate FGA tuples for the resource object:\r?\n\r?\n  ```ts\r?\n  readOpenFgaTuples\(\{ tuple: \{ object: `\$\{objectType\}:\$\{objectId\}` \} \}\)\r?\n  ```\r?\n\r?\n- Collect slugs via `extractTeamSlugsFromTuples`\./,
+    MDX_MODULE_API_P2_BLOCK
+  );
+
+  // 0.5.9: long inline reconcile call with \`{ objectType,\` shorthand.
+  content = content.replace(
+    /3\. Call `reconcileShareableResource\(\{ objectType, objectId, creatorSubject: ownerSubject, ownerSubject, ownerTeamSlug, previousOwnerTeamSlug, nextSharedTeamSlugs, previousSharedTeamSlugs, memberRelations: descriptor\.memberRelations, sharedWithOrg, previousSharedWithOrg \}\)`\.\r?\n4\. Never persist to Mongo\./,
+    MDX_MODULE_API_P3_BLOCK
+  );
+
+  // 0.5.10+: indented reconcile example inside numbered list.
+  content = content.replace(
+    /3\. Call `reconcileShareableResource` with the descriptor fields:\r?\n\r?\n   ```ts\r?\n   reconcileShareableResource\(\{\r?\n     objectType,\r?\n     objectId,\r?\n     creatorSubject: ownerSubject,\r?\n     ownerSubject,\r?\n     ownerTeamSlug,\r?\n     previousOwnerTeamSlug,\r?\n     nextSharedTeamSlugs,\r?\n     previousSharedTeamSlugs,\r?\n     memberRelations: descriptor\.memberRelations,\r?\n     sharedWithOrg,\r?\n     previousSharedWithOrg,\r?\n   \}\)\r?\n   ```\r?\n4\. Never persist to Mongo\./,
+    MDX_MODULE_API_P3_BLOCK
+  );
+
+  if (content === original) return false;
+  fs.writeFileSync(absFile, content);
+  return true;
 }
 
 function compareVersionsDesc(a, b) {


### PR DESCRIPTION
## Summary

- Fixes the failed [Docs Publish Version workflow](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/27513490547/job/81317819207) for `0.5.12`, where Docusaurus SSG crashed with `ReferenceError: objectType is not defined` on `/docs/0.5.9/specs/2026-06-04-fga-projected-team-shares/contracts/module-api`.
- Rewrites `module-api.md` examples to use top-level fenced code blocks and string concatenation instead of template literals / nested backticks that MDX interprets as expressions.
- Adds an MDX sanitizer in `generate-versioned-docs.js` so frozen tag snapshots (0.5.9, 0.5.10, etc.) are patched at build time without retagging old releases.

## Test plan

- [x] `node docs/scripts/generate-versioned-docs.js`
- [x] `cd docs && NODE_OPTIONS="--max-old-space-size=8192" npm run build`
- [ ] Merge PR, then re-run the [Docs] Publish Version workflow for `0.5.12` (or push tag) to confirm CI passes


Made with [Cursor](https://cursor.com)