### PR TITLE
fix(ui): prefer exact changelog release prompts

### DIFF
--- a/ui/src/app/api/admin/rebac/migrations/status/route.ts
+++ b/ui/src/app/api/admin/rebac/migrations/status/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest } from "next/server";
 
-// assisted-by Codex GPT-5.5
-
 import { successResponse,withErrorHandler } from "@/lib/api-middleware";
 import { getMigrationBlockingStatus } from "@/lib/rbac/migrations/registry";
 

--- a/ui/src/app/api/release-notes/__tests__/route.test.ts
+++ b/ui/src/app/api/release-notes/__tests__/route.test.ts
@@ -91,11 +91,11 @@ describe("/api/release-notes", () => {
     expect(data.body).toContain("Run the migration runbook");
   });
 
-  it("falls back to the nearest lower release when the exact version is missing", async () => {
-    // 0.5.7 has no file; the newest at-or-below is 0.5.6.
+  it("does not fall back to an older release when the exact version is missing", async () => {
     const data = await callGet("0.5.7-dev.14");
-    expect(data.matchedVersion).toBe("0.5.6");
-    expect(data.body).toContain("Newest available notes.");
+    expect(data.matchedVersion).toBeNull();
+    expect(data.body).toBeNull();
+    expect(data.source).toBe("none");
   });
 
   it("returns 400 when no version is provided", async () => {

--- a/ui/src/app/api/release-notes/route.ts
+++ b/ui/src/app/api/release-notes/route.ts
@@ -20,7 +20,6 @@ const CONTENT_TTL_MS = 10 * 60 * 1000;
 interface ReleaseFile {
   name: string;
   version: string;
-  versionParts: [number, number, number];
   rawUrl: string;
   localPath?: string;
 }
@@ -55,27 +54,12 @@ function baseVersion(value: string): string {
   return value.trim().replace(/^v/i, "").split(/[-+]/)[0];
 }
 
-function parseVersionParts(version: string): [number, number, number] | null {
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function compareVersionParts(a: [number, number, number], b: [number, number, number]): number {
-  for (let i = 0; i < 3; i += 1) {
-    if (a[i] !== b[i]) return a[i] - b[i];
-  }
-  return 0;
-}
-
 function buildReleaseFile(name: string, rawUrl: string, localPath?: string): ReleaseFile | null {
   const match = name.match(RELEASE_FILE_PATTERN);
   if (!match) return null;
-  const versionParts: [number, number, number] = [Number(match[1]), Number(match[2]), Number(match[3])];
   return {
     name,
-    version: versionParts.join("."),
-    versionParts,
+    version: [match[1], match[2], match[3]].map(Number).join("."),
     rawUrl,
     localPath,
   };
@@ -143,19 +127,7 @@ async function getReleaseFiles(): Promise<ReleaseFile[]> {
 
 function selectRelease(files: ReleaseFile[], requestedBase: string): ReleaseFile | null {
   if (files.length === 0) return null;
-  const exact = files.find((file) => file.version === requestedBase);
-  if (exact) return exact;
-
-  const target = parseVersionParts(requestedBase);
-  const sorted = [...files].sort((a, b) => compareVersionParts(a.versionParts, b.versionParts));
-  if (!target) return sorted[sorted.length - 1] ?? null;
-
-  // Highest available release at or below the requested version, else the newest.
-  let best: ReleaseFile | null = null;
-  for (const file of sorted) {
-    if (compareVersionParts(file.versionParts, target) <= 0) best = file;
-  }
-  return best ?? sorted[sorted.length - 1] ?? null;
+  return files.find((file) => file.version === requestedBase) ?? null;
 }
 
 async function readReleaseContent(file: ReleaseFile): Promise<{ body: string; source: "github" | "local" } | null> {

--- a/ui/src/components/release/ReleaseUpgradeDialog.tsx
+++ b/ui/src/components/release/ReleaseUpgradeDialog.tsx
@@ -65,6 +65,8 @@ const RELEASE_051_FALLBACK_SECTIONS: ReleaseNote["sections"] = [
   },
 ];
 
+const CHANGELOG_URL = "https://github.com/cnoe-io/ai-platform-engineering/blob/main/CHANGELOG.md";
+
 function fallbackSections(releaseVersion: string): ReleaseNote["sections"] {
   const normalizedReleaseVersion = releaseVersion.trim().replace(/^v/, "").toLowerCase();
   if (normalizedReleaseVersion === "0.5.1" || normalizedReleaseVersion === "dev") {
@@ -228,9 +230,9 @@ export function ReleaseUpgradeDialog({
           </div>
           <DialogTitle>What&apos;s new in {releaseVersion}</DialogTitle>
           <DialogDescription>
-            {isAdmin
+            {isAdmin && showMigrationCta
               ? "This deployment includes new release updates and schema migrations. Review the notes, then open the migration assistant when you are ready."
-              : "This deployment includes CAIPE updates that make agent access and chat connector setup easier to understand."}
+              : "This deployment includes CAIPE updates from the active release. Review the notes when you are ready."}
           </DialogDescription>
         </DialogHeader>
 
@@ -258,6 +260,17 @@ export function ReleaseUpgradeDialog({
               ))}
             </div>
           )}
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          <a
+            href={CHANGELOG_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary underline-offset-2 hover:underline"
+          >
+            View full changelog
+          </a>
         </div>
 
         {isAdmin && showMigrationCta && (

--- a/ui/src/components/release/__tests__/ReleaseUpgradeDialog.test.tsx
+++ b/ui/src/components/release/__tests__/ReleaseUpgradeDialog.test.tsx
@@ -94,6 +94,10 @@ describe("ReleaseUpgradeDialog", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("What's new in 0.5.1")).toBeInTheDocument();
     expect(screen.getByText("Added Slack and Webex ReBAC migration assistant")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View full changelog" })).toHaveAttribute(
+      "href",
+      "https://github.com/cnoe-io/ai-platform-engineering/blob/main/CHANGELOG.md",
+    );
     expect(screen.getByRole("button", { name: "Open Migration Assistant" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Skip until next login" })).toBeInTheDocument();
 
@@ -155,6 +159,25 @@ describe("ReleaseUpgradeDialog", () => {
     expect(screen.queryByText("Added Slack and Webex ReBAC migration assistant")).not.toBeInTheDocument();
     expect(screen.queryByText(/schema migrations/i)).not.toBeInTheDocument();
     expect(onDismissPermanently).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mention migrations to admins when the migration CTA is hidden", () => {
+    render(
+      <ReleaseUpgradeDialog
+        open
+        isAdmin
+        releaseVersion="0.5.1"
+        release={release}
+        showMigrationCta={false}
+        onOpenMigrationAssistant={jest.fn()}
+        onSkipUntilNextLogin={jest.fn()}
+        onDismissPermanently={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/schema migrations/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Admin migration reminder")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open Migration Assistant" })).not.toBeInTheDocument();
   });
 
   const markdownNotes = {

--- a/ui/src/hooks/__tests__/use-release-upgrade-prompt.test.tsx
+++ b/ui/src/hooks/__tests__/use-release-upgrade-prompt.test.tsx
@@ -86,6 +86,29 @@ describe("useReleaseUpgradePrompt", () => {
           },
         });
       }
+      if (href === "/api/rbac/migration-status") {
+        return jsonResponse({
+          success: true,
+          data: {
+            requires_attention: true,
+            is_blocking: true,
+            needs_version_bootstrap: false,
+            pending_required_count: 1,
+            blocking_required_count: 1,
+            version_bootstrap_required_count: 0,
+          },
+        });
+      }
+      if (href.startsWith("/api/release-notes")) {
+        return jsonResponse({
+          requestedVersion: "0.5.1",
+          matchedVersion: "0.5.1",
+          title: "Release 0.5.1",
+          date: "2026-05-19",
+          body: "Curated release notes body",
+          source: "github",
+        });
+      }
       if (href === "/api/settings/preferences" && init?.method === "PATCH") {
         return jsonResponse({ success: true });
       }
@@ -102,7 +125,127 @@ describe("useReleaseUpgradePrompt", () => {
 
     expect(result.current.releaseVersion).toBe("0.5.1");
     expect(result.current.release?.sections[0].items[0].text).toBe("Added migrations");
+    expect(result.current.releaseMarkdown).toBeNull();
+    expect(result.current.showMigrationCta).toBe(true);
     expect(result.current.isAdmin).toBe(true);
+  });
+
+  it("uses exact changelog entries before exact curated release markdown", async () => {
+    const { result } = renderHook(() => useReleaseUpgradePrompt());
+
+    await waitFor(() => expect(result.current.open).toBe(true));
+
+    expect(result.current.release?.version).toBe("0.5.1");
+    expect(result.current.releaseMarkdown).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith("/api/release-notes?version=0.5.1");
+  });
+
+  it("uses exact curated release markdown only when the changelog has no exact entry", async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (url: RequestInfo | URL) => {
+      const href = String(url);
+      if (href === "/api/settings") {
+        return jsonResponse({
+          success: true,
+          data: {
+            preferences: {
+              releaseNotesDismissedVersions: [],
+              releaseNotesDismissedAnnouncementIds: [],
+            },
+          },
+        });
+      }
+      if (href === "/api/changelog") {
+        return jsonResponse({ releases: [], scopes: [] });
+      }
+      if (href === "/api/admin/platform-config") {
+        return jsonResponse({
+          success: true,
+          data: {
+            release_notes: {
+              enabled: true,
+              release_version: "0.5.1",
+              announcement_revision: 1,
+              announcement_id: "0.5.1:revision-1",
+              show_toast: false,
+              toast_duration_ms: 5000,
+              show_migration_cta: false,
+            },
+          },
+        });
+      }
+      if (href.startsWith("/api/release-notes")) {
+        return jsonResponse({
+          requestedVersion: "0.5.1",
+          matchedVersion: "0.5.1",
+          title: "Release 0.5.1",
+          date: "2026-05-19",
+          body: "Curated release notes body",
+          source: "github",
+        });
+      }
+      return jsonResponse({}, false);
+    });
+
+    const { result } = renderHook(() => useReleaseUpgradePrompt());
+
+    await waitFor(() => expect(result.current.open).toBe(true));
+
+    expect(result.current.release).toBeNull();
+    expect(result.current.releaseMarkdown?.body).toBe("Curated release notes body");
+  });
+
+  it("hides the migration CTA when migration status is clean", async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (url: RequestInfo | URL) => {
+      const href = String(url);
+      if (href === "/api/settings") {
+        return jsonResponse({
+          success: true,
+          data: {
+            preferences: {
+              releaseNotesDismissedVersions: [],
+              releaseNotesDismissedAnnouncementIds: [],
+            },
+          },
+        });
+      }
+      if (href === "/api/changelog") return jsonResponse(changelogPayload);
+      if (href === "/api/admin/platform-config") {
+        return jsonResponse({
+          success: true,
+          data: {
+            release_notes: {
+              enabled: true,
+              release_version: "0.5.1",
+              announcement_revision: 1,
+              announcement_id: "0.5.1:revision-1",
+              show_toast: false,
+              toast_duration_ms: 5000,
+              show_migration_cta: true,
+            },
+          },
+        });
+      }
+      if (href === "/api/rbac/migration-status") {
+        return jsonResponse({
+          success: true,
+          data: {
+            requires_attention: false,
+            is_blocking: false,
+            needs_version_bootstrap: false,
+            pending_required_count: 0,
+            blocking_required_count: 0,
+            version_bootstrap_required_count: 0,
+          },
+        });
+      }
+      if (href.startsWith("/api/release-notes")) return jsonResponse({}, false);
+      return jsonResponse({}, false);
+    });
+
+    const { result } = renderHook(() => useReleaseUpgradePrompt());
+
+    await waitFor(() => expect(result.current.open).toBe(true));
+    expect(result.current.showMigrationCta).toBe(false);
   });
 
   it("opens the migration assistant and suppresses the prompt for the current session", async () => {

--- a/ui/src/hooks/use-release-upgrade-prompt.ts
+++ b/ui/src/hooks/use-release-upgrade-prompt.ts
@@ -32,6 +32,18 @@ interface ReleaseNotesResponse {
   body?: string | null;
 }
 
+interface MigrationStatusResponse {
+  success?: boolean;
+  data?: {
+    requires_attention?: boolean;
+    is_blocking?: boolean;
+    needs_version_bootstrap?: boolean;
+    pending_required_count?: number;
+    blocking_required_count?: number;
+    version_bootstrap_required_count?: number;
+  };
+}
+
 interface SettingsResponse {
   success?: boolean;
   data?: {
@@ -92,6 +104,22 @@ function normalizeVersion(value?: string | null): string | null {
   const version = value?.trim().replace(/^v/, "");
   if (!version) return null;
   return version;
+}
+
+function baseVersion(value: string): string {
+  return value.trim().replace(/^v/i, "").split(/[-+]/)[0];
+}
+
+function migrationStatusNeedsAttention(status: MigrationStatusResponse["data"] | undefined): boolean {
+  if (!status) return false;
+  return Boolean(
+    status.requires_attention ||
+      status.is_blocking ||
+      status.needs_version_bootstrap ||
+      (status.pending_required_count ?? 0) > 0 ||
+      (status.blocking_required_count ?? 0) > 0 ||
+      (status.version_bootstrap_required_count ?? 0) > 0,
+  );
 }
 
 function resolvePromptVersion(versionInfo: { version?: string; packageVersion?: string } | null): string | null {
@@ -183,6 +211,7 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
         setOpen(false);
         setToastNotification(null);
         setReleaseMarkdown(null);
+        setShowMigrationCta(false);
         return;
       }
 
@@ -222,6 +251,7 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
           setReleaseMarkdown(null);
           setOpen(false);
           setToastNotification(null);
+          setShowMigrationCta(false);
           return;
         }
 
@@ -229,7 +259,6 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
         const activeAnnouncementId = releaseConfig.announcement_id;
         setReleaseVersion(activeReleaseVersion);
         setAnnouncementId(activeAnnouncementId);
-        setShowMigrationCta(isAdmin && releaseConfig.show_migration_cta);
 
         const hasManagedAnnouncement = Boolean(
           normalizeVersion(platformConfigPayload?.data?.release_notes?.release_version),
@@ -246,6 +275,7 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
           setReleaseMarkdown(null);
           setOpen(false);
           setToastNotification(null);
+          setShowMigrationCta(false);
           return;
         }
 
@@ -254,8 +284,22 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
           null;
         setRelease(matchingRelease);
 
-        // Prefer the curated, full markdown release notes (docs/releases/*.md)
-        // over the terse parsed CHANGELOG bullets when available.
+        let migrationAttention = false;
+        if (isAdmin && releaseConfig.show_migration_cta) {
+          try {
+            const migrationStatusResponse = await fetch("/api/rbac/migration-status");
+            const migrationStatusPayload: MigrationStatusResponse | null = migrationStatusResponse.ok
+              ? await migrationStatusResponse.json()
+              : null;
+            migrationAttention = migrationStatusNeedsAttention(migrationStatusPayload?.data);
+          } catch (statusError) {
+            console.warn("[release-upgrade-prompt] Failed to load migration status:", statusError);
+          }
+        }
+        if (!cancelled) {
+          setShowMigrationCta(isAdmin && releaseConfig.show_migration_cta && migrationAttention);
+        }
+
         try {
           const notesResponse = await fetch(
             `/api/release-notes?version=${encodeURIComponent(activeReleaseVersion)}`,
@@ -264,8 +308,12 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
             ? await notesResponse.json()
             : null;
           if (!cancelled) {
+            const hasExactChangelog = Boolean(matchingRelease);
+            const hasExactCuratedNotes =
+              Boolean(notesPayload?.body) &&
+              normalizeVersion(notesPayload?.matchedVersion) === baseVersion(activeReleaseVersion);
             setReleaseMarkdown(
-              notesPayload?.body
+              !hasExactChangelog && hasExactCuratedNotes
                 ? {
                     matchedVersion: notesPayload.matchedVersion ?? null,
                     title: notesPayload.title ?? null,


### PR DESCRIPTION
## Summary
- prefer exact `CHANGELOG.md` release entries in the release notification dialog
- stop falling back to older curated `docs/releases` posts when the active version has no exact release note
- show curated release markdown only when there is no exact changelog entry and the curated note matches the active base version
- hide the migration CTA and migration language unless migration status reports attention is needed
- add a full changelog link and regression coverage for the source-priority rules

## Why
The release notification could show `What's new in 0.5.16` while rendering the nearest older curated release note, such as `0.5.10`. That makes release notifications misleading and creates manual upkeep pressure for every release. The prompt should track the generated changelog first and only use curated notes when they exactly match.

## Validation
- `npm test -- --runInBand src/app/api/release-notes/__tests__/route.test.ts src/hooks/__tests__/use-release-upgrade-prompt.test.tsx src/components/release/__tests__/ReleaseUpgradeDialog.test.tsx`
- `npm run lint -- src/app/api/release-notes/route.ts src/app/api/release-notes/__tests__/route.test.ts src/hooks/use-release-upgrade-prompt.ts src/hooks/__tests__/use-release-upgrade-prompt.test.tsx src/components/release/ReleaseUpgradeDialog.tsx src/components/release/__tests__/ReleaseUpgradeDialog.test.tsx src/app/api/admin/rebac/migrations/status/route.ts`

Note: lint exits successfully but the repo currently reports existing warnings because the script runs `eslint .`.
