### PR TITLE
fix(slack): fix loguru format strings and remove noisy oauth cache debug log

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -281,7 +281,7 @@ def _slack_agent_channel_grant_check(context, channel_id: str | None, agent_id: 
         return None
 
     logger.info(
-        "Slack channel grant denied channel=%s agent=%s reason=%s",
+        "Slack channel grant denied channel={} agent={} reason={}",
         channel_id,
         agent_id,
         decision.reason,
@@ -1515,7 +1515,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
     denial = _slack_agent_channel_grant_check(context, channel_id, agent_id)
     if denial:
       logger.warning(
-        "Slack channel grant denied for ambient message channel=%s agent=%s — silently dropping",
+        "Slack channel grant denied for ambient message channel={} agent={} — silently dropping",
         channel_id,
         agent_id,
       )

--- a/ai_platform_engineering/integrations/slack_bot/utils/oauth2_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/oauth2_client.py
@@ -107,7 +107,6 @@ class OAuth2ClientCredentials:
         RuntimeError: If token fetch fails.
     """
     if self._cached_token and time.time() < (self._cached_token.expires_at - 60):
-      logger.debug("Using cached OAuth2 access token")
       return self._cached_token.access_token
 
     logger.info("Fetching new OAuth2 access token")

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.14 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.15 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.14 -f your-values.yaml'}
+                  {'    --version 0.5.15 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.14 -f your-values.yaml'}
+              {'    --version 0.5.15 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15"
+version = "0.5.15-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15"
+version = "0.5.15.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Two log formatting bugs in the slack-bot where `%s`-style format strings were used with loguru (which requires `{}`-style), causing the variable values to not be interpolated. Also removes a noisy per-request debug log in the OAuth2 token cache path.

- `app.py` `_slack_agent_channel_grant_check`: fix `%s` → `{}` in channel grant denied `logger.info`
- `app.py` `_route_to_agent`: fix `%s` → `{}` in ambient message grant denied `logger.warning`
- `utils/oauth2_client.py` `get_access_token`: remove `logger.debug("Using cached OAuth2 access token")` (fires on every authenticated request)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass