### PR TITLE
fix(rag): sync uv lock metadata

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/agent_ontology/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_ontology/uv.lock
@@ -519,6 +519,9 @@ requires-dist = [
 ]
 provides-extras = ["huggingface"]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+
 [[package]]
 name = "cryptography"
 version = "46.0.7"

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
@@ -373,6 +373,9 @@ requires-dist = [
 ]
 provides-extras = ["huggingface"]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+
 [[package]]
 name = "constantly"
 version = "23.10.4"

--- a/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
@@ -589,6 +589,9 @@ requires-dist = [
 ]
 provides-extras = ["huggingface"]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+
 [[package]]
 name = "constantly"
 version = "23.10.4"


### PR DESCRIPTION
## Summary

- Sync RAG uv.lock metadata after the 0.5.13-dev.1 version bump
- Add regenerated dev metadata for pytest in agent ontology, ingestors, and server lockfiles

## Test plan

- [x] bash scripts/check_uv_lock_sync.sh
