### PR TITLE
fix(slack): remove ephemeral identity verification error message

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -1066,20 +1066,6 @@ def rbac_global_middleware(body, context, next, logger):
         )
     except Exception as exc:
         logger.error("Failed to resolve Slack user %s — denying request: %s", slack_user_id, exc)
-        channel = (
-            body.get("event", {}).get("channel")
-            or body.get("channel", {}).get("id")
-            or body.get("channel_id")  # slash command bodies
-        )
-        if channel:
-            try:
-                context["client"].chat_postEphemeral(
-                    channel=channel,
-                    user=slack_user_id,
-                    text="Identity verification is temporarily unavailable. Please try again later.",
-                )
-            except Exception:
-                logger.warning("Could not send RBAC error message to %s", slack_user_id)
         return _HANDLED_200
     finally:
         if loop is not None:


### PR DESCRIPTION
# Description

Removes the ephemeral Slack message sent to users when identity/RBAC verification fails. The failure is already logged as an error on the server side — surfacing it as a user-visible ephemeral message is unnecessary and potentially confusing. The error is now silently logged and the request is denied without notifying the user.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass