### PR TITLE
test(rbac): add identity sync browser regression

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -366,6 +366,7 @@ jobs:
             e2e/rbac/rbac-admin-regression.spec.ts \
             e2e/rbac/mcp-openfga-tuples.spec.ts \
             e2e/rbac/admin-settings-regression.spec.ts \
+            e2e/rbac/identity-sync-regression.spec.ts \
             --config=playwright.rbac.config.ts
 
       - name: Upload Playwright artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.5"
+version = "0.5.15-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/README.md
+++ b/ui/e2e/rbac/README.md
@@ -13,6 +13,7 @@ CAIPE + Keycloak stack:
 | `workflow-agent-access.spec.ts` | Mocked browser regression for workflow run access and denied agent-access grants. |
 | `rbac-admin-regression.spec.ts` | Mocked browser regression for the Permissions Tool and RBAC Audit export UX. |
 | `mcp-openfga-tuples.spec.ts` | Mocked browser regression for team MCP resource saves and MCP server list visibility. |
+| `identity-sync-regression.spec.ts` | Mocked browser regression for the Identity Sync admin tab and manual Okta sync trigger path. |
 | `service-accounts.spec.ts` | Mocked browser regression for Service Accounts create, see-once credential reveal, scope manage, rotate, and revoke UX. |
 | `slack-run-as.spec.ts` | Mocked browser regression for Slack route “Run as Service Account” selection and route-save payload. |
 | `slack-bff-user-directory-live.spec.ts` | Live-stack Slack bot service-account regression for BFF user-directory lookup, federation metadata, validation guardrails, and IdP broker summary. |
@@ -77,7 +78,7 @@ Keycloak/OpenFGA fixture data:
 
        RUN_RBAC_REGRESSION=1 \
        CAIPE_UI_BASE_URL=http://localhost:3000 \
-       npx playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/service-accounts.spec.ts e2e/rbac/slack-run-as.spec.ts --config=playwright.rbac.config.ts
+       npx playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/service-accounts.spec.ts e2e/rbac/admin-settings-regression.spec.ts e2e/rbac/identity-sync-regression.spec.ts e2e/rbac/slack-run-as.spec.ts --config=playwright.rbac.config.ts
 
 ## MCP OpenFGA tuple regression
 

--- a/ui/e2e/rbac/identity-sync-regression.spec.ts
+++ b/ui/e2e/rbac/identity-sync-regression.spec.ts
@@ -1,0 +1,169 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  fulfillJson,
+  installMockedRbacApp,
+  mockedRbacEnabled,
+  type MockRouteHandler,
+} from "./_mocked-rbac";
+
+const adminSession = {
+  email: "sraradhy@cisco.com",
+  name: "Sri Aradhyula",
+  role: "admin" as const,
+  canViewAdmin: true,
+};
+
+function identitySyncStatus(runs: unknown[] = []) {
+  return {
+    success: true,
+    data: {
+      provider: "okta",
+      connectors: [{ id: "okta", label: "Okta", implemented: true }],
+      provider_configured: true,
+      health: { ok: true, mode: "api_token" },
+      settings: {
+        provider_id: "okta",
+        enabled: true,
+        schedule_mode: "interval",
+        sync_interval_minutes: 60,
+        sync_cron: "",
+        group_filter: "",
+        updated_at: "2026-06-17T00:00:00.000Z",
+        updated_by: "playwright",
+      },
+      recent_runs: runs,
+    },
+  };
+}
+
+async function installIdentitySyncMock(page: Page) {
+  const requests: Array<{ method: string; path: string; search: string }> = [];
+  let statusCalls = 0;
+  let triggered = false;
+
+  const handler: MockRouteHandler = async ({ route, path, method, url }) => {
+    if (!path.startsWith("/api/admin/identity-group-sync/directory-sync")) {
+      return false;
+    }
+
+    requests.push({ method, path, search: url.search });
+
+    if (path.endsWith("/status") && method === "GET") {
+      statusCalls += 1;
+      await fulfillJson(
+        route,
+        identitySyncStatus(
+          triggered
+            ? [
+                {
+                  id: "run-okta-manual",
+                  provider_id: "okta",
+                  status: "running",
+                  started_at: "2026-06-17T00:01:00.000Z",
+                  triggered_by: "manual",
+                  triggered_by_user: adminSession.email,
+                  group_filter: "",
+                  groups_fetched: 2,
+                  membership_sources_added: 0,
+                  membership_sources_removed: 0,
+                  progress_scanned: 1,
+                  progress_total: 2,
+                },
+              ]
+            : [],
+        ),
+      );
+      return true;
+    }
+
+    if (path.endsWith("/trigger") && method === "POST") {
+      triggered = true;
+      await fulfillJson(route, { success: true, data: { run_id: "run-okta-manual" } });
+      return true;
+    }
+
+    if (path.endsWith("/settings") && method === "PUT") {
+      await fulfillJson(route, { success: true });
+      return true;
+    }
+
+    return false;
+  };
+
+  await installMockedRbacApp(page, {
+    isAdmin: true,
+    session: adminSession,
+    gates: { identity_group_sync: true },
+    handlers: [handler],
+  });
+
+  return {
+    requests,
+    statusCalls: () => statusCalls,
+  };
+}
+
+async function enableIdentitySyncTab(page: Page) {
+  await page.addInitScript(() => {
+    let appConfig: Record<string, unknown> | undefined;
+
+    Object.defineProperty(window, "__APP_CONFIG__", {
+      configurable: true,
+      get() {
+        return appConfig;
+      },
+      set(value) {
+        appConfig = {
+          ...(value as Record<string, unknown>),
+          oktaSyncEnabled: true,
+        };
+      },
+    });
+  });
+}
+
+test.describe("mocked identity sync browser regression", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run the mocked RBAC browser regression.",
+    );
+  });
+
+  test("opens Identity Sync and triggers Okta sync through the admin surface", async ({ page }) => {
+    await enableIdentitySyncTab(page);
+    const mock = await installIdentitySyncMock(page);
+
+    await page.goto("/admin?cat=people&tab=identity-sync", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByRole("button", { name: "Teams & Users" })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("tab", { name: "Identity Sync" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByText("Okta Connector Status")).toBeVisible();
+    await expect(page.getByText("Verified")).toBeVisible();
+    await expect(page.getByText("Every hour").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Run sync now" }).click();
+
+    await expect(page.getByText("Running").first()).toBeVisible();
+    await expect(page.getByText("Scanning members (1/2)")).toBeVisible();
+    await expect
+      .poll(() =>
+        mock.requests.some(
+          (request) =>
+            request.method === "POST" &&
+            request.path === "/api/admin/identity-group-sync/directory-sync/trigger" &&
+            request.search === "?provider=okta",
+        ),
+      )
+      .toBe(true);
+    await expect.poll(() => mock.statusCalls()).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "jest --coverage",
     "init-credential-indexes": "ts-node --project tsconfig.json ../scripts/init-credential-mongo-indexes.ts",
     "test:e2e:rbac": "playwright test --config=playwright.rbac.config.ts",
-    "test:e2e:rbac-regression": "WORKFLOWS_ENABLED=true playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/service-accounts.spec.ts e2e/rbac/admin-settings-regression.spec.ts e2e/rbac/slack-run-as.spec.ts --config=playwright.rbac.config.ts",
+    "test:e2e:rbac-regression": "WORKFLOWS_ENABLED=true playwright test e2e/rbac/workflow-agent-access.spec.ts e2e/rbac/rbac-admin-regression.spec.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/service-accounts.spec.ts e2e/rbac/admin-settings-regression.spec.ts e2e/rbac/identity-sync-regression.spec.ts e2e/rbac/slack-run-as.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-mcp": "RUN_RBAC_E2E=1 playwright test e2e/rbac/mcp-server-create-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-openfga": "RUN_RBAC_E2E=1 playwright test e2e/rbac/openfga-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-slack-bff": "RUN_RBAC_E2E=1 playwright test e2e/rbac/slack-bff-user-directory-live.spec.ts --config=playwright.rbac.config.ts",

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev5"
+version = "0.5.15.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Summary

- Add a mocked Playwright regression for the Identity Sync admin tab.
- Verify the Okta manual sync trigger path and running progress state.
- Include the spec in the mocked RBAC regression npm script and CI workflow.

## Context

PR #1881 has already merged, so this carries the E2E coverage as a clean follow-up against `main`.

## Validation

- `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3000 npx playwright test e2e/rbac/identity-sync-regression.spec.ts --config=playwright.rbac.config.ts`
