### PR TITLE
fix(dynamic-agents): surface CAS 4xx as its real status instead of collapsing to 503

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/authz.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/auth/authz.py
@@ -84,13 +84,24 @@ def _authz_service_url() -> str | None:
     return url or None
 
 
+class _CasMetaError(Exception):
+    """A CAS non-200 response. Carries the upstream status so the caller can
+    distinguish a definitive 4xx (not-retriable — bad request / unauthorized /
+    forbidden binding) from a transient 5xx or network failure (retriable)."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"CAS decision endpoint returned HTTP {status_code}")
+        self.status_code = status_code
+
+
 async def _decide_agent_use(subject_type: str, subject: str, agent_id: str, bearer: str) -> bool:
     """Ask CAS whether `subject` may use `agent_id`.
 
     Forwards the caller's bearer (OBO) so CAS's subject-binding (caller == subject)
     is satisfied; CAS evaluates the capability and the org-admin bypass. A DENY is
-    a 200 with ``decision: DENY``; any non-200 — or missing config — raises so the
-    caller fails closed (treated as PDP-unavailable)."""
+    a 200 with ``decision: DENY``; any non-200 raises ``_CasMetaError`` (carrying
+    the upstream status) and missing config raises ``RuntimeError`` — either way
+    the caller fails closed."""
     base = _authz_service_url()
     if not base:
         raise RuntimeError("AUTHZ_SERVICE_URL is not configured")
@@ -106,7 +117,7 @@ async def _decide_agent_use(subject_type: str, subject: str, agent_id: str, bear
     async with httpx.AsyncClient(timeout=5.0) as client:
         response = await client.post(f"{base}{_DECISIONS_PATH}", headers=headers, json=body)
     if response.status_code != 200:
-        raise RuntimeError(f"CAS decision endpoint returned HTTP {response.status_code}")
+        raise _CasMetaError(response.status_code)
     return response.json().get("decision") == "ALLOW"
 
 
@@ -129,7 +140,29 @@ async def require_agent_use_permission(agent_id: str) -> None:
 
     try:
         allowed = await _decide_agent_use(subject_type, subject, agent_id, token)
-    except Exception as exc:  # noqa: BLE001 — any failure to get a decision fails closed
+    except _CasMetaError as exc:
+        # A definitive 4xx from CAS (e.g. 403 subject-binding, 400 bad request, 401)
+        # is not transient — surface it as the same status so the caller sees a
+        # real "denied / misconfigured" signal instead of a misleading
+        # "retry later". Transient 5xx (and anything else below) stays 503/retry.
+        if 400 <= exc.status_code < 500:
+            logger.warning("CAS agent-use rejected request for agent=%s: HTTP %s", agent_id, exc.status_code)
+            _raise_authz(
+                exc.status_code,
+                "Authorization was refused for this request.",
+                "CAS_REJECTED",
+                "pdp_rejected",
+                "contact_admin",
+            )
+        logger.warning("CAS agent-use decision unavailable for agent=%s: %s", agent_id, exc)
+        _raise_authz(
+            503,
+            "Authorization service is temporarily unavailable. Please try again in a moment.",
+            "PDP_UNAVAILABLE",
+            "pdp_unavailable",
+            "retry",
+        )
+    except Exception as exc:  # noqa: BLE001 — any other failure to get a decision fails closed
         logger.warning("CAS agent-use decision unavailable for agent=%s: %s", agent_id, exc)
         _raise_authz(
             503,

--- a/ai_platform_engineering/dynamic_agents/tests/test_authz.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_authz.py
@@ -128,8 +128,8 @@ async def test_denies_when_cas_denies(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fails_closed_on_non_200(monkeypatch):
-    """Any non-200 from CAS (e.g. 503) denies via 503 — fail closed."""
+async def test_fails_closed_on_5xx(monkeypatch):
+    """A transient 5xx from CAS denies via 503/retry — fail closed."""
     from dynamic_agents.auth import authz
 
     monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://cas")
@@ -144,6 +144,27 @@ async def test_fails_closed_on_non_200(monkeypatch):
 
     assert exc.value.status_code == 503
     assert exc.value.detail["reason"] == "pdp_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cas_status", [400, 401, 403])
+async def test_cas_4xx_surfaces_as_same_status_not_503(monkeypatch, cas_status):
+    """A definitive 4xx from CAS (e.g. 403 subject-binding) is not transient, so
+    it surfaces as the same status with a non-retriable reason — not 503/retry."""
+    from dynamic_agents.auth import authz
+
+    monkeypatch.setenv("AUTHZ_SERVICE_URL", "http://cas")
+    monkeypatch.setattr(authz.httpx, "AsyncClient", _client([], _Resp(cas_status)))
+
+    token_ref = current_user_token.set(_fake_jwt({"sub": "alice-sub"}))
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await authz.require_agent_use_permission("agent-1")
+    finally:
+        current_user_token.reset(token_ref)
+
+    assert exc.value.status_code == cas_status
+    assert exc.value.detail["reason"] == "pdp_rejected"
 
 
 @pytest.mark.asyncio

--- a/docs/docs/security/rbac/workflows.md
+++ b/docs/docs/security/rbac/workflows.md
@@ -1604,7 +1604,7 @@ Dynamic Agents no longer perform in-process OpenFGA checks for agent invocation.
 
 1. Read `sub` from the already-validated bearer (signature verified upstream).
 2. `POST {AUTHZ_SERVICE_URL}/api/authz/v1/decisions` with `{ subject, resource: agent:<id>, action: use }`, forwarding the same OBO bearer so CAS **subject-binding** (`caller == subject`) holds.
-3. **Allow** on `decision: ALLOW`; **403** on deny; **503** when CAS is unreachable or `AUTHZ_SERVICE_URL` is unset (fail closed).
+3. **Allow** on `decision: ALLOW`; **403** on deny; **same 4xx status** when CAS returns a definitive 4xx (e.g. `403` subject-binding mismatch, `400` bad request, `401` — `reason: pdp_rejected`, `action: contact_admin`); **503** when CAS returns a 5xx, is unreachable, or `AUTHZ_SERVICE_URL` is unset (fail closed, `reason: pdp_unavailable`, `action: retry`). This ensures a misconfigured subject binding surfaces as a real denial signal rather than a misleading "temporarily unavailable".
 
 Workflow step execution in the BFF orchestrates agents in-process (`/api/v1/chat/stream/start` per step), so per-step agent-use checks run through the BFF CAS path rather than this DA HTTP client.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.1"
+version = "0.5.15-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev1"
+version = "0.5.15.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Stacked on #1877.

The Dynamic Agents CAS client (`require_agent_use_permission`) previously collapsed **every** non-200 from the CAS `/api/authz/v1/decisions` endpoint into `503 PDP_UNAVAILABLE / retry`. That conflates two very different failures:

- **Transient** (CAS 5xx, timeout, network, missing config) — retry is the right advice.
- **Definitive 4xx** (e.g. `403` subject-binding mismatch, `400` bad request, `401`) — not transient; retrying never helps, and the user/operator sees a misleading "temporarily unavailable" instead of the real "denied / misconfigured" signal.

Concretely: a service-account-run Slack channel whose CAS call 403'd surfaced in Slack as `503 Service Unavailable`. This change makes `_decide_agent_use` raise a typed `_CasMetaError` carrying the upstream status; the caller now surfaces a CAS **4xx as that same 4xx** (`reason: pdp_rejected`, action `contact_admin`), while **5xx / network / config** still fail closed as `503 / retry`. Still fully fail-closed — only the status code and message improve.

Added tests: CAS `400/401/403` surface as the same status with `pdp_rejected`; 5xx still maps to `503 / pdp_unavailable`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass