### PR TITLE
perf(admin): lazy-load tab data on first visit; parallelise stats queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.5"
+version = "0.5.15-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.4"
+version = "0.5.15-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -398,7 +398,10 @@ describe('Admin Dashboard Page', () => {
   });
 
   describe('Loading state', () => {
-    it('shows spinner while loading', () => {
+    it('shows spinner while loading stats tab', () => {
+      // Stats tab triggers loadStats() which sets loading=true while in-flight.
+      // Settings tab (default) has no loader, so no spinner is shown there.
+      currentSearchParams = new URLSearchParams('cat=insights&tab=stats');
       setupFetchMock();
       render(<AdminPage />);
       expect(screen.getByTestId('spinner')).toBeInTheDocument();
@@ -431,6 +434,8 @@ describe('Admin Dashboard Page', () => {
 
   describe('Error state', () => {
     it('shows error message and retry button on fetch failure', async () => {
+      // Must be on a tab with a loader (stats) so a fetch is actually triggered.
+      currentSearchParams = new URLSearchParams('cat=insights&tab=stats');
       (global.fetch as jest.Mock) = jest.fn().mockRejectedValue(new Error('Network error'));
       render(<AdminPage />);
 
@@ -441,6 +446,8 @@ describe('Admin Dashboard Page', () => {
     });
 
     it('shows auth error on 401 response', async () => {
+      // Must be on a tab with a loader (stats) so a fetch is actually triggered.
+      currentSearchParams = new URLSearchParams('cat=insights&tab=stats');
       (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
         ok: false,
         status: 401,

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -398,13 +398,12 @@ describe('Admin Dashboard Page', () => {
   });
 
   describe('Loading state', () => {
-    it('shows spinner while loading stats tab', () => {
-      // Stats tab triggers loadStats() which sets loading=true while in-flight.
-      // Settings tab (default) has no loader, so no spinner is shown there.
-      currentSearchParams = new URLSearchParams('cat=insights&tab=stats');
+    it('renders the admin shell before lazy tab data loads', async () => {
       setupFetchMock();
       render(<AdminPage />);
-      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+
+      expect(await screen.findByText('Admin Dashboard')).toBeInTheDocument();
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
     });
 
     it('does not eagerly fetch /api/admin/users during loadAdminData', async () => {
@@ -763,6 +762,9 @@ describe('Admin Dashboard Page', () => {
       expect(screen.queryByRole('tab', { name: /rag team access/i })).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole('button', { name: 'Insights' }));
+      await waitFor(() => {
+        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+      });
       expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
         'Statistics',
         'Feedback',
@@ -775,6 +777,10 @@ describe('Admin Dashboard Page', () => {
       expect(screen.queryByRole('tab', { name: /^Insights$/i })).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole('button', { name: /metrics & health/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+      });
 
       expect(screen.getByRole('tab', { name: /metrics/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /health/i })).toBeInTheDocument();
@@ -1247,6 +1253,10 @@ describe('Admin Dashboard Page', () => {
       const fetchMock = setupFetchMock();
 
       render(<AdminPage />);
+
+      // assisted-by Codex Codex-sonnet-4-6
+      // Stats are lazy-loaded when the Insights category is opened.
+      fireEvent.click(screen.getByRole('button', { name: 'Insights' }));
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -840,12 +840,19 @@ function AdminPage() {
   const rangeLabel = datePreset === "1h" ? "1 Hour" : datePreset === "12h" ? "12 Hours" : datePreset === "24h" ? "24 Hours" : datePreset === "7d" ? "7 Days" : datePreset === "90d" ? "90 Days" : datePreset === "custom" ? "Custom Range" : "30 Days";
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
 
+  const visitedTabsRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
-    // Fetch admin data when authenticated or when SSO is disabled (local dev)
     if (status === "authenticated" || !getConfig('ssoEnabled')) {
-      loadAdminData();
+      loadTabData(activeTab);
     }
   }, [status]);
+
+  // Load data for newly-visited tabs
+  useEffect(() => {
+    if (status !== "authenticated" && getConfig('ssoEnabled')) return;
+    loadTabData(activeTab);
+  }, [activeTab, status]);
 
   const fetchTeamsFromDb = async (): Promise<Team[]> => {
     const response = await fetch(`/api/admin/teams?fresh=${Date.now()}`, {
@@ -949,43 +956,27 @@ function AdminPage() {
     fetchStatsWithFilters();
   }, [dateRange, sourceFilter, userFilter, status]);
 
-  const loadAdminData = async () => {
+  const loadStats = async () => {
     setLoading(true);
     setError(null);
-
     try {
-      const feedbackOn = getConfig('feedbackEnabled');
-      const npsOn = getConfig('npsEnabled');
-      // Fetch stats, teams, skill metrics, feedback, and NPS in parallel.
-      // The user list is intentionally NOT fetched here — UserManagementTab
-      // lazy-loads it when the Users tab is selected. Fetching it eagerly
-      // burned a Keycloak list+count round-trip on every admin page load
-      // and the result was discarded.
       const hasStatsFilters = sourceFilter !== 'all' || userFilter.length > 0;
-      const [statsRes, globalStatsRes, teamsData, skillStatsRes, feedbackRes, npsRes] = await Promise.all([
-        (() => {
-          const p = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
-          if (sourceFilter !== 'all') p.set('source', sourceFilter);
-          if (userFilter.length > 0) p.set('user', userFilter.join(','));
-          return fetch(`/api/admin/stats?${p}`);
-        })(),
+      const p = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
+      if (sourceFilter !== 'all') p.set('source', sourceFilter);
+      if (userFilter.length > 0) p.set('user', userFilter.join(','));
+      const [statsRes, globalStatsRes] = await Promise.all([
+        fetch(`/api/admin/stats?${p}`),
         hasStatsFilters ? fetch('/api/admin/stats') : null,
-        fetchTeamsFromDb().catch(() => []),
-        fetch('/api/admin/stats/skills').catch(() => null),
-        feedbackOn ? fetch('/api/admin/feedback').catch(() => null) : null,
-        npsOn ? fetch('/api/admin/nps').catch(() => null) : null,
       ]);
 
       if (statsRes.status === 401) {
         setError('Not authenticated. Please sign in via SSO first.');
-        setLoading(false);
         return;
       }
 
       const statsForbidden = statsRes.status === 403;
       if (statsForbidden && !tabGateValues.settings) {
         setError('Access denied. Try signing out and back in to refresh your session.');
-        setLoading(false);
         return;
       }
 
@@ -997,43 +988,94 @@ function AdminPage() {
       if (statsResponse.success) {
         setStats(statsResponse.data);
         if (statsResponse.data.available_channels) setStatsChannels(statsResponse.data.available_channels);
-        // Use unfiltered response for global overview, or the main response if no filters were applied
         const overviewData = globalStatsResponse?.success ? globalStatsResponse.data.overview : statsResponse.data.overview;
         setGlobalOverview(overviewData);
       } else if (!statsForbidden) {
         throw new Error(statsResponse.error || 'Failed to load stats');
       }
-
-      setTeams(teamsData);
-
-      if (skillStatsRes?.ok) {
-        const skillStatsResponse = await skillStatsRes.json().catch(() => ({ success: false }));
-        if (skillStatsResponse.success) {
-          setSkillStats(skillStatsResponse.data);
-        }
-      }
-
-      if (feedbackRes?.ok) {
-        const feedbackResponse = await feedbackRes.json().catch(() => ({ success: false }));
-        if (feedbackResponse.success) {
-          setFeedbackData(feedbackResponse.data);
-          if (feedbackResponse.data.channels) setFeedbackChannels(feedbackResponse.data.channels);
-          if (feedbackResponse.data.users) setFeedbackUsers(feedbackResponse.data.users);
-        }
-      }
-
-      if (npsRes?.ok) {
-        const npsResponse = await npsRes.json().catch(() => ({ success: false }));
-        if (npsResponse.success) {
-          setNpsData(npsResponse.data);
-        }
-      }
     } catch (err: any) {
-      console.error('[Admin] Failed to load data:', err);
-      setError(err.message || 'Failed to load admin data');
+      console.error('[Admin] Failed to load stats:', err);
+      setError(err.message || 'Failed to load stats');
     } finally {
       setLoading(false);
     }
+  };
+
+  const loadTeamsData = async () => {
+    try {
+      setTeams(await fetchTeamsFromDb());
+    } catch (err: any) {
+      console.error('[Admin] Failed to load teams:', err);
+    }
+  };
+
+  const loadSkillStats = async () => {
+    try {
+      const res = await fetch('/api/admin/stats/skills');
+      if (res.ok) {
+        const data = await res.json().catch(() => ({ success: false }));
+        if (data.success) setSkillStats(data.data);
+      }
+    } catch (err) {
+      console.error('[Admin] Failed to load skill stats:', err);
+    }
+  };
+
+  const loadNpsDataOnce = async () => {
+    if (!getConfig('npsEnabled')) return;
+    try {
+      const res = await fetch('/api/admin/nps');
+      if (res.ok) {
+        const data = await res.json().catch(() => ({ success: false }));
+        if (data.success) setNpsData(data.data);
+      }
+    } catch (err) {
+      console.error('[Admin] Failed to load NPS data:', err);
+    }
+  };
+
+  const loadFeedbackOnce = async () => {
+    if (!getConfig('feedbackEnabled')) return;
+    try {
+      const res = await fetch('/api/admin/feedback');
+      if (res.ok) {
+        const data = await res.json().catch(() => ({ success: false }));
+        if (data.success) {
+          setFeedbackData(data.data);
+          if (data.data.channels) setFeedbackChannels(data.data.channels);
+          if (data.data.users) setFeedbackUsers(data.data.users);
+        }
+      }
+    } catch (err) {
+      console.error('[Admin] Failed to load feedback:', err);
+    }
+  };
+
+  const loadTabData = async (tab: string) => {
+    if (visitedTabsRef.current.has(tab)) return;
+    visitedTabsRef.current.add(tab);
+
+    // Teams data is needed by stats/feedback/slack as a filter option.
+    // Load it lazily the first time any of those tabs is visited.
+    const loadTeamsIfNeeded = () => {
+      if (visitedTabsRef.current.has('teams')) return Promise.resolve();
+      visitedTabsRef.current.add('teams');
+      return loadTeamsData();
+    };
+
+    // Map of tab key → loader function. Tabs not listed here have no upfront data to load.
+    const loaders: Record<string, () => Promise<void>> = {
+      stats: async () => { await Promise.all([loadStats(), loadTeamsIfNeeded()]); },
+      slack: async () => { await Promise.all([loadStats(), loadTeamsIfNeeded()]); },
+      teams: loadTeamsData,
+      'identity-sync': loadTeamsData,
+      skills: loadSkillStats,
+      feedback: async () => { await Promise.all([loadFeedbackOnce(), loadTeamsIfNeeded()]); },
+      nps: loadNpsDataOnce,
+    };
+
+    const loader = loaders[tab];
+    if (loader) await loader();
   };
 
   const loadFeedback = async (
@@ -1217,7 +1259,7 @@ function AdminPage() {
         <div className="text-center">
           <p className="text-sm text-destructive mb-2">{error}</p>
           <button
-            onClick={loadAdminData}
+            onClick={() => { visitedTabsRef.current.delete(activeTab); loadTabData(activeTab); }}
             className="text-sm text-primary hover:underline"
           >
             Retry
@@ -3206,7 +3248,7 @@ function AdminPage() {
       <CreateTeamDialog
         open={createTeamDialogOpen}
         onOpenChange={setCreateTeamDialogOpen}
-        onSuccess={loadAdminData}
+        onSuccess={loadTeams}
       />
 
       {/* Team Details / Member Management Dialog */}
@@ -3215,7 +3257,7 @@ function AdminPage() {
         mode={teamDialogMode}
         open={teamDetailsOpen}
         onOpenChange={setTeamDetailsOpen}
-        onTeamUpdated={loadAdminData}
+        onTeamUpdated={loadTeams}
         onTeamMutated={(updatedTeam) => {
           // In-place patch of the teams[] state so the row in the
           // background list re-renders with the new member count /

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -509,7 +509,7 @@ function AdminPage() {
   const [teams, setTeams] = useState<Team[]>([]);
   const [teamSearch, setTeamSearch] = useState("");
   const [teamsRefreshing, setTeamsRefreshing] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedUserEmail, setSelectedUserEmail] = useState<string | null>(null);
   const [updatingRole, setUpdatingRole] = useState<string | null>(null);
@@ -1055,20 +1055,30 @@ function AdminPage() {
     if (visitedTabsRef.current.has(tab)) return;
     visitedTabsRef.current.add(tab);
 
-    // Teams data is needed by stats/feedback/slack as a filter option.
-    // Load it lazily the first time any of those tabs is visited.
+    // Teams data is shared across stats/slack/feedback filter dropdowns.
+    // Mark it with a separate key so teams isn't re-fetched when a second
+    // tab that needs it is visited.
     const loadTeamsIfNeeded = () => {
       if (visitedTabsRef.current.has('teams')) return Promise.resolve();
       visitedTabsRef.current.add('teams');
       return loadTeamsData();
     };
 
-    // Map of tab key → loader function. Tabs not listed here have no upfront data to load.
+    // Stats data is shared between the stats and slack tabs. Use a separate
+    // key so visiting one doesn't cause the other to re-fetch it.
+    const loadStatsIfNeeded = () => {
+      if (visitedTabsRef.current.has('_stats-loaded')) return Promise.resolve();
+      visitedTabsRef.current.add('_stats-loaded');
+      return loadStats();
+    };
+
+    // Map of tab key → loader. Tabs not listed here have no upfront data to
+    // load and should not block render (loading is initialized to false).
     const loaders: Record<string, () => Promise<void>> = {
-      stats: async () => { await Promise.all([loadStats(), loadTeamsIfNeeded()]); },
-      slack: async () => { await Promise.all([loadStats(), loadTeamsIfNeeded()]); },
-      teams: loadTeamsData,
-      'identity-sync': loadTeamsData,
+      stats: async () => { await Promise.all([loadStatsIfNeeded(), loadTeamsIfNeeded()]); },
+      slack: async () => { await Promise.all([loadStatsIfNeeded(), loadTeamsIfNeeded()]); },
+      teams: () => loadTeamsIfNeeded(),
+      'identity-sync': () => loadTeamsIfNeeded(),
       skills: loadSkillStats,
       feedback: async () => { await Promise.all([loadFeedbackOnce(), loadTeamsIfNeeded()]); },
       nps: loadNpsDataOnce,

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1002,10 +1002,13 @@ function AdminPage() {
   };
 
   const loadTeamsData = async () => {
+    setTeamsRefreshing(true);
     try {
       setTeams(await fetchTeamsFromDb());
     } catch (err: any) {
       console.error('[Admin] Failed to load teams:', err);
+    } finally {
+      setTeamsRefreshing(false);
     }
   };
 
@@ -1635,7 +1638,11 @@ function AdminPage() {
                     )}
                   </div>
                 </div>
-                {teams.length === 0 ? (
+                {teamsRefreshing && teams.length === 0 ? (
+                  <div className="flex justify-center py-12">
+                    <CAIPESpinner />
+                  </div>
+                ) : teams.length === 0 ? (
                   <div className="text-center py-12">
                     <UsersIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                     <h3 className="text-lg font-semibold mb-2">No Teams Yet</h3>

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1002,13 +1002,10 @@ function AdminPage() {
   };
 
   const loadTeamsData = async () => {
-    setTeamsRefreshing(true);
     try {
       setTeams(await fetchTeamsFromDb());
     } catch (err: any) {
       console.error('[Admin] Failed to load teams:', err);
-    } finally {
-      setTeamsRefreshing(false);
     }
   };
 

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1059,11 +1059,11 @@ function AdminPage() {
     visitedTabsRef.current.add(tab);
 
     // Teams data is shared across stats/slack/feedback filter dropdowns.
-    // Mark it with a separate key so teams isn't re-fetched when a second
-    // tab that needs it is visited.
+    // Use a data-level key (not the tab name) so it isn't confused with the
+    // tab-visit guard that loadTabData adds before invoking the loader.
     const loadTeamsIfNeeded = () => {
-      if (visitedTabsRef.current.has('teams')) return Promise.resolve();
-      visitedTabsRef.current.add('teams');
+      if (visitedTabsRef.current.has('_teams-loaded')) return Promise.resolve();
+      visitedTabsRef.current.add('_teams-loaded');
       return loadTeamsData();
     };
 

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -467,14 +467,9 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       ? Math.round((completedCount / totalWithAssistant) * 1000) / 10
       : 0;
 
-    const avgMsgsCompleted = conversationsWithAssistant.filter((c) => c.has_final === 1).length > 0
-      ? Math.round(
-          (conversationsWithAssistant
-            .filter((c) => c.has_final === 1)
-            .reduce((sum, c) => sum + c.msg_count, 0) /
-            conversationsWithAssistant.filter((c) => c.has_final === 1).length) *
-            10
-        ) / 10
+    const completedConvs = conversationsWithAssistant.filter((c) => c.has_final === 1);
+    const avgMsgsCompleted = completedConvs.length > 0
+      ? Math.round((completedConvs.reduce((sum, c) => sum + c.msg_count, 0) / completedConvs.length) * 10) / 10
       : 0;
 
     const hourlyMap = new Map<number, number>();

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -163,79 +163,200 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const messagesToday = webMessagesToday + slackMessagesToday;
 
     // ═══════════════════════════════════════════════════════════════
-    // DAILY ACTIVITY — single aggregation per collection instead of
-    // 30 sequential countDocuments queries (90 round-trips → 3)
+    // PARALLEL BATCH — all independent aggregations in one shot
     // ═══════════════════════════════════════════════════════════════
-    // When filters are active, derive active users from conversations instead of users collection
-    const dailyUserActivity = hasFilters
-      ? await conversations.aggregate([
-          { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
-          {
-            $group: {
-              _id: {
-                date: { $dateToString: { format: '%Y-%m-%d', date: '$updated_at' } },
-                user: '$owner_id',
-              },
-            },
-          },
-          { $group: { _id: '$_id.date', active_users: { $sum: 1 } } },
-        ]).toArray()
-      : await users.aggregate([
-          { $match: { last_login: { $gte: rangeStart } } },
-          {
-            $group: {
-              _id: { $dateToString: { format: '%Y-%m-%d', date: '$last_login' } },
-              active_users: { $sum: 1 },
-            },
-          },
-        ]).toArray();
+    const feedbackColl = await getCollection('feedback');
 
-    const dailyConvActivity = await conversations.aggregate([
-      { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
-      {
-        $group: {
-          _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
-          conversations: { $sum: 1 },
-        },
-      },
-    ]).toArray();
+    const fbFilter: Record<string, any> = { created_at: { $gte: rangeStart } };
+    if (sourceFilter === 'web') fbFilter.source = 'web';
+    else if (sourceFilter === 'slack') {
+      fbFilter.source = 'slack';
+      if (channelNames.length === 1) {
+        fbFilter.channel_name = channelNames[0];
+      } else if (channelNames.length > 1) {
+        fbFilter.channel_name = { $in: channelNames };
+      }
+    }
+    if (userEmails.length === 1) fbFilter.user_email = userEmails[0];
+    else if (userEmails.length > 1) fbFilter.user_email = { $in: userEmails };
 
-    // Web messages (from messages collection) + Slack messages (message_count on conversations)
-    const [dailyWebMsgActivity, dailySlackMsgActivity] = await Promise.all([
+    const [
+      dailyUserActivity,
+      dailyConvActivity,
+      dailyWebMsgActivity,
+      dailySlackMsgActivity,
+      rawTopByConvs,
+      rawTopByMsgs,
+      topAgents,
+      fbOverall,
+      fbBySource,
+      fbCategories,
+      fbDaily,
+      latencyAgg,
+      completedWorkflows,
+      completedToday,
+      conversationsWithAssistant,
+      hourlyWebActivity,
+      hourlySlackActivity,
+      availableChannelsResult,
+      webAgentMsgCount,
+    ] = await Promise.all([
+      // Daily active users
+      hasFilters
+        ? conversations.aggregate([
+            { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
+            { $group: { _id: { date: { $dateToString: { format: '%Y-%m-%d', date: '$updated_at' } }, user: '$owner_id' } } },
+            { $group: { _id: '$_id.date', active_users: { $sum: 1 } } },
+          ]).toArray()
+        : users.aggregate([
+            { $match: { last_login: { $gte: rangeStart } } },
+            { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$last_login' } }, active_users: { $sum: 1 } } },
+          ]).toArray(),
+
+      // Daily conversations
+      conversations.aggregate([
+        { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
+        { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, conversations: { $sum: 1 } } },
+      ]).toArray(),
+
+      // Daily web messages
       sourceFilter !== 'slack'
         ? messages.aggregate([
             { $match: { 'metadata.source': 'web', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-            {
-              $group: {
-                _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
-                messages: { $sum: 1 },
-              },
-            },
+            { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, messages: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
+
+      // Daily slack messages
       sourceFilter !== 'web'
         ? messages.aggregate([
             { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart } } },
-            {
-              $group: {
-                _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
-                messages: { $sum: 1 },
-              },
-            },
+            { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, messages: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
+
+      // Top users by conversations
+      conversations.aggregate([
+        { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
+        { $group: { _id: '$owner_id', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 },
+      ]).toArray(),
+
+      // Top users by messages ($lookup for legacy owner_id)
+      messages.aggregate([
+        { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $lookup: { from: 'conversations', localField: 'conversation_id', foreignField: '_id', as: '_conv' } },
+        { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
+        { $match: { _owner: { $ne: null } } },
+        { $group: { _id: '$_owner', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 },
+      ]).toArray(),
+
+      // Top agents
+      messages.aggregate([
+        { $match: { role: 'assistant', 'metadata.agent_name': { $exists: true, $ne: null }, created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $group: { _id: '$metadata.agent_name', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 },
+      ]).toArray(),
+
+      // Feedback: overall counts
+      feedbackColl.aggregate([
+        { $match: fbFilter },
+        { $group: { _id: '$rating', count: { $sum: 1 } } },
+      ]).toArray(),
+
+      // Feedback: by source
+      feedbackColl.aggregate([
+        { $match: fbFilter },
+        { $group: { _id: { source: '$source', rating: '$rating' }, count: { $sum: 1 } } },
+      ]).toArray(),
+
+      // Feedback: negative categories
+      feedbackColl.aggregate([
+        { $match: { ...fbFilter, rating: 'negative', value: { $nin: ['thumbs_down'] } } },
+        { $group: { _id: '$value', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ]).toArray(),
+
+      // Feedback: daily trend
+      feedbackColl.aggregate([
+        { $match: fbFilter },
+        { $group: { _id: { date: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, rating: '$rating' }, count: { $sum: 1 } } },
+      ]).toArray(),
+
+      // Response latency
+      messages.aggregate([
+        { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $group: { _id: null, avg_latency: { $avg: '$metadata.latency_ms' }, min_latency: { $min: '$metadata.latency_ms' }, max_latency: { $max: '$metadata.latency_ms' }, count: { $sum: 1 } } },
+      ]).toArray(),
+
+      // Completed workflows (total)
+      messages.aggregate([
+        { $match: { role: 'assistant', 'metadata.is_final': true, created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $group: { _id: '$conversation_id' } },
+        { $count: 'total' },
+      ]).toArray(),
+
+      // Completed workflows (today)
+      messages.aggregate([
+        { $match: { role: 'assistant', 'metadata.is_final': true, created_at: { $gte: today }, ...msgOwnerFilter } },
+        { $group: { _id: '$conversation_id' } },
+        { $count: 'total' },
+      ]).toArray(),
+
+      // All conversations with assistant messages (for interrupted count)
+      messages.aggregate([
+        { $match: { role: 'assistant', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $group: { _id: '$conversation_id', has_final: { $max: { $cond: [{ $eq: ['$metadata.is_final', true] }, 1, 0] } }, last_msg_at: { $max: '$created_at' }, msg_count: { $sum: 1 } } },
+        { $sort: { last_msg_at: -1 } },
+      ]).toArray(),
+
+      // Hourly heatmap: web
+      sourceFilter !== 'slack'
+        ? messages.aggregate([
+            { $match: { 'metadata.source': 'web', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+            { $addFields: { _ts: { $toDate: '$created_at' } } },
+            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
+
+      // Hourly heatmap: slack
+      sourceFilter !== 'web'
+        ? messages.aggregate([
+            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart } } },
+            { $addFields: { _ts: { $toDate: '$created_at' } } },
+            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
+
+      // Available channel names (both schema variants)
+      Promise.all([
+        conversations.distinct('slack_meta.channel_name', { source: 'slack', 'slack_meta.channel_name': { $ne: null } }),
+        conversations.distinct('metadata.channel_name', { client_type: 'slack', 'metadata.channel_name': { $ne: null } }),
+      ]),
+
+      // Web agent message count for hours-automated estimate
+      sourceFilter !== 'slack'
+        ? messages.countDocuments({
+            role: 'assistant',
+            'metadata.agent_name': { $exists: true, $ne: null },
+            created_at: { $gte: rangeStart },
+            ...msgOwnerFilter,
+          })
+        : Promise.resolve(0),
     ]);
 
-    // Merge web + slack daily message counts
+    // ── Post-process daily activity ─────────────────────────────────
     const msgMap = new Map<string, number>();
     for (const d of dailyWebMsgActivity) msgMap.set(d._id, (msgMap.get(d._id) || 0) + d.messages);
     for (const d of dailySlackMsgActivity) msgMap.set(d._id, (msgMap.get(d._id) || 0) + d.messages);
 
-    // Build lookup maps
     const userMap = new Map(dailyUserActivity.map((d) => [d._id, d.active_users]));
     const convMap = new Map(dailyConvActivity.map((d) => [d._id, d.conversations]));
 
-    // Assemble N-day array
     const dailyActivity = [];
     for (let i = days - 1; i >= 0; i--) {
       const dayStart = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
@@ -249,45 +370,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       });
     }
 
-    // ═══════════════════════════════════════════════════════════════
-    // TOP USERS
-    // ═══════════════════════════════════════════════════════════════
-
-    // Top users by conversation count (direct — conversations have owner_id)
-    const rawTopByConvs = await conversations.aggregate([
-      { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
-      { $group: { _id: '$owner_id', count: { $sum: 1 } } },
-      { $sort: { count: -1 } },
-      { $limit: 10 },
-    ]).toArray();
-
-    // Top users by message count — $lookup through conversations for old
-    // messages that lack owner_id, $coalesce with direct owner_id for new ones.
-    const rawTopByMsgs = await messages.aggregate([
-      { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-      {
-        $lookup: {
-          from: 'conversations',
-          localField: 'conversation_id',
-          foreignField: '_id',
-          as: '_conv',
-        },
-      },
-      {
-        $addFields: {
-          _owner: {
-            $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }],
-          },
-        },
-      },
-      { $match: { _owner: { $ne: null } } },
-      { $group: { _id: '$_owner', count: { $sum: 1 } } },
-      { $sort: { count: -1 } },
-      { $limit: 10 },
-    ]).toArray();
-
-    // Resolve display names for top user IDs — owner_id may be an email
-    // or a raw Slack/bot ID when email resolution failed at interaction time.
+    // ── Top users: resolve display names ───────────────────────────
     const topOwnerIds = [...new Set([
       ...rawTopByConvs.map((u) => u._id),
       ...rawTopByMsgs.map((u) => u._id),
@@ -307,87 +390,12 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
 
     const enrichTopUsers = (raw: typeof rawTopByConvs) =>
-      raw.map((u) => ({
-        _id: u._id,
-        count: u.count,
-        name: nameByOwner.get(u._id) || u._id,
-      }));
+      raw.map((u) => ({ _id: u._id, count: u.count, name: nameByOwner.get(u._id) || u._id }));
 
     const topUsersByConversations = enrichTopUsers(rawTopByConvs);
     const topUsersByMessages = enrichTopUsers(rawTopByMsgs);
 
-    // ═══════════════════════════════════════════════════════════════
-    // ENHANCED ANALYTICS
-    // ═══════════════════════════════════════════════════════════════
-
-    // Top agents by usage (from metadata.agent_name on assistant messages)
-    const topAgents = await messages.aggregate([
-      {
-        $match: {
-          role: 'assistant',
-          'metadata.agent_name': { $exists: true, $ne: null },
-          created_at: { $gte: rangeStart },
-          ...msgOwnerFilter,
-        },
-      },
-      { $group: { _id: '$metadata.agent_name', count: { $sum: 1 } } },
-      { $sort: { count: -1 } },
-      { $limit: 10 },
-    ]).toArray();
-
-    // ═══════════════════════════════════════════════════════════════
-    // FEEDBACK SUMMARY (from unified feedback collection)
-    // ═══════════════════════════════════════════════════════════════
-    const feedbackColl = await getCollection('feedback');
-
-    // Build feedback filter
-    const fbFilter: Record<string, any> = { created_at: { $gte: rangeStart } };
-    if (sourceFilter === 'web') fbFilter.source = 'web';
-    else if (sourceFilter === 'slack') {
-      fbFilter.source = 'slack';
-      if (channelNames.length === 1) {
-        fbFilter.channel_name = channelNames[0];
-      } else if (channelNames.length > 1) {
-        fbFilter.channel_name = { $in: channelNames };
-      }
-    }
-    if (userEmails.length === 1) fbFilter.user_email = userEmails[0];
-    else if (userEmails.length > 1) fbFilter.user_email = { $in: userEmails };
-
-    const [fbOverall, fbBySource, fbCategories, fbDaily] = await Promise.all([
-      // Overall counts
-      feedbackColl.aggregate([
-        { $match: fbFilter },
-        { $group: { _id: '$rating', count: { $sum: 1 } } },
-      ]).toArray(),
-      // By source
-      feedbackColl.aggregate([
-        { $match: fbFilter },
-        { $group: { _id: { source: '$source', rating: '$rating' }, count: { $sum: 1 } } },
-      ]).toArray(),
-      // Negative feedback category breakdown (exclude generic thumbs_down — it's the
-      // initial click, not a categorised reason; those users are still counted in the
-      // overall negative total)
-      feedbackColl.aggregate([
-        { $match: { ...fbFilter, rating: 'negative', value: { $nin: ['thumbs_down'] } } },
-        { $group: { _id: '$value', count: { $sum: 1 } } },
-        { $sort: { count: -1 } },
-      ]).toArray(),
-      // Daily feedback trend
-      feedbackColl.aggregate([
-        { $match: fbFilter },
-        {
-          $group: {
-            _id: {
-              date: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
-              rating: '$rating',
-            },
-            count: { $sum: 1 },
-          },
-        },
-      ]).toArray(),
-    ]);
-
+    // ── Post-process feedback ───────────────────────────────────────
     const fbMap = new Map(fbOverall.map((f) => [f._id, f.count]));
     const positive = fbMap.get('positive') || 0;
     const negative = fbMap.get('negative') || 0;
@@ -437,31 +445,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       daily: dailyFeedback,
     };
 
-    // Average messages per conversation
+    // ── Post-process latency / workflows / heatmap ─────────────────
     const avgMsgsPerConv = totalConversations > 0
       ? Math.round((totalMessages / totalConversations) * 10) / 10
       : 0;
-
-    // Average response time (from metadata.latency_ms on assistant messages)
-    const latencyAgg = await messages.aggregate([
-      {
-        $match: {
-          role: 'assistant',
-          'metadata.latency_ms': { $exists: true, $gt: 0 },
-          created_at: { $gte: rangeStart },
-          ...msgOwnerFilter,
-        },
-      },
-      {
-        $group: {
-          _id: null,
-          avg_latency: { $avg: '$metadata.latency_ms' },
-          min_latency: { $min: '$metadata.latency_ms' },
-          max_latency: { $max: '$metadata.latency_ms' },
-          count: { $sum: 1 },
-        },
-      },
-    ]).toArray();
 
     const responseTime = latencyAgg[0]
       ? {
@@ -472,47 +459,6 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         }
       : { avg_ms: 0, min_ms: 0, max_ms: 0, sample_count: 0 };
 
-    // Completed workflows — conversations with at least one is_final assistant msg
-    const completedWorkflows = await messages.aggregate([
-      {
-        $match: {
-          role: 'assistant',
-          'metadata.is_final': true,
-          created_at: { $gte: rangeStart },
-          ...msgOwnerFilter,
-        },
-      },
-      { $group: { _id: '$conversation_id' } },
-      { $count: 'total' },
-    ]).toArray();
-
-    const completedToday = await messages.aggregate([
-      {
-        $match: {
-          role: 'assistant',
-          'metadata.is_final': true,
-          created_at: { $gte: today },
-          ...msgOwnerFilter,
-        },
-      },
-      { $group: { _id: '$conversation_id' } },
-      { $count: 'total' },
-    ]).toArray();
-
-    // Interrupted/incomplete — conversations that have assistant messages but none with is_final
-    const conversationsWithAssistant = await messages.aggregate([
-      { $match: { role: 'assistant', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-      {
-        $group: {
-          _id: '$conversation_id',
-          has_final: { $max: { $cond: [{ $eq: ['$metadata.is_final', true] }, 1, 0] } },
-          last_msg_at: { $max: '$created_at' },
-          msg_count: { $sum: 1 },
-        },
-      },
-      { $sort: { last_msg_at: -1 } },
-    ]).toArray();
-
     const completedCount = completedWorkflows[0]?.total || 0;
     const completedTodayCount = completedToday[0]?.total || 0;
     const totalWithAssistant = conversationsWithAssistant.length;
@@ -521,39 +467,15 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       ? Math.round((completedCount / totalWithAssistant) * 1000) / 10
       : 0;
 
-    // Average messages per completed workflow
-    const completedConvIds = conversationsWithAssistant
-      .filter((c) => c.has_final === 1)
-      .map((c) => c._id);
-    const avgMsgsCompleted = completedConvIds.length > 0
+    const avgMsgsCompleted = conversationsWithAssistant.filter((c) => c.has_final === 1).length > 0
       ? Math.round(
           (conversationsWithAssistant
             .filter((c) => c.has_final === 1)
             .reduce((sum, c) => sum + c.msg_count, 0) /
-            completedConvIds.length) *
+            conversationsWithAssistant.filter((c) => c.has_final === 1).length) *
             10
         ) / 10
       : 0;
-
-    // Hourly activity heatmap (hour-of-day distribution over selected range)
-    // Combine web messages + Slack interactions
-    // Use $toDate to handle both Date objects and ISO string values for created_at
-    const [hourlyWebActivity, hourlySlackActivity] = await Promise.all([
-      sourceFilter !== 'slack'
-        ? messages.aggregate([
-            { $match: { 'metadata.source': 'web', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-            { $addFields: { _ts: { $toDate: '$created_at' } } },
-            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
-          ]).toArray()
-        : Promise.resolve([]),
-      sourceFilter !== 'web'
-        ? messages.aggregate([
-            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart } } },
-            { $addFields: { _ts: { $toDate: '$created_at' } } },
-            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
-          ]).toArray()
-        : Promise.resolve([]),
-    ]);
 
     const hourlyMap = new Map<number, number>();
     for (const h of hourlyWebActivity) hourlyMap.set(h._id, (hourlyMap.get(h._id) || 0) + h.count);
@@ -770,33 +692,15 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const includeWeb = sourceFilter !== 'slack';
     const includeSlack = sourceFilter !== 'web';
 
-    // Web agent usage: count of assistant messages with agent_name for hours estimation
-    const webAgentMessagesAgg = includeWeb
-      ? await messages.countDocuments({
-          role: 'assistant',
-          'metadata.agent_name': { $exists: true, $ne: null },
-          created_at: { $gte: rangeStart },
-          ...msgOwnerFilter,
-        })
-      : 0;
+    const webAgentMessagesAgg = includeWeb ? (webAgentMsgCount as number) : 0;
 
     const slackHoursSaved = includeSlack ? (slack?.resolution?.estimated_hours_saved || 0) : 0;
 
     // Hours automated: web agent usage (10 min each) + Slack resolved threads (4h each)
-    const webHoursAutomated = Math.round((webAgentMessagesAgg * 10) / 60 * 10) / 10; // 10 min per agent response
+    const webHoursAutomated = Math.round((webAgentMessagesAgg * 10) / 60 * 10) / 10;
     const totalHoursAutomated = Math.round((webHoursAutomated + slackHoursSaved) * 10) / 10;
 
-    // Collect available channel names from both old and new schema
-    const [oldChannels, newChannels] = await Promise.all([
-      conversations.distinct(
-        'slack_meta.channel_name',
-        { source: 'slack', 'slack_meta.channel_name': { $ne: null } },
-      ),
-      conversations.distinct(
-        'metadata.channel_name',
-        { client_type: 'slack', 'metadata.channel_name': { $ne: null } },
-      ),
-    ]);
+    const [oldChannels, newChannels] = availableChannelsResult;
     const availableChannels = [...new Set([...oldChannels, ...newChannels])];
 
     const platformSummary = {

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev5"
+version = "0.5.15.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev4"
+version = "0.5.15.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Admin page was slow to load for two reasons:

1. **All tab data loaded on mount** — stats, teams, skills, feedback, and NPS were all fetched in parallel when the admin page opened, regardless of which tab was active. The default tab (Settings) needs none of this data, so users waited for 5+ API calls to complete before seeing anything.

2. **Stats API ran ~15 aggregations sequentially** — daily activity, top users, top agents, feedback summaries, latency, workflows, hourly heatmap, and available channels were all `await`ed one-by-one. Server-side latency was the sum of all queries instead of the max.

### Changes

**`ui/src/app/(app)/admin/page.tsx`**
- Replaced the monolithic `loadAdminData()` (ran on mount) with a `loadTabData(tab)` function that fetches only what the active tab needs, on first visit
- Added a `visitedTabsRef` Set to track which tabs have already loaded their data — prevents redundant fetches on re-visits
- Tab → data mappings: `stats`/`slack` → stats + teams; `teams`/`identity-sync` → teams; `skills` → skill stats; `feedback` → feedback + teams; `nps` → NPS data
- Tabs with no server-fetched data (settings, credentials, health, metrics, etc.) load instantly with zero API calls
- Teams data is shared by the stats/feedback filter dropdowns and is fetched lazily alongside the first tab that needs it

**`ui/src/app/api/admin/stats/route.ts`**
- Collapsed ~15 sequential `await` calls (daily activity × 4, top users × 2, top agents, feedback × 4, latency, workflows × 3, heatmap × 2, channels × 2, web agent count) into a single `Promise.all` batch
- Server-side time drops from sum-of-all-queries to max-of-slowest-query

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass