### PR TITLE
fix(slack): let team members manage shared integrations

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga/authorization-model.json
+++ b/charts/ai-platform-engineering/charts/openfga/authorization-model.json
@@ -97,6 +97,10 @@
               },
               {
                 "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
                 "relation": "admin"
               },
               {
@@ -960,6 +964,10 @@
               },
               {
                 "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "member"
               },
               {
                 "type": "team",

--- a/deploy/openfga/model.fga
+++ b/deploy/openfga/model.fga
@@ -120,7 +120,7 @@ type slack_channel
     define reader: [user, service_account, team#member, team#admin, external_group#member]
     define user: [user, service_account, team#member, team#admin, external_group#member]
     define writer: [user, service_account, team#member, team#admin, external_group#member]
-    define manager: [user, service_account, team#admin]
+    define manager: [user, service_account, team#member, team#admin]
     define auditor: [user, service_account, team#admin]
     define can_discover: can_read
     define can_read: reader or can_use or can_manage or owner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.2"
+version = "0.5.15-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/rbac-admin-regression.spec.ts
+++ b/ui/e2e/rbac/rbac-admin-regression.spec.ts
@@ -118,6 +118,23 @@ function policyManifestRecords() {
       description:
         "Assigning a Slack channel to a team lets team members use and manage the channel integration; team admins also manage it.",
       trigger: "admin assigns or reassigns a Slack channel to a team",
+      feature: {
+        name: "Slack integrations",
+        summary:
+          "Slack integrations let teams choose which bot routes and agents answer in their Slack channels.",
+        subfeatures: [
+          {
+            name: "Configured channels",
+            behavior: "Team members see the Slack channels shared with their team.",
+            authorization: "A shared channel gives that team's members access to view and update that channel's routing.",
+          },
+          {
+            name: "Channel routing",
+            behavior: "Team members can choose which agent answers in a shared channel.",
+            authorization: "The selected agent still needs to be usable by both the channel and the user's team.",
+          },
+        ],
+      },
       grants: [
         {
           subject: { type: "team", parameter: "teamSlug", relation: "admin" },
@@ -144,6 +161,18 @@ function policyManifestRecords() {
       description:
         "Assigning a Webex space to a team lets team members use the space integration; team admins manage it.",
       trigger: "admin assigns or reassigns a Webex space to a team",
+      feature: {
+        name: "Webex integrations",
+        summary:
+          "Webex integrations let teams connect spaces to CAIPE routing so messages can reach the right agents.",
+        subfeatures: [
+          {
+            name: "Configured spaces",
+            behavior: "Team members can use Webex spaces that are shared with their team.",
+            authorization: "The space assignment creates team access for that Webex space.",
+          },
+        ],
+      },
       grants: [
         {
           subject: { type: "team", parameter: "teamSlug", relation: "admin" },
@@ -389,23 +418,26 @@ test.describe("mocked RBAC admin browser regression", () => {
     });
 
     await expect(page.getByRole("tab", { name: "Policy Manifest" })).toHaveAttribute("aria-selected", "true");
-    await expect(page.getByRole("heading", { name: "Policy Manifest" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Sharing Rules" })).toBeVisible();
     await expect(page.getByTestId("policy-manifest-slack_channel_team_assignment_v1")).toContainText(
-      "Slack channel team assignment"
+      "When a Slack channel is assigned to a team"
     );
     await expect(page.getByTestId("policy-manifest-webex_space_team_assignment_v1")).toContainText(
-      "Webex space team assignment"
+      "When a Webex space is assigned to a team"
     );
     const slackPolicy = page.getByTestId("policy-manifest-slack_channel_team_assignment_v1");
-    await expect(slackPolicy.getByText("Team teamSlug member").first()).toBeVisible();
-    await expect(slackPolicy.getByText("Slack Channel slackChannelId").first()).toBeVisible();
+    await expect(slackPolicy.getByText("Slack integrations", { exact: true })).toBeVisible();
+    await expect(slackPolicy.getByText("Configured channels")).toBeVisible();
+    await expect(slackPolicy.getByText("Team members can choose which agent answers in a shared channel.")).toBeVisible();
+    await expect(slackPolicy.getByText("Team members can change settings for this Slack channel.")).toBeVisible();
+    await expect(slackPolicy.getByText("teamSlug").first()).toBeHidden();
     await expect(slackPolicy.getByText("team:{teamSlug}#member").first()).toBeHidden();
 
-    await page.getByLabel("Policy surface").selectOption("slack");
+    await page.getByLabel("Product").selectOption("slack");
     await expect(page.getByTestId("policy-manifest-slack_channel_team_assignment_v1")).toBeVisible();
     await expect(page.getByTestId("policy-manifest-webex_space_team_assignment_v1")).toHaveCount(0);
 
-    await slackPolicy.getByText("Technical details").click();
+    await slackPolicy.getByText("Show technical mapping").click();
     await expect(slackPolicy.getByText("team:{teamSlug}#member").first()).toBeVisible();
   });
 });

--- a/ui/e2e/rbac/rbac-admin-regression.spec.ts
+++ b/ui/e2e/rbac/rbac-admin-regression.spec.ts
@@ -108,6 +108,58 @@ function auditRecords() {
   ];
 }
 
+function policyManifestRecords() {
+  return [
+    {
+      id: "slack_channel_team_assignment_v1",
+      family: "messaging_team_assignment",
+      surface: "slack",
+      title: "Slack channel team assignment",
+      description:
+        "Assigning a Slack channel to a team lets team members use and manage the channel integration; team admins also manage it.",
+      trigger: "admin assigns or reassigns a Slack channel to a team",
+      grants: [
+        {
+          subject: { type: "team", parameter: "teamSlug", relation: "admin" },
+          action: "manage",
+          resource: { type: "slack_channel", parameter: "slackChannelId" },
+        },
+        {
+          subject: { type: "team", parameter: "teamSlug", relation: "member" },
+          action: "use",
+          resource: { type: "slack_channel", parameter: "slackChannelId" },
+        },
+        {
+          subject: { type: "team", parameter: "teamSlug", relation: "member" },
+          action: "manage",
+          resource: { type: "slack_channel", parameter: "slackChannelId" },
+        },
+      ],
+    },
+    {
+      id: "webex_space_team_assignment_v1",
+      family: "messaging_team_assignment",
+      surface: "webex",
+      title: "Webex space team assignment",
+      description:
+        "Assigning a Webex space to a team lets team members use the space integration; team admins manage it.",
+      trigger: "admin assigns or reassigns a Webex space to a team",
+      grants: [
+        {
+          subject: { type: "team", parameter: "teamSlug", relation: "admin" },
+          action: "manage",
+          resource: { type: "webex_space", parameter: "webexSpaceId" },
+        },
+        {
+          subject: { type: "team", parameter: "teamSlug", relation: "member" },
+          action: "use",
+          resource: { type: "webex_space", parameter: "webexSpaceId" },
+        },
+      ],
+    },
+  ];
+}
+
 test.describe("mocked RBAC admin browser regression", () => {
   test.beforeEach(() => {
     test.skip(
@@ -268,5 +320,92 @@ test.describe("mocked RBAC admin browser regression", () => {
     await expect.poll(() => auditQueries.some((query) => query.includes("type=cas_grant"))).toBe(true);
     await expect(page.getByText("1 event found")).toBeVisible();
     await expect(page.getByText("Denied to manage agent agent-private")).toHaveCount(0);
+  });
+
+  test("policy manifest visualizes reusable sharing rules without exposing tuple details by default", async ({
+    page,
+  }) => {
+    const policies = policyManifestRecords();
+    const policyHandler: MockRouteHandler = async ({ route, path, method, url }) => {
+      if (path === "/api/admin/openfga/catalog" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            status: {
+              configured: true,
+              reconcile_enabled: true,
+              store_name: "playwright-openfga",
+            },
+            teams: [],
+            resource_types: [],
+            actions: {},
+            resources: {
+              agents: [],
+              tools: [],
+              knowledge_bases: [],
+              by_type: {},
+            },
+            universal_resources: [],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/openfga/tuples" && method === "GET") {
+        await fulfillJson(route, { data: { tuples: [] } });
+        return true;
+      }
+
+      if (path === "/api/admin/rebac/graph" && method === "GET") {
+        await fulfillJson(route, { data: { nodes: [], edges: [] } });
+        return true;
+      }
+
+      if (path === "/api/admin/rebac/policies/catalog" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            policies,
+            count: policies.length,
+            filters: {
+              surface: url.searchParams.get("surface"),
+              resource_type: url.searchParams.get("resource_type"),
+              family: url.searchParams.get("family"),
+            },
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      handlers: [policyHandler],
+    });
+
+    await page.goto("/admin?cat=security&tab=openfga&subtab=manifest", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByRole("tab", { name: "Policy Manifest" })).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByRole("heading", { name: "Policy Manifest" })).toBeVisible();
+    await expect(page.getByTestId("policy-manifest-slack_channel_team_assignment_v1")).toContainText(
+      "Slack channel team assignment"
+    );
+    await expect(page.getByTestId("policy-manifest-webex_space_team_assignment_v1")).toContainText(
+      "Webex space team assignment"
+    );
+    const slackPolicy = page.getByTestId("policy-manifest-slack_channel_team_assignment_v1");
+    await expect(slackPolicy.getByText("Team teamSlug member").first()).toBeVisible();
+    await expect(slackPolicy.getByText("Slack Channel slackChannelId").first()).toBeVisible();
+    await expect(slackPolicy.getByText("team:{teamSlug}#member").first()).toBeHidden();
+
+    await page.getByLabel("Policy surface").selectOption("slack");
+    await expect(page.getByTestId("policy-manifest-slack_channel_team_assignment_v1")).toBeVisible();
+    await expect(page.getByTestId("policy-manifest-webex_space_team_assignment_v1")).toHaveCount(0);
+
+    await slackPolicy.getByText("Technical details").click();
+    await expect(slackPolicy.getByText("team:{teamSlug}#member").first()).toBeVisible();
   });
 });

--- a/ui/e2e/rbac/slack-run-as.spec.ts
+++ b/ui/e2e/rbac/slack-run-as.spec.ts
@@ -305,6 +305,9 @@ test.describe("mocked Slack Run as browser regression", () => {
     await expect(page.getByRole("tab", { name: "Advanced" })).toHaveCount(0);
     await page.getByRole("button", { name: /#grid-test-4/ }).click();
     await expect(page.getByRole("button", { name: "Add Agent" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Agent" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Edit" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Delete agent:jenkins-agent" })).toBeEnabled();
     await page.getByRole("button", { name: "Edit" }).click();
 
     const dialog = page.getByRole("dialog", { name: /Edit agent:jenkins-agent/ });
@@ -322,5 +325,126 @@ test.describe("mocked Slack Run as browser regression", () => {
         },
       ],
     });
+  });
+
+  test("keeps team-member Slack route controls locked when channel manage is denied", async ({
+    page,
+  }) => {
+    const routeWrites: unknown[] = [];
+    const nonAdminSession = {
+      email: "generic-user@caipe.local",
+      name: "Generic User",
+      role: "user" as const,
+      canViewAdmin: true,
+    };
+
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            channels: [
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0LOCKED",
+                channel_name: "locked-shared-channel",
+                team_slug: "eti-sre-admin-jenkins",
+                active_grants: 1,
+                can_manage: false,
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            items: [
+              { _id: "jenkins-agent", name: "Jenkins Agent" },
+              { _id: "meriki-docs", name: "Meriki Docs" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/teams" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            teams: [
+              { _id: "team-jenkins", slug: "eti-sre-admin-jenkins", name: "ETI SRE Admin Jenkins" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0LOCKED/routes" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            routes: [
+              {
+                agent_id: "jenkins-agent",
+                enabled: true,
+                priority: 100,
+                users: { enabled: true, listen: "all" },
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0LOCKED/routes" && method === "PUT") {
+        routeWrites.push(await postJson(route));
+        await fulfillJson(route, { error: "forbidden" }, 403);
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0LOCKED/diagnostics" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            openfga: { reachable: true, tuple_count: 1 },
+            routes: [],
+            warnings: [],
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: false,
+      session: nonAdminSession,
+      gates: {
+        settings: false,
+        teams: false,
+        users: false,
+        metrics: false,
+        health: false,
+        slack: true,
+      },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack", {
+      waitUntil: "domcontentloaded",
+    });
+
+    // assisted-by Codex Codex-sonnet-4-6
+    // Visibility alone is not enough. If the channel row is returned without
+    // can_manage, non-admin users may inspect it but cannot mutate routes.
+    await expect(page.getByText("My Slack Channel Settings")).toBeVisible();
+    await expect(page.getByText("#locked-shared-channel")).toBeVisible();
+    await page.getByRole("button", { name: /#locked-shared-channel/ }).click();
+
+    await expect(page.getByRole("button", { name: "Add Agent" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Edit" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Delete agent:jenkins-agent" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: /Delete channel/ })).toBeDisabled();
+    await expect.poll(() => routeWrites.length).toBe(0);
   });
 });

--- a/ui/e2e/rbac/slack-run-as.spec.ts
+++ b/ui/e2e/rbac/slack-run-as.spec.ts
@@ -178,4 +178,149 @@ test.describe("mocked Slack Run as browser regression", () => {
     });
     await expect(page.getByText("sa:slack-runner")).toBeVisible();
   });
+
+  test("lets team-member non-admins manage team-shared Slack channel routing", async ({
+    page,
+  }) => {
+    const routeWrites: unknown[] = [];
+    let routes: unknown[] = [
+      {
+        agent_id: "jenkins-agent",
+        enabled: true,
+        priority: 100,
+        users: { enabled: true, listen: "all" },
+      },
+    ];
+    const nonAdminSession = {
+      email: "generic-user@caipe.local",
+      name: "Generic User",
+      role: "user" as const,
+      canViewAdmin: true,
+    };
+
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            channels: [
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0B4QFN4Q21",
+                channel_name: "grid-test-4",
+                team_slug: "eti-sre-admin-jenkins",
+                active_grants: 1,
+                can_manage: true,
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            items: [
+              { _id: "jenkins-agent", name: "Jenkins Agent" },
+              { _id: "meriki-docs", name: "Meriki Docs" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/teams" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            teams: [
+              { _id: "team-jenkins", slug: "eti-sre-admin-jenkins", name: "ETI SRE Admin Jenkins" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0B4QFN4Q21/routes" && method === "GET") {
+        await fulfillJson(route, {
+          data: { routes },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0B4QFN4Q21/routes" && method === "PUT") {
+        const body = (await postJson(route)) as { routes?: unknown[] } | null;
+        routeWrites.push(body);
+        routes = Array.isArray(body?.routes) ? body.routes : [];
+        await fulfillJson(route, { data: { routes } });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0B4QFN4Q21/diagnostics" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            openfga: { reachable: true, tuple_count: 3 },
+            routes: [],
+            warnings: [],
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: false,
+      session: nonAdminSession,
+      gates: {
+        settings: false,
+        teams: false,
+        users: false,
+        metrics: false,
+        health: false,
+        slack: true,
+      },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack", {
+      waitUntil: "domcontentloaded",
+    });
+
+    // assisted-by Codex Codex-sonnet-4-6
+    // A team-shared Slack channel should show the non-admin configured view and
+    // allow route edits when the selected team grants channel manage.
+    await expect(page.getByRole("button", { name: "Integrations" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Slack" })).toBeVisible();
+    await expect(page.getByText("My Slack Channel Settings")).toBeVisible();
+    await expect(page.getByText("Manage Slack bot routing for channels shared with your team.")).toBeVisible();
+    await expect(page.getByText(/Members of the assigned team can update this Slack channel/)).toBeVisible();
+    await expect(page.getByText(/OpenFGA|can_use|team:<slug>/)).toHaveCount(0);
+    await page.getByLabel("Slack access details").focus();
+    await expect(page.getByText(/Technical details:/)).toBeVisible();
+    await expect(page.getByText("1 configured channels")).toBeVisible();
+    await expect(page.getByText("#grid-test-4")).toBeVisible();
+    await expect(page.getByText("team:eti-sre-admin-jenkins")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Onboard channels" })).toHaveCount(0);
+    await expect(page.getByRole("tab", { name: "Advanced" })).toHaveCount(0);
+    await page.getByRole("button", { name: /#grid-test-4/ }).click();
+    await expect(page.getByRole("button", { name: "Add Agent" })).toBeVisible();
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    const dialog = page.getByRole("dialog", { name: /Edit agent:jenkins-agent/ });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Dynamic Agent").click();
+    await page.getByRole("option", { name: /Meriki Docs/ }).click();
+    await dialog.getByRole("button", { name: "Update Agent" }).click();
+
+    await expect.poll(() => routeWrites.length).toBe(1);
+    expect(routeWrites[0]).toMatchObject({
+      routes: [
+        {
+          agent_id: "meriki-docs",
+          users: { enabled: true, listen: "all" },
+        },
+      ],
+    });
+  });
 });

--- a/ui/e2e/rbac/slack-run-as.spec.ts
+++ b/ui/e2e/rbac/slack-run-as.spec.ts
@@ -17,6 +17,13 @@ const adminSession = {
   canViewAdmin: true,
 };
 
+const genericTeamMemberSession = {
+  email: "eti-sre-cicd.gen@cisco.com",
+  name: "Generic User",
+  role: "user" as const,
+  canViewAdmin: true,
+};
+
 test.describe("mocked Slack Run as browser regression", () => {
   test.beforeEach(() => {
     test.skip(
@@ -446,5 +453,441 @@ test.describe("mocked Slack Run as browser regression", () => {
     await expect(page.getByRole("button", { name: "Delete agent:jenkins-agent" })).toBeDisabled();
     await expect(page.getByRole("button", { name: /Delete channel/ })).toBeDisabled();
     await expect.poll(() => routeWrites.length).toBe(0);
+  });
+
+  test("applies team-member manage per channel without leaking admin-only Slack surfaces", async ({
+    page,
+  }) => {
+    const routeWrites: unknown[] = [];
+    const routesByChannel: Record<string, unknown[]> = {
+      C0EDITABLE: [
+        {
+          agent_id: "jenkins-agent",
+          enabled: true,
+          priority: 100,
+          users: { enabled: true, listen: "all" },
+        },
+      ],
+      C0USEONLY: [
+        {
+          agent_id: "read-only-agent",
+          enabled: true,
+          priority: 100,
+          users: { enabled: true, listen: "mention" },
+        },
+      ],
+    };
+
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            channels: [
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0EDITABLE",
+                channel_name: "editable-channel",
+                team_slug: "eti-sre-admin-jenkins",
+                active_grants: 1,
+                can_manage: true,
+              },
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0USEONLY",
+                channel_name: "use-only-channel",
+                team_slug: "eti-sre-admin-jenkins",
+                active_grants: 1,
+                can_manage: false,
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            items: [
+              { _id: "jenkins-agent", name: "Jenkins Agent" },
+              { _id: "read-only-agent", name: "Read Only Agent" },
+              { _id: "meriki-docs", name: "Meriki Docs" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/teams" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            teams: [
+              { _id: "team-jenkins", slug: "eti-sre-admin-jenkins", name: "ETI SRE Admin Jenkins" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      const routeMatch = path.match(/^\/api\/admin\/slack\/channels\/CAIPE\/([^/]+)\/routes$/);
+      if (routeMatch) {
+        const channelId = routeMatch[1];
+        if (method === "GET") {
+          await fulfillJson(route, { data: { routes: routesByChannel[channelId] ?? [] } });
+          return true;
+        }
+        if (method === "PUT") {
+          const body = (await postJson(route)) as { routes?: unknown[] } | null;
+          routeWrites.push({ channelId, body });
+          routesByChannel[channelId] = Array.isArray(body?.routes) ? body.routes : [];
+          await fulfillJson(route, { data: { routes: routesByChannel[channelId] } });
+          return true;
+        }
+      }
+
+      if (path.match(/^\/api\/admin\/slack\/channels\/CAIPE\/[^/]+\/diagnostics$/)) {
+        await fulfillJson(route, {
+          data: {
+            openfga: { reachable: true, tuple_count: 3 },
+            routes: [],
+            warnings: [],
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: false,
+      session: genericTeamMemberSession,
+      gates: {
+        settings: false,
+        teams: false,
+        users: false,
+        metrics: false,
+        health: false,
+        slack: true,
+      },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack&subtab=onboard", {
+      waitUntil: "domcontentloaded",
+    });
+
+    // assisted-by Codex Codex-sonnet-4-6
+    // The generic team member should stay in the self-service configured view:
+    // no Onboard/Advanced admin surfaces, with editability decided per channel.
+    await expect(page.getByText("My Slack Channel Settings")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Onboard channels" })).toHaveCount(0);
+    await expect(page.getByRole("tab", { name: "Advanced" })).toHaveCount(0);
+    await expect(page.getByText("Discover channels")).toHaveCount(0);
+    await expect(page.getByText("#editable-channel")).toBeVisible();
+    await expect(page.getByText("#use-only-channel")).toBeVisible();
+
+    await page.getByRole("button", { name: /#editable-channel/ }).click();
+    await expect(page.getByRole("button", { name: "Add Agent" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Edit agent:jenkins-agent" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Delete agent:jenkins-agent" })).toBeEnabled();
+
+    await page.getByRole("button", { name: "Edit agent:jenkins-agent" }).click();
+    const dialog = page.getByRole("dialog", { name: /Edit agent:jenkins-agent/ });
+    await dialog.getByLabel("Dynamic Agent").click();
+    await page.getByRole("option", { name: /Meriki Docs/ }).click();
+    await dialog.getByRole("button", { name: "Update Agent" }).click();
+    await expect.poll(() => routeWrites.length).toBe(1);
+    expect(routeWrites[0]).toMatchObject({
+      channelId: "C0EDITABLE",
+      body: {
+        routes: [
+          {
+            agent_id: "meriki-docs",
+          },
+        ],
+      },
+    });
+
+    await page.getByRole("button", { name: /#use-only-channel/ }).click();
+    await expect(page.getByRole("button", { name: "Add Agent" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Edit agent:read-only-agent" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Delete agent:read-only-agent" })).toBeDisabled();
+    await expect.poll(() => routeWrites.length).toBe(1);
+  });
+
+  test("shows no Slack channel controls to non-admins when no shared integrations are returned", async ({
+    page,
+  }) => {
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, { data: { channels: [] } });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, { data: { items: [{ _id: "hidden-agent", name: "Hidden Agent" }] } });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: false,
+      session: genericTeamMemberSession,
+      gates: {
+        settings: false,
+        teams: false,
+        users: false,
+        metrics: false,
+        health: false,
+        slack: true,
+      },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByText("My Slack Channel Settings")).toBeVisible();
+    await expect(page.getByText("#hidden-channel")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Add Agent" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /Edit agent:/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /Delete channel/ })).toHaveCount(0);
+  });
+
+  test("lets platform admins manage Slack channels even when row-level team manage is absent", async ({
+    page,
+  }) => {
+    const routeWrites: unknown[] = [];
+    let routes: unknown[] = [
+      {
+        agent_id: "locked-agent",
+        enabled: true,
+        priority: 100,
+        users: { enabled: true, listen: "all" },
+      },
+    ];
+
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            channels: [
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0ADMIN",
+                channel_name: "admin-overrides-channel",
+                team_slug: "eti-sre-admin-jenkins",
+                active_grants: 1,
+                can_manage: false,
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            items: [
+              { _id: "locked-agent", name: "Locked Agent" },
+              { _id: "meriki-docs", name: "Meriki Docs" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/teams" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            teams: [
+              { _id: "team-jenkins", slug: "eti-sre-admin-jenkins", name: "ETI SRE Admin Jenkins" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/runtime/status" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            route_mode: "db_prefer",
+            static_config: { channels: 1, routes: 1 },
+            route_cache: { ttl_seconds: 60, cache_size: 1 },
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0ADMIN/routes") {
+        if (method === "GET") {
+          await fulfillJson(route, { data: { routes } });
+          return true;
+        }
+        if (method === "PUT") {
+          const body = (await postJson(route)) as { routes?: unknown[] } | null;
+          routeWrites.push(body);
+          routes = Array.isArray(body?.routes) ? body.routes : [];
+          await fulfillJson(route, { data: { routes } });
+          return true;
+        }
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0ADMIN/diagnostics" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            openfga: { reachable: true, tuple_count: 1 },
+            routes: [],
+            warnings: [],
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      gates: { slack: true },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByRole("tab", { name: "Configured channels" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Onboard channels" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Advanced" })).toBeVisible();
+    await page.getByRole("button", { name: /#admin-overrides-channel/ }).click();
+    await expect(page.getByRole("button", { name: "Team for #admin-overrides-channel" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Add Agent" })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Edit agent:locked-agent" })).toBeEnabled();
+
+    await page.getByRole("button", { name: "Edit agent:locked-agent" }).click();
+    const dialog = page.getByRole("dialog", { name: /Edit agent:locked-agent/ });
+    await dialog.getByLabel("Dynamic Agent").click();
+    await page.getByRole("option", { name: /Meriki Docs/ }).click();
+    await dialog.getByRole("button", { name: "Update Agent" }).click();
+
+    await expect.poll(() => routeWrites.length).toBe(1);
+    expect(routeWrites[0]).toMatchObject({
+      routes: [
+        {
+          agent_id: "meriki-docs",
+        },
+      ],
+    });
+  });
+
+  test("surfaces backend authorization denial even if a stale row says can_manage", async ({
+    page,
+  }) => {
+    const routeWrites: unknown[] = [];
+
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            channels: [
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0STALE",
+                channel_name: "stale-manage-channel",
+                team_slug: "eti-sre-admin-jenkins",
+                active_grants: 1,
+                can_manage: true,
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            items: [
+              { _id: "jenkins-agent", name: "Jenkins Agent" },
+              { _id: "meriki-docs", name: "Meriki Docs" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0STALE/routes") {
+        if (method === "GET") {
+          await fulfillJson(route, {
+            data: {
+              routes: [
+                {
+                  agent_id: "jenkins-agent",
+                  enabled: true,
+                  priority: 100,
+                  users: { enabled: true, listen: "all" },
+                },
+              ],
+            },
+          });
+          return true;
+        }
+
+        if (method === "PUT") {
+          routeWrites.push(await postJson(route));
+          await fulfillJson(route, { error: "channel manage denied by policy" }, 403);
+          return true;
+        }
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0STALE/diagnostics" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            openfga: { reachable: true, tuple_count: 3 },
+            routes: [],
+            warnings: [],
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: false,
+      session: genericTeamMemberSession,
+      gates: {
+        settings: false,
+        teams: false,
+        users: false,
+        metrics: false,
+        health: false,
+        slack: true,
+      },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: /#stale-manage-channel/ }).click();
+    await expect(page.getByRole("button", { name: "Edit agent:jenkins-agent" })).toBeEnabled();
+    await page.getByRole("button", { name: "Edit agent:jenkins-agent" }).click();
+    const dialog = page.getByRole("dialog", { name: /Edit agent:jenkins-agent/ });
+    await dialog.getByLabel("Dynamic Agent").click();
+    await page.getByRole("option", { name: /Meriki Docs/ }).click();
+    await dialog.getByRole("button", { name: "Update Agent" }).click();
+
+    await expect.poll(() => routeWrites.length).toBe(1);
+    await expect(page.getByText(/channel manage denied by policy/)).toBeVisible();
   });
 });

--- a/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
@@ -852,4 +852,51 @@ describe("admin ReBAC migrations API", () => {
     expect(collections.webex_space_team_mappings.createIndex).toHaveBeenCalled();
     expect(indexBody.data.applied_counts.indexes_created).toBeGreaterThan(0);
   });
+
+  it("backfills Slack team member manage tuples for configured channels", async () => {
+    const planRoute = await import("../migrations/[migrationId]/plan/route");
+    const applyRoute = await import("../migrations/[migrationId]/apply/route");
+
+    const planResponse = await planRoute.POST(
+      request("/api/admin/rebac/migrations/messaging_team_visibility_v1/plan", { method: "POST" }),
+      { params: Promise.resolve({ migrationId: "messaging_team_visibility_v1" }) },
+    );
+    const planBody = await planResponse.json();
+
+    expect(planResponse.status).toBe(200);
+    expect(planBody.data.counts).toMatchObject({
+      slack_channels_scanned: 1,
+      webex_spaces_scanned: 1,
+    });
+    expect(planBody.data.counts.tuple_writes_planned).toBeGreaterThanOrEqual(4);
+    expect(planBody.data.tuples).toEqual(
+      expect.arrayContaining([
+        {
+          user: "team:platform#member",
+          relation: "manager",
+          object: "slack_channel:T123--C123",
+        },
+      ]),
+    );
+
+    const applyResponse = await applyRoute.POST(
+      request("/api/admin/rebac/migrations/messaging_team_visibility_v1/apply", {
+        method: "POST",
+        body: JSON.stringify({ confirmation: "MIGRATE messaging_team_visibility TO v2" }),
+      }),
+      { params: Promise.resolve({ migrationId: "messaging_team_visibility_v1" }) },
+    );
+
+    expect(applyResponse.status).toBe(200);
+    expect(mockWriteOpenFgaTupleDiff).toHaveBeenCalledWith({
+      writes: expect.arrayContaining([
+        {
+          user: "team:platform#member",
+          relation: "manager",
+          object: "slack_channel:T123--C123",
+        },
+      ]),
+      deletes: [],
+    });
+  });
 });

--- a/ui/src/app/api/admin/rebac/__tests__/policy-catalog-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/policy-catalog-route.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetServerSession = jest.fn();
+const mockCheckPermission = jest.fn();
+
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+jest.mock("@/lib/auth-config", () => ({
+  authOptions: {},
+  isBootstrapAdmin: jest.fn().mockReturnValue(false),
+  REQUIRED_ADMIN_GROUP: "",
+}));
+
+jest.mock("@/lib/config", () => ({
+  getConfig: (key: string) => key === "ssoEnabled",
+}));
+
+jest.mock("@/lib/rbac/keycloak-authz", () => ({
+  checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
+}));
+
+jest.mock("@/lib/rbac/audit", () => ({
+  logAuthzDecision: jest.fn(),
+}));
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+function accessTokenWithRoles(roles: string[]): string {
+  const payload = Buffer.from(JSON.stringify({ realm_access: { roles } }), "utf8").toString(
+    "base64url"
+  );
+  return `h.${payload}.s`;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue({
+    user: { email: "admin@example.com", name: "Admin" },
+    role: "admin",
+    accessToken: accessTokenWithRoles(["admin"]),
+  });
+  mockCheckPermission.mockResolvedValue({ allowed: true, reason: "OK" });
+});
+
+describe("GET /api/admin/rebac/policies/catalog", () => {
+  it("returns the shared authorization policy manifest", async () => {
+    // assisted-by Codex Codex-sonnet-4-6
+    const { GET } = await import("../policies/catalog/route");
+
+    const response = await GET(makeRequest("/api/admin/rebac/policies/catalog"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.count).toBeGreaterThanOrEqual(2);
+    expect(body.data.policies.map((policy: any) => policy.id)).toEqual(
+      expect.arrayContaining(["slack_channel_team_assignment_v1", "webex_space_team_assignment_v1"])
+    );
+  });
+
+  it("filters policies by surface and family", async () => {
+    const { GET } = await import("../policies/catalog/route");
+
+    const response = await GET(
+      makeRequest("/api/admin/rebac/policies/catalog?surface=slack&family=messaging_team_assignment")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.policies.map((policy: any) => policy.id)).toEqual([
+      "slack_channel_team_assignment_v1",
+    ]);
+    expect(body.data.filters).toMatchObject({
+      surface: "slack",
+      family: "messaging_team_assignment",
+    });
+  });
+});

--- a/ui/src/app/api/admin/rebac/policies/catalog/route.ts
+++ b/ui/src/app/api/admin/rebac/policies/catalog/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from "next/server";
+
+import { successResponse, withErrorHandler } from "@/lib/api-middleware";
+import {
+  listAuthorizationPolicies,
+  listAuthorizationPoliciesByResourceType,
+  listAuthorizationPoliciesBySurface,
+} from "@/lib/rbac/authorization-policy-catalog";
+import type { UniversalRebacResourceType } from "@/types/rbac-universal";
+
+import { withRebacViewAuth } from "../../_lib";
+
+export const GET = withErrorHandler(async (request: NextRequest) =>
+  withRebacViewAuth(request, async () => {
+    // assisted-by Codex Codex-sonnet-4-6
+    const url = new URL(request.url);
+    const surface = url.searchParams.get("surface")?.trim();
+    const resourceType = url.searchParams.get("resource_type")?.trim() as
+      | UniversalRebacResourceType
+      | undefined;
+    const family = url.searchParams.get("family")?.trim();
+
+    let policies = resourceType
+      ? listAuthorizationPoliciesByResourceType(resourceType)
+      : surface
+        ? listAuthorizationPoliciesBySurface(surface)
+        : listAuthorizationPolicies();
+
+    if (family) {
+      policies = policies.filter((policy) => policy.family === family);
+    }
+
+    return successResponse({
+      policies,
+      count: policies.length,
+      filters: {
+        surface: surface || null,
+        resource_type: resourceType || null,
+        family: family || null,
+      },
+    });
+  })
+);

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -796,6 +796,7 @@ describe("Slack channel ReBAC APIs", () => {
         { user: `slack_channel:${workspaceAlias}--${channelId}`, relation: "user", object: "agent:incident-agent" },
         { user: `slack_channel:${workspaceAlias}--C987654321`, relation: "user", object: "agent:incident-agent" },
         { user: "team:platform-engineering#member", relation: "user", object: "agent:incident-agent" },
+        { user: `team:platform-engineering#member`, relation: "manager", object: `slack_channel:${workspaceAlias}--${channelId}` },
       ]),
       deletes: [],
     });
@@ -914,6 +915,7 @@ describe("Slack channel ReBAC APIs", () => {
         { user: `slack_channel:${workspaceAlias}--CNEWCONFIG`, relation: "user", object: "agent:incident-agent" },
         { user: `slack_channel:${workspaceAlias}--CNEWMISSING`, relation: "user", object: "agent:incident-agent" },
         { user: "team:platform-engineering#member", relation: "user", object: "agent:incident-agent" },
+        { user: "team:platform-engineering#member", relation: "manager", object: `slack_channel:${workspaceAlias}--CNEWMISSING` },
       ]),
       deletes: [],
     });
@@ -1048,6 +1050,7 @@ describe("Slack channel ReBAC APIs", () => {
       writes: expect.arrayContaining([
         { user: `slack_channel:${workspaceAlias}--CNEWMISSING`, relation: "user", object: "agent:test-april-2025" },
         { user: "team:security#member", relation: "user", object: "agent:test-april-2025" },
+        { user: "team:security#member", relation: "manager", object: `slack_channel:${workspaceAlias}--CNEWMISSING` },
       ]),
       deletes: [],
     });
@@ -1149,6 +1152,7 @@ describe("Slack channel ReBAC APIs", () => {
       writes: expect.arrayContaining([
         { user: `slack_channel:${workspaceAlias}--CCHANGED`, relation: "user", object: "agent:foo-bar" },
         { user: "team:platform-engineering#member", relation: "user", object: "agent:foo-bar" },
+        { user: "team:platform-engineering#member", relation: "manager", object: `slack_channel:${workspaceAlias}--CCHANGED` },
       ]),
       deletes: [
         {

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -339,6 +339,51 @@ describe("Slack channel ReBAC APIs", () => {
     );
   });
 
+  it("returns can_manage after a successful stale tuple repair even when OpenFGA read-after-write lags", async () => {
+    // Production OpenFGA can accept the new team-member manager tuple and still
+    // return the old check result for the immediate follow-up read. The list
+    // response should trust the successful repair write for this request so the
+    // configured channel UI does not keep Edit disabled until a later refresh.
+    // assisted-by Codex Codex-sonnet-4-6
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { relation: string; object: string }) => {
+      if (tuple.object === "organization:caipe") return { allowed: false };
+      if (tuple.object !== `slack_channel:${workspaceAlias}--${channelId}`) return { allowed: false };
+      if (tuple.relation === "can_read") return { allowed: true };
+      if (tuple.relation === "can_manage") return { allowed: false };
+      return { allowed: false };
+    });
+    mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/slack/channels"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.channels).toEqual([
+      expect.objectContaining({
+        channel_id: channelId,
+        team_slug: "platform-engineering",
+        can_manage: true,
+      }),
+    ]);
+    expect(mockCheckOpenFgaTuple).toHaveBeenCalledWith({
+      user: "user:alice-sub",
+      relation: "can_manage",
+      object: `slack_channel:${workspaceAlias}--${channelId}`,
+    });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writes: expect.arrayContaining([
+          {
+            user: "team:platform-engineering#member",
+            relation: "manager",
+            object: `slack_channel:${workspaceAlias}--${channelId}`,
+          },
+        ]),
+      }),
+    );
+  });
+
   it("replaces channel resource grants and writes channel OpenFGA tuples", async () => {
     // Not an org admin (organization:caipe denied) so the per-channel can_manage
     // check is what authorizes the actor — exercise that path explicitly.

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -297,6 +297,48 @@ describe("Slack channel ReBAC APIs", () => {
     ]);
   });
 
+  it("repairs stale team-shared Slack channel tuples so team members can edit routes", async () => {
+    // Old assignments may have a readable channel tuple but not the newer
+    // team-member manage tuple. Listing configured channels should converge
+    // that row to the central Slack team-assignment policy so the UI can enable
+    // Edit/Add Agent for team members.
+    // assisted-by Codex Codex-sonnet-4-6
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { relation: string; object: string }) => {
+      if (tuple.object === "organization:caipe") return { allowed: false };
+      if (tuple.object !== `slack_channel:${workspaceAlias}--${channelId}`) return { allowed: false };
+      if (tuple.relation === "can_read") return { allowed: true };
+      if (tuple.relation === "can_manage") {
+        return { allowed: mockWriteOpenFgaTuples.mock.calls.length > 0 };
+      }
+      return { allowed: false };
+    });
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/slack/channels"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.channels).toEqual([
+      expect.objectContaining({
+        channel_id: channelId,
+        channel_name: "incidents",
+        team_slug: "platform-engineering",
+        can_manage: true,
+      }),
+    ]);
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writes: expect.arrayContaining([
+          {
+            user: "team:platform-engineering#member",
+            relation: "manager",
+            object: `slack_channel:${workspaceAlias}--${channelId}`,
+          },
+        ]),
+      }),
+    );
+  });
+
   it("replaces channel resource grants and writes channel OpenFGA tuples", async () => {
     // Not an org admin (organization:caipe denied) so the per-channel can_manage
     // check is what authorizes the actor — exercise that path explicitly.

--- a/ui/src/app/api/admin/slack/channels/route.ts
+++ b/ui/src/app/api/admin/slack/channels/route.ts
@@ -2,14 +2,16 @@ import { NextRequest } from "next/server";
 
 import { getAuthFromBearerOrSession,successResponse,withErrorHandler } from "@/lib/api-middleware";
 import { getCollection } from "@/lib/mongodb";
-import { checkOpenFgaTuple } from "@/lib/rbac/openfga";
+import { checkOpenFgaTuple,writeOpenFgaTuples } from "@/lib/rbac/openfga";
 import { requireAdminSurfaceManage } from "@/lib/rbac/require-openfga";
 import { subjectFromSession } from "@/lib/rbac/resource-authz";
+import { slackChannelTeamVisibilityRelationships } from "@/lib/rbac/slack-channel-rebac";
 import {
 computeSlackChannelHealthSummary,
 type SlackChannelHealthSummary,
 } from "@/lib/rbac/slack-channel-diagnostics";
 import { listSlackChannelGrants,slackWorkspaceRef } from "@/lib/rbac/slack-channel-grant-store";
+import { buildUniversalRebacTupleDiff } from "@/lib/rbac/tuple-builders";
 import type { SlackChannelAgentRouteDocument } from "@/lib/rbac/slack-channel-route-store";
 
 interface ChannelTeamMappingDoc {
@@ -34,13 +36,35 @@ interface ChannelListRow {
 async function slackChannelAccess(
   openfgaUser: string,
   workspaceId: string,
-  channelId: string
+  channelId: string,
+  teamSlug?: string
 ): Promise<{ canRead: boolean; canManage: boolean }> {
   const object = `slack_channel:${workspaceId}--${channelId}`;
-  const [read, manage] = await Promise.all([
+  const checkAccess = () => Promise.all([
     checkOpenFgaTuple({ user: openfgaUser, relation: "can_read", object }).catch(() => ({ allowed: false })),
     checkOpenFgaTuple({ user: openfgaUser, relation: "can_manage", object }).catch(() => ({ allowed: false })),
   ]);
+  let [read, manage] = await checkAccess();
+  if (read.allowed && !manage.allowed && teamSlug) {
+    // assisted-by Codex Codex-sonnet-4-6
+    // Older channel assignments may only have the team-member use tuple.
+    // Re-materialize the central assignment policy so upgraded installs get
+    // the new team-member manage tuple without a manual migration first.
+    await writeOpenFgaTuples(
+      buildUniversalRebacTupleDiff({
+        writes: slackChannelTeamVisibilityRelationships(workspaceId, channelId, teamSlug),
+        deletes: [],
+      })
+    ).catch((error) => {
+      console.warn("[SlackChannels] Failed to repair team visibility tuples", {
+        workspaceId,
+        channelId,
+        teamSlug,
+        error,
+      });
+    });
+    [read, manage] = await checkAccess();
+  }
   return {
     canRead: read.allowed || manage.allowed,
     canManage: manage.allowed,
@@ -99,7 +123,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       rows.map(async (row) => {
         const workspaceId = slackWorkspaceRef(row.slack_workspace_id);
         const access = subject
-          ? await slackChannelAccess(subject, workspaceId, row.slack_channel_id)
+          ? await slackChannelAccess(subject, workspaceId, row.slack_channel_id, row.team_slug)
           : { canRead: false, canManage: false };
         // A Slack surface admin can see every channel row, including
         // team_mapping rows imported (config_sync) but not yet assigned to a

--- a/ui/src/app/api/admin/slack/channels/route.ts
+++ b/ui/src/app/api/admin/slack/channels/route.ts
@@ -45,12 +45,13 @@ async function slackChannelAccess(
     checkOpenFgaTuple({ user: openfgaUser, relation: "can_manage", object }).catch(() => ({ allowed: false })),
   ]);
   let [read, manage] = await checkAccess();
+  let repairedManageGrant = false;
   if (read.allowed && !manage.allowed && teamSlug) {
     // assisted-by Codex Codex-sonnet-4-6
     // Older channel assignments may only have the team-member use tuple.
     // Re-materialize the central assignment policy so upgraded installs get
     // the new team-member manage tuple without a manual migration first.
-    await writeOpenFgaTuples(
+    const repair = await writeOpenFgaTuples(
       buildUniversalRebacTupleDiff({
         writes: slackChannelTeamVisibilityRelationships(workspaceId, channelId, teamSlug),
         deletes: [],
@@ -62,12 +63,14 @@ async function slackChannelAccess(
         teamSlug,
         error,
       });
+      return null;
     });
+    repairedManageGrant = Boolean(repair?.enabled && repair.writes > 0);
     [read, manage] = await checkAccess();
   }
   return {
-    canRead: read.allowed || manage.allowed,
-    canManage: manage.allowed,
+    canRead: read.allowed || manage.allowed || repairedManageGrant,
+    canManage: manage.allowed || repairedManageGrant,
   };
 }
 

--- a/ui/src/app/api/admin/teams/[id]/slack-channels/route.ts
+++ b/ui/src/app/api/admin/teams/[id]/slack-channels/route.ts
@@ -28,7 +28,9 @@ withErrorHandler,
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import { writeOpenFgaTupleDiff } from "@/lib/rbac/openfga";
 import { requireResourcePermission } from "@/lib/rbac/resource-authz";
-import { slackChannelSubjectId,slackWorkspaceRef } from "@/lib/rbac/slack-channel-grant-store";
+import { slackWorkspaceRef } from "@/lib/rbac/slack-channel-grant-store";
+import { slackChannelTeamVisibilityRelationships } from "@/lib/rbac/slack-channel-rebac";
+import { buildUniversalRebacTupleDiff } from "@/lib/rbac/tuple-builders";
 import type { Team } from "@/types/teams";
 import { ObjectId } from "mongodb";
 import { NextRequest,NextResponse } from "next/server";
@@ -61,19 +63,21 @@ async function reconcileSlackChannelOwnership(
   removed: ChannelTeamMappingDoc[],
 ): Promise<void> {
   await writeOpenFgaTupleDiff({
-    writes: addedOrKept.flatMap((channel) => {
-      const object = `slack_channel:${slackChannelSubjectId(channel.slack_workspace_id ?? "", channel.slack_channel_id)}`;
-      return [
-        { user: `team:${slug}#member`, relation: "user", object },
-        { user: `team:${slug}#admin`, relation: "manager", object },
-      ];
-    }),
-    deletes: removed.flatMap((channel) => {
-      const object = `slack_channel:${slackChannelSubjectId(channel.slack_workspace_id ?? "", channel.slack_channel_id)}`;
-      return [
-        { user: `team:${slug}#member`, relation: "user", object },
-        { user: `team:${slug}#admin`, relation: "manager", object },
-      ];
+    ...buildUniversalRebacTupleDiff({
+      writes: addedOrKept.flatMap((channel) =>
+        slackChannelTeamVisibilityRelationships(
+          channel.slack_workspace_id ?? "",
+          channel.slack_channel_id,
+          slug,
+        )
+      ),
+      deletes: removed.flatMap((channel) =>
+        slackChannelTeamVisibilityRelationships(
+          channel.slack_workspace_id ?? "",
+          channel.slack_channel_id,
+          slug,
+        )
+      ),
     }),
   });
 }

--- a/ui/src/app/api/rbac/admin-tab-gates/__tests__/route.test.ts
+++ b/ui/src/app/api/rbac/admin-tab-gates/__tests__/route.test.ts
@@ -263,6 +263,51 @@ describe("GET /api/rbac/admin-tab-gates", () => {
     });
   });
 
+  it("shows Slack tab when a non-admin can read a team-shared Slack channel", async () => {
+    mockGetServerSession.mockResolvedValue({
+      role: "user",
+      sub: "user-sub",
+      user: { email: "user@example.com" },
+    });
+    mockGetCollection.mockImplementation((name: string) => {
+      if (name === "channel_team_mappings") {
+        return {
+          find: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnThis(),
+            toArray: jest.fn().mockResolvedValue([
+              { slack_workspace_id: "T123", slack_channel_id: "C123", active: true },
+            ]),
+          }),
+        };
+      }
+      if (name === "webex_space_team_mappings") {
+        return {
+          find: jest.fn().mockReturnValue({
+            limit: jest.fn().mockReturnThis(),
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    });
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: { user: string; relation: string; object: string }) => ({
+      allowed:
+        tuple.user === "user:user-sub" &&
+        tuple.relation === "can_read" &&
+        tuple.object === "slack_channel:T123--C123",
+    }));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.gates).toMatchObject({
+      slack: true,
+      webex: false,
+      openfga: false,
+    });
+  });
+
   it("can simulate admin tab gates for a real team userset", async () => {
     mockGetServerSession.mockResolvedValue({
       role: "admin",

--- a/ui/src/app/api/rbac/admin-tab-gates/route.ts
+++ b/ui/src/app/api/rbac/admin-tab-gates/route.ts
@@ -163,7 +163,7 @@ async function repairCurrentUserBaseline(subject: string, isAdmin: boolean): Pro
   }
 }
 
-async function hasManageableSlackChannel(openfgaUser: string): Promise<boolean> {
+async function hasAccessibleSlackChannel(openfgaUser: string): Promise<boolean> {
   try {
     const mappings = await getCollection<SlackChannelMapping>("channel_team_mappings");
     const rows = await mappings
@@ -173,11 +173,15 @@ async function hasManageableSlackChannel(openfgaUser: string): Promise<boolean> 
 
     for (const row of rows) {
       if (!row.slack_channel_id) continue;
-      if (await checkTupleAllowed({
-        user: openfgaUser,
-        relation: "can_manage",
-        object: `slack_channel:${slackChannelSubjectId(row.slack_workspace_id ?? "", row.slack_channel_id)}`,
-      })) {
+      const object = `slack_channel:${slackChannelSubjectId(row.slack_workspace_id ?? "", row.slack_channel_id)}`;
+      // assisted-by Codex Codex-sonnet-4-6
+      // Team-shared Slack channels should reveal the self-service integration
+      // surface for readers too; row edit controls still depend on can_manage.
+      const [readable, manageable] = await Promise.all([
+        checkTupleAllowed({ user: openfgaUser, relation: "can_read", object }),
+        checkTupleAllowed({ user: openfgaUser, relation: "can_manage", object }),
+      ]);
+      if (readable || manageable) {
         return true;
       }
     }
@@ -187,7 +191,7 @@ async function hasManageableSlackChannel(openfgaUser: string): Promise<boolean> 
   return false;
 }
 
-async function hasManageableWebexSpace(openfgaUser: string): Promise<boolean> {
+async function hasAccessibleWebexSpace(openfgaUser: string): Promise<boolean> {
   try {
     const mappings = await getCollection<WebexSpaceMapping>("webex_space_team_mappings");
     const rows = await mappings
@@ -197,11 +201,12 @@ async function hasManageableWebexSpace(openfgaUser: string): Promise<boolean> {
 
     for (const row of rows) {
       if (!row.webex_space_id) continue;
-      if (await checkTupleAllowed({
-        user: openfgaUser,
-        relation: "can_manage",
-        object: `webex_space:${webexSpaceSubjectId(row.webex_workspace_id ?? "", row.webex_space_id)}`,
-      })) {
+      const object = `webex_space:${webexSpaceSubjectId(row.webex_workspace_id ?? "", row.webex_space_id)}`;
+      const [readable, manageable] = await Promise.all([
+        checkTupleAllowed({ user: openfgaUser, relation: "can_read", object }),
+        checkTupleAllowed({ user: openfgaUser, relation: "can_manage", object }),
+      ]);
+      if (readable || manageable) {
         return true;
       }
     }
@@ -231,8 +236,8 @@ async function isMemberOfAnyTeam(openfgaUser: string): Promise<boolean> {
 }
 
 async function hasResourceScopedIntegrationAccess(openfgaUser: string, tab: AdminTabKey): Promise<boolean> {
-  if (tab === "slack") return hasManageableSlackChannel(openfgaUser);
-  if (tab === "webex") return hasManageableWebexSpace(openfgaUser);
+  if (tab === "slack") return hasAccessibleSlackChannel(openfgaUser);
+  if (tab === "webex") return hasAccessibleWebexSpace(openfgaUser);
   if (tab === "service_accounts") return isMemberOfAnyTeam(openfgaUser);
   return false;
 }

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { HelpCircle } from "lucide-react";
+
+import { Tooltip,TooltipContent,TooltipTrigger } from "@/components/ui/tooltip";
 import type {
 ConnectorAdminAdapter,
 DiagnosticRoute,
@@ -22,6 +25,38 @@ function formatSlackChannelName(value: unknown): string {
   const name = String(value ?? "").trim();
   if (!name) return "";
   return name.startsWith("#") ? name : `#${name}`;
+}
+
+// assisted-by Codex Codex-sonnet-4-6
+function SlackAccessNote() {
+  return (
+    <div className="flex max-w-4xl items-start gap-2 rounded-md border border-border/60 bg-background/50 px-3 py-2 text-sm text-muted-foreground">
+      <span>
+        Members of the assigned team can update this Slack channel&apos;s bot routing. Agents added here can answer in this channel.
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="Slack access details"
+            className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <HelpCircle className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-md whitespace-normal break-words text-xs">
+          <div className="space-y-2">
+            <p>
+              Team assignment controls who can manage this channel&apos;s integration. The channel and the assigned team must both be allowed to use an agent before the bot will call it.
+            </p>
+            <p>
+              Technical details: CAIPE records these access rules in the relationship store. Global or default agents may also be available outside this channel.
+            </p>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
 }
 
 const SLACK_ADAPTER: ConnectorAdminAdapter = {
@@ -126,7 +161,7 @@ const SLACK_ADAPTER: ConnectorAdminAdapter = {
     discoveryEmptyLabel: "No bot-member channels were discovered.",
     discoveryDiscoveredLabel: "bot-member channel",
     selfServiceTitle: "My Slack Channel Settings",
-    selfServiceDescription: "Manage bot routing behavior only for Slack channels where OpenFGA grants you channel admin access.",
+    selfServiceDescription: "Manage Slack bot routing for channels shared with your team.",
   },
   ariaLabels: {
     tablist: "Slack admin views",
@@ -145,34 +180,7 @@ const SLACK_ADAPTER: ConnectorAdminAdapter = {
   syncDialogueDescription: "Preview reads the Slack bot's loaded static YAML config. Apply upserts matching MongoDB route metadata and channel-agent OpenFGA tuples without deleting UI-managed associations.",
   syncSummaryItemsLabel: "Channels",
 
-  authzDisclaimer: (
-    <>
-      <div>
-        Slack authorization has two checks before dispatch: the channel must have
-        <code className="mx-1">can_use agent:&lt;id&gt;</code>, and the user&apos;s active
-        team must also have <code className="mx-1">can_use agent:&lt;id&gt;</code>.
-        If either check fails, the Slack bot denies the request before calling the agent.
-      </div>
-      <div className="rounded-md border border-amber-300/60 bg-amber-50 p-2 text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
-        <span className="font-medium">Sharing model:</span> Adding an agent to a
-        channel that is assigned to a team transitively grants <em>every member of
-        that team</em> permission to invoke the agent in this channel — even members
-        who were never granted the agent directly. If that is not what you want, share
-        the agent with a smaller subgroup (or with individual users) instead of the
-        channel&apos;s team.
-        <p className="mt-2">
-          Agents with <strong>global</strong> visibility or set as the{" "}
-          <strong>platform default</strong> (Admin → Settings) also carry an OpenFGA
-          grant <code className="mx-1">user:* can_use agent:&lt;id&gt;</code>, so every
-          signed-in user can DM the agent and use it in any mapped Slack channel or
-          Webex space. Channel onboarding here still writes{" "}
-          <code className="mx-1">slack_channel:… can_use agent:&lt;id&gt;</code> and{" "}
-          <code className="mx-1">team:&lt;slug&gt;#member can_use agent:&lt;id&gt;</code>{" "}
-          for the channel&apos;s team; the bot&apos;s dispatch checks above still apply.
-        </p>
-      </div>
-    </>
-  ),
+  authzDisclaimer: <SlackAccessNote />,
 
   configuredDetailExtra: (ctx) => (
     <SlackConfiguredChannelDetail

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -817,9 +817,13 @@ it("organizes Slack admin into Configured / Onboard / Advanced tabs", async () =
   // Onboard tab swaps in discovery wizard, hides the configured table.
   await switchToTab("Onboard channels");
   expect(screen.getByRole("button", { name: "Find channels" })).toBeInTheDocument();
-  expect(screen.getByText(/Sharing model:/i)).toBeInTheDocument();
-  expect(screen.getByText(/user:\* can_use agent/i)).toBeInTheDocument();
-  expect(screen.getByText(/platform default/i)).toBeInTheDocument();
+  // assisted-by Codex Codex-sonnet-4-6
+  expect(
+    screen.getByText(/Members of the assigned team can update this Slack channel's bot routing/i),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Slack access details" })).toBeInTheDocument();
+  expect(screen.queryByText(/user:\* can_use agent/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Sharing model:/i)).not.toBeInTheDocument();
   expect(
     screen.queryByRole("region", { name: "Configured Slack channels" }),
   ).not.toBeInTheDocument();
@@ -935,4 +939,3 @@ it("opens a runtime sync modal with preview progress and apply results", async (
   expect(screen.getByText("1 route upserted")).toBeInTheDocument();
   expect(screen.getByText("1 OpenFGA tuple written")).toBeInTheDocument();
 });
-

--- a/ui/src/components/admin/security/OpenFgaRebacTab.tsx
+++ b/ui/src/components/admin/security/OpenFgaRebacTab.tsx
@@ -50,6 +50,7 @@ import { cn } from "@/lib/utils";
 import { BaselineFgaProfilePanel } from "../rebac/BaselineFgaProfilePanel";
 import { PolicyChangeSetDiff } from "../rebac/PolicyChangeSetDiff";
 import { RebacGraphFilters, type RebacGraphUserOption } from "../rebac/RebacGraphFilters";
+import { PolicyManifestTab } from "./PolicyManifestTab";
 import type {
   UniversalRebacRelationship,
   UniversalRebacResourceAction,
@@ -130,7 +131,7 @@ interface GraphEdge {
 const ALL_RELATIONSHIPS_SCOPE = "__all_relationships__";
 const DEFAULT_GRAPH_LAYER: GraphLayer = "tuples";
 const DEFAULT_OPENFGA_TAB = "tuples";
-const OPENFGA_TABS = new Set(["tuples", "graph", "baseline"]);
+const OPENFGA_TABS = new Set(["tuples", "graph", "baseline", "manifest"]);
 const ACTION_TO_BASE_RELATION: Record<UniversalRebacResourceAction, string> = {
   discover: "reader",
   read: "reader",
@@ -682,8 +683,13 @@ export function OpenFgaRebacTab({ isAdmin }: { isAdmin: boolean }) {
         <TabsList>
           <TabsTrigger value="tuples" onClick={() => setActiveTab("tuples")}>OpenFGA Tuples</TabsTrigger>
           <TabsTrigger value="graph" onClick={() => setActiveTab("graph")}>Policy Graph</TabsTrigger>
+          <TabsTrigger value="manifest" onClick={() => setActiveTab("manifest")}>Policy Manifest</TabsTrigger>
           <TabsTrigger value="baseline" onClick={() => setActiveTab("baseline")}>Default FGA Grants</TabsTrigger>
         </TabsList>
+
+        <TabsContent value="manifest">
+          <PolicyManifestTab />
+        </TabsContent>
 
         <TabsContent value="baseline">
           <BaselineFgaProfilePanel isAdmin={isAdmin} />

--- a/ui/src/components/admin/security/PolicyManifestTab.tsx
+++ b/ui/src/components/admin/security/PolicyManifestTab.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { FileText, GitBranch, Loader2, RefreshCw, Search } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { AuthorizationPolicyDefinition } from "@/lib/rbac/authorization-policy-catalog";
+
+interface PolicyCatalogResponse {
+  policies: AuthorizationPolicyDefinition[];
+  count: number;
+}
+
+function apiData<T>(payload: { data?: T } & T): T {
+  return (payload.data ?? payload) as T;
+}
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function subjectLabel(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  const relation = grant.subject.relation ? ` ${grant.subject.relation}` : "";
+  return `${humanize(grant.subject.type)} ${grant.subject.parameter}${relation}`;
+}
+
+function resourceLabel(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  return `${humanize(grant.resource.type)} ${grant.resource.parameter}`;
+}
+
+function grantTemplate(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  const subjectRelation = grant.subject.relation ? `#${grant.subject.relation}` : "";
+  return `${grant.subject.type}:{${grant.subject.parameter}}${subjectRelation} ${grant.action} ${grant.resource.type}:{${grant.resource.parameter}}`;
+}
+
+function policyMatches(policy: AuthorizationPolicyDefinition, query: string): boolean {
+  const haystack = [
+    policy.id,
+    policy.family,
+    policy.surface,
+    policy.title,
+    policy.description,
+    policy.trigger,
+    ...policy.grants.flatMap((grant) => [
+      grant.subject.type,
+      grant.subject.parameter,
+      grant.subject.relation ?? "",
+      grant.action,
+      grant.resource.type,
+      grant.resource.parameter,
+    ]),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query.toLowerCase());
+}
+
+export function PolicyManifestTab() {
+  const [policies, setPolicies] = useState<AuthorizationPolicyDefinition[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [surface, setSurface] = useState("all");
+  const [family, setFamily] = useState("all");
+  const [query, setQuery] = useState("");
+
+  const loadPolicies = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/rebac/policies/catalog");
+      if (!response.ok) throw new Error(`Failed to load policy manifest: ${response.status}`);
+      const payload = await response.json();
+      setPolicies(apiData<PolicyCatalogResponse>(payload).policies ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load policy manifest");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPolicies();
+  }, [loadPolicies]);
+
+  const surfaces = useMemo(
+    () => ["all", ...Array.from(new Set(policies.map((policy) => policy.surface))).sort()],
+    [policies]
+  );
+  const families = useMemo(
+    () => ["all", ...Array.from(new Set(policies.map((policy) => policy.family))).sort()],
+    [policies]
+  );
+  const filteredPolicies = useMemo(
+    () =>
+      policies.filter(
+        (policy) =>
+          (surface === "all" || policy.surface === surface) &&
+          (family === "all" || policy.family === family) &&
+          (!query.trim() || policyMatches(policy, query.trim()))
+      ),
+    [family, policies, query, surface]
+  );
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <CardTitle role="heading" aria-level={2} className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Policy Manifest
+          </CardTitle>
+          <CardDescription>
+            Review the reusable authorization rules that product flows apply when teams share resources.
+          </CardDescription>
+        </div>
+        <Button variant="outline" size="sm" className="gap-2 self-start" onClick={loadPolicies}>
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 lg:grid-cols-[1fr_180px_220px]">
+          <label className="relative block">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              aria-label="Search policy manifest"
+              className="pl-9"
+              placeholder="Search policies, actions, or resources"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <label className="space-y-1 text-xs font-medium text-muted-foreground">
+            Surface
+            <select
+              aria-label="Policy surface"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
+              value={surface}
+              onChange={(event) => setSurface(event.target.value)}
+            >
+              {surfaces.map((option) => (
+                <option key={option} value={option}>
+                  {option === "all" ? "All surfaces" : humanize(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-xs font-medium text-muted-foreground">
+            Policy family
+            <select
+              aria-label="Policy family"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
+              value={family}
+              onChange={(event) => setFamily(event.target.value)}
+            >
+              {families.map((option) => (
+                <option key={option} value={option}>
+                  {option === "all" ? "All families" : humanize(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {loading && (
+          <div className="flex items-center gap-2 rounded-md border p-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading policy manifest...
+          </div>
+        )}
+        {error && <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div>}
+        {!loading && !error && (
+          <div className="space-y-3" data-testid="policy-manifest-list">
+            <div className="text-sm text-muted-foreground">
+              {filteredPolicies.length} of {policies.length} polic{policies.length === 1 ? "y" : "ies"} shown
+            </div>
+            {filteredPolicies.map((policy) => (
+              <section key={policy.id} className="rounded-md border p-4" data-testid={`policy-manifest-${policy.id}`}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-base font-semibold">{policy.title}</h3>
+                      <Badge variant="outline">{humanize(policy.surface)}</Badge>
+                      <Badge variant="secondary">{humanize(policy.family)}</Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{policy.description}</p>
+                    <p className="text-xs text-muted-foreground">Runs when {policy.trigger}.</p>
+                  </div>
+                  <Badge variant="outline">{policy.grants.length} grants</Badge>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  {policy.grants.map((grant, index) => (
+                    <div
+                      key={`${policy.id}-${index}`}
+                      className="grid gap-2 rounded-md bg-muted/40 p-3 text-sm md:grid-cols-[1fr_auto_1fr]"
+                    >
+                      <div>
+                        <div className="text-xs text-muted-foreground">Who</div>
+                        <div className="font-medium">{subjectLabel(grant)}</div>
+                      </div>
+                      <div className="flex items-center gap-2 font-medium text-primary">
+                        <GitBranch className="h-4 w-4" />
+                        {humanize(grant.action)}
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground">What</div>
+                        <div className="font-medium">{resourceLabel(grant)}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <details className="mt-3 rounded-md border bg-background/60 p-3 text-xs">
+                  <summary className="cursor-pointer font-medium text-muted-foreground">Technical details</summary>
+                  <div className="mt-3 space-y-2">
+                    <div>
+                      <span className="text-muted-foreground">Policy ID:</span>{" "}
+                      <code>{policy.id}</code>
+                    </div>
+                    <div className="space-y-1">
+                      {policy.grants.map((grant, index) => (
+                        <code key={`${policy.id}-template-${index}`} className="block whitespace-pre-wrap">
+                          {grantTemplate(grant)}
+                        </code>
+                      ))}
+                    </div>
+                  </div>
+                </details>
+              </section>
+            ))}
+            {filteredPolicies.length === 0 && (
+              <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                No policies match the current filters.
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/components/admin/security/PolicyManifestTab.tsx
+++ b/ui/src/components/admin/security/PolicyManifestTab.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { FileText, GitBranch, Loader2, RefreshCw, Search } from "lucide-react";
+import { FileText, Loader2, RefreshCw, Search } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import type { AuthorizationPolicyDefinition } from "@/lib/rbac/authorization-policy-catalog";
+
+// assisted-by Codex Codex-sonnet-4-6
 
 interface PolicyCatalogResponse {
   policies: AuthorizationPolicyDefinition[];
@@ -22,13 +24,59 @@ function humanize(value: string): string {
   return value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
-function subjectLabel(grant: AuthorizationPolicyDefinition["grants"][number]): string {
-  const relation = grant.subject.relation ? ` ${grant.subject.relation}` : "";
-  return `${humanize(grant.subject.type)} ${grant.subject.parameter}${relation}`;
+function plainSurface(surface: string): string {
+  if (surface === "slack") return "Slack";
+  if (surface === "webex") return "Webex";
+  return humanize(surface);
 }
 
-function resourceLabel(grant: AuthorizationPolicyDefinition["grants"][number]): string {
-  return `${humanize(grant.resource.type)} ${grant.resource.parameter}`;
+function plainSubject(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  if (grant.subject.type === "team" && grant.subject.relation === "member") return "Team members";
+  if (grant.subject.type === "team" && grant.subject.relation === "admin") return "Team admins";
+  if (grant.subject.type === "team") return "The assigned team";
+  return humanize(grant.subject.type);
+}
+
+function plainResource(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  if (grant.resource.type === "slack_channel") return "this Slack channel";
+  if (grant.resource.type === "webex_space") return "this Webex space";
+  return `this ${humanize(grant.resource.type).toLowerCase()}`;
+}
+
+function plainAction(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  if (grant.action === "manage") return "can change settings for";
+  if (grant.action === "use") return "can use";
+  if (grant.action === "read") return "can view";
+  if (grant.action === "call" || grant.action === "invoke") return "can call";
+  return `can ${humanize(grant.action).toLowerCase()}`;
+}
+
+function grantSentence(grant: AuthorizationPolicyDefinition["grants"][number]): string {
+  return `${plainSubject(grant)} ${plainAction(grant)} ${plainResource(grant)}.`;
+}
+
+function policyHeading(policy: AuthorizationPolicyDefinition): string {
+  if (policy.id === "slack_channel_team_assignment_v1") return "When a Slack channel is assigned to a team";
+  if (policy.id === "webex_space_team_assignment_v1") return "When a Webex space is assigned to a team";
+  return policy.title;
+}
+
+function policyOutcome(policy: AuthorizationPolicyDefinition): string {
+  if (policy.id === "slack_channel_team_assignment_v1") {
+    return "The team can use the Slack integration, and team members can update bot routing for that channel.";
+  }
+  if (policy.id === "webex_space_team_assignment_v1") {
+    return "The team can use the Webex integration, while team admins keep control of the space settings.";
+  }
+  return policy.description;
+}
+
+function featureName(policy: AuthorizationPolicyDefinition): string {
+  return policy.feature?.name ?? `${plainSurface(policy.surface)} feature`;
+}
+
+function featureSummary(policy: AuthorizationPolicyDefinition): string {
+  return policy.feature?.summary ?? policy.description;
 }
 
 function grantTemplate(grant: AuthorizationPolicyDefinition["grants"][number]): string {
@@ -44,7 +92,17 @@ function policyMatches(policy: AuthorizationPolicyDefinition, query: string): bo
     policy.title,
     policy.description,
     policy.trigger,
+    policyHeading(policy),
+    policyOutcome(policy),
+    policy.feature?.name ?? "",
+    policy.feature?.summary ?? "",
+    ...(policy.feature?.subfeatures.flatMap((subfeature) => [
+      subfeature.name,
+      subfeature.behavior,
+      subfeature.authorization,
+    ]) ?? []),
     ...policy.grants.flatMap((grant) => [
+      grantSentence(grant),
       grant.subject.type,
       grant.subject.parameter,
       grant.subject.relation ?? "",
@@ -110,10 +168,10 @@ export function PolicyManifestTab() {
         <div>
           <CardTitle role="heading" aria-level={2} className="flex items-center gap-2">
             <FileText className="h-5 w-5" />
-            Policy Manifest
+            Sharing Rules
           </CardTitle>
           <CardDescription>
-            Review the reusable authorization rules that product flows apply when teams share resources.
+            See what access people get when an admin shares a Slack channel, Webex space, or other resource with a team.
           </CardDescription>
         </div>
         <Button variant="outline" size="sm" className="gap-2 self-start" onClick={loadPolicies}>
@@ -128,15 +186,15 @@ export function PolicyManifestTab() {
             <Input
               aria-label="Search policy manifest"
               className="pl-9"
-              placeholder="Search policies, actions, or resources"
+              placeholder="Search sharing rules"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
             />
           </label>
           <label className="space-y-1 text-xs font-medium text-muted-foreground">
-            Surface
+            Product
             <select
-              aria-label="Policy surface"
+              aria-label="Product"
               className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
               value={surface}
               onChange={(event) => setSurface(event.target.value)}
@@ -149,9 +207,9 @@ export function PolicyManifestTab() {
             </select>
           </label>
           <label className="space-y-1 text-xs font-medium text-muted-foreground">
-            Policy family
+            Rule type
             <select
-              aria-label="Policy family"
+              aria-label="Rule type"
               className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
               value={family}
               onChange={(event) => setFamily(event.target.value)}
@@ -175,51 +233,87 @@ export function PolicyManifestTab() {
         {!loading && !error && (
           <div className="space-y-3" data-testid="policy-manifest-list">
             <div className="text-sm text-muted-foreground">
-              {filteredPolicies.length} of {policies.length} polic{policies.length === 1 ? "y" : "ies"} shown
+              {filteredPolicies.length} of {policies.length} sharing rule{policies.length === 1 ? "" : "s"} shown
             </div>
             {filteredPolicies.map((policy) => (
               <section key={policy.id} className="rounded-md border p-4" data-testid={`policy-manifest-${policy.id}`}>
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="space-y-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-base font-semibold">{policy.title}</h3>
-                      <Badge variant="outline">{humanize(policy.surface)}</Badge>
-                      <Badge variant="secondary">{humanize(policy.family)}</Badge>
+                      <h3 className="text-base font-semibold">{policyHeading(policy)}</h3>
+                      <Badge variant="outline">{plainSurface(policy.surface)}</Badge>
                     </div>
-                    <p className="text-sm text-muted-foreground">{policy.description}</p>
-                    <p className="text-xs text-muted-foreground">Runs when {policy.trigger}.</p>
+                    <p className="text-sm text-muted-foreground">{policyOutcome(policy)}</p>
                   </div>
-                  <Badge variant="outline">{policy.grants.length} grants</Badge>
+                  <Badge variant="secondary">{policy.grants.length} access changes</Badge>
                 </div>
 
-                <div className="mt-4 space-y-2">
+                <div className="mt-4 rounded-md border bg-background/50 p-3">
+                  <div className="text-xs font-medium uppercase text-muted-foreground">Feature</div>
+                  <div className="mt-1 text-sm font-medium">{featureName(policy)}</div>
+                  <p className="mt-1 text-sm text-muted-foreground">{featureSummary(policy)}</p>
+                  {policy.feature?.subfeatures.length ? (
+                    <div className="mt-3 grid gap-2 md:grid-cols-2">
+                      {policy.feature.subfeatures.map((subfeature) => (
+                        <div key={`${policy.id}-${subfeature.name}`} className="rounded-md bg-muted/30 p-3">
+                          <div className="text-sm font-medium">{subfeature.name}</div>
+                          <p className="mt-1 text-xs text-muted-foreground">{subfeature.behavior}</p>
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            <span className="font-medium text-foreground">Authorization:</span>{" "}
+                            {subfeature.authorization}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="mt-3 rounded-md bg-muted/30 p-3">
+                  <div className="text-xs font-medium uppercase text-muted-foreground">What happens</div>
+                  <ul className="mt-2 space-y-2 text-sm">
+                    {policy.grants.map((grant, index) => (
+                      <li key={`${policy.id}-summary-${index}`} className="flex gap-2">
+                        <span aria-hidden="true" className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                        <span>{grantSentence(grant)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    This happens automatically when {policy.trigger}.
+                  </p>
+                </div>
+
+                <details className="mt-3 rounded-md border bg-background/60 p-3 text-xs">
+                  <summary className="cursor-pointer font-medium text-muted-foreground">Show technical mapping</summary>
+                  <div className="mt-3 space-y-3">
+                    <div>
+                      <span className="text-muted-foreground">Policy ID:</span>{" "}
+                      <code>{policy.id}</code>
+                    </div>
+                    <div className="space-y-2">
                   {policy.grants.map((grant, index) => (
                     <div
-                      key={`${policy.id}-${index}`}
+                      key={`${policy.id}-template-${index}`}
                       className="grid gap-2 rounded-md bg-muted/40 p-3 text-sm md:grid-cols-[1fr_auto_1fr]"
                     >
                       <div>
                         <div className="text-xs text-muted-foreground">Who</div>
-                        <div className="font-medium">{subjectLabel(grant)}</div>
+                        <div className="font-medium">
+                          {grant.subject.type}:{`{${grant.subject.parameter}}`}
+                          {grant.subject.relation ? `#${grant.subject.relation}` : ""}
+                        </div>
                       </div>
-                      <div className="flex items-center gap-2 font-medium text-primary">
-                        <GitBranch className="h-4 w-4" />
-                        {humanize(grant.action)}
+                      <div className="font-medium text-primary">
+                        {grant.action}
                       </div>
                       <div>
                         <div className="text-xs text-muted-foreground">What</div>
-                        <div className="font-medium">{resourceLabel(grant)}</div>
+                        <div className="font-medium">
+                          {grant.resource.type}:{`{${grant.resource.parameter}}`}
+                        </div>
                       </div>
                     </div>
                   ))}
-                </div>
-
-                <details className="mt-3 rounded-md border bg-background/60 p-3 text-xs">
-                  <summary className="cursor-pointer font-medium text-muted-foreground">Technical details</summary>
-                  <div className="mt-3 space-y-2">
-                    <div>
-                      <span className="text-muted-foreground">Policy ID:</span>{" "}
-                      <code>{policy.id}</code>
                     </div>
                     <div className="space-y-1">
                       {policy.grants.map((grant, index) => (

--- a/ui/src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx
@@ -215,6 +215,30 @@ beforeEach(() => {
         },
       });
     }
+    if (url === "/api/admin/rebac/policies/catalog") {
+      return jsonResponse({
+        data: {
+          policies: [
+            {
+              id: "slack_channel_team_assignment_v1",
+              family: "messaging_team_assignment",
+              surface: "slack",
+              title: "Slack channel team assignment",
+              description: "Team members can use and manage Slack channel routing.",
+              trigger: "admin assigns or reassigns a Slack channel to a team",
+              grants: [
+                {
+                  subject: { type: "team", parameter: "teamSlug", relation: "member" },
+                  action: "manage",
+                  resource: { type: "slack_channel", parameter: "slackChannelId" },
+                },
+              ],
+            },
+          ],
+          count: 1,
+        },
+      });
+    }
     if (url === "/api/admin/users?search=alice&pageSize=20") {
       return jsonResponse({
         users: [
@@ -306,6 +330,7 @@ it("orders OpenFGA tabs by operational flow and defaults to tuples", async () =>
   expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
     "OpenFGA Tuples",
     "Policy Graph",
+    "Policy Manifest",
     "Default FGA Grants",
   ]);
   expect(await screen.findByText("OpenFGA Tuple Store")).toBeInTheDocument();
@@ -313,6 +338,19 @@ it("orders OpenFGA tabs by operational flow and defaults to tuples", async () =>
   fireEvent.click(screen.getByRole("tab", { name: "Policy Graph" }));
 
   expect(replaceMock).toHaveBeenCalledWith("/admin?subtab=graph&openfgaTab=graph", { scroll: false });
+});
+
+it("deep-links to the policy manifest tab", async () => {
+  // assisted-by Codex Codex-sonnet-4-6
+  currentSearchParams = new URLSearchParams("subtab=manifest");
+
+  render(<OpenFgaRebacTab isAdmin />);
+
+  expect(await screen.findByRole("tab", { name: "Policy Manifest" })).toHaveAttribute(
+    "aria-selected",
+    "true"
+  );
+  expect(await screen.findByText("Slack channel team assignment")).toBeInTheDocument();
 });
 
 it("falls back to tuples for integration-owned Slack/Webex query strings", async () => {
@@ -661,4 +699,3 @@ it("shows the manual user subject controls inside the fullscreen graph", async (
     expect(fetchMock).toHaveBeenCalledWith("/api/admin/rebac/graph?subject=user%3A*&layer=tuples&limit=1000");
   });
 });
-

--- a/ui/src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx
@@ -350,7 +350,9 @@ it("deep-links to the policy manifest tab", async () => {
     "aria-selected",
     "true"
   );
-  expect(await screen.findByText("Slack channel team assignment")).toBeInTheDocument();
+  expect(await screen.findByRole("heading", { name: "Sharing Rules" })).toBeInTheDocument();
+  expect(await screen.findByText("When a Slack channel is assigned to a team")).toBeInTheDocument();
+  expect(screen.getByText("Team members can change settings for this Slack channel.")).toBeInTheDocument();
 });
 
 it("falls back to tuples for integration-owned Slack/Webex query strings", async () => {

--- a/ui/src/lib/rbac/__tests__/authorization-policy-catalog.test.ts
+++ b/ui/src/lib/rbac/__tests__/authorization-policy-catalog.test.ts
@@ -1,0 +1,123 @@
+import {
+  AUTHORIZATION_POLICIES,
+  getAuthorizationPolicy,
+  instantiatePolicyRelationships,
+  listAuthorizationPolicies,
+  listAuthorizationPoliciesByResourceType,
+  listAuthorizationPoliciesBySurface,
+} from "../authorization-policy-catalog";
+
+describe("authorization policy catalog", () => {
+  it("keeps Slack channel team assignment in one policy definition", () => {
+    // assisted-by Codex Codex-sonnet-4-6
+    const policy = getAuthorizationPolicy("slack_channel_team_assignment_v1");
+
+    expect(policy).toMatchObject({
+      title: "Slack channel team assignment",
+      trigger: "admin assigns or reassigns a Slack channel to a team",
+    });
+    expect(policy.grants).toEqual([
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "admin" },
+        action: "manage",
+        resource: { type: "slack_channel", parameter: "slackChannelId" },
+      },
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "member" },
+        action: "use",
+        resource: { type: "slack_channel", parameter: "slackChannelId" },
+      },
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "member" },
+        action: "manage",
+        resource: { type: "slack_channel", parameter: "slackChannelId" },
+      },
+    ]);
+  });
+
+  it("keeps Webex space team assignment in the same manifest", () => {
+    const policy = getAuthorizationPolicy("webex_space_team_assignment_v1");
+
+    expect(policy).toMatchObject({
+      family: "messaging_team_assignment",
+      surface: "webex",
+      title: "Webex space team assignment",
+    });
+    expect(policy.grants).toEqual([
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "admin" },
+        action: "manage",
+        resource: { type: "webex_space", parameter: "webexSpaceId" },
+      },
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "member" },
+        action: "use",
+        resource: { type: "webex_space", parameter: "webexSpaceId" },
+      },
+    ]);
+  });
+
+  it("materializes Slack policy grants into universal ReBAC relationships", () => {
+    expect(
+      instantiatePolicyRelationships("slack_channel_team_assignment_v1", {
+        teamSlug: "platform",
+        slackChannelId: "CAIPE--C0B4QFN4Q21",
+      })
+    ).toEqual([
+      {
+        subject: { type: "team", id: "platform", relation: "admin" },
+        action: "manage",
+        resource: { type: "slack_channel", id: "CAIPE--C0B4QFN4Q21" },
+      },
+      {
+        subject: { type: "team", id: "platform", relation: "member" },
+        action: "use",
+        resource: { type: "slack_channel", id: "CAIPE--C0B4QFN4Q21" },
+      },
+      {
+        subject: { type: "team", id: "platform", relation: "member" },
+        action: "manage",
+        resource: { type: "slack_channel", id: "CAIPE--C0B4QFN4Q21" },
+      },
+    ]);
+  });
+
+  it("materializes Webex policy grants into universal ReBAC relationships", () => {
+    expect(
+      instantiatePolicyRelationships("webex_space_team_assignment_v1", {
+        teamSlug: "platform",
+        webexSpaceId: "WEBEX--space-1",
+      })
+    ).toEqual([
+      {
+        subject: { type: "team", id: "platform", relation: "admin" },
+        action: "manage",
+        resource: { type: "webex_space", id: "WEBEX--space-1" },
+      },
+      {
+        subject: { type: "team", id: "platform", relation: "member" },
+        action: "use",
+        resource: { type: "webex_space", id: "WEBEX--space-1" },
+      },
+    ]);
+  });
+
+  it("lists policies for future CAS readers by surface or resource type", () => {
+    // assisted-by Codex Codex-sonnet-4-6
+    expect(listAuthorizationPolicies().map((policy) => policy.id)).toEqual([
+      "slack_channel_team_assignment_v1",
+      "webex_space_team_assignment_v1",
+    ]);
+    expect(listAuthorizationPoliciesBySurface("slack").map((policy) => policy.id)).toEqual([
+      "slack_channel_team_assignment_v1",
+    ]);
+    expect(listAuthorizationPoliciesByResourceType("webex_space").map((policy) => policy.id)).toEqual([
+      "webex_space_team_assignment_v1",
+    ]);
+  });
+
+  it("uses stable unique policy ids", () => {
+    const ids = AUTHORIZATION_POLICIES.map((policy) => policy.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/ui/src/lib/rbac/__tests__/openfga.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga.test.ts
@@ -312,6 +312,10 @@ describe("OpenFGA team resource tuple reconciliation", () => {
         type: "team",
         relation: "admin",
       });
+      expect(directlyRelatedUserTypes(modelPath, "slack_channel", "manager")).toContainEqual({
+        type: "team",
+        relation: "member",
+      });
       expect(directlyRelatedUserTypes(modelPath, "mcp_server", "manager")).toContainEqual({
         type: "team",
         relation: "admin",

--- a/ui/src/lib/rbac/__tests__/slack/slack-channel-rebac.test.ts
+++ b/ui/src/lib/rbac/__tests__/slack/slack-channel-rebac.test.ts
@@ -21,21 +21,17 @@ describe("slack-channel-rebac helpers", () => {
   });
 
   describe("slackChannelTeamVisibilityRelationships", () => {
-    it("emits a team#admin -> manage and team#member -> use pair", () => {
-      // We use action `use` (not `read`) for the member tuple because that's what
-      // the team-channels PUT endpoint at
-      // `ui/src/app/api/admin/teams/[id]/slack-channels/route.ts` writes
-      // (`team:<slug>#member relation user slack_channel:...`). Keeping the same
-      // shape means the admin PUT path and the onboarding-defaults backfill path
-      // converge on identical OpenFGA tuple sets. `can_use` resolves through to
-      // `can_read` in the slack_channel type model.
+    it("emits team member use/manage and team admin manage tuples", () => {
+      // Team selection for Slack integrations intentionally lets every team
+      // member view/use the channel and manage its route configuration.
+      // assisted-by Codex Codex-sonnet-4-6
       const rels = slackChannelTeamVisibilityRelationships(
         "CAIPE",
         "C0B4QFN4Q21",
         "platform",
       );
 
-      expect(rels).toHaveLength(2);
+      expect(rels).toHaveLength(3);
       expect(rels).toEqual(
         expect.arrayContaining([
           {
@@ -46,6 +42,11 @@ describe("slack-channel-rebac helpers", () => {
           {
             subject: { type: "team", id: "platform", relation: "member" },
             action: "use",
+            resource: { type: "slack_channel", id: "CAIPE--C0B4QFN4Q21" },
+          },
+          {
+            subject: { type: "team", id: "platform", relation: "member" },
+            action: "manage",
             resource: { type: "slack_channel", id: "CAIPE--C0B4QFN4Q21" },
           },
         ]),

--- a/ui/src/lib/rbac/__tests__/webex-space-rebac.test.ts
+++ b/ui/src/lib/rbac/__tests__/webex-space-rebac.test.ts
@@ -22,9 +22,8 @@ describe("webex-space-rebac helpers", () => {
 
   describe("webexSpaceTeamVisibilityRelationships", () => {
     it("emits a team#admin -> manage and team#member -> use pair", () => {
-      // Mirrors the Slack helper: `use` (relation `user`) for member rather than
-      // `read` (relation `reader`) so this matches the existing team-spaces PUT
-      // endpoint and the two onboarding paths converge on identical tuples.
+      // Materializes policy `webex_space_team_assignment_v1`.
+      // assisted-by Codex Codex-sonnet-4-6
       const rels = webexSpaceTeamVisibilityRelationships(
         "WEBEX",
         "space-1",

--- a/ui/src/lib/rbac/authorization-policy-catalog.ts
+++ b/ui/src/lib/rbac/authorization-policy-catalog.ts
@@ -32,6 +32,15 @@ export interface AuthorizationPolicyDefinition {
   title: string;
   description: string;
   trigger: string;
+  feature: {
+    name: string;
+    summary: string;
+    subfeatures: readonly {
+      name: string;
+      behavior: string;
+      authorization: string;
+    }[];
+  };
   grants: readonly AuthorizationPolicyGrantTemplate[];
 }
 
@@ -44,6 +53,28 @@ export const AUTHORIZATION_POLICIES = [
     description:
       "Assigning a Slack channel to a team lets team members use and manage the channel integration; team admins also manage it.",
     trigger: "admin assigns or reassigns a Slack channel to a team",
+    feature: {
+      name: "Slack integrations",
+      summary:
+        "Slack integrations let teams choose which bot routes and agents answer in their Slack channels.",
+      subfeatures: [
+        {
+          name: "Configured channels",
+          behavior: "Team members see the Slack channels shared with their team.",
+          authorization: "A shared channel gives that team's members access to view and update that channel's routing.",
+        },
+        {
+          name: "Channel routing",
+          behavior: "Team members can choose which agent answers in a shared channel.",
+          authorization: "The selected agent still needs to be usable by both the channel and the user's team.",
+        },
+        {
+          name: "Slack message handling",
+          behavior: "The Slack bot only dispatches a message when the channel route and the sender's team access line up.",
+          authorization: "The runtime checks channel access and team agent access before calling the agent.",
+        },
+      ],
+    },
     grants: [
       {
         subject: { type: "team", parameter: "teamSlug", relation: "admin" },
@@ -70,6 +101,23 @@ export const AUTHORIZATION_POLICIES = [
     description:
       "Assigning a Webex space to a team lets team members use the space integration; team admins manage it.",
     trigger: "admin assigns or reassigns a Webex space to a team",
+    feature: {
+      name: "Webex integrations",
+      summary:
+        "Webex integrations let teams connect spaces to CAIPE routing so messages can reach the right agents.",
+      subfeatures: [
+        {
+          name: "Configured spaces",
+          behavior: "Team members can use Webex spaces that are shared with their team.",
+          authorization: "The space assignment creates team access for that Webex space.",
+        },
+        {
+          name: "Space administration",
+          behavior: "Team admins manage the Webex space integration settings.",
+          authorization: "Management access stays with the team's admins for Webex space settings.",
+        },
+      ],
+    },
     grants: [
       {
         subject: { type: "team", parameter: "teamSlug", relation: "admin" },

--- a/ui/src/lib/rbac/authorization-policy-catalog.ts
+++ b/ui/src/lib/rbac/authorization-policy-catalog.ts
@@ -1,0 +1,149 @@
+import type {
+UniversalRebacRelationship,
+UniversalRebacResourceAction,
+UniversalRebacResourceRef,
+UniversalRebacResourceType,
+UniversalRebacSubjectType,
+} from "@/types/rbac-universal";
+
+type SubjectRelation = NonNullable<UniversalRebacRelationship["subject"]["relation"]>;
+
+interface PolicySubjectTemplate {
+  type: UniversalRebacSubjectType;
+  parameter: string;
+  relation?: SubjectRelation;
+}
+
+interface PolicyResourceTemplate {
+  type: UniversalRebacResourceType;
+  parameter: string;
+}
+
+export interface AuthorizationPolicyGrantTemplate {
+  subject: PolicySubjectTemplate;
+  action: UniversalRebacResourceAction;
+  resource: PolicyResourceTemplate;
+}
+
+export interface AuthorizationPolicyDefinition {
+  id: string;
+  family: string;
+  surface: string;
+  title: string;
+  description: string;
+  trigger: string;
+  grants: readonly AuthorizationPolicyGrantTemplate[];
+}
+
+export const AUTHORIZATION_POLICIES = [
+  {
+    id: "slack_channel_team_assignment_v1",
+    family: "messaging_team_assignment",
+    surface: "slack",
+    title: "Slack channel team assignment",
+    description:
+      "Assigning a Slack channel to a team lets team members use and manage the channel integration; team admins also manage it.",
+    trigger: "admin assigns or reassigns a Slack channel to a team",
+    grants: [
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "admin" },
+        action: "manage",
+        resource: { type: "slack_channel", parameter: "slackChannelId" },
+      },
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "member" },
+        action: "use",
+        resource: { type: "slack_channel", parameter: "slackChannelId" },
+      },
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "member" },
+        action: "manage",
+        resource: { type: "slack_channel", parameter: "slackChannelId" },
+      },
+    ],
+  },
+  {
+    id: "webex_space_team_assignment_v1",
+    family: "messaging_team_assignment",
+    surface: "webex",
+    title: "Webex space team assignment",
+    description:
+      "Assigning a Webex space to a team lets team members use the space integration; team admins manage it.",
+    trigger: "admin assigns or reassigns a Webex space to a team",
+    grants: [
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "admin" },
+        action: "manage",
+        resource: { type: "webex_space", parameter: "webexSpaceId" },
+      },
+      {
+        subject: { type: "team", parameter: "teamSlug", relation: "member" },
+        action: "use",
+        resource: { type: "webex_space", parameter: "webexSpaceId" },
+      },
+    ],
+  },
+] as const satisfies readonly AuthorizationPolicyDefinition[];
+
+export type AuthorizationPolicyId = (typeof AUTHORIZATION_POLICIES)[number]["id"];
+
+export const AUTHORIZATION_POLICIES_BY_ID = new Map(
+  AUTHORIZATION_POLICIES.map((policy) => [policy.id, policy])
+);
+
+export function listAuthorizationPolicies(): readonly AuthorizationPolicyDefinition[] {
+  return AUTHORIZATION_POLICIES;
+}
+
+export function listAuthorizationPoliciesBySurface(
+  surface: string
+): readonly AuthorizationPolicyDefinition[] {
+  return AUTHORIZATION_POLICIES.filter((policy) => policy.surface === surface);
+}
+
+export function listAuthorizationPoliciesByResourceType(
+  resourceType: UniversalRebacResourceType
+): readonly AuthorizationPolicyDefinition[] {
+  return AUTHORIZATION_POLICIES.filter((policy) =>
+    policy.grants.some((grant) => grant.resource.type === resourceType)
+  );
+}
+
+export function getAuthorizationPolicy(id: AuthorizationPolicyId): AuthorizationPolicyDefinition {
+  const policy = AUTHORIZATION_POLICIES_BY_ID.get(id);
+  if (!policy) {
+    throw new Error(`Unknown authorization policy: ${id}`);
+  }
+  return policy;
+}
+
+export function instantiatePolicyRelationships(
+  policyId: AuthorizationPolicyId,
+  parameters: Record<string, string>
+): UniversalRebacRelationship[] {
+  const policy = getAuthorizationPolicy(policyId);
+  return policy.grants.map((grant) => ({
+    subject: {
+      type: grant.subject.type,
+      id: readPolicyParameter(parameters, grant.subject.parameter, policy.id),
+      ...(grant.subject.relation ? { relation: grant.subject.relation } : {}),
+    },
+    action: grant.action,
+    resource: {
+      type: grant.resource.type,
+      id: readPolicyParameter(parameters, grant.resource.parameter, policy.id),
+    } satisfies UniversalRebacResourceRef,
+  }));
+}
+
+function readPolicyParameter(
+  parameters: Record<string, string>,
+  name: string,
+  policyId: string
+): string {
+  const value = parameters[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing ${name} for authorization policy ${policyId}`);
+  }
+  return value;
+}

--- a/ui/src/lib/rbac/migrations/__tests__/messaging-migrations.test.ts
+++ b/ui/src/lib/rbac/migrations/__tests__/messaging-migrations.test.ts
@@ -173,7 +173,7 @@ describe("messaging RBAC migration derivation", () => {
 
   // assisted-by Cursor Claude:claude-opus-4-7
   describe("deriveMessagingTeamVisibilityPlan", () => {
-    it("emits team#admin->manage and team#member->use tuples per Slack channel mapping", () => {
+    it("emits member use/manage and admin manage tuples per Slack channel mapping", () => {
       const plan = deriveMessagingTeamVisibilityPlan({
         teams: [{ _id: "team-1", slug: "platform" }],
         slackMappings: [
@@ -200,16 +200,21 @@ describe("messaging RBAC migration derivation", () => {
             relation: "user",
             object: "slack_channel:CAIPE--C0B4QFN4Q21",
           },
+          {
+            user: "team:platform#member",
+            relation: "manager",
+            object: "slack_channel:CAIPE--C0B4QFN4Q21",
+          },
         ]),
       );
-      expect(plan.tuples).toHaveLength(2);
+      expect(plan.tuples).toHaveLength(3);
       expect(plan.counts).toMatchObject({
         slack_channels_scanned: 1,
         webex_spaces_scanned: 0,
-        relationships_planned: 2,
-        tuples_planned: 2,
+        relationships_planned: 3,
+        tuples_planned: 3,
         missing_teams: 0,
-        tuple_writes_planned: 2,
+        tuple_writes_planned: 3,
       });
     });
 
@@ -258,7 +263,7 @@ describe("messaging RBAC migration derivation", () => {
       });
 
       expect(plan.counts.missing_teams).toBe(0);
-      expect(plan.tuples).toHaveLength(2);
+      expect(plan.tuples).toHaveLength(3);
       expect(plan.tuples?.[0].object).toBe("slack_channel:CAIPE--C0AV2F7N2BX");
     });
 
@@ -356,7 +361,7 @@ describe("messaging RBAC migration derivation", () => {
         webexMappings: [],
       });
 
-      expect(plan.tuples).toHaveLength(2);
+      expect(plan.tuples).toHaveLength(3);
     });
 
     it("uses the correct migration identifiers", () => {

--- a/ui/src/lib/rbac/migrations/registry.ts
+++ b/ui/src/lib/rbac/migrations/registry.ts
@@ -170,8 +170,7 @@ const MESSAGING_REBAC_INDEXES_MIGRATION_ID = "messaging_rebac_indexes_v1";
 // ever written. The /api/admin/{slack,webex}/{channels,spaces} list routes
 // filter rows by user `can_read` on the channel/space object, so with no
 // inbound tuples every row got dropped. This migration backfills the missing
-// `team#admin → manage → slack_channel|webex_space` and
-// `team#member → read → slack_channel|webex_space` tuples derived from
+// `team#admin → manage → slack_channel|webex_space` and team-member access tuples derived from
 // existing `channel_team_mappings` / `webex_space_team_mappings` rows. It is
 // fully idempotent because writeOpenFgaTuples no-ops on identical writes.
 const MESSAGING_TEAM_VISIBILITY_MIGRATION_ID = "messaging_team_visibility_v1";
@@ -499,7 +498,7 @@ export const MIGRATION_DEFINITIONS: MigrationDefinition[] = [
     kind: "explicit",
     title: "Messaging team→channel/space visibility",
     description:
-      "Backfill team#admin→manage and team#member→read tuples onto previously-onboarded Slack channels and Webex spaces so admins can actually see them in the listing endpoints.",
+      "Backfill team#admin→manage plus team#member Slack channel use/manage and Webex space read tuples onto previously-onboarded messaging mappings so team members can see and maintain assigned Slack integrations.",
     confirmation: "MIGRATE messaging_team_visibility TO v2",
     required: true,
     implemented: true,
@@ -1886,7 +1885,8 @@ export function deriveMessagingTeamMappingPlan(input: {
 //
 // Tuple shape (per onboarded channel/space with a resolvable team_slug):
 //   team:<slug>#admin  → manage → slack_channel|webex_space:<workspace>--<id>
-//   team:<slug>#member → read   → slack_channel|webex_space:<workspace>--<id>
+//   team:<slug>#member → use/manage → slack_channel:<workspace>--<id>
+//   team:<slug>#member → read       → webex_space:<workspace>--<id>
 //
 // Idempotent: writeOpenFgaTuples no-ops on identical writes.
 export function deriveMessagingTeamVisibilityPlan(input: {

--- a/ui/src/lib/rbac/slack-channel-rebac.ts
+++ b/ui/src/lib/rbac/slack-channel-rebac.ts
@@ -8,6 +8,7 @@ SlackChannelAccessCheckResult,
 SlackChannelGrantResourceType,
 } from "@/types/slack-rebac";
 
+import { instantiatePolicyRelationships } from "./authorization-policy-catalog";
 import { checkUniversalRebacRelationship } from "./openfga";
 import {
 SLACK_CHANNEL_GRANT_RESOURCE_TYPES,
@@ -27,36 +28,17 @@ export function slackChannelGrantRelationship(
   };
 }
 
-// Team→channel visibility tuples. Without these, the channel exists in Mongo
-// but no one can `can_read` it in OpenFGA, so the admin /api/admin/slack/channels
-// listing endpoint silently filters it out. Pair of tuples:
-//   team:<slug>#admin  -> manage (relation `manager`) -> slack_channel
-//   team:<slug>#member -> use    (relation `user`)    -> slack_channel
-// `manager` covers can_read/can_manage/can_audit; `user` covers can_use which
-// resolves through to can_read. Matches the shape already written by
-// `ui/src/app/api/admin/teams/[id]/slack-channels/route.ts` so admin-PUT and
-// onboarding-defaults converge on the same OpenFGA tuple set.
+// Materializes policy `slack_channel_team_assignment_v1`.
+// assisted-by Codex Codex-sonnet-4-6
 export function slackChannelTeamVisibilityRelationships(
   workspaceId: string,
   channelId: string,
   teamSlug: string
 ): UniversalRebacRelationship[] {
-  const channelResource: UniversalRebacResourceRef = {
-    type: "slack_channel",
-    id: slackChannelSubjectId(workspaceId, channelId),
-  };
-  return [
-    {
-      subject: { type: "team", id: teamSlug, relation: "admin" },
-      action: "manage",
-      resource: channelResource,
-    },
-    {
-      subject: { type: "team", id: teamSlug, relation: "member" },
-      action: "use",
-      resource: channelResource,
-    },
-  ];
+  return instantiatePolicyRelationships("slack_channel_team_assignment_v1", {
+    teamSlug,
+    slackChannelId: slackChannelSubjectId(workspaceId, channelId),
+  });
 }
 
 export async function checkSlackChannelAccess(input: {

--- a/ui/src/lib/rbac/webex-space-rebac.ts
+++ b/ui/src/lib/rbac/webex-space-rebac.ts
@@ -10,6 +10,7 @@ WebexSpaceAccessCheckResult,
 WebexSpaceGrantResourceType,
 } from "@/types/webex-rebac";
 
+import { instantiatePolicyRelationships } from "./authorization-policy-catalog";
 import { checkUniversalRebacRelationship } from "./openfga";
 import {
 WEBEX_SPACE_GRANT_RESOURCE_TYPES,
@@ -72,31 +73,17 @@ export function webexSpaceGrantRelationship(
   };
 }
 
-// Team→space visibility tuples. Without these, the space exists in Mongo but
-// no one can `can_read` it in OpenFGA, so the admin /api/admin/webex/spaces
-// listing endpoint silently filters it out. Mirrors
-// slackChannelTeamVisibilityRelationships for parity with the Slack surface.
+// Materializes policy `webex_space_team_assignment_v1`.
+// assisted-by Codex Codex-sonnet-4-6
 export function webexSpaceTeamVisibilityRelationships(
   workspaceId: string,
   spaceId: string,
   teamSlug: string
 ): UniversalRebacRelationship[] {
-  const spaceResource: UniversalRebacResourceRef = {
-    type: "webex_space",
-    id: webexSpaceSubjectId(workspaceId, spaceId),
-  };
-  return [
-    {
-      subject: { type: "team", id: teamSlug, relation: "admin" },
-      action: "manage",
-      resource: spaceResource,
-    },
-    {
-      subject: { type: "team", id: teamSlug, relation: "member" },
-      action: "use",
-      resource: spaceResource,
-    },
-  ];
+  return instantiatePolicyRelationships("webex_space_team_assignment_v1", {
+    teamSlug,
+    webexSpaceId: webexSpaceSubjectId(workspaceId, spaceId),
+  });
 }
 
 export function parseWebexSpaceGrantSubject(

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev2"
+version = "0.5.15.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Fixes Slack integration sharing so channels assigned to a team are visible/editable to team members, while keeping admin-only onboarding/advanced surfaces out of the generic user flow. Also centralizes the Slack/Webex team-assignment authorization rules in a policy manifest and adds an OpenFGA ReBAC Policy Manifest tab to visualize those rules without showing tuple-level details by default.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- [x] `npm test -- --runTestsByPath src/lib/rbac/__tests__/authorization-policy-catalog.test.ts src/lib/rbac/__tests__/slack/slack-channel-rebac.test.ts src/lib/rbac/__tests__/webex-space-rebac.test.ts src/lib/rbac/migrations/__tests__/messaging-migrations.test.ts src/app/api/admin/rebac/__tests__/policy-catalog-route.test.ts src/components/admin/security/__tests__/OpenFgaRebacTab.test.tsx src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts src/app/api/rbac/admin-tab-gates/__tests__/route.test.ts src/lib/rbac/__tests__/openfga.test.ts --runInBand`
- [x] `npx eslint src/lib/rbac/authorization-policy-catalog.ts src/lib/rbac/slack-channel-rebac.ts src/lib/rbac/webex-space-rebac.ts src/app/api/admin/rebac/policies/catalog/route.ts src/components/admin/security/PolicyManifestTab.tsx src/components/admin/security/OpenFgaRebacTab.tsx src/components/admin/rebac/SlackChannelRebacPanel.tsx e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/slack-run-as.spec.ts`
- [x] `git diff --check`
- [x] `RUN_RBAC_REGRESSION=1 npx playwright test e2e/rbac/slack-run-as.spec.ts e2e/rbac/rbac-admin-regression.spec.ts --config=playwright.rbac.config.ts`
- [x] `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3100 npm run test:e2e:rbac-regression` against a fresh branch dev server; manifest and Slack regressions passed, workflow checks require `WORKFLOWS_ENABLED=true` at server startup.
- [x] `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3100 WORKFLOWS_ENABLED=true npx playwright test e2e/rbac/workflow-agent-access.spec.ts --config=playwright.rbac.config.ts`
- [x] `make caipe-ui-prod` rebuilt and restarted `caipe-ui-prod` on `localhost:3000`; `/api/version` responds and startup logs show Next.js ready + MongoDB connected.
- [x] Manual UI verification after rebuilding `caipe-ui-prod`: generic user in `team:eti-sre-admin-jenkins` can edit shared Slack channel routing.
- [x] PR CI is green, including `playwright-rbac-regression`.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in the UI/policy manifest
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
