### PR TITLE
fix(docker-compose): Update to wire openfga into first install ui

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -60,6 +60,21 @@ docker restart caipe-supervisor  # after agents are warm
 
 See [integration-testing/SKILL.md](./integration-testing/SKILL.md) for full testing procedure.
 
+### 🐳 [docker-compose-first-install](./docker-compose-first-install/)
+Validate and repair the plain OSS first-install path for `docker-compose.yaml`
+and `.env.example`.
+
+**Quick Start:**
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+NEXTAUTH_SECRET=test \
+docker compose --env-file .env.example -f docker-compose.yaml config --quiet
+```
+
+See [docker-compose-first-install/SKILL.md](./docker-compose-first-install/SKILL.md)
+before changing Compose profiles, release images, Keycloak/OpenFGA/RAG defaults,
+or first-launch UX.
+
 ### 📡 [streaming-testing](./streaming-testing/)
 Compare A2A streaming behaviour across supervisor versions (e.g. 0.3.0 vs 0.2.41).
 

--- a/.claude/skills/docker-compose-first-install/SKILL.md
+++ b/.claude/skills/docker-compose-first-install/SKILL.md
@@ -48,6 +48,8 @@ Required local Docker defaults:
 - `caipe-ui` in `docker-compose.yaml` uses the published release tag, without a local-only `-prod` suffix.
 - `caipe-ui` has `OPENFGA_HTTP=http://openfga:8080`.
 - `caipe-ui` has `OPENFGA_STORE_NAME=caipe-openfga`.
+- `dynamic-agents` has `AUTHZ_SERVICE_URL=http://caipe-ui:3000` so agent-use
+  decisions can reach the UI BFF/CAS.
 - `caipe-ui` has Keycloak admin-client values that match the local realm seed:
   - `KEYCLOAK_URL=http://keycloak:7080`
   - `KEYCLOAK_REALM=caipe`
@@ -85,6 +87,15 @@ docker compose --env-file .env.example -f docker-compose.yaml config --format js
       KEYCLOAK_ADMIN_CLIENT_ID,
       KEYCLOAK_ADMIN_CLIENT_SECRET
     }'
+```
+
+Inspect the rendered Dynamic Agents env:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+NEXTAUTH_SECRET=test \
+docker compose --env-file .env.example -f docker-compose.yaml config --format json \
+| jq '.services["dynamic-agents"].environment | {AUTHZ_SERVICE_URL}'
 ```
 
 Inspect Keycloak init secrets:

--- a/.claude/skills/docker-compose-first-install/SKILL.md
+++ b/.claude/skills/docker-compose-first-install/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: docker-compose-first-install
+description: >
+  Validate and repair the OSS first-install Docker Compose path. Use when
+  editing docker-compose.yaml, docker-compose.dev.yaml, .env.example,
+  release image tags, Compose profiles, Keycloak/OpenFGA/RAG defaults, or
+  first-launch UI behavior for local all-in-one installs.
+---
+
+# Docker Compose First Install
+
+Protect the plain OSS setup path:
+
+```bash
+cp .env.example .env
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+docker compose --env-file .env -f docker-compose.yaml up -d
+```
+
+This flow must work without Cisco-only systems, Slack/Webex bots, local image
+suffix overrides, or hidden operator knowledge.
+
+## When This Skill Applies
+
+Use this skill when a task touches:
+
+- `docker-compose.yaml`
+- `docker-compose.dev.yaml`
+- `.env.example`
+- release image tags or image suffixes
+- first-install docs or launch commands
+- Keycloak, OpenFGA, RBAC, RAG, MongoDB, supervisor, dynamic agents, web ingestor
+- first-launch UI alerts, release prompts, migrations, or Keycloak health
+
+## Required Defaults
+
+The minimal first-install profile set is:
+
+```bash
+mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+```
+
+Do not add `slack-bot` or `webex-bot` to the default all-in-one path.
+
+Required local Docker defaults:
+
+- `IMAGE_TAG` points at the latest supported stable release.
+- `caipe-ui` in `docker-compose.yaml` uses the published release tag, without a local-only `-prod` suffix.
+- `caipe-ui` has `OPENFGA_HTTP=http://openfga:8080`.
+- `caipe-ui` has `OPENFGA_STORE_NAME=caipe-openfga`.
+- `caipe-ui` has Keycloak admin-client values that match the local realm seed:
+  - `KEYCLOAK_URL=http://keycloak:7080`
+  - `KEYCLOAK_REALM=caipe`
+  - `KEYCLOAK_RESOURCE_SERVER_ID=caipe-platform`
+  - `KEYCLOAK_CLIENT_SECRET=caipe-platform-dev-secret`
+  - `KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform`
+  - `KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret`
+- `keycloak-init` receives matching `KEYCLOAK_UI_CLIENT_SECRET` and `KEYCLOAK_PLATFORM_CLIENT_SECRET`.
+- UI healthchecks inside containers use `127.0.0.1`, not `localhost`, when probing the local Next.js listener.
+
+## Validation Commands
+
+Run these before committing Compose/env changes:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+NEXTAUTH_SECRET=test \
+docker compose --env-file .env.example -f docker-compose.yaml config --quiet
+```
+
+Inspect the rendered UI env:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+NEXTAUTH_SECRET=test \
+docker compose --env-file .env.example -f docker-compose.yaml config --format json \
+| jq '.services["caipe-ui"].environment
+  | {
+      OPENFGA_HTTP,
+      OPENFGA_STORE_NAME,
+      KEYCLOAK_URL,
+      KEYCLOAK_REALM,
+      KEYCLOAK_RESOURCE_SERVER_ID,
+      KEYCLOAK_CLIENT_SECRET,
+      KEYCLOAK_ADMIN_CLIENT_ID,
+      KEYCLOAK_ADMIN_CLIENT_SECRET
+    }'
+```
+
+Inspect Keycloak init secrets:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+NEXTAUTH_SECRET=test \
+docker compose --env-file .env.example -f docker-compose.yaml config --format json \
+| jq '.services["keycloak-init"].environment
+  | {KEYCLOAK_UI_CLIENT_SECRET, KEYCLOAK_PLATFORM_CLIENT_SECRET}'
+```
+
+Check rendered images:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+NEXTAUTH_SECRET=test \
+docker compose --env-file .env.example -f docker-compose.yaml config --images \
+| sort
+```
+
+The UI image should be `ghcr.io/cnoe-io/caipe-ui:<version>`, not
+`ghcr.io/cnoe-io/caipe-ui:<version>-prod`, unless that suffixed image is known
+to be published for the release.
+
+## Recovery Commands For Local Testing
+
+Use non-destructive recovery first:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui keycloak-init
+```
+
+If Keycloak or OpenFGA state was seeded with bad env, reset only the local auth
+data volumes:
+
+```bash
+docker compose --env-file .env -f docker-compose.yaml down
+docker volume rm docker-compose-fixes_keycloak_postgres_data docker-compose-fixes_openfga_postgres_data
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+docker compose --env-file .env -f docker-compose.yaml up -d
+```
+
+Only reset MongoDB when the user explicitly accepts losing local CAIPE data:
+
+```bash
+docker volume rm docker-compose-fixes_mongodb_data docker-compose-fixes_mongodb_config
+```
+
+## Guardrails
+
+- Do not add AI attribution comments or examples.
+- Use conventional commit titles.
+- Use only an explicitly provided human DCO trailer.
+- Keep `.env.example` runnable for a first-time local OSS user.
+- Keep Docker Compose first install independent of proprietary providers.

--- a/.claude/skills/docker-compose-first-install/SKILL.md
+++ b/.claude/skills/docker-compose-first-install/SKILL.md
@@ -13,7 +13,7 @@ Protect the plain OSS setup path:
 
 ```bash
 cp .env.example .env
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 docker compose --env-file .env -f docker-compose.yaml up -d
 ```
 
@@ -37,7 +37,7 @@ Use this skill when a task touches:
 The minimal first-install profile set is:
 
 ```bash
-mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor
 ```
 
 Do not add `slack-bot` or `webex-bot` to the default all-in-one path.
@@ -65,7 +65,7 @@ Required local Docker defaults:
 Run these before committing Compose/env changes:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 NEXTAUTH_SECRET=test \
 docker compose --env-file .env.example -f docker-compose.yaml config --quiet
 ```
@@ -73,7 +73,7 @@ docker compose --env-file .env.example -f docker-compose.yaml config --quiet
 Inspect the rendered UI env:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 NEXTAUTH_SECRET=test \
 docker compose --env-file .env.example -f docker-compose.yaml config --format json \
 | jq '.services["caipe-ui"].environment
@@ -92,7 +92,7 @@ docker compose --env-file .env.example -f docker-compose.yaml config --format js
 Inspect the rendered Dynamic Agents env:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 NEXTAUTH_SECRET=test \
 docker compose --env-file .env.example -f docker-compose.yaml config --format json \
 | jq '.services["dynamic-agents"].environment | {AUTHZ_SERVICE_URL}'
@@ -101,7 +101,7 @@ docker compose --env-file .env.example -f docker-compose.yaml config --format js
 Inspect Keycloak init secrets:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 NEXTAUTH_SECRET=test \
 docker compose --env-file .env.example -f docker-compose.yaml config --format json \
 | jq '.services["keycloak-init"].environment
@@ -111,7 +111,7 @@ docker compose --env-file .env.example -f docker-compose.yaml config --format js
 Check rendered images:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 NEXTAUTH_SECRET=test \
 docker compose --env-file .env.example -f docker-compose.yaml config --images \
 | sort
@@ -126,8 +126,8 @@ to be published for the release.
 Use non-destructive recovery first:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
-docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui keycloak-init
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
+docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui dynamic-agents web_ingestor keycloak-init
 ```
 
 If Keycloak or OpenFGA state was seeded with bad env, reset only the local auth
@@ -136,7 +136,7 @@ data volumes:
 ```bash
 docker compose --env-file .env -f docker-compose.yaml down
 docker volume rm docker-compose-fixes_keycloak_postgres_data docker-compose-fixes_openfga_postgres_data
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 docker compose --env-file .env -f docker-compose.yaml up -d
 ```
 

--- a/.cursor/rules/docker-compose-first-install.mdc
+++ b/.cursor/rules/docker-compose-first-install.mdc
@@ -15,7 +15,7 @@ The plain OSS path must work from:
 
 ```bash
 cp .env.example .env
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 docker compose --env-file .env -f docker-compose.yaml up -d
 ```
 

--- a/.cursor/rules/docker-compose-first-install.mdc
+++ b/.cursor/rules/docker-compose-first-install.mdc
@@ -1,0 +1,23 @@
+---
+description: Use the Docker Compose first-install skill when Compose, env examples, release images, Keycloak/OpenFGA/RAG defaults, or first-launch UX changes
+alwaysApply: false
+---
+
+# Docker Compose First Install
+
+When a task touches `docker-compose.yaml`, `docker-compose.dev.yaml`,
+`.env.example`, release image tags, Compose profiles, Keycloak/OpenFGA/RAG
+defaults, or first-launch UI behavior, follow:
+
+`.claude/skills/docker-compose-first-install/SKILL.md`
+
+The plain OSS path must work from:
+
+```bash
+cp .env.example .env
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+docker compose --env-file .env -f docker-compose.yaml up -d
+```
+
+Do not add Slack/Webex bots to the default all-in-one path. Do not add AI
+attribution comments.

--- a/.cursorrules
+++ b/.cursorrules
@@ -9,6 +9,19 @@
 **Package Manager**: uv
 **Testing**: pytest
 
+## Docker Compose First Install
+
+When changing `docker-compose.yaml`, `docker-compose.dev.yaml`, `.env.example`,
+release image tags, Compose profiles, Keycloak/OpenFGA/RAG defaults, or
+first-launch UX, follow `.claude/skills/docker-compose-first-install/SKILL.md`.
+The plain OSS path must work from `.env.example` with:
+
+```bash
+mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+```
+
+Do not add Slack/Webex bots to that default all-in-one path.
+
 ## Git Commit Standards
 
 ### Conventional Commits (REQUIRED)

--- a/.cursorrules
+++ b/.cursorrules
@@ -17,7 +17,7 @@ first-launch UX, follow `.claude/skills/docker-compose-first-install/SKILL.md`.
 The plain OSS path must work from `.env.example` with:
 
 ```bash
-mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor
 ```
 
 Do not add Slack/Webex bots to that default all-in-one path.

--- a/.env.example
+++ b/.env.example
@@ -302,6 +302,8 @@ KEYCLOAK_CLIENT_SECRET=caipe-platform-dev-secret
 # Production deployments should replace this secret through their secret store.
 KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform
 KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret
+# Dynamic Agents delegates agent-use decisions to the UI BFF/CAS.
+AUTHZ_SERVICE_URL=http://caipe-ui:3000
 # Slack bot Admin REST API (user lookup by slack_user_id attribute). MUST be a
 # confidential client with view-users + query-users on realm-management.
 # Distinct from KEYCLOAK_ADMIN_* above to avoid the namespace collision that

--- a/.env.example
+++ b/.env.example
@@ -297,10 +297,11 @@ KEYCLOAK_URL=http://keycloak:7080
 KEYCLOAK_REALM=caipe
 KEYCLOAK_RESOURCE_SERVER_ID=caipe-platform
 KEYCLOAK_CLIENT_SECRET=caipe-platform-dev-secret
-# UI BFF Admin REST API (NextAuth.js, role-mapping CRUD). In dev defaults to
-# admin-cli password grant. In prod, point at a confidential admin client.
-# KEYCLOAK_ADMIN_CLIENT_ID=
-# KEYCLOAK_ADMIN_CLIENT_SECRET=
+# UI BFF Admin REST API (NextAuth.js, role-mapping CRUD). The local Docker
+# Keycloak seed creates the confidential caipe-platform client with this secret.
+# Production deployments should replace this secret through their secret store.
+KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform
+KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret
 # Slack bot Admin REST API (user lookup by slack_user_id attribute). MUST be a
 # confidential client with view-users + query-users on realm-management.
 # Distinct from KEYCLOAK_ADMIN_* above to avoid the namespace collision that

--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@
 IMAGE_TAG=0.5.16
 
 # Start the supervisor in all-in-one mode with MCP servers, production UI,
-# dynamic agents, local Keycloak/RBAC, MongoDB, and RAG.
-COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+# dynamic agents, local Keycloak/RBAC, MongoDB, RAG, and web ingestion.
+COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor
 
 # All-in-one mode: do not start remote A2A sub-agent containers.
 DISTRIBUTED_AGENTS=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,20 @@ Before committing code changes, run relevant checks:
 - Python: `uv run ruff check`, `uv run pytest` (always use `uv run` to ensure virtual env)
 - UI: `nvm use` first (if available), then `npm run lint`, `npm run build`
 
+## Docker Compose First Install
+
+When changing `docker-compose.yaml`, `docker-compose.dev.yaml`, `.env.example`,
+release image tags, Compose profiles, Keycloak/OpenFGA/RAG defaults, or
+first-launch UX, follow `.claude/skills/docker-compose-first-install/SKILL.md`.
+The `docker-compose.yaml` + `.env.example` path must work for a first-time OSS
+user with the minimal profiles:
+
+```bash
+mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+```
+
+Do not add Slack/Webex bots to that default path.
+
 ## Code Style
 
 - **Imports at top** - All imports must be at the top of the file, unless otherwise specified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ The `docker-compose.yaml` + `.env.example` path must work for a first-time OSS
 user with the minimal profiles:
 
 ```bash
-mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor
 ```
 
 Do not add Slack/Webex bots to that default path.

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -724,14 +724,9 @@ print(json.dumps(realm))
   fi
 fi
 
-UNSAFE_RBAC_BYPASS="$(printf '%s' "${CAIPE_UNSAFE_RBAC_BYPASS:-false}" | tr '[:upper:]' '[:lower:]')"
 if [ -z "${IDP_ISSUER:-}" ] && [ -z "${IDP_CLIENT_ID:-}" ] && [ -z "${IDP_CLIENT_SECRET:-}" ]; then
-  if [ "${UNSAFE_RBAC_BYPASS}" = "true" ] || [ "${UNSAFE_RBAC_BYPASS}" = "1" ] || [ "${UNSAFE_RBAC_BYPASS}" = "yes" ]; then
-    echo "[init-idp] CAIPE_UNSAFE_RBAC_BYPASS=true and no upstream IdP broker configured; skipping IdP setup after local realm reconciliation."
-    exit 0
-  fi
-  echo "[init-idp] ERROR: IDP_ISSUER, IDP_CLIENT_ID, and IDP_CLIENT_SECRET are required unless CAIPE_UNSAFE_RBAC_BYPASS=true." >&2
-  exit 1
+  echo "[init-idp] No upstream IdP broker configured; local Keycloak is the identity provider."
+  exit 0
 fi
 
 MISSING_IDP_ENV=0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -474,6 +474,15 @@ services:
       - OIDC_REQUIRED_ADMIN_GROUP=${OIDC_REQUIRED_ADMIN_GROUP:-}
       - BOOTSTRAP_ADMIN_EMAILS=${BOOTSTRAP_ADMIN_EMAILS:-}
       - OIDC_ENABLE_REFRESH_TOKEN=${OIDC_ENABLE_REFRESH_TOKEN:-true}
+      # Local Docker Keycloak admin client. The rbac profile seeds this
+      # confidential client in realm-config.json; Kubernetes should inject
+      # production values from its secret store instead.
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:7080}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-caipe}
+      - KEYCLOAK_RESOURCE_SERVER_ID=${KEYCLOAK_RESOURCE_SERVER_ID:-caipe-platform}
+      - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET:-caipe-platform-dev-secret}
+      - KEYCLOAK_ADMIN_CLIENT_ID=${KEYCLOAK_ADMIN_CLIENT_ID:-caipe-platform}
+      - KEYCLOAK_ADMIN_CLIENT_SECRET=${KEYCLOAK_ADMIN_CLIENT_SECRET:-caipe-platform-dev-secret}
       # Workflow runner - set WORKFLOW_RUNNER_ENABLED=true to show Run Workflow button and Multi-Step Workflows
       - WORKFLOW_RUNNER_ENABLED=${WORKFLOW_RUNNER_ENABLED:-false}
       # Dynamic Agents - set DYNAMIC_AGENTS_ENABLED=true and add dynamic-agents profile to enable Custom Agents tab
@@ -1166,6 +1175,8 @@ services:
       IDP_PKCE_ENABLED: ${IDP_PKCE_ENABLED:-false}
       KEYCLOAK_FORCE_IDP_REDIRECT: ${KEYCLOAK_FORCE_IDP_REDIRECT:-false}
       KEYCLOAK_ADMIN_FRONTEND_URL: ${KEYCLOAK_ADMIN_FRONTEND_URL:-}
+      KEYCLOAK_UI_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-caipe-ui-dev-secret}
+      KEYCLOAK_PLATFORM_CLIENT_SECRET: ${KEYCLOAK_ADMIN_CLIENT_SECRET:-caipe-platform-dev-secret}
       CAIPE_UNSAFE_RBAC_BYPASS: ${CAIPE_UNSAFE_RBAC_BYPASS:-false}
       SLACK_BOT_ADMIN_AUDIENCE: ${SLACK_BOT_ADMIN_AUDIENCE:-caipe-slack-bot-admin}
       KC_REALM: caipe

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -594,6 +594,9 @@ services:
       - OIDC_DISCOVERY_URL=${OIDC_DISCOVERY_URL:-}
       - OIDC_GROUP_CLAIM=${OIDC_GROUP_CLAIM:-}
       - OIDC_REQUIRED_ADMIN_GROUP=${OIDC_REQUIRED_ADMIN_GROUP:-}
+      # Centralized Authorization Service. Dynamic Agents delegates agent-use
+      # decisions to the UI BFF and fails closed with 503 if this is unset.
+      - AUTHZ_SERVICE_URL=${AUTHZ_SERVICE_URL:-http://caipe-ui:3000}
       # Tracing (Langfuse)
       - ENABLE_TRACING=${ENABLE_TRACING:-false}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -434,7 +434,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.16}-prod
+    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.16}
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -458,9 +458,12 @@ services:
       # `docker compose up` with the supplied message if the env var is
       # missing or empty so an operator never silently inherits a shared
       # placeholder. (For local dev that genuinely wants a placeholder,
-      # use docker-compose.dev.yaml instead.) assisted-by Claude:claude-opus-4-7
+      # use docker-compose.dev.yaml instead.)
       - "NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET must be set in your .env (run: openssl rand -base64 48)}"
       - NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}
+      # OpenFGA ReBAC reconciliation for the local RBAC profile.
+      - OPENFGA_HTTP=${OPENFGA_HTTP:-http://openfga:8080}
+      - OPENFGA_STORE_NAME=${OPENFGA_STORE_NAME:-caipe-openfga}
       # SSO Configuration - set NEXT_PUBLIC_SSO_ENABLED=true to enable
       - NEXT_PUBLIC_SSO_ENABLED=${NEXT_PUBLIC_SSO_ENABLED:-false}
       - OIDC_ISSUER=${OIDC_ISSUER:-}
@@ -495,7 +498,7 @@ services:
       - WEBEX_CLIENT_SECRET=${WEBEX_CLIENT_SECRET:-}
       - WEBEX_REDIRECT_URI=${WEBEX_REDIRECT_URI:-}
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -115,6 +115,16 @@ starting Compose, run:
 The helper uses the GitHub CLI to resolve the latest release and rewrites
 `IMAGE_TAG` in `.env`, leaving a `.env.bak` backup.
 
+You can also have the setup helper update `.env` and start the
+`docker-compose.yaml` stack in one step:
+
+```bash
+./setup-caipe.sh --docker-compose
+```
+
+Running `./setup-caipe.sh` without that option still follows the default
+Kind/Kubernetes setup path.
+
 The default profile set includes `web_ingestor` so the Knowledge Bases ingest
 page can submit web datasource jobs. Add `slack-bot` or `webex-bot` only when
 you want those bot integrations.

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -27,7 +27,7 @@ Set up CAIPE on a laptop or VM (e.g. EC2) using Docker Compose.
 
    ```bash
    IMAGE_TAG=0.5.16
-   COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb
+   COMPOSE_PROFILES=mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor
 
    # All-in-one mode: agents run in-process and use MCP server containers.
    DISTRIBUTED_AGENTS=
@@ -105,8 +105,9 @@ docker compose up
 
 Open the UI at **http://localhost:3000** and the supervisor API at **http://localhost:8000**.
 
-Add `web_ingestor` when you want the web ingestion worker. Add `slack-bot` or
-`webex-bot` only when you want those bot integrations.
+The default profile set includes `web_ingestor` so the Knowledge Bases ingest
+page can submit web datasource jobs. Add `slack-bot` or `webex-bot` only when
+you want those bot integrations.
 
 **Primary profiles:**
 
@@ -199,11 +200,11 @@ grep -q '^OPENFGA_STORE_NAME=' .env || echo 'OPENFGA_STORE_NAME=caipe-openfga' >
 grep -q '^AUTHZ_SERVICE_URL=' .env || echo 'AUTHZ_SERVICE_URL=http://caipe-ui:3000' >> .env
 ```
 
-Then rerun the UI, Dynamic Agents, and Keycloak seed job:
+Then rerun the UI, Dynamic Agents, Web Ingestor, and Keycloak seed job:
 
 ```bash
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
-docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui dynamic-agents keycloak-init
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
+docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui dynamic-agents web_ingestor keycloak-init
 ```
 
 If Keycloak or OpenFGA were already initialized with bad settings, reset only
@@ -215,7 +216,7 @@ docker compose --env-file .env -f docker-compose.yaml down
 docker volume ls | grep -E 'keycloak_postgres_data|openfga_postgres_data'
 docker volume rm <keycloak_postgres_data_volume> <openfga_postgres_data_volume>
 
-COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor" \
 docker compose --env-file .env -f docker-compose.yaml up -d
 ```
 

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -175,6 +175,54 @@ DISTRIBUTED_AGENTS=argocd,github docker compose -f docker-compose.dev.yaml --pro
 
 ---
 
+## Troubleshooting first install
+
+If the first launch reports Keycloak reconciliation errors, failed migrations
+with `OPENFGA_HTTP is not set`, or missing Keycloak admin credentials, make
+sure your local `.env` has the first-install RBAC defaults from `.env.example`:
+
+```bash
+KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform
+KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret
+OPENFGA_HTTP=http://openfga:8080
+OPENFGA_STORE_NAME=caipe-openfga
+```
+
+You can add any missing values without overwriting your existing `.env`:
+
+```bash
+grep -q '^KEYCLOAK_ADMIN_CLIENT_ID=' .env || echo 'KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform' >> .env
+grep -q '^KEYCLOAK_ADMIN_CLIENT_SECRET=' .env || echo 'KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret' >> .env
+grep -q '^OPENFGA_HTTP=' .env || echo 'OPENFGA_HTTP=http://openfga:8080' >> .env
+grep -q '^OPENFGA_STORE_NAME=' .env || echo 'OPENFGA_STORE_NAME=caipe-openfga' >> .env
+```
+
+Then rerun the UI and Keycloak seed job:
+
+```bash
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui keycloak-init
+```
+
+If Keycloak or OpenFGA were already initialized with bad settings, reset only
+the local auth/RBAC volumes. This keeps MongoDB and CAIPE application data:
+
+```bash
+docker compose --env-file .env -f docker-compose.yaml down
+
+docker volume ls | grep -E 'keycloak_postgres_data|openfga_postgres_data'
+docker volume rm <keycloak_postgres_data_volume> <openfga_postgres_data_volume>
+
+COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
+docker compose --env-file .env -f docker-compose.yaml up -d
+```
+
+Use the exact volume names printed by `docker volume ls`. Avoid
+`docker compose down -v` unless you also want to delete MongoDB and other local
+CAIPE data.
+
+---
+
 ## Connect to the agent
 
 Once services are running, connect with the agent chat CLI:

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -186,6 +186,7 @@ KEYCLOAK_ADMIN_CLIENT_ID=caipe-platform
 KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret
 OPENFGA_HTTP=http://openfga:8080
 OPENFGA_STORE_NAME=caipe-openfga
+AUTHZ_SERVICE_URL=http://caipe-ui:3000
 ```
 
 You can add any missing values without overwriting your existing `.env`:
@@ -195,13 +196,14 @@ grep -q '^KEYCLOAK_ADMIN_CLIENT_ID=' .env || echo 'KEYCLOAK_ADMIN_CLIENT_ID=caip
 grep -q '^KEYCLOAK_ADMIN_CLIENT_SECRET=' .env || echo 'KEYCLOAK_ADMIN_CLIENT_SECRET=caipe-platform-dev-secret' >> .env
 grep -q '^OPENFGA_HTTP=' .env || echo 'OPENFGA_HTTP=http://openfga:8080' >> .env
 grep -q '^OPENFGA_STORE_NAME=' .env || echo 'OPENFGA_STORE_NAME=caipe-openfga' >> .env
+grep -q '^AUTHZ_SERVICE_URL=' .env || echo 'AUTHZ_SERVICE_URL=http://caipe-ui:3000' >> .env
 ```
 
-Then rerun the UI and Keycloak seed job:
+Then rerun the UI, Dynamic Agents, and Keycloak seed job:
 
 ```bash
 COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" \
-docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui keycloak-init
+docker compose --env-file .env -f docker-compose.yaml up -d --force-recreate caipe-ui dynamic-agents keycloak-init
 ```
 
 If Keycloak or OpenFGA were already initialized with bad settings, reset only

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -105,6 +105,16 @@ docker compose up
 
 Open the UI at **http://localhost:3000** and the supervisor API at **http://localhost:8000**.
 
+To update your local `.env` to the latest published CAIPE release before
+starting Compose, run:
+
+```bash
+./setup-caipe.sh update-compose-release
+```
+
+The helper uses the GitHub CLI to resolve the latest release and rewrites
+`IMAGE_TAG` in `.env`, leaving a `.env.bak` backup.
+
 The default profile set includes `web_ingestor` so the Knowledge Bases ingest
 page can submit web datasource jobs. Add `slack-bot` or `webex-bot` only when
 you want those bot integrations.

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -122,8 +122,9 @@ You can also have the setup helper update `.env` and start the
 ./setup-caipe.sh --docker-compose
 ```
 
-Running `./setup-caipe.sh` without that option still follows the default
-Kind/Kubernetes setup path.
+Running `./setup-caipe.sh` interactively asks whether to use Kind/Kubernetes or
+Docker Compose. Kind/Kubernetes remains the default, and any saved setup
+configuration applies only to that Kind/Kubernetes path.
 
 The default profile set includes `web_ingestor` so the Knowledge Bases ingest
 page can submit web datasource jobs. Add `slack-bot` or `webex-bot` only when

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -196,6 +196,8 @@ TLS_CERT_FILE=""
 TLS_KEY_FILE=""
 ENV_FILE=""
 UI_ENV_FILE=""
+COMPOSE_ENV_FILE=""
+COMPOSE_PROFILES_DEFAULT="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor"
 # Dynamic agents: default ON (custom agent builder UI is part of the
 # baseline CAIPE experience). Set ENABLE_DYNAMIC_AGENTS=false or pass
 # --no-dynamic-agents to skip.
@@ -3059,6 +3061,55 @@ _env_true() {
   local val
   val=$(echo "$1" | tr '[:upper:]' '[:lower:]')
   [[ "$val" == "true" || "$val" == "yes" || "$val" == "1" ]]
+}
+
+_compose_env_file() {
+  if [[ -n "${COMPOSE_ENV_FILE:-}" ]]; then
+    echo "$COMPOSE_ENV_FILE"
+  elif [[ -n "${ENV_FILE:-}" ]]; then
+    echo "$ENV_FILE"
+  else
+    echo ".env"
+  fi
+}
+
+_ensure_compose_env_file() {
+  local env_file="$1"
+  if [[ -f "$env_file" ]]; then
+    return 0
+  fi
+  if [[ ! -f ".env.example" ]]; then
+    err "Env file not found: ${env_file}; .env.example is also missing"
+    exit 1
+  fi
+  cp .env.example "$env_file"
+  log "Created ${env_file} from .env.example"
+}
+
+_update_compose_image_tag() {
+  local env_file="$1"
+  _ensure_compose_env_file "$env_file"
+  if ! command -v gh &>/dev/null; then
+    err "GitHub CLI (gh) is required to fetch the latest CAIPE release"
+    err "Install gh or edit IMAGE_TAG in ${env_file} manually."
+    exit 1
+  fi
+
+  local latest
+  latest=$(gh release view --repo cnoe-io/ai-platform-engineering --json tagName -q .tagName)
+  latest="${latest#v}"
+  if [[ -z "$latest" ]]; then
+    err "Could not resolve the latest CAIPE release tag"
+    exit 1
+  fi
+
+  if grep -q '^IMAGE_TAG=' "$env_file"; then
+    sed -i.bak "s/^IMAGE_TAG=.*/IMAGE_TAG=${latest}/" "$env_file"
+  else
+    cp "$env_file" "${env_file}.bak"
+    printf '\nIMAGE_TAG=%s\n' "$latest" >> "$env_file"
+  fi
+  log "Updated IMAGE_TAG=${latest} in ${env_file} (backup: ${env_file}.bak)"
 }
 
 # Create a Kubernetes generic secret from a list of key names sourced from a
@@ -8160,6 +8211,36 @@ cmd_status() {
   helm list -A 2>/dev/null
 }
 
+cmd_update_compose_release() {
+  local env_file
+  env_file=$(_compose_env_file)
+  _update_compose_image_tag "$env_file"
+}
+
+cmd_docker_compose() {
+  local env_file
+  env_file=$(_compose_env_file)
+  _ensure_compose_env_file "$env_file"
+  _update_compose_image_tag "$env_file"
+
+  if ! command -v docker &>/dev/null; then
+    err "docker is required for Docker Compose setup"
+    exit 1
+  fi
+
+  COMPOSE_PROFILES="${COMPOSE_PROFILES:-$(_env_get "$env_file" COMPOSE_PROFILES)}"
+  COMPOSE_PROFILES="${COMPOSE_PROFILES:-$COMPOSE_PROFILES_DEFAULT}"
+  export COMPOSE_PROFILES
+
+  step "Starting Docker Compose all-in-one stack"
+  log "Env file: ${env_file}"
+  log "Profiles: ${COMPOSE_PROFILES}"
+  docker compose --env-file "$env_file" -f docker-compose.yaml up -d
+
+  log "CAIPE UI: http://localhost:3000"
+  log "Knowledge Bases ingest: http://localhost:3000/knowledge-bases/ingest"
+}
+
 # ─── Auto-Detect Features ────────────────────────────────────────────────────
 detect_deployed_features() {
   if helm status langfuse -n langfuse &>/dev/null; then
@@ -8902,6 +8983,12 @@ Commands:
                 PVCs, namespaces, and optionally the Kind cluster
   nuke          Non-interactive cleanup (same as: cleanup --yes)
   status        Show pod status and Helm releases
+  docker-compose
+                Prepare .env, update IMAGE_TAG to the latest GitHub release,
+                and start the OSS all-in-one Docker Compose stack
+  update-compose-release
+                Update IMAGE_TAG in .env (or --env-file=FILE) to the latest
+                GitHub release using gh
 
 Options:
   --non-interactive  Skip all prompts (use current context, latest chart,
@@ -8970,6 +9057,11 @@ Options:
                      in the caipe-local-user Secret)
   --env-file=FILE    Path to .env file with agent credentials (ENABLE_ARGOCD=true, ARGOCD_TOKEN=..., etc.)
                      Creates per-agent k8s secrets and enables corresponding agents in Helm.
+                     For docker-compose/update-compose-release, selects the
+                     Compose env file to update/use (default: .env).
+  --compose-env-file=FILE
+                     Alias for selecting the Docker Compose env file without
+                     affecting Helm agent-secret provisioning.
                      Also honors feature toggles to mirror docker-compose.dev.yaml:
                      ENABLE_RAG, ENABLE_GRAPH_RAG, ENABLE_TRACING, ENABLE_SLACK(_BOT),
                      ENABLE_WEBEX(_BOT) (enable-only; CLI flags win). Supported agents:
@@ -9076,6 +9168,8 @@ Examples:
   $(basename "$0")                                        # re-run: offers monitor/upgrade/full menu
   $(basename "$0") cleanup                                # interactive teardown
   $(basename "$0") nuke                                   # teardown (confirm once with 'yes')
+  $(basename "$0") docker-compose                         # update .env IMAGE_TAG + start Docker Compose
+  $(basename "$0") update-compose-release                 # only update IMAGE_TAG in .env
   LLM_PROVIDER=openai $(basename "$0") --non-interactive  # OpenAI instead of Claude
   LLM_PROVIDER=aws-bedrock $(basename "$0") --non-interactive       # AWS Bedrock (uses profile)
   ENABLE_VLLM=true $(basename "$0") --non-interactive                    # vLLM + LiteLLM (gpt-oss-20B in-cluster)
@@ -9137,6 +9231,7 @@ for arg in "$@"; do
     --tls-cert=*)      TLS_CERT_FILE="${arg#--tls-cert=}" ;;
     --tls-key=*)       TLS_KEY_FILE="${arg#--tls-key=}" ;;
     --env-file=*)      ENV_FILE="${arg#--env-file=}" ;;
+    --compose-env-file=*) COMPOSE_ENV_FILE="${arg#--compose-env-file=}" ;;
     --ui-env-file=*)   UI_ENV_FILE="${arg#--ui-env-file=}" ;;
     --load-config=*)   CAIPE_CONFIG_FILE="${arg#--load-config=}" ;;
     --dynamic-agents)    ENABLE_DYNAMIC_AGENTS=true ;;
@@ -9167,6 +9262,8 @@ case "${args[0]:-setup}" in
   cleanup)      cmd_cleanup ;;
   nuke)         AUTO_YES=true; cmd_cleanup ;;
   status)       cmd_status ;;
+  docker-compose|compose) cmd_docker_compose ;;
+  update-compose-release) cmd_update_compose_release ;;
   -h|--help)    usage ;;
   *)            err "Unknown command: ${args[0]}"; usage ;;
 esac

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -8263,10 +8263,25 @@ cmd_docker_compose() {
   _ensure_compose_env_file "$env_file"
   _update_compose_image_tag "$env_file"
 
-  if ! command -v docker &>/dev/null; then
-    err "docker is required for Docker Compose setup"
-    exit 1
+  if [[ "$(uname -s)" == "Darwin" && -x "/usr/local/bin/docker" && ! "$(command -v docker 2>/dev/null)" ]]; then
+    export PATH="/usr/local/bin:$PATH"
   fi
+  if ! command -v docker &>/dev/null; then
+    warn "Docker is not installed — it is required for Docker Compose setup."
+    local os; os="$(uname -s)"
+    if [[ "$os" == "Linux" || "$os" == "Darwin" ]] && ask_yn "Install Docker now?" "y"; then
+      step "Installing Docker"
+      if [[ "$os" == "Linux" ]]; then
+        _install_docker_linux
+      else
+        _install_docker_macos
+      fi
+    else
+      err "Docker is required. Install it from https://docs.docker.com/engine/install/ and re-run."
+      exit 1
+    fi
+  fi
+  _check_docker_access
 
   COMPOSE_PROFILES="${COMPOSE_PROFILES:-$(_env_get "$env_file" COMPOSE_PROFILES)}"
   COMPOSE_PROFILES="${COMPOSE_PROFILES:-$COMPOSE_PROFILES_DEFAULT}"

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -8242,6 +8242,36 @@ cmd_docker_compose() {
   log "Knowledge Bases ingest: http://localhost:3000/knowledge-bases/ingest"
 }
 
+choose_setup_target() {
+  $NON_INTERACTIVE && return 0
+
+  echo ""
+  echo -e "  ${BOLD}How do you want to run CAIPE?${NC}"
+  echo -e "    ${CYAN}1)${NC} Kind/Kubernetes ${DIM}(default; uses saved setup configuration when available)${NC}"
+  echo -e "    ${CYAN}2)${NC} Docker Compose ${DIM}(uses docker-compose.yaml + .env)${NC}"
+  echo ""
+  prompt "Select runtime [1]: "
+
+  local choice
+  tty_read -r choice
+  choice="${choice:-1}"
+  choice="$(echo "$choice" | tr '[:upper:]' '[:lower:]')"
+
+  case "$choice" in
+    1|kind|kubernetes|k8s)
+      return 0
+      ;;
+    2|compose|docker-compose|docker)
+      cmd_docker_compose
+      exit 0
+      ;;
+    *)
+      warn "Unknown choice '${choice}', continuing with Kind/Kubernetes"
+      return 0
+      ;;
+  esac
+}
+
 # ─── Auto-Detect Features ────────────────────────────────────────────────────
 detect_deployed_features() {
   if helm status langfuse -n langfuse &>/dev/null; then
@@ -8690,6 +8720,7 @@ BANNER
   # the same file and see the same cluster and contexts.
   export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
 
+  choose_setup_target
   check_prerequisites
   _load_caipe_config
   choose_cluster

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -3108,14 +3108,17 @@ _compose_env_edit_target() {
 _update_compose_image_tag() {
   local env_file="$1"
   _ensure_compose_env_file "$env_file"
-  if ! command -v gh &>/dev/null; then
-    err "GitHub CLI (gh) is required to fetch the latest CAIPE release"
-    err "Install gh or edit IMAGE_TAG in ${env_file} manually."
+  local latest
+  if command -v gh &>/dev/null; then
+    latest=$(gh release view --repo cnoe-io/ai-platform-engineering --json tagName -q .tagName)
+  elif command -v curl &>/dev/null; then
+    latest=$(curl -sf "https://api.github.com/repos/cnoe-io/ai-platform-engineering/releases/latest" \
+      | jq .tag_name)
+  else
+    err "Either GitHub CLI (gh) or curl is required to fetch the latest CAIPE release"
+    err "Install gh/curl or edit IMAGE_TAG in ${env_file} manually."
     exit 1
   fi
-
-  local latest
-  latest=$(gh release view --repo cnoe-io/ai-platform-engineering --json tagName -q .tagName)
   latest="${latest#v}"
   if [[ -z "$latest" ]]; then
     err "Could not resolve the latest CAIPE release tag"

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -3087,6 +3087,24 @@ _ensure_compose_env_file() {
   log "Created ${env_file} from .env.example"
 }
 
+_compose_env_edit_target() {
+  local env_file="$1"
+  if [[ ! -L "$env_file" ]]; then
+    echo "$env_file"
+    return 0
+  fi
+
+  local target
+  target=$(readlink "$env_file")
+  if [[ "$target" != /* ]]; then
+    local env_dir
+    env_dir=$(cd "$(dirname "$env_file")" && pwd)
+    target="${env_dir}/${target}"
+  fi
+
+  echo "$target"
+}
+
 _update_compose_image_tag() {
   local env_file="$1"
   _ensure_compose_env_file "$env_file"
@@ -3104,13 +3122,31 @@ _update_compose_image_tag() {
     exit 1
   fi
 
-  if grep -q '^IMAGE_TAG=' "$env_file"; then
-    sed -i.bak "s/^IMAGE_TAG=.*/IMAGE_TAG=${latest}/" "$env_file"
-  else
-    cp "$env_file" "${env_file}.bak"
-    printf '\nIMAGE_TAG=%s\n' "$latest" >> "$env_file"
+  local edit_file
+  edit_file=$(_compose_env_edit_target "$env_file")
+  if [[ ! -f "$edit_file" ]]; then
+    err "Compose env file target is not a regular file: ${edit_file}"
+    exit 1
   fi
-  log "Updated IMAGE_TAG=${latest} in ${env_file} (backup: ${env_file}.bak)"
+
+  cp "$edit_file" "${env_file}.bak"
+  if grep -q '^IMAGE_TAG=' "$edit_file"; then
+    local tmp_file
+    tmp_file=$(mktemp "${edit_file}.XXXXXX")
+    awk -v latest="$latest" '
+      /^IMAGE_TAG=/ { print "IMAGE_TAG=" latest; next }
+      { print }
+    ' "$edit_file" > "$tmp_file"
+    mv "$tmp_file" "$edit_file"
+  else
+    printf '\nIMAGE_TAG=%s\n' "$latest" >> "$edit_file"
+  fi
+
+  if [[ "$edit_file" != "$env_file" ]]; then
+    log "Updated IMAGE_TAG=${latest} in ${env_file} -> ${edit_file} (backup: ${env_file}.bak)"
+  else
+    log "Updated IMAGE_TAG=${latest} in ${env_file} (backup: ${env_file}.bak)"
+  fi
 }
 
 # Create a Kubernetes generic secret from a list of key names sourced from a

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -198,6 +198,7 @@ ENV_FILE=""
 UI_ENV_FILE=""
 COMPOSE_ENV_FILE=""
 COMPOSE_PROFILES_DEFAULT="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb,web_ingestor"
+USE_DOCKER_COMPOSE=false
 # Dynamic agents: default ON (custom agent builder UI is part of the
 # baseline CAIPE experience). Set ENABLE_DYNAMIC_AGENTS=false or pass
 # --no-dynamic-agents to skip.
@@ -8232,7 +8233,7 @@ cmd_docker_compose() {
   COMPOSE_PROFILES="${COMPOSE_PROFILES:-$COMPOSE_PROFILES_DEFAULT}"
   export COMPOSE_PROFILES
 
-  step "Starting Docker Compose all-in-one stack"
+  step "Starting Docker Compose all-in-one stack from docker-compose.yaml"
   log "Env file: ${env_file}"
   log "Profiles: ${COMPOSE_PROFILES}"
   docker compose --env-file "$env_file" -f docker-compose.yaml up -d
@@ -8973,7 +8974,8 @@ Usage: $(basename "$0") [COMMAND] [OPTIONS]
 
 Commands:
   setup         Interactive setup: cluster, chart version, credentials,
-                features (RAG, tracing), deploy, port-forward (default)
+                features (RAG, tracing), deploy to Kind/Kubernetes,
+                port-forward (default)
   port-forward  Start port-forwarding, run validation + sanity tests,
                 monitor with auto-restart and periodic health checks (5m)
   validate      Run validation and sanity tests (A2A, agents, RAG, tracing)
@@ -8985,7 +8987,8 @@ Commands:
   status        Show pod status and Helm releases
   docker-compose
                 Prepare .env, update IMAGE_TAG to the latest GitHub release,
-                and start the OSS all-in-one Docker Compose stack
+                and start the OSS all-in-one Docker Compose stack from
+                docker-compose.yaml
   update-compose-release
                 Update IMAGE_TAG in .env (or --env-file=FILE) to the latest
                 GitHub release using gh
@@ -8993,6 +8996,8 @@ Commands:
 Options:
   --non-interactive  Skip all prompts (use current context, latest chart,
                      defaults for endpoint/model, no RAG/tracing unless flagged)
+  --docker-compose   Run the Docker Compose setup path instead of the default
+                     Kind/Kubernetes setup path
   --load-config=FILE Load wizard config from FILE instead of the default
                      ~/.config/caipe/config.yaml (shows summary, asks confirmation)
   --create-cluster   Create a Kind cluster if no kubectl context exists
@@ -9157,6 +9162,7 @@ Supported providers (via cnoe-agent-utils LLMFactory):
 
 Examples:
   $(basename "$0")                                        # interactive setup (default)
+  $(basename "$0") --docker-compose                       # update .env IMAGE_TAG + start Docker Compose
   $(basename "$0") --non-interactive --create-cluster     # create Kind cluster + deploy Claude (default)
   $(basename "$0") --non-interactive --rag --tracing      # Claude + vector RAG + tracing
   $(basename "$0") --non-interactive --graph-rag --tracing # Claude + Graph RAG + tracing
@@ -9194,6 +9200,7 @@ args=()
 for arg in "$@"; do
   case "$arg" in
     --yes|-y)          AUTO_YES=true ;;
+    --docker-compose)  USE_DOCKER_COMPOSE=true ;;
     --non-interactive) NON_INTERACTIVE=true ;;
     --create-cluster)  CREATE_CLUSTER=true ;;
     --rag)             ENABLE_RAG=true ;;
@@ -9249,6 +9256,14 @@ for arg in "$@"; do
     *)                 args+=("$arg") ;;
   esac
 done
+
+if $USE_DOCKER_COMPOSE; then
+  if [[ ${#args[@]} -gt 0 && "${args[0]}" != "setup" ]]; then
+    err "--docker-compose cannot be combined with the '${args[0]}' command"
+    usage
+  fi
+  args=(docker-compose)
+fi
 
 $ENABLE_RBAC_RUNTIME && ENABLE_AGENTGATEWAY=true
 $ENABLE_GRAPH_RAG && ENABLE_RAG=true


### PR DESCRIPTION
## Summary
- use the published CAIPE UI release image in `docker-compose.yaml`
- pass OpenFGA connection defaults into the UI service for the local RBAC profile
- switch the UI healthcheck to `127.0.0.1` so it does not fail on container-local IPv6 localhost resolution

## Why
Fresh OSS all-in-one installs can reach the migrations page but ReBAC migrations fail with `OPENFGA_HTTP is not set`. The production compose file also referenced a `-prod` UI image tag that is not published for the release image, which forces local overrides before first launch works.

## Validation
- `COMPOSE_PROFILES="mcp-servers,caipe-ui-prod,rbac,caipe-supervisor,dynamic-agents,rag,caipe-mongodb" NEXTAUTH_SECRET=test docker compose --env-file /Users/sraradhy/outshift/ai-platform-engineering/.env -f docker-compose.yaml config --quiet`
- confirmed rendered UI config resolves `ghcr.io/cnoe-io/caipe-ui:0.5.16`, `OPENFGA_HTTP=http://openfga:8080`, `OPENFGA_STORE_NAME=caipe-openfga`, and the `127.0.0.1` healthcheck
