### PR TITLE
fix(workflows): portal visibility dropdown and fix runs-to-workflows nav

### DIFF
--- a/ui/src/components/workflows/WorkflowSidebar.tsx
+++ b/ui/src/components/workflows/WorkflowSidebar.tsx
@@ -244,10 +244,14 @@ export function WorkflowSidebar({
 
   const switchTab = useCallback(
     (tab: SidebarTab) => {
-      if (tab === activeTab) return;
+      if (tab === activeTab && !activeRunId) return;
       const doSwitch = () => {
         setTabDirection(tab === "runs" ? 1 : -1);
         setActiveTab(tab);
+        // When switching to workflows from the run detail page, navigate back
+        if (tab === "workflows" && activeRunId) {
+          router.push("/workflows");
+        }
       };
       if (editMode) {
         requestDeferredAction(doSwitch);
@@ -255,7 +259,7 @@ export function WorkflowSidebar({
       }
       doSwitch();
     },
-    [activeTab, editMode, requestDeferredAction],
+    [activeTab, activeRunId, editMode, requestDeferredAction, router],
   );
 
   const handleRefresh = useCallback(async () => {

--- a/ui/src/components/workflows/WorkflowToolbar.tsx
+++ b/ui/src/components/workflows/WorkflowToolbar.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import type { WorkflowConfigVisibility } from "@/types/workflow-config";
 import { ArrowLeft,Copy,Download,Globe,Lock,Play,Save,Trash2,Upload,Users } from "lucide-react";
 import React,{ useEffect,useMemo,useRef,useState } from "react";
+import { createPortal } from "react-dom";
 import YAML from "yaml";
 
 interface Team {
@@ -85,15 +86,33 @@ function VisibilityPopover({
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [dropdownCoords, setDropdownCoords] = useState<{ top: number; left: number } | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Close on click outside
+  const updateCoords = () => {
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setDropdownCoords({ top: rect.bottom + 4, left: rect.left });
+    }
+  };
+
+  const handleOpen = () => {
+    if (disabled) return;
+    if (!open) updateCoords();
+    setOpen((prev) => !prev);
+  };
+
+  // Close on click outside (both button and portal dropdown)
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const target = e.target as Node;
+      if (
+        buttonRef.current?.contains(target) ||
+        dropdownRef.current?.contains(target)
+      ) return;
+      setOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
@@ -113,11 +132,73 @@ function VisibilityPopover({
     [teams],
   );
 
+  const dropdown = open && dropdownCoords ? createPortal(
+    <div
+      ref={dropdownRef}
+      style={{ position: "fixed", top: dropdownCoords.top, left: dropdownCoords.left }}
+      className="z-[200] w-72 rounded-lg border border-border bg-card shadow-lg p-2"
+      onPointerDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {(["global", "team", "private"] as WorkflowConfigVisibility[]).map((v) => {
+        const opt = VISIBILITY_CONFIG[v];
+        return (
+          <button
+            key={v}
+            type="button"
+            onClick={() => {
+              onVisibilityChange(v);
+              if (v !== "team") setOpen(false);
+            }}
+            className={cn(
+              "w-full flex items-start gap-2.5 p-2 rounded-md text-left transition-colors",
+              visibility === v
+                ? "bg-primary/5 border border-primary/30"
+                : "hover:bg-muted/50 border border-transparent",
+            )}
+          >
+            <span className={cn("mt-0.5", VISIBILITY_CONFIG[v].color)}>{opt.icon}</span>
+            <div>
+              <div className="text-xs font-medium">{opt.label}</div>
+              <div className="text-[10px] text-muted-foreground">{opt.description}</div>
+            </div>
+          </button>
+        );
+      })}
+
+      {visibility === "team" && (
+        <div className="mt-2 pt-2 border-t border-border px-0.5">
+          {teamOptions.length === 0 ? (
+            <p className="text-[10px] text-muted-foreground italic px-1">
+              No teams available.
+            </p>
+          ) : (
+            <TeamMultiPicker
+              options={teamOptions}
+              selected={sharedWithTeams}
+              onChange={onSharedWithTeamsChange}
+              disabled={disabled}
+              ariaLabel="Share workflow with teams"
+              placeholder="Share with teams…"
+              searchPlaceholder="Search teams…"
+              emptyLabel="No teams match"
+              triggerChipCap={1}
+              contentClassName="z-[210]"
+            />
+          )}
+        </div>
+      )}
+    </div>,
+    document.body,
+  ) : null;
+
   return (
-    <div className="relative" ref={ref}>
+    <div className="relative">
       <button
+        ref={buttonRef}
         type="button"
-        onClick={() => !disabled && setOpen(!open)}
+        onClick={handleOpen}
         disabled={disabled}
         className={cn(
           "flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-xs font-medium transition-colors",
@@ -131,63 +212,7 @@ function VisibilityPopover({
         <span className="hidden sm:inline">{config.label}</span>
       </button>
 
-      {open && (
-        <div
-          className="absolute top-full left-0 mt-1 z-[100] w-72 rounded-lg border border-border bg-card shadow-lg p-2"
-          onPointerDown={(e) => e.stopPropagation()}
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {(["global", "team", "private"] as WorkflowConfigVisibility[]).map((v) => {
-            const opt = VISIBILITY_CONFIG[v];
-            return (
-              <button
-                key={v}
-                type="button"
-                onClick={() => {
-                  onVisibilityChange(v);
-                  if (v !== "team") setOpen(false);
-                }}
-                className={cn(
-                  "w-full flex items-start gap-2.5 p-2 rounded-md text-left transition-colors",
-                  visibility === v
-                    ? "bg-primary/5 border border-primary/30"
-                    : "hover:bg-muted/50 border border-transparent",
-                )}
-              >
-                <span className={cn("mt-0.5", VISIBILITY_CONFIG[v].color)}>{opt.icon}</span>
-                <div>
-                  <div className="text-xs font-medium">{opt.label}</div>
-                  <div className="text-[10px] text-muted-foreground">{opt.description}</div>
-                </div>
-              </button>
-            );
-          })}
-
-          {visibility === "team" && (
-            <div className="mt-2 pt-2 border-t border-border px-0.5">
-              {teamOptions.length === 0 ? (
-                <p className="text-[10px] text-muted-foreground italic px-1">
-                  No teams available.
-                </p>
-              ) : (
-                <TeamMultiPicker
-                  options={teamOptions}
-                  selected={sharedWithTeams}
-                  onChange={onSharedWithTeamsChange}
-                  disabled={disabled}
-                  ariaLabel="Share workflow with teams"
-                  placeholder="Share with teams…"
-                  searchPlaceholder="Search teams…"
-                  emptyLabel="No teams match"
-                  triggerChipCap={1}
-                  contentClassName="z-[110]"
-                />
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      {dropdown}
     </div>
   );
 }


### PR DESCRIPTION
# Description

Two bug fixes in the workflow editor UI:

1. **Team dropdown blocked** — The `VisibilityPopover` dropdown was rendered as `position: absolute` inside the toolbar, clipped by the `overflow: hidden` ancestor wrapping the workflow canvas. Fixed by rendering via `createPortal` into `document.body` with `position: fixed` coordinates from `getBoundingClientRect()`. Click-outside handling updated to cover both trigger and portalled dropdown.

2. **Workflows tab does nothing from run page** — Clicking the Workflows tab while on `/workflows/run/[id]` did nothing: the sidebar tab was already `"workflows"` so `switchTab` returned early. Fixed by relaxing the guard when `activeRunId` is set and calling `router.push("/workflows")` when switching to workflows from a run.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass