### PR TITLE
fix(admin): allow unlinked service account tool grants

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.14 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.15 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -257,7 +257,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.14 -f your-values.yaml'}
+                  {'    --version 0.5.15 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -422,7 +422,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.14 -f your-values.yaml'}
+              {'    --version 0.5.15 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15"
+version = "0.5.15-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/admin-settings-regression.spec.ts
+++ b/ui/e2e/rbac/admin-settings-regression.spec.ts
@@ -59,7 +59,7 @@ test.describe("mocked admin settings browser regression", () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText("Grant agents and tools to unlinked users")).toBeVisible();
     await expect(
-      dialog.getByText(/Any platform admin can add agents or tools they own/),
+      dialog.getByText(/Any platform admin can add enabled agents or tools here/),
     ).toBeVisible();
   });
 });

--- a/ui/e2e/rbac/service-accounts.spec.ts
+++ b/ui/e2e/rbac/service-accounts.spec.ts
@@ -615,4 +615,114 @@ test.describe("mocked service accounts browser regression", () => {
     await expect(manageDialog.getByText("Add a token", { exact: true })).toHaveCount(0);
     await expect(manageDialog.getByLabel("Access token")).toHaveCount(0);
   });
+
+  test("grants full-catalog tool scopes to the unlinked service account", async ({ page }) => {
+    const requests: Array<{ method: string; path: string; search: string; body: unknown }> = [];
+    const scopes: ScopeRef[] = [];
+
+    const unlinkedHandler: MockRouteHandler = async ({ route, path, method, url }) => {
+      if (path === "/api/admin/platform-config" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            default_agent_id: "incident-resolver",
+            release_notes: { enabled: false },
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: [{ _id: "incident-resolver", name: "Incident Resolver", enabled: true }],
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/service-accounts/unlinked" && method === "GET") {
+        await fulfillJson(route, {
+          success: true,
+          data: {
+            id: "sa-unlinked-platform",
+            name: "platform-unlinked",
+            scopes,
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/service-accounts/grantable" && method === "GET") {
+        requests.push({ method, path, search: url.search, body: null });
+        await fulfillJson(route, {
+          success: true,
+          data: {
+            agents: [{ ref: "incident-resolver", name: "Incident Resolver" }],
+            tools: [
+              { ref: "jira/*", name: "jira: all tools" },
+              { ref: "github/*", name: "github: all tools" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/service-accounts/sa-unlinked-platform/scopes" && method === "POST") {
+        const body = (await postJson(route)) as ScopeRef;
+        requests.push({ method, path, search: url.search, body });
+        scopes.push(body);
+        await fulfillJson(route, { success: true, data: { added: body } });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      handlers: [unlinkedHandler],
+    });
+
+    await page.goto("/admin?cat=settings&tab=settings", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Manage Unlinked Access" }).click();
+    const dialog = page.getByRole("dialog", { name: "Unlinked Access" });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel("Scope type").selectOption("tool");
+    await expect(dialog.getByLabel("Scope ref")).toContainText("jira: all tools");
+    await expect(dialog.getByTestId("unlinked-modal-grantable-empty-note")).toHaveCount(0);
+
+    await dialog.getByLabel("Scope ref").selectOption("jira/*");
+    await dialog.getByRole("button", { name: "Add" }).click();
+
+    await expect
+      .poll(() =>
+        requests.some(
+          (request) =>
+            request.method === "GET" &&
+            request.path === "/api/admin/service-accounts/grantable" &&
+            request.search === "?context=unlinked",
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        requests.some(
+          (request) =>
+            request.method === "POST" &&
+            request.path === "/api/admin/service-accounts/sa-unlinked-platform/scopes",
+        ),
+      )
+      .toBe(true);
+    expect(
+      requests.find(
+        (request) =>
+          request.method === "POST" &&
+          request.path === "/api/admin/service-accounts/sa-unlinked-platform/scopes",
+      )?.body,
+    ).toEqual({ type: "tool", ref: "jira/*" });
+    await expect(dialog.getByText("tool/jira/*")).toBeVisible();
+  });
 });

--- a/ui/src/app/api/admin/service-accounts/[id]/scopes/route.ts
+++ b/ui/src/app/api/admin/service-accounts/[id]/scopes/route.ts
@@ -1,3 +1,4 @@
+// assisted-by Codex Codex-sonnet-4-6
 import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-config";
@@ -58,7 +59,7 @@ async function authorizeScopeMutation(
   id: string,
 ): Promise<
   | { response: NextResponse }
-  | { actor: ResolvedActor; scope: ScopeRef }
+  | { actor: ResolvedActor; scope: ScopeRef; bypassHeldScopeCheck: boolean }
 > {
   const session = (await getServerSession(authOptions)) as {
     sub?: string;
@@ -101,26 +102,17 @@ async function authorizeScopeMutation(
     relation: "can_manage",
     object: `service_account:${id}`,
   });
+  const targetDoc = await getBySub(id);
+  const isUnlinkedSa = targetDoc?.is_platform_unlinked === true;
+  const unlinkedPlatformAdmin = isUnlinkedSa ? await isPlatformAdmin(session) : false;
+
   if (!canManage.allowed) {
     // [unlinked-sa][TS-B1] Org-admin bypass for the unlinked SA.
     // The unlinked SA is owned by super-admins, but its scopes are intended to be
     // managed by any platform/org-admin (mirrors the unlinked GET route's auth gate).
     // ADDITIVE: normal SAs still require owning-team can_manage; the bypass ONLY
     // fires for is_platform_unlinked===true docs when the caller is a platform admin.
-    const targetDoc = await getBySub(id);
-    const isUnlinkedSa = targetDoc?.is_platform_unlinked === true;
-    if (isUnlinkedSa) {
-      const admin = await isPlatformAdmin(session);
-      if (!admin) {
-        return {
-          response: NextResponse.json(
-            { success: false, error: "Service account not found" },
-            { status: 404 },
-          ),
-        };
-      }
-      // Org-admin managing the unlinked SA — allow.
-    } else {
+    if (!unlinkedPlatformAdmin) {
       return {
         response: NextResponse.json(
           { success: false, error: "Service account not found" },
@@ -128,9 +120,14 @@ async function authorizeScopeMutation(
         ),
       };
     }
+    // Org-admin managing the unlinked SA — allow.
   }
 
-  return { actor: { callerSub: session.sub, email: session.user.email ?? undefined }, scope };
+  return {
+    actor: { callerSub: session.sub, email: session.user.email ?? undefined },
+    scope,
+    bypassHeldScopeCheck: unlinkedPlatformAdmin,
+  };
 }
 
 /**
@@ -178,20 +175,24 @@ export async function POST(request: Request, context: RouteContext) {
   const { id } = await context.params;
   const pre = await authorizeScopeMutation(request, id);
   if ("response" in pre) return pre.response;
-  const { actor, scope } = pre;
+  const { actor, scope, bypassHeldScopeCheck } = pre;
 
   try {
-    // FR-015: the editor must hold the scope they're granting.
-    const held = await checkOpenFgaTuple(scopeCheckTuple(scope, `user:${actor.callerSub}`));
-    if (!held.allowed) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "You cannot grant a scope you do not hold",
-          data: { rejected_scope: scope },
-        },
-        { status: 403 },
-      );
+    // FR-015: normal SA editors must hold the scope they're granting. The
+    // platform unlinked SA is different: tools are granted to runtime callers,
+    // so human admins structurally cannot hold many grantable tool scopes.
+    if (!bypassHeldScopeCheck) {
+      const held = await checkOpenFgaTuple(scopeCheckTuple(scope, `user:${actor.callerSub}`));
+      if (!held.allowed) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "You cannot grant a scope you do not hold",
+            data: { rejected_scope: scope },
+          },
+          { status: 403 },
+        );
+      }
     }
 
     const saSubject = `service_account:${id}`;

--- a/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
@@ -26,14 +26,40 @@ jest.mock("@/lib/rbac/resource-catalog", () => ({
   listRebacCatalog: (...args: unknown[]) => mockListRebacCatalog(...args),
 }));
 
+const mockHasOrganizationAdmin = jest.fn();
+jest.mock("@/lib/rbac/platform-admin", () => ({
+  hasOrganizationAdmin: (...args: unknown[]) => mockHasOrganizationAdmin(...args),
+}));
+
+const mockGetCollection = jest.fn();
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
 import { GET } from "../grantable/route";
 
 const SESSION = { sub: "caller-sub", user: { email: "caller@example.com" } };
 
+function request(path: string): Request {
+  return new Request(`http://localhost:3000${path}`);
+}
+
+function collectionReturning(rows: unknown[]) {
+  return {
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
 beforeEach(() => {
-  jest.clearAllMocks();
+  jest.resetAllMocks();
   mockGetServerSession.mockResolvedValue(SESSION);
   mockListRebacCatalog.mockResolvedValue({ resources: [] });
+  mockHasOrganizationAdmin.mockResolvedValue(false);
 });
 
 describe("GET /api/admin/service-accounts/grantable", () => {
@@ -99,5 +125,51 @@ describe("GET /api/admin/service-accounts/grantable", () => {
     mockListOpenFgaObjects.mockRejectedValue(new Error("openfga down"));
     const res = await GET();
     expect(res.status).toBe(503);
+  });
+
+  it("returns the full platform catalog for the unlinked context when caller is a platform admin", async () => {
+    mockHasOrganizationAdmin.mockResolvedValue(true);
+    mockGetCollection.mockImplementation((name: string) => {
+      if (name === "dynamic_agents") {
+        return Promise.resolve(
+          collectionReturning([
+            { _id: "incident-resolver", name: "Incident Resolver", description: "" },
+            { _id: "runbook-agent", name: "Runbook Agent", description: "" },
+          ]),
+        );
+      }
+      if (name === "mcp_servers") {
+        return Promise.resolve(
+          collectionReturning([
+            { _id: "jira", name: "Jira", description: "" },
+            { _id: "github", name: "GitHub", description: "" },
+          ]),
+        );
+      }
+      throw new Error(`unexpected collection ${name}`);
+    });
+
+    const res = await GET(request("/api/admin/service-accounts/grantable?context=unlinked"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(mockListOpenFgaObjects).not.toHaveBeenCalled();
+    expect(body.data.agents).toEqual([
+      { ref: "incident-resolver", name: "Incident Resolver" },
+      { ref: "runbook-agent", name: "Runbook Agent" },
+    ]);
+    expect(body.data.tools).toEqual([
+      { ref: "github/*", name: "github: all tools" },
+      { ref: "jira/*", name: "jira: all tools" },
+    ]);
+  });
+
+  it("403s the unlinked full-catalog context when the caller is not a platform admin", async () => {
+    mockHasOrganizationAdmin.mockResolvedValue(false);
+
+    const res = await GET(request("/api/admin/service-accounts/grantable?context=unlinked"));
+    expect(res.status).toBe(403);
+    expect(mockGetCollection).not.toHaveBeenCalled();
+    expect(mockListOpenFgaObjects).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/api/admin/service-accounts/__tests__/scopes.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/scopes.test.ts
@@ -217,6 +217,37 @@ describe("org-admin bypass for the unlinked SA (TS-B1)", () => {
     expect(mockWriteOpenFgaTuples).toHaveBeenCalled();
   });
 
+  it("POST: org-admin can add an unheld tool scope to the unlinked SA", async () => {
+    mockCheckOpenFgaTuple.mockImplementation(
+      async (t: { relation: string; object: string }) => {
+        if (t.relation === "can_manage" && t.object.startsWith("service_account:")) {
+          return { allowed: false };
+        }
+        if (t.relation === "can_manage" && t.object.startsWith("organization:")) {
+          return { allowed: true };
+        }
+        if (t.relation === "can_call" && t.object === "tool:jira/*") {
+          return { allowed: false };
+        }
+        return { allowed: true };
+      },
+    );
+    mockGetBySub.mockResolvedValue({
+      sa_sub: SA_ID,
+      is_platform_unlinked: true,
+      scopes_snapshot: [],
+    });
+
+    const res = await POST(scopeRequest({ type: "tool", ref: "jira/*" }), ctx());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.added).toEqual({ type: "tool", ref: "jira/*" });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [{ user: `service_account:${SA_ID}`, relation: "caller", object: "tool:jira/*" }],
+      deletes: [],
+    });
+  });
+
   it("DELETE: org-admin can remove a scope from the unlinked SA", async () => {
     orgAdminNotInSuperAdmins();
     mockGetBySub.mockResolvedValue({

--- a/ui/src/app/api/admin/service-accounts/grantable/route.ts
+++ b/ui/src/app/api/admin/service-accounts/grantable/route.ts
@@ -1,8 +1,11 @@
-import { NextResponse } from "next/server";
+// assisted-by Codex Codex-sonnet-4-6
+import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-config";
 import { listOpenFgaObjects } from "@/lib/rbac/openfga";
 import { listRebacCatalog } from "@/lib/rbac/resource-catalog";
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
+import { hasOrganizationAdmin } from "@/lib/rbac/platform-admin";
 
 /**
  * GET /api/admin/service-accounts/grantable
@@ -24,6 +27,18 @@ interface GrantableItem {
   name: string;
 }
 
+interface DynamicAgentLite {
+  _id: string;
+  name?: string;
+  enabled?: boolean;
+}
+
+interface MCPServerLite {
+  _id: string;
+  name?: string;
+  enabled?: boolean;
+}
+
 /** Strip the OpenFGA `<type>:` prefix, returning the bare object id. */
 function stripType(object: string, type: string): string {
   const prefix = `${type}:`;
@@ -39,7 +54,39 @@ function humanizeToolRef(ref: string): string {
   return tool === "*" ? `${server}: all tools` : `${server}: ${tool}`;
 }
 
-export async function GET() {
+async function listFullPlatformCatalog(): Promise<{ agents: GrantableItem[]; tools: GrantableItem[] }> {
+  if (!isMongoDBConfigured) {
+    throw new Error("MongoDB not configured");
+  }
+
+  const agentsCol = await getCollection<DynamicAgentLite>("dynamic_agents");
+  const mcpCol = await getCollection<MCPServerLite>("mcp_servers");
+  const [allAgents, allServers] = await Promise.all([
+    agentsCol
+      .find({ enabled: { $ne: false } } as never, { projection: { _id: 1, name: 1 } })
+      .sort({ name: 1 })
+      .toArray(),
+    mcpCol
+      .find({ enabled: { $ne: false } } as never, { projection: { _id: 1, name: 1 } })
+      .sort({ name: 1 })
+      .toArray(),
+  ]);
+
+  const agents = allAgents.map((agent) => ({
+    ref: agent._id,
+    name: agent.name ?? agent._id,
+  }));
+  const tools = allServers.map((server) => {
+    const ref = `${server._id}/*`;
+    return { ref, name: humanizeToolRef(ref) };
+  });
+
+  agents.sort((a, b) => a.name.localeCompare(b.name));
+  tools.sort((a, b) => a.name.localeCompare(b.name));
+  return { agents, tools };
+}
+
+export async function GET(request?: NextRequest | Request) {
   const session = (await getServerSession(authOptions)) as {
     sub?: string;
     user?: { email?: string | null };
@@ -53,8 +100,23 @@ export async function GET() {
   }
 
   const caller = `user:${session.sub}`;
+  const url = request ? new URL(request.url) : null;
+  const isUnlinkedContext = url?.searchParams.get("context") === "unlinked";
 
   try {
+    if (isUnlinkedContext) {
+      const admin = await hasOrganizationAdmin(session);
+      if (!admin) {
+        return NextResponse.json(
+          { success: false, error: "Forbidden" },
+          { status: 403 },
+        );
+      }
+
+      const data = await listFullPlatformCatalog();
+      return NextResponse.json({ success: true, data });
+    }
+
     const [agentObjects, toolObjects] = await Promise.all([
       listOpenFgaObjects({ user: caller, relation: "can_use", type: "agent" }),
       listOpenFgaObjects({ user: caller, relation: "can_call", type: "tool" }),

--- a/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
+++ b/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
@@ -13,14 +13,14 @@
  * Reuses:
  *  - GET /api/admin/service-accounts/unlinked  (our new resolver endpoint)
  *  - POST/DELETE /api/admin/service-accounts/[id]/scopes  (existing scope edit)
- *  - GET /api/admin/service-accounts/grantable   (existing scope picker)
+ *  - GET /api/admin/service-accounts/grantable?context=unlinked
  *
- * Note on grantable: the endpoint returns scopes the CALLING ADMIN holds.
- * For the unlinked SA the "correct" set is the full platform set. If the
- * admin doesn't hold all platform scopes, some options will not appear in the
- * picker. This is a known limitation tracked as a follow-up (see report).
+ * Note on grantable: unlinked access uses the full platform catalog, gated by
+ * the BFF to platform admins. Normal service-account pickers still use the
+ * caller-held grantable set.
  *
  * assisted-by Claude:claude-sonnet-4-6
+ * assisted-by Codex Codex-sonnet-4-6
  */
 
 import React, { useCallback, useEffect, useState } from "react";
@@ -92,7 +92,7 @@ export function UnlinkedServiceAccountModal({
         fetch("/api/admin/service-accounts/unlinked")
           .then((r) => r.json())
           .catch(() => ({ success: false, error: "Network error loading service account" })),
-        fetch("/api/admin/service-accounts/grantable")
+        fetch("/api/admin/service-accounts/grantable?context=unlinked")
           .then((r) => r.json())
           .catch(() => ({ success: false, error: "Network error loading grantable scopes" })),
       ]);
@@ -196,7 +196,7 @@ export function UnlinkedServiceAccountModal({
           <DialogDescription>
             Grant agents and tools to unlinked users — people who have messaged via Slack
             or Webex but never signed in to the web UI, so the platform has no linked account
-            for them. Any platform admin can add agents or tools they own here, and whatever
+            for them. Any platform admin can add enabled agents or tools here, and whatever
             you grant becomes the base access every unlinked Slack/Webex caller and bot
             receives.
             {!isAdmin && (
@@ -307,19 +307,17 @@ export function UnlinkedServiceAccountModal({
                   <div className="space-y-2 rounded-md border border-dashed border-input p-3">
                     <span className="text-sm font-medium">Add a scope</span>
                     <p className="text-xs text-muted-foreground">
-                      Only scopes you currently hold are shown. If a scope is missing, ensure
-                      your team has been granted it first.
+                      Platform catalog scopes are shown for unlinked callers.
                     </p>
-                    {/* TEST-11/UX-5: show platform-admin limitation when grantable loaded
+                    {/* TEST-11/UX-5: show an empty catalog note when grantable loaded
                         successfully but returned zero items for the selected type. */}
                     {!grantableError && grantable !== null && held.length === 0 && (
                       <p
                         className="text-xs text-amber-700 dark:text-amber-400"
                         data-testid="unlinked-modal-grantable-empty-note"
                       >
-                        No {addType}s available to grant. As a platform admin you can only
-                        grant scopes your account currently holds. Ensure your team has been
-                        granted the desired {addType} scope first.
+                        No {addType}s available to grant. Check that platform {addType} resources
+                        are enabled.
                       </p>
                     )}
                     <div
@@ -346,8 +344,8 @@ export function UnlinkedServiceAccountModal({
                       >
                         <option value="">
                           {addableOptions.length === 0
-                            ? `No more ${addType}s you can grant`
-                            : `Select a ${addType} you hold...`}
+                            ? `No more ${addType}s available`
+                            : `Select a ${addType}...`}
                         </option>
                         {addableOptions.map((item) => (
                           <option key={item.ref} value={item.ref}>

--- a/ui/src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx
+++ b/ui/src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx
@@ -107,6 +107,9 @@ describe("UnlinkedServiceAccountModal", () => {
     await waitFor(() => {
       expect(screen.getByText(/add a scope/i)).toBeInTheDocument();
     });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/admin/service-accounts/grantable?context=unlinked",
+    );
   });
 
   it("keeps Add scope controls in a responsive row that cannot bleed past the modal", async () => {
@@ -302,7 +305,7 @@ describe("UnlinkedServiceAccountModal — grantable fetch failure (TEST-11/UX-5)
     );
   });
 
-  it("UX-5: shows the platform-admin limitation note when grantable is empty (loaded OK)", async () => {
+  it("UX-5: shows the empty platform-catalog note when grantable is empty (loaded OK)", async () => {
     mockFetch({
       grantable: { success: true, data: { agents: [], tools: [] } },
     });
@@ -315,7 +318,7 @@ describe("UnlinkedServiceAccountModal — grantable fetch failure (TEST-11/UX-5)
       expect(screen.getByTestId("unlinked-modal-grantable-empty-note")).toBeInTheDocument();
     });
     expect(screen.getByTestId("unlinked-modal-grantable-empty-note")).toHaveTextContent(
-      /platform admin.*can only grant/i,
+      /platform agent resources.*enabled/i,
     );
     // Error banner must not be shown — this is a normal (empty) result, not a failure
     expect(screen.queryByTestId("unlinked-modal-grantable-error")).not.toBeInTheDocument();

--- a/ui/src/components/admin/settings/PlatformSettingsTab.tsx
+++ b/ui/src/components/admin/settings/PlatformSettingsTab.tsx
@@ -252,7 +252,7 @@ export function PlatformSettingsTab({ isAdmin }: PlatformSettingsTabProps) {
             <CardDescription>
               Grant agents and tools to unlinked users — people who have messaged via Slack
               or Webex but never signed in to the web UI, so the platform has no linked
-              account for them. Any platform admin can add agents or tools they own here, and
+              account for them. Any platform admin can add enabled agents or tools here, and
               whatever you grant becomes the base access every unlinked Slack/Webex caller and
               bot receives.
             </CardDescription>

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15"
+version = "0.5.15.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Fixes #1860.

The unlinked service account scope picker was backed by the normal service-account grantable endpoint, which only listed scopes the calling admin personally held. In the OpenFGA model, MCP tool grants are runtime caller grants and human admins often do not hold the tool scopes directly, so platform admins saw an empty Tools picker and could not grant unlinked Slack/Webex access through the UI.

This change:

- adds `?context=unlinked` support to `GET /api/admin/service-accounts/grantable`, gated to platform admins, returning the enabled platform agent catalog and MCP server wildcard tools
- keeps normal service-account grantable behavior scoped to the caller-held set
- allows platform admins to add unheld scopes only for the platform unlinked service account, while preserving the FR-015 held-scope rule for normal service accounts
- updates Unlinked Access copy to describe the full platform catalog behavior
- adds Jest and mocked Playwright coverage for the unlinked full-catalog tool grant flow

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; no chart changes.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

```bash
npm test -- --runTestsByPath src/app/api/admin/service-accounts/__tests__/grantable.test.ts src/app/api/admin/service-accounts/__tests__/scopes.test.ts src/components/admin/__tests__/UnlinkedServiceAccountModal.test.tsx --runInBand

RUN_RBAC_REGRESSION=1 npx playwright test e2e/rbac/service-accounts.spec.ts e2e/rbac/admin-settings-regression.spec.ts --config=playwright.rbac.config.ts --project=chromium
```
