### PR TITLE
fix(agentgateway): add extraVolumes/extraVolumeMounts to config-bridge

### DIFF
--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 # pyproject.toml version
-appVersion: 0.5.13 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.13-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 name: ai-platform-engineering
 description: Parent chart to deploy multiple agent subcharts as different platform agents
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent
     # Chart version for agent subchart
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore
@@ -169,7 +169,7 @@ dependencies:
     repository: oci://ghcr.io/agntcy/slim/helm
     condition: global.slim.enabled
   - name: rag-stack
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: file://../rag-stack # TODO: might be changed to be separate
     tags:
       - rag-stack
@@ -179,36 +179,36 @@ dependencies:
         parent: global.enabledSubAgents.rag
   # CAIPE UI
   - name: caipe-ui
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - caipe-ui
   # Dynamic Agents - Standalone agent builder with MCP tool support
   - name: dynamic-agents
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - dynamic-agents
   # MongoDB for CAIPE UI persistence
   - name: caipe-ui-mongodb
-    version: 0.5.13
+    version: 0.5.13-dev.1
     condition: caipe-ui.mongodb.enabled
     alias: mongodb
   # Redis Stack for LangGraph checkpoint + store persistence
   - name: langgraph-redis
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.langgraphRedis.enabled
   # Skill Scanner — standalone cisco-ai-defense/skill-scanner REST API.
   # Required for the UI's skill safety scan; off by default.
   - name: skill-scanner
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: global.skillScanner.enabled
   # Slack Bot Integration (client, not an agent)
   - name: slack-bot
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - slack-bot
   # Webex Bot Integration (client, not an agent)
   - name: webex-bot
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - webex-bot
   # Keycloak Identity Provider for CAIPE RBAC/OIDC.
@@ -217,16 +217,16 @@ dependencies:
   # wiring. There is no upstream Keycloak chart that provides these CAIPE
   # bootstrap invariants without additional Jobs/templates.
   - name: keycloak
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     tags:
       - keycloak
   # OpenFGA relationship authorization service
   - name: openfga
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: openfga.enabled
   # AgentGateway ext_authz bridge backed by OpenFGA
   - name: openfga-authz-bridge
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: openfgaAuthzBridge.enabled
   # AgentGateway standalone proxy for RBAC-protected MCP routing.
   # Intentional local subchart for this release: this deploys the standalone
@@ -235,5 +235,5 @@ dependencies:
   # and remain the target for a later migration once we can preserve this
   # release's static MCP routing and authz bridge contract.
   - name: agentgateway
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     condition: agentgateway.enabled

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.13 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.13-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/agentgateway/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agentgateway
 description: AgentGateway standalone proxy for CAIPE MCP traffic
 type: application
-version: 0.5.13
-appVersion: 0.5.13
+version: 0.5.13-dev.1
+appVersion: 0.5.13-dev.1

--- a/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
@@ -165,6 +165,9 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- with $cb.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           securityContext:
             {{- toYaml ($cb.securityContext | default .Values.securityContext) | nindent 12 }}
           resources:
@@ -179,6 +182,9 @@ spec:
         - name: bootstrap-config
           configMap:
             name: {{ printf "%s-agentgateway-static-config" .Release.Name }}
+        {{- with $cb.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- else }}
         - name: config
           configMap:

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caipe-ui-mongodb
 description: MongoDB database for CAIPE UI persistence
 type: application
-version: 0.5.13
-appVersion: "0.5.13"
+version: 0.5.13-dev.1
+appVersion: "0.5.13-dev.1"

--- a/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.13 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.13-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Dynamic Agents - Standalone agent builder service 
 # Application chart that can be packaged and deployed
 type: application
 # Chart version - automatically updated by release workflow
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # Application version - automatically updated by release workflow
-appVersion: 0.5.13 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.13-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/keycloak/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
 description: Keycloak identity provider for CAIPE RBAC, token exchange, and identity federation
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.5.13
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.5.13-dev.1
 type: application

--- a/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/langgraph-redis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: langgraph-redis
 description: Redis Stack for LangGraph checkpoint and store persistence
 type: application
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.13" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.13-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openfga-authz-bridge
 description: Envoy ext_authz bridge that adapts AgentGateway authorization checks to OpenFGA
 type: application
-version: 0.5.13
-appVersion: 0.5.13
+version: 0.5.13-dev.1
+appVersion: 0.5.13-dev.1

--- a/charts/ai-platform-engineering/charts/openfga/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openfga
 description: OpenFGA authorization service for CAIPE relationship-based access control
 type: application
-version: 0.5.13
-appVersion: 0.5.13
+version: 0.5.13-dev.1
+appVersion: 0.5.13-dev.1

--- a/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   for safety analysis. The service is unauthenticated and MUST stay
   cluster-internal (ClusterIP only — no Ingress).
 type: application
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.13" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.13-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: slack-bot
 description: Slack bot integration for AI Platform Engineering using A2A protocol
-version: 0.5.13
-appVersion: 0.5.13
+version: 0.5.13-dev.1
+appVersion: 0.5.13-dev.1
 type: application

--- a/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/supervisor-agent/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.13 # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: 0.5.13-dev.1 # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/ai-platform-engineering/charts/webex-bot/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: webex-bot
 description: Webex bot integration for AI Platform Engineering using A2A protocol
-version: 0.5.13
-appVersion: 0.5.13
+version: 0.5.13-dev.1
+appVersion: 0.5.13-dev.1
 type: application

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -195,6 +195,10 @@ global:
         # securityContext: {}  # optional; defaults to agentgateway.securityContext
         # resources: {}        # optional; defaults to agentgateway.resources
         extraEnv: []
+        # Extra volumes/mounts for the config-bridge container, e.g. to mount a
+        # TLS CA file referenced by the Mongo URI's tlsCAFile.
+        extraVolumeMounts: []
+        extraVolumes: []
     extAuth:
       enabled: false
       serviceName: ""

--- a/charts/rag-stack/Chart.yaml
+++ b/charts/rag-stack/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: rag-stack
 description: A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 type: application
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: 0.5.13 # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: 0.5.13-dev.1 # Do NOT modify. It will be updated automatically using the release workflow
 dependencies:
   - name: rag-server
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-server"
     condition: rag-server.enabled
   - name: agent-ontology
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/agent-ontology"
     condition: agent-ontology.enabled
   - name: rag-ingestors
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-ingestors"
     condition: rag-ingestors.enabled
   - name: neo4j
@@ -23,7 +23,7 @@ dependencies:
     alias: neo4j
     condition: neo4j.enabled
   - name: rag-redis
-    version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     repository: "file://./charts/rag-redis"
     condition: rag-redis.enabled
   - name: milvus

--- a/charts/rag-stack/charts/agent-ontology/Chart.yaml
+++ b/charts/rag-stack/charts/agent-ontology/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.13" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.5.13-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-ingestors/Chart.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-ingestors
 description: Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and Webex
 type: application
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.13" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.13-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-redis/Chart.yaml
+++ b/charts/rag-stack/charts/rag-redis/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.13" # Do NOT modify. It will be updated automatically using the release workflow
+appVersion: "0.5.13-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/charts/rag-stack/charts/rag-server/Chart.yaml
+++ b/charts/rag-stack/charts/rag-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rag-server
 description: RAG server
 type: application
-version: 0.5.13 # Do NOT bump this. It will be updated automatically using the PR or release workflow
-appVersion: "0.5.13" # Do NOT modify. It will be updated automatically using the release workflow
+version: 0.5.13-dev.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+appVersion: "0.5.13-dev.1" # Do NOT modify. It will be updated automatically using the release workflow

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.12 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.13 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.12 -f your-values.yaml'}
+                  {'    --version 0.5.13 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.12 -f your-values.yaml'}
+              {'    --version 0.5.13 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.13"
+version = "0.5.13-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.13"
+version = "0.5.13.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

The agentgateway `config-bridge` sidecar (added in 0.5.13) mounts only `generated-config`, `bootstrap-config`, and `tmp`. When `MONGODB_URI` references a TLS CA file — e.g. AWS DocumentDB's `tlsCAFile=/etc/ssl/certs/global-bundle.pem` — pymongo validates the path by opening it, and the sidecar crashes with `FileNotFoundError` because the CA bundle is not mounted into its filesystem.

This adds optional `extraVolumeMounts` / `extraVolumes` knobs under `global.agentgateway.static.configBridge`, letting operators mount the CA bundle (or any other volume) into the sidecar. Both default to `[]`, so behavior is unchanged unless set.

Changes:
- `charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml` — render `$cb.extraVolumeMounts` on the config-bridge container and `$cb.extraVolumes` at the pod level (config-bridge-enabled branch only; the seed init container is unaffected).
- `charts/ai-platform-engineering/values.yaml` — document the two new keys.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass