### PR TITLE
fix(chart):  duplicate app.kubernetes.io/name

### DIFF
--- a/charts/ai-platform-engineering/charts/agent/templates/mcp-deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/mcp-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "agent.fullname" . }}-mcp
   labels:
     {{- include "agent.labels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ include "agent.fullname" . }}-mcp
     app.kubernetes.io/component: mcp
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -15,7 +14,6 @@ spec:
   selector:
     matchLabels:
       {{- include "agent.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/name: {{ include "agent.fullname" . }}-mcp
       app.kubernetes.io/component: mcp
   template:
     metadata:
@@ -25,7 +23,6 @@ spec:
       {{- end }}
       labels:
         {{- include "agent.labels" . | nindent 8 }}
-        app.kubernetes.io/name: {{ include "agent.fullname" . }}-mcp
         app.kubernetes.io/component: mcp
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/ai-platform-engineering/charts/agent/templates/mcp-service.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/mcp-service.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "agent.fullname" . }}-mcp
   labels:
     {{- include "agent.labels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ include "agent.fullname" . }}-mcp
     app.kubernetes.io/component: mcp
 spec:
   type: {{ .Values.mcp.service.type | default "ClusterIP" }}
@@ -19,6 +18,5 @@ spec:
       {{- end }}
   selector:
     {{- include "agent.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ include "agent.fullname" . }}-mcp
     app.kubernetes.io/component: mcp
 {{- end }}


### PR DESCRIPTION
Fixes #914

# Description

This PR will remove the YAML Strict Parser of Kustomize error on having duplicate labels in the Deployment and Service of models, leaving the `app.kubernetes.io/component: mcp` label as the identifier for them. The `app.kubernetes.io/name` is already defined in the _helpers.tpl in `agents.label` where is included (more specific into `agents.selectorLabels`)


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
