### PR TITLE
fix(chat): prevent auto-create on login race and unify permanent delete logic

### DIFF
--- a/ui/e2e/rbac/chat-auto-create.spec.ts
+++ b/ui/e2e/rbac/chat-auto-create.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import { rbacEnvOrSkip } from "./_env";
+import { expectChatComposerReady, installChatBootMocks, signIn } from "./_helpers";
+
+test.describe("chat — auto-create regression", () => {
+  test("navigating to /chat with an existing conversation never creates a new one", async ({ page }) => {
+    const env = rbacEnvOrSkip();
+    let createCallCount = 0;
+
+    await page.route("**/api/chat/conversations", async (route) => {
+      if (route.request().method() === "POST") {
+        createCallCount++;
+      }
+      await route.continue();
+    });
+
+    await installChatBootMocks(page, env);
+    await signIn(page, env);
+
+    // Navigate to /chat three times (simulates clicking the Chat tab repeatedly)
+    await page.goto("/chat");
+    await expect(page).toHaveURL(/\/chat\/.+/);
+    await page.goto("/chat");
+    await expect(page).toHaveURL(/\/chat\/.+/);
+    await page.goto("/chat");
+    await expect(page).toHaveURL(/\/chat\/.+/);
+
+    await expectChatComposerReady(page);
+
+    expect(createCallCount).toBe(0);
+  });
+
+  test("navigating to /chat with no conversations creates exactly one new conversation", async ({ page }) => {
+    const env = rbacEnvOrSkip();
+    let createCallCount = 0;
+
+    // Override the default mock to return an empty list
+    await page.route("**/api/admin/platform-config", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: { default_agent_id: null } }),
+      });
+    });
+
+    await page.route("**/api/chat/conversations**", async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const method = request.method();
+
+      if (url.pathname === "/api/chat/conversations" && method === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: { items: [], total: 0, page: 1, page_size: 100, has_more: false },
+          }),
+        });
+        return;
+      }
+
+      if (url.pathname === "/api/chat/conversations" && method === "POST") {
+        createCallCount++;
+        const now = new Date().toISOString();
+        const id = "new-e2e-conversation";
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              conversation: {
+                _id: id,
+                title: "New Conversation",
+                client_type: "webui",
+                owner_id: env.user.email,
+                participants: [],
+                created_at: now,
+                updated_at: now,
+                metadata: { client_type: "webui", total_messages: 0 },
+                sharing: { is_public: false, shared_with: [], shared_with_teams: [], share_link_enabled: false },
+                tags: [],
+                is_archived: false,
+                is_pinned: false,
+                deleted_at: null,
+              },
+              created: true,
+            },
+          }),
+        });
+        return;
+      }
+
+      if (url.pathname === "/api/chat/conversations/new-e2e-conversation" && method === "GET") {
+        const now = new Date().toISOString();
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              _id: "new-e2e-conversation",
+              title: "New Conversation",
+              client_type: "webui",
+              owner_id: env.user.email,
+              participants: [],
+              created_at: now,
+              updated_at: now,
+              metadata: { client_type: "webui", total_messages: 0 },
+              sharing: { is_public: false, shared_with: [], shared_with_teams: [], share_link_enabled: false },
+              tags: [],
+              is_archived: false,
+              is_pinned: false,
+              deleted_at: null,
+            },
+          }),
+        });
+        return;
+      }
+
+      if (
+        (url.pathname === "/api/chat/conversations/new-e2e-conversation/turns" ||
+          url.pathname === "/api/chat/conversations/new-e2e-conversation/messages") &&
+        method === "GET"
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: { items: [], total: 0, page: 1, page_size: 100, has_more: false },
+          }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await signIn(page, env);
+    await page.goto("/chat");
+    await expect(page).toHaveURL(/\/chat\/.+/);
+    await expectChatComposerReady(page);
+
+    // Only one conversation should have been created
+    expect(createCallCount).toBe(1);
+  });
+});

--- a/ui/src/app/(app)/chat/__tests__/page.test.tsx
+++ b/ui/src/app/(app)/chat/__tests__/page.test.tsx
@@ -20,8 +20,13 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
 }));
 
+let mockSessionStatus: "loading" | "authenticated" | "unauthenticated" = "authenticated";
+
 jest.mock("next-auth/react", () => ({
-  useSession: () => ({ data: { user: { email: "test@example.com" } }, status: "authenticated" }),
+  useSession: () => ({
+    data: mockSessionStatus === "authenticated" ? { user: { email: "test@example.com" } } : null,
+    status: mockSessionStatus,
+  }),
 }));
 
 jest.mock("@/lib/config", () => ({
@@ -95,6 +100,7 @@ describe("Chat Redirect Page", () => {
     mockConversations = [];
     mockActiveConversationId = null;
     mockGetLastActiveConversationId.mockReturnValue(null);
+    mockSessionStatus = "authenticated";
   });
 
   it("renders CAIPESpinner with branded loading message", () => {
@@ -153,5 +159,33 @@ describe("Chat Redirect Page", () => {
 
     await waitFor(() => expect(mockCreateConversation).toHaveBeenCalledWith(undefined));
     expect(mockReplace).toHaveBeenCalledWith("/chat/new-conv-id");
+  });
+
+  it("does not create a conversation while the session is still loading", async () => {
+    mockSessionStatus = "loading";
+
+    render(<Chat />);
+
+    // Give the effect time to run if it were going to
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockLoadConversationsFromServer).not.toHaveBeenCalled();
+  });
+
+  it("does not create a new conversation when owned conversations already exist", async () => {
+    mockConversations = [
+      {
+        id: "existing-conv",
+        owner_id: "test@example.com",
+        updatedAt: new Date("2026-05-18T10:00:00Z"),
+      },
+    ];
+
+    render(<Chat />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/chat/existing-conv"));
+    expect(mockCreateConversation).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/(app)/chat/page.tsx
+++ b/ui/src/app/(app)/chat/page.tsx
@@ -37,13 +37,14 @@ async function resolveDefaultAgentId(): Promise<string | undefined> {
  */
 function ChatRedirectPage() {
   const router = useRouter();
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const redirected = useRef(false);
 
   const createConversation = useChatStore((s) => s.createConversation);
   const loadConversationsFromServer = useChatStore((s) => s.loadConversationsFromServer);
 
   useEffect(() => {
+    if (status === "loading") return;
     if (redirected.current) return;
 
     const resolve = async () => {
@@ -102,7 +103,7 @@ function ChatRedirectPage() {
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [status]);
 
   return (
     <div className="flex-1 flex items-center justify-center h-full bg-background">

--- a/ui/src/app/api/__tests__/recycle-bin.test.ts
+++ b/ui/src/app/api/__tests__/recycle-bin.test.ts
@@ -203,9 +203,9 @@ describe('Archive API', () => {
       expect(body.data.deleted).toBe(true);
       expect(body.data.permanent).toBe(true);
 
-      // Should have called deleteOne (hard-delete) and deleteMany for messages
-      expect(convCollection.deleteOne).toHaveBeenCalledWith({ _id: '550e8400-e29b-41d4-a716-446655440000' });
-      expect(msgCollection.deleteMany).toHaveBeenCalledWith({ conversation_id: '550e8400-e29b-41d4-a716-446655440000' });
+      // Should have called deleteMany (via shared helper) for both conversations and messages
+      expect(convCollection.deleteMany).toHaveBeenCalledWith({ _id: { $in: ['550e8400-e29b-41d4-a716-446655440000'] } });
+      expect(msgCollection.deleteMany).toHaveBeenCalledWith({ conversation_id: { $in: ['550e8400-e29b-41d4-a716-446655440000'] } });
     });
 
     it('returns 404 for non-existent conversation', async () => {
@@ -625,9 +625,9 @@ describe('Archive API', () => {
 
       await DELETE(req, { params: Promise.resolve({ id: '550e8400-e29b-41d4-a716-446655440000' }) });
 
-      // Verify messages are deleted for the correct conversation ID
+      // Verify messages are deleted for the correct conversation ID (via shared helper, uses $in)
       expect(msgCollection.deleteMany).toHaveBeenCalledWith({
-        conversation_id: '550e8400-e29b-41d4-a716-446655440000',
+        conversation_id: { $in: ['550e8400-e29b-41d4-a716-446655440000'] },
       });
     });
 

--- a/ui/src/app/api/chat/conversations/[id]/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/route.ts
@@ -14,6 +14,7 @@ import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
 import { requireConversationResourcePermission } from '@/lib/rbac/conversation-implicit-authz';
 import type { Conversation,UpdateConversationRequest } from '@/types/mongodb';
 import { NextRequest,NextResponse } from 'next/server';
+import { deleteConversationsPermanently } from '../delete-permanently';
 
 // GET /api/chat/conversations/[id]
 export const GET = withErrorHandler(async (
@@ -147,10 +148,7 @@ export const DELETE = withErrorHandler(async (
     await requireConversationResourcePermission(session, user.email, conversation, 'delete');
 
     if (permanent) {
-      // Hard delete: remove conversation and all messages permanently
-      await conversations.deleteOne({ _id: conversationId });
-      const messages = await getCollection('messages');
-      await messages.deleteMany({ conversation_id: conversationId });
+      await deleteConversationsPermanently([conversation]);
       return successResponse({ deleted: true, permanent: true });
     } else {
       // Soft delete: move to archive by setting deleted_at timestamp

--- a/ui/src/app/api/chat/conversations/delete-permanently.ts
+++ b/ui/src/app/api/chat/conversations/delete-permanently.ts
@@ -1,0 +1,31 @@
+import { getCollection } from '@/lib/mongodb';
+import type { Conversation } from '@/types/mongodb';
+
+/**
+ * Hard-delete one or more conversations and all associated data
+ * (messages + Dynamic Agent checkpoint records).
+ */
+export async function deleteConversationsPermanently(
+  items: Pick<Conversation, '_id' | 'participants'>[]
+): Promise<void> {
+  if (items.length === 0) return;
+
+  const ids = items.map((c) => c._id);
+
+  const conversations = await getCollection<Conversation>('conversations');
+  await conversations.deleteMany({ _id: { $in: ids } });
+
+  const messages = await getCollection('messages');
+  await messages.deleteMany({ conversation_id: { $in: ids } });
+
+  const agentIds = items
+    .filter((c) => c.participants?.some((p: { type: string }) => p.type === 'agent'))
+    .map((c) => c._id);
+
+  if (agentIds.length > 0) {
+    const checkpoints = await getCollection('checkpoints_conversation');
+    const checkpointWrites = await getCollection('checkpoint_writes_conversation');
+    await checkpoints.deleteMany({ thread_id: { $in: agentIds } });
+    await checkpointWrites.deleteMany({ thread_id: { $in: agentIds } });
+  }
+}

--- a/ui/src/app/api/chat/conversations/trash/route.ts
+++ b/ui/src/app/api/chat/conversations/trash/route.ts
@@ -11,6 +11,7 @@ import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
 import { filterConversationsByImplicitOrExplicitPermission } from '@/lib/rbac/conversation-implicit-authz';
 import type { Conversation } from '@/types/mongodb';
 import { NextRequest,NextResponse } from 'next/server';
+import { deleteConversationsPermanently } from '../delete-permanently';
 
 const ARCHIVE_RETENTION_DAYS = 7;
 
@@ -43,29 +44,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }).toArray();
 
     if (expired.length > 0) {
-      const expiredIds = expired.map(c => c._id);
-      await conversations.deleteMany({ _id: { $in: expiredIds } });
-
-      // Delete messages for purged Platform Engineer conversations
-      const messages = await getCollection('messages');
-      await messages.deleteMany({ conversation_id: { $in: expiredIds } });
-
-      // Delete checkpoint data for purged Dynamic Agent conversations
-      // Dynamic Agent conversations have an agent participant
-      const dynamicAgentIds = expired
-        .filter(c => c.participants?.some((p: { type: string }) => p.type === 'agent'))
-        .map(c => c._id);
-
-      if (dynamicAgentIds.length > 0) {
-        const checkpoints = await getCollection('checkpoints_conversation');
-        const checkpointWrites = await getCollection('checkpoint_writes_conversation');
-
-        await checkpoints.deleteMany({ thread_id: { $in: dynamicAgentIds } });
-        await checkpointWrites.deleteMany({ thread_id: { $in: dynamicAgentIds } });
-
-        console.log(`[Trash] Also purged checkpoint data for ${dynamicAgentIds.length} Dynamic Agent conversations`);
-      }
-
+      await deleteConversationsPermanently(expired);
       console.log(`[Trash] Auto-purged ${expired.length} conversations older than ${ARCHIVE_RETENTION_DAYS} days for ${user.email}`);
     }
 


### PR DESCRIPTION
# Description

Two fixes:

1. **Auto-create chat race condition** — `chat/page.tsx` fired its redirect `useEffect` before `next-auth` finished resolving the session. When `session?.user?.email` was still `undefined`, `loadConversationsFromServer()` returned 0 owned conversations and the fallback created a blank new chat. Fix: bail early while `status === 'loading'` and re-run when `status` changes.

2. **Unified permanent delete** — the manual \"delete permanently\" path in `DELETE /api/chat/conversations/[id]?permanent=true` was missing checkpoint cleanup for Dynamic Agent conversations (the auto-purge in the trash route did clean them up). Extracted a shared `deleteConversationsPermanently()` helper used by both paths.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass