### PR TITLE
fix(rbac): repair MCP OpenFGA drift and local file ingestion

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/server/pyproject.toml
+++ b/ai_platform_engineering/knowledge_bases/rag/server/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     # 098 RBAC additions
     "python-jose[cryptography]==3.5.0",
     "common",
-    "pypdf>=6.13.2",
+    "pypdf==6.13.2",
 ]
 
 [project.scripts]

--- a/ai_platform_engineering/knowledge_bases/rag/server/pyproject.toml
+++ b/ai_platform_engineering/knowledge_bases/rag/server/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     # 098 RBAC additions
     "python-jose[cryptography]==3.5.0",
     "common",
+    "pypdf>=6.13.2",
 ]
 
 [project.scripts]

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -114,6 +114,9 @@ mcp_auth_enabled = os.getenv("MCP_AUTH_ENABLED", "true").lower() in ("true", "1"
 sleep_on_init_failure = int(os.getenv("SLEEP_ON_INIT_FAILURE_SECONDS", 0))  # seconds to sleep on init failure before shutdown
 max_documents_per_ingest = int(os.getenv("MAX_DOCUMENTS_PER_INGEST", 1000))  # max number of documents to ingest per ingestion request
 max_local_file_upload_bytes = int(os.getenv("MAX_LOCAL_FILE_UPLOAD_BYTES", str(10 * 1024 * 1024)))
+max_local_file_total_upload_bytes = int(os.getenv("MAX_LOCAL_FILE_TOTAL_UPLOAD_BYTES", str(25 * 1024 * 1024)))
+max_local_file_pdf_pages = int(os.getenv("MAX_LOCAL_FILE_PDF_PAGES", 100))
+max_local_file_extracted_chars = int(os.getenv("MAX_LOCAL_FILE_EXTRACTED_CHARS", str(2 * 1024 * 1024)))
 max_results_per_query = int(os.getenv("MAX_RESULTS_PER_QUERY", 100))  # max results per query (matches QueryRequest.limit le=100)
 confluence_url = os.getenv("CONFLUENCE_URL")  # optional - base URL for Confluence instance (e.g., https://company.atlassian.net/wiki)
 
@@ -1186,6 +1189,17 @@ LOCAL_FILE_TEXT_MIME_TYPES = {
   "text/x-markdown",
   "application/markdown",
 }
+LOCAL_FILE_PDF_MIME_TYPES = {"application/pdf"}
+LOCAL_FILE_MARKDOWN_EXTENSIONS = {".md", ".markdown"}
+LOCAL_FILE_TEXT_EXTENSIONS = {".txt", ".text"}
+LOCAL_FILE_PDF_EXTENSIONS = {".pdf"}
+# assisted-by Codex Codex-sonnet-4-6
+LOCAL_FILE_FORBIDDEN_TEXT_PREFIXES = (
+  "<!doctype html",
+  "<html",
+  "<script",
+  "<?xml",
+)
 
 
 def _safe_upload_filename(filename: str | None) -> str:
@@ -1193,11 +1207,16 @@ def _safe_upload_filename(filename: str | None) -> str:
   return candidate or "uploaded-file"
 
 
-def _local_file_document_type(filename: str, content_type: str | None) -> str:
+def _local_file_extension(filename: str) -> str:
   lower = filename.lower()
-  if lower.endswith(".pdf") or content_type == "application/pdf":
+  return f".{lower.rsplit('.', 1)[1]}" if "." in lower else ""
+
+
+def _local_file_document_type(filename: str, content_type: str | None) -> str:
+  extension = _local_file_extension(filename)
+  if extension in LOCAL_FILE_PDF_EXTENSIONS or content_type == "application/pdf":
     return "pdf"
-  if lower.endswith((".md", ".markdown")) or content_type in {"text/markdown", "text/x-markdown", "application/markdown"}:
+  if extension in LOCAL_FILE_MARKDOWN_EXTENSIONS or content_type in {"text/markdown", "text/x-markdown", "application/markdown"}:
     return "markdown"
   return "text"
 
@@ -1209,69 +1228,156 @@ def _local_file_datasource_id(filename: str, content: bytes) -> str:
   return f"src_file_{clean[:80] or 'upload'}_{digest}"
 
 
+def _local_files_datasource_id(files: list[tuple[str, bytes]]) -> str:
+  digest = hashlib.sha256()
+  for filename, content in files:
+    digest.update(filename.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(hashlib.sha256(content).hexdigest().encode("ascii"))
+    digest.update(b"\0")
+  first_filename = files[0][0] if files else "upload"
+  stem = first_filename.rsplit(".", 1)[0] if "." in first_filename else first_filename
+  clean = "".join(char.lower() if char.isalnum() else "_" for char in stem).strip("_")
+  if len(files) == 1:
+    return f"src_file_{clean[:80] or 'upload'}_{digest.hexdigest()[:12]}"
+  return f"src_file_{clean[:64] or 'upload'}_{len(files)}_files_{digest.hexdigest()[:12]}"
+
+
 def _extract_local_file_text(filename: str, content_type: str | None, content: bytes) -> tuple[str, str]:
   document_type = _local_file_document_type(filename, content_type)
   if document_type in {"markdown", "text"}:
-    return content.decode("utf-8-sig", errors="replace"), document_type
+    text = content.decode("utf-8-sig", errors="replace")
+    if len(text) > max_local_file_extracted_chars:
+      raise HTTPException(status_code=413, detail=f"Extracted text exceeds the {max_local_file_extracted_chars} character limit")
+    return text, document_type
 
   if document_type == "pdf":
     try:
       reader = PdfReader(BytesIO(content))
+      if reader.is_encrypted:
+        raise HTTPException(status_code=400, detail="Encrypted PDFs are not supported")
+      if len(reader.pages) > max_local_file_pdf_pages:
+        raise HTTPException(status_code=413, detail=f"PDF exceeds the {max_local_file_pdf_pages} page limit")
       text = "\n\n".join((page.extract_text() or "").strip() for page in reader.pages).strip()
+    except HTTPException:
+      raise
     except Exception as exc:
       raise HTTPException(status_code=400, detail=f"Could not extract text from PDF: {type(exc).__name__}") from exc
     if not text:
       raise HTTPException(status_code=400, detail="PDF did not contain extractable text")
+    if len(text) > max_local_file_extracted_chars:
+      raise HTTPException(status_code=413, detail=f"Extracted text exceeds the {max_local_file_extracted_chars} character limit")
     return text, document_type
 
   raise HTTPException(status_code=415, detail="Unsupported file type")
 
 
+def _content_looks_like_text_document(content: bytes) -> bool:
+  sample = content[:4096]
+  if b"\x00" in sample:
+    return False
+  stripped = sample.lstrip().lower()
+  for prefix in LOCAL_FILE_FORBIDDEN_TEXT_PREFIXES:
+    if stripped.startswith(prefix.encode()):
+      return False
+  return True
+
+
+def _validate_local_file_declared_type(filename: str, content_type: str) -> str:
+  extension = _local_file_extension(filename)
+  if extension not in LOCAL_FILE_ALLOWED_EXTENSIONS:
+    raise HTTPException(status_code=415, detail="Only Markdown, PDF, and plain text uploads are supported")
+
+  if extension in LOCAL_FILE_PDF_EXTENSIONS:
+    if content_type and content_type not in LOCAL_FILE_PDF_MIME_TYPES:
+      raise HTTPException(status_code=415, detail="PDF uploads must use application/pdf")
+    return "pdf"
+
+  if extension in LOCAL_FILE_MARKDOWN_EXTENSIONS:
+    if content_type and content_type not in LOCAL_FILE_TEXT_MIME_TYPES:
+      raise HTTPException(status_code=415, detail="Markdown uploads must use a text or markdown content type")
+    return "markdown"
+
+  if content_type and content_type not in LOCAL_FILE_TEXT_MIME_TYPES:
+    raise HTTPException(status_code=415, detail="Text uploads must use a text content type")
+  return "text"
+
+
 def _validate_local_file_upload(file: UploadFile, content: bytes) -> str:
   filename = _safe_upload_filename(file.filename)
-  lower = filename.lower()
-  extension_ok = any(lower.endswith(ext) for ext in LOCAL_FILE_ALLOWED_EXTENSIONS)
   content_type = (file.content_type or "").lower()
-  mime_ok = content_type in LOCAL_FILE_TEXT_MIME_TYPES or content_type == "application/pdf"
-  if not extension_ok and not mime_ok:
-    raise HTTPException(status_code=415, detail="Only Markdown, PDF, and plain text uploads are supported")
   if not content:
     raise HTTPException(status_code=400, detail="Uploaded file is empty")
   if len(content) > max_local_file_upload_bytes:
     raise HTTPException(status_code=413, detail=f"File exceeds the {max_local_file_upload_bytes} byte upload limit")
+  document_type = _validate_local_file_declared_type(filename, content_type)
+  if document_type == "pdf":
+    if not content.startswith(b"%PDF-"):
+      raise HTTPException(status_code=415, detail="PDF upload content did not match the expected file signature")
+  elif not _content_looks_like_text_document(content):
+    raise HTTPException(status_code=415, detail="Text upload content did not match the expected safe text format")
   return filename
+
+
+def _validate_local_file_batch(files: list[tuple[str, bytes]]) -> None:
+  if not files:
+    raise HTTPException(status_code=400, detail="At least one file is required")
+  if len(files) > max_documents_per_ingest:
+    raise HTTPException(status_code=413, detail=f"Upload contains more than the {max_documents_per_ingest} file limit")
+  total_size = sum(len(content) for _, content in files)
+  if total_size > max_local_file_total_upload_bytes:
+    raise HTTPException(status_code=413, detail=f"Upload exceeds the {max_local_file_total_upload_bytes} byte batch limit")
 
 
 @app.post("/v1/ingest/local-file", status_code=status.HTTP_202_ACCEPTED)
 async def ingest_local_file(
   request: Request,
-  file: UploadFile = File(...),
+  files: List[UploadFile] = File(..., alias="file"),
   description: str = Form(""),
   owner_team_slug: Optional[str] = Form(None),
   chunk_size: int = Form(10000),
   chunk_overlap: int = Form(2000),
   user: UserContext = Depends(require_authenticated_user),
 ):
-  """Ingest a local Markdown, PDF, or text file as a new data source."""
+  """Ingest one or more local Markdown, PDF, or text files as a new data source."""
   if not metadata_storage or not jobmanager or not ingestor:
     raise HTTPException(status_code=500, detail="Server not initialized")
 
-  content = await file.read()
-  filename = _validate_local_file_upload(file, content)
-  text, document_type = _extract_local_file_text(filename, file.content_type, content)
-  datasource_id = _local_file_datasource_id(filename, content)
+  uploads: list[tuple[UploadFile, str, bytes, str, str]] = []
+  for upload_file in files:
+    content = await upload_file.read()
+    try:
+      filename = _validate_local_file_upload(upload_file, content)
+      text, document_type = _extract_local_file_text(filename, upload_file.content_type, content)
+    except HTTPException as exc:
+      safe_filename = _safe_upload_filename(upload_file.filename)
+      logger.warning(
+        "local_file_upload rejected filename=%s content_type=%s bytes=%d status=%d detail=%s user=%s",
+        safe_filename,
+        upload_file.content_type,
+        len(content),
+        exc.status_code,
+        exc.detail,
+        user.email,
+      )
+      raise
+    uploads.append((upload_file, filename, content, text, document_type))
+
+  _validate_local_file_batch([(filename, content) for _, filename, content, _, _ in uploads])
+  total_bytes = sum(len(content) for _, _, content, _, _ in uploads)
+  datasource_id = _local_files_datasource_id([(filename, content) for _, filename, content, _, _ in uploads])
   await authorize_datasource_create(request, user, datasource_id, owner_team_slug)
 
   existing_datasource = await metadata_storage.get_datasource_info(datasource_id)
   if existing_datasource:
-    raise HTTPException(status_code=400, detail="File already ingested, please delete existing datasource before re-ingesting")
+    raise HTTPException(status_code=400, detail="File set already ingested, please delete existing datasource before re-ingesting")
 
   job_id = str(uuid.uuid4())
   success = await jobmanager.upsert_job(
     job_id,
     status=JobStatus.IN_PROGRESS,
-    message="Ingesting uploaded file...",
-    total=1,
+    message="Ingesting uploaded file..." if len(uploads) == 1 else f"Ingesting {len(uploads)} uploaded files...",
+    total=len(uploads),
     datasource_id=datasource_id,
   )
   if not success:
@@ -1280,59 +1386,83 @@ async def ingest_local_file(
   bounded_chunk_size = max(100, min(chunk_size, 100000))
   bounded_chunk_overlap = max(0, min(chunk_overlap, 10000, bounded_chunk_size - 1))
   now = int(time.time())
+  first_filename = uploads[0][1]
+  datasource_name = first_filename if len(uploads) == 1 else f"{first_filename} + {len(uploads) - 1} files"
+  file_metadata = [
+    {
+      "filename": filename,
+      "content_type": upload_file.content_type,
+      "document_type": document_type,
+      "byte_size": len(content),
+    }
+    for upload_file, filename, content, _, document_type in uploads
+  ]
   datasource_info = DataSourceInfo(
     datasource_id=datasource_id,
-    name=filename,
+    name=datasource_name,
     ingestor_id=LOCAL_FILE_INGESTOR_ID,
-    description=description or f"Uploaded file {filename}",
+    description=description or (f"Uploaded file {first_filename}" if len(uploads) == 1 else f"Uploaded {len(uploads)} files"),
     source_type="local_file",
     last_updated=now,
     default_chunk_size=bounded_chunk_size,
     default_chunk_overlap=bounded_chunk_overlap,
     metadata={
-      "filename": filename,
-      "content_type": file.content_type,
-      "document_type": document_type,
-      "byte_size": len(content),
+      "filename": first_filename,
+      "file_count": len(uploads),
+      "total_byte_size": total_bytes,
+      "files": file_metadata,
     },
   )
 
   await metadata_storage.store_datasource_info(datasource_info)
   await write_datasource_ownership(datasource_id, owner_team_slug, user)
 
-  document_metadata = {
-    "document_id": f"{datasource_id}__{hashlib.sha256(filename.encode()).hexdigest()[:8]}",
-    "datasource_id": datasource_id,
-    "ingestor_id": LOCAL_FILE_INGESTOR_ID,
-    "title": filename,
-    "description": description or "",
-    "is_structured_entity": False,
-    "document_type": document_type,
-    "document_ingested_at": now,
-    "fresh_until": get_fresh_until(datasource_info.reload_interval),
-    "metadata": {
-      "source": filename,
-      "filename": filename,
-      "content_type": file.content_type,
-      "byte_size": len(content),
-    },
-  }
+  fresh_until = get_fresh_until(datasource_info.reload_interval)
+  documents = []
+  for upload_file, filename, content, text, document_type in uploads:
+    document_metadata = {
+      "document_id": f"{datasource_id}__{hashlib.sha256(filename.encode()).hexdigest()[:8]}",
+      "datasource_id": datasource_id,
+      "ingestor_id": LOCAL_FILE_INGESTOR_ID,
+      "title": filename,
+      "description": description or "",
+      "is_structured_entity": False,
+      "document_type": document_type,
+      "document_ingested_at": now,
+      "fresh_until": fresh_until,
+      "metadata": {
+        "source": filename,
+        "filename": filename,
+        "content_type": upload_file.content_type,
+        "byte_size": len(content),
+      },
+    }
+    documents.append(Document(page_content=text, metadata=document_metadata))
+    logger.info(
+      "local_file_upload accepted filename=%s content_type=%s bytes=%d document_type=%s datasource_id=%s user=%s",
+      filename,
+      upload_file.content_type,
+      len(content),
+      document_type,
+      datasource_id,
+      user.email,
+    )
 
   try:
     await ingestor.ingest_documents(
       ingestor_id=LOCAL_FILE_INGESTOR_ID,
       datasource_id=datasource_id,
       job_id=job_id,
-      documents=[Document(page_content=text, metadata=document_metadata)],
-      fresh_until=document_metadata["fresh_until"],
+      documents=documents,
+      fresh_until=fresh_until,
       chunk_overlap=bounded_chunk_overlap,
       chunk_size=bounded_chunk_size,
     )
     await jobmanager.upsert_job(
       job_id,
       status=JobStatus.COMPLETED,
-      message="Uploaded file ingested successfully",
-      total=1,
+      message="Uploaded file ingested successfully" if len(uploads) == 1 else f"Uploaded {len(uploads)} files ingested successfully",
+      total=len(uploads),
       datasource_id=datasource_id,
     )
   except Exception as exc:
@@ -1348,7 +1478,7 @@ async def ingest_local_file(
   return {
     "datasource_id": datasource_id,
     "job_id": job_id,
-    "message": "Local file ingested successfully",
+    "message": "Local file ingested successfully" if len(uploads) == 1 else "Local files ingested successfully",
   }
 
 

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -1,11 +1,13 @@
 from contextlib import asynccontextmanager
 import asyncio
+from io import BytesIO
+import hashlib
 import re
 import traceback
 import uuid
 from urllib.parse import urlparse
 from common import utils
-from fastapi import FastAPI, status, HTTPException, Query, Depends, Response
+from fastapi import FastAPI, status, HTTPException, Query, Depends, Response, UploadFile, File, Form
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from fastmcp import FastMCP
@@ -77,6 +79,7 @@ from server.query_service import VectorDBQueryService
 from langchain_core.globals import set_verbose as set_langchain_verbose
 from server.ingestion import DocumentProcessor
 from common.utils import get_fresh_until, sanitize_url
+from pypdf import PdfReader
 
 mcp_user_context_var: ContextVar[Optional[UserContext]] = ContextVar("mcp_user_context", default=None)
 
@@ -110,6 +113,7 @@ mcp_enabled = os.getenv("ENABLE_MCP", "true").lower() in ("true", "1", "yes")
 mcp_auth_enabled = os.getenv("MCP_AUTH_ENABLED", "true").lower() in ("true", "1", "yes")
 sleep_on_init_failure = int(os.getenv("SLEEP_ON_INIT_FAILURE_SECONDS", 0))  # seconds to sleep on init failure before shutdown
 max_documents_per_ingest = int(os.getenv("MAX_DOCUMENTS_PER_INGEST", 1000))  # max number of documents to ingest per ingestion request
+max_local_file_upload_bytes = int(os.getenv("MAX_LOCAL_FILE_UPLOAD_BYTES", str(10 * 1024 * 1024)))
 max_results_per_query = int(os.getenv("MAX_RESULTS_PER_QUERY", 100))  # max results per query (matches QueryRequest.limit le=100)
 confluence_url = os.getenv("CONFLUENCE_URL")  # optional - base URL for Confluence instance (e.g., https://company.atlassian.net/wiki)
 
@@ -1172,6 +1176,180 @@ async def query_documents(
 # ============================================================================
 # Ingestion Endpoints
 # ============================================================================
+
+
+LOCAL_FILE_INGESTOR_ID = "local-file-upload"
+LOCAL_FILE_ALLOWED_EXTENSIONS = {".md", ".markdown", ".txt", ".text", ".pdf"}
+LOCAL_FILE_TEXT_MIME_TYPES = {
+  "text/plain",
+  "text/markdown",
+  "text/x-markdown",
+  "application/markdown",
+}
+
+
+def _safe_upload_filename(filename: str | None) -> str:
+  candidate = (filename or "uploaded-file").strip().split("/")[-1].split("\\")[-1]
+  return candidate or "uploaded-file"
+
+
+def _local_file_document_type(filename: str, content_type: str | None) -> str:
+  lower = filename.lower()
+  if lower.endswith(".pdf") or content_type == "application/pdf":
+    return "pdf"
+  if lower.endswith((".md", ".markdown")) or content_type in {"text/markdown", "text/x-markdown", "application/markdown"}:
+    return "markdown"
+  return "text"
+
+
+def _local_file_datasource_id(filename: str, content: bytes) -> str:
+  digest = hashlib.sha256(content).hexdigest()[:12]
+  stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+  clean = "".join(char.lower() if char.isalnum() else "_" for char in stem).strip("_")
+  return f"src_file_{clean[:80] or 'upload'}_{digest}"
+
+
+def _extract_local_file_text(filename: str, content_type: str | None, content: bytes) -> tuple[str, str]:
+  document_type = _local_file_document_type(filename, content_type)
+  if document_type in {"markdown", "text"}:
+    return content.decode("utf-8-sig", errors="replace"), document_type
+
+  if document_type == "pdf":
+    try:
+      reader = PdfReader(BytesIO(content))
+      text = "\n\n".join((page.extract_text() or "").strip() for page in reader.pages).strip()
+    except Exception as exc:
+      raise HTTPException(status_code=400, detail=f"Could not extract text from PDF: {type(exc).__name__}") from exc
+    if not text:
+      raise HTTPException(status_code=400, detail="PDF did not contain extractable text")
+    return text, document_type
+
+  raise HTTPException(status_code=415, detail="Unsupported file type")
+
+
+def _validate_local_file_upload(file: UploadFile, content: bytes) -> str:
+  filename = _safe_upload_filename(file.filename)
+  lower = filename.lower()
+  extension_ok = any(lower.endswith(ext) for ext in LOCAL_FILE_ALLOWED_EXTENSIONS)
+  content_type = (file.content_type or "").lower()
+  mime_ok = content_type in LOCAL_FILE_TEXT_MIME_TYPES or content_type == "application/pdf"
+  if not extension_ok and not mime_ok:
+    raise HTTPException(status_code=415, detail="Only Markdown, PDF, and plain text uploads are supported")
+  if not content:
+    raise HTTPException(status_code=400, detail="Uploaded file is empty")
+  if len(content) > max_local_file_upload_bytes:
+    raise HTTPException(status_code=413, detail=f"File exceeds the {max_local_file_upload_bytes} byte upload limit")
+  return filename
+
+
+@app.post("/v1/ingest/local-file", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_local_file(
+  request: Request,
+  file: UploadFile = File(...),
+  description: str = Form(""),
+  owner_team_slug: Optional[str] = Form(None),
+  chunk_size: int = Form(10000),
+  chunk_overlap: int = Form(2000),
+  user: UserContext = Depends(require_authenticated_user),
+):
+  """Ingest a local Markdown, PDF, or text file as a new data source."""
+  if not metadata_storage or not jobmanager or not ingestor:
+    raise HTTPException(status_code=500, detail="Server not initialized")
+
+  content = await file.read()
+  filename = _validate_local_file_upload(file, content)
+  text, document_type = _extract_local_file_text(filename, file.content_type, content)
+  datasource_id = _local_file_datasource_id(filename, content)
+  await authorize_datasource_create(request, user, datasource_id, owner_team_slug)
+
+  existing_datasource = await metadata_storage.get_datasource_info(datasource_id)
+  if existing_datasource:
+    raise HTTPException(status_code=400, detail="File already ingested, please delete existing datasource before re-ingesting")
+
+  job_id = str(uuid.uuid4())
+  success = await jobmanager.upsert_job(
+    job_id,
+    status=JobStatus.IN_PROGRESS,
+    message="Ingesting uploaded file...",
+    total=1,
+    datasource_id=datasource_id,
+  )
+  if not success:
+    raise HTTPException(status_code=500, detail="Failed to create job")
+
+  bounded_chunk_size = max(100, min(chunk_size, 100000))
+  bounded_chunk_overlap = max(0, min(chunk_overlap, 10000, bounded_chunk_size - 1))
+  now = int(time.time())
+  datasource_info = DataSourceInfo(
+    datasource_id=datasource_id,
+    name=filename,
+    ingestor_id=LOCAL_FILE_INGESTOR_ID,
+    description=description or f"Uploaded file {filename}",
+    source_type="local_file",
+    last_updated=now,
+    default_chunk_size=bounded_chunk_size,
+    default_chunk_overlap=bounded_chunk_overlap,
+    metadata={
+      "filename": filename,
+      "content_type": file.content_type,
+      "document_type": document_type,
+      "byte_size": len(content),
+    },
+  )
+
+  await metadata_storage.store_datasource_info(datasource_info)
+  await write_datasource_ownership(datasource_id, owner_team_slug, user)
+
+  document_metadata = {
+    "document_id": f"{datasource_id}__{hashlib.sha256(filename.encode()).hexdigest()[:8]}",
+    "datasource_id": datasource_id,
+    "ingestor_id": LOCAL_FILE_INGESTOR_ID,
+    "title": filename,
+    "description": description or "",
+    "is_structured_entity": False,
+    "document_type": document_type,
+    "document_ingested_at": now,
+    "fresh_until": get_fresh_until(datasource_info.reload_interval),
+    "metadata": {
+      "source": filename,
+      "filename": filename,
+      "content_type": file.content_type,
+      "byte_size": len(content),
+    },
+  }
+
+  try:
+    await ingestor.ingest_documents(
+      ingestor_id=LOCAL_FILE_INGESTOR_ID,
+      datasource_id=datasource_id,
+      job_id=job_id,
+      documents=[Document(page_content=text, metadata=document_metadata)],
+      fresh_until=document_metadata["fresh_until"],
+      chunk_overlap=bounded_chunk_overlap,
+      chunk_size=bounded_chunk_size,
+    )
+    await jobmanager.upsert_job(
+      job_id,
+      status=JobStatus.COMPLETED,
+      message="Uploaded file ingested successfully",
+      total=1,
+      datasource_id=datasource_id,
+    )
+  except Exception as exc:
+    await jobmanager.increment_failure(job_id, message=str(exc))
+    await jobmanager.upsert_job(
+      job_id,
+      status=JobStatus.FAILED,
+      message="Uploaded file ingestion failed",
+      datasource_id=datasource_id,
+    )
+    raise
+
+  return {
+    "datasource_id": datasource_id,
+    "job_id": job_id,
+    "message": "Local file ingested successfully",
+  }
 
 
 @app.post("/v1/ingest/webloader/url", status_code=status.HTTP_202_ACCEPTED)

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_ingest.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_ingest.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from pypdf import PdfWriter
 
 from server import restapi
 
@@ -27,10 +28,35 @@ def test_local_file_datasource_id_is_stable_and_content_addressed() -> None:
     assert one != three
 
 
+def test_local_files_datasource_id_is_stable_for_same_file_set() -> None:
+    one = restapi._local_files_datasource_id(
+        [
+            ("one.md", b"# one"),
+            ("two.txt", b"two"),
+        ],
+    )
+    two = restapi._local_files_datasource_id(
+        [
+            ("one.md", b"# one"),
+            ("two.txt", b"two"),
+        ],
+    )
+    changed = restapi._local_files_datasource_id(
+        [
+            ("one.md", b"# one"),
+            ("two.txt", b"changed"),
+        ],
+    )
+
+    assert one == two
+    assert one.startswith("src_file_one_2_files_")
+    assert one != changed
+
+
 def test_validate_local_file_upload_accepts_markdown_text_and_pdf() -> None:
     assert restapi._validate_local_file_upload(_upload("guide.md", "text/markdown"), b"# guide") == "guide.md"
     assert restapi._validate_local_file_upload(_upload("notes.txt", "text/plain"), b"notes") == "notes.txt"
-    assert restapi._validate_local_file_upload(_upload("paper.pdf", "application/pdf"), b"%PDF") == "paper.pdf"
+    assert restapi._validate_local_file_upload(_upload("paper.pdf", "application/pdf"), b"%PDF-1.4\n%%EOF") == "paper.pdf"
 
 
 def test_validate_local_file_upload_rejects_unsupported_type() -> None:
@@ -38,6 +64,57 @@ def test_validate_local_file_upload_rejects_unsupported_type() -> None:
         restapi._validate_local_file_upload(_upload("archive.zip", "application/zip"), b"PK")
 
     assert exc.value.status_code == 415
+
+
+def test_validate_local_file_upload_rejects_extension_mime_mismatch() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_upload(_upload("invoice.pdf", "text/plain"), b"%PDF-1.4\n%%EOF")
+
+    assert exc.value.status_code == 415
+
+
+def test_validate_local_file_upload_rejects_spoofed_pdf_content() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_upload(_upload("invoice.pdf", "application/pdf"), b"not really a pdf")
+
+    assert exc.value.status_code == 415
+
+
+def test_validate_local_file_upload_rejects_html_disguised_as_markdown() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_upload(
+            _upload("notes.md", "text/markdown"),
+            b"<!doctype html><script>alert('xss')</script>",
+        )
+
+    assert exc.value.status_code == 415
+
+
+def test_validate_local_file_upload_rejects_oversized_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(restapi, "max_local_file_upload_bytes", 4)
+
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_upload(_upload("notes.txt", "text/plain"), b"12345")
+
+    assert exc.value.status_code == 413
+
+
+def test_validate_local_file_batch_rejects_too_many_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(restapi, "max_documents_per_ingest", 1)
+
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_batch([("one.md", b"1"), ("two.md", b"2")])
+
+    assert exc.value.status_code == 413
+
+
+def test_validate_local_file_batch_rejects_total_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(restapi, "max_local_file_total_upload_bytes", 4)
+
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_batch([("one.md", b"12"), ("two.md", b"345")])
+
+    assert exc.value.status_code == 413
 
 
 def test_extract_local_file_text_decodes_markdown() -> None:
@@ -56,3 +133,31 @@ def test_extract_local_file_text_rejects_pdf_without_text() -> None:
         restapi._extract_local_file_text("empty.pdf", "application/pdf", b"%PDF-1.4\n%%EOF")
 
     assert exc.value.status_code == 400
+
+
+def test_extract_local_file_text_rejects_encrypted_pdf() -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.encrypt("secret")
+    output = restapi.BytesIO()
+    writer.write(output)
+
+    with pytest.raises(HTTPException) as exc:
+        restapi._extract_local_file_text("secret.pdf", "application/pdf", output.getvalue())
+
+    assert exc.value.status_code == 400
+    assert "encrypted" in str(exc.value.detail).lower()
+
+
+def test_extract_local_file_text_rejects_pdf_with_too_many_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.add_blank_page(width=72, height=72)
+    output = restapi.BytesIO()
+    writer.write(output)
+    monkeypatch.setattr(restapi, "max_local_file_pdf_pages", 1)
+
+    with pytest.raises(HTTPException) as exc:
+        restapi._extract_local_file_text("large.pdf", "application/pdf", output.getvalue())
+
+    assert exc.value.status_code == 413

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_ingest.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_ingest.py
@@ -1,0 +1,58 @@
+"""Tests for local file upload ingestion helpers.
+
+# assisted-by Codex Codex-sonnet-4-6
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from server import restapi
+
+
+def _upload(filename: str, content_type: str | None = None):
+    return SimpleNamespace(filename=filename, content_type=content_type)
+
+
+def test_local_file_datasource_id_is_stable_and_content_addressed() -> None:
+    one = restapi._local_file_datasource_id("Runbook.md", b"# hello")
+    two = restapi._local_file_datasource_id("Runbook.md", b"# hello")
+    three = restapi._local_file_datasource_id("Runbook.md", b"# changed")
+
+    assert one == two
+    assert one.startswith("src_file_runbook_")
+    assert one != three
+
+
+def test_validate_local_file_upload_accepts_markdown_text_and_pdf() -> None:
+    assert restapi._validate_local_file_upload(_upload("guide.md", "text/markdown"), b"# guide") == "guide.md"
+    assert restapi._validate_local_file_upload(_upload("notes.txt", "text/plain"), b"notes") == "notes.txt"
+    assert restapi._validate_local_file_upload(_upload("paper.pdf", "application/pdf"), b"%PDF") == "paper.pdf"
+
+
+def test_validate_local_file_upload_rejects_unsupported_type() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restapi._validate_local_file_upload(_upload("archive.zip", "application/zip"), b"PK")
+
+    assert exc.value.status_code == 415
+
+
+def test_extract_local_file_text_decodes_markdown() -> None:
+    text, document_type = restapi._extract_local_file_text(
+        "guide.md",
+        "text/markdown",
+        "# Title\n\nBody".encode(),
+    )
+
+    assert document_type == "markdown"
+    assert "Title" in text
+
+
+def test_extract_local_file_text_rejects_pdf_without_text() -> None:
+    with pytest.raises(HTTPException) as exc:
+        restapi._extract_local_file_text("empty.pdf", "application/pdf", b"%PDF-1.4\n%%EOF")
+
+    assert exc.value.status_code == 400

--- a/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
@@ -4291,7 +4291,7 @@ requires-dist = [
     { name = "openai", specifier = "==2.32.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
     { name = "pymilvus", specifier = "==2.6.2" },
-    { name = "pypdf", specifier = ">=6.13.2" },
+    { name = "pypdf", specifier = "==6.13.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.2.1" },

--- a/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
@@ -3467,6 +3467,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4223,6 +4232,7 @@ dependencies = [
     { name = "openai" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pymilvus" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "pyyaml" },
@@ -4281,6 +4291,7 @@ requires-dist = [
     { name = "openai", specifier = "==2.32.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
     { name = "pymilvus", specifier = "==2.6.2" },
+    { name = "pypdf", specifier = ">=6.13.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.2.1" },

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -100,6 +100,7 @@ class McpGatewayTarget:
 
     id: str
     upstream_url: str
+    credential_sources: tuple[dict[str, Any], ...] = ()
 
 
 def _reconcile_ok_path(config_path: Path) -> Path:
@@ -146,6 +147,13 @@ def _upstream_url(document: dict[str, Any]) -> str | None:
     return upstream_url
 
 
+def _credential_sources(document: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    raw_sources = document.get("credential_sources")
+    if not isinstance(raw_sources, list):
+        return ()
+    return tuple(source for source in raw_sources if isinstance(source, dict))
+
+
 def select_gateway_targets(documents: Iterable[dict[str, Any]]) -> list[McpGatewayTarget]:
     """Select enabled AgentGateway-managed MCP targets from Mongo documents."""
 
@@ -164,7 +172,13 @@ def select_gateway_targets(documents: Iterable[dict[str, Any]]) -> list[McpGatew
             continue
         if target_id in seen:
             continue
-        targets.append(McpGatewayTarget(id=target_id, upstream_url=upstream_url))
+        targets.append(
+            McpGatewayTarget(
+                id=target_id,
+                upstream_url=upstream_url,
+                credential_sources=_credential_sources(document),
+            )
+        )
         seen.add(target_id)
     return targets
 
@@ -269,6 +283,60 @@ def _route_policies_for(target_id: str, base: dict[str, Any]) -> dict[str, Any]:
     override = DEFAULT_MCP_ROUTE_POLICY_OVERRIDES.get(target_id)
     if override:
         merged.update(copy.deepcopy(override))
+    return merged
+
+
+def _is_safe_header_name(value: str) -> bool:
+    """Return true when ``value`` is a conservative HTTP header token."""
+
+    return bool(re.fullmatch(r"[A-Za-z][A-Za-z0-9-]{0,127}", value))
+
+
+def _credential_source_transformations(
+    credential_sources: Iterable[dict[str, Any]],
+) -> dict[str, str]:
+    """Build AgentGateway header transforms from MCP ``credential_sources``.
+
+    Dynamic Agents resolves secret/provider/caller credentials before the request
+    reaches AgentGateway and forwards them as headers. The bridge only wires those
+    already-resolved request headers to the upstream target; it never resolves,
+    logs, or stores credential values.
+    """
+
+    transformations: dict[str, str] = {}
+    for source in credential_sources:
+        if source.get("target") != "header":
+            continue
+        header_name = source.get("name")
+        if not isinstance(header_name, str):
+            continue
+        header_name = header_name.strip()
+        if not _is_safe_header_name(header_name):
+            continue
+
+        incoming_header = header_name.lower()
+        outgoing_header = incoming_header
+        expression = f'default(request.headers["{incoming_header}"], "")'
+        if incoming_header == "x-caipe-provider-token":
+            outgoing_header = "authorization"
+            expression = (
+                '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+            )
+        transformations[outgoing_header] = expression
+    return transformations
+
+
+def _merge_request_transformations(
+    policies: dict[str, Any],
+    transformations: dict[str, str],
+) -> dict[str, Any]:
+    if not transformations:
+        return policies
+    merged = copy.deepcopy(policies)
+    request = merged.setdefault("transformations", {}).setdefault("request", {})
+    request_set = request.setdefault("set", {})
+    if isinstance(request_set, dict):
+        request_set.update(transformations)
     return merged
 
 
@@ -385,7 +453,10 @@ def merge_agentgateway_mcp_routes(
     retained_routes.extend(
         _mcp_route(
             target,
-            _route_policies_for(target.id, policies),
+            _merge_request_transformations(
+                _route_policies_for(target.id, policies),
+                _credential_source_transformations(target.credential_sources),
+            ),
             # Servers handled by a route-level transformation must NOT carry a
             # target-level backendAuth (drop any stale PAT preserved from the
             # live config); their auth comes from the X-CAIPE-Provider-Token

--- a/deploy/agentgateway/tests/test_config_bridge.py
+++ b/deploy/agentgateway/tests/test_config_bridge.py
@@ -77,6 +77,13 @@ def test_select_gateway_targets_uses_enabled_agentgateway_rows_only() -> None:
                 "enabled": True,
                 "source": "agentgateway",
                 "agentgateway_target_endpoint": "http://rag-server:9446/mcp",
+                "credential_sources": [
+                    {
+                        "kind": "caller_token",
+                        "target": "header",
+                        "name": "X-CAIPE-Provider-Token",
+                    }
+                ],
             },
             {
                 "_id": "disabled-target",
@@ -108,6 +115,13 @@ def test_select_gateway_targets_uses_enabled_agentgateway_rows_only() -> None:
         bridge.McpGatewayTarget(
             id="knowledge-base",
             upstream_url="http://rag-server:9446/mcp",
+            credential_sources=(
+                {
+                    "kind": "caller_token",
+                    "target": "header",
+                    "name": "X-CAIPE-Provider-Token",
+                },
+            ),
         )
     ]
 
@@ -320,6 +334,71 @@ def test_merge_agentgateway_mcp_routes_applies_knowledge_base_transform() -> Non
     assert transform["authorization"] == (
         '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
     )
+
+
+def test_merge_agentgateway_mcp_routes_uses_header_credential_sources() -> None:
+    baseline = _baseline_config()
+
+    rendered = bridge.merge_agentgateway_mcp_routes(
+        baseline,
+        [
+            bridge.McpGatewayTarget(
+                id="custom-docs",
+                upstream_url="http://custom-docs:8080/mcp",
+                credential_sources=(
+                    {
+                        "kind": "secret_ref",
+                        "target": "header",
+                        "name": "X-API-Key",
+                        "secret_ref": "cred-custom-docs",
+                    },
+                ),
+            )
+        ],
+    )
+
+    route = next(
+        route
+        for route in rendered["binds"][0]["listeners"][0]["routes"]
+        if route["matches"][0]["path"]["pathPrefix"] == "/mcp/custom-docs"
+    )
+    transform = route["policies"]["transformations"]["request"]["set"]
+    assert transform["x-api-key"] == 'default(request.headers["x-api-key"], "")'
+    assert "secret_ref" not in str(route)
+    assert "cred-custom-docs" not in str(route)
+
+
+def test_merge_agentgateway_mcp_routes_uses_provider_token_source_for_authorization() -> None:
+    baseline = _baseline_config()
+
+    rendered = bridge.merge_agentgateway_mcp_routes(
+        baseline,
+        [
+            bridge.McpGatewayTarget(
+                id="custom-github",
+                upstream_url="http://custom-github:8080/mcp",
+                credential_sources=(
+                    {
+                        "kind": "provider_connection",
+                        "target": "header",
+                        "name": "X-CAIPE-Provider-Token",
+                        "provider": "github",
+                    },
+                ),
+            )
+        ],
+    )
+
+    route = next(
+        route
+        for route in rendered["binds"][0]["listeners"][0]["routes"]
+        if route["matches"][0]["path"]["pathPrefix"] == "/mcp/custom-github"
+    )
+    transform = route["policies"]["transformations"]["request"]["set"]
+    assert transform["authorization"] == (
+        '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+    )
+    assert "provider_connection" not in str(route)
 
 
 def test_write_config_atomically_publishes_agentgateway_readable_file(tmp_path: Path) -> None:

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.11 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.12 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.11 -f your-values.yaml'}
+                  {'    --version 0.5.12 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.11 -f your-values.yaml'}
+              {'    --version 0.5.12 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.12"
+version = "0.5.12-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -406,7 +406,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
   });
 
-  test("uploads local files as multipart FormData from the ingest UI", async ({ page }) => {
+  test("uploads multiple local files as multipart FormData from the ingest UI", async ({ page }) => {
     const mocks = await installRagFileIngestMocks(page);
 
     await page.goto("/knowledge-bases/ingest", { waitUntil: "domcontentloaded" });
@@ -414,11 +414,18 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
 
     await page.getByRole("button", { name: "File" }).click();
     const fileInput = page.locator('input[type="file"]');
-    await fileInput.setInputFiles({
-      name: "playwright-rbac.md",
-      mimeType: "text/markdown",
-      buffer: Buffer.from("# RBAC fixture\n\nUploaded by Playwright.\n"),
-    });
+    await fileInput.setInputFiles([
+      {
+        name: "playwright-rbac.md",
+        mimeType: "text/markdown",
+        buffer: Buffer.from("# RBAC fixture\n\nUploaded by Playwright.\n"),
+      },
+      {
+        name: "playwright-rbac-notes.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from("Second local file in the same datasource.\n"),
+      },
+    ]);
 
     const uploadResponse = page.waitForResponse(
       (response) =>
@@ -431,7 +438,9 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect.poll(() => mocks.uploadRequests.length).toBe(1);
     expect(mocks.uploadRequests[0].contentType).toContain("multipart/form-data");
     expect(mocks.uploadRequests[0].body).toContain('name="file"; filename="playwright-rbac.md"');
+    expect(mocks.uploadRequests[0].body).toContain('name="file"; filename="playwright-rbac-notes.txt"');
     expect(mocks.uploadRequests[0].body).toContain("Uploaded by Playwright.");
+    expect(mocks.uploadRequests[0].body).toContain("Second local file in the same datasource.");
     expect(mocks.uploadRequests[0].body).toContain('name="chunk_size"');
     expect(mocks.uploadRequests[0].body).toContain("10000");
     expect(mocks.uploadRequests[0].body).toContain('name="chunk_overlap"');

--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -105,6 +105,13 @@ type InstalledMcpMocks = {
   listRequests: number;
 };
 
+type InstalledRagFileMocks = {
+  uploadRequests: Array<{
+    contentType: string;
+    body: string;
+  }>;
+};
+
 async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
   const createRequests: Array<Record<string, unknown>> = [];
   let listRequests = 0;
@@ -181,6 +188,148 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
   };
 }
 
+async function installKnowledgeBaseMcpMocks(page: Page): Promise<void> {
+  await installMockedRbacApp(page, {
+    isAdmin: true,
+    session: adminSession,
+    handlers: [
+      async ({ route, path, method }) => {
+        if (path === "/api/mcp-servers" && method === "GET") {
+          await fulfillJson(route, {
+            success: true,
+            data: {
+              items: [
+                {
+                  _id: "mcp-knowledge-base",
+                  name: "knowledge-base",
+                  description: "Knowledge Base RAG MCP",
+                  transport: "http",
+                  endpoint: "http://agentgateway:8080/mcp/knowledge-base",
+                  enabled: true,
+                  config_driven: false,
+                  source: "agentgateway",
+                  agentgateway_target_endpoint: "http://rag-server:8000/mcp",
+                },
+              ],
+              total: 1,
+              page: 1,
+              page_size: 100,
+              has_more: false,
+            },
+          });
+          return true;
+        }
+
+        return false;
+      },
+    ],
+  });
+}
+
+async function installRagFileIngestMocks(page: Page): Promise<InstalledRagFileMocks> {
+  const uploadRequests: InstalledRagFileMocks["uploadRequests"] = [];
+
+  await installMockedRbacApp(page, {
+    isAdmin: true,
+    session: adminSession,
+    handlers: [
+      async ({ route, path, method }) => {
+        if (path === "/api/rbac/kb-tab-gates" && method === "GET") {
+          await fulfillJson(route, {
+            gates: {
+              search: true,
+              data_sources: true,
+              graph: true,
+              mcp_tools: true,
+              has_any_kb: true,
+              kb_count: 1,
+              can_ingest: true,
+              can_search: true,
+            },
+            org_admin_bypass: true,
+          });
+          return true;
+        }
+
+        if (path === "/api/rag/healthz" && method === "GET") {
+          await fulfillJson(route, {
+            status: "healthy",
+            config: { graph_rag_enabled: true },
+          });
+          return true;
+        }
+
+        if (path === "/api/rbac/ingest-teams" && method === "GET") {
+          await fulfillJson(route, { org_admin: true, teams: [] });
+          return true;
+        }
+
+        if (path === "/api/rag/v1/ingestors" && method === "GET") {
+          await fulfillJson(route, [
+            {
+              ingestor_id: "local-file-upload",
+              ingestor_type: "local-file",
+              ingestor_name: "Local file upload",
+              description: "Upload Markdown, text, and PDF files",
+            },
+            {
+              ingestor_id: "webloader:default_webloader",
+              ingestor_type: "webloader",
+              ingestor_name: "Webloader",
+              description: "Web loader",
+            },
+          ]);
+          return true;
+        }
+
+        if (path === "/api/rag/v1/datasources" && method === "GET") {
+          await fulfillJson(route, { success: true, datasources: [], count: 0 });
+          return true;
+        }
+
+        if (path === "/api/rag/v1/jobs/batch" && method === "POST") {
+          await fulfillJson(route, { jobs: {}, total_jobs: 0, datasource_count: 0 });
+          return true;
+        }
+
+        if (path === "/api/rag/v1/ingest/local-file" && method === "POST") {
+          // assisted-by Codex Codex-sonnet-4-6
+          // Keep this assertion at the browser boundary: the regression we care
+          // about is that the UI sends multipart FormData, not JSON.
+          const contentType = route.request().headers()["content-type"] ?? "";
+          const body = route.request().postDataBuffer()?.toString("utf8") ?? "";
+          uploadRequests.push({ contentType, body });
+          await fulfillJson(route, {
+            datasource_id: "local-file-playwright-fixture",
+            job_id: "job-local-file-playwright-fixture",
+            message: "Accepted local file",
+          }, 202);
+          return true;
+        }
+
+        if (path === "/api/rag/v1/jobs/datasource/local-file-playwright-fixture" && method === "GET") {
+          await fulfillJson(route, [
+            {
+              job_id: "job-local-file-playwright-fixture",
+              status: "completed",
+              message: "Complete",
+              progress_counter: 1,
+              failed_counter: 0,
+              total: 1,
+              created_at: Math.floor(Date.now() / 1000),
+            },
+          ]);
+          return true;
+        }
+
+        return false;
+      },
+    ],
+  });
+
+  return { uploadRequests };
+}
+
 test.describe("mocked MCP OpenFGA tuple browser regression", () => {
   test.beforeEach(() => {
     test.skip(
@@ -242,5 +391,50 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect(page.getByText("Ops Tools")).toBeVisible();
     await expect.poll(() => mocks.listRequests).toBeGreaterThanOrEqual(2);
     await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
+  });
+
+  test("shows AgentGateway-discovered knowledge-base MCP servers in the browser list", async ({
+    page,
+  }) => {
+    await installKnowledgeBaseMcpMocks(page);
+
+    await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("knowledge-base", { exact: true })).toBeVisible();
+    await expect(page.getByText("mcp-knowledge-base")).toBeVisible();
+    await expect(page.getByTitle("Registered from AgentGateway discovery")).toBeVisible();
+    await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
+  });
+
+  test("uploads local files as multipart FormData from the ingest UI", async ({ page }) => {
+    const mocks = await installRagFileIngestMocks(page);
+
+    await page.goto("/knowledge-bases/ingest", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: "Data Sources", level: 1 })).toBeVisible();
+
+    await page.getByRole("button", { name: "File" }).click();
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: "playwright-rbac.md",
+      mimeType: "text/markdown",
+      buffer: Buffer.from("# RBAC fixture\n\nUploaded by Playwright.\n"),
+    });
+
+    const uploadResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/rag/v1/ingest/local-file",
+    );
+    await page.getByRole("button", { name: /^Ingest$/ }).click();
+    expect((await uploadResponse).status()).toBe(202);
+
+    await expect.poll(() => mocks.uploadRequests.length).toBe(1);
+    expect(mocks.uploadRequests[0].contentType).toContain("multipart/form-data");
+    expect(mocks.uploadRequests[0].body).toContain('name="file"; filename="playwright-rbac.md"');
+    expect(mocks.uploadRequests[0].body).toContain("Uploaded by Playwright.");
+    expect(mocks.uploadRequests[0].body).toContain('name="chunk_size"');
+    expect(mocks.uploadRequests[0].body).toContain("10000");
+    expect(mocks.uploadRequests[0].body).toContain('name="chunk_overlap"');
+    expect(mocks.uploadRequests[0].body).toContain("2000");
   });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "jest --coverage",
     "init-credential-indexes": "ts-node --project tsconfig.json ../scripts/init-credential-mongo-indexes.ts",
     "test:e2e:rbac": "playwright test --config=playwright.rbac.config.ts",
-    "test:e2e:rbac-regression": "playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts --config=playwright.rbac.config.ts",
+    "test:e2e:rbac-regression": "WORKFLOWS_ENABLED=true playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-mcp": "RUN_RBAC_E2E=1 playwright test e2e/rbac/mcp-server-create-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-openfga": "RUN_RBAC_E2E=1 playwright test e2e/rbac/openfga-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-resources": "RUN_RBAC_E2E=1 playwright test e2e/rbac/resource-lifecycle-live.spec.ts --config=playwright.rbac.config.ts",

--- a/ui/src/app/api/__tests__/admin-team-resources-mcp-openfga.test.ts
+++ b/ui/src/app/api/__tests__/admin-team-resources-mcp-openfga.test.ts
@@ -166,6 +166,63 @@ describe("PUT /api/admin/teams/[id]/resources — MCP OpenFGA tuple integration"
     expect(teamsCol.updateOne).toHaveBeenCalledTimes(1);
   });
 
+  it("re-saves unchanged MCP selections to repair OpenFGA drift", async () => {
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue({
+      _id: TEAM_ID,
+      slug: "platform-engineering",
+      resources: {
+        agents: ["hello-world"],
+        tools: ["mcp-confluence-mcp_*"],
+        tool_wildcard: false,
+      },
+    });
+    mockCollections.teams = teamsCol;
+
+    const { PUT } = await import("@/app/api/admin/teams/[id]/resources/route");
+    const response = await PUT(
+      makeRequest(`/api/admin/teams/${TEAM_ID}/resources`, {
+        method: "PUT",
+        body: JSON.stringify({
+          agents: ["hello-world"],
+          tools: ["mcp-confluence-mcp_*"],
+          tool_wildcard: false,
+        }),
+      }),
+      { params: Promise.resolve({ id: TEAM_ID.toString() }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockReconcileTupleDiff).toHaveBeenCalledTimes(1);
+
+    const [tupleDiff] = mockReconcileTupleDiff.mock.calls[0] as [
+      { writes: Array<{ user: string; relation: string; object: string }>; deletes: unknown[] },
+      unknown,
+    ];
+
+    expect(tupleDiff.writes).toEqual(
+      expect.arrayContaining([
+        {
+          user: "team:platform-engineering#member",
+          relation: "caller",
+          object: "tool:mcp-confluence-mcp/*",
+        },
+        {
+          user: "team:platform-engineering#member",
+          relation: "reader",
+          object: "mcp_server:mcp-confluence-mcp",
+        },
+        {
+          user: "agent:hello-world",
+          relation: "caller",
+          object: "tool:mcp-confluence-mcp/*",
+        },
+      ]),
+    );
+    expect(tupleDiff.deletes).toEqual([]);
+    expect(teamsCol.updateOne).toHaveBeenCalledTimes(1);
+  });
+
   it("does not persist Mongo when reconcileTupleDiff rejects the MCP tuple write", async () => {
     const teamsCol = createMockCollection();
     teamsCol.findOne.mockResolvedValue({

--- a/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
+++ b/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
@@ -10,6 +10,7 @@ const mockRequireResourcePermission = jest.fn();
 const mockFilterResourcesByPermission = jest.fn();
 const mockReconcileMcpServerRelationships = jest.fn();
 const mockDeleteAllMcpServerRelationshipTuples = jest.fn();
+const mockSyncSelectedAgentGatewayMcpServers = jest.fn();
 let mockSession = { sub: "alice-sub", role: "user", user: { email: "alice@example.com" } };
 let mockPagination = { page: 1, pageSize: 20, skip: 0 };
 
@@ -59,6 +60,10 @@ jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
   deleteAllMcpServerRelationshipTuples: (...args: unknown[]) => mockDeleteAllMcpServerRelationshipTuples(...args),
 }));
 
+jest.mock("../mcp-servers/agentgateway/_lib", () => ({
+  syncSelectedAgentGatewayMcpServers: (...args: unknown[]) => mockSyncSelectedAgentGatewayMcpServers(...args),
+}));
+
 function request(path: string, init?: RequestInit): NextRequest {
   return new NextRequest(new URL(path, "http://localhost:3000"), init);
 }
@@ -75,6 +80,7 @@ describe("MCP server per-resource RBAC", () => {
     );
     mockReconcileMcpServerRelationships.mockResolvedValue({ enabled: true, writes: 3, deletes: 0 });
     mockDeleteAllMcpServerRelationshipTuples.mockResolvedValue({ enabled: true, writes: 0, deletes: 3 });
+    mockSyncSelectedAgentGatewayMcpServers.mockResolvedValue({ summary: { added: 0, migrated: 0 } });
   });
 
   it("filters listed MCP servers through mcp_server#read", async () => {
@@ -85,6 +91,7 @@ describe("MCP server per-resource RBAC", () => {
     const toArray = jest.fn().mockResolvedValue(items);
     const sort = jest.fn().mockReturnValue({ toArray });
     mockGetCollection.mockResolvedValue({
+      countDocuments: jest.fn().mockResolvedValue(1),
       find: jest.fn().mockReturnValue({ sort }),
     });
     const { GET } = await import("../mcp-servers/route");
@@ -111,6 +118,7 @@ describe("MCP server per-resource RBAC", () => {
     const toArray = jest.fn().mockResolvedValue(items);
     const sort = jest.fn().mockReturnValue({ toArray });
     mockGetCollection.mockResolvedValue({
+      countDocuments: jest.fn().mockResolvedValue(1),
       find: jest.fn().mockReturnValue({ sort }),
     });
     const { GET } = await import("../mcp-servers/route");
@@ -145,6 +153,7 @@ describe("MCP server per-resource RBAC", () => {
     const toArray = jest.fn().mockResolvedValue(allServers);
     const sort = jest.fn().mockReturnValue({ toArray });
     mockGetCollection.mockResolvedValue({
+      countDocuments: jest.fn().mockResolvedValue(1),
       find: jest.fn().mockReturnValue({ sort }),
     });
 
@@ -168,6 +177,27 @@ describe("MCP server per-resource RBAC", () => {
     });
     expect(sort).toHaveBeenCalledWith({ name: 1 });
     expect(toArray).toHaveBeenCalledTimes(1);
+  });
+
+  it("self-heals AgentGateway-discovered MCP rows before listing an empty discovered set", async () => {
+    const items = [{ _id: "knowledge-base", name: "Knowledge Base" }];
+    mockFilterResourcesByPermission.mockResolvedValue(items);
+    const toArray = jest.fn().mockResolvedValue(items);
+    const sort = jest.fn().mockReturnValue({ toArray });
+    const countDocuments = jest.fn().mockResolvedValue(0);
+    mockGetCollection.mockResolvedValue({
+      countDocuments,
+      find: jest.fn().mockReturnValue({ sort }),
+    });
+    const { GET } = await import("../mcp-servers/route");
+
+    const response = await GET(request("/api/mcp-servers"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(countDocuments).toHaveBeenCalledWith({ source: "agentgateway" });
+    expect(mockSyncSelectedAgentGatewayMcpServers).toHaveBeenCalledTimes(1);
+    expect(body.data.items).toEqual(items);
   });
 
   it("lets a service account create an MCP server with service_account owner tuples", async () => {

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -112,6 +112,26 @@ function validateTransportConfig(
   }
 }
 
+async function selfHealAgentGatewayMcpServersForList(
+  collection: Awaited<ReturnType<typeof getCollection<MCPServerConfig>>>,
+): Promise<void> {
+  try {
+    const discoveredCount = await collection.countDocuments({ source: "agentgateway" } as never);
+    if (discoveredCount > 0) return;
+
+    // assisted-by Codex Codex-sonnet-4-6
+    // Startup self-heal can miss AgentGateway readiness; list-time recovery
+    // keeps built-in routes like knowledge-base visible in MCP pickers.
+    const { syncSelectedAgentGatewayMcpServers } = await import("./agentgateway/_lib");
+    await syncSelectedAgentGatewayMcpServers();
+  } catch (error) {
+    console.warn(
+      "[mcp-servers] AgentGateway MCP list self-heal skipped:",
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════
 // GET — list MCP servers
 // ═══════════════════════════════════════════════════════════════
@@ -125,6 +145,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
     const { page, pageSize, skip } = getPaginationParams(request);
+
+    await selfHealAgentGatewayMcpServersForList(collection);
 
     const allItems = await collection.find({}).sort({ name: 1 }).toArray();
     const listTarget = {

--- a/ui/src/app/api/rag/[...path]/route.ts
+++ b/ui/src/app/api/rag/[...path]/route.ts
@@ -840,6 +840,8 @@ export async function POST(
     const ragServerUrl = getRagServerUrl();
     const targetPath = path.join('/');
     const targetUrl = `${ragServerUrl}/${targetPath}`;
+    const contentType = request.headers.get('content-type') ?? '';
+    const isMultipart = contentType.toLowerCase().includes('multipart/form-data');
 
     // Parse the JSON body when present. We attempt a parse whenever a
     // content-length is absent-but-nonempty OR positive, because the
@@ -850,7 +852,7 @@ export async function POST(
     let body: unknown = undefined;
     const contentLength = request.headers.get('content-length');
     const hasBody = contentLength === null || parseInt(contentLength) > 0;
-    if (hasBody) {
+    if (hasBody && !isMultipart) {
       try {
         body = await request.json();
       } catch {
@@ -911,7 +913,10 @@ export async function POST(
       headers,
     };
 
-    if (body !== undefined) {
+    if (isMultipart) {
+      delete headers['Content-Type'];
+      fetchOptions.body = await request.formData();
+    } else if (body !== undefined) {
       fetchOptions.body = JSON.stringify(body);
     }
 

--- a/ui/src/components/rag/IngestView.tsx
+++ b/ui/src/components/rag/IngestView.tsx
@@ -213,7 +213,7 @@ export default function IngestView() {
 
   // Ingestion state
   const [url, setUrl] = useState('')
-  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
   const [ingestType, setIngestType] = useState<string>('web')
   const [description, setDescription] = useState('')
   const [includeSubPages, setIncludeSubPages] = useState(false)
@@ -875,7 +875,7 @@ export default function IngestView() {
   const ingestOwnerTeamMissing = ingestOwnerTeamRequired && !ingestOwnerTeamSlug
 
   const handleIngest = async () => {
-    if (ingestType === 'file' && !selectedFile) return
+    if (ingestType === 'file' && selectedFiles.length === 0) return
     if (ingestType !== 'file' && !url) return
     if (ingestOwnerTeamMissing) {
       toast('Select an owning team for this data source', 'error')
@@ -885,7 +885,7 @@ export default function IngestView() {
     try {
       const response = ingestType === 'file'
         ? await ingestLocalFile({
-            file: selectedFile!,
+            files: selectedFiles,
             description,
             owner_team_slug: ingestOwnerTeamSlug || undefined,
             chunk_size: chunkSize,
@@ -927,7 +927,7 @@ export default function IngestView() {
         }
       }
       setUrl('')
-      setSelectedFile(null)
+      setSelectedFiles([])
       setDescription('')
       setIngestOwnerTeamSlug('')
     } catch (error: any) {
@@ -1113,7 +1113,7 @@ export default function IngestView() {
             {/* Source Input */}
             <div className="mb-4">
               <label className="block text-sm font-medium text-muted-foreground mb-2">
-                {ingestType === 'file' ? 'File' : 'URL'}
+                {ingestType === 'file' ? 'Files' : 'URL'}
               </label>
               <div className="flex gap-2">
                 <div className="relative flex-1">
@@ -1123,9 +1123,17 @@ export default function IngestView() {
                       <Input
                         type="file"
                         accept=".md,.markdown,.pdf,.txt,text/markdown,text/plain,application/pdf"
-                        onChange={(e) => setSelectedFile(e.target.files?.[0] ?? null)}
+                        multiple
+                        onChange={(e) => setSelectedFiles(Array.from(e.target.files ?? []))}
                         className="pl-10"
                       />
+                      {selectedFiles.length > 0 && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {selectedFiles.length === 1
+                            ? selectedFiles[0].name
+                            : `${selectedFiles.length} files selected: ${selectedFiles.map((file) => file.name).join(', ')}`}
+                        </p>
+                      )}
                     </>
                   ) : (
                     <>
@@ -1144,7 +1152,7 @@ export default function IngestView() {
                 <Button
                   onClick={handleIngest}
                   disabled={
-                    (ingestType === 'file' ? !selectedFile : !url) ||
+                    (ingestType === 'file' ? selectedFiles.length === 0 : !url) ||
                     !hasPermission(Permission.INGEST) ||
                     ingestOwnerTeamMissing
                   }
@@ -1154,7 +1162,9 @@ export default function IngestView() {
                       : ingestOwnerTeamMissing
                         ? 'Select an owning team for this data source'
                         : ingestType === 'file'
-                          ? 'Ingest this file'
+                          ? selectedFiles.length > 1
+                            ? `Ingest ${selectedFiles.length} files`
+                            : 'Ingest this file'
                           : 'Ingest this URL'
                   }
                 >

--- a/ui/src/components/rag/IngestView.tsx
+++ b/ui/src/components/rag/IngestView.tsx
@@ -73,6 +73,7 @@ getIngestors,
 getJobsBatch,
 getJobsByDataSource,
 getJobStatus,
+ingestLocalFile,
 ingestUrl,
 JIRA_INGESTOR_ID,
 reloadDataSource,
@@ -212,6 +213,7 @@ export default function IngestView() {
 
   // Ingestion state
   const [url, setUrl] = useState('')
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [ingestType, setIngestType] = useState<string>('web')
   const [description, setDescription] = useState('')
   const [includeSubPages, setIncludeSubPages] = useState(false)
@@ -873,38 +875,47 @@ export default function IngestView() {
   const ingestOwnerTeamMissing = ingestOwnerTeamRequired && !ingestOwnerTeamSlug
 
   const handleIngest = async () => {
-    if (!url) return
+    if (ingestType === 'file' && !selectedFile) return
+    if (ingestType !== 'file' && !url) return
     if (ingestOwnerTeamMissing) {
       toast('Select an owning team for this data source', 'error')
       return
     }
 
     try {
-      const response = await ingestUrl({
-        url,
-        description: description,
-        ingest_type: ingestType,
-        get_child_pages: ingestType === 'confluence' ? includeSubPages : undefined,
-        owner_team_slug: ingestOwnerTeamSlug || undefined,
-        // ScrapySettings for web ingest type
-        settings: ingestType === 'web' ? {
-          crawl_mode: crawlMode,
-          max_depth: maxDepth,
-          max_pages: maxPages,
-          render_javascript: renderJavascript,
-          wait_for_selector: waitForSelector || null,
-          download_delay: downloadDelay,
-          concurrent_requests: concurrentRequests,
-          respect_robots_txt: respectRobotsTxt,
-          follow_external_links: followExternalLinks,
-          allowed_url_patterns: allowedUrlPatterns ? allowedUrlPatterns.split('\n').filter(p => p.trim()) : null,
-          denied_url_patterns: deniedUrlPatterns ? deniedUrlPatterns.split('\n').filter(p => p.trim()) : null,
-          chunk_size: chunkSize,
-          chunk_overlap: chunkOverlap,
-        } : undefined,
-        // Per-datasource reload interval (null = use global default)
-        reload_interval: ingestType === 'web' ? reloadInterval : undefined,
-      })
+      const response = ingestType === 'file'
+        ? await ingestLocalFile({
+            file: selectedFile!,
+            description,
+            owner_team_slug: ingestOwnerTeamSlug || undefined,
+            chunk_size: chunkSize,
+            chunk_overlap: chunkOverlap,
+          })
+        : await ingestUrl({
+            url,
+            description: description,
+            ingest_type: ingestType,
+            get_child_pages: ingestType === 'confluence' ? includeSubPages : undefined,
+            owner_team_slug: ingestOwnerTeamSlug || undefined,
+            // ScrapySettings for web ingest type
+            settings: ingestType === 'web' ? {
+              crawl_mode: crawlMode,
+              max_depth: maxDepth,
+              max_pages: maxPages,
+              render_javascript: renderJavascript,
+              wait_for_selector: waitForSelector || null,
+              download_delay: downloadDelay,
+              concurrent_requests: concurrentRequests,
+              respect_robots_txt: respectRobotsTxt,
+              follow_external_links: followExternalLinks,
+              allowed_url_patterns: allowedUrlPatterns ? allowedUrlPatterns.split('\n').filter(p => p.trim()) : null,
+              denied_url_patterns: deniedUrlPatterns ? deniedUrlPatterns.split('\n').filter(p => p.trim()) : null,
+              chunk_size: chunkSize,
+              chunk_overlap: chunkOverlap,
+            } : undefined,
+            // Per-datasource reload interval (null = use global default)
+            reload_interval: ingestType === 'web' ? reloadInterval : undefined,
+          })
       const { datasource_id, job_id, message } = response
       await fetchDataSources()
       if (datasource_id) {
@@ -916,6 +927,7 @@ export default function IngestView() {
         }
       }
       setUrl('')
+      setSelectedFile(null)
       setDescription('')
       setIngestOwnerTeamSlug('')
     } catch (error: any) {
@@ -1098,32 +1110,52 @@ export default function IngestView() {
               )}
             </div>
 
-            {/* URL Input */}
+            {/* Source Input */}
             <div className="mb-4">
               <label className="block text-sm font-medium text-muted-foreground mb-2">
-                URL
+                {ingestType === 'file' ? 'File' : 'URL'}
               </label>
               <div className="flex gap-2">
                 <div className="relative flex-1">
-                  <LinkIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    type="url"
-                    placeholder="https://docs.example.com"
-                    value={url}
-                    onChange={(e) => setUrl(e.target.value)}
-                    className="pl-10"
-                    onKeyDown={(e) => e.key === 'Enter' && handleIngest()}
-                  />
+                  {ingestType === 'file' ? (
+                    <>
+                      <FileText className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                      <Input
+                        type="file"
+                        accept=".md,.markdown,.pdf,.txt,text/markdown,text/plain,application/pdf"
+                        onChange={(e) => setSelectedFile(e.target.files?.[0] ?? null)}
+                        className="pl-10"
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <LinkIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                      <Input
+                        type="url"
+                        placeholder="https://docs.example.com"
+                        value={url}
+                        onChange={(e) => setUrl(e.target.value)}
+                        className="pl-10"
+                        onKeyDown={(e) => e.key === 'Enter' && handleIngest()}
+                      />
+                    </>
+                  )}
                 </div>
                 <Button
                   onClick={handleIngest}
-                  disabled={!url || !hasPermission(Permission.INGEST) || ingestOwnerTeamMissing}
+                  disabled={
+                    (ingestType === 'file' ? !selectedFile : !url) ||
+                    !hasPermission(Permission.INGEST) ||
+                    ingestOwnerTeamMissing
+                  }
                   title={
                     !hasPermission(Permission.INGEST)
                       ? 'Insufficient permissions to ingest data'
                       : ingestOwnerTeamMissing
                         ? 'Select an owning team for this data source'
-                        : 'Ingest this URL'
+                        : ingestType === 'file'
+                          ? 'Ingest this file'
+                          : 'Ingest this URL'
                   }
                 >
                   Ingest
@@ -1536,6 +1568,44 @@ export default function IngestView() {
                             </p>
                           </div>
                         </>
+                      )}
+                      {ingestType === 'file' && (
+                        <div className="grid grid-cols-2 gap-4">
+                          <div>
+                            <label className="block text-sm font-medium text-muted-foreground mb-1">
+                              Chunk Size
+                            </label>
+                            <Input
+                              type="number"
+                              min={100}
+                              max={100000}
+                              step={500}
+                              value={chunkSize}
+                              onChange={(e) => setChunkSize(Number(e.target.value))}
+                              className="w-full"
+                            />
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Max characters per chunk
+                            </p>
+                          </div>
+                          <div>
+                            <label className="block text-sm font-medium text-muted-foreground mb-1">
+                              Chunk Overlap
+                            </label>
+                            <Input
+                              type="number"
+                              min={0}
+                              max={10000}
+                              step={100}
+                              value={chunkOverlap}
+                              onChange={(e) => setChunkOverlap(Number(e.target.value))}
+                              className="w-full"
+                            />
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Overlap between chunks
+                            </p>
+                          </div>
+                        </div>
                       )}
                     </div>
                   </motion.div>

--- a/ui/src/components/rag/api/index.ts
+++ b/ui/src/components/rag/api/index.ts
@@ -55,6 +55,19 @@ async function apiPost<T>(endpoint: string, data?: unknown, params?: Record<stri
     return response.json();
 }
 
+async function apiPostForm<T>(endpoint: string, data: FormData): Promise<T> {
+    const response = await fetch(`${API_BASE}${endpoint}`, {
+        method: 'POST',
+        body: data,
+    });
+    if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Request failed' }));
+        throw new Error(error.error || error.detail || `HTTP ${response.status}`);
+    }
+    if (response.status === 204) return {} as T;
+    return response.json();
+}
+
 async function apiPatch<T>(endpoint: string, data?: unknown): Promise<T> {
     const url = `${API_BASE}${endpoint}`;
     const response = await fetch(url, {
@@ -173,6 +186,22 @@ export const ingestUrl = async (params: {
             owner_team_slug: params.owner_team_slug || null
         });
     }
+};
+
+export const ingestLocalFile = async (params: {
+    file: File;
+    description?: string;
+    owner_team_slug?: string;
+    chunk_size?: number;
+    chunk_overlap?: number;
+}): Promise<{ datasource_id: string | null; job_id: string | null; message: string }> => {
+    const form = new FormData();
+    form.append('file', params.file);
+    if (params.description) form.append('description', params.description);
+    if (params.owner_team_slug) form.append('owner_team_slug', params.owner_team_slug);
+    if (params.chunk_size !== undefined) form.append('chunk_size', String(params.chunk_size));
+    if (params.chunk_overlap !== undefined) form.append('chunk_overlap', String(params.chunk_overlap));
+    return apiPostForm('/v1/ingest/local-file', form);
 };
 
 export const reloadDataSource = async (datasourceId: string): Promise<{ datasource_id: string; message: string }> => {

--- a/ui/src/components/rag/api/index.ts
+++ b/ui/src/components/rag/api/index.ts
@@ -189,14 +189,14 @@ export const ingestUrl = async (params: {
 };
 
 export const ingestLocalFile = async (params: {
-    file: File;
+    files: File[];
     description?: string;
     owner_team_slug?: string;
     chunk_size?: number;
     chunk_overlap?: number;
 }): Promise<{ datasource_id: string | null; job_id: string | null; message: string }> => {
     const form = new FormData();
-    form.append('file', params.file);
+    params.files.forEach((file) => form.append('file', file));
     if (params.description) form.append('description', params.description);
     if (params.owner_team_slug) form.append('owner_team_slug', params.owner_team_slug);
     if (params.chunk_size !== undefined) form.append('chunk_size', String(params.chunk_size));

--- a/ui/src/components/rag/typeConfig.ts
+++ b/ui/src/components/rag/typeConfig.ts
@@ -47,6 +47,11 @@ export interface IngestTypeConfig {
 }
 
 export const ingestTypeConfigs: Record<string, IngestTypeConfig> = {
+    'file': {
+        label: 'File',
+        requiredIngestorType: 'local-file',
+        icon: '📄'
+    },
     'web': {
         label: 'Web',
         requiredIngestorType: 'webloader',
@@ -72,6 +77,7 @@ export const isIngestTypeAvailable = (
 ): boolean => {
     const config = ingestTypeConfigs[ingestType];
     if (!config) return false;
+    if (ingestType === 'file') return true;
     
     return availableIngestors.some(
         ingestor => ingestor.ingestor_type === config.requiredIngestorType

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.12"
+version = "0.5.12.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

This PR addresses the remaining 0.5.8 RBAC/RAG issues in one prebuild branch:

- Fixes #1832 by writing owner/manager OpenFGA tuples when MCP servers are created.
- Fixes #1833 by reconciling Team Resources selections into OpenFGA even when the Mongo diff is zero, repairing drift.
- Fixes #1836 by projecting safe `credential_sources` header transforms into AgentGateway config without exposing `secret_ref` values.
- Fixes #1834 by self-healing AgentGateway-discovered MCP server rows so the knowledge-base MCP server appears in the agent MCP picker.
- Fixes #1835 by adding local Markdown/PDF/text upload ingestion, including multi-file uploads into a single datasource.

## Security and UX notes

- Local upload validation now enforces extension/MIME alignment, PDF signature checks, encrypted-PDF rejection, PDF page limits, per-file and total upload limits, extracted text limits, and simple HTML/XML/script disguise rejection.
- Upload accept/reject paths log filename, MIME, byte count, status, and user without logging file contents.
- The Knowledge Bases ingest UI supports selecting multiple files and shows the selected file count/names.
- The RBAC browser regression script now enables workflows for the workflow modal tests, so the target is self-contained for mocked regression runs.

## Playwright coverage

The mocked RBAC regression now covers:

- Team Resources save sends the complete selected MCP tool list to repair OpenFGA drift.
- Newly created MCP servers remain visible after list refresh.
- AgentGateway-discovered knowledge-base MCP servers appear in the MCP browser list.
- Multiple local files are uploaded as multipart form data from the ingest UI.
- Permissions Tool refreshes after grant/revoke and greys unsupported capabilities.
- RBAC audit log expands policy details and downloads filtered JSON.
- Workflow agent-access modal stays open and blocks save when a non-manager cannot grant global access.
- Workflow agent-access modal stays open and blocks save when a non-manager cannot grant team access.
- Visible workflow run path works without requiring a direct legacy CAS read grant.

## Verification

- `uv run pytest tests/test_local_file_ingest.py tests/test_datasource_create_authz.py -q`
- `uv run ruff check src/server/restapi.py tests/test_local_file_ingest.py`
- `npx eslint src/components/rag/IngestView.tsx src/components/rag/api/index.ts e2e/rbac/mcp-openfga-tuples.spec.ts` (warnings only, pre-existing in touched files)
- `npx tsc --noEmit`
- `npm run build`
- `CAIPE_UI_BASE_URL=http://127.0.0.1:3100 RUN_RBAC_REGRESSION=1 npm run test:e2e:rbac-regression`