### PR TITLE
fix: unlinked service account catalog grants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.2"
+version = "0.5.15-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/service-accounts.spec.ts
+++ b/ui/e2e/rbac/service-accounts.spec.ts
@@ -187,16 +187,6 @@ test.describe("mocked service accounts browser regression", () => {
         return true;
       }
 
-      if (path === "/api/admin/service-accounts/sa-sub-playwright/credentials" && method === "GET") {
-        await fulfillJson(route, { success: true, data: [] });
-        return true;
-      }
-
-      if (path === "/api/admin/service-accounts/token-providers" && method === "GET") {
-        await fulfillJson(route, { success: false, code: "CREDENTIALS_DISABLED" }, 404);
-        return true;
-      }
-
       if (path === "/api/admin/service-accounts/sa-sub-playwright/scopes") {
         const body = (await postJson(route)) as ScopeRef;
         requests.push({ method, path, body });
@@ -652,16 +642,20 @@ test.describe("mocked service accounts browser regression", () => {
 
       if (path === "/api/admin/service-accounts/grantable" && method === "GET") {
         requests.push({ method, path, search: url.search, body: null });
-        await fulfillJson(route, {
-          success: true,
-          data: {
-            agents: [{ ref: "incident-resolver", name: "Incident Resolver" }],
-            tools: [
-              { ref: "jira/*", name: "jira: all tools" },
-              { ref: "github/*", name: "github: all tools" },
-            ],
-          },
-        });
+        if (url.searchParams.get("context") === "unlinked") {
+          await fulfillJson(route, {
+            success: true,
+            data: {
+              agents: [{ ref: "incident-resolver", name: "Incident Resolver" }],
+              tools: [
+                { ref: "jira/*", name: "jira: all tools" },
+                { ref: "github/*", name: "github: all tools" },
+              ],
+            },
+          });
+          return true;
+        }
+        await fulfillJson(route, { success: true, data: { agents: [], tools: [] } });
         return true;
       }
 

--- a/ui/e2e/rbac/service-accounts.spec.ts
+++ b/ui/e2e/rbac/service-accounts.spec.ts
@@ -648,7 +648,8 @@ test.describe("mocked service accounts browser regression", () => {
             data: {
               agents: [{ ref: "incident-resolver", name: "Incident Resolver" }],
               tools: [
-                { ref: "jira/*", name: "jira: all tools" },
+                { ref: "jira/search", name: "jira: search" },
+                { ref: "jira/create_issue", name: "jira: create issue" },
                 { ref: "github/*", name: "github: all tools" },
               ],
             },
@@ -685,10 +686,11 @@ test.describe("mocked service accounts browser regression", () => {
     await expect(dialog).toBeVisible();
 
     await dialog.getByLabel("Scope type").selectOption("tool");
-    await expect(dialog.getByLabel("Scope ref")).toContainText("jira: all tools");
+    await expect(dialog.getByLabel("Scope ref")).toContainText("jira: search");
+    await expect(dialog.getByLabel("Scope ref")).toContainText("github: all tools");
     await expect(dialog.getByTestId("unlinked-modal-grantable-empty-note")).toHaveCount(0);
 
-    await dialog.getByLabel("Scope ref").selectOption("jira/*");
+    await dialog.getByLabel("Scope ref").selectOption("jira/search");
     await dialog.getByRole("button", { name: "Add" }).click();
 
     await expect
@@ -716,7 +718,7 @@ test.describe("mocked service accounts browser regression", () => {
           request.method === "POST" &&
           request.path === "/api/admin/service-accounts/sa-unlinked-platform/scopes",
       )?.body,
-    ).toEqual({ type: "tool", ref: "jira/*" });
-    await expect(dialog.getByText("tool/jira/*")).toBeVisible();
+    ).toEqual({ type: "tool", ref: "jira/search" });
+    await expect(dialog.getByText("tool/jira/search")).toBeVisible();
   });
 });

--- a/ui/e2e/rbac/service-accounts.spec.ts
+++ b/ui/e2e/rbac/service-accounts.spec.ts
@@ -721,4 +721,91 @@ test.describe("mocked service accounts browser regression", () => {
     ).toEqual({ type: "tool", ref: "jira/search" });
     await expect(dialog.getByText("tool/jira/search")).toBeVisible();
   });
+
+  test("shows no tool choices for unlinked access when catalog discovery found no tools", async ({
+    page,
+  }) => {
+    const requests: Array<{ method: string; path: string; search: string; body: unknown }> = [];
+
+    const unlinkedEmptyToolsHandler: MockRouteHandler = async ({ route, path, method, url }) => {
+      if (path === "/api/admin/platform-config" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            default_agent_id: "incident-resolver",
+            release_notes: { enabled: false },
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: [{ _id: "incident-resolver", name: "Incident Resolver", enabled: true }],
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/service-accounts/unlinked" && method === "GET") {
+        await fulfillJson(route, {
+          success: true,
+          data: {
+            id: "sa-unlinked-platform",
+            name: "platform-unlinked",
+            scopes: [],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/service-accounts/grantable" && method === "GET") {
+        requests.push({ method, path, search: url.search, body: null });
+        if (url.searchParams.get("context") === "unlinked") {
+          await fulfillJson(route, {
+            success: true,
+            data: {
+              agents: [{ ref: "incident-resolver", name: "Incident Resolver" }],
+              tools: [],
+            },
+          });
+          return true;
+        }
+        await fulfillJson(route, { success: true, data: { agents: [], tools: [] } });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      handlers: [unlinkedEmptyToolsHandler],
+    });
+
+    await page.goto("/admin?cat=settings&tab=settings", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Manage Unlinked Access" }).click();
+    const dialog = page.getByRole("dialog", { name: "Unlinked Access" });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel("Scope type").selectOption("tool");
+    await expect(dialog.getByTestId("unlinked-modal-grantable-empty-note")).toHaveText(
+      /No tools available to grant/i,
+    );
+    await expect(dialog.getByLabel("Scope ref")).toContainText("No more tools available");
+    await expect(dialog.getByLabel("Scope ref")).not.toContainText("jira: all tools");
+    await expect(dialog.getByRole("button", { name: "Add" })).toBeDisabled();
+    await expect
+      .poll(() =>
+        requests.some(
+          (request) =>
+            request.method === "GET" &&
+            request.path === "/api/admin/service-accounts/grantable" &&
+            request.search === "?context=unlinked",
+        ),
+      )
+      .toBe(true);
+  });
 });

--- a/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
@@ -208,6 +208,39 @@ describe("GET /api/admin/service-accounts/grantable", () => {
     expect(body.data.tools).toEqual([{ ref: "jira/*", name: "jira: all tools" }]);
   });
 
+  it("does not fall back to a wildcard when a server was cataloged with no tools", async () => {
+    mockHasOrganizationAdmin.mockResolvedValue(true);
+    mockGetCollection.mockImplementation((name: string) => {
+      if (name === "dynamic_agents") {
+        return Promise.resolve(collectionReturning([]));
+      }
+      if (name === "mcp_servers") {
+        return Promise.resolve(collectionReturning([{ _id: "jira", name: "Jira" }]));
+      }
+      if (name === "mcp_tool_catalog") {
+        return Promise.resolve(
+          collectionReturning([
+            {
+              server_id: "jira",
+              tool_id: "__catalog_marker__",
+              ref: "jira/__catalog_marker__",
+              display_name: "jira: catalog discovered",
+              enabled: false,
+              kind: "server_catalog",
+            },
+          ]),
+        );
+      }
+      throw new Error(`unexpected collection ${name}`);
+    });
+
+    const res = await GET(request("/api/admin/service-accounts/grantable?context=unlinked"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.data.tools).toEqual([]);
+  });
+
   it("403s the unlinked full-catalog context when the caller is not a platform admin", async () => {
     mockHasOrganizationAdmin.mockResolvedValue(false);
 

--- a/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
@@ -146,6 +146,27 @@ describe("GET /api/admin/service-accounts/grantable", () => {
           ]),
         );
       }
+      if (name === "mcp_tool_catalog") {
+        return Promise.resolve(
+          collectionReturning([
+            {
+              server_id: "jira",
+              tool_id: "search",
+              ref: "jira/search",
+              display_name: "jira: search",
+              description: "Search Jira issues",
+              enabled: true,
+            },
+            {
+              server_id: "jira",
+              tool_id: "create_issue",
+              ref: "jira/create_issue",
+              display_name: "jira: create issue",
+              enabled: true,
+            },
+          ]),
+        );
+      }
       throw new Error(`unexpected collection ${name}`);
     });
 
@@ -160,8 +181,31 @@ describe("GET /api/admin/service-accounts/grantable", () => {
     ]);
     expect(body.data.tools).toEqual([
       { ref: "github/*", name: "github: all tools" },
-      { ref: "jira/*", name: "jira: all tools" },
+      { ref: "jira/create_issue", name: "jira: create issue" },
+      { ref: "jira/search", name: "jira: search" },
     ]);
+  });
+
+  it("falls back to server wildcards for unlinked tools when no cached individual tools exist", async () => {
+    mockHasOrganizationAdmin.mockResolvedValue(true);
+    mockGetCollection.mockImplementation((name: string) => {
+      if (name === "dynamic_agents") {
+        return Promise.resolve(collectionReturning([]));
+      }
+      if (name === "mcp_servers") {
+        return Promise.resolve(collectionReturning([{ _id: "jira", name: "Jira" }]));
+      }
+      if (name === "mcp_tool_catalog") {
+        return Promise.resolve(collectionReturning([]));
+      }
+      throw new Error(`unexpected collection ${name}`);
+    });
+
+    const res = await GET(request("/api/admin/service-accounts/grantable?context=unlinked"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.data.tools).toEqual([{ ref: "jira/*", name: "jira: all tools" }]);
   });
 
   it("403s the unlinked full-catalog context when the caller is not a platform admin", async () => {

--- a/ui/src/app/api/admin/service-accounts/grantable/route.ts
+++ b/ui/src/app/api/admin/service-accounts/grantable/route.ts
@@ -6,6 +6,7 @@ import { listOpenFgaObjects } from "@/lib/rbac/openfga";
 import { listRebacCatalog } from "@/lib/rbac/resource-catalog";
 import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
 import { hasOrganizationAdmin } from "@/lib/rbac/platform-admin";
+import { listCachedMcpTools } from "@/lib/rbac/mcp-tool-catalog";
 
 /**
  * GET /api/admin/service-accounts/grantable
@@ -76,9 +77,14 @@ async function listFullPlatformCatalog(): Promise<{ agents: GrantableItem[]; too
     ref: agent._id,
     name: agent.name ?? agent._id,
   }));
-  const tools = allServers.map((server) => {
+  const cachedTools = await listCachedMcpTools(allServers.map((server) => server._id));
+  const tools = allServers.flatMap((server) => {
+    const cached = cachedTools.get(server._id);
+    if (cached && cached.length > 0) {
+      return cached.map((tool) => ({ ref: tool.ref, name: tool.name }));
+    }
     const ref = `${server._id}/*`;
-    return { ref, name: humanizeToolRef(ref) };
+    return [{ ref, name: humanizeToolRef(ref) }];
   });
 
   agents.sort((a, b) => a.name.localeCompare(b.name));

--- a/ui/src/app/api/admin/service-accounts/grantable/route.ts
+++ b/ui/src/app/api/admin/service-accounts/grantable/route.ts
@@ -77,11 +77,14 @@ async function listFullPlatformCatalog(): Promise<{ agents: GrantableItem[]; too
     ref: agent._id,
     name: agent.name ?? agent._id,
   }));
-  const cachedTools = await listCachedMcpTools(allServers.map((server) => server._id));
+  const cachedToolCatalog = await listCachedMcpTools(allServers.map((server) => server._id));
   const tools = allServers.flatMap((server) => {
-    const cached = cachedTools.get(server._id);
+    const cached = cachedToolCatalog.toolsByServer.get(server._id);
     if (cached && cached.length > 0) {
       return cached.map((tool) => ({ ref: tool.ref, name: tool.name }));
+    }
+    if (cachedToolCatalog.catalogedServerIds.has(server._id)) {
+      return [];
     }
     const ref = `${server._id}/*`;
     return [{ ref, name: humanizeToolRef(ref) }];

--- a/ui/src/app/api/mcp-servers/probe/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/probe/__tests__/route.test.ts
@@ -27,6 +27,7 @@ const mockRequireResourcePermission = jest.fn();
 const mockGetCollection = jest.fn();
 const mockAuthenticateRequest = jest.fn();
 const mockBuildBackendHeaders = jest.fn();
+const mockCacheMcpToolCatalog = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -72,6 +73,10 @@ jest.mock("@/lib/da-proxy", () => ({
   buildBackendHeaders: (...args: unknown[]) => mockBuildBackendHeaders(...args),
 }));
 
+jest.mock("@/lib/rbac/mcp-tool-catalog", () => ({
+  cacheMcpToolCatalog: (...args: unknown[]) => mockCacheMcpToolCatalog(...args),
+}));
+
 function request(path: string, init?: RequestInit): NextRequest {
   return new NextRequest(new URL(path, "http://localhost:3000"), init);
 }
@@ -100,6 +105,7 @@ describe("POST /api/mcp-servers/probe", () => {
       "Content-Type": "application/json",
       Authorization: "Bearer token",
     });
+    mockCacheMcpToolCatalog.mockResolvedValue(1);
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ success: true, tools: [{ name: "ls", description: "list" }] }),
@@ -125,6 +131,21 @@ describe("POST /api/mcp-servers/probe", () => {
     for (const call of mockRequireResourcePermission.mock.calls) {
       expect(call[1]).not.toMatchObject({ action: "invoke" });
     }
+  });
+
+  it("caches discovered tools after a successful probe", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/mcp-servers/probe?id=argocd", { method: "POST" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCacheMcpToolCatalog).toHaveBeenCalledWith({
+      serverId: "argocd",
+      source: "probe",
+      tools: [{ name: "ls", description: "list" }],
+    });
   });
 
   it("returns 403 when OpenFGA denies can_discover on the server", async () => {

--- a/ui/src/app/api/mcp-servers/probe/route.ts
+++ b/ui/src/app/api/mcp-servers/probe/route.ts
@@ -14,6 +14,7 @@ withErrorHandler,
 } from "@/lib/api-middleware";
 import { authenticateRequest,buildBackendHeaders } from "@/lib/da-proxy";
 import { getCollection } from "@/lib/mongodb";
+import { cacheMcpToolCatalog } from "@/lib/rbac/mcp-tool-catalog";
 import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import type { MCPServerConfig } from "@/types/dynamic-agent";
 import { NextRequest,NextResponse } from "next/server";
@@ -99,6 +100,16 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
           error: probeResult.error || "Probe failed",
           tools: [],
         });
+      }
+
+      try {
+        await cacheMcpToolCatalog({
+          serverId: id,
+          tools: Array.isArray(probeResult.tools) ? probeResult.tools : [],
+          source: "probe",
+        });
+      } catch (cacheError) {
+        console.warn("[mcp-servers/probe] failed to cache tool catalog:", cacheError);
       }
 
       return successResponse({

--- a/ui/src/lib/rbac/mcp-tool-catalog.ts
+++ b/ui/src/lib/rbac/mcp-tool-catalog.ts
@@ -1,0 +1,141 @@
+import { createHash } from "crypto";
+
+import { getCollection } from "@/lib/mongodb";
+import type { MCPToolInfo } from "@/types/dynamic-agent";
+
+export const MCP_TOOL_CATALOG_COLLECTION = "mcp_tool_catalog";
+
+export interface McpToolCatalogEntry {
+  _id: string;
+  server_id: string;
+  tool_id: string;
+  ref: string;
+  display_name: string;
+  description?: string;
+  input_schema_hash?: string;
+  enabled: boolean;
+  source: "probe" | "agentgateway" | "static";
+  discovered_at: string;
+  last_seen_at: string;
+}
+
+export interface CachedMcpToolItem {
+  server_id: string;
+  tool_id: string;
+  ref: string;
+  name: string;
+  description?: string;
+}
+
+function isValidToolName(value: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+function hashSchema(schema: unknown): string | undefined {
+  if (schema === undefined || schema === null) return undefined;
+  return createHash("sha256").update(JSON.stringify(schema)).digest("hex");
+}
+
+function displayNameForTool(serverId: string, toolName: string, tool: Partial<MCPToolInfo>): string {
+  const label = tool.namespaced_name || tool.name || toolName;
+  return label.includes("/") ? label : `${serverId}: ${label}`;
+}
+
+function toToolName(serverId: string, tool: Partial<MCPToolInfo>): string | null {
+  const raw = tool.name || tool.namespaced_name;
+  if (!raw) return null;
+  const name = raw.startsWith(`${serverId}/`) ? raw.slice(serverId.length + 1) : raw;
+  return isValidToolName(name) ? name : null;
+}
+
+export async function cacheMcpToolCatalog(input: {
+  serverId: string;
+  tools: Array<Partial<MCPToolInfo> & { input_schema?: unknown }>;
+  source?: McpToolCatalogEntry["source"];
+  now?: Date;
+}): Promise<number> {
+  const serverId = input.serverId.trim();
+  if (!isValidToolName(serverId)) return 0;
+
+  const now = (input.now ?? new Date()).toISOString();
+  const source = input.source ?? "probe";
+  const entries: McpToolCatalogEntry[] = [];
+  for (const tool of input.tools) {
+    const toolName = toToolName(serverId, tool);
+    if (!toolName) continue;
+    const ref = `${serverId}/${toolName}`;
+    const inputSchemaHash = hashSchema(tool.input_schema);
+    entries.push({
+      _id: ref,
+      server_id: serverId,
+      tool_id: toolName,
+      ref,
+      display_name: displayNameForTool(serverId, toolName, tool),
+      ...(tool.description ? { description: tool.description } : {}),
+      ...(inputSchemaHash ? { input_schema_hash: inputSchemaHash } : {}),
+      enabled: true,
+      source,
+      discovered_at: now,
+      last_seen_at: now,
+    });
+  }
+
+  const collection = await getCollection<McpToolCatalogEntry>(MCP_TOOL_CATALOG_COLLECTION);
+  await collection.updateMany({ server_id: serverId } as never, { $set: { enabled: false } } as never);
+  if (entries.length === 0) return 0;
+
+  await collection.bulkWrite(
+    entries.map((entry) => ({
+      updateOne: {
+        filter: { _id: entry._id },
+        update: {
+          $set: {
+            server_id: entry.server_id,
+            tool_id: entry.tool_id,
+            ref: entry.ref,
+            display_name: entry.display_name,
+            description: entry.description,
+            input_schema_hash: entry.input_schema_hash,
+            enabled: true,
+            source: entry.source,
+            last_seen_at: entry.last_seen_at,
+          },
+          $setOnInsert: { discovered_at: entry.discovered_at },
+        },
+        upsert: true,
+      },
+    })) as never,
+  );
+
+  return entries.length;
+}
+
+export async function listCachedMcpTools(serverIds: string[]): Promise<Map<string, CachedMcpToolItem[]>> {
+  const validServerIds = [...new Set(serverIds.filter(isValidToolName))];
+  const toolsByServer = new Map<string, CachedMcpToolItem[]>();
+  if (validServerIds.length === 0) return toolsByServer;
+
+  const collection = await getCollection<McpToolCatalogEntry>(MCP_TOOL_CATALOG_COLLECTION);
+  const rows = await collection
+    .find(
+      { server_id: { $in: validServerIds }, enabled: true } as never,
+      { projection: { server_id: 1, tool_id: 1, ref: 1, display_name: 1, description: 1 } },
+    )
+    .sort({ server_id: 1, display_name: 1 })
+    .toArray();
+
+  for (const row of rows) {
+    const item: CachedMcpToolItem = {
+      server_id: row.server_id,
+      tool_id: row.tool_id,
+      ref: row.ref,
+      name: row.display_name,
+      ...(row.description ? { description: row.description } : {}),
+    };
+    const list = toolsByServer.get(row.server_id) ?? [];
+    list.push(item);
+    toolsByServer.set(row.server_id, list);
+  }
+
+  return toolsByServer;
+}

--- a/ui/src/lib/rbac/mcp-tool-catalog.ts
+++ b/ui/src/lib/rbac/mcp-tool-catalog.ts
@@ -1,9 +1,11 @@
+// assisted-by Codex Codex-sonnet-4-6
 import { createHash } from "crypto";
 
 import { getCollection } from "@/lib/mongodb";
 import type { MCPToolInfo } from "@/types/dynamic-agent";
 
 export const MCP_TOOL_CATALOG_COLLECTION = "mcp_tool_catalog";
+const CATALOG_MARKER_TOOL_ID = "__catalog_marker__";
 
 export interface McpToolCatalogEntry {
   _id: string;
@@ -14,6 +16,7 @@ export interface McpToolCatalogEntry {
   description?: string;
   input_schema_hash?: string;
   enabled: boolean;
+  kind?: "tool" | "server_catalog";
   source: "probe" | "agentgateway" | "static";
   discovered_at: string;
   last_seen_at: string;
@@ -25,6 +28,11 @@ export interface CachedMcpToolItem {
   ref: string;
   name: string;
   description?: string;
+}
+
+export interface CachedMcpToolCatalog {
+  catalogedServerIds: Set<string>;
+  toolsByServer: Map<string, CachedMcpToolItem[]>;
 }
 
 function isValidToolName(value: string): boolean {
@@ -46,6 +54,22 @@ function toToolName(serverId: string, tool: Partial<MCPToolInfo>): string | null
   if (!raw) return null;
   const name = raw.startsWith(`${serverId}/`) ? raw.slice(serverId.length + 1) : raw;
   return isValidToolName(name) ? name : null;
+}
+
+function catalogMarker(serverId: string, source: McpToolCatalogEntry["source"], now: string): McpToolCatalogEntry {
+  const ref = `${serverId}/${CATALOG_MARKER_TOOL_ID}`;
+  return {
+    _id: ref,
+    server_id: serverId,
+    tool_id: CATALOG_MARKER_TOOL_ID,
+    ref,
+    display_name: `${serverId}: catalog discovered`,
+    enabled: false,
+    kind: "server_catalog",
+    source,
+    discovered_at: now,
+    last_seen_at: now,
+  };
 }
 
 export async function cacheMcpToolCatalog(input: {
@@ -74,6 +98,7 @@ export async function cacheMcpToolCatalog(input: {
       ...(tool.description ? { description: tool.description } : {}),
       ...(inputSchemaHash ? { input_schema_hash: inputSchemaHash } : {}),
       enabled: true,
+      kind: "tool",
       source,
       discovered_at: now,
       last_seen_at: now,
@@ -82,10 +107,10 @@ export async function cacheMcpToolCatalog(input: {
 
   const collection = await getCollection<McpToolCatalogEntry>(MCP_TOOL_CATALOG_COLLECTION);
   await collection.updateMany({ server_id: serverId } as never, { $set: { enabled: false } } as never);
-  if (entries.length === 0) return 0;
+  const writes = [catalogMarker(serverId, source, now), ...entries];
 
   await collection.bulkWrite(
-    entries.map((entry) => ({
+    writes.map((entry) => ({
       updateOne: {
         filter: { _id: entry._id },
         update: {
@@ -96,7 +121,8 @@ export async function cacheMcpToolCatalog(input: {
             display_name: entry.display_name,
             description: entry.description,
             input_schema_hash: entry.input_schema_hash,
-            enabled: true,
+            enabled: entry.enabled,
+            kind: entry.kind ?? "tool",
             source: entry.source,
             last_seen_at: entry.last_seen_at,
           },
@@ -110,21 +136,27 @@ export async function cacheMcpToolCatalog(input: {
   return entries.length;
 }
 
-export async function listCachedMcpTools(serverIds: string[]): Promise<Map<string, CachedMcpToolItem[]>> {
+export async function listCachedMcpTools(serverIds: string[]): Promise<CachedMcpToolCatalog> {
   const validServerIds = [...new Set(serverIds.filter(isValidToolName))];
+  const catalogedServerIds = new Set<string>();
   const toolsByServer = new Map<string, CachedMcpToolItem[]>();
-  if (validServerIds.length === 0) return toolsByServer;
+  if (validServerIds.length === 0) return { catalogedServerIds, toolsByServer };
 
   const collection = await getCollection<McpToolCatalogEntry>(MCP_TOOL_CATALOG_COLLECTION);
   const rows = await collection
     .find(
-      { server_id: { $in: validServerIds }, enabled: true } as never,
-      { projection: { server_id: 1, tool_id: 1, ref: 1, display_name: 1, description: 1 } },
+      { server_id: { $in: validServerIds } } as never,
+      { projection: { server_id: 1, tool_id: 1, ref: 1, display_name: 1, description: 1, enabled: 1, kind: 1 } },
     )
     .sort({ server_id: 1, display_name: 1 })
     .toArray();
 
   for (const row of rows) {
+    if (row.kind === "server_catalog") {
+      catalogedServerIds.add(row.server_id);
+      continue;
+    }
+    if (row.enabled !== true) continue;
     const item: CachedMcpToolItem = {
       server_id: row.server_id,
       tool_id: row.tool_id,
@@ -137,5 +169,5 @@ export async function listCachedMcpTools(serverIds: string[]): Promise<Map<strin
     toolsByServer.set(row.server_id, list);
   }
 
-  return toolsByServer;
+  return { catalogedServerIds, toolsByServer };
 }

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev2"
+version = "0.5.15.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

Fixes #1860.

- Adds an unlinked-service-account context to `GET /api/admin/service-accounts/grantable` that returns the full enabled platform catalog for agents and MCP tools.
- Uses cached MCP tool discovery to show individual tool grants such as `jira/search` when available, with `server/*` wildcard fallback for servers that have not been probed yet.
- Caches discovered MCP tools after successful server probes so the admin grant picker does not need to call AgentGateway from the browser.
- Gates the full catalog to platform admins while preserving caller-held scope behavior for normal service-account flows.
- Lets platform admins grant catalog scopes to the platform unlinked service account without requiring the human caller to personally hold the tool scope.
- Updates the unlinked access modal and adds unit plus Playwright coverage for individual and wildcard tool grants.

## Root Cause

The unlinked service account picker used the normal grantable endpoint, which lists scopes held by the calling human. In the OpenFGA model, tool call scopes are held by runtime callers such as agents and service accounts, so human platform admins often had no `tool.can_call` objects to list. The subsequent POST route also enforced the same human-held scope rule, blocking direct grants to the unlinked service account.

The first implementation also exposed only wildcard MCP scopes such as `jira/*`. That was correct as a fallback but too coarse when AgentGateway already exposes concrete tool names from probe results.

## Validation

- Focused service-account grantable API tests passed.
- Focused MCP-server probe API tests passed.
- TypeScript `tsc --noEmit` passed.
- Focused ESLint passed with one existing warning in `mcp-servers/probe/route.ts`.
- PR CI is running on the pushed branch.
