### PR TITLE
test(ui): add admin settings e2e regression

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -361,6 +361,7 @@ jobs:
             e2e/rbac/workflow-agent-access.spec.ts \
             e2e/rbac/rbac-admin-regression.spec.ts \
             e2e/rbac/mcp-openfga-tuples.spec.ts \
+            e2e/rbac/admin-settings-regression.spec.ts \
             --config=playwright.rbac.config.ts
 
       - name: Upload Playwright artifacts

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ caipe-ui-e2e-rbac: ## Run mocked RBAC Playwright regression (dev server on :3000
 			e2e/rbac/workflow-agent-access.spec.ts \
 			e2e/rbac/rbac-admin-regression.spec.ts \
 			e2e/rbac/mcp-openfga-tuples.spec.ts \
+			e2e/rbac/admin-settings-regression.spec.ts \
 			--config=playwright.rbac.config.ts
 
 migrate-canonical-team-membership: ## Backfill team_membership_sources from legacy teams.members[] and $$unset the field. Dry-run by default; APPLY=1 to apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.14-dev.3"
+version = "0.5.14-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/README.md
+++ b/ui/e2e/rbac/README.md
@@ -260,6 +260,7 @@ To run it:
 * `workflow-agent-access.spec.ts`
 * `rbac-admin-regression.spec.ts`
 * `mcp-openfga-tuples.spec.ts`
+* `admin-settings-regression.spec.ts`
 
 Local parity: `make caipe-ui-e2e-rbac` (with `npm run dev` already on
 `:3000`) or `RUN_RBAC_REGRESSION=1 npm run test:e2e:rbac-regression`.

--- a/ui/e2e/rbac/admin-settings-regression.spec.ts
+++ b/ui/e2e/rbac/admin-settings-regression.spec.ts
@@ -1,0 +1,65 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import { expect, test } from "@playwright/test";
+
+import { installMockedRbacApp, mockedRbacEnabled } from "./_mocked-rbac";
+
+const adminSession = {
+  email: "sraradhy@cisco.com",
+  name: "Sri Aradhyula",
+  role: "admin" as const,
+  canViewAdmin: true,
+};
+
+test.describe("mocked admin settings browser regression", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run the mocked RBAC browser regression.",
+    );
+  });
+
+  test("defaults bare admin route to Settings General", async ({ page }) => {
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+    });
+
+    await page.goto("/admin", { waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveURL(/\/admin\?cat=settings&tab=settings$/);
+    await expect(page.getByRole("button", { name: "Settings" })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("tab", { name: "General" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByRole("tab", { name: "Default Agent" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Manage Unlinked Access" })).toBeVisible();
+  });
+
+  test("explains Unlinked Access on the settings card and modal", async ({ page }) => {
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+    });
+
+    await page.goto("/admin?cat=settings&tab=settings", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByText("Grant agents and tools to unlinked users")).toBeVisible();
+    await expect(page.getByText(/messaged via Slack or Webex but never signed in/)).toBeVisible();
+    await expect(
+      page.getByText(/base access every unlinked Slack\/Webex caller and bot/),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Manage Unlinked Access" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Unlinked Access" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Grant agents and tools to unlinked users")).toBeVisible();
+    await expect(
+      dialog.getByText(/Any platform admin can add agents or tools they own/),
+    ).toBeVisible();
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "jest --coverage",
     "init-credential-indexes": "ts-node --project tsconfig.json ../scripts/init-credential-mongo-indexes.ts",
     "test:e2e:rbac": "playwright test --config=playwright.rbac.config.ts",
-    "test:e2e:rbac-regression": "WORKFLOWS_ENABLED=true playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/service-accounts.spec.ts e2e/rbac/slack-run-as.spec.ts --config=playwright.rbac.config.ts",
+    "test:e2e:rbac-regression": "WORKFLOWS_ENABLED=true playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/service-accounts.spec.ts e2e/rbac/admin-settings-regression.spec.ts e2e/rbac/slack-run-as.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-mcp": "RUN_RBAC_E2E=1 playwright test e2e/rbac/mcp-server-create-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-openfga": "RUN_RBAC_E2E=1 playwright test e2e/rbac/openfga-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-slack-bff": "RUN_RBAC_E2E=1 playwright test e2e/rbac/slack-bff-user-directory-live.spec.ts --config=playwright.rbac.config.ts",

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.14.dev3"
+version = "0.5.14.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Add a mocked RBAC Playwright regression for the merged admin Settings → General default route behavior.
- Cover the clarified Unlinked Access card and modal copy from the admin settings page.
- Wire the new spec into the local mocked RBAC regression command, Makefile target, CI workflow list, and RBAC E2E README.

## Validation

- `npm ci`
- `RUN_RBAC_REGRESSION=1 WORKFLOWS_ENABLED=true CAIPE_UI_BASE_URL=http://localhost:3011 npx playwright test e2e/rbac/admin-settings-regression.spec.ts --config=playwright.rbac.config.ts --trace on`
- `npx eslint e2e/rbac/admin-settings-regression.spec.ts`
- `git diff --check`

## Notes

This branch was created from current `origin/main`, where PRs #1861 and #1862 are already merged, so the PR contains only the E2E coverage and regression-list wiring.