### PR TITLE
fix(ui): prevent unlinked access modal control bleed

### DIFF
--- a/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
+++ b/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
@@ -321,7 +321,10 @@ export function UnlinkedServiceAccountModal({
                         granted the desired {addType} scope first.
                       </p>
                     )}
-                    <div className="flex gap-2">
+                    <div
+                      className="flex min-w-0 flex-col gap-2 sm:flex-row"
+                      data-testid="unlinked-add-scope-controls"
+                    >
                       <select
                         aria-label="Scope type"
                         value={addType}
@@ -329,7 +332,7 @@ export function UnlinkedServiceAccountModal({
                           setAddType(e.target.value as "agent" | "tool");
                           setAddRef("");
                         }}
-                        className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+                        className="h-9 min-w-0 rounded-md border border-input bg-background px-2 text-sm sm:w-24"
                       >
                         <option value="agent">Agent</option>
                         <option value="tool">Tool</option>
@@ -338,7 +341,7 @@ export function UnlinkedServiceAccountModal({
                         aria-label="Scope ref"
                         value={addRef}
                         onChange={(e) => setAddRef(e.target.value)}
-                        className="h-9 flex-1 rounded-md border border-input bg-background px-2 text-sm"
+                        className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-sm"
                       >
                         <option value="">
                           {addableOptions.length === 0
@@ -354,7 +357,7 @@ export function UnlinkedServiceAccountModal({
                       <Button
                         onClick={addScope}
                         disabled={busy || !addRef}
-                        className="gap-1.5"
+                        className="w-full gap-1.5 sm:w-auto"
                       >
                         <Plus className="h-4 w-4" />
                         Add

--- a/ui/src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx
+++ b/ui/src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx
@@ -109,6 +109,18 @@ describe("UnlinkedServiceAccountModal", () => {
     });
   });
 
+  it("keeps Add scope controls in a responsive row that cannot bleed past the modal", async () => {
+    render(
+      <UnlinkedServiceAccountModal open isAdmin onOpenChange={jest.fn()} />,
+    );
+
+    const controls = await screen.findByTestId("unlinked-add-scope-controls");
+    expect(controls).toHaveClass("min-w-0", "flex-col", "sm:flex-row");
+    expect(screen.getByRole("combobox", { name: /scope type/i })).toHaveClass("min-w-0");
+    expect(screen.getByRole("combobox", { name: /scope ref/i })).toHaveClass("min-w-0", "flex-1");
+    expect(screen.getByRole("button", { name: /^add$/i })).toHaveClass("w-full", "sm:w-auto");
+  });
+
   it("hides Add a scope and shows read-only notice for non-admins", async () => {
     render(
       <UnlinkedServiceAccountModal open isAdmin={false} onOpenChange={jest.fn()} />,


### PR DESCRIPTION
## Summary
- keep Unlinked Access add-scope controls inside the modal with responsive wrapping
- add a focused Jest regression for the overflow-prone controls\n\n## Testing
- `npm test -- --runInBand src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx\n- npx tsc --noEmit`