### PR TITLE
fix(docker-compose): align docker-compose files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,26 @@
 # =============================================================================
 
 # =============================================================================
+# OSS ALL-IN-ONE DOCKER COMPOSE DEFAULTS
+# =============================================================================
+
+IMAGE_TAG=0.5.14
+
+# Start the supervisor in all-in-one mode with MCP servers, RAG, RBAC,
+# MongoDB, the production UI image, dynamic agents, bots, and web ingestion.
+COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor
+
+# All-in-one mode: do not start remote A2A sub-agent containers.
+DISTRIBUTED_AGENTS=
+CAIPE_DISTRIBUTED_AGENTS=false
+
+# Prod UI build/run settings used by docker-compose.dev.yaml.
+CAIPE_UI_BUILD_TARGET=runner
+CAIPE_UI_NODE_ENV=production
+CAIPE_UI_COMMAND=/app/entrypoint.sh
+CAIPE_UI_IMAGE_SUFFIX=-prod
+
+# =============================================================================
 # AGENT DEPLOYMENT FLAGS (true=deploy, false=skip)
 # =============================================================================
 
@@ -57,7 +77,7 @@ SLIM_ENDPOINT=http://slim-dataplane:46357
 # =============================================================================
 
 # LLM provider <aws-bedrock|azure-openai|openai>
-LLM_PROVIDER='azure-openai'
+LLM_PROVIDER=openai
 
 
 # --- AWS Bedrock details ---
@@ -79,6 +99,11 @@ AZURE_OPENAI_ENDPOINT='https://resource_group_name.openai.azure.com'
 OPENAI_API_KEY=
 OPENAI_ENDPOINT=https://api.openai.com/v1
 OPENAI_MODEL_NAME=gpt-4o
+# For a fully local OpenAI-compatible runtime, point these at your local
+# inference server instead, for example:
+# OPENAI_API_KEY=ollama
+# OPENAI_ENDPOINT=http://host.docker.internal:11434/v1
+# OPENAI_MODEL_NAME=gpt-oss:20b
 
 
 # =============================================================================
@@ -95,17 +120,27 @@ OPENAI_MODEL_NAME=gpt-4o
 
 # GitHub - Option 2: Personal Access Token (fallback - requires manual rotation)
 GITHUB_PERSONAL_ACCESS_TOKEN=
+GITHUB_ORG=
+
+# GitLab
+GITLAB_TOKEN=
+GITLAB_PERSONAL_ACCESS_TOKEN=
 
 # ArgoCD
 ARGOCD_TOKEN=
 ARGOCD_API_URL=
 ARGOCD_VERIFY_SSL=true
+SERVER_URL=
+ARGOCD_AUTH_TOKEN=
 
 # Atlassian (Jira/Confluence)
 ATLASSIAN_TOKEN=
 ATLASSIAN_EMAIL=
 ATLASSIAN_API_URL=
 ATLASSIAN_VERIFY_SSL=true
+JIRA_URL=
+JIRA_EMAIL=
+JIRA_PROJECTS=
 
 # Backstage
 BACKSTAGE_API_TOKEN=
@@ -132,9 +167,12 @@ SLACK_APP_TOKEN=
 SLACK_SIGNING_SECRET=
 SLACK_CLIENT_SECRET=
 SLACK_TEAM_ID=
+SLACK_BOT_NAME=
 
 # Webex
 WEBEX_TOKEN=<your-bot-webex-token>
+WEBEX_ACCESS_TOKEN=
+WEBEX_BOT_NAME=
 
 # AgentForge
 AGENT_FORGE_BASE_URL=http://localhost:8000
@@ -169,7 +207,7 @@ AGENT_CONNECTIVITY_FAST_CHECK_TIMEOUT=2.0
 NEXT_PUBLIC_A2A_BASE_URL=http://localhost:8000
 
 # RAG Server URLs
-RAG_SERVER_URL=http://rag_server:9446
+RAG_SERVER_URL=http://rag-server:9446
 NEXT_PUBLIC_RAG_URL=http://localhost:9446
 NEXT_PUBLIC_RAG_WEBUI_URL=http://localhost:9447
 
@@ -186,6 +224,13 @@ RBAC_INGESTONLY_GROUPS=
 RBAC_DEFAULT_AUTHENTICATED_ROLE=readonly    # Role when no group matches: admin|readonly|ingestonly
 RBAC_CLIENT_CREDENTIALS_ROLE=ingestonly     # Role for client-credentials (M2M) tokens
 
+# RAG ingestor OIDC client-credentials settings for the local Keycloak stack.
+INGESTOR_OIDC_ISSUER=http://localhost:7080/realms/caipe
+INGESTOR_OIDC_DISCOVERY_URL=http://keycloak:7080/realms/caipe/.well-known/openid-configuration
+INGESTOR_OIDC_CLIENT_ID=caipe-platform
+INGESTOR_OIDC_CLIENT_SECRET=caipe-platform-dev-secret
+INGESTOR_OIDC_SCOPE=
+
 # RAG Trusted Network Configuration
 # Enable trusted network access (bypasses JWT authentication for specific IPs/networks)
 ALLOW_TRUSTED_NETWORK=true
@@ -193,7 +238,7 @@ TRUSTED_NETWORK_CIDRS=127.0.0.0/8,192.168.0.0/16,172.16.0.0/12
 TRUSTED_NETWORK_DEFAULT_ROLE=admin
 
 # Feature Flags
-NEXT_PUBLIC_SSO_ENABLED=false
+NEXT_PUBLIC_SSO_ENABLED=true
 NEXT_PUBLIC_RAG_ENABLED=true  # Set to false to disable RAG Knowledge Bases
 NEXT_PUBLIC_ENABLE_SUBAGENT_CARDS=true
 NEXT_PUBLIC_MONGODB_ENABLED=false
@@ -205,15 +250,15 @@ NEXTAUTH_SECRET=changeme  # Generate with: openssl rand -base64 32
 NEXTAUTH_URL=http://localhost:3000
 
 # SSO master switch (server-side mirror of NEXT_PUBLIC_SSO_ENABLED above)
-SSO_ENABLED=false
+SSO_ENABLED=true
 # Comma-separated emails granted admin role on first login (regardless of IdP groups)
-BOOTSTRAP_ADMIN_EMAILS=
+BOOTSTRAP_ADMIN_EMAILS=admin@caipe.local
 # Enable Custom Agents tab + dynamic-agents service (also requires the dynamic-agents profile)
 DYNAMIC_AGENTS_ENABLED=false
 
 # OIDC Provider Configuration (for SSO)
 #
-# Option A — Direct IdP (Duo SSO, Okta, etc.)
+# Option A — Direct IdP (Okta, Authentik, Dex, etc.)
 #   OIDC_ISSUER=https://sso.example.com/oidc/<client-id>
 #   OIDC_CLIENT_ID=<client-id>
 #   OIDC_CLIENT_SECRET=<secret>
@@ -228,21 +273,21 @@ DYNAMIC_AGENTS_ENABLED=false
 #   OIDC_DISCOVERY_URL=http://keycloak:7080/realms/caipe      # internal URL for server-side discovery
 #   OIDC_CLIENT_ID=caipe-ui                                   # Keycloak client (not the upstream IdP client)
 #   OIDC_CLIENT_SECRET=<keycloak-caipe-ui-client-secret>
-#   OIDC_IDP_HINT=duo-sso                                     # auto-redirect to upstream IdP alias
+#   OIDC_IDP_HINT=okta                                        # auto-redirect to upstream IdP alias
 #   Also enable identity sync flags below to auto-sync AD groups → teams.
-OIDC_ISSUER=
+OIDC_ISSUER=http://localhost:7080/realms/caipe
 # Server-side OIDC discovery URL. Set to a Docker-internal URL when the issuer
 # is browser-facing but server-side fetches need to bypass the host network
 # (typical of dockerised/in-cluster Keycloak). Leave blank to use OIDC_ISSUER.
-OIDC_DISCOVERY_URL=
-OIDC_CLIENT_ID=
-OIDC_CLIENT_SECRET=
+OIDC_DISCOVERY_URL=http://keycloak:7080/realms/caipe
+OIDC_CLIENT_ID=caipe-ui
+OIDC_CLIENT_SECRET=caipe-ui-dev-secret
 # Group claims (leave blank for default behaviour: any authenticated user is allowed)
 OIDC_GROUP_CLAIM=
 OIDC_REQUIRED_GROUP=
 OIDC_REQUIRED_ADMIN_GROUP=
 OIDC_ENABLE_REFRESH_TOKEN=true
-# Auto-redirect to upstream IdP (matches IDP_ALIAS in Keycloak, e.g. duo-sso, okta).
+# Auto-redirect to upstream IdP (matches IDP_ALIAS in Keycloak, e.g. okta).
 # Leave blank to show the Keycloak login page.
 OIDC_IDP_HINT=
 
@@ -251,7 +296,7 @@ OIDC_IDP_HINT=
 KEYCLOAK_URL=http://keycloak:7080
 KEYCLOAK_REALM=caipe
 KEYCLOAK_RESOURCE_SERVER_ID=caipe-platform
-KEYCLOAK_CLIENT_SECRET=changeme
+KEYCLOAK_CLIENT_SECRET=caipe-platform-dev-secret
 # UI BFF Admin REST API (NextAuth.js, role-mapping CRUD). In dev defaults to
 # admin-cli password grant. In prod, point at a confidential admin client.
 # KEYCLOAK_ADMIN_CLIENT_ID=
@@ -319,6 +364,9 @@ MONGODB_DATABASE=caipe
 MONGODB_ROOT_USERNAME=admin
 MONGODB_ROOT_PASSWORD=changeme
 
+# Kubernetes ingest defaults
+CLUSTER_NAME=
+
 # =============================================================================
 # LANGGRAPH PERSISTENCE
 # =============================================================================
@@ -376,6 +424,8 @@ ENABLE_FACT_EXTRACTION=false
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
 LANGFUSE_HOST=
+LANGFUSE_SESSION_ID=ai-platform-engineering
+LANGFUSE_USER_ID=platform-engineer
 
 # =============================================================================
 # ADDITIONAL API KEYS

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1788,7 +1788,6 @@ services:
       # server-to-server credential API instead of browser/session cookies.
       - CAIPE_CREDENTIALS_ENABLED=${CAIPE_CREDENTIALS_ENABLED:-false}
       - CREDENTIAL_API_URL=${CREDENTIAL_API_URL:-http://caipe-ui:3000/api/credentials}
-      # assisted-by Codex Codex-sonnet-4-6
       - CAIPE_API_URL=${CAIPE_API_URL:-http://caipe-ui:3000}
       - CREDENTIAL_SERVICE_AUDIENCE=${CREDENTIAL_SERVICE_AUDIENCE:-caipe-credential-service}
       - USE_IMPERSONATION_TOKENS=${USE_IMPERSONATION_TOKENS:-false}
@@ -1976,6 +1975,7 @@ services:
     restart: unless-stopped
     profiles:
       - web-ingestor
+      - web_ingestor
 
   backstage_ingestor:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
   #                                 CAIPE Supervisor Deep Agent                                      #
   ####################################################################################################
   caipe-supervisor:
-    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.5.14}
     container_name: caipe-supervisor
     volumes:
       - ${PROMPT_CONFIG_PATH:-./charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml}:/app/prompt_config.yaml
@@ -75,6 +75,8 @@ services:
       - ARGOCD_MCP_HOST=mcp-argocd
       - BACKSTAGE_MCP_HOST=mcp-backstage
       - CONFLUENCE_MCP_HOST=mcp-confluence
+      - GITHUB_MCP_HOST=github-mcp-server
+      - GITHUB_MCP_PORT=8082
       - JIRA_MCP_HOST=mcp-jira
       - KOMODOR_MCP_HOST=mcp-komodor
       - PAGERDUTY_MCP_HOST=mcp-pagerduty
@@ -100,7 +102,6 @@ services:
       - ENABLE_SLACK=${ENABLE_SLACK:-false}
       - ENABLE_SPLUNK=${ENABLE_SPLUNK:-false}
       - ENABLE_WEBEX=${ENABLE_WEBEX:-false}
-      - ENABLE_WEBEX=${ENABLE_WEBEX:-false}
       - ENABLE_WEATHER=${ENABLE_WEATHER:-false}
       - ENABLE_NETUTILS=${ENABLE_NETUTILS:-false}
 
@@ -112,6 +113,8 @@ services:
       - LANGFUSE_SESSION_ID=${LANGFUSE_SESSION_ID:-ai-platform-engineering}
       - LANGFUSE_USER_ID=${LANGFUSE_USER_ID:-platform-engineer}
     command: platform-engineer
+    profiles:
+      - caipe-supervisor
 
   ####################################################################################################
   #                                      SLIM Transport                                              #
@@ -141,129 +144,22 @@ services:
       - slim
 
   ####################################################################################################
-  #                                         Sub-Agents                                               #
+  #                                         MCP Servers                                              #
   ####################################################################################################
-  # AWS Agent
-  agent-aws:
-    image: ghcr.io/cnoe-io/agent-aws:${IMAGE_TAG:-0.2.36}
-    container_name: agent-aws
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.aws_agent.yaml:/app/prompt_config.aws_agent.yaml
-    env_file: [.env]
-    ports: ["8012:8000"]
-    environment:
-      - AWS_AGENT_BACKEND=${AWS_AGENT_BACKEND:-langgraph}
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-      - ENABLE_TRACING=${ENABLE_TRACING:-false}
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse-web:3000}
-      - AWS_REGION=${AWS_REGION}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - ENABLE_EKS_MCP=${ENABLE_EKS_MCP:-true}
-      - ENABLE_COST_EXPLORER_MCP=${ENABLE_COST_EXPLORER_MCP:-true}
-      - ENABLE_IAM_MCP=${ENABLE_IAM_MCP:-true}
-      - IAM_MCP_READONLY=${IAM_MCP_READONLY:-true}
-      - STRANDS_LOG_LEVEL=${STRANDS_LOG_LEVEL:-INFO}
-      - FASTMCP_LOG_LEVEL=${FASTMCP_LOG_LEVEL:-ERROR}
-      - DEFAULT_AWS_ACCOUNT_ID=${DEFAULT_AWS_ACCOUNT_ID:-common-dev:123456789012}
-      - AWS_ACCOUNT_LIST=${AWS_ACCOUNT_LIST:-account1:123456789012,account2:123456789013}
-    profiles:
-      - aws
-      - all-agents
 
-  # Petstore Agent
-  agent-petstore:
-    image: ghcr.io/cnoe-io/agent-template:${IMAGE_TAG:-0.2.36}
-    container_name: agent-petstore
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.petstore_agent.yaml:/app/prompt_config.petstore_agent.yaml
-    env_file: [.env]
-    ports: ["8013:8000"]
+  # Official GitHub MCP server for all-in-one mode.
+  github-mcp-server:
+    image: ghcr.io/github/github-mcp-server:latest
+    container_name: github-mcp-server
     environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_PORT=443
-      - MCP_HOST=petstore.outshift.io
-      - PETSTORE_API_KEY=${PETSTORE_API_KEY}
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-      - ENABLE_TRACING=${ENABLE_TRACING:-false}
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse-web:3000}
-    profiles:
-      - petstore
-      - all-agents
-
-  # GitHub
-  agent-github:
-    image: ghcr.io/cnoe-io/agent-github:${IMAGE_TAG:-0.2.36}
-    container_name: agent-github
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.github_agent.yaml:/app/prompt_config.github_agent.yaml
-    env_file: [.env]
-    ports: ["8001:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-      - ENABLE_TRACING=${ENABLE_TRACING:-false}
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-      - LANGFUSE_HOST=${LANGFUSE_HOST:-http://langfuse-web:3000}
-      - GH_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}  # gh CLI authentication
-    # Docker socket mount is only needed when MCP_MODE=stdio
-    # For local Github Offical MCP server execution.
-    # Uncomment this when MCP_MODE=stdio is supported
-    # volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
+    ports: ["18000:8082"]
     profiles:
       - github
-      - all-agents
-
-  # Weather Agent
-  agent-weather:
-    image: ghcr.io/cnoe-io/agent-weather:${IMAGE_TAG:-0.2.36}
-    container_name: agent-weather
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.weather_agent.yaml:/app/prompt_config.weather_agent.yaml
-    env_file: [.env]
-    ports: ["8002:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=weather.outshift.io
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    profiles:
-      - weather
-      - all-agents
-
-  # Backstage Agent
-  agent-backstage:
-    image: ghcr.io/cnoe-io/agent-backstage:${IMAGE_TAG:-0.2.36}
-    container_name: agent-backstage
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.backstage_agent.yaml:/app/prompt_config.backstage_agent.yaml
-    env_file: [.env]
-    ports: ["8003:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-backstage
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-backstage:
-        condition: service_healthy
-    profiles:
-      - backstage
-      - all-agents
+      - mcp-servers
 
   mcp-backstage:
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.5.14}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -280,30 +176,12 @@ services:
     profiles:
       - backstage
       - all-agents
+      - mcp-servers
 
-  # ArgoCD Agents
-  agent-argocd:
-    image: ghcr.io/cnoe-io/agent-argocd:${IMAGE_TAG:-0.2.36}
-    container_name: agent-argocd
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.argocd_agent.yaml:/app/prompt_config.argocd_agent.yaml
-    env_file: [.env]
-    ports: ["8004:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-argocd
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-argocd:
-        condition: service_healthy
-    profiles:
-      - argocd
-      - all-agents
+  # ArgoCD MCP
 
   mcp-argocd:
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.5.14}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -320,27 +198,9 @@ services:
     profiles:
       - argocd
       - all-agents
+      - mcp-servers
 
-  # Confluence Agents
-  agent-confluence:
-    image: ghcr.io/cnoe-io/agent-confluence:${IMAGE_TAG:-0.2.36}
-    container_name: agent-confluence
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.confluence_agent.yaml:/app/prompt_config.confluence_agent.yaml
-    env_file: [.env]
-    ports: ["8005:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-confluence
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-confluence:
-        condition: service_started
-    profiles:
-      - confluence
-      - all-agents
+  # Confluence MCP
 
   mcp-confluence:
     image: ghcr.io/sooperset/mcp-atlassian:latest
@@ -354,30 +214,12 @@ services:
     profiles:
       - confluence
       - all-agents
+      - mcp-servers
 
-  # Jira Agent
-  agent-jira:
-    image: ghcr.io/cnoe-io/agent-jira:${IMAGE_TAG:-0.2.36}
-    container_name: agent-jira
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.jira_agent.yaml:/app/prompt_config.jira_agent.yaml
-    env_file: [.env]
-    ports: ["8006:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-jira
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-jira:
-        condition: service_healthy
-    profiles:
-      - jira
-      - all-agents
+  # Jira MCP
 
   mcp-jira:
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.5.14}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -394,29 +236,12 @@ services:
     profiles:
       - jira
       - all-agents
+      - mcp-servers
 
-  # Komodor Agent
-  agent-komodor:
-    image: ghcr.io/cnoe-io/agent-komodor:${IMAGE_TAG:-0.2.36}
-    container_name: agent-komodor
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.komodor_agent.yaml:/app/prompt_config.komodor_agent.yaml
-    env_file: [.env]
-    ports: ["8007:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-komodor
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-komodor:
-        condition: service_healthy
-    profiles:
-      - komodor
+  # Komodor MCP
 
   mcp-komodor:
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.5.14}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -432,30 +257,12 @@ services:
       start_period: 15s
     profiles:
       - komodor
+      - mcp-servers
 
-  # PagerDuty Agent
-  agent-pagerduty:
-    image: ghcr.io/cnoe-io/agent-pagerduty:${IMAGE_TAG:-0.2.36}
-    container_name: agent-pagerduty
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.pagerduty_agent.yaml:/app/prompt_config.pagerduty_agent.yaml
-    env_file: [.env]
-    ports: ["8008:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-pagerduty
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-pagerduty:
-        condition: service_healthy
-    profiles:
-      - pagerduty
-      - all-agents
+  # PagerDuty MCP
 
   mcp-pagerduty:
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.5.14}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -472,29 +279,10 @@ services:
     profiles:
       - pagerduty
       - all-agents
+      - mcp-servers
 
-  # Slack Agent
-  agent-slack:
-    image: ghcr.io/cnoe-io/agent-slack:${IMAGE_TAG:-0.2.36}
-    container_name: agent-slack
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.slack_agent.yaml:/app/prompt_config.slack_agent.yaml
-    env_file: [.env]
-    ports: ["8009:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-slack
-      - MCP_PORT=3001
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-slack:
-        condition: service_healthy
-    profiles:
-      - slack
-      - all-agents
+  # Slack MCP
 
-  # OSS Slack MCP Server (https://github.com/korotovsky/slack-mcp-server)
   mcp-slack:
     image: ghcr.io/korotovsky/slack-mcp-server:v1.2.3
     container_name: mcp-slack
@@ -519,30 +307,12 @@ services:
     profiles:
       - slack
       - all-agents
+      - mcp-servers
 
   # Splunk
-  agent-splunk:
-    image: ghcr.io/cnoe-io/agent-splunk:${IMAGE_TAG:-0.2.36}
-    container_name: agent-splunk
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.splunk_agent.yaml:/app/prompt_config.splunk_agent.yaml
-    env_file: [.env]
-    ports: ["8010:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-splunk
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-splunk:
-        condition: service_healthy
-    profiles:
-      - splunk
-      - all-agents
 
   mcp-splunk:
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.5.14}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -559,30 +329,12 @@ services:
     profiles:
       - splunk
       - all-agents
+      - mcp-servers
 
   # Webex
-  agent-webex:
-    image: ghcr.io/cnoe-io/agent-webex:${IMAGE_TAG:-0.2.36}
-    container_name: agent-webex
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.webex_agent.yaml:/app/prompt_config.webex_agent.yaml
-    env_file: [.env]
-    ports: ["8011:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-webex
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-webex:
-        condition: service_healthy
-    profiles:
-      - webex
-      - all-agents
 
   mcp-webex:
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.5.14}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -599,30 +351,12 @@ services:
     profiles:
       - webex
       - all-agents
+      - mcp-servers
 
-  # NetUtils Agent
-  agent-netutils:
-    image: ghcr.io/cnoe-io/agent-netutils:${IMAGE_TAG:-0.2.36}
-    container_name: agent-netutils
-    volumes:
-      - ./charts/ai-platform-engineering/data/prompt_config.netutils_agent.yaml:/app/prompt_config.netutils_agent.yaml
-    env_file: [.env]
-    ports: ["8015:8000"]
-    environment:
-      - A2A_TRANSPORT=${A2A_TRANSPORT:-p2p}
-      - MCP_MODE=http
-      - MCP_HOST=mcp-netutils
-      - MCP_PORT=8000
-      - SLIM_ENDPOINT=${SLIM_ENDPOINT:-http://slim-dataplane:46357}
-    depends_on:
-      mcp-netutils:
-        condition: service_healthy
-    profiles:
-      - netutils-agent
-      - all-agents
+  # NetUtils MCP
 
   mcp-netutils:
-    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.5.14}
     container_name: mcp-netutils
     env_file: [.env]
     ports: ["18011:8000"]
@@ -639,14 +373,15 @@ services:
     profiles:
       - netutils-agent
       - all-agents
+      - mcp-servers
 
   ####################################################################################################
   #                                      CAIPE UI & MongoDB                                          #
   ####################################################################################################
   # MongoDB for CAIPE UI chat history and user settings
-  caipe-ui-mongodb:
+  caipe-mongodb:
     image: mongo:7.0
-    container_name: caipe-ui-mongodb
+    container_name: caipe-mongodb
     ports:
       - "27017:27017"
     environment:
@@ -654,8 +389,8 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=${MONGODB_ROOT_PASSWORD:-changeme}
       - MONGO_INITDB_DATABASE=${MONGODB_DATABASE:-caipe}
     volumes:
-      - caipe_ui_mongodb_data:/data/db
-      - caipe_ui_mongodb_config:/data/configdb
+      - mongodb_data:/data/db
+      - mongodb_config:/data/configdb
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 10s
@@ -663,7 +398,7 @@ services:
       retries: 5
       start_period: 40s
     profiles:
-      - caipe-ui-with-mongodb
+      - caipe-mongodb
 
   # MongoDB Admin UI (optional)
   caipe-ui-mongo-express:
@@ -674,10 +409,10 @@ services:
     environment:
       - ME_CONFIG_MONGODB_ADMINUSERNAME=${MONGODB_ROOT_USERNAME:-admin}
       - ME_CONFIG_MONGODB_ADMINPASSWORD=${MONGODB_ROOT_PASSWORD:-changeme}
-      - ME_CONFIG_MONGODB_URL=mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-ui-mongodb:27017/
+      - ME_CONFIG_MONGODB_URL=mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-mongodb:27017/
       - ME_CONFIG_BASICAUTH=false
     depends_on:
-      caipe-ui-mongodb:
+      caipe-mongodb:
         condition: service_healthy
     profiles:
       - caipe-ui-mongo-express
@@ -699,7 +434,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.14}-prod
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -707,16 +442,15 @@ services:
     environment:
       - NODE_ENV=production
       # CAIPE supervisor A2A endpoint URL
-      # Override with NEXT_PUBLIC_A2A_BASE_URL environment variable
-      - NEXT_PUBLIC_A2A_BASE_URL=${NEXT_PUBLIC_A2A_BASE_URL:-http://localhost:8000}
+      - A2A_BASE_URL=${A2A_BASE_URL:-http://caipe-supervisor:8000}
       # Enable/Disable RAG Knowledge Bases (default: true)
-      - NEXT_PUBLIC_RAG_ENABLED=${NEXT_PUBLIC_RAG_ENABLED:-true}
+      - RAG_ENABLED=${RAG_ENABLED:-true}
       # RAG Server URL for knowledge base API (internal Docker network)
       - RAG_SERVER_URL=${RAG_SERVER_URL:-http://rag-server:9446}
-      - NEXT_PUBLIC_RAG_URL=${RAG_URL:-http://localhost:9446}
+      - RAG_URL=${RAG_URL:-http://localhost:9446}
       # MongoDB configuration - Enable/disable MongoDB persistence
       - NEXT_PUBLIC_MONGODB_ENABLED=${NEXT_PUBLIC_MONGODB_ENABLED:-false}
-      - MONGODB_URI=${MONGODB_URI:-mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-ui-mongodb:27017/${MONGODB_DATABASE:-caipe}?authSource=admin}
+      - "MONGODB_URI=${MONGODB_URI:-mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-mongodb:27017/${MONGODB_DATABASE:-caipe}?authSource=admin}"
       # NextAuth configuration (required for production)
       # Generate a secret with: openssl rand -base64 48
       # R4: NEXTAUTH_SECRET MUST be set in the environment (e.g. via .env)
@@ -725,7 +459,7 @@ services:
       # missing or empty so an operator never silently inherits a shared
       # placeholder. (For local dev that genuinely wants a placeholder,
       # use docker-compose.dev.yaml instead.) assisted-by Claude:claude-opus-4-7
-      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in your .env (run: openssl rand -base64 48)}
+      - "NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in your .env (run: openssl rand -base64 48)}"
       - NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}
       # SSO Configuration - set NEXT_PUBLIC_SSO_ENABLED=true to enable
       - NEXT_PUBLIC_SSO_ENABLED=${NEXT_PUBLIC_SSO_ENABLED:-false}
@@ -766,14 +500,15 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    command: /app/entrypoint.sh
     profiles:
-      - caipe-ui
+      - caipe-ui-prod
 
   ####################################################################################################
   #                                      RAG Services                                                #
   ####################################################################################################
   rag-server:
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.5.14}
     container_name: rag-server
     # Network alias keeps the legacy `rag_server` hostname working for any
     # client that still has it hardcoded. AGW's hickory-dns resolver rejects
@@ -825,7 +560,7 @@ services:
   # Ports:
   #   - 8100: Dynamic Agents API (proxied via UI at /api/dynamic-agents)
   dynamic-agents:
-    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-0.2.43}
+    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-0.5.14}
     container_name: dynamic-agents
     ports: ["8100:8001"]
     volumes:
@@ -838,7 +573,7 @@ services:
       - AWS_BEDROCK_USE_CONVERSE_API=${AWS_BEDROCK_USE_CONVERSE_API:-true}
       - AWS_BEDROCK_BASE_MODEL_ID=${AWS_BEDROCK_BASE_MODEL_ID:-}
       # MongoDB (same as CAIPE UI)
-      - MONGODB_URI=${MONGODB_URI:-mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-ui-mongodb:27017/${MONGODB_DATABASE:-caipe}?authSource=admin}
+      - MONGODB_URI=${MONGODB_URI:-mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-mongodb:27017/${MONGODB_DATABASE:-caipe}?authSource=admin}
       - MONGODB_DATABASE=${MONGODB_DATABASE:-caipe}
       # Authentication (same OIDC config as CAIPE UI)
       - AUTH_ENABLED=${AUTH_ENABLED:-false}
@@ -866,7 +601,7 @@ services:
       - dynamic-agents
 
   agent_ontology:
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.5.14}
     container_name: agent_ontology
     ports: ["8098:8098"]
     environment:
@@ -884,8 +619,8 @@ services:
       - graph_rag
 
 
-  rag_web_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.2.36}
+  web_ingestor:
+    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.14}
     container_name: web-ingestor
     environment:
       - INGESTOR_TYPE=webloader
@@ -900,9 +635,11 @@ services:
     profiles:
       - rag
       - graph_rag
+      - web-ingestor
+      - web_ingestor
 
-  rag_jira_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.2.36}
+  jira_ingestor:
+    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.14}
     container_name: jira-ingestor
     environment:
       - INGESTOR_TYPE=jira
@@ -918,8 +655,7 @@ services:
     restart: unless-stopped
     depends_on: [rag-server]
     profiles:
-      - rag
-      - graph_rag
+      - jira-ingestor
 
   # RAG Dependencies
   neo4j:
@@ -1235,7 +971,7 @@ services:
   #                                 Slack Bot Integration                                            #
   ####################################################################################################
   slack-bot:
-    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-0.4.0}
+    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-0.5.14}
     container_name: slack-bot
     env_file: [.env]
     ports: ["8030:3000"]
@@ -1260,7 +996,7 @@ services:
   #                                 Webex Bot Integration                                            #
   ####################################################################################################
   webex-bot:
-    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-0.4.0}
+    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-0.5.14}
     container_name: webex-bot
     env_file: [.env]
     ports: ["8032:3002"]
@@ -1282,10 +1018,451 @@ services:
       - webex-bot
       - all-integrations
 
+  ####################################################################################################
+  #                                  Enterprise RBAC (098)                                       #
+  ####################################################################################################
+  # Keycloak + OpenFGA + AgentGateway for Enterprise RBAC.
+  # Usage (Slack + RAG RBAC — copy deploy/rbac/.env.rbac.example into .env and set embeddings keys):
+  #   COMPOSE_PROFILES=rbac,rag,slack-bot,caipe-supervisor,caipe-mongodb \
+  #     docker compose -f docker-compose.dev.yaml up -d
+  #
+  # RAG: http://localhost:9446  (requires Milvus stack + embedding provider env, e.g. AZURE_OPENAI_*)
+  # Slack bot: socket mode or http://localhost:8030 — set SLACK_* tokens in .env
+  #
+  # Admin console: http://localhost:7080/admin (admin / admin)
+  # OpenFGA API: http://localhost:18080  Playground: http://localhost:13002
+  # Agent Gateway proxy: http://localhost:4000
+  # Agent Gateway admin UI: http://localhost:15000/ui
+  #
+  # Test personas (see deploy/keycloak/realm-config.json):
+  #   admin-user / admin       → admin, chat_user
+  #   standard-user / standard → chat_user, team_member
+  #   kb-admin-user / kbadmin  → chat_user, team_member, kb_admin
+  #   denied-user / denied     → (no roles)
+  #   org-b-user / orgb        → chat_user (tenant: globex)
+
+  # Durable Postgres for Keycloak.
+  #
+  # Why this exists: Keycloak's default `start-dev` uses an embedded H2 DB
+  # written under /opt/keycloak/data/h2. Without an external DB AND a named
+  # volume, every `docker compose up` on a recreated container wipes ALL
+  # Keycloak state — users, role assignments, per-team client scopes, the
+  # `team_member:<slug>` realm roles, Slack identity links (slack_user_id
+  # user attribute), token-exchange grants, etc. Mongo still holds the team
+  # docs, so the system silently drifts: BFF startup re-creates the
+  # `team-<slug>` client scopes (via syncTeamScopesOnStartup), but realm
+  # roles + role assignments + identity links are NOT reconciled, leading
+  # to OBO failures like "I couldn't start your CAIPE session".
+  #
+  # Putting Keycloak on Postgres with a named volume makes the dev stack
+  # behave like prod: `docker compose down && up` preserves state;
+  # `docker compose down -v` is the only destructive op.
+  keycloak-postgres:
+    image: postgres:16-alpine
+    container_name: keycloak-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+      POSTGRES_DB: keycloak
+    volumes:
+      - keycloak_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak -d keycloak"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    profiles:
+      - rbac
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.3
+    container_name: keycloak
+    environment:
+      # Keycloak 26 requires hostname as a full URL when backchannel-dynamic
+      # is enabled. Frontchannel/browser URLs use this base; backchannel URLs
+      # are rewritten to use the request's hostname (so caipe-ui calling
+      # http://keycloak:7080/.well-known/... gets back token_endpoint that
+      # also uses keycloak:7080 — fixing ECONNREFUSED on server-to-server
+      # token exchange).
+      # See: https://www.keycloak.org/server/hostname#_backchannel_dynamic
+      KC_HOSTNAME: "http://localhost:7080"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_LOG_LEVEL: info
+      # Persist KC state in Postgres instead of the ephemeral embedded H2 DB.
+      # Without this, every container recreate wipes users, roles, role
+      # assignments, per-team client scopes, identity links, etc. — and
+      # Mongo's team docs end up referencing KC objects that no longer exist.
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://keycloak-postgres:5432/keycloak # gitleaks:allow - local dev database URL
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: keycloak
+      # Cap JVM heap so KC plays nicely on a busy dev laptop. Default
+      # `start-dev` lets the JVM scale to 25% of host memory, which on a
+      # heavily-loaded compose stack can trip Docker Desktop's OOM killer
+      # during schema init (exit 137). 768m headroom is plenty for dev.
+      JAVA_OPTS_KC_HEAP: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=256m"
+    # `--import-realm` is still safe with a durable DB: KC only imports on
+    # an empty realm, so subsequent boots become idempotent no-ops and your
+    # runtime mutations (teams, role assignments, identity links) survive.
+    command: ["start-dev", "--import-realm", "--http-port", "7080", "--https-port", "7443", "--features=token-exchange,admin-fine-grained-authz:v1"]
+    volumes:
+      - ./charts/ai-platform-engineering/charts/keycloak/realm-config.json:/opt/keycloak/data/import/realm-config.json:ro
+      - ./deploy/keycloak/themes/caipe:/opt/keycloak/themes/caipe:ro
+    ports:
+      # Keep direct Keycloak access local to the Docker host. Public/browser
+      # ingress should go through the HTTPS reverse proxy.
+      - "127.0.0.1:7080:7080"
+      - "127.0.0.1:7443:7443"
+    depends_on:
+      keycloak-postgres:
+        condition: service_healthy
+    # Wait until management is up AND the realm JWKS route returns 200 (TCP-only on 7080 was
+    # too early — realm import can lag, leaving the fetcher in an endless curl loop).
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          bash -c "exec 3<>/dev/tcp/127.0.0.1/9000 && exec 3<&- && exec 3>&- &&
+          exec 3<>/dev/tcp/127.0.0.1/7080 &&
+          printf $$'GET /realms/caipe/protocol/openid-connect/certs HTTP/1.0\r\nHost: localhost:7080\r\nConnection: close\r\n\r\n' >&3 &&
+          head -n 1 <&3 | grep -q ' 200'"
+      interval: 10s
+      timeout: 10s
+      retries: 25
+      start_period: 120s
+    profiles:
+      - rbac
+
+  # One-shot init container: creates the upstream OIDC identity-provider
+  # broker in Keycloak from IDP_* env vars (set in .env).
+  # Skips silently when IDP_ISSUER is unset — local-only users + test
+  # personas still work via direct Keycloak login.
+  keycloak-init:
+    image: ${KEYCLOAK_INIT_IMAGE:-caipe/keycloak-init:dev}
+    build:
+      context: .
+      dockerfile: build/Dockerfile.keycloak-init
+    container_name: keycloak-init
+    entrypoint: ["/bin/sh", "/scripts/init-idp.sh"]
+    volumes:
+      - ./charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh:/scripts/init-idp.sh:ro
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      IDP_ALIAS: ${IDP_ALIAS:-}
+      IDP_DISPLAY_NAME: ${IDP_DISPLAY_NAME:-}
+      IDP_ISSUER: ${IDP_ISSUER:-}
+      IDP_CLIENT_ID: ${IDP_CLIENT_ID:-}
+      IDP_CLIENT_SECRET: ${IDP_CLIENT_SECRET:-}
+      IDP_ACCESS_GROUP: ${IDP_ACCESS_GROUP:-}
+      IDP_ADMIN_GROUP: ${IDP_ADMIN_GROUP:-}
+      IDP_PKCE_ENABLED: ${IDP_PKCE_ENABLED:-false}
+      KEYCLOAK_FORCE_IDP_REDIRECT: ${KEYCLOAK_FORCE_IDP_REDIRECT:-false}
+      KEYCLOAK_ADMIN_FRONTEND_URL: ${KEYCLOAK_ADMIN_FRONTEND_URL:-}
+      CAIPE_UNSAFE_RBAC_BYPASS: ${CAIPE_UNSAFE_RBAC_BYPASS:-false}
+      SLACK_BOT_ADMIN_AUDIENCE: ${SLACK_BOT_ADMIN_AUDIENCE:-caipe-slack-bot-admin}
+      KC_REALM: caipe
+      # Spec 104: comma-separated emails that get the admin_user role and the
+      # demo team/agent/tool bundle on first run of init-idp.sh. Sourced from
+      # the same env var the UI uses for bootstrap admin bypass.
+      BOOTSTRAP_ADMIN_EMAILS: ${BOOTSTRAP_ADMIN_EMAILS:-}
+    network_mode: "service:keycloak"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    # `on-failure` so transient KC unavailability (start_period race) is
+    # auto-retried instead of leaving the realm half-seeded. Both init
+    # scripts are idempotent — re-running is safe. Use `make rbac-reinit`
+    # to force a re-run after the container has already exited cleanly
+    # (e.g. after `docker compose restart keycloak`, where the existing
+    # exited init container does NOT auto-rerun).
+    restart: on-failure
+    profiles:
+      - rbac
+
+  # One-shot init container: configures token exchange + impersonation
+  # permissions on caipe-slack-bot so the Slack bot can mint JWTs on
+  # behalf of users (RFC 8693).  Idempotent — safe to re-run.
+  keycloak-init-token-exchange:
+    image: ${KEYCLOAK_INIT_IMAGE:-caipe/keycloak-init:dev}
+    build:
+      context: .
+      dockerfile: build/Dockerfile.keycloak-init
+    container_name: keycloak-init-token-exchange
+    entrypoint: ["/bin/sh", "/scripts/init-token-exchange.sh"]
+    volumes:
+      - ./deploy/keycloak/init-token-exchange.sh:/scripts/init-token-exchange.sh:ro
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_REALM: caipe
+      KC_BOT_CLIENT_ID: caipe-slack-bot
+      KC_SSL_REQUIRED: none
+      # Seed the Slack bot's service-account read grant on
+      # system_config:platform_settings so it can read platform-wide settings
+      # (default agent, VictorOps agent) from the BFF. The BFF graphs the bot's
+      # client-credentials token as service_account:<sub>; without this grant
+      # the read 403s and the bot falls back to env/YAML defaults.
+      OPENFGA_HTTP: http://openfga:8080
+      OPENFGA_STORE_NAME: caipe-openfga
+    network_mode: "service:keycloak"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      # Run AFTER init-idp.sh so we're configuring token exchange against a
+      # realm that already has the slack-bot client wired up by the IdP seed.
+      keycloak-init:
+        condition: service_completed_successfully
+      # Need the OpenFGA store + model seeded before we can write the bot's
+      # platform-settings grant tuple.
+      openfga-init:
+        condition: service_completed_successfully
+    restart: on-failure
+    profiles:
+      - rbac
+
+  # OpenFGA remote PDP for AgentGateway ext_authz.
+  #
+  # AgentGateway calls openfga-authz-bridge on every MCP request; OpenFGA is
+  # the authorization source for the gateway path. We do not run a CEL policy
+  # config bridge for AgentGateway.
+  openfga-postgres:
+    image: postgres:17-alpine
+    container_name: openfga-postgres
+    restart: unless-stopped
+    profiles:
+      - rbac
+    environment:
+      POSTGRES_USER: ${OPENFGA_POSTGRES_USER:-openfga}
+      POSTGRES_PASSWORD: ${OPENFGA_POSTGRES_PASSWORD:-openfga}
+      POSTGRES_DB: ${OPENFGA_POSTGRES_DB:-openfga}
+    volumes:
+      - openfga_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  openfga-migrate:
+    image: openfga/openfga:latest
+    container_name: openfga-migrate
+    profiles:
+      - rbac
+    depends_on:
+      openfga-postgres:
+        condition: service_healthy
+    environment:
+      OPENFGA_DATASTORE_ENGINE: postgres
+      OPENFGA_DATASTORE_URI: postgres://${OPENFGA_POSTGRES_USER:-openfga}:${OPENFGA_POSTGRES_PASSWORD:-openfga}@openfga-postgres:5432/${OPENFGA_POSTGRES_DB:-openfga}?sslmode=disable
+    command: migrate
+
+  openfga:
+    image: openfga/openfga:latest
+    container_name: openfga
+    restart: unless-stopped
+    profiles:
+      - rbac
+    depends_on:
+      openfga-migrate:
+        condition: service_completed_successfully
+    environment:
+      OPENFGA_DATASTORE_ENGINE: postgres
+      OPENFGA_DATASTORE_URI: postgres://${OPENFGA_POSTGRES_USER:-openfga}:${OPENFGA_POSTGRES_PASSWORD:-openfga}@openfga-postgres:5432/${OPENFGA_POSTGRES_DB:-openfga}?sslmode=disable
+      OPENFGA_DATASTORE_MAX_OPEN_CONNS: "50"
+      OPENFGA_PLAYGROUND_ENABLED: "true"
+      OPENFGA_TRACE_ENABLED: "false"
+    command: run
+    ports:
+      - "127.0.0.1:${OPENFGA_HTTP_PORT:-18080}:8080"
+      - "127.0.0.1:${OPENFGA_GRPC_PORT:-18081}:8081"
+      - "127.0.0.1:${OPENFGA_PLAYGROUND_PORT:-13002}:3000"
+    healthcheck:
+      test:
+        - CMD
+        - /usr/local/bin/grpc_health_probe
+        - -addr=localhost:8081
+      interval: 5s
+      timeout: 30s
+      retries: 10
+
+  openfga-init:
+    build:
+      context: ./deploy/openfga/init
+    container_name: openfga-init
+    profiles:
+      - rbac
+    volumes:
+      - ./charts/ai-platform-engineering/charts/openfga/authorization-model.json:/app/authorization-model.json:ro
+    environment:
+      OPENFGA_HTTP: http://openfga:8080
+      OPENFGA_STORE_NAME: caipe-openfga
+      # Seed a dev allow tuple with a Keycloak user `sub`. If unset, OpenFGA
+      # starts deny-by-default and you can write tuples later.
+      OPENFGA_SEED_SUB: ${OPENFGA_SEED_SUB:-}
+    depends_on:
+      openfga:
+        condition: service_healthy
+
+  openfga-authz-bridge:
+    build:
+      context: ./deploy/openfga/bridge
+    container_name: openfga-authz-bridge
+    restart: unless-stopped
+    profiles:
+      - rbac
+    environment:
+      OPENFGA_HTTP: http://openfga:8080
+      OPENFGA_STORE_NAME: caipe-openfga
+      OPENFGA_RELATION: can_call
+      OPENFGA_OBJECT: mcp_gateway:list
+      OPENFGA_BYPASS_SUBS: ${OPENFGA_BYPASS_SUBS:-}
+      # JWT validation config so the bridge can DECODE the caller's bearer and
+      # detect service accounts (preferred_username starts "service-account-", T002)
+      # → namespace service_account:<sub> vs user:<sub>. Without these,
+      # _decode_verified_bearer_claims returns None, SA detection is always False,
+      # and SA tool calls are mis-graphed as user:<sub> → DENY_NO_CAPABILITY (#46).
+      # Values match the AgentGateway listener jwtAuth + every other service's OIDC
+      # config so the iss/aud claims validate identically.
+      JWT_JWKS_URL: ${BRIDGE_JWT_JWKS_URL:-http://keycloak:7080/realms/caipe/protocol/openid-connect/certs}
+      JWT_ISSUER: ${BRIDGE_JWT_ISSUER:-http://localhost:7080/realms/caipe}
+      JWT_AUDIENCES: ${BRIDGE_JWT_AUDIENCES:-caipe-platform,agentgateway}
+      CAIPE_AGENT_CONTEXT_HMAC_SECRET: ${CAIPE_AGENT_CONTEXT_HMAC_SECRET:-}
+      # Caller-keyed tool-authorization rollout flag (FR-012c). Default-off so
+      # prod/compose without the var keeps legacy agent-only tool enforcement;
+      # set CAIPE_CALLER_TOOL_CHECK_ENABLED=true (in .env) to enforce the dual
+      # agent+caller tool check for E2E.
+      CAIPE_CALLER_TOOL_CHECK_ENABLED: ${CAIPE_CALLER_TOOL_CHECK_ENABLED:-false}
+      MONGODB_URI: ${MONGODB_URI:-mongodb://${MONGODB_ROOT_USERNAME:-admin}:${MONGODB_ROOT_PASSWORD:-changeme}@caipe-mongodb:27017/${MONGODB_DATABASE:-caipe}?authSource=admin}
+      MONGODB_DATABASE: ${MONGODB_DATABASE:-caipe}
+      TENANT_ID: ${TENANT_ID:-default}
+      AUDIT_SUBJECT_SALT: ${AUDIT_SUBJECT_SALT:-caipe-098-audit}
+    ports:
+      - "127.0.0.1:${OPENFGA_BRIDGE_PORT:-9100}:9100"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import socket; socket.create_connection(('localhost', 9100), timeout=2).close()"
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    depends_on:
+      openfga-init:
+        condition: service_completed_successfully
+      openfga:
+        condition: service_healthy
+
+  agentgateway-config-bridge:
+    build:
+      context: ./deploy/agentgateway
+      dockerfile: Dockerfile.config-bridge
+    image: ghcr.io/cnoe-io/agentgateway-config-bridge:${IMAGE_TAG:-0.5.14}
+    container_name: agentgateway-config-bridge
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    profiles:
+      - rbac
+    environment:
+      AGENTGATEWAY_TARGETS_URL: ${AGENTGATEWAY_TARGETS_URL:-http://caipe-ui:3000/api/internal/agentgateway/mcp-targets}
+      AGENTGATEWAY_TARGETS_TOKEN: ${AGENTGATEWAY_TARGETS_TOKEN:-agentgateway-config-bridge-dev-token}
+      AGENTGATEWAY_CONFIG_PATH: /generated/config.yaml
+      AGENTGATEWAY_BOOTSTRAP_CONFIG_PATH: /bootstrap/config.yaml
+      AGENTGATEWAY_ADMIN_CONFIG_URL: http://agentgateway:15000/config
+      AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS: ${AGENTGATEWAY_CONFIG_BRIDGE_POLL_SECONDS:-5}
+      AGENTGATEWAY_LOG_LEVEL: ${AGENTGATEWAY_LOG_LEVEL:-info}
+      LOG_LEVEL: ${AGENTGATEWAY_CONFIG_BRIDGE_LOG_LEVEL:-INFO}
+    volumes:
+      - agentgateway_config:/generated
+      - ./deploy/agentgateway/config.yaml:/bootstrap/config.yaml:ro
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - |
+          from pathlib import Path
+          import json
+          import sys
+          import yaml
+
+          config_path = Path("/generated/config.yaml")
+          marker_path = Path("/generated/.reconcile_ok")
+          if not config_path.is_file() or config_path.stat().st_size <= 0 or not marker_path.is_file():
+              sys.exit(1)
+          text = config_path.read_text(encoding="utf-8")
+          try:
+              json.loads(text)
+          except json.JSONDecodeError:
+              try:
+                  parsed = yaml.safe_load(text)
+              except yaml.YAMLError:
+                  sys.exit(1)
+              if not isinstance(parsed, dict):
+                  sys.exit(1)
+          sys.exit(0)
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    depends_on:
+      caipe-ui:
+        condition: service_started
+        required: false
+
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:v1.1.0
+    container_name: agentgateway
+    restart: unless-stopped
+    command: ["--file", "/etc/agentgateway/config.yaml"]
+    environment:
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN:-}
+      GITLAB_PERSONAL_ACCESS_TOKEN: ${GITLAB_PERSONAL_ACCESS_TOKEN:-${GITLAB_TOKEN:-}}
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    profiles:
+      - rbac
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      # Wait for the IdP broker + spec-104 role bundle to be seeded before
+      # AG starts validating tokens — otherwise the very first request after
+      # `compose up` can race the seed and 403 a user who SHOULD have roles.
+      keycloak-init:
+        condition: service_completed_successfully
+      # Token-exchange is for Slack bot OBO, not AgentGateway — do not block AG on it.
+      openfga-authz-bridge:
+        condition: service_healthy
+      agentgateway-config-bridge:
+        condition: service_healthy
+    ports:
+      - "4000:4000"
+      - "127.0.0.1:15000:15000" # Admin UI (config.config.adminAddr)
+    volumes:
+      - agentgateway_config:/etc/agentgateway:ro
+    tmpfs:
+      - /tmp
+    healthcheck:
+      disable: true
+
+
 volumes:
-  caipe_ui_mongodb_data:
+  mongodb_data:
     driver: local
-  caipe_ui_mongodb_config:
+  mongodb_config:
     driver: local
   langfuse_postgres_data:
     driver: local
@@ -1304,4 +1481,10 @@ volumes:
   milvus_minio:
     driver: local
   milvus_data:
+    driver: local
+  openfga_postgres_data:
+    driver: local
+  agentgateway_config:
+    driver: local
+  keycloak_postgres_data:
     driver: local


### PR DESCRIPTION
## Summary

- Align `docker-compose.yaml` with the dev compose all-in-one shape: supervisor plus MCP servers, production UI profile, RAG/web ingestor, MongoDB, dynamic agents, and the OSS RBAC stack.
- Update `.env.example` for a vanilla OSS/local Keycloak setup using image tag `0.5.14` and the requested profile set.
- Add the `web_ingestor` profile alias to `docker-compose.dev.yaml` so the requested profile spelling selects the web ingestor.

## Why

The production compose file had fallen behind the dev compose file and still exposed remote sub-agent services and older image defaults. The example env also reflected a less self-contained setup. This makes the public example and compose profile set match the desired all-in-one deployment path.

## Validation

- `COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor" docker compose --env-file .env.example -f docker-compose.yaml config --services`
- `COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor" docker compose --env-file .env.example -f docker-compose.dev.yaml config --services`