### PR TITLE
chore(compose): align oss all-in-one stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,9 @@
 
 IMAGE_TAG=0.5.14
 
-# Start the supervisor in all-in-one mode with MCP servers, RAG, RBAC,
-# MongoDB, the production UI image, dynamic agents, bots, and web ingestion.
-COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor
+# Start the supervisor in all-in-one mode with MCP servers, production UI,
+# dynamic agents, local Keycloak/RBAC, MongoDB, and RAG.
+COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
 
 # All-in-one mode: do not start remote A2A sub-agent containers.
 DISTRIBUTED_AGENTS=

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # OSS ALL-IN-ONE DOCKER COMPOSE DEFAULTS
 # =============================================================================
 
-IMAGE_TAG=0.5.14
+IMAGE_TAG=0.5.16
 
 # Start the supervisor in all-in-one mode with MCP servers, production UI,
 # dynamic agents, local Keycloak/RBAC, MongoDB, and RAG.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,8 @@ Each component has its own environment variables - see `env.example` in `ui/` an
 AI agents operating in this repository **must** follow these rules on every commit:
 
 1. **No AI sign-off** - `Signed-off-by` is a human DCO certification. AI agents must never invent, assume, or add this trailer on their own.
-2. **Use Sri's DCO on every commit** - Every commit must include:
- ```
- Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
- ```
-3. **Do not invent identities** - Use only the DCO identity above unless Sri explicitly provides a different one.
+2. **Use an explicit human DCO on every commit** - Every commit must include the `Signed-off-by` trailer that the human contributor explicitly provided.
+3. **Do not invent identities** - Use only a DCO identity explicitly provided by the human contributor.
 
 ## Git Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,26 +34,20 @@ Each component has its own environment variables - see `env.example` in `ui/` an
 - No wall of text.
 - Remove words that do not change decisions.
 
-## DCO and AI Attribution Policy
-
-**Authority**: Linux kernel [AI Coding Assistants policy](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst)
+## DCO Policy
 
 AI agents operating in this repository **must** follow these rules on every commit:
 
 1. **No AI sign-off** - `Signed-off-by` is a human DCO certification. AI agents must never invent, assume, or add this trailer on their own.
-2. **Explicit human approval is required** - Before creating any commit with `Signed-off-by`, ask whether the human signs off that exact commit and receive an explicit yes in the current chat session.
-3. **No approval means no signed commit** - If explicit sign-off approval is absent or unclear, do not create a signed-off commit. Tell the human that DCO will fail until a human sign-off is added.
-4. **Use only the configured human identity after approval** - If the human explicitly signs off, use the current git identity. Never override it, invent an identity, or sign off as the AI.
-5. **Always include or suggest `Assisted-by`** when code was materially AI-assisted:
+2. **Use Sri's DCO on every commit** - Every commit must include:
  ```
- Assisted-by: <agent>:<model>
+ Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
  ```
-The chat message granting sign-off approval is the audit record.
+3. **Do not invent identities** - Use only the DCO identity above unless Sri explicitly provides a different one.
 
 ## Git Guidelines
 
-- **Sign off every commit after human approval** - Use `git commit -s` only after the human explicitly confirms DCO sign-off for that commit.
-- **Conventional Commits** - Format: `type(scope): description`
+- **Conventional Commits for commits and PR titles** - Format: `type(scope): description`
   - Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
   - Example: `feat(rag): add userinfo caching`
 - **Branch naming** - Use `prebuild/` prefix for CI to build Docker images

--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ Access the UI at **http://localhost:3000** and the supervisor API at **http://lo
 The default `.env.example` uses image tag `0.5.14` and enables this profile set:
 
 ```bash
-COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor
+COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
 ```
 
-That starts the supervisor in all-in-one mode, the MCP server containers, production UI, local Keycloak/OpenFGA/AgentGateway RBAC, MongoDB, RAG, the web ingestor, and Slack/Webex bot services. Remote A2A sub-agent containers are not started by default.
+That starts the supervisor in all-in-one mode, the MCP server containers, production UI, dynamic agents, local Keycloak/OpenFGA/AgentGateway RBAC, MongoDB, and RAG. Remote A2A sub-agent containers are not started by default.
+
+Add `web_ingestor` when you want the web ingestion worker. Add `slack-bot` or `webex-bot` only when you want those bot integrations.
 
 ### Optional Profiles
 
@@ -105,6 +107,9 @@ docker compose --profile tracing up
 
 # With Graph RAG (adds Neo4j and ontology services)
 docker compose --profile graph_rag up
+
+# With web ingestion worker
+docker compose --profile web_ingestor up
 
 # Development mode (build from source)
 docker compose -f docker-compose.dev.yaml up --build

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker compose up
 
 Access the UI at **http://localhost:3000** and the supervisor API at **http://localhost:8000**.
 
-The default `.env.example` uses image tag `0.5.14` and enables this profile set:
+The default `.env.example` uses image tag `0.5.16` and enables this profile set:
 
 ```bash
 COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Together, these sub-agents enable users to perform complex operations using agen
 
 ## 🚀 Quick Start with Docker Compose
 
-Run CAIPE locally with a single command:
+Run CAIPE locally with the OSS all-in-one stack:
 
 ```bash
 # Clone the repository
@@ -79,13 +79,21 @@ cd ai-platform-engineering
 
 # Copy and configure environment variables
 cp .env.example .env
-# Edit .env with your API keys (OPENAI_API_KEY, etc.)
+# Edit .env with your LLM API key or local OpenAI-compatible endpoint.
 
-# Run CAIPE with the web UI
-docker compose --profile caipe-ui up
+# Run the stack described by .env.example
+docker compose up
 ```
 
-Access the UI at **http://localhost:3001** and the API at **http://localhost:8000**.
+Access the UI at **http://localhost:3000** and the supervisor API at **http://localhost:8000**.
+
+The default `.env.example` uses image tag `0.5.14` and enables this profile set:
+
+```bash
+COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor
+```
+
+That starts the supervisor in all-in-one mode, the MCP server containers, production UI, local Keycloak/OpenFGA/AgentGateway RBAC, MongoDB, RAG, the web ingestor, and Slack/Webex bot services. Remote A2A sub-agent containers are not started by default.
 
 ### Optional Profiles
 
@@ -93,40 +101,41 @@ Enable additional features with profiles:
 
 ```bash
 # With tracing (Langfuse)
-docker compose --profile caipe-ui --profile tracing up
+docker compose --profile tracing up
 
-# With RAG (knowledge base)
-docker compose --profile caipe-ui --profile rag up
+# With Graph RAG (adds Neo4j and ontology services)
+docker compose --profile graph_rag up
 
 # Development mode (build from source)
-docker compose -f docker-compose.dev.yaml --profile caipe-ui up --build
+docker compose -f docker-compose.dev.yaml up --build
 ```
 
 ### Deployment Modes
 
-CAIPE supports two deployment modes:
+CAIPE supports all-in-one, distributed, and hybrid supervisor modes:
 
 | Mode | Description | Use Case |
 |------|-------------|----------|
-| **Multi-Node** (default) | Supervisor orchestrates multiple remote sub-agents via A2A protocol | Production, scalable deployments |
-| **Single-Node** | All agents run in-process with MCP tools via stdio transport | Development, simpler deployments |
+| **All-in-one** (default) | Supervisor runs agents in-process and connects to MCP server containers | OSS local deployments, VM deployments, demos |
+| **Distributed** | Supervisor orchestrates remote sub-agent containers via A2A | Scale-out testing and specialized deployments |
+| **Hybrid** | Only selected agents run remotely | Gradual migration or debugging |
 
-#### Single-Node Mode
+#### All-in-One Mode
 
-All-in-one (single-node) mode runs everything in a single container, making it ideal for development and simpler deployments:
+All-in-one mode leaves `DISTRIBUTED_AGENTS` empty and starts MCP servers instead of sub-agent containers:
 
 ```bash
-# Run all-in-one mode
-docker compose -f docker-compose.single-node.yaml --profile caipe-ui up
+# Image-based stack
+docker compose up
 
 # Development mode — all-in-one (build from source)
-docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile caipe-mongodb --profile caipe-ui up --build
+docker compose -f docker-compose.dev.yaml up --build
 
 # Development mode — fully distributed (all agents as separate A2A containers)
-DISTRIBUTED_AGENTS=all docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile caipe-mongodb --profile caipe-ui up --build
+DISTRIBUTED_AGENTS=all docker compose -f docker-compose.dev.yaml --profile all-agents up --build
 
 # Development mode — hybrid (only specific agents distributed)
-DISTRIBUTED_AGENTS=argocd,github docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile caipe-mongodb --profile caipe-ui up --build
+DISTRIBUTED_AGENTS=argocd,github docker compose -f docker-compose.dev.yaml --profile argocd --profile github up --build
 ```
 
 The supervisor mode is controlled by the `DISTRIBUTED_AGENTS` environment variable:
@@ -136,21 +145,22 @@ The supervisor mode is controlled by the `DISTRIBUTED_AGENTS` environment variab
 
 ##### All-in-One with RAG (Knowledge Base)
 
-Enable RAG services to give the agent access to ingested knowledge bases:
+RAG is included in the default profile set. Use `graph_rag` only when you also want Neo4j-backed graph relationships:
 
 ```bash
-# All-in-one with RAG (no graph database)
-docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile caipe-mongodb --profile rag --profile caipe-ui up --build
+# Vector RAG, included by default
+docker compose up
 
 # All-in-one with full Graph RAG (includes Neo4j)
-docker compose -f docker-compose.dev.yaml --profile caipe-supervisor --profile caipe-mongodb --profile graph_rag --profile caipe-ui up --build
+docker compose --profile graph_rag up
 ```
 
 **RAG Profiles:**
 
 | Profile | Services Included | Use Case |
 |---------|-------------------|----------|
-| `rag` | rag_server, web_ingestor, milvus, redis | Vector search without graph relationships |
+| `rag` | rag-server, milvus, redis | Vector search without graph relationships |
+| `web_ingestor` / `web-ingestor` | web-ingestor | Web datasource ingestion worker |
 | `graph_rag` | All `rag` services + Neo4j, agent_ontology | Full knowledge graph with entity relationships |
 
 **Ingesting Content:**
@@ -166,16 +176,12 @@ curl -X POST http://localhost:9446/v1/datasources \
 
 The agent will automatically use the knowledge base when answering questions about ingested content.
 
-#### Multi-Node Mode (Default)
+#### Distributed Mode
 
-Multi-node mode runs a supervisor agent that orchestrates specialized sub-agents as separate services:
+Distributed mode runs a supervisor that orchestrates specialized sub-agents as separate services:
 
 ```bash
-# Run multi-node mode (default docker-compose.yaml)
-docker compose --profile caipe-ui up
-
-# Development mode with multi-node
-docker compose -f docker-compose.dev.yaml --profile caipe-ui up --build
+DISTRIBUTED_AGENTS=all docker compose -f docker-compose.dev.yaml --profile all-agents up --build
 ```
 
 ### Kubernetes Deployment

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
   #                                 CAIPE Supervisor Deep Agent                                      #
   ####################################################################################################
   caipe-supervisor:
-    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.5.16}
     container_name: caipe-supervisor
     volumes:
       - ${PROMPT_CONFIG_PATH:-./charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml}:/app/prompt_config.yaml
@@ -159,7 +159,7 @@ services:
       - mcp-servers
 
   mcp-backstage:
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.5.16}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -181,7 +181,7 @@ services:
   # ArgoCD MCP
 
   mcp-argocd:
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.5.16}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -219,7 +219,7 @@ services:
   # Jira MCP
 
   mcp-jira:
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.5.16}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -241,7 +241,7 @@ services:
   # Komodor MCP
 
   mcp-komodor:
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.5.16}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -262,7 +262,7 @@ services:
   # PagerDuty MCP
 
   mcp-pagerduty:
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.5.16}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -312,7 +312,7 @@ services:
   # Splunk
 
   mcp-splunk:
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.5.16}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -334,7 +334,7 @@ services:
   # Webex
 
   mcp-webex:
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.5.16}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -356,7 +356,7 @@ services:
   # NetUtils MCP
 
   mcp-netutils:
-    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.5.16}
     container_name: mcp-netutils
     env_file: [.env]
     ports: ["18011:8000"]
@@ -434,7 +434,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.14}-prod
+    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.16}-prod
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -508,7 +508,7 @@ services:
   #                                      RAG Services                                                #
   ####################################################################################################
   rag-server:
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.5.16}
     container_name: rag-server
     # Network alias keeps the legacy `rag_server` hostname working for any
     # client that still has it hardcoded. AGW's hickory-dns resolver rejects
@@ -560,7 +560,7 @@ services:
   # Ports:
   #   - 8100: Dynamic Agents API (proxied via UI at /api/dynamic-agents)
   dynamic-agents:
-    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-0.5.16}
     container_name: dynamic-agents
     ports: ["8100:8001"]
     volumes:
@@ -601,7 +601,7 @@ services:
       - dynamic-agents
 
   agent_ontology:
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.5.16}
     container_name: agent_ontology
     ports: ["8098:8098"]
     environment:
@@ -620,7 +620,7 @@ services:
 
 
   web_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.16}
     container_name: web-ingestor
     environment:
       - INGESTOR_TYPE=webloader
@@ -637,7 +637,7 @@ services:
       - web_ingestor
 
   jira_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.16}
     container_name: jira-ingestor
     environment:
       - INGESTOR_TYPE=jira
@@ -969,7 +969,7 @@ services:
   #                                 Slack Bot Integration                                            #
   ####################################################################################################
   slack-bot:
-    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-0.5.16}
     container_name: slack-bot
     env_file: [.env]
     ports: ["8030:3000"]
@@ -994,7 +994,7 @@ services:
   #                                 Webex Bot Integration                                            #
   ####################################################################################################
   webex-bot:
-    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-0.5.16}
     container_name: webex-bot
     env_file: [.env]
     ports: ["8032:3002"]
@@ -1363,7 +1363,7 @@ services:
     build:
       context: ./deploy/agentgateway
       dockerfile: Dockerfile.config-bridge
-    image: ghcr.io/cnoe-io/agentgateway-config-bridge:${IMAGE_TAG:-0.5.14}
+    image: ghcr.io/cnoe-io/agentgateway-config-bridge:${IMAGE_TAG:-0.5.16}
     container_name: agentgateway-config-bridge
     restart: unless-stopped
     read_only: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -633,8 +633,6 @@ services:
     restart: unless-stopped
     depends_on: [rag-server]
     profiles:
-      - rag
-      - graph_rag
       - web-ingestor
       - web_ingestor
 

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -23,11 +23,11 @@ Set up CAIPE on a laptop or VM (e.g. EC2) using Docker Compose.
 
    Edit `.env` with your LLM configuration. The checked-in example is an OSS
    all-in-one profile set that starts the supervisor, MCP servers, production UI,
-   local RBAC, MongoDB, RAG, web ingestion, and bot services:
+   dynamic agents, local Keycloak/RBAC, MongoDB, and RAG:
 
    ```bash
    IMAGE_TAG=0.5.14
-   COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor
+   COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
 
    # All-in-one mode: agents run in-process and use MCP server containers.
    DISTRIBUTED_AGENTS=
@@ -105,6 +105,9 @@ docker compose up
 
 Open the UI at **http://localhost:3000** and the supervisor API at **http://localhost:8000**.
 
+Add `web_ingestor` when you want the web ingestion worker. Add `slack-bot` or
+`webex-bot` only when you want those bot integrations.
+
 **Primary profiles:**
 
 | Profile | Description |
@@ -141,6 +144,9 @@ docker compose --profile tracing up
 
 # Add graph RAG
 docker compose --profile graph_rag up
+
+# Add the web ingestion worker
+docker compose --profile web_ingestor up
 
 # Build from source with the same profile set
 docker compose -f docker-compose.dev.yaml up --build

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -21,25 +21,25 @@ Set up CAIPE on a laptop or VM (e.g. EC2) using Docker Compose.
    cp .env.example .env
    ```
 
-   Edit `.env` with your configuration. Minimal example:
+   Edit `.env` with your LLM configuration. The checked-in example is an OSS
+   all-in-one profile set that starts the supervisor, MCP servers, production UI,
+   local RBAC, MongoDB, RAG, web ingestion, and bot services:
 
    ```bash
-   ########### CAIPE Agent Configuration ###########
+   IMAGE_TAG=0.5.14
+   COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,slack-bot,webex-bot,web_ingestor
 
-   # Enable the agents you want to deploy
+   # All-in-one mode: agents run in-process and use MCP server containers.
+   DISTRIBUTED_AGENTS=
+
+   # Enable the tools you want the supervisor to expose.
    ENABLE_GITHUB=true
 
-   # A2A transport configuration (p2p or slim)
-   A2A_TRANSPORT=p2p
+   # LLM provider (openai, azure-openai, aws-bedrock)
+   LLM_PROVIDER=openai
+   OPENAI_API_KEY=<token>
 
-   # MCP mode configuration (http or stdio)
-   MCP_MODE=http
-
-   # LLM provider (anthropic-claude, aws-bedrock, openai, azure-openai)
-   LLM_PROVIDER=anthropic-claude
-   ANTHROPIC_API_KEY=sk-ant-...
-
-   ########### GitHub Agent Configuration ###########
+   # GitHub MCP server token, if GitHub tools are enabled.
    GITHUB_PERSONAL_ACCESS_TOKEN=<token>
    ```
 
@@ -96,47 +96,75 @@ Set up CAIPE on a laptop or VM (e.g. EC2) using Docker Compose.
 
 ## Start CAIPE
 
-Use Docker Compose **profiles** to enable specific agents. If no profile is specified, only the supervisor starts.
+Use Docker Compose **profiles** to select services. The default `.env.example`
+starts the OSS all-in-one stack:
 
-**Available agent profiles:**
+```bash
+docker compose up
+```
+
+Open the UI at **http://localhost:3000** and the supervisor API at **http://localhost:8000**.
+
+**Primary profiles:**
 
 | Profile | Description |
 |---------|-------------|
-| `argocd` | ArgoCD GitOps for Kubernetes deployments |
-| `aws` | AWS cloud operations |
-| `backstage` | Backstage developer portal |
-| `confluence` | Confluence documentation |
-| `github` | GitHub repos and pull requests |
-| `jira` | Jira issue tracking |
-| `komodor` | Komodor Kubernetes troubleshooting |
-| `pagerduty` | PagerDuty incident management |
-| `rag` | RAG knowledge base (Milvus, Neo4j, Redis) |
-| `slack` | Slack messaging |
-| `splunk` | Splunk observability |
-| `webex` | Webex collaboration |
+| `caipe-supervisor` | Supervisor API and all-in-one agent runtime |
+| `mcp-servers` | MCP server containers used by all-in-one agents |
+| `caipe-ui-prod` | Production CAIPE UI image |
+| `caipe-mongodb` | MongoDB for UI, RBAC, dynamic agents, and checkpoint data |
+| `rbac` | Local Keycloak, OpenFGA, AgentGateway, and config bridge |
+| `dynamic-agents` | Dynamic agent runtime used by the UI |
+| `rag` | Vector RAG services (Milvus, Redis, RAG server) |
+| `web_ingestor` / `web-ingestor` | Web datasource ingestion worker |
+| `slack-bot` | Slack bot integration service |
+| `webex-bot` | Webex bot integration service |
 | `slim` | AGNTCY Slim dataplane (set `A2A_TRANSPORT=slim`) |
 | `tracing` | Langfuse distributed tracing (Clickhouse, Postgres) |
+
+Domain profiles such as `github`, `argocd`, `jira`, `slack`, and `webex` are
+kept as compatibility aliases for individual MCP services. In all-in-one mode,
+prefer `mcp-servers` plus the matching `ENABLE_*` flags instead of starting
+remote sub-agent containers.
 
 **Examples:**
 
 ```bash
-# Supervisor only
+# Default OSS all-in-one stack from .env
 docker compose up
 
-# Single agent
-COMPOSE_PROFILES="github" docker compose up
+# Render the selected services without starting them
+docker compose config --services
 
-# Multiple agents
-COMPOSE_PROFILES="argocd,aws,backstage" docker compose up
+# Add tracing
+docker compose --profile tracing up
 
-# With RAG knowledge base
-COMPOSE_PROFILES="github,rag" docker compose up
+# Add graph RAG
+docker compose --profile graph_rag up
 
-# With tracing
-COMPOSE_PROFILES="github,tracing" docker compose up
+# Build from source with the same profile set
+docker compose -f docker-compose.dev.yaml up --build
+```
 
-# Full stack: agents + RAG + tracing
-COMPOSE_PROFILES="github,rag,tracing" docker compose up
+### Deployment modes
+
+The supervisor mode is controlled by `DISTRIBUTED_AGENTS`:
+
+| Value | Mode |
+|-------|------|
+| empty | All-in-one; agents run in-process and call MCP server containers |
+| `all` | Fully distributed; all agents run as remote A2A containers |
+| comma-separated agent names | Hybrid; only listed agents run remotely |
+
+```bash
+# All-in-one, the default in .env.example
+DISTRIBUTED_AGENTS= docker compose up
+
+# Fully distributed in the dev compose file
+DISTRIBUTED_AGENTS=all docker compose -f docker-compose.dev.yaml --profile all-agents up --build
+
+# Hybrid example
+DISTRIBUTED_AGENTS=argocd,github docker compose -f docker-compose.dev.yaml --profile argocd --profile github up --build
 ```
 
 ---
@@ -163,10 +191,10 @@ The `tracing` profile starts Langfuse v3 (web UI, worker, ClickHouse, Postgres, 
 
 1. Start with tracing:
    ```bash
-   COMPOSE_PROFILES="github,tracing" docker compose up
+   docker compose --profile tracing up
    ```
 
-2. Open Langfuse at **http://localhost:3000**, create an account, and copy the API keys.
+2. Open Langfuse at **http://localhost:3001**, create an account, and copy the API keys.
 
 3. Add to `.env` and restart:
    ```bash

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -26,7 +26,7 @@ Set up CAIPE on a laptop or VM (e.g. EC2) using Docker Compose.
    dynamic agents, local Keycloak/RBAC, MongoDB, and RAG:
 
    ```bash
-   IMAGE_TAG=0.5.14
+   IMAGE_TAG=0.5.16
    COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
 
    # All-in-one mode: agents run in-process and use MCP server containers.


### PR DESCRIPTION
## Summary

- Align `docker-compose.yaml` with the dev compose path for the OSS all-in-one deployment.
- Update `.env.example` to use image tag `0.5.16` and a minimal default profile set: MCP servers, production UI, supervisor, dynamic agents, Keycloak/RBAC, MongoDB, and RAG.
- Keep Slack/Webex bots and the web ingestion worker as optional profiles instead of default services.
- Remove AI attribution guidance from agent instructions and document DCO/conventional-commit requirements.
- Update README and Docker Compose docs with the minimal profile set and optional profile examples.

## Validation

- `COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" docker compose --env-file .env.example -f docker-compose.yaml config --services`
- `COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" docker compose --env-file .env.example -f docker-compose.dev.yaml config --services`
- `npm --prefix docs run build`


## Related Issue

Closes #1888

Root cause: production compose defaulted `caipe-rag-ingestors` to `IMAGE_TAG:-0.2.36`, which predates the Jira RAG ingestor added in `959627ace` / PR #988. Tag `0.5.16` contains `ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/jira/ingestor.py`.


