### PR TITLE
ci(agents): make a2a image builds opt-in

### DIFF
--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -84,6 +83,7 @@ jobs:
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: read
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -214,15 +214,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_A2A_APP_ID }}
-          private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Docker Buildx
@@ -333,6 +324,7 @@ jobs:
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-packages: write
 
       - name: 📦 Install crane
         run: |
@@ -343,8 +335,9 @@ jobs:
       - name: 🔐 Log in to registry
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GHCR_ACTOR: ${{ github.actor }}
         run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GHCR_ACTOR" --password-stdin
 
       - name: 🔍 Check source image and retag or build
         id: retag-or-build
@@ -489,11 +482,13 @@ jobs:
           private-key: ${{ secrets.CI_A2A_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: 🔔 Notify release finalize
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_VERSION: ${{ needs.determine-agents.outputs.tag_version }}
+          WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           # Determine overall conclusion
           BUILD_RESULT="${{ needs.build-and-push.result }}"
@@ -514,10 +509,10 @@ jobs:
           gh api --method POST /repos/${{ github.repository }}/dispatches --input - <<EOF
           {
             "event_type": "ci-completed",
-            "client_payload": {
-              "tag": "$TAG_VERSION",
-              "workflow": "${{ github.workflow }}",
-              "conclusion": "$CONCLUSION"
-            }
+              "client_payload": {
+                "tag": "$TAG_VERSION",
+                "workflow": "$WORKFLOW_NAME",
+                "conclusion": "$CONCLUSION"
+              }
           }
           EOF

--- a/.github/workflows/ci-a2a-sub-agent.yml
+++ b/.github/workflows/ci-a2a-sub-agent.yml
@@ -5,12 +5,18 @@ on:
     tags:
       - '**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'ai_platform_engineering/utils/**'
       - 'ai_platform_engineering/agents/**'
       - 'build/agents/Dockerfile.a2a'
   workflow_dispatch:
     inputs:
+      build_a2a_agents:
+        description: 'Opt in to A2A sub-agent image publishing. Release/tag builds skip A2A sub-agent images unless CAIPE_BUILD_A2A_AGENT_IMAGES=true or this is checked.'
+        required: false
+        default: false
+        type: boolean
       build_all:
         description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
         required: false
@@ -57,9 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: load-config
     if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/')) ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && vars.CAIPE_BUILD_A2A_AGENT_IMAGES == 'true') ||
+      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'prebuild/') && contains(github.event.pull_request.labels.*.name, 'build-a2a-agents')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.build_a2a_agents == true)
     outputs:
       agents_to_build: ${{ steps.set-matrix.outputs.agents_to_build }}
       agents_to_retag: ${{ steps.set-matrix.outputs.agents_to_retag }}

--- a/.github/workflows/prebuild-a2a-sub-agent.yml
+++ b/.github/workflows/prebuild-a2a-sub-agent.yml
@@ -39,8 +39,7 @@ on:
         default: false
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -205,10 +204,14 @@ jobs:
       - name: Compute prebuild tag
         id: compute_tag
         shell: bash
+        env:
+          PR_HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          PR_BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
         run: |
-          BRANCH="${{ inputs.head_ref || github.head_ref }}"
-          BASE_REF="${{ inputs.base_ref || github.event.pull_request.base.ref }}"
-          BASE_SHA="${{ inputs.base_sha || github.event.pull_request.base.sha }}"
+          BRANCH="$PR_HEAD_REF"
+          BASE_REF="$PR_BASE_REF"
+          BASE_SHA="$PR_BASE_SHA"
           BRANCH_NO_PREFIX="${BRANCH#prebuild/}"
           BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
           git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"

--- a/.github/workflows/prebuild-a2a-sub-agent.yml
+++ b/.github/workflows/prebuild-a2a-sub-agent.yml
@@ -3,7 +3,7 @@ description: "Build and push A2A Docker images for sub-agents"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened, labeled, closed]
     paths:
       - 'ai_platform_engineering/utils/**'
       - 'ai_platform_engineering/agents/**'
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ''
+      build_a2a_agents:
+        description: 'Opt in to publishing prebuild A2A sub-agent images'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -49,6 +54,10 @@ jobs:
       (
         startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
         !contains(inputs.head_ref || github.head_ref, 'single-node') &&
+        (
+          inputs.build_a2a_agents == true ||
+          contains(github.event.pull_request.labels.*.name, 'build-a2a-agents')
+        ) &&
         github.event.action != 'closed'
       )
     outputs:
@@ -76,6 +85,10 @@ jobs:
     if: |
       startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
       !contains(inputs.head_ref || github.head_ref, 'single-node') &&
+      (
+        inputs.build_a2a_agents == true ||
+        contains(github.event.pull_request.labels.*.name, 'build-a2a-agents')
+      ) &&
       github.event.action != 'closed'
     outputs:
       agents: ${{ steps.set-matrix.outputs.agents }}
@@ -147,6 +160,10 @@ jobs:
       needs.determine-agents.outputs.should_build == 'true' &&
       startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
       !contains(inputs.head_ref || github.head_ref, 'single-node') &&
+      (
+        inputs.build_a2a_agents == true ||
+        contains(github.event.pull_request.labels.*.name, 'build-a2a-agents')
+      ) &&
       github.event.action != 'closed'
     permissions:
       contents: write

--- a/.github/workflows/prebuild-manual.yml
+++ b/.github/workflows/prebuild-manual.yml
@@ -35,10 +35,8 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  issues: write
-  packages: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   resolve-pr:
@@ -191,6 +189,10 @@ jobs:
     name: MCP Agent Images
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'mcp-agent' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.mcp_agent_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-mcp-agent.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -204,6 +206,10 @@ jobs:
     name: A2A Sub-Agent Images
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'a2a-sub-agent' || (inputs.build_a2a_agents == true && (needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.a2a_sub_agent_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-a2a-sub-agent.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -218,6 +224,10 @@ jobs:
     name: Supervisor Agent Image
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'supervisor-agent' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.supervisor_agent_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-supervisor-agent.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -231,6 +241,10 @@ jobs:
     name: CAIPE UI Image
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'caipe-ui' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.caipe_ui_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-caipe-ui.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -244,6 +258,10 @@ jobs:
     name: Skill Scanner Image
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'skill-scanner' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.skill_scanner_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-skill-scanner.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -257,6 +275,10 @@ jobs:
     name: Dynamic Agents Image
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'dynamic-agents' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.dynamic_agents_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-dynamic-agents.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -270,6 +292,10 @@ jobs:
     name: Slack Bot Image
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'slack-bot' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.slack_bot_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-slack-bot.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -283,6 +309,10 @@ jobs:
     name: A2A RAG Images
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'a2a-rag' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.a2a_rag_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-a2a-rag.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -296,6 +326,10 @@ jobs:
     name: Helm Charts
     needs: resolve-pr
     if: ${{ needs.resolve-pr.outputs.target == 'helm' || (needs.resolve-pr.outputs.target == 'all' && needs.resolve-pr.outputs.helm_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     uses: ./.github/workflows/prebuild-helm.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}

--- a/.github/workflows/prebuild-manual.yml
+++ b/.github/workflows/prebuild-manual.yml
@@ -27,6 +27,11 @@ on:
           - dynamic-agents
           - slack-bot
           - a2a-rag
+      build_a2a_agents:
+        description: "Also build A2A sub-agent images when target is all or docker"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -198,7 +203,7 @@ jobs:
   prebuild-a2a-sub-agent:
     name: A2A Sub-Agent Images
     needs: resolve-pr
-    if: ${{ needs.resolve-pr.outputs.target == 'a2a-sub-agent' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.a2a_sub_agent_changed == 'true') }}
+    if: ${{ needs.resolve-pr.outputs.target == 'a2a-sub-agent' || (inputs.build_a2a_agents == true && (needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.a2a_sub_agent_changed == 'true') }}
     uses: ./.github/workflows/prebuild-a2a-sub-agent.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
@@ -206,6 +211,7 @@ jobs:
       head_sha: ${{ needs.resolve-pr.outputs.head_sha }}
       base_ref: ${{ needs.resolve-pr.outputs.base_ref }}
       base_sha: ${{ needs.resolve-pr.outputs.base_sha }}
+      build_a2a_agents: true
     secrets: inherit
 
   prebuild-supervisor-agent:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -95,7 +95,6 @@ jobs:
           # tag, so an unbuilt image would otherwise produce ImagePullBackOff
           # on every fresh install with global.skillScanner.enabled=true.
           REQUIRED_WORKFLOWS=(
-            "[CI][A2A] Sub-Agents A2A Docker Build and Push"
             "[CI][MCP] Sub-Agents MCP Docker Build and Push"
             "[CI][A2A] CAIPE RAG Build and Push"
             "[CI][A2A] Supervisor Agent Docker Build and Push"

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -212,12 +212,13 @@ jobs:
           echo "CI workflows run from the pushed \`$NEW_VERSION\` tag and publish matching artifacts when complete:" >> $GITHUB_STEP_SUMMARY
           echo "- Supervisor agent" >> $GITHUB_STEP_SUMMARY
           echo "- Dynamic agents" >> $GITHUB_STEP_SUMMARY
-          echo "- A2A sub-agents" >> $GITHUB_STEP_SUMMARY
           echo "- MCP sub-agents" >> $GITHUB_STEP_SUMMARY
           echo "- RAG components" >> $GITHUB_STEP_SUMMARY
           echo "- CAIPE UI" >> $GITHUB_STEP_SUMMARY
           echo "- Slack bot" >> $GITHUB_STEP_SUMMARY
           echo "- Helm charts" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A2A sub-agent images are skipped by default. Set repository variable \`CAIPE_BUILD_A2A_AGENT_IMAGES=true\` before the tag push, or run \`ci-a2a-sub-agent.yml\` manually with \`build_a2a_agents=true\`, when those images are required." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### GitHub Release (Draft) 📝" >> $GITHUB_STEP_SUMMARY
           echo "🔗 [Release $NEW_VERSION](https://github.com/${{ github.repository }}/releases/tag/$NEW_VERSION)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -17,13 +17,16 @@ description: "Create an rc/hotfix tag on a release/* branch and trigger a coordi
 #           creates the chart tag.
 #      Both commits are pushed to the release branch so that ci-helm.yml
 #      finds the expected version in Chart.yaml when it checks out at the tag.
-#   4. The push-tag event triggers all container CI workflows automatically.
+#   4. The push-tag event triggers required container CI workflows automatically.
 #   5. Explicitly dispatches ci-helm.yml with force_build=true so the Helm
 #      chart is published even when no chart files changed in this commit.
 #
 # To force-rebuild every container image fresh (bypass retag for unchanged
 # components), run each ci-*.yml individually via workflow_dispatch with
 # force_build=true after this workflow has created the tag.
+# A2A sub-agent images are skipped by default. Set repository variable
+# CAIPE_BUILD_A2A_AGENT_IMAGES=true before pushing the tag, or dispatch
+# ci-a2a-sub-agent.yml manually with build_a2a_agents=true, to publish them.
 
 on:
   workflow_dispatch:
@@ -257,17 +260,21 @@ jobs:
 
           ## What happens next
 
-          The tag push triggers these CI workflows automatically:
+          The tag push triggers these required CI workflows automatically:
           - \`ci-caipe-ui\`
           - \`ci-dynamic-agents\`
           - \`ci-supervisor-agent\`
           - \`ci-slack-bot\`
           - \`ci-webex-bot\`
           - \`ci-skill-scanner\`
-          - \`ci-a2a-sub-agent\`
           - \`ci-mcp-sub-agent\`
           - \`ci-a2a-rag\`
           - \`ci-helm\` (also dispatched explicitly with \`force_build=true\`)
+
+          A2A sub-agent images are skipped by default. To publish them, set
+          repository variable \`CAIPE_BUILD_A2A_AGENT_IMAGES=true\` before this
+          workflow creates the tag, or dispatch \`ci-a2a-sub-agent.yml\`
+          manually with \`build_a2a_agents=true\` and \`tag_version=${RC_TAG}\`.
 
           > To force-rebuild every image fresh (bypass retag for unchanged components),
           > run each \`ci-*.yml\` manually via **workflow_dispatch** with

--- a/.github/workflows/test-rbac.yaml
+++ b/.github/workflows/test-rbac.yaml
@@ -1,4 +1,4 @@
-# GitHub Actions workflow — spec 102 task T060
+# GitHub Actions workflow — RBAC tests
 #
 # Strategy (chosen 2026-04-22 in /speckit.implement Phase 4 dialogue):
 #   - PR (any branch → main / release/*): run the cheap lane only
@@ -19,7 +19,7 @@
 #
 #   - workflow_dispatch: manual trigger for runbook validation.
 
-name: "[CI] Spec 102 RBAC tests"
+name: "[CI] RBAC tests"
 
 on:
   pull_request:
@@ -116,7 +116,6 @@ jobs:
       - name: Install ui/ npm deps
         working-directory: ui
         run: |
-          # assisted-by Codex Codex-sonnet-4-6
           for attempt in 1 2 3; do
             npm ci --no-audit --no-fund && break
             status=$?
@@ -227,7 +226,6 @@ jobs:
       - name: Install ui/ npm deps
         working-directory: ui
         run: |
-          # assisted-by Codex Codex-sonnet-4-6
           for attempt in 1 2 3; do
             npm ci --no-audit --no-fund && break
             status=$?
@@ -240,7 +238,6 @@ jobs:
       - name: Install Playwright browsers
         working-directory: tests/rbac/e2e
         run: |
-          # assisted-by Codex Codex-sonnet-4-6
           for attempt in 1 2 3; do
             npm install --no-audit --no-fund && break
             status=$?

--- a/Makefile
+++ b/Makefile
@@ -637,7 +637,7 @@ scan-image: ## Scan a single image with grype (make scan-image IMG=ghcr.io/cnoe-
 	@[ -n "$(IMG)" ] || { echo "Usage: make scan-image IMG=<image:tag>"; exit 1; }
 	@grype "$(IMG)" --fail-on "$(GRYPE_SEVERITY)"
 
-## ========== Comprehensive RBAC tests (spec 102) ==========
+## ========== RBAC tests ==========
 # See docs/docs/specs/102-comprehensive-rbac-tests-and-completion/quickstart.md
 
 # Profile selection. Override with E2E_PROFILES=...

--- a/tests/rbac/e2e/package.json
+++ b/tests/rbac/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbac-e2e",
   "private": true,
-  "description": "Playwright suite for spec 102 RBAC e2e tests. Lives outside ui/ so the matrix-completeness spec (T058) can read tests/rbac/rbac-matrix.yaml without crossing into the Next.js bundle.",
+  "description": "Playwright suite for RBAC e2e tests. Lives outside ui/ so the matrix-completeness spec (T058) can read tests/rbac/rbac-matrix.yaml without crossing into the Next.js bundle.",
   "scripts": {
     "test": "playwright test",
     "test:list": "playwright test --list"

--- a/tests/rbac/e2e/playwright.config.ts
+++ b/tests/rbac/e2e/playwright.config.ts
@@ -1,5 +1,5 @@
 /**
- * Playwright config for the spec-102 RBAC e2e suite — task T056.
+ * Playwright config for the RBAC e2e suite.
  *
  * Scope
  * -----

--- a/ui/e2e/rbac/README.md
+++ b/ui/e2e/rbac/README.md
@@ -1,4 +1,4 @@
-# RBAC End-to-End Harness (Spec 102 / US7)
+# RBAC End-to-End Harness
 
 Playwright specs that exercise the BFF auth contract against a **live**
 CAIPE + Keycloak stack:

--- a/ui/playwright.rbac.config.ts
+++ b/ui/playwright.rbac.config.ts
@@ -1,6 +1,5 @@
-// assisted-by Codex Codex-sonnet-4-6
 /**
- * Playwright config for the RBAC e2e harness (Spec 102 / US7).
+ * Playwright config for the RBAC e2e harness.
  *
  * Scope: this config is intentionally separate from any future
  * application-wide playwright config. It only runs the specs under


### PR DESCRIPTION
## Summary

- Stop building/publishing A2A sub-agent images by default in tag/release CI.
- Keep MCP sub-agent images, supervisor, and dynamic-agents on their existing build paths.
- Add explicit A2A opt-ins via `CAIPE_BUILD_A2A_AGENT_IMAGES=true`, workflow_dispatch `build_a2a_agents=true`, or the `build-a2a-agents` PR label.
- Remove A2A sub-agent image CI from the final release required workflow list and update release summaries.

## Validation

- `python3` YAML parse over `.github/workflows/*.{yml,yaml}`
- `actionlint` on changed workflows, with existing top-level `description`, shellcheck, and pre-existing `github.head_ref` warnings ignored
- Confirmed MCP workflows do not contain the new A2A opt-in gate
- `git diff --check`
