### PR TITLE
fix(admin): default to Settings tab and rename Default Agent to General

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/agent_ontology/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/agent_ontology/uv.lock
@@ -520,7 +520,7 @@ requires-dist = [
 provides-extras = ["huggingface"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+dev = [{ name = "pytest", specifier = "==9.1.0" }]
 
 [[package]]
 name = "cryptography"

--- a/ai_platform_engineering/knowledge_bases/rag/common/pyproject.toml
+++ b/ai_platform_engineering/knowledge_bases/rag/common/pyproject.toml
@@ -39,5 +39,5 @@ ignore = ["F403"]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.1.0",
+    "pytest==9.1.0",
 ]

--- a/ai_platform_engineering/knowledge_bases/rag/common/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/common/uv.lock
@@ -282,7 +282,7 @@ requires-dist = [
 provides-extras = ["huggingface"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+dev = [{ name = "pytest", specifier = "==9.1.0" }]
 
 [[package]]
 name = "cymple"

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/uv.lock
@@ -374,7 +374,7 @@ requires-dist = [
 provides-extras = ["huggingface"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+dev = [{ name = "pytest", specifier = "==9.1.0" }]
 
 [[package]]
 name = "constantly"

--- a/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
+++ b/ai_platform_engineering/knowledge_bases/rag/server/uv.lock
@@ -590,7 +590,7 @@ requires-dist = [
 provides-extras = ["huggingface"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.1.0" }]
+dev = [{ name = "pytest", specifier = "==9.1.0" }]
 
 [[package]]
 name = "constantly"

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.13 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.14 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.13 -f your-values.yaml'}
+                  {'    --version 0.5.14 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.13 -f your-values.yaml'}
+              {'    --version 0.5.14 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.14"
+version = "0.5.14-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -740,7 +740,7 @@ describe('Admin Dashboard Page', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
       expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
-        'Default Agent',
+        'General',
         'Release notes',
         'AI Review',
         'Credentials',
@@ -805,19 +805,19 @@ describe('Admin Dashboard Page', () => {
       expect(screen.queryByRole('tab', { name: /^Users$/i })).not.toBeInTheDocument();
     });
 
-    it('defaults bare /admin to Security & Policy Permissions Tool tab', async () => {
+    it('defaults bare /admin to Settings General tab', async () => {
       render(<AdminPage />);
 
-      expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
+      expect(await screen.findByText('Settings')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
-      expect(screen.getByRole('tab', { name: /^Permissions Tool$/i })).toHaveAttribute(
+      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('tab', { name: /^General$/i })).toHaveAttribute(
         'aria-selected',
         'true'
       );
-      expect(screen.getByTestId('permissions-tool-tab')).toBeInTheDocument();
+      expect(screen.getByTestId('platform-settings-tab')).toBeInTheDocument();
       expect(replaceMock).toHaveBeenCalledWith(
-        '/admin?cat=security&tab=cas-permissions-tool',
+        '/admin?cat=settings&tab=settings',
         { scroll: false }
       );
     });
@@ -840,7 +840,7 @@ describe('Admin Dashboard Page', () => {
     });
 
     it.each([
-      ['settings', 'settings', /^Default Agent$/i],
+      ['settings', 'settings', /^General$/i],
       ['settings', 'release-notes', /^Release notes$/i],
       ['settings', 'ai-review', /^AI Review$/i],
       ['settings', 'rag-access', /^Knowledge Bases$/i],

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -267,8 +267,8 @@ const MOVED_OPENFGA_DEEPLINK_TAB_MAP = {
 } as const;
 
 type CategoryKey = 'settings' | 'people' | 'integrations' | 'insights' | 'platform' | 'security';
-const DEFAULT_ADMIN_CATEGORY: CategoryKey = 'security';
-const DEFAULT_ADMIN_TAB = 'cas-permissions-tool';
+const DEFAULT_ADMIN_CATEGORY: CategoryKey = 'settings';
+const DEFAULT_ADMIN_TAB = 'settings';
 const DEFAULT_READONLY_TAB = 'users';
 
 interface Category {
@@ -289,7 +289,7 @@ const CATEGORIES: Category[] = [
     label: 'Settings',
     icon: Settings,
     tabs: [
-      { value: 'settings', label: 'Default Agent', icon: Settings, gateKey: 'settings' },
+      { value: 'settings', label: 'General', icon: Settings, gateKey: 'settings' },
       { value: 'release-notes', label: 'Release notes', icon: FileText, gateKey: 'settings' },
       { value: 'ai-review', label: 'AI Review', icon: ShieldCheck, gateKey: 'ai_review' },
       { value: 'credentials', label: 'Credentials', icon: Shield, gateKey: 'credentials' },

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.14"
+version = "0.5.14.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Two small frontend fixes to the Admin page (`ui/src/app/(app)/admin/page.tsx`):

1. **Default landing tab** — A bare `/admin` now defaults to the **Settings** category and the **General** tab (`cat=settings&tab=settings`) instead of **Security & Policy** → Permissions Tool. Changed `DEFAULT_ADMIN_CATEGORY` from `'security'` to `'settings'` and `DEFAULT_ADMIN_TAB` from `'cas-permissions-tool'` to `'settings'`. `DEFAULT_READONLY_TAB` is unchanged (`'users'`).
2. **Tab label rename** — Renamed the first Settings tab label from **"Default Agent"** to **"General"**. The tab `value` stays `'settings'` so existing deep links and gate keys are unaffected.

The admin-page test (`ui/src/app/(app)/admin/__tests__/admin-page.test.tsx`) was updated to reflect the new intended behavior: the bare-`/admin` default test now asserts the Settings/General landing and `replaceMock` call to `/admin?cat=settings&tab=settings`, and the tab-label assertions were updated from "Default Agent" to "General". Tests that assert Security & Policy via explicit query params were left unchanged. All 58 tests in the file pass.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass