### PR TITLE
fix(ui): soften required-field treatment on agent create form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.14-dev.5"
+version = "0.5.14-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
@@ -1961,40 +1961,6 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
             </>
           )}
         </div>
-        {!readOnly && firstBlocker && !loading && (
-          // Inline blocker hint. Renders only when the submit button is
-          // disabled AND we're not mid-save. Includes a click-to-jump shortcut
-          // so the user can land on the offending step in one click without
-          // hunting through the wizard. Wrapped in flex so the label and the
-          // jump-to button sit on one line on wide screens and wrap on narrow.
-          <div
-            role="status"
-            aria-live="polite"
-            data-testid="create-agent-blocker-hint"
-            className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-destructive"
-          >
-            <span>
-              Required: <span className="font-medium">{firstBlocker.label}</span>
-              {blockerStepLabel ? (
-                <>
-                  {" "}<span className="text-muted-foreground">(on {blockerStepLabel} step)</span>
-                </>
-              ) : null}
-              {blockers.length > 1 ? (
-                <span className="text-muted-foreground"> · {blockers.length - 1} more</span>
-              ) : null}
-            </span>
-            {blockerStepLabel && firstBlocker.step !== activeStep ? (
-              <button
-                type="button"
-                onClick={() => setActiveStep(firstBlocker.step)}
-                className="underline underline-offset-2 hover:text-destructive/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive rounded-sm"
-              >
-                Go to {blockerStepLabel}
-              </button>
-            ) : null}
-          </div>
-        )}
         <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
           {readOnly ? "Close" : "Cancel"}
         </Button>

--- a/ui/src/components/dynamic-agents/__tests__/DynamicAgentEditor.blockers.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/DynamicAgentEditor.blockers.test.tsx
@@ -1,15 +1,12 @@
 /**
- * Tests for the "what's blocking submit" hint on DynamicAgentEditor.
+ * Tests for how DynamicAgentEditor enforces required fields on submit.
  *
- * Before this fix, the Create Agent button silently went `disabled` whenever
- * any required field was missing — most commonly Owner Team — with no
- * explanation. The form is a 5-step wizard; the picker lives on step 1 but
- * the submit button is below step 5, so users on later steps saw a disabled
- * button with nothing telling them why. This suite locks in the new
- * behaviour: a visible blocker hint + a one-click "go to that step" shortcut
- * + a native title= mirror for hover.
- *
- * assisted-by Cursor claude-opus-4-7
+ * Enforcement is intentionally quiet: the Create Agent button is `disabled`
+ * while any required field is missing (Owner Team, name, model, system
+ * prompt), with a hover-only native `title=` explaining what's left. The
+ * owner picker carries a silent `aria-invalid` for screen readers. We
+ * deliberately do NOT render loud red badges, inline error boxes, or a
+ * footer "Required: …" banner — the asterisk + disabled button are enough.
  */
 
 import React from "react";
@@ -144,7 +141,7 @@ async function flushAsync() {
 // Tests
 // ============================================================================
 
-describe("DynamicAgentEditor — submit-blocked hint", () => {
+describe("DynamicAgentEditor — required-field enforcement", () => {
   beforeEach(() => {
     mockApi();
   });
@@ -153,70 +150,72 @@ describe("DynamicAgentEditor — submit-blocked hint", () => {
     jest.restoreAllMocks();
   });
 
-  it("shows an Owner Team required hint when creating an agent and the picker is empty", async () => {
+  it("disables Create Agent (with a hover tooltip) while Owner Team is empty", async () => {
     render(<DynamicAgentEditor onCancel={jest.fn()} onSave={jest.fn()} />);
     await flushAsync();
 
     // Fill the blockers that come BEFORE Owner Team in the array — name
     // and model — so Owner Team is the first remaining blocker. (System
-    // prompt comes AFTER ownerTeam in the blockers list, so we don't need
-    // to fill it for this test; the inline hint always surfaces blockers[0].)
+    // prompt comes AFTER ownerTeam in the blockers list; the title= mirror
+    // always reflects blockers[0].)
     const nameInput = screen.getByPlaceholderText(/Code Review Agent/i) as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "blocker-test-agent" } });
 
     // At this point: name ✔, model ✔ (auto-picked from the models fetch),
-    // owner_team ✗. The blocker hint MUST surface Owner Team.
-    const hint = await screen.findByTestId("create-agent-blocker-hint");
-    expect(hint).toHaveTextContent(/Owner Team/);
-    expect(hint).toHaveTextContent(/Basic Info/);
-
-    // The Create Agent button is the disabled one (and has the tooltip).
-    const createButton = screen.getByRole("button", { name: /Create Agent/i });
+    // owner_team ✗. Enforcement is quiet: the button stays disabled and only
+    // the hover tooltip names what's missing — no loud footer banner.
+    const createButton = await screen.findByRole("button", { name: /Create Agent/i });
     expect(createButton).toBeDisabled();
     expect(createButton).toHaveAttribute(
       "title",
       expect.stringContaining("Owner Team is required") as unknown as string
     );
+
+    // The loud footer "Required: …" hint must NOT be rendered.
+    expect(screen.queryByTestId("create-agent-blocker-hint")).not.toBeInTheDocument();
   });
 
-  it("highlights the empty Owner Team field inline while creating an agent", async () => {
+  it("marks the empty Owner Team picker aria-invalid without rendering a loud error box", async () => {
     render(<DynamicAgentEditor onCancel={jest.fn()} onSave={jest.fn()} />);
     await flushAsync();
 
     const nameInput = screen.getByPlaceholderText(/Code Review Agent/i) as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "blocker-test-agent" } });
 
+    // Silent accessibility hook stays; the loud "is required" alert box is gone.
     expect(screen.getByLabelText(/Owner Team/i)).toHaveAttribute("aria-invalid", "true");
-    expect(await screen.findByText(/Owner Team is required/i)).toBeVisible();
-    expect(screen.getByText(/Choose a team before creating this agent/i)).toBeVisible();
+    expect(screen.queryByText(/Owner Team is required/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Choose a team before creating this agent/i),
+    ).not.toBeInTheDocument();
   });
 
-  it("removes the Owner Team blocker from the hint once the picker is filled", async () => {
+  it("enables Create Agent once Owner Team and the remaining fields are filled", async () => {
     render(<DynamicAgentEditor onCancel={jest.fn()} onSave={jest.fn()} />);
     await flushAsync();
 
     const nameInput = screen.getByPlaceholderText(/Code Review Agent/i) as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "blocker-test-agent" } });
 
-    // Pre-condition: Owner Team is currently the first blocker.
-    expect(await screen.findByTestId("create-agent-blocker-hint")).toHaveTextContent(/Owner Team/);
+    // Pre-condition: button disabled, owner picker flagged.
+    const createButton = screen.getByRole("button", { name: /Create Agent/i });
+    expect(createButton).toBeDisabled();
 
     // Pick the team via the searchable TeamPicker (2026-05-27).
     await pickTeam(/Owner Team/i, "platform");
 
-    // System prompt is still empty — so the hint stays visible, but now it
-    // surfaces Instructions instead of Owner Team. Owner Team must be gone.
+    // Owner Team is no longer the blocker, so the picker clears aria-invalid
+    // and the tooltip stops naming it (system prompt is the remaining blocker).
     await waitFor(() => {
-      const hint = screen.queryByTestId("create-agent-blocker-hint");
-      // Either the hint disappeared entirely (no remaining blockers) or it
-      // no longer surfaces Owner Team. Both indicate the picker fixed it.
-      if (hint) {
-        expect(hint).not.toHaveTextContent(/Owner Team/);
-      }
+      expect(screen.getByLabelText(/Owner Team/i)).not.toHaveAttribute("aria-invalid", "true");
+      expect(createButton).not.toHaveAttribute(
+        "title",
+        expect.stringContaining("Owner Team is required") as unknown as string,
+      );
     });
   });
 
-  it("does NOT render the hint or block submit when editing an existing agent (Owner Team is fixed at create time)", async () => {
+  it("does NOT block submit when editing an existing agent (Owner Team is fixed at create time)", async () => {
     // When `agent` is supplied, isEditing is true and the Owner Team picker
     // is disabled; the blocker logic skips the Owner Team check entirely.
     const agent = {
@@ -247,35 +246,5 @@ describe("DynamicAgentEditor — submit-blocked hint", () => {
     expect(screen.queryByTestId("create-agent-blocker-hint")).not.toBeInTheDocument();
     const saveButton = screen.getByRole("button", { name: /Save Changes/i });
     expect(saveButton).not.toBeDisabled();
-  });
-
-  it("offers a 'Go to Basic Info' shortcut that jumps the wizard to the right step", async () => {
-    render(<DynamicAgentEditor onCancel={jest.fn()} onSave={jest.fn()} />);
-    await flushAsync();
-
-    // Fill the name so Owner Team becomes blockers[0] (otherwise "Agent name"
-    // is the first blocker and the Go-to shortcut would still point at basic
-    // but we couldn't differentiate "ownerTeam-blocked" from "name-blocked").
-    const nameInput = screen.getByPlaceholderText(/Code Review Agent/i) as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "blocker-test-agent" } });
-
-    // Click "Next" once to leave the basic step. The Next button has the
-    // exact label "Next" inside the step navigation row.
-    const nextBtn = screen.getByRole("button", { name: /^Next$/i });
-    fireEvent.click(nextBtn); // basic → instructions
-
-    // The blocker hint should still render (it lives in the footer, outside
-    // the step content) and the "Go to Basic Info" link should appear because
-    // we're no longer on the basic step.
-    const hint = await screen.findByTestId("create-agent-blocker-hint");
-    expect(hint).toHaveTextContent(/Owner Team/);
-
-    const goToBtn = screen.getByRole("button", { name: /Go to Basic Info/i });
-    expect(goToBtn).toBeInTheDocument();
-    fireEvent.click(goToBtn);
-
-    // After clicking, the Owner Team picker is back on screen (i.e. we
-    // jumped to basic). Use the select's label as proof of presence.
-    expect(screen.getByLabelText(/Owner Team/i)).toBeInTheDocument();
   });
 });

--- a/ui/src/components/rbac/TeamOwnershipFields.tsx
+++ b/ui/src/components/rbac/TeamOwnershipFields.tsx
@@ -26,7 +26,6 @@
  * its UI (SC-006). RAG/MCP editors simply omit them.
  */
 
-import { AlertCircle } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
@@ -36,7 +35,6 @@ TeamMultiPicker,
 TeamPicker,
 type TeamPickerOption,
 } from "@/components/ui/team-picker";
-import { cn } from "@/lib/utils";
 
 export interface TeamOwnershipFieldsProps {
   // ---- current values --------------------------------------------------
@@ -138,9 +136,6 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
   // Transfer mode: only meaningful on edit when transfers are allowed. While
   // active, the owner picker is re-enabled so a new destination can be chosen.
   const [transferring, setTransferring] = React.useState(false);
-  // Missing-treatment (asterisk, "Required" badge, inline error, aria-invalid)
-  // is a create-flow concern: on edit the owner is fixed and the picker is
-  // disabled, so it can never be missing-and-fixable.
   const ownerMissing = ownerRequired && !isEditing && !ownerTeamSlug?.trim();
   const ownerPickerDisabled = disabled || (isEditing && !transferring);
 
@@ -182,12 +177,7 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
   return (
     <div className="space-y-4">
       {/* Owner team ------------------------------------------------------ */}
-      <div
-        className={cn(
-          "space-y-2 rounded-lg transition-colors",
-          ownerMissing && "border border-destructive/40 bg-destructive/5 p-3",
-        )}
-      >
+      <div className="space-y-2 rounded-lg">
         <div className="flex items-center justify-between gap-2">
           <Label htmlFor="ownerTeam">
             {ownerLabel}{" "}
@@ -195,11 +185,6 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
               <span className="text-destructive">*</span>
             )}
           </Label>
-          {ownerMissing && (
-            <span className="rounded-full bg-destructive px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-destructive-foreground">
-              Required
-            </span>
-          )}
           {isEditing && allowTransfer && onTransfer && (
             <Button
               type="button"
@@ -218,15 +203,7 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
           onChange={handleOwnerChange}
           disabled={ownerPickerDisabled}
           ariaInvalid={ownerMissing}
-          ariaDescribedBy={
-            ownerMissing
-              ? "owner-team-required-message owner-team-help"
-              : "owner-team-help"
-          }
-          triggerClassName={cn(
-            ownerMissing &&
-              "border-destructive/70 bg-destructive/5 ring-1 ring-destructive/30 focus:ring-destructive",
-          )}
+          ariaDescribedBy="owner-team-help"
           placeholder={`Select a team that will own this ${resourceNoun}`}
           searchPlaceholder="Search your teams..."
           emptyLabel={
@@ -236,19 +213,6 @@ export function TeamOwnershipFields(props: TeamOwnershipFieldsProps) {
           }
           options={ownerOptions}
         />
-        {ownerMissing && (
-          <p
-            id="owner-team-required-message"
-            role="alert"
-            className="flex items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-xs text-destructive"
-          >
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>
-              <span className="font-semibold">{ownerLabel} is required.</span>{" "}
-              Choose a team before creating this {resourceNoun}.
-            </span>
-          </p>
-        )}
         <p id="owner-team-help" className="text-xs text-muted-foreground">
           {ownerHelpText ?? (
             <>

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.14.dev5"
+version = "0.5.14.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

The agent creation form treated the **Owner Team** field too aggressively: a red `REQUIRED` pill badge, a red inline error box, a red border/background around the whole field card, and a red ring on the picker — on top of the standard red asterisk. The sticky footer also rendered a red `Required: Owner Team (on Basic Info step) · 1 more` banner with a "Go to step" jump link.

This de-loudens required-field treatment while keeping enforcement intact:

- **`TeamOwnershipFields.tsx`** — removed the `REQUIRED` badge, the inline error box, the red card border/background, and the red picker outline. Kept the red `*` asterisk and the silent `aria-invalid` hook for screen readers. Dropped now-unused `AlertCircle` and `cn` imports.
- **`DynamicAgentEditor.tsx`** — removed the footer `Required: …` banner and its "Go to step" shortcut. The disabled **Create Agent** button (with a hover-only `title=` tooltip) plus the server-side guard still prevent creating an agent with missing required fields.
- **`DynamicAgentEditor.blockers.test.tsx`** — rewrote the suite to assert the quiet behavior (disabled button, `aria-invalid` present, loud banner/error-box absent) and removed the now-defunct "Go to Basic Info" test.

Enforcement is unchanged: the Create button stays disabled until name, model, owner team, and system prompt are filled, and `handleSubmit` re-validates model + owner team server-side.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A — no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass