### PR TITLE
fix(ui): keep service account team picker searchable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.12-dev.3"
+version = "0.5.12-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/service-accounts.spec.ts
+++ b/ui/e2e/rbac/service-accounts.spec.ts
@@ -210,6 +210,7 @@ test.describe("mocked service accounts browser regression", () => {
     await createDialog.getByLabel("Name").fill("incident-bot");
     await createDialog.getByLabel(/Description/).fill("PagerDuty integration");
     await createDialog.getByLabel("Owning team").click();
+    await page.getByLabel("Search teams...").fill("sre");
     await page.getByRole("option", { name: /SRE Team/ }).click();
     await createDialog.getByRole("button", { name: "Grant agents you hold..." }).click();
     await page.getByRole("button", { name: "Incident Resolver" }).first().click({ force: true });

--- a/ui/src/components/admin/ServiceAccountsTab.tsx
+++ b/ui/src/components/admin/ServiceAccountsTab.tsx
@@ -498,6 +498,7 @@ function CreateServiceAccountDialog({
                 onChange={setOwningTeam}
                 options={teams.map<TeamPickerOption>((t) => ({ slug: t.slug, name: t.name }))}
                 placeholder="Select one of your teams..."
+                portalled={false}
               />
             </div>
 

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -116,6 +116,7 @@ interface PopoverContentProps {
   sideOffset?: number;
   alignOffset?: number;
   className?: string;
+  portalled?: boolean;
 }
 
 /**
@@ -142,6 +143,7 @@ export function PopoverContent({
   sideOffset = 8,
   alignOffset = 0,
   className,
+  portalled = true,
 }: PopoverContentProps) {
   const { open, setOpen, triggerRef } = React.useContext(PopoverStateContext);
   const contentRef = React.useRef<HTMLDivElement>(null);
@@ -235,6 +237,22 @@ export function PopoverContent({
   }, [open, setOpen, triggerRef]);
 
   if (!open || !mounted) return null;
+
+  if (!portalled) {
+    return (
+      <div
+        ref={contentRef}
+        data-popover-content=""
+        className={cn(
+          "absolute left-0 top-full z-[60] mt-2 pointer-events-auto rounded-lg bg-popover text-popover-foreground shadow-lg border border-border",
+          "animate-in fade-in-0 zoom-in-95 slide-in-from-top-2",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    );
+  }
 
   const node = (
     <div

--- a/ui/src/components/ui/team-picker.tsx
+++ b/ui/src/components/ui/team-picker.tsx
@@ -96,6 +96,10 @@ interface CommonPickerProps {
    *  KB team assignments) where rendering `team:<objectid>` is just
    *  noise. */
   hideSlugSuffix?: boolean;
+  /** Render inside the trigger wrapper instead of document.body.
+   *  Use inside modal dialogs so focus traps keep the search input usable.
+   */
+  portalled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -129,6 +133,7 @@ export function TeamPicker({
   ariaInvalid,
   ariaDescribedBy,
   hideSlugSuffix = false,
+  portalled = true,
   toggleOnReselect = false,
   helperText,
 }: TeamPickerProps) {
@@ -224,6 +229,7 @@ export function TeamPicker({
       <PopoverContent
         align="start"
         className={cn("w-[min(360px,90vw)] p-0", contentClassName)}
+        portalled={portalled}
       >
         <div className="flex items-center gap-2 border-b border-border px-3 py-2">
           <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -324,6 +330,7 @@ export function TeamMultiPicker({
   id,
   ariaLabel,
   hideSlugSuffix = false,
+  portalled = true,
   triggerChipCap = 2,
   helperText,
   allowClearAll = true,
@@ -465,6 +472,7 @@ export function TeamMultiPicker({
       <PopoverContent
         align="start"
         className={cn("w-[min(360px,90vw)] p-0", contentClassName)}
+        portalled={portalled}
       >
         <div className="flex items-center gap-2 border-b border-border px-3 py-2">
           <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.12.dev3"
+version = "0.5.12.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Follow-up to #1780. Fixes the Service Accounts create dialog team picker so search and selection work reliably inside the modal.

The shared popover is normally portaled to `document.body`, but Radix Dialog traps focus inside the dialog. For the Service Accounts owning-team picker, render the popover inline so the search input remains inside the dialog focus boundary.

## Changes

- Add an optional `portalled` prop to the shared popover/team picker.
- Use inline popover rendering for the Service Accounts owning-team picker.
- Extend the Service Accounts Playwright regression to type into team search before selecting a team.

## Testing

- `cd ui && npm test -- --runInBand src/components/ui/__tests__/team-picker.test.tsx src/app/api/admin/service-accounts/__tests__ src/lib/rbac/__tests__/keycloak-admin.service-accounts.test.ts src/lib/__tests__/service-account-scopes.test.ts`
- `cd ui && npx tsc --noEmit`
- Focused Playwright Service Accounts spec passed locally before commit: `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3100 npx playwright test e2e/rbac/service-accounts.spec.ts --config=playwright.rbac.config.ts`

assisted-by Codex Codex-sonnet-4-6
