### PR TITLE
feat(admin): scope teams, users, stats, and feedback for non-admin users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.15-dev.6"
+version = "0.5.15-dev.7"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -218,6 +218,11 @@ interface Team {
   // the team, server-decorated from team_membership_sources. Drives the
   // "synced from <IdP>" badge so synced teams are distinguishable from manual.
   idp_source_types?: string[];
+  // Per-row management gate, server-decorated from OpenFGA. True for org/super
+  // admins on every team and for team admins on the teams they own. Drives
+  // the "Manage team" vs "View team" affordance on the team card so that team
+  // admins (without admin_ui#view) still get the manage entry-point.
+  can_manage?: boolean;
   members?: Array<{
     user_id: string;
     role: string;
@@ -1717,14 +1722,12 @@ function AdminPage() {
                           <div className="mt-4">
                             <Button
                               size="sm"
-                              variant={isAdmin ? "default" : "outline"}
+                              variant={(isAdmin || team.can_manage) ? "default" : "outline"}
                               className="w-full gap-1.5"
-                              onClick={() =>
-                                openTeamDialog(team, isAdmin ? "details" : "details")
-                              }
+                              onClick={() => openTeamDialog(team, "details")}
                             >
                               <Settings className="h-3.5 w-3.5" />
-                              {isAdmin ? "Manage team" : "View team"}
+                              {(isAdmin || team.can_manage) ? "Manage team" : "View team"}
                             </Button>
                           </div>
                         </CardContent>

--- a/ui/src/app/api/__tests__/admin-feedback.test.ts
+++ b/ui/src/app/api/__tests__/admin-feedback.test.ts
@@ -50,6 +50,11 @@ const mockCheckPermission = jest.requireMock<{ checkPermission: jest.Mock }>(
   '@/lib/rbac/keycloak-authz'
 ).checkPermission;
 
+const mockGetReadableSlackChannelNames = jest.fn<Promise<string[]>, [string]>();
+jest.mock('@/lib/rbac/user-insights-scope', () => ({
+  getReadableSlackChannelNames: (...args: any[]) => mockGetReadableSlackChannelNames(...args),
+}));
+
 let mockFeedbackEnabled = true;
 jest.mock('@/lib/config', () => ({
   getConfig: (key: string) => {
@@ -137,6 +142,15 @@ function userSession() {
   return {
     user: { email: 'user@example.com', name: 'User' },
     role: 'user',
+    sub: 'user-sub',
+    accessToken: accessTokenWithRoles(['chat_user']),
+  };
+}
+
+function userSessionNoSub() {
+  return {
+    user: { email: 'user@example.com', name: 'User' },
+    role: 'user',
     accessToken: accessTokenWithRoles(['chat_user']),
   };
 }
@@ -212,6 +226,8 @@ describe('GET /api/admin/feedback', () => {
     mockCheckPermission.mockReset();
     // Default to allow — individual tests override for deny scenarios.
     mockCheckPermission.mockResolvedValue({ allowed: true, reason: 'OK' });
+    mockGetReadableSlackChannelNames.mockReset();
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
     mockIsMongoDBConfigured = true;
     mockFeedbackEnabled = true;
   });
@@ -231,19 +247,101 @@ describe('GET /api/admin/feedback', () => {
     expect(res.status).toBe(401);
   });
 
-  // Spec 102 / FR-001 — route was migrated in T052 from withAuth-only to
-  // requireRbacPermission(session, 'admin_ui', 'view'). Non-admin users now
-  // hit a Keycloak PDP deny.
-  it('returns 403 for non-admin users (admin_ui#view denied)', async () => {
-    mockGetServerSession.mockResolvedValue(userSession());
+  // Non-admin users no longer get a hard 403; instead, the route returns
+  // feedback scoped to (a) Slack channels they can_read and (b) their own
+  // web feedback (matched by user_email).
+  it('returns 401 for non-admin users with no sub claim', async () => {
+    mockGetServerSession.mockResolvedValue(userSessionNoSub());
     mockCheckPermission.mockResolvedValue({
       allowed: false,
       reason: 'DENY_NO_CAPABILITY',
     });
     const res = await GET(makeRequest('/api/admin/feedback'));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.success).toBe(false);
+    expect(body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('scopes filter to user_email when non-admin has no readable channels', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockCheckPermission.mockResolvedValue({
+      allowed: false,
+      reason: 'DENY_NO_CAPABILITY',
+    });
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(200);
+    const filter = feedbackCol.find.mock.calls[0][0];
+    expect(filter.$or).toEqual([{ user_email: 'user@example.com' }]);
+    expect(mockGetReadableSlackChannelNames).toHaveBeenCalledWith('user:user-sub');
+  });
+
+  it('scopes filter to readable channels OR own email when non-admin has channels', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockCheckPermission.mockResolvedValue({
+      allowed: false,
+      reason: 'DENY_NO_CAPABILITY',
+    });
+    mockGetReadableSlackChannelNames.mockResolvedValue(['general', 'random']);
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(200);
+    const filter = feedbackCol.find.mock.calls[0][0];
+    expect(filter.$or).toEqual([
+      { source: 'slack', channel_name: { $in: ['general', 'random'] } },
+      { user_email: 'user@example.com' },
+    ]);
+  });
+
+  it('does not inject scope filter for full admin', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    await GET(makeRequest('/api/admin/feedback'));
+    const filter = feedbackCol.find.mock.calls[0][0];
+    expect(filter.$or).toBeUndefined();
+    expect(filter.$and).toBeUndefined();
+    expect(mockGetReadableSlackChannelNames).not.toHaveBeenCalled();
+  });
+
+  it('scopes distinct channel/user dropdowns to filter for non-admin', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockCheckPermission.mockResolvedValue({
+      allowed: false,
+      reason: 'DENY_NO_CAPABILITY',
+    });
+    mockGetReadableSlackChannelNames.mockResolvedValue(['general']);
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    await GET(makeRequest('/api/admin/feedback'));
+    const channelDistinctArgs = feedbackCol.distinct.mock.calls.find(
+      (call: any[]) => call[0] === 'channel_name'
+    );
+    const userDistinctArgs = feedbackCol.distinct.mock.calls.find(
+      (call: any[]) => call[0] === 'user_email'
+    );
+    expect(channelDistinctArgs?.[1].$or).toBeDefined();
+    expect(userDistinctArgs?.[1].$or).toBeDefined();
+  });
+
+  it('combines existing $or (search) with scope using $and for non-admin', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockCheckPermission.mockResolvedValue({
+      allowed: false,
+      reason: 'DENY_NO_CAPABILITY',
+    });
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    await GET(makeRequest('/api/admin/feedback?search=wrong'));
+    const filter = feedbackCol.find.mock.calls[0][0];
+    expect(filter.$and).toBeDefined();
+    expect(filter.$and).toHaveLength(2);
+    expect(filter.$or).toBeUndefined();
   });
 
   it('returns 503 when MongoDB is not configured', async () => {

--- a/ui/src/app/api/__tests__/admin-feedback.test.ts
+++ b/ui/src/app/api/__tests__/admin-feedback.test.ts
@@ -247,9 +247,9 @@ describe('GET /api/admin/feedback', () => {
     expect(res.status).toBe(401);
   });
 
-  // Non-admin users no longer get a hard 403; instead, the route returns
-  // feedback scoped to (a) Slack channels they can_read and (b) their own
-  // web feedback (matched by user_email).
+  // Non-admins are scoped, not denied — but a non-admin with no `sub` claim
+  // can't be scoped (no OpenFGA subject), so the route must 401 rather than
+  // fall through to an unscoped query.
   it('returns 401 for non-admin users with no sub claim', async () => {
     mockGetServerSession.mockResolvedValue(userSessionNoSub());
     mockCheckPermission.mockResolvedValue({

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -49,18 +49,16 @@ jest.mock('@/lib/rbac/audit', () => ({
   logAuthzDecision: jest.fn(),
 }));
 
-// Admin route handlers were retrofitted with the OpenFGA-backed
-// `requireAdminSurfaceManage`/`requireBaselineAdminSurfaceRead` gates from
-// `@/lib/rbac/require-openfga`, which calls `checkOpenFgaTuple` and rejects
-// any session without `sub`. Mock it so tests can drive allow/deny per
+// The OpenFGA gate (`requireAdminSurfaceManage`) calls `checkOpenFgaTuple` and
+// rejects any session without `sub`. Mock it so tests can drive allow/deny per
 // `tuple.user`.
 const mockCheckOpenFgaTuple = jest.fn();
 jest.mock('@/lib/rbac/openfga', () => ({
   checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
 }));
 
-// Stats route now scopes non-admins via getReadableSlackChannelNames; mock so
-// tests can drive which Slack channels a non-admin can see.
+// Non-admins are scoped via getReadableSlackChannelNames; mock so tests can
+// drive which Slack channels a non-admin can see.
 const mockGetReadableSlackChannelNames = jest.fn<Promise<string[]>, [string]>();
 jest.mock('@/lib/rbac/user-insights-scope', () => ({
   getReadableSlackChannelNames: (...args: unknown[]) =>
@@ -257,11 +255,10 @@ describe('GET /api/admin/stats — Authentication & Authorization', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns 200 with scoped data for non-admins (optimistic auth — no 403)', async () => {
-    // Stats is now optimistic: non-admins (no admin_surface:stats#can_manage)
-    // see only their own readable Slack channels and own web conversations.
-    // With no readable channels and the user's email present, the route still
-    // returns 200 — scoped to that user's email.
+  it('non-admins are scoped, not denied — returns 200 even with no readable channels', async () => {
+    // A non-admin (no admin_surface:stats#can_manage) is scoped rather than
+    // 403'd. With no readable Slack channels but a session email present, the
+    // view is scoped to that user's own web conversations.
     mockGetServerSession.mockResolvedValue(userSession());
     mockGetReadableSlackChannelNames.mockResolvedValue([]);
 
@@ -275,14 +272,10 @@ describe('GET /api/admin/stats — Authentication & Authorization', () => {
   });
 
   // ────────────────────────────────────────────────────────────────────────
-  // RBAC contract: full admin access still requires OpenFGA admin_surface:stats
-  // #can_manage. Non-admins are NOT denied — they get a scoped view limited
-  // to (a) Slack channels they can_read in OpenFGA and (b) their own web
-  // conversations (matched by owner_id == session email).
-  //
-  // The two assertions below pin that contract. Side-channels like
-  // `session.canViewAdmin` or the MongoDB `metadata.role: 'admin'` fallback
-  // do NOT grant admin scope; they only ever produce a non-admin scoped view.
+  // RBAC contract: full admin scope requires OpenFGA admin_surface:stats
+  // #can_manage. Side-channels (`session.canViewAdmin`, the MongoDB
+  // `metadata.role: 'admin'` fallback) must NOT grant admin scope — they only
+  // ever yield the non-admin scoped view. The two tests below pin that.
   // ────────────────────────────────────────────────────────────────────────
 
   it('viewer-only OIDC session (canViewAdmin) gets scoped view — NOT full admin', async () => {
@@ -896,7 +889,7 @@ describe('GET /api/admin/stats — Source & User Filters', () => {
 });
 
 // ============================================================================
-// Tests: Non-admin Scoping (optimistic auth + visibility boundary)
+// Tests: Non-admin Scoping (visibility boundary)
 // ============================================================================
 
 describe('GET /api/admin/stats — non-admin scoping', () => {
@@ -980,5 +973,113 @@ describe('GET /api/admin/stats — non-admin scoping', () => {
       return inspect.includes('admin@example.com');
     });
     expect(hasUserEmailScope).toBe(false);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Leak boundary: every aggregate in the payload must respect the scope, not
+  // just the conversation counts. Each test below pins one query family that
+  // would otherwise return platform-wide data to a non-admin.
+  // ──────────────────────────────────────────────────────────────────────
+
+  it('does not count platform-wide users — total_users derives from scoped conversations', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
+    const { usersCol } = setupNonAdminCollections();
+    // If the route read the users collection for total_users it would report 999.
+    usersCol.countDocuments.mockResolvedValue(999);
+
+    const req = makeRequest('/api/admin/stats');
+    const res = await GET(req);
+    const body = await res.json();
+    // Scoped conversations are empty in this fixture → 0, never the global 999.
+    expect(body.data.overview.total_users).toBe(0);
+    // The unscoped `users.countDocuments({})` headcount must not be used.
+    expect(usersCol.countDocuments).not.toHaveBeenCalledWith({});
+  });
+
+  it('scopes slack message counts by owner_id (messages carry no channel_name)', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue(['ops-help']);
+    const { msgCol } = setupNonAdminCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    await GET(req);
+
+    // Every slack-message query must carry the owner scope; none may run a bare
+    // { 'metadata.source': 'slack' } across the whole platform.
+    const slackMsgCalls = msgCol.countDocuments.mock.calls.filter(
+      (call: any[]) => call[0]?.['metadata.source'] === 'slack'
+    );
+    expect(slackMsgCalls.length).toBeGreaterThan(0);
+    for (const call of slackMsgCalls) {
+      expect(JSON.stringify(call[0])).toContain('user@example.com');
+    }
+  });
+
+  it('scopes the feedback summary to readable channels OR own email', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue(['ops-help']);
+    const { feedbackCol } = setupNonAdminCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    await GET(req);
+
+    // The feedback aggregations $match must embed the scope, not run globally.
+    const fbAggCalls = feedbackCol.aggregate.mock.calls;
+    expect(fbAggCalls.length).toBeGreaterThan(0);
+    const matchStage = fbAggCalls[0][0].find((s: any) => s.$match);
+    const inspect = JSON.stringify(matchStage);
+    expect(inspect).toContain('ops-help');
+    expect(inspect).toContain('user@example.com');
+  });
+
+  it('available_channels exposes only the readable set, never a platform-wide distinct', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue(['ops-help', 'ai-support']);
+    const { convCol } = setupNonAdminCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.data.available_channels.sort()).toEqual(['ai-support', 'ops-help']);
+    // No distinct over the channel name fields (which would enumerate every
+    // channel on the platform).
+    const distinctFields = convCol.distinct.mock.calls.map((c: any[]) => c[0]);
+    expect(distinctFields).not.toContain('slack_meta.channel_name');
+    expect(distinctFields).not.toContain('metadata.channel_name');
+  });
+
+  it('skips the Slack-block probe query when a non-admin has no readable channels', async () => {
+    // The Slack block is gated by a `countDocuments(SLACK_CONV_MATCH, {limit:1})`
+    // probe. A channel-less non-admin can see no Slack data, so that probe (and
+    // the whole block) must be skipped — never run platform-wide.
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
+    const { convCol } = setupNonAdminCollections();
+
+    await GET(makeRequest('/api/admin/stats'));
+
+    // The probe is the only countDocuments call that passes an options object
+    // ({ limit: 1 }) as its second argument.
+    const probeCalls = convCol.countDocuments.mock.calls.filter(
+      (call: any[]) => call[1]?.limit === 1
+    );
+    expect(probeCalls).toHaveLength(0);
+  });
+
+  it('runs the Slack-block probe when a non-admin has readable channels', async () => {
+    // Positive control for the test above — with at least one readable channel
+    // the probe must run (bounded, via slackChannelScope downstream).
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue(['ops-help']);
+    const { convCol } = setupNonAdminCollections();
+
+    await GET(makeRequest('/api/admin/stats'));
+
+    const probeCalls = convCol.countDocuments.mock.calls.filter(
+      (call: any[]) => call[1]?.limit === 1
+    );
+    expect(probeCalls.length).toBeGreaterThan(0);
   });
 });

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -59,6 +59,14 @@ jest.mock('@/lib/rbac/openfga', () => ({
   checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
 }));
 
+// Stats route now scopes non-admins via getReadableSlackChannelNames; mock so
+// tests can drive which Slack channels a non-admin can see.
+const mockGetReadableSlackChannelNames = jest.fn<Promise<string[]>, [string]>();
+jest.mock('@/lib/rbac/user-insights-scope', () => ({
+  getReadableSlackChannelNames: (...args: unknown[]) =>
+    mockGetReadableSlackChannelNames(...(args as [string])),
+}));
+
 const mockCheckPermission = jest.requireMock<{ checkPermission: jest.Mock }>(
   '@/lib/rbac/keycloak-authz'
 ).checkPermission;
@@ -164,6 +172,8 @@ function resetMocks() {
   mockCheckOpenFgaTuple.mockImplementation(async (tuple: { user?: string }) => ({
     allowed: tuple.user === 'user:admin-user-sub',
   }));
+  mockGetReadableSlackChannelNames.mockReset();
+  mockGetReadableSlackChannelNames.mockResolvedValue([]);
   Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
 }
 
@@ -178,6 +188,33 @@ function setupAdminWithCollections() {
   mockGetServerSession.mockResolvedValue(adminSession());
 
   // Users collection — no findOne needed for OIDC admin (session.role = 'admin')
+  const usersCol = createMockCollection();
+  usersCol.countDocuments.mockResolvedValue(0);
+  mockCollections['users'] = usersCol;
+
+  const convCol = createMockCollection();
+  convCol.countDocuments.mockResolvedValue(0);
+  mockCollections['conversations'] = convCol;
+
+  const msgCol = createMockCollection();
+  msgCol.countDocuments.mockResolvedValue(0);
+  mockCollections['messages'] = msgCol;
+
+  const feedbackCol = createMockCollection();
+  feedbackCol.countDocuments.mockResolvedValue(0);
+  mockCollections['feedback'] = feedbackCol;
+
+  const platformConfigCol = createMockCollection();
+  mockCollections['platform_config'] = platformConfigCol;
+
+  return { usersCol, convCol, msgCol, feedbackCol };
+}
+
+/**
+ * Setup non-admin collections — same shape as admin, but the caller (not us)
+ * is responsible for setting `mockGetServerSession` / `mockCheckOpenFgaTuple`.
+ */
+function setupNonAdminCollections() {
   const usersCol = createMockCollection();
   usersCol.countDocuments.mockResolvedValue(0);
   mockCollections['users'] = usersCol;
@@ -220,71 +257,68 @@ describe('GET /api/admin/stats — Authentication & Authorization', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns 403 when user lacks admin_ui#view (no admin realm role / PDP deny)', async () => {
+  it('returns 200 with scoped data for non-admins (optimistic auth — no 403)', async () => {
+    // Stats is now optimistic: non-admins (no admin_surface:stats#can_manage)
+    // see only their own readable Slack channels and own web conversations.
+    // With no readable channels and the user's email present, the route still
+    // returns 200 — scoped to that user's email.
     mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
 
-    const usersCol = createMockCollection();
-    usersCol.findOne.mockResolvedValue(null);
-    mockCollections['users'] = usersCol;
+    setupNonAdminCollections();
 
     const req = makeRequest('/api/admin/stats');
     const res = await GET(req);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission');
+    expect(body.success).toBe(true);
   });
 
   // ────────────────────────────────────────────────────────────────────────
-  // RBAC contract: Keycloak is the single source of truth for admin_ui#view.
+  // RBAC contract: full admin access still requires OpenFGA admin_surface:stats
+  // #can_manage. Non-admins are NOT denied — they get a scoped view limited
+  // to (a) Slack channels they can_read in OpenFGA and (b) their own web
+  // conversations (matched by owner_id == session email).
   //
-  // Older drafts of the admin layer let `session.canViewAdmin` (set from the
-  // OIDC view-only group) or the MongoDB `metadata.role: 'admin'` fallback
-  // grant access to read-only admin endpoints. Under the 098-enterprise-rbac
-  // spec we deprecated those side-channels for any endpoint guarded by
-  // `requireRbacPermission(...)` — only the access-token's `realm_access.roles`
-  // (and bootstrap-admin emails) can grant `admin_ui#view`.
-  //
-  // The two assertions below pin that contract. If you want to grant viewer
-  // access to /api/admin/stats, do it in Keycloak (give the user the `admin`
-  // realm role or assign `admin_ui#view` to a `viewer` realm role and add it
-  // to RESOURCE_ROLE_FALLBACK in api-middleware.ts).
+  // The two assertions below pin that contract. Side-channels like
+  // `session.canViewAdmin` or the MongoDB `metadata.role: 'admin'` fallback
+  // do NOT grant admin scope; they only ever produce a non-admin scoped view.
   // ────────────────────────────────────────────────────────────────────────
 
-  it('returns 403 for a viewer-only OIDC session (canViewAdmin alone is NOT honored by RBAC)', async () => {
-    // Pre-RBAC code paths used `session.canViewAdmin` to grant read-only admin
-    // access. Under Keycloak-only RBAC this MUST be ignored — the access
-    // token has no `admin` realm role, so `admin_ui#view` is denied.
+  it('viewer-only OIDC session (canViewAdmin) gets scoped view — NOT full admin', async () => {
     mockGetServerSession.mockResolvedValue({ ...userSession(), canViewAdmin: true });
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
 
-    const usersCol = createMockCollection();
-    usersCol.findOne.mockResolvedValue(null);
-    mockCollections['users'] = usersCol;
+    setupNonAdminCollections();
 
     const req = makeRequest('/api/admin/stats');
     const res = await GET(req);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission');
+    // The OpenFGA gate must have been consulted (and denied) — proving we
+    // didn't short-circuit on the side-channel.
+    expect(mockCheckOpenFgaTuple).toHaveBeenCalledWith(
+      expect.objectContaining({ user: 'user:regular-user-sub', relation: 'can_manage' })
+    );
+    expect(body.success).toBe(true);
   });
 
-  it('returns 403 when MongoDB has admin role but realm_access does not (Mongo fallback NOT honored by RBAC)', async () => {
-    // Pre-RBAC code paths upgraded `session.role` to 'admin' if the user's
-    // MongoDB profile said so. Under Keycloak-only RBAC this MUST be ignored —
-    // only realm_access.roles (and bootstrap emails) count.
+  it('MongoDB admin-role fallback gets scoped view — NOT full admin', async () => {
     mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
 
-    const usersCol = createMockCollection();
+    setupNonAdminCollections();
+    const usersCol = mockCollections['users'];
     usersCol.findOne.mockResolvedValue({
       email: 'user@example.com',
       metadata: { role: 'admin' },
     });
-    mockCollections['users'] = usersCol;
 
     const req = makeRequest('/api/admin/stats');
     const res = await GET(req);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toContain('You do not have permission');
+    expect(body.success).toBe(true);
   });
 
   it('returns 503 when MongoDB is not configured', async () => {
@@ -858,5 +892,93 @@ describe('GET /api/admin/stats — Source & User Filters', () => {
       (call: any[]) => call[0]?.owner_id?.$in?.includes('alice@co.com')
     );
     expect(hasUserFilter).toBe(true);
+  });
+});
+
+// ============================================================================
+// Tests: Non-admin Scoping (optimistic auth + visibility boundary)
+// ============================================================================
+
+describe('GET /api/admin/stats — non-admin scoping', () => {
+  beforeEach(resetMocks);
+
+  it('non-admin with readable channels: convSourceFilter ANDs in the channel scope', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue(['ops-help', 'ai-support']);
+
+    const { convCol } = setupNonAdminCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    expect(mockGetReadableSlackChannelNames).toHaveBeenCalledWith('user:regular-user-sub');
+
+    // Every conversations.countDocuments call must include the scope ($and).
+    // The scope clauses include $or with channel_name $in [readable channels]
+    // OR owner_id == session email.
+    const convCountCalls = convCol.countDocuments.mock.calls;
+    expect(convCountCalls.length).toBeGreaterThan(0);
+    const hasScope = convCountCalls.some((call: any[]) => {
+      const filter = call[0];
+      const inspect = JSON.stringify(filter ?? {});
+      return inspect.includes('ops-help') && inspect.includes('user@example.com');
+    });
+    expect(hasScope).toBe(true);
+  });
+
+  it('non-admin with no readable channels but has email: scopes by owner_id only', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
+
+    const { convCol } = setupNonAdminCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // owner_id scope must be applied to conversation queries
+    const convCountCalls = convCol.countDocuments.mock.calls;
+    const hasOwnerScope = convCountCalls.some((call: any[]) => {
+      const inspect = JSON.stringify(call[0] ?? {});
+      return inspect.includes('user@example.com');
+    });
+    expect(hasOwnerScope).toBe(true);
+  });
+
+  it('non-admin with no sub and no email: returns 401', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: '', name: '' },
+      role: 'user',
+      sub: '',
+      accessToken: accessTokenWithRoles(['chat_user']),
+    });
+
+    setupNonAdminCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('admin path is unaffected — no scope filter is applied', async () => {
+    const { convCol } = setupAdminWithCollections();
+
+    const req = makeRequest('/api/admin/stats');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    // Admin path must NOT call getReadableSlackChannelNames
+    expect(mockGetReadableSlackChannelNames).not.toHaveBeenCalled();
+
+    // No conversation query should embed the user's email as a scope
+    const convCountCalls = convCol.countDocuments.mock.calls;
+    const hasUserEmailScope = convCountCalls.some((call: any[]) => {
+      const inspect = JSON.stringify(call[0] ?? {});
+      return inspect.includes('admin@example.com');
+    });
+    expect(hasUserEmailScope).toBe(false);
   });
 });

--- a/ui/src/app/api/__tests__/admin-users.test.ts
+++ b/ui/src/app/api/__tests__/admin-users.test.ts
@@ -64,6 +64,7 @@ const mockListRealmRoleMappingsForUser = jest.fn();
 const mockGetUserFederatedIdentities = jest.fn();
 const mockGetRealmUserById = jest.fn();
 const mockIsValidTeamSlug = jest.fn();
+const mockFindRealmUsersByExactEmail = jest.fn();
 
 jest.mock('@/lib/rbac/keycloak-admin', () => ({
   searchRealmUsers: (...args: unknown[]) => mockSearchRealmUsers(...args),
@@ -75,6 +76,8 @@ jest.mock('@/lib/rbac/keycloak-admin', () => ({
     mockGetUserFederatedIdentities(...args),
   getRealmUserById: (...args: unknown[]) => mockGetRealmUserById(...args),
   isValidTeamSlug: (...args: unknown[]) => mockIsValidTeamSlug(...args),
+  findRealmUsersByExactEmail: (...args: unknown[]) =>
+    mockFindRealmUsersByExactEmail(...args),
 }));
 
 function makeRequest(url: string): NextRequest {
@@ -120,6 +123,8 @@ function resetMocks() {
   mockGetUserFederatedIdentities.mockReset();
   mockGetRealmUserById.mockReset();
   mockIsValidTeamSlug.mockReset();
+  mockFindRealmUsersByExactEmail.mockReset();
+  mockFindRealmUsersByExactEmail.mockResolvedValue([]);
   mockCheckPermission.mockReset();
   mockCheckOpenFgaTuple.mockReset();
   mockListOpenFgaObjects.mockReset();
@@ -366,21 +371,27 @@ describe("GET /api/admin/users — non-admin team-scoped view", () => {
     );
   }
 
-  function setMembershipDocs(docs: Array<{ user_email: string; status: string }>) {
-    const sortChain = { toArray: jest.fn().mockResolvedValue(docs) };
-    const findChain = { sort: jest.fn().mockReturnValue(sortChain) };
+  // Membership is resolved via `listActiveTeamMembershipSourcesBySlug`, which
+  // queries `team_membership_sources` by { team_slug, status: 'active' } — NOT
+  // by team_id. Keying these mocks by slug guards the prod bug where the slug
+  // from OpenFGA was passed to a team_id-keyed lookup and matched nobody.
+  function setMembershipBySlug(
+    bySlug: Record<string, string[]>
+  ) {
     mockGetCollection.mockImplementation((name: string) => {
       if (name === 'team_membership_sources') {
         return Promise.resolve({
-          find: jest.fn().mockReturnValue(findChain),
+          find: jest.fn().mockImplementation((filter: { team_slug?: string }) => {
+            const emails = bySlug[filter?.team_slug ?? ''] ?? [];
+            const docs = emails.map((user_email) => ({ user_email, status: 'active' }));
+            return { sort: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue(docs) }) };
+          }),
         });
       }
       return Promise.resolve({
         find: jest.fn().mockReturnValue({
           toArray: jest.fn().mockResolvedValue([]),
-          project: jest.fn().mockReturnValue({
-            toArray: jest.fn().mockResolvedValue([]),
-          }),
+          project: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
         }),
         findOne: jest.fn().mockResolvedValue(null),
         updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
@@ -388,32 +399,12 @@ describe("GET /api/admin/users — non-admin team-scoped view", () => {
     });
   }
 
-  function setMembershipDocsByTeam(
-    byTeam: Record<string, Array<{ user_email: string; status: string }>>
-  ) {
-    mockGetCollection.mockImplementation((name: string) => {
-      if (name === 'team_membership_sources') {
-        return Promise.resolve({
-          find: jest.fn().mockImplementation((filter: { team_id?: string }) => {
-            const docs = byTeam[filter?.team_id ?? ''] ?? [];
-            return {
-              sort: jest.fn().mockReturnValue({
-                toArray: jest.fn().mockResolvedValue(docs),
-              }),
-            };
-          }),
-        });
-      }
-      return Promise.resolve({
-        find: jest.fn().mockReturnValue({
-          toArray: jest.fn().mockResolvedValue([]),
-          project: jest.fn().mockReturnValue({
-            toArray: jest.fn().mockResolvedValue([]),
-          }),
-        }),
-        findOne: jest.fn().mockResolvedValue(null),
-        updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
-      });
+  // Resolve each member email to a realm user via the indexed exact-email
+  // lookup (mirrors prod, where we no longer scan the whole realm).
+  function resolveUsersByEmail(byEmail: Record<string, { id: string }>) {
+    mockFindRealmUsersByExactEmail.mockImplementation(async (email: string) => {
+      const u = byEmail[email];
+      return u ? [{ id: u.id, username: email.split('@')[0], email, attributes: {} }] : [];
     });
   }
 
@@ -423,19 +414,15 @@ describe("GET /api/admin/users — non-admin team-scoped view", () => {
     mockNonAdminAuth();
   });
 
-  it("returns scoped:'team' and team members when non-admin belongs to a team", async () => {
+  it("returns scoped:'team' with the members of the user's team", async () => {
     mockListOpenFgaObjects.mockResolvedValue({ objects: ['team:platform-eng'] });
-    setMembershipDocs([
-      { user_email: 'alice@example.com', status: 'active' },
-      { user_email: 'bob@example.com', status: 'active' },
-    ]);
-    mockSearchRealmUsers
-      .mockResolvedValueOnce([
-        { id: 'u-alice', username: 'alice', email: 'alice@example.com', attributes: {} },
-        { id: 'u-bob', username: 'bob', email: 'bob@example.com', attributes: {} },
-        { id: 'u-carol', username: 'carol', email: 'carol@example.com', attributes: {} },
-      ])
-      .mockResolvedValueOnce([]);
+    setMembershipBySlug({
+      'platform-eng': ['alice@example.com', 'bob@example.com'],
+    });
+    resolveUsersByEmail({
+      'alice@example.com': { id: 'u-alice' },
+      'bob@example.com': { id: 'u-bob' },
+    });
 
     const res = await GET(makeRequest('/api/admin/users'));
     expect(res.status).toBe(200);
@@ -444,6 +431,10 @@ describe("GET /api/admin/users — non-admin team-scoped view", () => {
     const emails = body.users.map((u: { email: string }) => u.email).sort();
     expect(emails).toEqual(['alice@example.com', 'bob@example.com']);
     expect(body.total).toBe(2);
+    // Perf contract: members are resolved by exact email, never by a full
+    // realm scan.
+    expect(mockFindRealmUsersByExactEmail).toHaveBeenCalledWith('alice@example.com');
+    expect(mockSearchRealmUsers).not.toHaveBeenCalled();
   });
 
   it("returns scoped:'self' for non-admin with no team memberships", async () => {
@@ -466,34 +457,48 @@ describe("GET /api/admin/users — non-admin team-scoped view", () => {
     expect(mockSearchRealmUsers).not.toHaveBeenCalled();
   });
 
-  it("returns union of members across multiple teams", async () => {
+  it("returns scoped:'self' when team memberships resolve to zero members", async () => {
+    // OpenFGA reports a team, but the canonical store has no active members for
+    // its slug (e.g. the slug→id keying bug, or all members deactivated). The
+    // route must fall back to self rather than return an empty list.
+    mockListOpenFgaObjects.mockResolvedValue({ objects: ['team:ghost-team'] });
+    setMembershipBySlug({});
+    mockGetRealmUserById.mockResolvedValue({
+      id: 'user-sub',
+      email: 'user@example.com',
+      username: 'user',
+      enabled: true,
+      attributes: {},
+    });
+
+    const res = await GET(makeRequest('/api/admin/users'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scoped).toBe('self');
+    expect(body.users.map((u: { email: string }) => u.email)).toEqual(['user@example.com']);
+  });
+
+  it("unions members across teams and de-duplicates users in multiple teams", async () => {
     mockListOpenFgaObjects.mockResolvedValue({
       objects: ['team:team-a', 'team:team-b'],
     });
-    setMembershipDocsByTeam({
-      'team-a': [
-        { user_email: 'alice@example.com', status: 'active' },
-        { user_email: 'dave@example.com', status: 'active' },
-      ],
-      'team-b': [
-        { user_email: 'alice@example.com', status: 'active' },
-        { user_email: 'dave@example.com', status: 'active' },
-      ],
+    setMembershipBySlug({
+      'team-a': ['alice@example.com', 'dave@example.com'],
+      'team-b': ['alice@example.com', 'erin@example.com'],
     });
-    mockSearchRealmUsers
-      .mockResolvedValueOnce([
-        { id: 'u-alice', username: 'alice', email: 'alice@example.com', attributes: {} },
-        { id: 'u-dave', username: 'dave', email: 'dave@example.com', attributes: {} },
-        { id: 'u-eve', username: 'eve', email: 'eve@example.com', attributes: {} },
-      ])
-      .mockResolvedValueOnce([]);
+    resolveUsersByEmail({
+      'alice@example.com': { id: 'u-alice' },
+      'dave@example.com': { id: 'u-dave' },
+      'erin@example.com': { id: 'u-erin' },
+    });
 
     const res = await GET(makeRequest('/api/admin/users'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.scoped).toBe('team');
     const emails = body.users.map((u: { email: string }) => u.email).sort();
-    expect(emails).toEqual(['alice@example.com', 'dave@example.com']);
-    expect(body.total).toBe(2);
+    // alice is in both teams but appears once.
+    expect(emails).toEqual(['alice@example.com', 'dave@example.com', 'erin@example.com']);
+    expect(body.total).toBe(3);
   });
 });

--- a/ui/src/app/api/__tests__/admin-users.test.ts
+++ b/ui/src/app/api/__tests__/admin-users.test.ts
@@ -28,8 +28,10 @@ jest.mock('@/lib/rbac/keycloak-authz', () => ({
 }));
 
 const mockCheckOpenFgaTuple = jest.fn();
+const mockListOpenFgaObjects = jest.fn();
 jest.mock('@/lib/rbac/openfga', () => ({
   checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+  listOpenFgaObjects: (...args: unknown[]) => mockListOpenFgaObjects(...args),
 }));
 
 jest.mock('@/lib/rbac/audit', () => ({
@@ -60,6 +62,8 @@ const mockCountRealmUsers = jest.fn();
 const mockListUsersWithRole = jest.fn();
 const mockListRealmRoleMappingsForUser = jest.fn();
 const mockGetUserFederatedIdentities = jest.fn();
+const mockGetRealmUserById = jest.fn();
+const mockIsValidTeamSlug = jest.fn();
 
 jest.mock('@/lib/rbac/keycloak-admin', () => ({
   searchRealmUsers: (...args: unknown[]) => mockSearchRealmUsers(...args),
@@ -69,6 +73,8 @@ jest.mock('@/lib/rbac/keycloak-admin', () => ({
     mockListRealmRoleMappingsForUser(...args),
   getUserFederatedIdentities: (...args: unknown[]) =>
     mockGetUserFederatedIdentities(...args),
+  getRealmUserById: (...args: unknown[]) => mockGetRealmUserById(...args),
+  isValidTeamSlug: (...args: unknown[]) => mockIsValidTeamSlug(...args),
 }));
 
 function makeRequest(url: string): NextRequest {
@@ -95,20 +101,34 @@ function userSession() {
 
 function resetMocks() {
   mockGetServerSession.mockReset();
-  mockGetCollection.mockClear();
+  mockGetCollection.mockReset();
   mockIsMongoDBConfigured = true;
   Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+  mockGetCollection.mockImplementation((name: string) => {
+    if (!mockCollections[name]) {
+      mockCollections[name] = {
+        find: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+        findOne: jest.fn().mockResolvedValue(null),
+      };
+    }
+    return Promise.resolve(mockCollections[name]);
+  });
   mockSearchRealmUsers.mockReset();
   mockCountRealmUsers.mockReset();
   mockListUsersWithRole.mockReset();
   mockListRealmRoleMappingsForUser.mockReset();
   mockGetUserFederatedIdentities.mockReset();
+  mockGetRealmUserById.mockReset();
+  mockIsValidTeamSlug.mockReset();
   mockCheckPermission.mockReset();
   mockCheckOpenFgaTuple.mockReset();
+  mockListOpenFgaObjects.mockReset();
   mockCheckPermission.mockResolvedValue({ allowed: true, reason: 'OK' });
   mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true, reason: 'OK' });
+  mockListOpenFgaObjects.mockResolvedValue({ objects: [] });
   mockListRealmRoleMappingsForUser.mockResolvedValue([{ name: 'user' }]);
   mockGetUserFederatedIdentities.mockResolvedValue([]);
+  mockIsValidTeamSlug.mockReturnValue(true);
 }
 
 import { GET } from '../admin/users/route';
@@ -331,5 +351,149 @@ describe('GET /api/admin/users — Keycloak list', () => {
       webex_link_status: 'linked',
     });
     expect(body.total).toBe(1);
+  });
+});
+
+describe("GET /api/admin/users — non-admin team-scoped view", () => {
+  // Mock pattern: baseline `admin_surface:users#can_read` allows; the
+  // org-level `admin_ui#view` (relation `can_audit` on `organization:caipe`)
+  // denies — so the route enters the `!hasAdminView` branch.
+  function mockNonAdminAuth() {
+    mockCheckOpenFgaTuple.mockImplementation(
+      async (t: { user: string; relation: string; object: string }) => ({
+        allowed: t.relation === 'can_read' && t.object === 'admin_surface:users',
+      })
+    );
+  }
+
+  function setMembershipDocs(docs: Array<{ user_email: string; status: string }>) {
+    const sortChain = { toArray: jest.fn().mockResolvedValue(docs) };
+    const findChain = { sort: jest.fn().mockReturnValue(sortChain) };
+    mockGetCollection.mockImplementation((name: string) => {
+      if (name === 'team_membership_sources') {
+        return Promise.resolve({
+          find: jest.fn().mockReturnValue(findChain),
+        });
+      }
+      return Promise.resolve({
+        find: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+          project: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+        findOne: jest.fn().mockResolvedValue(null),
+        updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      });
+    });
+  }
+
+  function setMembershipDocsByTeam(
+    byTeam: Record<string, Array<{ user_email: string; status: string }>>
+  ) {
+    mockGetCollection.mockImplementation((name: string) => {
+      if (name === 'team_membership_sources') {
+        return Promise.resolve({
+          find: jest.fn().mockImplementation((filter: { team_id?: string }) => {
+            const docs = byTeam[filter?.team_id ?? ''] ?? [];
+            return {
+              sort: jest.fn().mockReturnValue({
+                toArray: jest.fn().mockResolvedValue(docs),
+              }),
+            };
+          }),
+        });
+      }
+      return Promise.resolve({
+        find: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+          project: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+        findOne: jest.fn().mockResolvedValue(null),
+        updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      });
+    });
+  }
+
+  beforeEach(() => {
+    resetMocks();
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockNonAdminAuth();
+  });
+
+  it("returns scoped:'team' and team members when non-admin belongs to a team", async () => {
+    mockListOpenFgaObjects.mockResolvedValue({ objects: ['team:platform-eng'] });
+    setMembershipDocs([
+      { user_email: 'alice@example.com', status: 'active' },
+      { user_email: 'bob@example.com', status: 'active' },
+    ]);
+    mockSearchRealmUsers
+      .mockResolvedValueOnce([
+        { id: 'u-alice', username: 'alice', email: 'alice@example.com', attributes: {} },
+        { id: 'u-bob', username: 'bob', email: 'bob@example.com', attributes: {} },
+        { id: 'u-carol', username: 'carol', email: 'carol@example.com', attributes: {} },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest('/api/admin/users'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scoped).toBe('team');
+    const emails = body.users.map((u: { email: string }) => u.email).sort();
+    expect(emails).toEqual(['alice@example.com', 'bob@example.com']);
+    expect(body.total).toBe(2);
+  });
+
+  it("returns scoped:'self' for non-admin with no team memberships", async () => {
+    mockListOpenFgaObjects.mockResolvedValue({ objects: [] });
+    mockGetRealmUserById.mockResolvedValue({
+      id: 'user-sub',
+      email: 'user@example.com',
+      username: 'user',
+      enabled: true,
+      attributes: {},
+    });
+
+    const res = await GET(makeRequest('/api/admin/users'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scoped).toBe('self');
+    expect(body.total).toBe(1);
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].email).toBe('user@example.com');
+    expect(mockSearchRealmUsers).not.toHaveBeenCalled();
+  });
+
+  it("returns union of members across multiple teams", async () => {
+    mockListOpenFgaObjects.mockResolvedValue({
+      objects: ['team:team-a', 'team:team-b'],
+    });
+    setMembershipDocsByTeam({
+      'team-a': [
+        { user_email: 'alice@example.com', status: 'active' },
+        { user_email: 'dave@example.com', status: 'active' },
+      ],
+      'team-b': [
+        { user_email: 'alice@example.com', status: 'active' },
+        { user_email: 'dave@example.com', status: 'active' },
+      ],
+    });
+    mockSearchRealmUsers
+      .mockResolvedValueOnce([
+        { id: 'u-alice', username: 'alice', email: 'alice@example.com', attributes: {} },
+        { id: 'u-dave', username: 'dave', email: 'dave@example.com', attributes: {} },
+        { id: 'u-eve', username: 'eve', email: 'eve@example.com', attributes: {} },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest('/api/admin/users'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scoped).toBe('team');
+    const emails = body.users.map((u: { email: string }) => u.email).sort();
+    expect(emails).toEqual(['alice@example.com', 'dave@example.com']);
+    expect(body.total).toBe(2);
   });
 });

--- a/ui/src/app/api/admin/feedback/route.ts
+++ b/ui/src/app/api/admin/feedback/route.ts
@@ -128,7 +128,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           entries: [],
           channels: [],
           users: [],
-          pagination: { page: 1, limit: 50, total: 0, total_pages: 0 },
+          pagination: { page, limit, total: 0, total_pages: 0 },
         });
       }
       if (filter.$or) {

--- a/ui/src/app/api/admin/feedback/route.ts
+++ b/ui/src/app/api/admin/feedback/route.ts
@@ -11,6 +11,7 @@ withErrorHandler,
 } from '@/lib/api-middleware';
 import { getConfig } from '@/lib/config';
 import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
+import { getReadableSlackChannelNames } from '@/lib/rbac/user-insights-scope';
 import { NextRequest,NextResponse } from 'next/server';
 
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -33,7 +34,25 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   }
 
   const { session } = await getAuthFromBearerOrSession(request);
-  await requireRbacPermission(session, 'admin_ui', 'view');
+  const isFullAdmin = await requireRbacPermission(session, 'admin_ui', 'view').then(
+    () => true,
+    () => false
+  );
+
+  let scopedChannelNames: string[] | null = null;
+  let scopedOwnerEmail: string | null = null;
+  if (!isFullAdmin) {
+    const sub = typeof session.sub === 'string' ? session.sub.trim() : '';
+    const email = typeof session.user?.email === 'string' ? session.user.email.trim() : '';
+    if (!sub) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized', code: 'UNAUTHORIZED' },
+        { status: 401 }
+      );
+    }
+    scopedChannelNames = await getReadableSlackChannelNames(`user:${sub}`);
+    scopedOwnerEmail = email || null;
+  }
 
     const { searchParams } = new URL(request.url);
     const rating = searchParams.get('rating'); // 'positive' | 'negative' | null (all)
@@ -90,6 +109,44 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       if (to) filter.created_at.$lte = new Date(to);
     }
 
+    // Non-admin: scope to their readable Slack channels OR their own web feedback.
+    if (!isFullAdmin) {
+      const scopeClauses: Record<string, unknown>[] = [];
+      if (scopedChannelNames && scopedChannelNames.length > 0) {
+        scopeClauses.push({
+          source: 'slack',
+          channel_name: scopedChannelNames.length === 1
+            ? scopedChannelNames[0]
+            : { $in: scopedChannelNames },
+        });
+      }
+      if (scopedOwnerEmail) {
+        scopeClauses.push({ user_email: scopedOwnerEmail });
+      }
+      if (scopeClauses.length === 0) {
+        return successResponse({
+          entries: [],
+          channels: [],
+          users: [],
+          pagination: { page: 1, limit: 50, total: 0, total_pages: 0 },
+        });
+      }
+      if (filter.$or) {
+        const existingOr = filter.$or;
+        delete filter.$or;
+        filter.$and = [{ $or: existingOr }, { $or: scopeClauses }];
+      } else {
+        filter.$or = scopeClauses;
+      }
+    }
+
+    const channelDistinctFilter = isFullAdmin
+      ? { source: 'slack', channel_name: { $ne: null } }
+      : { ...filter, source: 'slack', channel_name: { $ne: null } };
+    const userDistinctFilter = isFullAdmin
+      ? { user_email: { $ne: null } }
+      : { ...filter, user_email: { $ne: null } };
+
     const [docs, totalCount, channels, distinctUsers] = await Promise.all([
       feedbackColl
         .find(filter)
@@ -98,8 +155,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         .limit(limit)
         .toArray(),
       feedbackColl.countDocuments(filter),
-      feedbackColl.distinct('channel_name', { source: 'slack', channel_name: { $ne: null } }),
-      feedbackColl.distinct('user_email', { user_email: { $ne: null } }),
+      feedbackColl.distinct('channel_name', channelDistinctFilter),
+      feedbackColl.distinct('user_email', userDistinctFilter),
     ]);
 
     // For web feedback that has a conversation_id, batch-fetch conversation titles

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -7,6 +7,7 @@ withErrorHandler,
 } from '@/lib/api-middleware';
 import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
 import { requireAdminSurfaceManage } from '@/lib/rbac/require-openfga';
+import { getReadableSlackChannelNames } from '@/lib/rbac/user-insights-scope';
 import { NextRequest,NextResponse } from 'next/server';
 
 /** Parse range params into a { rangeStart, days } pair. Supports preset strings and explicit from/to ISO dates. */
@@ -51,7 +52,22 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   }
 
   const { session } = await getAuthFromBearerOrSession(request);
-  await requireAdminSurfaceManage(session, 'stats');
+  const isFullAdmin = await requireAdminSurfaceManage(session, 'stats').then(() => true, () => false);
+
+  // Non-admin: scope to their readable Slack channels + their own web conversations.
+  let nonAdminScope: { channelNames: string[]; ownerEmail: string } | null = null;
+  if (!isFullAdmin) {
+    const sub = typeof session.sub === 'string' ? session.sub.trim() : '';
+    const email = typeof session.user?.email === 'string' ? session.user.email.trim() : '';
+    if (!sub && !email) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized', code: 'UNAUTHORIZED' },
+        { status: 401 }
+      );
+    }
+    const channelNames = sub ? await getReadableSlackChannelNames(`user:${sub}`) : [];
+    nonAdminScope = { channelNames, ownerEmail: email };
+  }
 
     const { searchParams } = new URL(request.url);
     const { rangeStart, days } = parseRange(searchParams);
@@ -94,6 +110,84 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     } else if (userEmails.length > 1) {
       convSourceFilter.owner_id = { $in: userEmails };
       msgOwnerFilter.owner_id = { $in: userEmails };
+    }
+
+    // Non-admin scope: restrict to their slack channels OR own web conversations.
+    if (nonAdminScope) {
+      const { channelNames: scopeChannelNames, ownerEmail } = nonAdminScope;
+      const scopeClauses: Record<string, unknown>[] = [];
+      if (scopeChannelNames.length > 0) {
+        const names = scopeChannelNames.length === 1 ? scopeChannelNames[0] : { $in: scopeChannelNames };
+        scopeClauses.push({
+          $and: [
+            { $or: [{ source: 'slack' }, { client_type: 'slack' }] },
+            { $or: [
+              { 'slack_meta.channel_name': names },
+              { 'metadata.channel_name': names },
+            ]},
+          ],
+        });
+      }
+      if (ownerEmail) scopeClauses.push({ owner_id: ownerEmail });
+
+      if (scopeClauses.length === 0) {
+        return successResponse({
+          range: searchParams.get('range') || '30d',
+          days,
+          platform_summary: { satisfaction_rate: 0, estimated_hours_automated: 0 },
+          overview: {
+            total_users: 0,
+            total_conversations: 0,
+            total_messages: 0,
+            shared_conversations: 0,
+            dau: 0,
+            mau: 0,
+            conversations_today: 0,
+            messages_today: 0,
+            avg_messages_per_conversation: 0,
+          },
+          daily_activity: [],
+          top_users: { by_conversations: [], by_messages: [] },
+          top_agents: [],
+          feedback_summary: {
+            positive: 0,
+            negative: 0,
+            total: 0,
+            satisfaction_rate: 0,
+            by_source: {},
+            categories: [],
+            daily: [],
+          },
+          response_time: { avg_ms: 0, min_ms: 0, max_ms: 0, sample_count: 0 },
+          hourly_heatmap: Array.from({ length: 24 }, (_, hour) => ({ hour, count: 0 })),
+          completed_workflows: {
+            total: 0,
+            today: 0,
+            interrupted: 0,
+            completion_rate: 0,
+            avg_messages_per_workflow: 0,
+          },
+          available_channels: [],
+        });
+      }
+
+      const scopeFilter = scopeClauses.length === 1 ? scopeClauses[0] : { $or: scopeClauses };
+      const existingConvKeys = Object.keys(convSourceFilter);
+      if (existingConvKeys.length > 0) {
+        const saved = { ...convSourceFilter };
+        for (const k of existingConvKeys) delete (convSourceFilter as Record<string, unknown>)[k];
+        (convSourceFilter as Record<string, unknown>).$and = [saved, scopeFilter];
+      } else {
+        Object.assign(convSourceFilter, scopeFilter);
+      }
+      const existingMsgKeys = Object.keys(msgOwnerFilter);
+      if (existingMsgKeys.length > 0) {
+        const saved = { ...msgOwnerFilter };
+        for (const k of existingMsgKeys) delete (msgOwnerFilter as Record<string, unknown>)[k];
+        (msgOwnerFilter as Record<string, unknown>).$and = [saved, scopeFilter];
+      } else {
+        Object.assign(msgOwnerFilter, scopeFilter);
+      }
     }
 
     const users = await getCollection('users');

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -38,6 +38,22 @@ function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: nu
   return { rangeStart: new Date(now.getTime() - ms), days: Math.max(1, Math.round(ms / (24 * 60 * 60 * 1000))) };
 }
 
+/**
+ * Merge `clause` into an existing Mongo filter without clobbering keys. When
+ * `target` already has conditions we wrap both in `$and` (rather than spreading,
+ * which would silently drop a duplicate key like `$or`). Mutates `target`.
+ */
+function andInto(target: Record<string, unknown>, clause: Record<string, unknown>): void {
+  const existingKeys = Object.keys(target);
+  if (existingKeys.length === 0) {
+    Object.assign(target, clause);
+    return;
+  }
+  const saved = { ...target };
+  for (const k of existingKeys) delete target[k];
+  target.$and = [saved, clause];
+}
+
 // GET /api/admin/stats
 export const GET = withErrorHandler(async (request: NextRequest) => {
   if (!isMongoDBConfigured) {
@@ -83,7 +99,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // Support both legacy (source/slack_meta) and new (client_type/metadata) schemas.
     const SLACK_CONV_MATCH = { $or: [{ source: 'slack' }, { client_type: 'slack' }] };
 
-    const hasFilters = !!sourceFilter || userEmails.length > 0;
+    // A non-admin view is always "filtered" — DAU/MAU and daily-user activity
+    // must derive from the scoped conversations, never from the platform-wide
+    // users collection (which would leak global active-user counts).
+    const hasFilters = !!sourceFilter || userEmails.length > 0 || !!nonAdminScope;
     const convSourceFilter: Record<string, any> = {};
     const msgOwnerFilter: Record<string, any> = {};
     if (sourceFilter === 'web') {
@@ -112,7 +131,16 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       msgOwnerFilter.owner_id = { $in: userEmails };
     }
 
-    // Non-admin scope: restrict to their slack channels OR own web conversations.
+    // Non-admin scope, reused by every query below so the whole payload stays
+    // within the caller's visibility:
+    //   - `nonAdminScopeFilter` matches conversations/web-messages the user may
+    //     see (their readable Slack channels OR their own web conversations).
+    //   - `nonAdminChannelNames` bounds Slack-channel-keyed queries (feedback,
+    //     the Slack block, available_channels). Slack docs in the `messages`
+    //     collection carry no channel_name, so Slack message counts can only
+    //     be bounded by owner_id via the shared scope filter.
+    let nonAdminScopeFilter: Record<string, unknown> | null = null;
+    const nonAdminChannelNames = nonAdminScope?.channelNames ?? [];
     if (nonAdminScope) {
       const { channelNames: scopeChannelNames, ownerEmail } = nonAdminScope;
       const scopeClauses: Record<string, unknown>[] = [];
@@ -171,23 +199,9 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         });
       }
 
-      const scopeFilter = scopeClauses.length === 1 ? scopeClauses[0] : { $or: scopeClauses };
-      const existingConvKeys = Object.keys(convSourceFilter);
-      if (existingConvKeys.length > 0) {
-        const saved = { ...convSourceFilter };
-        for (const k of existingConvKeys) delete (convSourceFilter as Record<string, unknown>)[k];
-        (convSourceFilter as Record<string, unknown>).$and = [saved, scopeFilter];
-      } else {
-        Object.assign(convSourceFilter, scopeFilter);
-      }
-      const existingMsgKeys = Object.keys(msgOwnerFilter);
-      if (existingMsgKeys.length > 0) {
-        const saved = { ...msgOwnerFilter };
-        for (const k of existingMsgKeys) delete (msgOwnerFilter as Record<string, unknown>)[k];
-        (msgOwnerFilter as Record<string, unknown>).$and = [saved, scopeFilter];
-      } else {
-        Object.assign(msgOwnerFilter, scopeFilter);
-      }
+      nonAdminScopeFilter = scopeClauses.length === 1 ? scopeClauses[0] : { $or: scopeClauses };
+      andInto(convSourceFilter, nonAdminScopeFilter);
+      andInto(msgOwnerFilter, nonAdminScopeFilter);
     }
 
     const users = await getCollection('users');
@@ -213,13 +227,21 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       slackMessagesToday,
       sharedConversations,
     ] = await Promise.all([
-      users.countDocuments({}),
+      // Non-admins must not see platform-wide headcount — derive their
+      // total_users from distinct owners of the conversations they can see.
+      nonAdminScope
+        ? conversations.aggregate([
+            { $match: { ...convSourceFilter } },
+            { $group: { _id: '$owner_id' } },
+            { $count: 'total' },
+          ]).toArray().then((r) => r[0]?.total || 0)
+        : users.countDocuments({}),
       conversations.countDocuments({ ...convSourceFilter }),
       sourceFilter !== 'slack'
         ? messages.countDocuments({ 'metadata.source': 'web', ...msgOwnerFilter })
         : Promise.resolve(0),
       sourceFilter !== 'web'
-        ? messages.countDocuments({ 'metadata.source': 'slack' })
+        ? messages.countDocuments({ 'metadata.source': 'slack', ...msgOwnerFilter })
         : Promise.resolve(0),
       // DAU/MAU: derive from conversations when filters are applied, otherwise from users
       hasFilters
@@ -241,16 +263,24 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         ? messages.countDocuments({ 'metadata.source': 'web', created_at: { $gte: today }, ...msgOwnerFilter })
         : Promise.resolve(0),
       sourceFilter !== 'web'
-        ? messages.countDocuments({ 'metadata.source': 'slack', created_at: { $gte: today } })
+        ? messages.countDocuments({ 'metadata.source': 'slack', created_at: { $gte: today }, ...msgOwnerFilter })
         : Promise.resolve(0),
-      conversations.countDocuments({
-        ...convSourceFilter,
-        $or: [
-          { 'sharing.is_public': true },
-          { 'sharing.shared_with.0': { $exists: true } },
-          { 'sharing.share_link_enabled': true },
-        ],
-      }),
+      // `andInto` rather than spreading a literal `$or` — the non-admin scope
+      // can itself be an `$or`, which a spread would clobber (leaking shared
+      // conversation counts outside the caller's scope).
+      conversations.countDocuments(
+        (() => {
+          const sharedFilter: Record<string, unknown> = { ...convSourceFilter };
+          andInto(sharedFilter, {
+            $or: [
+              { 'sharing.is_public': true },
+              { 'sharing.shared_with.0': { $exists: true } },
+              { 'sharing.share_link_enabled': true },
+            ],
+          });
+          return sharedFilter;
+        })()
+      ),
     ]);
 
     const totalMessages = webTotalMessages + slackTotalMessages;
@@ -273,6 +303,22 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
     if (userEmails.length === 1) fbFilter.user_email = userEmails[0];
     else if (userEmails.length > 1) fbFilter.user_email = { $in: userEmails };
+
+    // Non-admin: feedback is keyed by channel_name (slack) / user_email (web),
+    // so scope it directly rather than via the conversation-shaped scope filter.
+    if (nonAdminScope) {
+      const fbScope: Record<string, unknown>[] = [];
+      if (nonAdminChannelNames.length > 0) {
+        fbScope.push({
+          source: 'slack',
+          channel_name: nonAdminChannelNames.length === 1
+            ? nonAdminChannelNames[0]
+            : { $in: nonAdminChannelNames },
+        });
+      }
+      if (nonAdminScope.ownerEmail) fbScope.push({ user_email: nonAdminScope.ownerEmail });
+      andInto(fbFilter, fbScope.length === 1 ? fbScope[0] : { $or: fbScope });
+    }
 
     const [
       dailyUserActivity,
@@ -324,7 +370,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       // Daily slack messages
       sourceFilter !== 'web'
         ? messages.aggregate([
-            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart } } },
+            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
             { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, messages: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -420,17 +466,21 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       // Hourly heatmap: slack
       sourceFilter !== 'web'
         ? messages.aggregate([
-            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart } } },
+            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
             { $addFields: { _ts: { $toDate: '$created_at' } } },
             { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
 
-      // Available channel names (both schema variants)
-      Promise.all([
-        conversations.distinct('slack_meta.channel_name', { source: 'slack', 'slack_meta.channel_name': { $ne: null } }),
-        conversations.distinct('metadata.channel_name', { client_type: 'slack', 'metadata.channel_name': { $ne: null } }),
-      ]),
+      // Available channel names (both schema variants). Non-admins get exactly
+      // their readable channels (resolved after this batch) — a platform-wide
+      // distinct would enumerate every channel name, so skip it for them.
+      nonAdminScope
+        ? Promise.resolve([[], []] as [string[], string[]])
+        : Promise.all([
+            conversations.distinct('slack_meta.channel_name', { source: 'slack', 'slack_meta.channel_name': { $ne: null } }),
+            conversations.distinct('metadata.channel_name', { client_type: 'slack', 'metadata.channel_name': { $ne: null } }),
+          ]),
 
       // Web agent message count for hours-automated estimate
       sourceFilter !== 'slack'
@@ -580,10 +630,17 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // ═══════════════════════════════════════════════════════════════
     let slack: any = undefined;
 
+    // Slack block channel scope: admins use the `channel` query param; a
+    // non-admin is hard-bounded to their readable channels (their web
+    // conversations don't appear in this Slack-only section). A non-admin with
+    // no readable channels sees no Slack block at all.
+    const slackChannelScope = nonAdminScope ? nonAdminChannelNames : channelNames;
+    const skipSlackBlock = !!nonAdminScope && nonAdminChannelNames.length === 0;
+
     try {
       const slackFilter: Record<string, any> = { ...SLACK_CONV_MATCH, created_at: { $gte: rangeStart } };
-      if (channelNames.length > 0) {
-        const names = channelNames.length === 1 ? channelNames[0] : { $in: channelNames };
+      if (slackChannelScope.length > 0) {
+        const names = slackChannelScope.length === 1 ? slackChannelScope[0] : { $in: slackChannelScope };
         // Override $or with $and to combine slack match + channel match
         delete slackFilter.$or;
         slackFilter.$and = [
@@ -593,7 +650,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         ];
         delete slackFilter.created_at;
       }
-      const slackHasData = await conversations.countDocuments(SLACK_CONV_MATCH, { limit: 1 });
+      const slackHasData = skipSlackBlock ? 0 : await conversations.countDocuments(SLACK_CONV_MATCH, { limit: 1 });
 
       if (slackHasData > 0) {
         const platformConfig = await getCollection('platform_config');
@@ -684,10 +741,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
             {
               source: 'slack',
               created_at: { $gte: rangeStart },
-              ...(channelNames.length === 1
-                ? { channel_name: channelNames[0] }
-                : channelNames.length > 1
-                  ? { channel_name: { $in: channelNames } }
+              ...(slackChannelScope.length === 1
+                ? { channel_name: slackChannelScope[0] }
+                : slackChannelScope.length > 1
+                  ? { channel_name: { $in: slackChannelScope } }
                   : {}),
             },
             { projection: { conversation_id: 1, rating: 1, created_at: 1 } },
@@ -790,7 +847,9 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const totalHoursAutomated = Math.round((webHoursAutomated + slackHoursSaved) * 10) / 10;
 
     const [oldChannels, newChannels] = availableChannelsResult;
-    const availableChannels = [...new Set([...oldChannels, ...newChannels])];
+    const availableChannels = nonAdminScope
+      ? [...new Set(nonAdminChannelNames)]
+      : [...new Set([...oldChannels, ...newChannels])];
 
     const platformSummary = {
       satisfaction_rate: feedbackSummary.satisfaction_rate || 0,

--- a/ui/src/app/api/admin/teams/route.ts
+++ b/ui/src/app/api/admin/teams/route.ts
@@ -4,11 +4,13 @@
 import {
 ApiError,
 getAuthFromBearerOrSession,
+requireRbacPermission,
 successResponse,
 withErrorHandler,
 } from '@/lib/api-middleware';
 import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
 import { isValidTeamSlug } from '@/lib/rbac/keycloak-admin';
+import { listOpenFgaObjects } from '@/lib/rbac/openfga';
 import { requireAdminSurfaceManage,requireBaselineAdminSurfaceRead } from '@/lib/rbac/require-openfga';
 import { upsertTeamMembershipSource } from '@/lib/rbac/team-membership-source-store';
 import { loadTeamIdpSourceTypes,loadTeamMemberCounts } from '@/lib/rbac/team-membership-store';
@@ -61,12 +63,51 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const { session } = await getAuthFromBearerOrSession(request);
   await requireBaselineAdminSurfaceRead(session, 'teams');
 
+  // Mirror the per-row access pattern from PR #1883 (Slack channels). Org/super
+  // admins keep the unscoped view; everyone else only sees teams they're a
+  // member of, with `can_manage` flipped on for teams where they're a team
+  // admin. Failures resolving membership fail-closed so a transiently broken
+  // PDP can't accidentally leak the full team list to a regular user.
+  const hasAdminView = await requireRbacPermission(session, 'admin_ui', 'view').then(
+    () => true,
+    () => false
+  );
+
+  let memberSlugs = new Set<string>();
+  let adminSlugs = new Set<string>();
+  if (!hasAdminView) {
+    const sub = typeof session.sub === 'string' ? session.sub.trim() : '';
+    if (sub) {
+      try {
+        const [memberResult, adminResult] = await Promise.all([
+          listOpenFgaObjects({ user: `user:${sub}`, relation: 'member', type: 'team' }),
+          listOpenFgaObjects({ user: `user:${sub}`, relation: 'admin', type: 'team' }),
+        ]);
+        memberSlugs = new Set(
+          memberResult.objects.map((obj) => obj.split(':').slice(1).join(':')).filter(Boolean)
+        );
+        adminSlugs = new Set(
+          adminResult.objects.map((obj) => obj.split(':').slice(1).join(':')).filter(Boolean)
+        );
+      } catch {
+        // fail-closed: no teams visible
+      }
+    }
+  }
+
   const teams = await getCollection('teams');
 
   const allTeams = await teams
     .find({})
     .sort({ created_at: -1 })
     .toArray();
+
+  const visibleTeams = hasAdminView
+    ? allTeams
+    : allTeams.filter((team) => {
+        const slug = typeof team.slug === 'string' ? team.slug : '';
+        return slug ? memberSlugs.has(slug) : false;
+      });
 
   // Commit 4/8 of the canonical-team-membership refactor (spec
   // 2026-05-26-canonical-team-membership): instead of returning
@@ -76,7 +117,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   // query. This is a tracer-bullet step — the legacy team.members[]
   // payload is still emitted so older UI revisions and integration
   // tests keep working until commit 5/8 drops the embedded array.
-  const slugs = allTeams
+  const slugs = visibleTeams
     .map((team) => (typeof team.slug === 'string' ? team.slug : ''))
     .filter((slug): slug is string => slug.length > 0);
   const memberCounts = slugs.length > 0 ? await loadTeamMemberCounts(slugs) : new Map<string, number>();
@@ -92,7 +133,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   // has KBs assigned (issue #1642 follow-up). We count distinct kb_ids per
   // team in a single query, falling back to the legacy doc field when no
   // ownership row exists yet.
-  const teamIdStrings = allTeams.map((team) => team._id.toString());
+  const teamIdStrings = visibleTeams.map((team) => team._id.toString());
   const kbCounts = new Map<string, number>();
   if (teamIdStrings.length > 0) {
     const ownership = await getCollection<{ team_id?: string; kb_ids?: string[] }>('team_kb_ownership');
@@ -106,7 +147,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
   }
 
-  const teamsWithCounts = allTeams.map((team) => {
+  const teamsWithCounts = visibleTeams.map((team) => {
     const slug = typeof team.slug === 'string' ? team.slug : '';
     const idStr = team._id.toString();
     const legacyKbCount = Array.isArray(team.resources?.knowledge_bases)
@@ -117,6 +158,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       member_count: slug ? memberCounts.get(slug) ?? 0 : 0,
       kb_count: kbCounts.get(idStr) ?? legacyKbCount,
       idp_source_types: slug ? idpSourceTypes.get(slug) ?? [] : [],
+      can_manage: hasAdminView || (slug ? adminSlugs.has(slug) : false),
     };
   });
 

--- a/ui/src/app/api/admin/users/route.ts
+++ b/ui/src/app/api/admin/users/route.ts
@@ -7,6 +7,7 @@ withErrorHandler,
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import {
 countRealmUsers,
+findRealmUsersByExactEmail,
 getRealmUserById,
 listRealmRoleMappingsForUser,
 listUsersWithRole,
@@ -18,7 +19,10 @@ type RealmRoleClassification,
 } from "@/lib/rbac/keycloak-transition";
 import { listOpenFgaObjects } from "@/lib/rbac/openfga";
 import { requireBaselineAdminSurfaceRead } from "@/lib/rbac/require-openfga";
-import { listTeamMembershipSources } from "@/lib/rbac/team-membership-source-store";
+import {
+listActiveTeamMembershipSourcesBySlug,
+listTeamMembershipSources,
+} from "@/lib/rbac/team-membership-source-store";
 import { type NextRequest,NextResponse } from "next/server";
 
 type AdminUsersListBase = {
@@ -132,18 +136,27 @@ async function loadRoleUserIdSet(roleName: string): Promise<Set<string>> {
   return ids;
 }
 
-async function loadTeamMemberEmails(teamId: string): Promise<Set<string>> {
-  // Canonical source of team membership is `team_membership_sources` (post
-  // 2026-05-26 canonical-membership refactor). The legacy `team_kb_ownership`
-  // store this used to read is no longer populated, which is why the team
-  // filter silently matched nobody.
-  const sources = await listTeamMembershipSources(teamId);
+// `team_membership_sources` is the canonical membership store. It carries
+// BOTH a `team_id` (Mongo `_id` string) and a `team_slug`; the two are not
+// interchangeable, so a caller must look up by whichever identifier it holds.
+function membershipEmails(sources: { status?: string; user_email?: string }[]): Set<string> {
   const emails = new Set<string>();
   for (const s of sources) {
     if (s.status !== "active") continue;
     if (s.user_email) emails.add(s.user_email.trim().toLowerCase());
   }
   return emails;
+}
+
+// Admin `?team=` filter passes the team's Mongo `_id` string.
+async function loadTeamMemberEmails(teamId: string): Promise<Set<string>> {
+  return membershipEmails(await listTeamMembershipSources(teamId));
+}
+
+// Non-admin team scope resolves teams from OpenFGA `team:<slug>` objects, so
+// it holds slugs rather than ids.
+async function loadTeamMemberEmailsBySlug(slug: string): Promise<Set<string>> {
+  return membershipEmails(await listActiveTeamMembershipSourcesBySlug(slug));
 }
 
 function mapBaseRow(
@@ -267,7 +280,7 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
     await Promise.all(
       teamSlugs.map(async (slug) => {
         try {
-          const emails = await loadTeamMemberEmails(slug);
+          const emails = await loadTeamMemberEmailsBySlug(slug);
           for (const email of emails) teamEmailUnion.add(email);
         } catch {
           // skip this team on error
@@ -290,29 +303,27 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
       });
     }
 
-    const filterOpts = {
-      roleIdSet: null,
-      teamEmailSet: teamEmailUnion,
-      slackStatus: null,
-      webexStatus: null,
-      pendingSlackIds,
-    };
-
+    // Resolve each team member by exact email rather than scanning the whole
+    // realm. The membership store already gives us the exact set of emails, so
+    // an indexed per-email lookup is O(team size) instead of O(realm size) —
+    // critical now that every non-admin pays this on each Users-tab load.
+    const seenIds = new Set<string>();
     const teamUsers: AdminUsersListItem[] = [];
-    let kcFirst = 0;
-    const batchSize = 100;
-    for (;;) {
-      const batch = await searchRealmUsers({ first: kcFirst, max: batchSize });
-      if (batch.length === 0) break;
-      for (const u of batch) {
-        if (!userMatchesFilters(u as Record<string, unknown>, filterOpts)) continue;
-        teamUsers.push(
-          await enrichListRow(u as Record<string, unknown>, pendingSlackIds, false)
-        );
-      }
-      if (batch.length < batchSize) break;
-      kcFirst += batch.length;
-    }
+    await Promise.all(
+      [...teamEmailUnion].map(async (email) => {
+        try {
+          const matches = await findRealmUsersByExactEmail(email);
+          for (const u of matches) {
+            const id = String(u.id ?? "");
+            if (!id || seenIds.has(id)) continue;
+            seenIds.add(id);
+            teamUsers.push(await enrichListRow(u, pendingSlackIds, false));
+          }
+        } catch {
+          // skip this email on error
+        }
+      })
+    );
 
     return NextResponse.json({
       users: teamUsers,

--- a/ui/src/app/api/admin/users/route.ts
+++ b/ui/src/app/api/admin/users/route.ts
@@ -16,6 +16,7 @@ import {
 curateRealmRolesForUser,
 type RealmRoleClassification,
 } from "@/lib/rbac/keycloak-transition";
+import { listOpenFgaObjects } from "@/lib/rbac/openfga";
 import { requireBaselineAdminSurfaceRead } from "@/lib/rbac/require-openfga";
 import { listTeamMembershipSources } from "@/lib/rbac/team-membership-source-store";
 import { type NextRequest,NextResponse } from "next/server";
@@ -224,23 +225,101 @@ export const GET = withErrorHandler(async (request: NextRequest): Promise<NextRe
   const includeRoles = includeRolesRaw === "true" || includeRolesRaw === "1";
 
   if (!hasAdminView) {
-    const subject = typeof session.sub === "string" ? session.sub : "";
+    const subject = typeof session.sub === "string" ? session.sub.trim() : "";
     if (!subject) {
       throw new ApiError("A stable user subject is required to load your user profile.", 401);
     }
     const pendingSlackIds = await loadPendingSlackIds();
-    // Self-scoped fallback always includes roles; cost is one user.
-    const self = await enrichListRow(
-      await getRealmUserById(subject),
-      pendingSlackIds,
-      true
+
+    let teamSlugs: string[] = [];
+    try {
+      const teamObjects = await listOpenFgaObjects({
+        user: `user:${subject}`,
+        relation: "member",
+        type: "team",
+      });
+      teamSlugs = teamObjects.objects
+        .map((obj) => {
+          const parts = obj.split(":");
+          return parts.length >= 2 ? parts.slice(1).join(":") : "";
+        })
+        .filter(Boolean);
+    } catch {
+      // fall through to self-only
+    }
+
+    if (teamSlugs.length === 0) {
+      const self = await enrichListRow(
+        await getRealmUserById(subject),
+        pendingSlackIds,
+        true
+      );
+      return NextResponse.json({
+        users: [self],
+        total: 1,
+        page: 1,
+        pageSize: 1,
+        scoped: "self",
+      });
+    }
+
+    const teamEmailUnion = new Set<string>();
+    await Promise.all(
+      teamSlugs.map(async (slug) => {
+        try {
+          const emails = await loadTeamMemberEmails(slug);
+          for (const email of emails) teamEmailUnion.add(email);
+        } catch {
+          // skip this team on error
+        }
+      })
     );
+
+    if (teamEmailUnion.size === 0) {
+      const self = await enrichListRow(
+        await getRealmUserById(subject),
+        pendingSlackIds,
+        true
+      );
+      return NextResponse.json({
+        users: [self],
+        total: 1,
+        page: 1,
+        pageSize: 1,
+        scoped: "self",
+      });
+    }
+
+    const filterOpts = {
+      roleIdSet: null,
+      teamEmailSet: teamEmailUnion,
+      slackStatus: null,
+      webexStatus: null,
+      pendingSlackIds,
+    };
+
+    const teamUsers: AdminUsersListItem[] = [];
+    let kcFirst = 0;
+    const batchSize = 100;
+    for (;;) {
+      const batch = await searchRealmUsers({ first: kcFirst, max: batchSize });
+      if (batch.length === 0) break;
+      for (const u of batch) {
+        if (!userMatchesFilters(u as Record<string, unknown>, filterOpts)) continue;
+        teamUsers.push(
+          await enrichListRow(u as Record<string, unknown>, pendingSlackIds, false)
+        );
+      }
+      if (batch.length < batchSize) break;
+      kcFirst += batch.length;
+    }
+
     return NextResponse.json({
-      users: [self],
-      total: 1,
+      users: teamUsers,
+      total: teamUsers.length,
       page: 1,
-      pageSize: 1,
-      scoped: "self",
+      pageSize: teamUsers.length,
+      scoped: "team",
     });
   }
 

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -527,7 +527,7 @@ export async function searchRealmUsers(
   return parseJsonArray<Record<string, unknown>>(response);
 }
 
-async function findRealmUsersByExactEmail(email: string): Promise<Array<Record<string, unknown>>> {
+export async function findRealmUsersByExactEmail(email: string): Promise<Array<Record<string, unknown>>> {
   const qs = new URLSearchParams({
     email,
     exact: "true",

--- a/ui/src/lib/rbac/user-insights-scope.ts
+++ b/ui/src/lib/rbac/user-insights-scope.ts
@@ -1,0 +1,36 @@
+import { getCollection } from '@/lib/mongodb';
+import { checkOpenFgaTuple } from '@/lib/rbac/openfga';
+import { slackChannelSubjectId } from '@/lib/rbac/slack-channel-grant-store';
+
+interface ChannelTeamMappingDoc {
+  slack_workspace_id?: string;
+  slack_channel_id?: string;
+  channel_name?: string;
+  active?: boolean;
+}
+
+/**
+ * Returns the channel_names of every Slack channel the given OpenFGA user
+ * can can_read. Used to scope Insights (Stats + Feedback) for non-admins.
+ * Fail-closed: any error returns [].
+ */
+export async function getReadableSlackChannelNames(openfgaUser: string): Promise<string[]> {
+  try {
+    const mappings = await getCollection<ChannelTeamMappingDoc>('channel_team_mappings');
+    const rows = await mappings
+      .find({ active: { $ne: false } } as never)
+      .limit(500)
+      .toArray();
+
+    const names: string[] = [];
+    for (const row of rows) {
+      if (!row.slack_channel_id || !row.channel_name) continue;
+      const object = `slack_channel:${slackChannelSubjectId(row.slack_workspace_id ?? '', row.slack_channel_id)}`;
+      const result = await checkOpenFgaTuple({ user: openfgaUser, relation: 'can_read', object }).catch(() => ({ allowed: false }));
+      if (result.allowed) names.push(row.channel_name);
+    }
+    return names;
+  } catch {
+    return [];
+  }
+}

--- a/ui/src/types/teams.ts
+++ b/ui/src/types/teams.ts
@@ -77,6 +77,14 @@ export interface Team {
     department?: string;
     tags?: string[];
   };
+  /**
+   * Per-row management gate decorated by GET /api/admin/teams. True for
+   * org/super admins on every team and for team admins on teams they own.
+   * Drives the "Manage team" vs "View team" affordance on the admin team
+   * card. Optional because callers may build Team objects locally before
+   * the server round-trip; a missing flag means "no edit privilege".
+   */
+  can_manage?: boolean;
 }
 
 export interface TeamMember {

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.15.dev6"
+version = "0.5.15.dev7"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
# Description

Extends the team-scoped admin surfaces pattern (established in #1883 for Slack/Webex) to four remaining admin surfaces:

- **Teams & Users → Users**: non-admins see other members of their own team(s) instead of just themselves. Falls back to self-only when user has no team memberships. Returns a `scoped: "team" | "self"` field to the frontend.
- **Teams & Users → Teams**: non-admins see only teams they belong to. Per-row `can_manage` flag (from OpenFGA `team#admin` check) gates "Manage team" vs "View team" button and dialog editability.
- **Insights → Statistics**: non-admins see stats scoped to Slack channels they `can_read` in OpenFGA plus their own web conversations. Empty scope returns a valid zero-valued payload.
- **Insights → Feedback**: non-admins see feedback for their readable Slack channels plus their own web feedback. Scoped `distinct` queries prevent leaking all channel names / user emails in dropdowns.

New shared helper `ui/src/lib/rbac/user-insights-scope.ts` (`getReadableSlackChannelNames`) is used by both Stats and Feedback to avoid duplication. Follows the per-row capability flag pattern from #1883. No OpenFGA model changes required.

Unit tests added/extended for all four routes.

## Follow-up correctness fixes (review pass)

A self-review surfaced two scoping bugs in the original implementation, now fixed:

- **Users — team scope never matched (broken feature).** Team members were resolved by passing the OpenFGA `team:<slug>` slug to a `team_id`-keyed membership lookup, so it matched nobody and every non-admin silently fell back to `scoped: "self"`. Now resolves members via `listActiveTeamMembershipSourcesBySlug` (slug-keyed). The original test mocks encoded the same slug-as-id mismatch, masking the bug — rewritten to key by `team_slug`.
- **Users — full-realm scan (perf).** The team-scoped path scanned the entire Keycloak realm in 100-user batches on every non-admin Users-tab load. Now resolves each member by exact email (indexed lookup), O(team size) instead of O(realm size).
- **Stats — partial scope leak.** The non-admin scope was applied only to conversation counts; `feedback_summary`, the Slack block, `available_channels`, Slack message counts, and `total_users` all still ran platform-wide — leaking global aggregates and every channel name. The scope is now threaded through every query: `total_users` derives from scoped conversations, the Slack block is bounded to readable channels (and skipped entirely when none), and `available_channels` returns only the readable set. Also hardened a `$or` clobber in the shared-conversations count.

Added stats leak-boundary tests (feedback, Slack messages, `total_users`, `available_channels`, Slack-block probe) and a users de-dup/perf test; each was verified to fail against the pre-fix code.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
