### PR TITLE
fix(chart): make GitHub MCP server opt-in

### DIFF
--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -200,9 +200,11 @@ transformation rewrites it into Authorization: Bearer. */ -}}
 {{- end -}}
 {{- /* GitHub MCP server — official GitHub MCP server container (mcp-servers profile).
 Routes /mcp/github-mcp-server to the in-cluster Deployment rendered by
-github-mcp-server.yaml when global.agentgateway.githubMcpServer.enabled is true. */ -}}
+github-mcp-server.yaml when global.agentgateway.githubMcpServer.enabled is true.
+assisted-by Codex Codex-sonnet-4-6 */ -}}
 {{- $ghMcp := $agw.githubMcpServer | default dict -}}
-{{- if or (not (hasKey $ghMcp "enabled")) $ghMcp.enabled -}}
+{{- if and (hasKey $ghMcp "enabled") $ghMcp.enabled -}}
+{{- $_ := required "global.agentgateway.githubMcpServer.existingSecret.name is required when githubMcpServer.enabled=true" (($ghMcp.existingSecret | default dict).name) -}}
 {{- $ghPort := $ghMcp.port | default 8082 -}}
 {{- $ghPath := $ghMcp.pathPrefix | default "/mcp/github-mcp-server" -}}
 {{- $ghHost := printf "%s-github-mcp-server.%s.svc.cluster.local" $root.Release.Name $ns -}}
@@ -301,4 +303,3 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $repository -}}
 {{- end -}}
 {{- end -}}
-

--- a/charts/ai-platform-engineering/templates/github-mcp-server.yaml
+++ b/charts/ai-platform-engineering/templates/github-mcp-server.yaml
@@ -2,25 +2,27 @@
 GitHub MCP server — official GitHub MCP server container.
 
 Enabled when global.agentgateway.enabled=true AND
-global.agentgateway.githubMcpServer.enabled=true (default).
+global.agentgateway.githubMcpServer.enabled=true.
 
 The container runs in HTTP mode on port 8082 (matching the docker-compose
 mcp-servers profile) and exposes all toolsets. GITHUB_PERSONAL_ACCESS_TOKEN
-is injected via secretKeyRef when global.agentgateway.githubMcpServer.existingSecret.name
-is set, or falls through to agentgateway.extraEnv entries.
+is injected via global.agentgateway.githubMcpServer.existingSecret.
 
 The agentgateway static-config template wires /mcp/github-mcp-server ->
 this Service via the ai-platform-engineering.agentgatewayMcpTargets helper.
+assisted-by Codex Codex-sonnet-4-6
 */ -}}
 {{- $agw := (.Values.global).agentgateway | default dict -}}
 {{- $ghMcp := $agw.githubMcpServer | default dict -}}
-{{- if and $agw.enabled (or (not (hasKey $ghMcp "enabled")) $ghMcp.enabled) -}}
+{{- if and $agw.enabled (hasKey $ghMcp "enabled") $ghMcp.enabled -}}
 {{- $port := $ghMcp.port | default 8082 -}}
 {{- $image := $ghMcp.image | default dict -}}
 {{- $imageRepo := $image.repository | default "ghcr.io/github/github-mcp-server" -}}
-{{- $imageTag := $image.tag | default "latest" -}}
+{{- $imageTag := $image.tag | default "latest@sha256:5c83359327a0bacc3d34db730bea6557d39d341cee0bf6c58c9a896e33150e80" -}}
 {{- $imagePullPolicy := $image.pullPolicy | default "IfNotPresent" -}}
 {{- $secret := $ghMcp.existingSecret | default dict -}}
+{{- $secretName := required "global.agentgateway.githubMcpServer.existingSecret.name is required when githubMcpServer.enabled=true" $secret.name -}}
+{{- $secretKey := $secret.key | default "GITHUB_PERSONAL_ACCESS_TOKEN" -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -28,22 +30,19 @@ metadata:
   name: {{ printf "%s-github-mcp-server" .Release.Name }}
   labels:
     {{- include "ai-platform-engineering.labels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-github-mcp-server" .Release.Name }}
-    app.kubernetes.io/component: mcp
+    app.kubernetes.io/component: github-mcp-server
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ printf "%s-github-mcp-server" .Release.Name }}
-      app.kubernetes.io/component: mcp
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: github-mcp-server
   template:
     metadata:
       labels:
         {{- include "ai-platform-engineering.labels" . | nindent 8 }}
-        app.kubernetes.io/name: {{ printf "%s-github-mcp-server" .Release.Name }}
-        app.kubernetes.io/component: mcp
+        app.kubernetes.io/component: github-mcp-server
     spec:
       automountServiceAccountToken: false
       containers:
@@ -56,13 +55,11 @@ spec:
               containerPort: {{ $port }}
               protocol: TCP
           env:
-            {{- if $secret.name }}
             - name: GITHUB_PERSONAL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ $secret.name | quote }}
-                  key: {{ $secret.key | default "GITHUB_PERSONAL_ACCESS_TOKEN" | quote }}
-            {{- end }}
+                  name: {{ $secretName | quote }}
+                  key: {{ $secretKey | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -82,13 +79,11 @@ metadata:
   name: {{ printf "%s-github-mcp-server" .Release.Name }}
   labels:
     {{- include "ai-platform-engineering.labels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-github-mcp-server" .Release.Name }}
-    app.kubernetes.io/component: mcp
+    app.kubernetes.io/component: github-mcp-server
 spec:
   selector:
-    app.kubernetes.io/name: {{ printf "%s-github-mcp-server" .Release.Name }}
-    app.kubernetes.io/component: mcp
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: github-mcp-server
   ports:
     - name: http
       port: {{ $port }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -222,20 +222,21 @@ global:
       pathPrefix: /mcp/knowledge-base
     # GitHub MCP server — official GitHub MCP server container.
     # Routes /mcp/github-mcp-server -> the in-cluster Deployment.
-    # The Deployment is enabled by this same section; set enabled: false to
-    # skip both the Deployment/Service and the agentgateway route.
-    # GITHUB_PERSONAL_ACCESS_TOKEN is read from agentgateway.extraEnv (via
-    # secretKeyRef) and injected into the github-mcp-server container.
+    # The Deployment is enabled by this same section; keep it opt-in because
+    # the official GitHub MCP server needs a GitHub PAT secret at startup.
+    # When enabled, GITHUB_PERSONAL_ACCESS_TOKEN is injected from
+    # existingSecret; Helm fails early if the secret name is omitted.
+    # assisted-by Codex Codex-sonnet-4-6
     githubMcpServer:
-      enabled: true
+      enabled: false
       image:
         repository: ghcr.io/github/github-mcp-server
-        tag: latest
+        # Multi-arch index digest inspected from ghcr.io/github/github-mcp-server:latest.
+        tag: latest@sha256:5c83359327a0bacc3d34db730bea6557d39d341cee0bf6c58c9a896e33150e80
         pullPolicy: IfNotPresent
       port: 8082
       pathPrefix: /mcp/github-mcp-server
       # Secret containing GITHUB_PERSONAL_ACCESS_TOKEN.
-      # Leave name empty to fall back to agentgateway.extraEnv entries.
       existingSecret:
         name: ""   # e.g. "github-mcp-secret"
         key: GITHUB_PERSONAL_ACCESS_TOKEN


### PR DESCRIPTION
## Summary

Follow-up to #1762. This keeps AgentGateway enabled by default but makes the bundled GitHub MCP server safe to opt into.

Changes:
- Default `global.agentgateway.githubMcpServer.enabled` to `false` so default installs do not deploy a broken GitHub MCP pod without credentials.
- Fail Helm rendering early with a clear message when GitHub MCP is enabled without `existingSecret.name`.
- Pin the default GitHub MCP image to the current multi-arch digest instead of floating on `latest`.
- Remove duplicate `app.kubernetes.io/name` labels from the GitHub MCP template and use a precise component selector.
- Remove the unsupported `agentgateway.extraEnv` fallback wording.

## Validation

- `helm template test charts/ai-platform-engineering > /tmp/caipe-default.yaml` and verified `github-mcp-server` is absent by default
- `helm template test charts/ai-platform-engineering --set global.agentgateway.githubMcpServer.enabled=true` fails with the expected required-secret error
- `helm template test charts/ai-platform-engineering --set global.agentgateway.githubMcpServer.enabled=true --set global.agentgateway.githubMcpServer.existingSecret.name=github-mcp-secret > /tmp/caipe-gh-mcp.yaml` renders the Deployment, Service, route, pinned image, and token env
- `helm lint charts/ai-platform-engineering` passes
- `git diff --check` passes
- PyYAML duplicate-key rejecting loader passes for default and GitHub-MCP-enabled rendered YAML

Note: `kustomize` is not installed in this local environment, so I validated the duplicate-key failure class with a strict YAML loader.