### PR TITLE
chore(slack-bot): remove SLACK_INTEGRATION_SILENCE_ENV flag

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -49,10 +49,7 @@ from utils.slack_agent_routes import (  # noqa: E402
     slack_agent_route_mode,
     slack_workspace_ref,
 )
-from utils.slack_runtime_policy import (  # noqa: E402
-    should_post_route_miss_notice,
-    should_process_slack_payload,
-)
+from utils.slack_runtime_policy import should_post_route_miss_notice  # noqa: E402
 from utils.dispatch_identity import apply_execution_identity  # noqa: E402
 from utils.unlinked_fallback import apply_unlinked_fallback  # noqa: E402
 from utils.slack_admin_api import start_slack_admin_api_server  # noqa: E402
@@ -558,11 +555,6 @@ def _match_channel_agents(
   return config_matches
 
 
-def _slack_responses_suppressed() -> bool:
-  """Return whether setup mode should suppress user-visible Slack responses."""
-  return not should_process_slack_payload(silence_env=bool(getattr(config, "silence_env", False)))
-
-
 def _post_route_miss_notice(
   client,
   channel_id: str,
@@ -574,14 +566,7 @@ def _post_route_miss_notice(
   """Tell the sender why Slack routing did not dispatch an agent."""
   if not channel_id or not text:
     return
-  silence_env = bool(getattr(config, "silence_env", False))
-  if silence_env:
-    logger.info("Suppressing Slack route miss notice because setup silence mode is enabled")
-    return
-  if not should_post_route_miss_notice(
-    silence_env=silence_env,
-    explicit_invocation=explicit_invocation,
-  ):
+  if not should_post_route_miss_notice(explicit_invocation=explicit_invocation):
     logger.debug("Suppressing Slack route miss notice for ambient channel message")
     return
   try:
@@ -1020,9 +1005,6 @@ def rbac_global_middleware(body, context, next, logger):
             logger.debug("Ignoring duplicate event_id=%s", event_id)
             return _HANDLED_200
         _seen_events[event_id] = now
-    if _slack_responses_suppressed():
-        logger.info("Ignoring Slack payload while SLACK_INTEGRATION_SILENCE_ENV=true")
-        return _HANDLED_200
     """Enterprise RBAC enforcement checkpoint (098).
 
     When SLACK_RBAC_ENABLED=true:

--- a/ai_platform_engineering/integrations/slack_bot/tests/conftest.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/conftest.py
@@ -21,4 +21,3 @@ C123:
         overthink:
           enabled: false
 """
-os.environ["SLACK_INTEGRATION_SILENCE_ENV"] = "false"

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_config.py
@@ -14,23 +14,6 @@ from ai_platform_engineering.integrations.slack_bot.utils.config_models import (
 )
 
 
-class TestSilenceEnv:
-  def test_silence_env_true(self, monkeypatch):
-    monkeypatch.setenv("SLACK_INTEGRATION_SILENCE_ENV", "true")
-    cfg = Config.from_env()
-    assert cfg.silence_env is True
-
-  def test_silence_env_false(self, monkeypatch):
-    monkeypatch.setenv("SLACK_INTEGRATION_SILENCE_ENV", "false")
-    cfg = Config.from_env()
-    assert cfg.silence_env is False
-
-  def test_silence_env_default(self, monkeypatch):
-    monkeypatch.delenv("SLACK_INTEGRATION_SILENCE_ENV", raising=False)
-    cfg = Config.from_env()
-    assert cfg.silence_env is False  # Default is false
-
-
 class TestChannelWithAgentsList:
   def test_channel_with_agents_parses(self):
     # Uses default from conftest

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slack_route_no_silent_failure.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slack_route_no_silent_failure.py
@@ -15,7 +15,6 @@ if str(_APP_DIR) not in sys.path:
 
 _POLICY = importlib.import_module("utils.slack_runtime_policy")
 should_post_route_miss_notice = _POLICY.should_post_route_miss_notice
-should_process_slack_payload = _POLICY.should_process_slack_payload
 
 
 class _Logger:
@@ -56,7 +55,6 @@ class _Client:
 def _load_slack_app(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    silence_env: bool = False,
     rbac_enabled: bool = False,
 ):
     monkeypatch.syspath_prepend(str(_APP_DIR))
@@ -65,7 +63,6 @@ def _load_slack_app(
     monkeypatch.setenv("CAIPE_CONNECT_RETRIES", "1")
     monkeypatch.setenv("SLACK_RBAC_ENABLED", "true" if rbac_enabled else "false")
     monkeypatch.setenv("SLACK_INTEGRATION_ENABLE_AUTH", "false")
-    monkeypatch.setenv("SLACK_INTEGRATION_SILENCE_ENV", "true" if silence_env else "false")
     monkeypatch.setattr(
         "slack_sdk.web.client.WebClient.auth_test",
         lambda _self, **_kwargs: {"ok": True, "user_id": "UBOT"},
@@ -78,58 +75,9 @@ def _load_slack_app(
     return importlib.import_module("app")
 
 
-def test_silence_env_stops_slack_payload_processing() -> None:
-    assert should_process_slack_payload(silence_env=False) is True
-    assert should_process_slack_payload(silence_env=True) is False
-
-
 def test_route_miss_notice_requires_explicit_invocation() -> None:
-    assert (
-        should_post_route_miss_notice(
-            silence_env=False,
-            explicit_invocation=True,
-        )
-        is True
-    )
-    assert (
-        should_post_route_miss_notice(
-            silence_env=False,
-            explicit_invocation=False,
-        )
-        is False
-    )
-
-
-def test_setup_mode_middleware_stops_handlers_before_they_can_respond(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    app_module = _load_slack_app(monkeypatch, silence_env=True)
-    next_called = False
-
-    def next_handler() -> None:
-        nonlocal next_called
-        next_called = True
-
-    result = app_module.rbac_global_middleware(
-        {
-            "event_id": "E-silenced",
-            "event": {"type": "message", "channel": "C123", "user": "U123"},
-        },
-        {},
-        next_handler,
-        _Logger(),
-    )
-
-    # Downstream handlers must not run while silence_env is true.
-    assert next_called is False
-    # And we must return a BoltResponse(200) so Slack stops retrying the
-    # envelope — otherwise Socket Mode delivers the same event up to 4
-    # times and we see "skipped calling next()" warnings on every retry.
-    # See: https://github.com/slackapi/bolt-python/issues/235
-    from slack_bolt.response import BoltResponse
-
-    assert isinstance(result, BoltResponse)
-    assert result.status == 200
+    assert should_post_route_miss_notice(explicit_invocation=True) is True
+    assert should_post_route_miss_notice(explicit_invocation=False) is False
 
 
 def test_deduplicated_event_returns_200(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -138,7 +86,7 @@ def test_deduplicated_event_returns_200(monkeypatch: pytest.MonkeyPatch) -> None
     Without the 200, Slack keeps retrying the envelope which produces the
     "middleware skipped calling next()" warning storm we hit in dev.
     """
-    app_module = _load_slack_app(monkeypatch, silence_env=False)
+    app_module = _load_slack_app(monkeypatch)
     from slack_bolt.response import BoltResponse
 
     payload = {
@@ -185,9 +133,7 @@ def test_rbac_deny_logs_warning_and_returns_200(
          to 4 times (which also produced bolt-python's "middleware skipped
          calling next()" warning).
     """
-    app_module = _load_slack_app(
-        monkeypatch, silence_env=False, rbac_enabled=True
-    )
+    app_module = _load_slack_app(monkeypatch, rbac_enabled=True)
     from slack_bolt.response import BoltResponse
 
     async def _fake_enrich(body, slack_user_id, context, *, require_mapping=True):
@@ -264,7 +210,7 @@ def test_rbac_deny_logs_warning_and_returns_200(
 def test_route_miss_notice_does_not_call_slack_for_ambient_messages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    app_module = _load_slack_app(monkeypatch, silence_env=False)
+    app_module = _load_slack_app(monkeypatch)
     client = _Client()
 
     app_module._post_route_miss_notice(
@@ -282,7 +228,7 @@ def test_route_miss_notice_does_not_call_slack_for_ambient_messages(
 def test_route_miss_notice_posts_for_explicit_invocations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    app_module = _load_slack_app(monkeypatch, silence_env=False)
+    app_module = _load_slack_app(monkeypatch)
     client = _Client()
 
     app_module._post_route_miss_notice(
@@ -297,31 +243,3 @@ def test_route_miss_notice_posts_for_explicit_invocations(
         {"channel": "C123", "user": "U123", "text": "route miss diagnostic"}
     ]
     assert client.channel_posts == []
-
-
-def test_route_miss_notice_setup_mode_suppresses_explicit_invocations(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    app_module = _load_slack_app(monkeypatch, silence_env=True)
-    client = _Client()
-
-    app_module._post_route_miss_notice(
-        client,
-        "C123",
-        "U123",
-        "route miss diagnostic",
-        explicit_invocation=True,
-    )
-
-    assert client.ephemeral_posts == []
-    assert client.channel_posts == []
-
-
-def test_route_miss_notice_is_suppressed_in_setup_mode() -> None:
-    assert (
-        should_post_route_miss_notice(
-            silence_env=True,
-            explicit_invocation=True,
-        )
-        is False
-    )

--- a/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/config_models.py
@@ -143,7 +143,6 @@ def get_escalation_config(agent_match: AgentBinding) -> EscalationConfig | None:
 class Config(BaseModel):
   defaults: GlobalDefaults = Field(default_factory=GlobalDefaults)
   channels: dict[str, ChannelConfig]
-  silence_env: bool = False
 
   @classmethod
   def from_env(cls) -> "Config":
@@ -185,12 +184,10 @@ class Config(BaseModel):
     for channel_id, channel_data in raw_config.items():
       channels[channel_id] = ChannelConfig(**channel_data)
 
-    silence_env = os.environ.get("SLACK_INTEGRATION_SILENCE_ENV", "false").lower() == "true"
-
     defaults = GlobalDefaults(
       default_agent_id=os.environ.get("SLACK_INTEGRATION_DEFAULT_AGENT_ID"),
       dm_agent_id=os.environ.get("SLACK_INTEGRATION_DM_AGENT_ID"),
       victorops_agent_id=os.environ.get("SLACK_INTEGRATION_VICTOROPS_AGENT_ID"),
     )
 
-    return cls(channels=channels, defaults=defaults, silence_env=silence_env)
+    return cls(channels=channels, defaults=defaults)

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_runtime_policy.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_runtime_policy.py
@@ -3,11 +3,6 @@
 from __future__ import annotations
 
 
-def should_process_slack_payload(*, silence_env: bool) -> bool:
-  """Return whether Slack handlers should process inbound payloads."""
-  return not silence_env
-
-
-def should_post_route_miss_notice(*, silence_env: bool, explicit_invocation: bool) -> bool:
+def should_post_route_miss_notice(*, explicit_invocation: bool) -> bool:
   """Return whether a route miss should be visible to the Slack user."""
-  return not silence_env and explicit_invocation
+  return explicit_invocation

--- a/charts/ai-platform-engineering/charts/slack-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/values.yaml
@@ -22,7 +22,6 @@ serviceAccount:
 #   APP_NAME:                          Display name used in Slack messages (default: CAIPE)
 #   SLACK_BOT_MODE:                    "socket" (WebSocket) or "http" (webhooks)
 #   CAIPE_API_URL:                     Next.js gateway URL the bot routes requests through
-#   SLACK_INTEGRATION_SILENCE_ENV:     "true" to suppress environment info in responses
 #   SLACK_WORKSPACE_URL:               e.g. "https://mycompany.slack.com" for permalink deep links
 #   SLACK_WORKSPACE_ALIAS:             Canonical workspace alias used for Slack ReBAC/routes
 #   MONGODB_URI:                       MongoDB connection string
@@ -76,7 +75,6 @@ config:
   APP_NAME: "CAIPE"
   SLACK_BOT_MODE: "socket"
   CAIPE_API_URL: ""
-  SLACK_INTEGRATION_SILENCE_ENV: "false"
   MONGODB_DATABASE: "caipe"
   SLACK_WORKSPACE_ALIAS: "CAIPE"
   SLACK_AGENT_ROUTES_MODE: "db_prefer"

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -1294,7 +1294,6 @@ slack-bot:
     APP_NAME: "CAIPE"
     SLACK_BOT_MODE: "socket"
     CAIPE_API_URL: ""
-    SLACK_INTEGRATION_SILENCE_ENV: "false"
     # MONGODB_URI: ""                          # Override per environment
     # SLACK_WORKSPACE_URL: ""                  # e.g. "https://mycompany.slack.com"
     SLACK_WORKSPACE_ALIAS: "CAIPE"             # Canonical workspace namespace for Slack ReBAC/routes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.14-dev.7"
+version = "0.5.14-dev.8"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.14.dev7"
+version = "0.5.14.dev8"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Removes the `SLACK_INTEGRATION_SILENCE_ENV` bootstrap escape hatch entirely. This flag was originally introduced to suppress all Slack payload processing during initial setup, but operators can achieve the same result by simply not configuring any channels. The flag added complexity across the config model, middleware, policy functions, tests, and Helm charts for no ongoing benefit.

**Changes:**
- `utils/config_models.py` — drop `silence_env` field and env var read from `Config.from_env()`
- `utils/slack_runtime_policy.py` — remove `should_process_slack_payload` and `silence_env` param from `should_post_route_miss_notice`
- `app.py` — remove `_slack_responses_suppressed` helper, silence check in `rbac_global_middleware`, and silence guard in `_post_route_miss_notice`
- `tests/conftest.py` — remove `SLACK_INTEGRATION_SILENCE_ENV` env stub
- `tests/test_config.py` — remove `TestSilenceEnv` class
- `tests/test_slack_route_no_silent_failure.py` — remove silence-mode tests and `silence_env` param from `_load_slack_app`
- `charts/ai-platform-engineering/values.yaml` — remove `SLACK_INTEGRATION_SILENCE_ENV` key
- `charts/ai-platform-engineering/charts/slack-bot/values.yaml` — remove key and comment

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass