### PR TITLE
fix(rbac): simplify owner-team ownership UI and drop grant-preview copy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.14-dev.3"
+version = "0.5.14-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.14-dev.1"
+version = "0.5.14-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/dynamic-agents/__tests__/DynamicAgentEditor.platform-default.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/DynamicAgentEditor.platform-default.test.tsx
@@ -136,16 +136,15 @@ describe("DynamicAgentEditor — platform default grant preview", () => {
     jest.restoreAllMocks();
   });
 
-  it("shows user:* platform-default grant in Share with Teams preview", async () => {
+  it("shows the platform-default visibility note when the agent is the platform default", async () => {
     mockFetch("hello-world");
     render(<DynamicAgentEditor agent={editAgent} onCancel={jest.fn()} onSave={jest.fn()} />);
     await flushAsync();
 
+    // The shared TeamOwnershipFields "Effective access summary" grant preview
+    // (including its user:* platform-default line) was intentionally removed;
+    // the platform-default note remains the user-facing signal here.
     expect(await screen.findByTestId("platform-default-visibility-note")).toBeInTheDocument();
-    const note = screen.getByRole("note", { name: /Effective access summary/i });
-    expect(note).toHaveTextContent("user:*");
-    expect(note).toHaveTextContent("platform default");
-    expect(note).toHaveTextContent("team:platform#member");
   });
 
   it("shows user:* global visibility grant when visibility is global", async () => {

--- a/ui/src/components/rbac/TeamOwnershipFields.tsx
+++ b/ui/src/components/rbac/TeamOwnershipFields.tsx
@@ -7,11 +7,9 @@
  *
  * Renders, for any shareable resource (agent, datasource, MCP tool, future
  * types):
- *   - an owner-team picker (single-select; disabled on edit unless a transfer
- *     is in progress),
+ *   - an owner-team picker (single-select; disabled on edit unless transfers
+ *     are allowed, in which case changing it directly performs a transfer),
  *   - a share-with-teams multi-select,
- *   - an effective-access preview that names exactly the grants the next save
- *     will write (transparency, not decoration),
  *   - a read-only creator (provenance) line,
  *   - a not-a-member transfer confirmation when transferring to a team the
  *     caller does not belong to.
@@ -29,7 +27,6 @@
 import { AlertCircle } from "lucide-react";
 import * as React from "react";
 
-import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
 TeamMultiPicker,
@@ -100,14 +97,6 @@ export interface TeamOwnershipFieldsProps {
   }>;
 }
 
-/** Resolve a share entry (slug or legacy _id) to a canonical slug via the options. */
-function resolveSlug(entry: string, options: TeamPickerOption[]): string | null {
-  const match = options.find(
-    (o) => o.slug === entry || o.id === entry || o._id === entry,
-  );
-  return match?.slug ?? (typeof entry === "string" && entry.trim() ? entry : null);
-}
-
 export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
   const {
     ownerTeamSlug,
@@ -131,18 +120,18 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
     showShare = true,
     betweenOwnerAndShare,
     ownerExtra,
-    renderGrantDetail,
-    extraGrantPreviewItems = [],
+    // `renderGrantDetail` and `extraGrantPreviewItems` remain in the props
+    // interface for caller compatibility but are no longer rendered (the
+    // grant-preview block was removed).
   } = props;
 
-  // Transfer mode: only meaningful on edit when transfers are allowed. While
-  // active, the owner picker is re-enabled so a new destination can be chosen.
-  const [transferring, setTransferring] = React.useState(false);
   // Missing-treatment (asterisk, "Required" badge, inline error, aria-invalid)
   // is a create-flow concern: on edit the owner is fixed and the picker is
   // disabled, so it can never be missing-and-fixable.
   const ownerMissing = ownerRequired && !isEditing && !ownerTeamSlug?.trim();
-  const ownerPickerDisabled = disabled || (isEditing && !transferring);
+  // On edit the picker is editable only when transfers are allowed; otherwise
+  // it stays locked. On create it is always enabled (unless globally disabled).
+  const ownerPickerDisabled = disabled || (isEditing && !allowTransfer);
 
   const shareOptions = availableTeams.filter(
     (t): t is TeamPickerOption & { slug: string } => Boolean(t.slug),
@@ -151,19 +140,10 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
     (t): t is TeamPickerOption & { slug: string } => Boolean(t.slug),
   );
 
-  // Effective grants = owner (if any) + shared (resolved to slugs, owner deduped).
-  const ownerSlug = ownerTeamSlug?.trim() || null;
-  const effectiveShared = sharedTeamSlugs
-    .map((entry) => resolveSlug(entry, availableTeams))
-    .filter((slug): slug is string => Boolean(slug))
-    .filter((slug) => slug !== ownerSlug);
-  const grants: Array<{ slug: string; kind: "owner" | "shared" }> = [
-    ...(ownerSlug ? [{ slug: ownerSlug, kind: "owner" as const }] : []),
-    ...effectiveShared.map((slug) => ({ slug, kind: "shared" as const })),
-  ];
-
   function handleOwnerChange(slug: string) {
-    if (transferring && allowTransfer) {
+    // On edit, changing the owner performs a transfer (with the not-a-member
+    // confirm). On create there is no transfer — just set the owner.
+    if (isEditing && allowTransfer && onTransfer) {
       const confirmedNotMember = !currentUserTeamSlugs.includes(slug);
       if (confirmedNotMember) {
         const ok = window.confirm(
@@ -172,8 +152,7 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
         if (!ok) return;
       }
       onOwnerTeamChange(slug);
-      onTransfer?.(slug, confirmedNotMember);
-      setTransferring(false);
+      onTransfer(slug, confirmedNotMember);
       return;
     }
     onOwnerTeamChange(slug);
@@ -199,17 +178,6 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
             <span className="rounded-full bg-destructive px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-destructive-foreground">
               Required
             </span>
-          )}
-          {isEditing && allowTransfer && onTransfer && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={disabled}
-              onClick={() => setTransferring((t) => !t)}
-            >
-              {transferring ? "Cancel transfer" : "Transfer ownership"}
-            </Button>
           )}
         </div>
         <TeamPicker
@@ -249,18 +217,9 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
             </span>
           </p>
         )}
-        <p id="owner-team-help" className="text-xs text-muted-foreground">
-          {ownerHelpText ?? (
-            <>
-              Owner-team members can use the {resourceNoun}; owner-team admins
-              can manage it.
-            </>
-          )}
-        </p>
-        {transferring && allowTransfer && (
-          <p className="text-xs text-amber-600 dark:text-amber-400">
-            Pick the destination team. If you are not a member you will be asked
-            to confirm — transferring may remove your own access.
+        {ownerHelpText && (
+          <p id="owner-team-help" className="text-xs text-muted-foreground">
+            {ownerHelpText}
           </p>
         )}
         {creatorSubject && (
@@ -295,41 +254,6 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
               searchPlaceholder="Search your teams..."
               emptyLabel="No teams match"
             />
-          )}
-
-          {(extraGrantPreviewItems.length > 0 || grants.length > 0) && (
-            <div
-              role="note"
-              aria-label="Effective access summary"
-              className="mt-4 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-xs text-amber-950 dark:bg-amber-950/30 dark:text-amber-200"
-            >
-              <div className="mb-2 font-medium">
-                On save, these OpenFGA grants will be written:
-              </div>
-              <ul className="space-y-1.5">
-                {extraGrantPreviewItems.map(({ id, line, detail }) => (
-                  <li key={id}>
-                    {line}
-                    {detail && (
-                      <span className="block pl-4 text-amber-900/80 dark:text-amber-300/80">
-                        {detail}
-                      </span>
-                    )}
-                  </li>
-                ))}
-                {grants.map(({ slug, kind }) => (
-                  <li key={`${kind}-${slug}`}>
-                    <code>team:{slug}#member</code> can use this {resourceNoun}
-                    {kind === "owner" && " (owner team)"}
-                    {renderGrantDetail && (
-                      <span className="block pl-4 text-amber-900/80 dark:text-amber-300/80">
-                        {renderGrantDetail(slug, kind)}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
           )}
         </div>
       )}

--- a/ui/src/components/rbac/__tests__/TeamOwnershipFields.test.tsx
+++ b/ui/src/components/rbac/__tests__/TeamOwnershipFields.test.tsx
@@ -2,14 +2,13 @@
  * Tests for the shared <TeamOwnershipFields> control bundle
  * (spec 2026-06-03-unified-shareable-resource-rbac, US1 contract ui-component.md).
  *
- * Pins the behavior every host editor relies on: owner picker disabled on edit,
- * effective-access preview names exactly the grants the save will write, share
- * multi-select toggles, creator shown read-only, and (US3) the not-a-member
- * transfer confirmation gates onTransfer.
+ * Pins the behavior every host editor relies on: owner picker disabled on edit
+ * (unless transfers are allowed), share multi-select toggles, creator shown
+ * read-only, and (US3) the not-a-member transfer confirmation gates onTransfer.
  */
 
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { TeamOwnershipFields } from "@/components/rbac/TeamOwnershipFields";
@@ -53,20 +52,13 @@ describe("TeamOwnershipFields", () => {
     expect(screen.getByLabelText(/Owner Team/i)).toBeDisabled();
   });
 
-  it("shows the effective-access preview naming the owner team", () => {
-    setup({ ownerTeamSlug: "platform", sharedTeamSlugs: ["data-eng"] });
-    const note = screen.getByRole("note", { name: /Effective access summary/i });
-    expect(note).toHaveTextContent("team:platform#member");
-    expect(note).toHaveTextContent("(owner team)");
-    expect(note).toHaveTextContent("team:data-eng#member");
-  });
-
-  it("dedupes the owner team out of the shared preview", () => {
-    setup({ ownerTeamSlug: "platform", sharedTeamSlugs: ["platform", "sre"] });
-    const note = screen.getByRole("note", { name: /Effective access summary/i });
-    const platformGrants = note.querySelectorAll("li");
-    // platform appears once (as owner), sre once (as shared) → 2 list items.
-    expect(platformGrants).toHaveLength(2);
+  it("keeps the owner picker editable on edit when transfers are allowed", () => {
+    setup({ isEditing: true, allowTransfer: true });
+    // Directly editable — no "Transfer ownership" unlock button needed.
+    expect(screen.getByLabelText(/Owner Team/i)).not.toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /Transfer ownership/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows the creator subject read-only when present", () => {
@@ -82,9 +74,8 @@ describe("TeamOwnershipFields", () => {
       ownerTeamSlug: "platform",
       currentUserTeamSlugs: ["platform"], // NOT a member of sre
     });
-    // Enter transfer mode.
-    fireEvent.click(screen.getByRole("button", { name: /Transfer ownership/i }));
-    // Attempt to transfer to sre (not a member) → confirm returns false → no call.
+    // The picker is directly editable; attempt to transfer to sre (not a
+    // member) → confirm returns false → no call.
     await pickTeam(/Owner Team/i, "sre");
     expect(confirmSpy).toHaveBeenCalled();
     expect(onTransfer).not.toHaveBeenCalled();
@@ -99,7 +90,6 @@ describe("TeamOwnershipFields", () => {
       ownerTeamSlug: "platform",
       currentUserTeamSlugs: ["platform"],
     });
-    fireEvent.click(screen.getByRole("button", { name: /Transfer ownership/i }));
     await pickTeam(/Owner Team/i, "sre");
     expect(onOwnerTeamChange).toHaveBeenCalledWith("sre");
     expect(onTransfer).toHaveBeenCalledWith("sre", true);
@@ -108,39 +98,16 @@ describe("TeamOwnershipFields", () => {
 
   it("hides the share section when showShare is false", () => {
     setup({ showShare: false });
-    expect(
-      screen.queryByRole("note", { name: /Effective access summary/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Share with Teams/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the share section when showShare is true", () => {
+    setup({ showShare: true });
+    expect(screen.getByText(/Share with Teams/i)).toBeInTheDocument();
   });
 
   it("renders betweenOwnerAndShare slot content", () => {
     setup({ betweenOwnerAndShare: <div data-testid="vis-toggle">visibility</div> });
     expect(screen.getByTestId("vis-toggle")).toBeInTheDocument();
-  });
-
-  it("shows extra grant preview items (e.g. user:*) above team grants", () => {
-    setup({
-      showShare: true,
-      ownerTeamSlug: "platform",
-      sharedTeamSlugs: [],
-      extraGrantPreviewItems: [
-        {
-          id: "wildcard",
-          line: (
-            <>
-              <code>user:*</code> can use this agent (platform default)
-            </>
-          ),
-          detail: "every signed-in user",
-        },
-      ],
-    });
-    const note = screen.getByRole("note", { name: /Effective access summary/i });
-    expect(note).toHaveTextContent("user:*");
-    expect(note).toHaveTextContent("platform default");
-    expect(note).toHaveTextContent("team:platform#member");
-    const items = note.querySelectorAll("li");
-    expect(items[0]).toHaveTextContent("user:*");
-    expect(items[1]).toHaveTextContent("team:platform#member");
   });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.14.dev1"
+version = "0.5.14.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.14.dev3"
+version = "0.5.14.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Cleans up the shared `<TeamOwnershipFields>` control (used by the agent editor, knowledge-base sharing panel, and MCP tools view) so the Owner Team UX is simpler and stops leaking OpenFGA implementation details:

- **Removed the separate "Transfer ownership" unlock button.** Previously, on edit, the Owner Team picker was locked behind a button that just toggled an editable state. Now the picker is directly editable when the host enables transfers (`allowTransfer`), and changing it performs the transfer with the existing not-a-member confirmation. Backend authorization is unchanged — `shareable-resource.ts` still enforces that only an owner-team admin or org admin may transfer.
- **Removed the default owner help text** ("Owner-team members can use the …; owner-team admins can manage it."). The `<p>` now renders only when a host explicitly passes `ownerHelpText`.
- **Removed the "On save, these OpenFGA grants will be written:" effective-access preview block**, which exposed raw tuple syntax (`team:<slug>#member can use …`, "DM this agent in a 1:1 chat", etc.) to end users.

The `renderGrantDetail` and `extraGrantPreviewItems` props remain in the interface for caller compatibility (now no-ops). The separate "global visibility" grant preview inside `DynamicAgentEditor` is intentionally left untouched. No backend or API changes.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass