### PR TITLE
feat(ui): add platform health probes

### DIFF
--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -131,6 +131,7 @@ async function installSessionAndOpenHome(page: Page, env: RbacEnv): Promise<void
 }
 
 async function openSystemStatus(page: Page) {
+  await dismissReleaseUpgradeDialog(page);
   const trigger = page.getByRole("button", { name: /system status:/i });
   await expect(trigger).toBeVisible({ timeout: 15_000 });
   await trigger.click();
@@ -158,7 +159,7 @@ test.describe("platform health probes", () => {
     await expect(page.getByText("5/5")).toBeVisible();
     await expect(page.getByText("Core Runtime", { exact: true })).toBeVisible();
     await expect(page.getByText("Identity & Authz")).toBeVisible();
-    await expect(page.getByText("Core runtime, identity, storage, RAG, web ingestor queue readiness, and migrations look ready.")).toBeVisible();
+    await expect(page.getByText("All critical checks are ready.")).toBeVisible();
   });
 
   test("a down platform dependency changes the header to issues detected", async ({ page }) => {
@@ -187,7 +188,7 @@ test.describe("platform health probes", () => {
     await expect(page.getByText("Action needed")).toBeVisible();
     await expect(page.getByText("OpenFGA", { exact: true })).toBeVisible();
     await expect(page.getByText("HTTP 503")).toBeVisible();
-    await expect(page.getByText("DOWN").first()).toBeVisible();
+    await expect(page.getByText("Down").first()).toBeVisible();
     await expect(page.getByText("Check logs for details")).toBeVisible();
   });
 

--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -2,7 +2,7 @@ import { expect, Page, test } from "@playwright/test";
 import { rbacEnvOrSkip, type RbacEnv } from "./_env";
 import { dismissReleaseUpgradeDialog, installTestSession } from "./_helpers";
 
-type ProbeStatus = "healthy" | "down";
+type ProbeStatus = "healthy" | "warning" | "down";
 
 type Probe = {
   id: string;
@@ -12,17 +12,23 @@ type Probe = {
   detail: string;
   target: string;
   latency_ms: number;
+  remediation?: {
+    label: string;
+    href: string;
+    description: string;
+  };
 };
 
 function platformHealthPayload(probes: Probe[]) {
   const down = probes.filter((probe) => probe.status === "down").length;
+  const warning = probes.filter((probe) => probe.status === "warning").length;
   return {
-    status: down > 0 ? "down" : "healthy",
+    status: down > 0 ? "down" : warning > 0 ? "degraded" : "healthy",
     checked_at: new Date("2026-06-18T12:00:00Z").toISOString(),
     summary: {
       total: probes.length,
-      healthy: probes.length - down,
-      warning: 0,
+      healthy: probes.length - down - warning,
+      warning,
       down,
     },
     probes,
@@ -74,6 +80,78 @@ const healthyProbes: Probe[] = [
     detail: "HTTP 200",
     target: "http://agentgateway:15000/config",
     latency_ms: 7,
+  },
+  {
+    id: "openfga-bootstrap",
+    label: "OpenFGA Bootstrap",
+    group: "bootstrap",
+    status: "healthy",
+    detail: "Store and model ready",
+    target: "http://openfga:8080/stores/caipe/authorization-models",
+    latency_ms: 16,
+  },
+  {
+    id: "keycloak-bootstrap",
+    label: "Keycloak Bootstrap",
+    group: "bootstrap",
+    status: "healthy",
+    detail: "Realm and clients ready",
+    target: "caipe realm",
+    latency_ms: 13,
+  },
+  {
+    id: "rbac-migrations",
+    label: "RBAC Migrations",
+    group: "bootstrap",
+    status: "healthy",
+    detail: "Schema migrations current",
+    target: "0.5.16",
+    latency_ms: 9,
+  },
+  {
+    id: "mongodb",
+    label: "MongoDB",
+    group: "storage",
+    status: "healthy",
+    detail: "TCP connection accepted",
+    target: "caipe-mongodb:27017",
+    latency_ms: 3,
+  },
+  {
+    id: "keycloak-postgres",
+    label: "Keycloak Postgres",
+    group: "storage",
+    status: "healthy",
+    detail: "TCP connection accepted",
+    target: "keycloak-postgres:5432",
+    latency_ms: 4,
+  },
+  {
+    id: "openfga-postgres",
+    label: "OpenFGA Postgres",
+    group: "storage",
+    status: "healthy",
+    detail: "TCP connection accepted",
+    target: "openfga-postgres:5432",
+    latency_ms: 4,
+  },
+  {
+    id: "rag-server",
+    label: "RAG Server",
+    group: "rag",
+    status: "healthy",
+    detail: "HTTP 200",
+    target: "http://caipe-rag-server:9446/healthz",
+    latency_ms: 24,
+  },
+  {
+    id: "web-ingestor",
+    label: "Web Ingestor",
+    group: "rag",
+    status: "healthy",
+    detail: "Queue ready",
+    target: "web-ingestor",
+    latency_ms: 6,
   },
 ];
 
@@ -137,6 +215,27 @@ async function openSystemStatus(page: Page) {
   await trigger.click();
 }
 
+async function expectGroupTooltip(page: Page, label: string, expectedProbe: string, expectedTarget: string) {
+  const group = page.getByText(label, { exact: true });
+  await expect(group).toBeVisible();
+  await group.hover();
+  await expect(page.getByText(expectedProbe, { exact: true }).first()).toBeVisible();
+  await expect(page.getByText(expectedTarget, { exact: true }).first()).toBeVisible();
+  await page.mouse.move(0, 0);
+}
+
+function manyHealthyProbes(count: number): Probe[] {
+  return Array.from({ length: count }, (_, index) => {
+    const base = healthyProbes[index % healthyProbes.length];
+    return {
+      ...base,
+      id: `${base.id}-${index}`,
+      label: `${base.label} ${index + 1}`,
+      target: `${base.target}?probe=${index + 1}`,
+    };
+  });
+}
+
 test.describe("platform health probes", () => {
   test("healthy probes replace connected integrations in the status popover", async ({ page }) => {
     const env = rbacEnvOrSkip({ requireUserSub: true });
@@ -156,7 +255,7 @@ test.describe("platform health probes", () => {
 
     await expect(page.getByText("Platform Health")).toBeVisible();
     await expect(page.getByText("Connected Integrations")).toHaveCount(0);
-    await expect(page.getByText("5/5")).toBeVisible();
+    await expect(page.getByText("13/13")).toBeVisible();
     const dynamicAgentRuntime = page.getByText("Dynamic Agent Runtime", { exact: true });
     await expect(dynamicAgentRuntime).toBeVisible();
     await expect(page.getByText("Identity & Authz")).toBeVisible();
@@ -165,6 +264,52 @@ test.describe("platform health probes", () => {
     await dynamicAgentRuntime.hover();
     await expect(page.getByText("AgentGateway Config Bridge")).toBeVisible();
     await expect(page.getByText("http://caipe-ui:3000/api/internal/agentgateway/mcp-targets")).toBeVisible();
+  });
+
+  test("every health group tooltip lists the probes and targets behind the rollup", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(healthyProbes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+    await openSystemStatus(page);
+
+    await expectGroupTooltip(
+      page,
+      "Dynamic Agent Runtime",
+      "AgentGateway Config Bridge",
+      "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets",
+    );
+    await expectGroupTooltip(
+      page,
+      "Identity & Authz",
+      "Keycloak",
+      "http://keycloak:7080/realms/caipe/protocol/openid-connect/certs",
+    );
+    await expectGroupTooltip(
+      page,
+      "Bootstrap & Migrations",
+      "RBAC Migrations",
+      "0.5.16",
+    );
+    await expectGroupTooltip(
+      page,
+      "Storage",
+      "MongoDB",
+      "caipe-mongodb:27017",
+    );
+    await expectGroupTooltip(
+      page,
+      "RAG & Web Ingestor",
+      "Web Ingestor",
+      "web-ingestor",
+    );
   });
 
   test("a down platform dependency changes the header to issues detected", async ({ page }) => {
@@ -189,12 +334,82 @@ test.describe("platform health probes", () => {
     await openSystemStatus(page);
 
     await expect(page.getByText("Issues Detected")).toBeVisible();
-    await expect(page.getByText("4/5")).toBeVisible();
+    await expect(page.getByText("12/13")).toBeVisible();
     await expect(page.getByText("Action needed")).toBeVisible();
     await expect(page.getByText("OpenFGA", { exact: true }).first()).toBeVisible();
     await expect(page.getByText("HTTP 503").first()).toBeVisible();
     await expect(page.getByText("Down").first()).toBeVisible();
     await expect(page.getByText("Check logs for details")).toBeVisible();
+  });
+
+  test("remediation buttons navigate to the configured admin surface", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "openfga"
+        ? {
+            ...probe,
+            status: "down" as const,
+            detail: "HTTP 503",
+            latency_ms: 31,
+            remediation: {
+              label: "OpenFGA",
+              href: "/admin?cat=security&tab=openfga",
+              description: "Open the OpenFGA diagnostics tab.",
+            },
+          }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+    await openSystemStatus(page);
+
+    await page.locator('button[title="Open the OpenFGA diagnostics tab."]').click();
+    await expect(page).toHaveURL(/\/admin\?cat=security&tab=openfga/);
+  });
+
+  test("long probe output scrolls inside the status popover", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(manyHealthyProbes(40))),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+    await openSystemStatus(page);
+
+    const popoverScroller = page.getByTestId("platform-health-scroll");
+    const probeList = page.getByTestId("platform-health-probe-list");
+    await expect(probeList).toBeVisible();
+    await expect(probeList).toHaveJSProperty("scrollTop", 0);
+    await expect
+      .poll(async () =>
+        probeList.evaluate((node) => node.scrollHeight > node.clientHeight),
+      )
+      .toBe(true);
+    await expect
+      .poll(async () =>
+        popoverScroller.evaluate((node) => node.scrollHeight <= node.clientHeight || getComputedStyle(node).overflowY === "auto"),
+      )
+      .toBe(true);
+
+    await probeList.evaluate((node) => {
+      node.scrollTop = node.scrollHeight;
+    });
+    await expect
+      .poll(async () => probeList.evaluate((node) => node.scrollTop > 0))
+      .toBe(true);
   });
 
   test("pending probe results show an explicit checking state", async ({ page }) => {

--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -157,9 +157,14 @@ test.describe("platform health probes", () => {
     await expect(page.getByText("Platform Health")).toBeVisible();
     await expect(page.getByText("Connected Integrations")).toHaveCount(0);
     await expect(page.getByText("5/5")).toBeVisible();
-    await expect(page.getByText("Core Runtime", { exact: true })).toBeVisible();
+    const dynamicAgentRuntime = page.getByText("Dynamic Agent Runtime", { exact: true });
+    await expect(dynamicAgentRuntime).toBeVisible();
     await expect(page.getByText("Identity & Authz")).toBeVisible();
     await expect(page.getByText("All critical checks are ready.")).toBeVisible();
+
+    await dynamicAgentRuntime.hover();
+    await expect(page.getByText("AgentGateway Config Bridge")).toBeVisible();
+    await expect(page.getByText("http://caipe-ui:3000/api/internal/agentgateway/mcp-targets")).toBeVisible();
   });
 
   test("a down platform dependency changes the header to issues detected", async ({ page }) => {
@@ -186,8 +191,8 @@ test.describe("platform health probes", () => {
     await expect(page.getByText("Issues Detected")).toBeVisible();
     await expect(page.getByText("4/5")).toBeVisible();
     await expect(page.getByText("Action needed")).toBeVisible();
-    await expect(page.getByText("OpenFGA", { exact: true })).toBeVisible();
-    await expect(page.getByText("HTTP 503")).toBeVisible();
+    await expect(page.getByText("OpenFGA", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("HTTP 503").first()).toBeVisible();
     await expect(page.getByText("Down").first()).toBeVisible();
     await expect(page.getByText("Check logs for details")).toBeVisible();
   });

--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -1,0 +1,215 @@
+import { expect, Page, test } from "@playwright/test";
+import { rbacEnvOrSkip, type RbacEnv } from "./_env";
+import { dismissReleaseUpgradeDialog, installTestSession } from "./_helpers";
+
+type ProbeStatus = "healthy" | "down";
+
+type Probe = {
+  id: string;
+  label: string;
+  status: ProbeStatus;
+  detail: string;
+  target: string;
+  latency_ms: number;
+};
+
+function platformHealthPayload(probes: Probe[]) {
+  const down = probes.filter((probe) => probe.status === "down").length;
+  return {
+    status: down > 0 ? "down" : "healthy",
+    checked_at: new Date("2026-06-18T12:00:00Z").toISOString(),
+    summary: {
+      total: probes.length,
+      healthy: probes.length - down,
+      down,
+    },
+    probes,
+  };
+}
+
+const healthyProbes: Probe[] = [
+  {
+    id: "keycloak",
+    label: "Keycloak",
+    status: "healthy",
+    detail: "HTTP 200",
+    target: "http://keycloak:7080/realms/caipe/protocol/openid-connect/certs",
+    latency_ms: 10,
+  },
+  {
+    id: "openfga",
+    label: "OpenFGA",
+    status: "healthy",
+    detail: "HTTP 200",
+    target: "http://openfga:8080/healthz",
+    latency_ms: 11,
+  },
+  {
+    id: "openfga-authz-bridge",
+    label: "OpenFGA Bridge",
+    status: "healthy",
+    detail: "TCP connection accepted",
+    target: "openfga-authz-bridge:9100",
+    latency_ms: 2,
+  },
+  {
+    id: "agentgateway-config-bridge",
+    label: "AgentGateway Config Bridge",
+    status: "healthy",
+    detail: "HTTP 200",
+    target: "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets",
+    latency_ms: 18,
+  },
+  {
+    id: "agentgateway",
+    label: "AgentGateway",
+    status: "healthy",
+    detail: "HTTP 200",
+    target: "http://agentgateway:15000/config",
+    latency_ms: 7,
+  },
+];
+
+async function installStableHeaderHealthMocks(page: Page): Promise<void> {
+  await page.route("**/.well-known/agent-card.json", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        name: "AI Platform Engineer",
+        description: "Central orchestrator",
+        skills: [],
+      }),
+    });
+  });
+
+  await page.route("**/api/rag/healthz", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "healthy",
+        config: {
+          graph_rag_enabled: false,
+          cleanup: {
+            enabled: true,
+            interval_seconds: 86400,
+            last_cleanup: null,
+          },
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/dynamic-agents/health", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "healthy" }),
+    });
+  });
+}
+
+async function installSessionAndOpenHome(page: Page, env: RbacEnv): Promise<void> {
+  test.skip(!process.env.NEXTAUTH_SECRET, "NEXTAUTH_SECRET is required for deterministic local session e2e.");
+  test.skip(!env.user.sub, "RBAC_USER_SUB is required for deterministic local session e2e.");
+
+  await installTestSession(page, env, {
+    email: env.user.email,
+    subject: env.user.sub,
+    role: "admin",
+  });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await dismissReleaseUpgradeDialog(page);
+}
+
+async function openSystemStatus(page: Page) {
+  const trigger = page.getByRole("button", { name: /system status:/i });
+  await expect(trigger).toBeVisible({ timeout: 15_000 });
+  await trigger.click();
+}
+
+test.describe("platform health probes", () => {
+  test("healthy probes replace connected integrations in the status popover", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(healthyProbes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+
+    await expect(page.getByRole("button", { name: /system status: connected/i })).toBeVisible();
+    await openSystemStatus(page);
+
+    await expect(page.getByText("Platform Probes")).toBeVisible();
+    await expect(page.getByText("Connected Integrations")).toHaveCount(0);
+    await expect(page.getByText("5/5")).toBeVisible();
+
+    for (const probe of healthyProbes) {
+      await expect(page.getByText(probe.label, { exact: true })).toBeVisible();
+    }
+    await expect(page.getByText("OK")).toHaveCount(5);
+  });
+
+  test("a down platform dependency changes the header to issues detected", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "openfga"
+        ? { ...probe, status: "down" as const, detail: "HTTP 503", latency_ms: 31 }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+
+    await expect(page.getByRole("button", { name: /system status: disconnected/i })).toBeVisible();
+    await openSystemStatus(page);
+
+    await expect(page.getByText("Issues Detected")).toBeVisible();
+    await expect(page.getByText("4/5")).toBeVisible();
+    await expect(page.getByText("OpenFGA", { exact: true })).toBeVisible();
+    await expect(page.getByText("HTTP 503 · 31ms")).toBeVisible();
+    await expect(page.getByText("DOWN")).toBeVisible();
+    await expect(page.getByText("Check logs for details")).toBeVisible();
+  });
+
+  test("pending probe results show an explicit checking state", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+
+    let releasePlatformHealth!: () => void;
+    const platformHealthCanReturn = new Promise<void>((resolve) => {
+      releasePlatformHealth = resolve;
+    });
+
+    await page.route("**/api/platform/health", async (route) => {
+      await platformHealthCanReturn;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(healthyProbes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+
+    await expect(page.getByRole("button", { name: /system status: checking/i })).toBeVisible();
+    await openSystemStatus(page);
+    await expect(page.getByText("Checking Keycloak, OpenFGA, AgentGateway, and bridge health...")).toBeVisible();
+
+    releasePlatformHealth();
+    await expect(page.getByRole("button", { name: /system status: connected/i })).toBeVisible();
+  });
+});

--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -7,6 +7,7 @@ type ProbeStatus = "healthy" | "down";
 type Probe = {
   id: string;
   label: string;
+  group: "core" | "identity" | "storage" | "rag" | "bootstrap";
   status: ProbeStatus;
   detail: string;
   target: string;
@@ -21,6 +22,7 @@ function platformHealthPayload(probes: Probe[]) {
     summary: {
       total: probes.length,
       healthy: probes.length - down,
+      warning: 0,
       down,
     },
     probes,
@@ -31,6 +33,7 @@ const healthyProbes: Probe[] = [
   {
     id: "keycloak",
     label: "Keycloak",
+    group: "identity",
     status: "healthy",
     detail: "HTTP 200",
     target: "http://keycloak:7080/realms/caipe/protocol/openid-connect/certs",
@@ -39,6 +42,7 @@ const healthyProbes: Probe[] = [
   {
     id: "openfga",
     label: "OpenFGA",
+    group: "identity",
     status: "healthy",
     detail: "HTTP 200",
     target: "http://openfga:8080/healthz",
@@ -47,6 +51,7 @@ const healthyProbes: Probe[] = [
   {
     id: "openfga-authz-bridge",
     label: "OpenFGA Bridge",
+    group: "identity",
     status: "healthy",
     detail: "TCP connection accepted",
     target: "openfga-authz-bridge:9100",
@@ -55,6 +60,7 @@ const healthyProbes: Probe[] = [
   {
     id: "agentgateway-config-bridge",
     label: "AgentGateway Config Bridge",
+    group: "core",
     status: "healthy",
     detail: "HTTP 200",
     target: "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets",
@@ -63,6 +69,7 @@ const healthyProbes: Probe[] = [
   {
     id: "agentgateway",
     label: "AgentGateway",
+    group: "core",
     status: "healthy",
     detail: "HTTP 200",
     target: "http://agentgateway:15000/config",
@@ -146,14 +153,12 @@ test.describe("platform health probes", () => {
     await expect(page.getByRole("button", { name: /system status: connected/i })).toBeVisible();
     await openSystemStatus(page);
 
-    await expect(page.getByText("Platform Probes")).toBeVisible();
+    await expect(page.getByText("Platform Health")).toBeVisible();
     await expect(page.getByText("Connected Integrations")).toHaveCount(0);
     await expect(page.getByText("5/5")).toBeVisible();
-
-    for (const probe of healthyProbes) {
-      await expect(page.getByText(probe.label, { exact: true })).toBeVisible();
-    }
-    await expect(page.getByText("OK")).toHaveCount(5);
+    await expect(page.getByText("Core Runtime", { exact: true })).toBeVisible();
+    await expect(page.getByText("Identity & Authz")).toBeVisible();
+    await expect(page.getByText("Core runtime, identity, storage, RAG, web ingestor queue readiness, and migrations look ready.")).toBeVisible();
   });
 
   test("a down platform dependency changes the header to issues detected", async ({ page }) => {
@@ -179,9 +184,10 @@ test.describe("platform health probes", () => {
 
     await expect(page.getByText("Issues Detected")).toBeVisible();
     await expect(page.getByText("4/5")).toBeVisible();
+    await expect(page.getByText("Action needed")).toBeVisible();
     await expect(page.getByText("OpenFGA", { exact: true })).toBeVisible();
-    await expect(page.getByText("HTTP 503 · 31ms")).toBeVisible();
-    await expect(page.getByText("DOWN")).toBeVisible();
+    await expect(page.getByText("HTTP 503")).toBeVisible();
+    await expect(page.getByText("DOWN").first()).toBeVisible();
     await expect(page.getByText("Check logs for details")).toBeVisible();
   });
 
@@ -207,7 +213,7 @@ test.describe("platform health probes", () => {
 
     await expect(page.getByRole("button", { name: /system status: checking/i })).toBeVisible();
     await openSystemStatus(page);
-    await expect(page.getByText("Checking Keycloak, OpenFGA, AgentGateway, and bridge health...")).toBeVisible();
+    await expect(page.getByText("Checking Keycloak, OpenFGA, AgentGateway, RAG, storage, web ingestor readiness, and migrations...")).toBeVisible();
 
     releasePlatformHealth();
     await expect(page.getByRole("button", { name: /system status: connected/i })).toBeVisible();

--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -342,6 +342,83 @@ test.describe("platform health probes", () => {
     await expect(page.getByText("Check logs for details")).toBeVisible();
   });
 
+  test("down probes render as red outages, not amber warnings", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "agentgateway"
+        ? { ...probe, status: "down" as const, detail: "connection refused", latency_ms: 31 }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+
+    const statusButton = page.getByRole("button", { name: /system status: disconnected/i });
+    await expect(statusButton).toBeVisible();
+    await expect(statusButton).toHaveClass(/red/);
+    await openSystemStatus(page);
+
+    await expect(page.getByText("Issues Detected")).toBeVisible();
+    await expect(page.getByText("12/13 Down")).toBeVisible();
+    await expect(page.getByText("Check logs for details")).toBeVisible();
+    await expect(page.getByText("Needs Attention")).toHaveCount(0);
+    await expect(page.getByText("AgentGateway", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("connection refused").first()).toBeVisible();
+    await expect(page.getByText("Down").first()).toBeVisible();
+  });
+
+  test("warning probes render as amber degraded state without marking the stack down", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "rbac-migrations"
+        ? {
+            ...probe,
+            status: "warning" as const,
+            detail: "2 blocking migrations pending",
+            latency_ms: 0,
+            remediation: {
+              label: "Migration Assistant",
+              href: "/admin?cat=security&tab=migrations",
+              description: "Open the migration assistant to apply required schema migrations.",
+            },
+          }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+
+    const statusButton = page.getByRole("button", { name: /system status: needs attention/i });
+    await expect(statusButton).toBeVisible();
+    await expect(statusButton).toHaveClass(/amber/);
+    await expect(page.getByRole("button", { name: /system status: disconnected/i })).toHaveCount(0);
+    await openSystemStatus(page);
+
+    await expect(page.getByText("Action Needed", { exact: true })).toBeVisible();
+    await expect(page.getByText("12/13 Attention")).toBeVisible();
+    await expect(page.getByText("Action available")).toBeVisible();
+    await expect(page.getByText("Issues Detected")).toHaveCount(0);
+    await expect(page.getByText("RBAC Migrations").first()).toBeVisible();
+    await expect(page.getByText("2 blocking migrations pending").first()).toBeVisible();
+    await expect(page.getByText("Check").first()).toBeVisible();
+    await page.getByText("Bootstrap & Migrations", { exact: true }).hover();
+    await expect(page.getByText("1 of 3 need attention")).toBeVisible();
+  });
+
   test("remediation buttons navigate to the configured admin surface", async ({ page }) => {
     const env = rbacEnvOrSkip({ requireUserSub: true });
     await installStableHeaderHealthMocks(page);

--- a/ui/src/app/api/platform/health/__tests__/route.test.ts
+++ b/ui/src/app/api/platform/health/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+import { EventEmitter } from "node:events";
+
+const mockCreateConnection = jest.fn();
+
+jest.mock("node:net", () => ({
+  __esModule: true,
+  default: {
+    createConnection: (...args: unknown[]) => mockCreateConnection(...args),
+  },
+}));
+
+function mockTcpConnect() {
+  mockCreateConnection.mockImplementation(() => {
+    const socket = new EventEmitter() as EventEmitter & { destroy: jest.Mock };
+    socket.destroy = jest.fn();
+    process.nextTick(() => socket.emit("connect"));
+    return socket;
+  });
+}
+
+describe("/api/platform/health", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      KEYCLOAK_URL: "http://keycloak:7080",
+      KEYCLOAK_REALM: "caipe",
+      OPENFGA_HTTP: "http://openfga:8080",
+      AGENTGATEWAY_ADMIN_CONFIG_URL: "http://agentgateway:15000/config",
+      AGENTGATEWAY_TARGETS_URL: "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets",
+      AGENTGATEWAY_TARGETS_TOKEN: "bridge-token",
+    };
+    mockTcpConnect();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns healthy when all platform probes pass", async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+
+    const { GET } = await import("../route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("healthy");
+    expect(body.summary).toEqual({ total: 5, healthy: 5, down: 0 });
+    expect(body.probes.map((probe: { id: string }) => probe.id)).toEqual([
+      "keycloak",
+      "openfga",
+      "openfga-authz-bridge",
+      "agentgateway-config-bridge",
+      "agentgateway",
+    ]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets",
+      expect.objectContaining({
+        headers: { authorization: "Bearer bridge-token" },
+      }),
+    );
+  });
+
+  it("returns 503 and marks failed probes down", async () => {
+    (global.fetch as jest.Mock) = jest.fn((url: string) =>
+      Promise.resolve(new Response("{}", { status: url.includes("openfga") ? 503 : 200 })),
+    );
+
+    const { GET } = await import("../route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("down");
+    expect(body.summary).toEqual({ total: 5, healthy: 4, down: 1 });
+    expect(body.probes.find((probe: { id: string }) => probe.id === "openfga")).toMatchObject({
+      status: "down",
+      detail: "HTTP 503",
+    });
+  });
+});

--- a/ui/src/app/api/platform/health/__tests__/route.test.ts
+++ b/ui/src/app/api/platform/health/__tests__/route.test.ts
@@ -13,6 +13,44 @@ jest.mock("node:net", () => ({
   },
 }));
 
+jest.mock("@/lib/rbac/keycloak-migration-health", () => ({
+  getKeycloakMigrationHealth: jest.fn(async () => ({
+    keycloak: {
+      configured: true,
+      reachable: true,
+      status: "reachable",
+      realm: "caipe",
+      last_probe_at: "2026-06-18T12:00:00Z",
+    },
+    schema_area: {
+      area: "keycloak_rbac_mappings",
+      current_version: 1,
+      target_version: 1,
+      status: "current",
+    },
+    keycloak_invariants: {
+      summary: { total: 1, passing: 1, failing: 0, unknown: 0, reconcileRecommended: false },
+      items: [],
+    },
+  })),
+}));
+
+jest.mock("@/lib/rbac/migrations/registry", () => ({
+  getMigrationBlockingStatus: jest.fn(async () => ({
+    release: "0.5.8",
+    runtime: "0.5.8",
+    schema_versions: [],
+    pending_required_count: 0,
+    blocking_required_count: 0,
+    version_bootstrap_required_count: 0,
+    version_bootstrap_schema_areas: [],
+    needs_version_bootstrap: false,
+    requires_attention: false,
+    is_blocking: false,
+    override_active: false,
+  })),
+}));
+
 function mockTcpConnect() {
   mockCreateConnection.mockImplementation(() => {
     const socket = new EventEmitter() as EventEmitter & { destroy: jest.Mock };
@@ -45,7 +83,15 @@ describe("/api/platform/health", () => {
   });
 
   it("returns healthy when all platform probes pass", async () => {
-    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    (global.fetch as jest.Mock) = jest.fn(async (url: string) => {
+      if (url.endsWith("/stores")) {
+        return new Response(JSON.stringify({ stores: [{ id: "store-1", name: "caipe-openfga" }] }), { status: 200 });
+      }
+      if (url.endsWith("/authorization-models")) {
+        return new Response(JSON.stringify({ authorization_models: [{ id: "model-1" }] }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
 
     const { GET } = await import("../route");
     const response = await GET();
@@ -53,13 +99,25 @@ describe("/api/platform/health", () => {
 
     expect(response.status).toBe(200);
     expect(body.status).toBe("healthy");
-    expect(body.summary).toEqual({ total: 5, healthy: 5, down: 0 });
+    expect(body.summary).toEqual({ total: 17, healthy: 17, warning: 0, down: 0 });
     expect(body.probes.map((probe: { id: string }) => probe.id)).toEqual([
       "keycloak",
       "openfga",
       "openfga-authz-bridge",
       "agentgateway-config-bridge",
       "agentgateway",
+      "caipe-mongodb",
+      "keycloak-postgres",
+      "openfga-postgres",
+      "rag-server",
+      "rag-redis",
+      "milvus",
+      "milvus-minio",
+      "etcd",
+      "openfga-bootstrap",
+      "keycloak-bootstrap",
+      "rebac-migrations",
+      "web-ingestor",
     ]);
     expect(global.fetch).toHaveBeenCalledWith(
       "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets",
@@ -71,7 +129,7 @@ describe("/api/platform/health", () => {
 
   it("returns 503 and marks failed probes down", async () => {
     (global.fetch as jest.Mock) = jest.fn((url: string) =>
-      Promise.resolve(new Response("{}", { status: url.includes("openfga") ? 503 : 200 })),
+      Promise.resolve(new Response(JSON.stringify({ stores: [] }), { status: url.includes("healthz") && url.includes("openfga") ? 503 : 200 })),
     );
 
     const { GET } = await import("../route");
@@ -80,7 +138,7 @@ describe("/api/platform/health", () => {
 
     expect(response.status).toBe(503);
     expect(body.status).toBe("down");
-    expect(body.summary).toEqual({ total: 5, healthy: 4, down: 1 });
+    expect(body.summary.down).toBeGreaterThanOrEqual(1);
     expect(body.probes.find((probe: { id: string }) => probe.id === "openfga")).toMatchObject({
       status: "down",
       detail: "HTTP 503",

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -1,0 +1,167 @@
+import net from "node:net";
+
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+type ProbeStatus = "healthy" | "down";
+
+interface ProbeResult {
+  id: string;
+  label: string;
+  status: ProbeStatus;
+  detail: string;
+  target: string;
+  latency_ms: number | null;
+}
+
+const HTTP_TIMEOUT_MS = 3000;
+const TCP_TIMEOUT_MS = 2000;
+
+function env(name: string): string | undefined {
+  return process.env[name] || process.env[`NEXT_PUBLIC_${name}`] || undefined;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/$/, "");
+}
+
+async function probeHttp({
+  id,
+  label,
+  target,
+  headers,
+}: {
+  id: string;
+  label: string;
+  target: string;
+  headers?: HeadersInit;
+}): Promise<ProbeResult> {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(target, {
+      method: "GET",
+      headers,
+      signal: controller.signal,
+      cache: "no-store",
+    });
+    const latencyMs = Date.now() - startedAt;
+    return {
+      id,
+      label,
+      status: response.ok ? "healthy" : "down",
+      detail: response.ok ? `HTTP ${response.status}` : `HTTP ${response.status}`,
+      target,
+      latency_ms: latencyMs,
+    };
+  } catch (error) {
+    const latencyMs = Date.now() - startedAt;
+    return {
+      id,
+      label,
+      status: "down",
+      detail: error instanceof Error ? error.message : "request failed",
+      target,
+      latency_ms: latencyMs,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function probeTcp({
+  id,
+  label,
+  host,
+  port,
+}: {
+  id: string;
+  label: string;
+  host: string;
+  port: number;
+}): Promise<ProbeResult> {
+  const startedAt = Date.now();
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port, timeout: TCP_TIMEOUT_MS });
+
+    const finish = (status: ProbeStatus, detail: string) => {
+      socket.destroy();
+      resolve({
+        id,
+        label,
+        status,
+        detail,
+        target: `${host}:${port}`,
+        latency_ms: Date.now() - startedAt,
+      });
+    };
+
+    socket.once("connect", () => finish("healthy", "TCP connection accepted"));
+    socket.once("timeout", () => finish("down", "connection timed out"));
+    socket.once("error", (error) => finish("down", error.message));
+  });
+}
+
+export async function GET(): Promise<Response> {
+  const keycloakUrl = trimTrailingSlash(env("KEYCLOAK_URL") || "http://keycloak:7080");
+  const keycloakRealm = env("KEYCLOAK_REALM") || "caipe";
+  const openfgaUrl = trimTrailingSlash(env("OPENFGA_HTTP") || "http://openfga:8080");
+  const agentgatewayAdminUrl = trimTrailingSlash(
+    env("AGENTGATEWAY_ADMIN_CONFIG_URL") || "http://agentgateway:15000/config",
+  );
+  const agentgatewayTargetsUrl =
+    env("AGENTGATEWAY_TARGETS_URL") || "http://caipe-ui:3000/api/internal/agentgateway/mcp-targets";
+  const agentgatewayTargetsToken =
+    env("AGENTGATEWAY_TARGETS_TOKEN") || "agentgateway-config-bridge-dev-token";
+
+  const probes = await Promise.all([
+    probeHttp({
+      id: "keycloak",
+      label: "Keycloak",
+      target: `${keycloakUrl}/realms/${keycloakRealm}/protocol/openid-connect/certs`,
+    }),
+    probeHttp({
+      id: "openfga",
+      label: "OpenFGA",
+      target: `${openfgaUrl}/healthz`,
+    }),
+    probeTcp({
+      id: "openfga-authz-bridge",
+      label: "OpenFGA Bridge",
+      host: env("OPENFGA_AUTHZ_BRIDGE_HOST") || "openfga-authz-bridge",
+      port: Number(env("OPENFGA_AUTHZ_BRIDGE_PORT") || 9100),
+    }),
+    probeHttp({
+      id: "agentgateway-config-bridge",
+      label: "AgentGateway Config Bridge",
+      target: agentgatewayTargetsUrl,
+      headers: {
+        authorization: `Bearer ${agentgatewayTargetsToken}`,
+      },
+    }),
+    probeHttp({
+      id: "agentgateway",
+      label: "AgentGateway",
+      target: agentgatewayAdminUrl,
+    }),
+  ]);
+
+  const down = probes.filter((probe) => probe.status === "down").length;
+
+  return NextResponse.json(
+    {
+      status: down > 0 ? "down" : "healthy",
+      checked_at: new Date().toISOString(),
+      summary: {
+        total: probes.length,
+        healthy: probes.length - down,
+        down,
+      },
+      probes,
+    },
+    { status: down > 0 ? 503 : 200 },
+  );
+}

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -2,17 +2,29 @@ import net from "node:net";
 
 import { NextResponse } from "next/server";
 
+import { getKeycloakMigrationHealth } from "@/lib/rbac/keycloak-migration-health";
+import { getMigrationBlockingStatus } from "@/lib/rbac/migrations/registry";
+
 export const runtime = "nodejs";
 
-type ProbeStatus = "healthy" | "down";
+type ProbeStatus = "healthy" | "warning" | "down";
+type ProbeGroup = "core" | "identity" | "storage" | "rag" | "bootstrap";
+
+interface ProbeRemediation {
+  label: string;
+  href: string;
+  description: string;
+}
 
 interface ProbeResult {
   id: string;
   label: string;
+  group: ProbeGroup;
   status: ProbeStatus;
   detail: string;
   target: string;
   latency_ms: number | null;
+  remediation?: ProbeRemediation;
 }
 
 const HTTP_TIMEOUT_MS = 3000;
@@ -29,13 +41,17 @@ function trimTrailingSlash(value: string): string {
 async function probeHttp({
   id,
   label,
+  group,
   target,
   headers,
+  remediation,
 }: {
   id: string;
   label: string;
+  group: ProbeGroup;
   target: string;
   headers?: HeadersInit;
+  remediation?: ProbeRemediation;
 }): Promise<ProbeResult> {
   const startedAt = Date.now();
   const controller = new AbortController();
@@ -52,20 +68,24 @@ async function probeHttp({
     return {
       id,
       label,
+      group,
       status: response.ok ? "healthy" : "down",
       detail: response.ok ? `HTTP ${response.status}` : `HTTP ${response.status}`,
       target,
       latency_ms: latencyMs,
+      remediation: response.ok ? undefined : remediation,
     };
   } catch (error) {
     const latencyMs = Date.now() - startedAt;
     return {
       id,
       label,
+      group,
       status: "down",
       detail: error instanceof Error ? error.message : "request failed",
       target,
       latency_ms: latencyMs,
+      remediation,
     };
   } finally {
     clearTimeout(timeoutId);
@@ -75,13 +95,17 @@ async function probeHttp({
 async function probeTcp({
   id,
   label,
+  group,
   host,
   port,
+  remediation,
 }: {
   id: string;
   label: string;
+  group: ProbeGroup;
   host: string;
   port: number;
+  remediation?: ProbeRemediation;
 }): Promise<ProbeResult> {
   const startedAt = Date.now();
   return new Promise((resolve) => {
@@ -92,10 +116,12 @@ async function probeTcp({
       resolve({
         id,
         label,
+        group,
         status,
         detail,
         target: `${host}:${port}`,
         latency_ms: Date.now() - startedAt,
+        remediation: status === "healthy" ? undefined : remediation,
       });
     };
 
@@ -105,10 +131,237 @@ async function probeTcp({
   });
 }
 
+async function probeOpenFgaBootstrap(openfgaUrl: string): Promise<ProbeResult> {
+  const startedAt = Date.now();
+  const storeName = env("OPENFGA_STORE_NAME") || "caipe-openfga";
+  const remediation = {
+    label: "View OpenFGA",
+    href: "/admin?cat=security&tab=openfga",
+    description: "Open the OpenFGA admin view and re-run the compose RBAC init services if the store or model is missing.",
+  };
+
+  try {
+    const storesResponse = await fetch(`${openfgaUrl}/stores`, { method: "GET", cache: "no-store" });
+    if (!storesResponse.ok) {
+      return {
+        id: "openfga-bootstrap",
+        label: "OpenFGA Bootstrap",
+        group: "bootstrap",
+        status: "down",
+        detail: `Store discovery HTTP ${storesResponse.status}`,
+        target: `${openfgaUrl}/stores`,
+        latency_ms: Date.now() - startedAt,
+        remediation,
+      };
+    }
+    const storesBody = (await storesResponse.json()) as { stores?: Array<{ id?: string; name?: string }> };
+    const store = storesBody.stores?.find((candidate) => candidate.name === storeName);
+    if (!store?.id) {
+      return {
+        id: "openfga-bootstrap",
+        label: "OpenFGA Bootstrap",
+        group: "bootstrap",
+        status: "down",
+        detail: `Store ${storeName} not found`,
+        target: `${openfgaUrl}/stores`,
+        latency_ms: Date.now() - startedAt,
+        remediation,
+      };
+    }
+
+    const modelsResponse = await fetch(`${openfgaUrl}/stores/${store.id}/authorization-models`, {
+      method: "GET",
+      cache: "no-store",
+    });
+    if (!modelsResponse.ok) {
+      return {
+        id: "openfga-bootstrap",
+        label: "OpenFGA Bootstrap",
+        group: "bootstrap",
+        status: "down",
+        detail: `Model discovery HTTP ${modelsResponse.status}`,
+        target: `${openfgaUrl}/stores/${store.id}/authorization-models`,
+        latency_ms: Date.now() - startedAt,
+        remediation,
+      };
+    }
+    const modelsBody = (await modelsResponse.json()) as { authorization_models?: unknown[] };
+    if (!Array.isArray(modelsBody.authorization_models) || modelsBody.authorization_models.length === 0) {
+      return {
+        id: "openfga-bootstrap",
+        label: "OpenFGA Bootstrap",
+        group: "bootstrap",
+        status: "down",
+        detail: "No authorization model found",
+        target: `${openfgaUrl}/stores/${store.id}/authorization-models`,
+        latency_ms: Date.now() - startedAt,
+        remediation,
+      };
+    }
+
+    return {
+      id: "openfga-bootstrap",
+      label: "OpenFGA Bootstrap",
+      group: "bootstrap",
+      status: "healthy",
+      detail: "Store and model ready",
+      target: `${openfgaUrl}/stores/${store.id}`,
+      latency_ms: Date.now() - startedAt,
+    };
+  } catch (error) {
+    return {
+      id: "openfga-bootstrap",
+      label: "OpenFGA Bootstrap",
+      group: "bootstrap",
+      status: "down",
+      detail: error instanceof Error ? error.message : "bootstrap check failed",
+      target: `${openfgaUrl}/stores`,
+      latency_ms: Date.now() - startedAt,
+      remediation,
+    };
+  }
+}
+
+async function probeKeycloakBootstrap(): Promise<ProbeResult> {
+  const remediation = {
+    label: "Keycloak Health",
+    href: "/admin?cat=security&tab=keycloak",
+    description: "Open Keycloak health to inspect reconciliation and admin credential setup.",
+  };
+  try {
+    const health = await getKeycloakMigrationHealth({ actor: "platform-health" });
+    const failingInvariants = health.keycloak_invariants?.summary.failing ?? 0;
+    if (!health.keycloak.reachable || health.keycloak.status !== "reachable") {
+      return {
+        id: "keycloak-bootstrap",
+        label: "Keycloak Bootstrap",
+        group: "bootstrap",
+        status: "warning",
+        detail: health.keycloak.probe_error || `Realm ${health.keycloak.realm} needs attention`,
+        target: health.keycloak.realm,
+        latency_ms: null,
+        remediation,
+      };
+    }
+    if (health.schema_area.status !== "current" || failingInvariants > 0) {
+      return {
+        id: "keycloak-bootstrap",
+        label: "Keycloak Bootstrap",
+        group: "bootstrap",
+        status: "warning",
+        detail:
+          health.schema_area.status !== "current"
+            ? `Schema ${health.schema_area.current_version ?? "unknown"} → ${health.schema_area.target_version}`
+            : `${failingInvariants} invariant${failingInvariants === 1 ? "" : "s"} failing`,
+        target: health.keycloak.realm,
+        latency_ms: null,
+        remediation,
+      };
+    }
+    return {
+      id: "keycloak-bootstrap",
+      label: "Keycloak Bootstrap",
+      group: "bootstrap",
+      status: "healthy",
+      detail: "Realm and reconciliation ready",
+      target: health.keycloak.realm,
+      latency_ms: null,
+    };
+  } catch (error) {
+    return {
+      id: "keycloak-bootstrap",
+      label: "Keycloak Bootstrap",
+      group: "bootstrap",
+      status: "warning",
+      detail: error instanceof Error ? error.message : "bootstrap check failed",
+      target: env("KEYCLOAK_REALM") || "caipe",
+      latency_ms: null,
+      remediation,
+    };
+  }
+}
+
+async function probeRebacMigrations(): Promise<ProbeResult> {
+  const remediation = {
+    label: "Migration Assistant",
+    href: "/admin?cat=security&tab=migrations",
+    description: "Open the migration assistant to review and apply required schema migrations.",
+  };
+  try {
+    const status = await getMigrationBlockingStatus({ actor: "platform-health" });
+    if (status.is_blocking) {
+      return {
+        id: "rebac-migrations",
+        label: "RBAC Migrations",
+        group: "bootstrap",
+        status: "warning",
+        detail: `${status.blocking_required_count} blocking migration${status.blocking_required_count === 1 ? "" : "s"} pending`,
+        target: status.release,
+        latency_ms: null,
+        remediation,
+      };
+    }
+    if (status.needs_version_bootstrap) {
+      return {
+        id: "rebac-migrations",
+        label: "RBAC Migrations",
+        group: "bootstrap",
+        status: "warning",
+        detail: `${status.version_bootstrap_required_count} schema area${status.version_bootstrap_required_count === 1 ? "" : "s"} need version metadata`,
+        target: status.release,
+        latency_ms: null,
+        remediation,
+      };
+    }
+    return {
+      id: "rebac-migrations",
+      label: "RBAC Migrations",
+      group: "bootstrap",
+      status: "healthy",
+      detail: "Current",
+      target: status.release,
+      latency_ms: null,
+    };
+  } catch (error) {
+    return {
+      id: "rebac-migrations",
+      label: "RBAC Migrations",
+      group: "bootstrap",
+      status: "warning",
+      detail: error instanceof Error ? error.message : "migration status unavailable",
+      target: "schema_migrations",
+      latency_ms: null,
+      remediation,
+    };
+  }
+}
+
+function probeWebIngestorReadiness(ragServerHealthy: boolean, redisHealthy: boolean): ProbeResult {
+  const status = ragServerHealthy && redisHealthy ? "healthy" : "warning";
+  return {
+    id: "web-ingestor",
+    label: "Web Ingestor",
+    group: "rag",
+    status,
+    detail: status === "healthy" ? "Queue ready; worker liveness not exposed" : "Requires RAG server and Redis",
+    target: "web-ingestor",
+    latency_ms: null,
+    remediation:
+      status === "healthy"
+        ? undefined
+        : {
+            label: "RAG Setup",
+            href: "/knowledge-bases/ingest",
+            description: "Check that the rag and web_ingestor compose profiles are running.",
+          },
+  };
+}
+
 export async function GET(): Promise<Response> {
   const keycloakUrl = trimTrailingSlash(env("KEYCLOAK_URL") || "http://keycloak:7080");
   const keycloakRealm = env("KEYCLOAK_REALM") || "caipe";
   const openfgaUrl = trimTrailingSlash(env("OPENFGA_HTTP") || "http://openfga:8080");
+  const ragServerUrl = trimTrailingSlash(env("RAG_SERVER_URL") || "http://rag-server:9446");
   const agentgatewayAdminUrl = trimTrailingSlash(
     env("AGENTGATEWAY_ADMIN_CONFIG_URL") || "http://agentgateway:15000/config",
   );
@@ -121,43 +374,147 @@ export async function GET(): Promise<Response> {
     probeHttp({
       id: "keycloak",
       label: "Keycloak",
+      group: "identity",
       target: `${keycloakUrl}/realms/${keycloakRealm}/protocol/openid-connect/certs`,
+      remediation: {
+        label: "Keycloak Health",
+        href: "/admin?cat=security&tab=keycloak",
+        description: "Inspect Keycloak realm, credentials, and reconciliation status.",
+      },
     }),
     probeHttp({
       id: "openfga",
       label: "OpenFGA",
+      group: "identity",
       target: `${openfgaUrl}/healthz`,
+      remediation: {
+        label: "OpenFGA",
+        href: "/admin?cat=security&tab=openfga",
+        description: "Inspect OpenFGA connectivity and seeded authorization model.",
+      },
     }),
     probeTcp({
       id: "openfga-authz-bridge",
       label: "OpenFGA Bridge",
+      group: "identity",
       host: env("OPENFGA_AUTHZ_BRIDGE_HOST") || "openfga-authz-bridge",
       port: Number(env("OPENFGA_AUTHZ_BRIDGE_PORT") || 9100),
+      remediation: {
+        label: "OpenFGA",
+        href: "/admin?cat=security&tab=openfga",
+        description: "Check OpenFGA bridge logs and authz configuration.",
+      },
     }),
     probeHttp({
       id: "agentgateway-config-bridge",
       label: "AgentGateway Config Bridge",
+      group: "core",
       target: agentgatewayTargetsUrl,
       headers: {
         authorization: `Bearer ${agentgatewayTargetsToken}`,
+      },
+      remediation: {
+        label: "AgentGateway",
+        href: "/skills/gateway",
+        description: "Check AgentGateway target discovery and bridge token configuration.",
       },
     }),
     probeHttp({
       id: "agentgateway",
       label: "AgentGateway",
+      group: "core",
       target: agentgatewayAdminUrl,
+      remediation: {
+        label: "AgentGateway",
+        href: "/skills/gateway",
+        description: "Check AgentGateway admin API and compose service logs.",
+      },
     }),
+    probeTcp({
+      id: "caipe-mongodb",
+      label: "MongoDB",
+      group: "storage",
+      host: env("MONGODB_HOST") || "caipe-mongodb",
+      port: Number(env("MONGODB_PORT") || 27017),
+    }),
+    probeTcp({
+      id: "keycloak-postgres",
+      label: "Keycloak Postgres",
+      group: "storage",
+      host: env("KEYCLOAK_POSTGRES_HOST") || "keycloak-postgres",
+      port: Number(env("KEYCLOAK_POSTGRES_PORT") || 5432),
+    }),
+    probeTcp({
+      id: "openfga-postgres",
+      label: "OpenFGA Postgres",
+      group: "storage",
+      host: env("OPENFGA_POSTGRES_HOST") || "openfga-postgres",
+      port: Number(env("OPENFGA_POSTGRES_PORT") || 5432),
+    }),
+    probeHttp({
+      id: "rag-server",
+      label: "RAG Server",
+      group: "rag",
+      target: `${ragServerUrl}/healthz`,
+      remediation: {
+        label: "Knowledge Bases",
+        href: "/knowledge-bases",
+        description: "Check RAG server dependencies and compose profile.",
+      },
+    }),
+    probeTcp({
+      id: "rag-redis",
+      label: "RAG Redis",
+      group: "rag",
+      host: env("RAG_REDIS_HOST") || "rag-redis",
+      port: Number(env("RAG_REDIS_PORT") || 6379),
+    }),
+    probeHttp({
+      id: "milvus",
+      label: "Milvus",
+      group: "rag",
+      target: trimTrailingSlash(env("MILVUS_HEALTH_URL") || "http://milvus-standalone:9091/healthz"),
+    }),
+    probeTcp({
+      id: "milvus-minio",
+      label: "Milvus MinIO",
+      group: "rag",
+      host: env("MILVUS_MINIO_HOST") || "milvus-minio",
+      port: Number(env("MILVUS_MINIO_PORT") || 9000),
+    }),
+    probeTcp({
+      id: "etcd",
+      label: "etcd",
+      group: "rag",
+      host: env("ETCD_HOST") || "etcd",
+      port: Number(env("ETCD_PORT") || 2379),
+    }),
+    probeOpenFgaBootstrap(openfgaUrl),
+    probeKeycloakBootstrap(),
+    probeRebacMigrations(),
   ]);
 
+  const ragServerProbe = probes.find((probe) => probe.id === "rag-server");
+  const ragRedisProbe = probes.find((probe) => probe.id === "rag-redis");
+  probes.push(
+    probeWebIngestorReadiness(
+      ragServerProbe?.status === "healthy",
+      ragRedisProbe?.status === "healthy",
+    ),
+  );
+
   const down = probes.filter((probe) => probe.status === "down").length;
+  const warning = probes.filter((probe) => probe.status === "warning").length;
+  const status = down > 0 ? "down" : warning > 0 ? "degraded" : "healthy";
 
   return NextResponse.json(
     {
-      status: down > 0 ? "down" : "healthy",
+      status,
       checked_at: new Date().toISOString(),
       summary: {
         total: probes.length,
-        healthy: probes.length - down,
+        healthy: probes.length - down - warning,
+        warning,
         down,
       },
       probes,

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -761,7 +761,10 @@ export function AppHeader() {
                   </div>
                 </div>
 
-                <div className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain p-4">
+                <div
+                  data-testid="platform-health-scroll"
+                  className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain p-4"
+                >
                   <div className="rounded-xl border border-border/70 bg-background/40 p-3">
                     <div className="flex items-start justify-between gap-3">
                       <div>
@@ -915,7 +918,10 @@ export function AppHeader() {
                           <span>Probe</span>
                           <span>Status</span>
                         </div>
-                        <div className="max-h-48 divide-y divide-border/60 overflow-y-auto overscroll-contain">
+                        <div
+                          data-testid="platform-health-probe-list"
+                          className="max-h-48 divide-y divide-border/60 overflow-y-auto overscroll-contain"
+                        >
                           {platformProbes.map((probe) => (
                             <Tooltip key={probe.id}>
                               <TooltipTrigger asChild>

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -271,6 +271,7 @@ export function AppHeader() {
     if (platformProbeStatus === "checking") return "checking";
     if (caipeStatus === "disconnected") return "disconnected";
     if (platformProbeStatus === "down") return "disconnected";
+    if (platformProbeStatus === "degraded") return "degraded";
     if (ragEnabled && ragStatus === "disconnected") return "rag-disconnected";
     return "connected";
   };
@@ -279,8 +280,18 @@ export function AppHeader() {
   const combinedStatusLabel =
     combinedStatus === "connected" ? "Connected" :
     combinedStatus === "checking" ? "Checking" :
+    combinedStatus === "degraded" ? "Needs Attention" :
     combinedStatus === "rag-disconnected" ? "RAG Disconnected" :
     "Disconnected";
+  const platformProbeGroups = [
+    { id: "core", label: "Core Runtime" },
+    { id: "identity", label: "Identity & Authz" },
+    { id: "bootstrap", label: "Bootstrap & Migrations" },
+    { id: "storage", label: "Storage" },
+    { id: "rag", label: "RAG & Web Ingestor" },
+  ] as const;
+  const platformProbeIssues = platformProbes.filter((probe) => probe.status !== "healthy");
+  const platformProbeHealthyCount = platformProbes.filter((probe) => probe.status === "healthy").length;
 
   const getActiveTab = () => {
     if (pathname === "/") return "home";
@@ -667,6 +678,7 @@ export function AppHeader() {
                     ? "h-8 w-8 justify-center bg-green-500/15 text-green-400 border border-green-500/30 hover:bg-green-500/20"
                     : "px-2.5 py-1",
                   combinedStatus === "checking" && "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20",
+                  combinedStatus === "degraded" && "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20",
                   combinedStatus === "rag-disconnected" && "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/20",
                   combinedStatus === "disconnected" && "bg-red-500/15 text-red-400 border border-red-500/30 hover:bg-red-500/20"
                 )}
@@ -677,6 +689,7 @@ export function AppHeader() {
                   <div className={cn(
                     "h-2 w-2 rounded-full shrink-0",
                     combinedStatus === "connected" && "bg-green-400 animate-pulse",
+                    combinedStatus === "degraded" && "bg-amber-400",
                     combinedStatus === "rag-disconnected" && "bg-amber-400",
                     combinedStatus === "disconnected" && "bg-red-400",
                   )} />
@@ -712,11 +725,13 @@ export function AppHeader() {
                         "inline-block w-2 h-2 rounded-full",
                         combinedStatus === "connected" ? "bg-green-400 animate-pulse" :
                         combinedStatus === "checking" ? "bg-amber-400 animate-pulse" :
+                        combinedStatus === "degraded" ? "bg-amber-400" :
                         combinedStatus === "rag-disconnected" ? "bg-amber-400" : "bg-red-400"
                       )} />
                       <span className="text-xs font-medium text-white">
                         {combinedStatus === "connected" ? "All Systems Live" :
                          combinedStatus === "checking" ? "Checking" :
+                         combinedStatus === "degraded" ? "Action Needed" :
                          combinedStatus === "rag-disconnected" ? "RAG Offline" :
                          "Issues Detected"}
                       </span>
@@ -816,11 +831,12 @@ export function AppHeader() {
                     <div>
                       <div className="flex items-center justify-between mb-2">
                         <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                          Platform Probes
+                          Platform Health
                         </div>
                         <div className={cn(
                           "flex items-center gap-1.5 px-2 py-0.5 rounded-full border",
                           platformProbeStatus === "healthy" && "bg-green-500/10 border-green-500/20",
+                          platformProbeStatus === "degraded" && "bg-amber-500/10 border-amber-500/20",
                           platformProbeStatus === "down" && "bg-red-500/10 border-red-500/20",
                           platformProbeStatus === "checking" && "bg-muted/50 border-border"
                         )}>
@@ -830,12 +846,14 @@ export function AppHeader() {
                             <span className={cn(
                               "inline-block w-1.5 h-1.5 rounded-full",
                               platformProbeStatus === "healthy" && "bg-green-400",
+                              platformProbeStatus === "degraded" && "bg-amber-400",
                               platformProbeStatus === "down" && "bg-red-400"
                             )} />
                           )}
                           <span className={cn(
                             "text-[10px] font-bold",
                             platformProbeStatus === "healthy" && "text-green-600 dark:text-green-400",
+                            platformProbeStatus === "degraded" && "text-amber-600 dark:text-amber-400",
                             platformProbeStatus === "down" && "text-red-600 dark:text-red-400",
                             platformProbeStatus === "checking" && "text-muted-foreground"
                           )}>
@@ -845,37 +863,106 @@ export function AppHeader() {
                           </span>
                         </div>
                       </div>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+                      <div className="space-y-2">
                         {platformProbes.length === 0 && (
                           <div className="text-xs text-muted-foreground bg-muted/20 rounded px-2 py-1.5">
-                            Checking Keycloak, OpenFGA, AgentGateway, and bridge health...
+                            Checking Keycloak, OpenFGA, AgentGateway, RAG, storage, web ingestor readiness, and migrations...
                           </div>
                         )}
-                        {platformProbes.map((probe) => (
-                          <div
-                            key={probe.id}
-                            title={`${probe.target} — ${probe.detail}`}
-                            className="flex items-center justify-between gap-2 bg-muted/20 rounded px-2 py-1.5"
-                          >
-                            <div className="min-w-0">
-                              <div className="truncate text-xs font-medium text-foreground">
-                                {probe.label}
+                        {platformProbes.length > 0 && (
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+                            {platformProbeGroups.map((group) => {
+                              const groupProbes = platformProbes.filter((probe) => probe.group === group.id);
+                              if (groupProbes.length === 0) return null;
+                              const downCount = groupProbes.filter((probe) => probe.status === "down").length;
+                              const warningCount = groupProbes.filter((probe) => probe.status === "warning").length;
+                              const groupStatus = downCount > 0 ? "down" : warningCount > 0 ? "warning" : "healthy";
+                              return (
+                                <div
+                                  key={group.id}
+                                  className="flex items-center justify-between gap-2 bg-muted/20 rounded px-2 py-1.5"
+                                >
+                                  <div className="min-w-0">
+                                    <div className="truncate text-xs font-medium text-foreground">
+                                      {group.label}
+                                    </div>
+                                    <div className="truncate text-[10px] text-muted-foreground">
+                                      {groupStatus === "healthy"
+                                        ? `${groupProbes.length} checks OK`
+                                        : `${downCount + warningCount} of ${groupProbes.length} need attention`}
+                                    </div>
+                                  </div>
+                                  <div className={cn(
+                                    "px-2 py-0.5 rounded-full text-[10px] font-bold shrink-0 border",
+                                    groupStatus === "healthy" && "bg-green-500/15 text-green-400 border-green-500/30",
+                                    groupStatus === "warning" && "bg-amber-500/15 text-amber-400 border-amber-500/30",
+                                    groupStatus === "down" && "bg-red-500/15 text-red-400 border-red-500/30"
+                                  )}>
+                                    {groupStatus === "healthy" ? "OK" : groupStatus === "warning" ? "CHECK" : "DOWN"}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                        {platformProbeIssues.length > 0 ? (
+                          <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-2 space-y-2">
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="text-xs font-semibold text-amber-700 dark:text-amber-300">
+                                Action needed
                               </div>
-                              <div className="truncate text-[10px] text-muted-foreground">
-                                {probe.detail}
-                                {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
+                              <div className="text-[10px] text-amber-700/80 dark:text-amber-300/80">
+                                {platformProbeHealthyCount} healthy · {platformProbeIssues.length} attention
                               </div>
                             </div>
-                            <div className={cn(
-                              "px-2 py-0.5 rounded-full text-[10px] font-bold shrink-0 border",
-                              probe.status === "healthy"
-                                ? "bg-green-500/15 text-green-400 border-green-500/30"
-                                : "bg-red-500/15 text-red-400 border-red-500/30"
-                            )}>
-                              {probe.status === "healthy" ? "OK" : "DOWN"}
+                            <div className="space-y-1.5">
+                              {platformProbeIssues.slice(0, 4).map((probe) => (
+                                <div
+                                  key={probe.id}
+                                  title={`${probe.target} — ${probe.detail}`}
+                                  className="flex items-center justify-between gap-2 rounded bg-background/60 px-2 py-1.5"
+                                >
+                                  <div className="min-w-0">
+                                    <div className="truncate text-xs font-medium text-foreground">
+                                      {probe.label}
+                                    </div>
+                                    <div className="truncate text-[10px] text-muted-foreground">
+                                      {probe.detail}
+                                    </div>
+                                  </div>
+                                  {probe.remediation ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => router.push(probe.remediation!.href)}
+                                      className="shrink-0 rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-[10px] font-semibold text-primary hover:bg-primary/15"
+                                      title={probe.remediation.description}
+                                    >
+                                      {probe.remediation.label}
+                                    </button>
+                                  ) : (
+                                    <div className={cn(
+                                      "px-2 py-0.5 rounded-full text-[10px] font-bold shrink-0 border",
+                                      probe.status === "warning"
+                                        ? "bg-amber-500/15 text-amber-400 border-amber-500/30"
+                                        : "bg-red-500/15 text-red-400 border-red-500/30"
+                                    )}>
+                                      {probe.status === "warning" ? "CHECK" : "DOWN"}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                              {platformProbeIssues.length > 4 && (
+                                <div className="text-[10px] text-muted-foreground">
+                                  {platformProbeIssues.length - 4} more checks need attention.
+                                </div>
+                              )}
                             </div>
                           </div>
-                        ))}
+                        ) : platformProbes.length > 0 ? (
+                          <div className="text-xs text-muted-foreground bg-green-500/10 border border-green-500/20 rounded px-2 py-1.5">
+                            Core runtime, identity, storage, RAG, web ingestor queue readiness, and migrations look ready.
+                          </div>
+                        ) : null}
                       </div>
                       <div className="mt-1.5 text-[10px] text-muted-foreground font-mono text-right">
                         Next probe: {platformProbeNextCheck}s
@@ -1003,6 +1090,7 @@ export function AppHeader() {
                     <div className="text-muted-foreground">
                       {combinedStatus === "connected" ? "All systems operational" :
                        combinedStatus === "checking" ? "Checking status..." :
+                       combinedStatus === "degraded" ? "Action available" :
                        combinedStatus === "rag-disconnected" ? "RAG server unavailable" :
                        "Check logs for details"}
                     </div>

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -11,10 +11,15 @@ Popover,
 PopoverContent,
 PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+Tooltip,
+TooltipContent,
+TooltipProvider,
+TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useToast } from "@/components/ui/toast";
 import { UserMenu } from "@/components/user-menu";
 import { useAdminRole } from "@/hooks/use-admin-role";
-import { useAgentRuntimeHealth } from "@/hooks/use-agent-runtime-health";
 import { useCAIPEHealth } from "@/hooks/use-caipe-health";
 import { useKeycloakHealthSummary } from "@/hooks/use-keycloak-health-summary";
 import { useMigrationStatus } from "@/hooks/use-migration-status";
@@ -36,6 +41,7 @@ ChevronRight,
 Database,
 FileText,
 Home,
+Info,
 KeyRound,
 Loader2,
 Shield,
@@ -46,19 +52,6 @@ import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { usePathname,useRouter } from "next/navigation";
 import React from "react";
-
-/** Format seconds into a human-readable interval (e.g., "3h", "30m", "45s") */
-function formatInterval(seconds: number): string {
-  if (seconds >= 3600) {
-    const hours = seconds / 3600;
-    return hours % 1 === 0 ? `${hours}h` : `${hours.toFixed(1)}h`;
-  }
-  if (seconds >= 60) {
-    const minutes = Math.round(seconds / 60);
-    return `${minutes}m`;
-  }
-  return `${seconds}s`;
-}
 
 /**
  * Editor routes that participate in the unsaved-changes guard.
@@ -205,24 +198,16 @@ export function AppHeader() {
     }
   }, [session, isAdmin]);
 
-  // Health check for CAIPE supervisor (polls every 30 seconds)
+  // Health check for the CAIPE API path (polls every 30 seconds)
   const {
     status: caipeStatus,
-    secondsUntilNextCheck: caipeNextCheck,
-    agents,
-    mongoDBStatus,
     storageMode
   } = useCAIPEHealth();
 
   // Health check for RAG server (polls every 30 seconds)
   const {
-    status: ragStatus,
-    graphRagEnabled,
-    cleanupConfig
+    status: ragStatus
   } = useRAGHealth();
-
-  // Health check for Agent Runtime (polls every 30 seconds)
-  const { status: agentRuntimeStatus } = useAgentRuntimeHealth();
   const {
     status: platformProbeStatus,
     probes: platformProbes,
@@ -259,7 +244,7 @@ export function AppHeader() {
     releasePrompt.markToastShown();
   }, [releasePrompt, session, toast]);
 
-  // Combined status: hard failures from the supervisor or platform
+  // Combined status: hard failures from the API path or platform
   // dependencies mark the system as disconnected; optional RAG failures are
   // degraded so the core chat/runtime path can still show separately.
   const getCombinedStatus = () => {
@@ -281,11 +266,31 @@ export function AppHeader() {
     combinedStatus === "rag-disconnected" ? "RAG Disconnected" :
     "Disconnected";
   const platformProbeGroups = [
-    { id: "core", label: "Core Runtime" },
-    { id: "identity", label: "Identity & Authz" },
-    { id: "bootstrap", label: "Bootstrap & Migrations" },
-    { id: "storage", label: "Storage" },
-    { id: "rag", label: "RAG & Web Ingestor" },
+    {
+      id: "core",
+      label: "Dynamic Agent Runtime",
+      description: "The path dynamic agents use to reach tools: AgentGateway plus the config bridge that publishes MCP targets.",
+    },
+    {
+      id: "identity",
+      label: "Identity & Authz",
+      description: "Keycloak sign-in, OpenFGA authorization, and the OpenFGA bridge used by runtime permission checks.",
+    },
+    {
+      id: "bootstrap",
+      label: "Bootstrap & Migrations",
+      description: "Outcome checks for one-time setup: Keycloak realm reconciliation, OpenFGA store/model seeding, and required RBAC migrations.",
+    },
+    {
+      id: "storage",
+      label: "Storage",
+      description: "Databases backing CAIPE, Keycloak, and OpenFGA.",
+    },
+    {
+      id: "rag",
+      label: "RAG & Web Ingestor",
+      description: "Knowledge services, vector-store dependencies, Redis queue readiness, and web ingestor readiness.",
+    },
   ] as const;
   const platformProbeIssues = platformProbes.filter((probe) => probe.status !== "healthy");
   const platformProbeHealthyCount = platformProbes.filter((probe) => probe.status === "healthy").length;
@@ -300,23 +305,6 @@ export function AppHeader() {
     platformProbeStatus === "down" ? "red" :
     platformProbeStatus === "checking" ? "muted" :
     "amber";
-  const storageLabel =
-    mongoDBStatus === "connected" ? "MongoDB" :
-    mongoDBStatus === "checking" ? "Checking" :
-    "localStorage";
-  const ragSummaryLabel = !ragEnabled
-    ? "Disabled"
-    : ragStatus === "connected"
-      ? "Online"
-      : ragStatus === "checking"
-        ? "Checking"
-        : "Offline";
-  const agentRuntimeLabel =
-    agentRuntimeStatus === "connected" ? "Online" :
-    agentRuntimeStatus === "checking" ? "Checking" :
-    "Offline";
-  const statusCardClassName =
-    "rounded-lg border border-border/60 bg-muted/20 px-3 py-2.5";
   const statusBadgeClassName = (tone: "green" | "amber" | "red" | "muted") =>
     cn(
       "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold",
@@ -744,14 +732,15 @@ export function AppHeader() {
                 </AnimatePresence>
               </button>
             </PopoverTrigger>
-            <PopoverContent side="bottom" align="end" className="w-[600px] max-w-[calc(100vw-1rem)] p-0 overflow-hidden border-2">
-              <div className="bg-gradient-to-br from-card via-card to-card/95">
+            <PopoverContent side="bottom" align="end" className="w-[600px] max-w-[calc(100vw-1rem)] max-h-[min(760px,calc(100vh-5rem))] p-0 overflow-hidden border-2">
+              <TooltipProvider delayDuration={150}>
+              <div className="flex max-h-[min(760px,calc(100vh-5rem))] flex-col bg-gradient-to-br from-card via-card to-card/95">
                 {/* Header with gradient */}
                 <div className="gradient-primary-br p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1">
                       <div className="text-base font-bold text-white mb-1">System Status</div>
-                      <div className="text-xs text-white/80">{config.appName} Agents & Knowledge Services</div>
+                      <div className="text-xs text-white/80">Dynamic agents, tools, identity, and knowledge services</div>
                     </div>
                     <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-white/20 backdrop-blur-sm">
                       <span className={cn(
@@ -772,75 +761,15 @@ export function AppHeader() {
                   </div>
                 </div>
 
-                <div className="p-4 space-y-3">
-                  <div className="grid grid-cols-2 gap-2">
-                    <div className={statusCardClassName}>
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="text-xs font-semibold text-muted-foreground">Supervisor</div>
-                        <span className={statusBadgeClassName(
-                          caipeStatus === "connected" ? "green" : caipeStatus === "checking" ? "amber" : "red",
-                        )}>
-                          {caipeStatus === "connected" ? "Online" : caipeStatus === "checking" ? "Checking" : "Offline"}
-                        </span>
-                      </div>
-                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
-                        Next check in {caipeNextCheck}s
-                      </div>
-                    </div>
-
-                    <div className={statusCardClassName}>
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="text-xs font-semibold text-muted-foreground">Storage</div>
-                        <span className={statusBadgeClassName(
-                          mongoDBStatus === "connected" ? "green" : mongoDBStatus === "checking" ? "muted" : "amber",
-                        )}>
-                          {storageLabel}
-                        </span>
-                      </div>
-                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
-                        {mongoDBStatus === "connected" ? "Persistent data enabled" : "Local browser fallback"}
-                      </div>
-                    </div>
-
-                    <div className={statusCardClassName}>
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="text-xs font-semibold text-muted-foreground">RAG</div>
-                        <span className={statusBadgeClassName(
-                          !ragEnabled ? "muted" : ragStatus === "connected" ? "green" : ragStatus === "checking" ? "amber" : "red",
-                        )}>
-                          {ragSummaryLabel}
-                        </span>
-                      </div>
-                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
-                        {ragEnabled
-                          ? `Graph ${graphRagEnabled ? "on" : "off"}${cleanupConfig?.enabled ? ` · cleanup ${formatInterval(cleanupConfig.interval_seconds)}` : ""}`
-                          : "Knowledge services are off"}
-                      </div>
-                    </div>
-
-                    <div className={statusCardClassName}>
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="text-xs font-semibold text-muted-foreground">Agents</div>
-                        <span className={statusBadgeClassName(
-                          agentRuntimeStatus === "connected" ? "green" : agentRuntimeStatus === "checking" ? "amber" : "red",
-                        )}>
-                          {agentRuntimeLabel}
-                        </span>
-                      </div>
-                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
-                        {agents[0]?.name || "Dynamic agent runtime"}
-                      </div>
-                    </div>
-                  </div>
-
+                <div className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain p-4">
                   <div className="rounded-xl border border-border/70 bg-background/40 p-3">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <div className="text-sm font-semibold text-foreground">Platform Health</div>
                         <div className="mt-0.5 text-xs text-muted-foreground">
                           {platformProbeSummary
-                            ? `${platformProbeSummary.total} checks across runtime, auth, storage, RAG, web ingestor, and migrations`
-                            : "Checking runtime, auth, storage, RAG, web ingestor, and migrations"}
+                            ? `${platformProbeSummary.total} checks across dynamic agents, auth, storage, RAG, web ingestor, and migrations`
+                            : "Checking dynamic agents, auth, storage, RAG, web ingestor, and migrations"}
                         </div>
                       </div>
                       <span className={statusBadgeClassName(platformHealthTone)}>
@@ -863,24 +792,64 @@ export function AppHeader() {
                           const warningCount = groupProbes.filter((probe) => probe.status === "warning").length;
                           const groupStatus = downCount > 0 ? "down" : warningCount > 0 ? "warning" : "healthy";
                           return (
-                            <span
-                              key={group.id}
-                              className={cn(
-                                "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium",
-                                groupStatus === "healthy" && "border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400",
-                                groupStatus === "warning" && "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400",
-                                groupStatus === "down" && "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400",
-                              )}
-                              title={`${groupProbes.length} checks`}
-                            >
-                              <span className={cn(
-                                "h-1.5 w-1.5 rounded-full",
-                                groupStatus === "healthy" && "bg-green-400",
-                                groupStatus === "warning" && "bg-amber-400",
-                                groupStatus === "down" && "bg-red-400",
-                              )} />
-                              {group.label}
-                            </span>
+                            <Tooltip key={group.id}>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  className={cn(
+                                    "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium",
+                                    groupStatus === "healthy" && "border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400",
+                                    groupStatus === "warning" && "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+                                    groupStatus === "down" && "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400",
+                                  )}
+                                >
+                                  <span className={cn(
+                                    "h-1.5 w-1.5 rounded-full",
+                                    groupStatus === "healthy" && "bg-green-400",
+                                    groupStatus === "warning" && "bg-amber-400",
+                                    groupStatus === "down" && "bg-red-400",
+                                  )} />
+                                  {group.label}
+                                  <Info className="h-3 w-3 opacity-70" />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent side="top" className="max-h-80 max-w-[28rem] overflow-y-auto whitespace-normal text-left">
+                                <div className="font-semibold">{group.label}</div>
+                                <div className="mt-1 text-muted-foreground">{group.description}</div>
+                                <div className="mt-1 text-[10px] text-muted-foreground">
+                                  {groupStatus === "healthy"
+                                    ? `${groupProbes.length} checks OK`
+                                    : `${downCount + warningCount} of ${groupProbes.length} need attention`}
+                                </div>
+                                <div className="mt-2 space-y-1.5 border-t border-border/60 pt-2">
+                                  <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                    Probes
+                                  </div>
+                                  {groupProbes.map((probe) => (
+                                    <div key={probe.id} className="rounded bg-muted/35 px-2 py-1.5">
+                                      <div className="flex items-center justify-between gap-2 text-[11px] font-medium">
+                                        <span>{probe.label}</span>
+                                        <span className={cn(
+                                          "shrink-0",
+                                          probe.status === "healthy" && "text-green-500 dark:text-green-400",
+                                          probe.status === "warning" && "text-amber-600 dark:text-amber-400",
+                                          probe.status === "down" && "text-red-500 dark:text-red-400",
+                                        )}>
+                                          {probe.status === "healthy" ? "OK" : probe.status === "warning" ? "Check" : "Down"}
+                                        </span>
+                                      </div>
+                                      <div className="mt-0.5 text-[10px] text-muted-foreground">
+                                        {probe.detail}
+                                        {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
+                                      </div>
+                                      <div className="mt-1 break-all font-mono text-[10px] text-muted-foreground">
+                                        {probe.target}
+                                      </div>
+                                    </div>
+                                  ))}
+                                </div>
+                              </TooltipContent>
+                            </Tooltip>
                           );
                         })}
                       </div>
@@ -940,6 +909,54 @@ export function AppHeader() {
                       </div>
                     ) : null}
 
+                    {platformProbes.length > 0 && (
+                      <div className="mt-3 overflow-hidden rounded-lg border border-border/60">
+                        <div className="grid grid-cols-[minmax(0,1fr)_auto] bg-muted/30 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                          <span>Probe</span>
+                          <span>Status</span>
+                        </div>
+                        <div className="max-h-48 divide-y divide-border/60 overflow-y-auto overscroll-contain">
+                          {platformProbes.map((probe) => (
+                            <Tooltip key={probe.id}>
+                              <TooltipTrigger asChild>
+                                <div className="grid cursor-help grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 hover:bg-muted/30">
+                                  <div className="min-w-0">
+                                    <div className="truncate text-xs font-medium text-foreground">
+                                      {probe.label}
+                                    </div>
+                                    <div className="truncate text-[10px] text-muted-foreground">
+                                      {probe.detail}
+                                      {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
+                                    </div>
+                                  </div>
+                                  <span className={statusBadgeClassName(
+                                    probe.status === "healthy" ? "green" : probe.status === "warning" ? "amber" : "red",
+                                  )}>
+                                    {probe.status === "healthy" ? "OK" : probe.status === "warning" ? "Check" : "Down"}
+                                  </span>
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipContent side="left" className="max-w-96 whitespace-normal text-left">
+                                <div className="font-semibold">{probe.label}</div>
+                                <div className="mt-1 text-muted-foreground">Validation: {probe.detail}</div>
+                                <div className="mt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                  Probe target
+                                </div>
+                                <div className="mt-2 break-all rounded bg-muted/40 px-2 py-1 font-mono text-[10px] text-muted-foreground">
+                                  {probe.target}
+                                </div>
+                                {probe.remediation && (
+                                  <div className="mt-2 text-[10px] text-muted-foreground">
+                                    Action: {probe.remediation.description}
+                                  </div>
+                                )}
+                              </TooltipContent>
+                            </Tooltip>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
                     <div className="mt-2 text-right text-[10px] font-mono text-muted-foreground">
                       Next probe: {platformProbeNextCheck}s
                     </div>
@@ -987,7 +1004,8 @@ export function AppHeader() {
                     </div>
                   )}
                 </div>
-              </div>
+                </div>
+              </TooltipProvider>
             </PopoverContent>
           </Popover>
           {noAuthConfigured && (

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -23,7 +23,7 @@ import { useRAGHealth } from "@/hooks/use-rag-health";
 import { useReleaseUpgradePrompt } from "@/hooks/use-release-upgrade-prompt";
 import { useVersion } from "@/hooks/use-version";
 import { config,getLogoFilterClass } from "@/lib/config";
-import { cn,formatRelativeTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { useChatStore } from "@/store/chat-store";
 import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import { AnimatePresence,motion } from "framer-motion";
@@ -155,7 +155,7 @@ export function AppHeader() {
   const pathname = usePathname();
   const { data: session } = useSession();
   const { isAdmin } = useAdminRole();
-  const { isStreaming, streamingConversations, unviewedConversations, inputRequiredConversations } = useChatStore();
+  const { streamingConversations, unviewedConversations, inputRequiredConversations } = useChatStore();
   const {
     hasUnsavedChanges,
     pendingNavigationHref,
@@ -208,7 +208,6 @@ export function AppHeader() {
   // Health check for CAIPE supervisor (polls every 30 seconds)
   const {
     status: caipeStatus,
-    url: caipeUrl,
     secondsUntilNextCheck: caipeNextCheck,
     agents,
     mongoDBStatus,
@@ -218,8 +217,6 @@ export function AppHeader() {
   // Health check for RAG server (polls every 30 seconds)
   const {
     status: ragStatus,
-    url: ragUrl,
-    secondsUntilNextCheck: ragNextCheck,
     graphRagEnabled,
     cleanupConfig
   } = useRAGHealth();
@@ -292,6 +289,42 @@ export function AppHeader() {
   ] as const;
   const platformProbeIssues = platformProbes.filter((probe) => probe.status !== "healthy");
   const platformProbeHealthyCount = platformProbes.filter((probe) => probe.status === "healthy").length;
+  const platformProbeIssueCount = platformProbeIssues.length;
+  const platformHealthLabel =
+    platformProbeStatus === "healthy" ? "Ready" :
+    platformProbeStatus === "degraded" ? "Attention" :
+    platformProbeStatus === "down" ? "Down" :
+    "Checking";
+  const platformHealthTone =
+    platformProbeStatus === "healthy" ? "green" :
+    platformProbeStatus === "down" ? "red" :
+    platformProbeStatus === "checking" ? "muted" :
+    "amber";
+  const storageLabel =
+    mongoDBStatus === "connected" ? "MongoDB" :
+    mongoDBStatus === "checking" ? "Checking" :
+    "localStorage";
+  const ragSummaryLabel = !ragEnabled
+    ? "Disabled"
+    : ragStatus === "connected"
+      ? "Online"
+      : ragStatus === "checking"
+        ? "Checking"
+        : "Offline";
+  const agentRuntimeLabel =
+    agentRuntimeStatus === "connected" ? "Online" :
+    agentRuntimeStatus === "checking" ? "Checking" :
+    "Offline";
+  const statusCardClassName =
+    "rounded-lg border border-border/60 bg-muted/20 px-3 py-2.5";
+  const statusBadgeClassName = (tone: "green" | "amber" | "red" | "muted") =>
+    cn(
+      "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold",
+      tone === "green" && "border-green-500/25 bg-green-500/10 text-green-500 dark:text-green-400",
+      tone === "amber" && "border-amber-500/25 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+      tone === "red" && "border-red-500/25 bg-red-500/10 text-red-500 dark:text-red-400",
+      tone === "muted" && "border-border bg-muted/40 text-muted-foreground",
+    );
 
   const getActiveTab = () => {
     if (pathname === "/") return "home";
@@ -739,345 +772,178 @@ export function AppHeader() {
                   </div>
                 </div>
 
-                <div className="p-4 space-y-4">
-                  {/* CAIPE Supervisor Section */}
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className="text-sm font-bold text-foreground">{config.appName} Supervisor</div>
-                        <div className={cn(
-                          "px-2 py-0.5 rounded-full text-[10px] font-bold",
-                          caipeStatus === "connected" && "bg-green-500/15 text-green-400 border border-green-500/30",
-                          caipeStatus === "checking" && "bg-amber-500/15 text-amber-400 border border-amber-500/30",
-                          caipeStatus === "disconnected" && "bg-red-500/15 text-red-400 border border-red-500/30"
+                <div className="p-4 space-y-3">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className={statusCardClassName}>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold text-muted-foreground">Supervisor</div>
+                        <span className={statusBadgeClassName(
+                          caipeStatus === "connected" ? "green" : caipeStatus === "checking" ? "amber" : "red",
                         )}>
-                          {caipeStatus === "connected" ? "ONLINE" : caipeStatus === "checking" ? "CHECKING" : "OFFLINE"}
-                        </div>
+                          {caipeStatus === "connected" ? "Online" : caipeStatus === "checking" ? "Checking" : "Offline"}
+                        </span>
                       </div>
-                      <div className="text-[10px] text-muted-foreground font-mono">
-                        Next check: {caipeNextCheck}s
-                      </div>
-                    </div>
-                    <div className="text-xs text-muted-foreground font-mono break-all bg-muted/30 rounded px-2 py-1">
-                      {caipeUrl}
-                    </div>
-
-                    {/* Agent Info */}
-                    {agents.length > 0 && (
-                      <div className="bg-muted/30 rounded-lg p-3 border border-border/50">
-                        <div className="flex items-start gap-3">
-                          <div className="w-10 h-10 rounded-lg gradient-primary-br flex items-center justify-center shrink-0">
-                            <span className="text-lg font-bold text-white">AI</span>
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="font-semibold text-sm text-foreground mb-1">
-                              {agents[0].name}
-                            </div>
-                            {agents[0].description && (
-                              <div className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
-                                {agents[0].description}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Storage Status */}
-                    <div className="bg-muted/30 rounded-lg p-3 border border-border/50">
-                      <div className="flex items-center justify-between mb-2">
-                        <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                          Storage Backend
-                        </div>
-                        <div className={cn(
-                          "flex items-center gap-1.5 px-2 py-0.5 rounded-full border",
-                          mongoDBStatus === 'connected' && "bg-green-500/10 border-green-500/20",
-                          mongoDBStatus === 'disconnected' && "bg-amber-500/10 border-amber-500/20",
-                          mongoDBStatus === 'checking' && "bg-muted/50 border-border"
-                        )}>
-                          {mongoDBStatus === 'checking' ? (
-                            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-                          ) : (
-                            <span className={cn(
-                              "inline-block w-1.5 h-1.5 rounded-full",
-                              mongoDBStatus === 'connected' && "bg-green-400",
-                              mongoDBStatus === 'disconnected' && "bg-amber-400"
-                            )} />
-                          )}
-                          <span className={cn(
-                            "text-[10px] font-bold",
-                            mongoDBStatus === 'connected' && "text-green-600 dark:text-green-400",
-                            mongoDBStatus === 'disconnected' && "text-amber-600 dark:text-amber-400",
-                            mongoDBStatus === 'checking' && "text-muted-foreground"
-                          )}>
-                            {mongoDBStatus === 'checking' ? 'Checking' : mongoDBStatus === 'connected' ? 'MongoDB' : 'localStorage'}
-                          </span>
-                        </div>
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {mongoDBStatus === 'connected' && (
-                          <span>✓ Persistent storage with cross-device sync</span>
-                        )}
-                        {mongoDBStatus === 'disconnected' && (
-                          <span>Local browser storage (no sync)</span>
-                        )}
-                        {mongoDBStatus === 'checking' && (
-                          <span>Checking backend availability...</span>
-                        )}
+                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
+                        Next check in {caipeNextCheck}s
                       </div>
                     </div>
 
-                    {/* Platform dependency probes */}
-                    <div>
-                      <div className="flex items-center justify-between mb-2">
-                        <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                          Platform Health
-                        </div>
-                        <div className={cn(
-                          "flex items-center gap-1.5 px-2 py-0.5 rounded-full border",
-                          platformProbeStatus === "healthy" && "bg-green-500/10 border-green-500/20",
-                          platformProbeStatus === "degraded" && "bg-amber-500/10 border-amber-500/20",
-                          platformProbeStatus === "down" && "bg-red-500/10 border-red-500/20",
-                          platformProbeStatus === "checking" && "bg-muted/50 border-border"
+                    <div className={statusCardClassName}>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold text-muted-foreground">Storage</div>
+                        <span className={statusBadgeClassName(
+                          mongoDBStatus === "connected" ? "green" : mongoDBStatus === "checking" ? "muted" : "amber",
                         )}>
-                          {platformProbeStatus === "checking" ? (
-                            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-                          ) : (
-                            <span className={cn(
-                              "inline-block w-1.5 h-1.5 rounded-full",
-                              platformProbeStatus === "healthy" && "bg-green-400",
-                              platformProbeStatus === "degraded" && "bg-amber-400",
-                              platformProbeStatus === "down" && "bg-red-400"
-                            )} />
-                          )}
-                          <span className={cn(
-                            "text-[10px] font-bold",
-                            platformProbeStatus === "healthy" && "text-green-600 dark:text-green-400",
-                            platformProbeStatus === "degraded" && "text-amber-600 dark:text-amber-400",
-                            platformProbeStatus === "down" && "text-red-600 dark:text-red-400",
-                            platformProbeStatus === "checking" && "text-muted-foreground"
-                          )}>
-                            {platformProbeSummary
-                              ? `${platformProbeSummary.healthy}/${platformProbeSummary.total}`
-                              : platformProbeStatus === "checking" ? "Checking" : "Unavailable"}
-                          </span>
-                        </div>
+                          {storageLabel}
+                        </span>
                       </div>
-                      <div className="space-y-2">
-                        {platformProbes.length === 0 && (
-                          <div className="text-xs text-muted-foreground bg-muted/20 rounded px-2 py-1.5">
-                            Checking Keycloak, OpenFGA, AgentGateway, RAG, storage, web ingestor readiness, and migrations...
-                          </div>
-                        )}
-                        {platformProbes.length > 0 && (
-                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
-                            {platformProbeGroups.map((group) => {
-                              const groupProbes = platformProbes.filter((probe) => probe.group === group.id);
-                              if (groupProbes.length === 0) return null;
-                              const downCount = groupProbes.filter((probe) => probe.status === "down").length;
-                              const warningCount = groupProbes.filter((probe) => probe.status === "warning").length;
-                              const groupStatus = downCount > 0 ? "down" : warningCount > 0 ? "warning" : "healthy";
-                              return (
-                                <div
-                                  key={group.id}
-                                  className="flex items-center justify-between gap-2 bg-muted/20 rounded px-2 py-1.5"
-                                >
-                                  <div className="min-w-0">
-                                    <div className="truncate text-xs font-medium text-foreground">
-                                      {group.label}
-                                    </div>
-                                    <div className="truncate text-[10px] text-muted-foreground">
-                                      {groupStatus === "healthy"
-                                        ? `${groupProbes.length} checks OK`
-                                        : `${downCount + warningCount} of ${groupProbes.length} need attention`}
-                                    </div>
-                                  </div>
-                                  <div className={cn(
-                                    "px-2 py-0.5 rounded-full text-[10px] font-bold shrink-0 border",
-                                    groupStatus === "healthy" && "bg-green-500/15 text-green-400 border-green-500/30",
-                                    groupStatus === "warning" && "bg-amber-500/15 text-amber-400 border-amber-500/30",
-                                    groupStatus === "down" && "bg-red-500/15 text-red-400 border-red-500/30"
-                                  )}>
-                                    {groupStatus === "healthy" ? "OK" : groupStatus === "warning" ? "CHECK" : "DOWN"}
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-                        {platformProbeIssues.length > 0 ? (
-                          <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-2 space-y-2">
-                            <div className="flex items-center justify-between gap-2">
-                              <div className="text-xs font-semibold text-amber-700 dark:text-amber-300">
-                                Action needed
-                              </div>
-                              <div className="text-[10px] text-amber-700/80 dark:text-amber-300/80">
-                                {platformProbeHealthyCount} healthy · {platformProbeIssues.length} attention
-                              </div>
-                            </div>
-                            <div className="space-y-1.5">
-                              {platformProbeIssues.slice(0, 4).map((probe) => (
-                                <div
-                                  key={probe.id}
-                                  title={`${probe.target} — ${probe.detail}`}
-                                  className="flex items-center justify-between gap-2 rounded bg-background/60 px-2 py-1.5"
-                                >
-                                  <div className="min-w-0">
-                                    <div className="truncate text-xs font-medium text-foreground">
-                                      {probe.label}
-                                    </div>
-                                    <div className="truncate text-[10px] text-muted-foreground">
-                                      {probe.detail}
-                                    </div>
-                                  </div>
-                                  {probe.remediation ? (
-                                    <button
-                                      type="button"
-                                      onClick={() => router.push(probe.remediation!.href)}
-                                      className="shrink-0 rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-[10px] font-semibold text-primary hover:bg-primary/15"
-                                      title={probe.remediation.description}
-                                    >
-                                      {probe.remediation.label}
-                                    </button>
-                                  ) : (
-                                    <div className={cn(
-                                      "px-2 py-0.5 rounded-full text-[10px] font-bold shrink-0 border",
-                                      probe.status === "warning"
-                                        ? "bg-amber-500/15 text-amber-400 border-amber-500/30"
-                                        : "bg-red-500/15 text-red-400 border-red-500/30"
-                                    )}>
-                                      {probe.status === "warning" ? "CHECK" : "DOWN"}
-                                    </div>
-                                  )}
-                                </div>
-                              ))}
-                              {platformProbeIssues.length > 4 && (
-                                <div className="text-[10px] text-muted-foreground">
-                                  {platformProbeIssues.length - 4} more checks need attention.
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        ) : platformProbes.length > 0 ? (
-                          <div className="text-xs text-muted-foreground bg-green-500/10 border border-green-500/20 rounded px-2 py-1.5">
-                            Core runtime, identity, storage, RAG, web ingestor queue readiness, and migrations look ready.
-                          </div>
-                        ) : null}
+                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
+                        {mongoDBStatus === "connected" ? "Persistent data enabled" : "Local browser fallback"}
                       </div>
-                      <div className="mt-1.5 text-[10px] text-muted-foreground font-mono text-right">
-                        Next probe: {platformProbeNextCheck}s
+                    </div>
+
+                    <div className={statusCardClassName}>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold text-muted-foreground">RAG</div>
+                        <span className={statusBadgeClassName(
+                          !ragEnabled ? "muted" : ragStatus === "connected" ? "green" : ragStatus === "checking" ? "amber" : "red",
+                        )}>
+                          {ragSummaryLabel}
+                        </span>
+                      </div>
+                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
+                        {ragEnabled
+                          ? `Graph ${graphRagEnabled ? "on" : "off"}${cleanupConfig?.enabled ? ` · cleanup ${formatInterval(cleanupConfig.interval_seconds)}` : ""}`
+                          : "Knowledge services are off"}
+                      </div>
+                    </div>
+
+                    <div className={statusCardClassName}>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold text-muted-foreground">Agents</div>
+                        <span className={statusBadgeClassName(
+                          agentRuntimeStatus === "connected" ? "green" : agentRuntimeStatus === "checking" ? "amber" : "red",
+                        )}>
+                          {agentRuntimeLabel}
+                        </span>
+                      </div>
+                      <div className="mt-1 truncate text-[11px] text-muted-foreground">
+                        {agents[0]?.name || "Dynamic agent runtime"}
                       </div>
                     </div>
                   </div>
 
-                  {/* RAG Server Section - only show if RAG is enabled */}
-                  {ragEnabled && (
-                    <>
-                      {/* Divider */}
-                      <div className="border-t border-border/50" />
-
-                      <div className="space-y-3">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <div className="text-sm font-bold text-foreground">RAG Server</div>
-                            <div className={cn(
-                              "px-2 py-0.5 rounded-full text-[10px] font-bold",
-                              ragStatus === "connected" && "bg-green-500/15 text-green-400 border border-green-500/30",
-                              ragStatus === "checking" && "bg-amber-500/15 text-amber-400 border border-amber-500/30",
-                              ragStatus === "disconnected" && "bg-red-500/15 text-red-400 border border-red-500/30"
-                            )}>
-                              {ragStatus === "connected" ? "ONLINE" : ragStatus === "checking" ? "CHECKING" : "OFFLINE"}
-                            </div>
-                          </div>
-                          <div className="text-[10px] text-muted-foreground font-mono">
-                            Next check: {ragNextCheck}s
-                          </div>
-                        </div>
-                        <div className="text-xs text-muted-foreground font-mono break-all bg-muted/30 rounded px-2 py-1">
-                          {ragUrl}
-                        </div>
-
-                        {/* Graph RAG Status */}
-                        <div className="flex items-center justify-between bg-muted/20 rounded px-2 py-1.5">
-                          <div className="text-xs text-muted-foreground">Knowledge Graph</div>
-                          <div className={cn(
-                            "px-2 py-0.5 rounded-full text-[10px] font-bold",
-                            graphRagEnabled
-                              ? "bg-green-500/15 text-green-400 border border-green-500/30"
-                              : "bg-gray-500/15 text-gray-400 border border-gray-500/30"
-                          )}>
-                            {graphRagEnabled ? "ON" : "OFF"}
-                          </div>
-                        </div>
-
-                        {/* Auto-Cleanup Status */}
-                        {cleanupConfig && (
-                          <div className="bg-muted/20 rounded px-2 py-1.5 space-y-1">
-                            <div className="flex items-center justify-between">
-                              <div className="text-xs text-muted-foreground">Auto-Cleanup</div>
-                              <div className={cn(
-                                "px-2 py-0.5 rounded-full text-[10px] font-bold",
-                                cleanupConfig.enabled
-                                  ? "bg-green-500/15 text-green-400 border border-green-500/30"
-                                  : "bg-gray-500/15 text-gray-400 border border-gray-500/30"
-                              )}>
-                                {cleanupConfig.enabled ? formatInterval(cleanupConfig.interval_seconds) : "OFF"}
-                              </div>
-                            </div>
-                            {cleanupConfig.enabled && (
-                              <div className="text-[10px] text-muted-foreground">
-                                {cleanupConfig.last_cleanup ? (
-                                  <>
-                                    <div>Last: {formatRelativeTime(cleanupConfig.last_cleanup)}</div>
-                                    <div>Next: {formatRelativeTime(cleanupConfig.last_cleanup + cleanupConfig.interval_seconds)}</div>
-                                  </>
-                                ) : (
-                                  <>Waiting for first cleanup...</>
-                                )}
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </>
-                  )}
-
-                  {/* Agent Runtime Section */}
-                  <>
-                    {/* Divider */}
-                    <div className="border-t border-border/50" />
-
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <div className="text-sm font-bold text-foreground">Agent Runtime</div>
-                          <div className={cn(
-                            "px-2 py-0.5 rounded-full text-[10px] font-bold",
-                            agentRuntimeStatus === "connected" && "bg-green-500/15 text-green-400 border border-green-500/30",
-                            agentRuntimeStatus === "checking" && "bg-amber-500/15 text-amber-400 border border-amber-500/30",
-                            agentRuntimeStatus === "disconnected" && "bg-red-500/15 text-red-400 border border-red-500/30"
-                          )}>
-                            {agentRuntimeStatus === "connected" ? "ONLINE" : agentRuntimeStatus === "checking" ? "CHECKING" : "OFFLINE"}
-                          </div>
+                  <div className="rounded-xl border border-border/70 bg-background/40 p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-semibold text-foreground">Platform Health</div>
+                        <div className="mt-0.5 text-xs text-muted-foreground">
+                          {platformProbeSummary
+                            ? `${platformProbeSummary.total} checks across runtime, auth, storage, RAG, web ingestor, and migrations`
+                            : "Checking runtime, auth, storage, RAG, web ingestor, and migrations"}
                         </div>
                       </div>
-
-                      {/* Dynamic Agents sub-item */}
-                      <div className="flex items-center justify-between bg-muted/20 rounded px-2 py-1.5">
-                        <div className="text-xs text-muted-foreground">CAIPE Dynamic Agents</div>
-                        <div className={cn(
-                          "px-2 py-0.5 rounded-full text-[10px] font-bold",
-                          agentRuntimeStatus === "connected"
-                            ? "bg-green-500/15 text-green-400 border border-green-500/30"
-                            : agentRuntimeStatus === "checking"
-                            ? "bg-amber-500/15 text-amber-400 border border-amber-500/30"
-                            : "bg-red-500/15 text-red-400 border border-red-500/30"
-                        )}>
-                          {agentRuntimeStatus === "connected" ? "ON" : agentRuntimeStatus === "checking" ? "..." : "OFF"}
-                        </div>
-                      </div>
+                      <span className={statusBadgeClassName(platformHealthTone)}>
+                        {platformProbeSummary
+                          ? `${platformProbeSummary.healthy}/${platformProbeSummary.total} ${platformHealthLabel}`
+                          : platformHealthLabel}
+                      </span>
                     </div>
-                  </>
+
+                    {platformProbes.length === 0 ? (
+                      <div className="mt-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                        Checking Keycloak, OpenFGA, AgentGateway, RAG, storage, web ingestor readiness, and migrations...
+                      </div>
+                    ) : (
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        {platformProbeGroups.map((group) => {
+                          const groupProbes = platformProbes.filter((probe) => probe.group === group.id);
+                          if (groupProbes.length === 0) return null;
+                          const downCount = groupProbes.filter((probe) => probe.status === "down").length;
+                          const warningCount = groupProbes.filter((probe) => probe.status === "warning").length;
+                          const groupStatus = downCount > 0 ? "down" : warningCount > 0 ? "warning" : "healthy";
+                          return (
+                            <span
+                              key={group.id}
+                              className={cn(
+                                "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium",
+                                groupStatus === "healthy" && "border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400",
+                                groupStatus === "warning" && "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+                                groupStatus === "down" && "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400",
+                              )}
+                              title={`${groupProbes.length} checks`}
+                            >
+                              <span className={cn(
+                                "h-1.5 w-1.5 rounded-full",
+                                groupStatus === "healthy" && "bg-green-400",
+                                groupStatus === "warning" && "bg-amber-400",
+                                groupStatus === "down" && "bg-red-400",
+                              )} />
+                              {group.label}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {platformProbeIssues.length > 0 ? (
+                      <div className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/10 p-2.5">
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                          <div className="text-xs font-semibold text-amber-700 dark:text-amber-300">
+                            Action needed
+                          </div>
+                          <div className="text-[10px] text-amber-700/80 dark:text-amber-300/80">
+                            {platformProbeHealthyCount} healthy · {platformProbeIssueCount} attention
+                          </div>
+                        </div>
+                        <div className="space-y-1.5">
+                          {platformProbeIssues.slice(0, 3).map((probe) => (
+                            <div
+                              key={probe.id}
+                              title={`${probe.target} — ${probe.detail}`}
+                              className="flex items-center justify-between gap-2 rounded-md bg-background/70 px-2.5 py-2"
+                            >
+                              <div className="min-w-0">
+                                <div className="truncate text-xs font-medium text-foreground">
+                                  {probe.label}
+                                </div>
+                                <div className="truncate text-[10px] text-muted-foreground">
+                                  {probe.detail}
+                                </div>
+                              </div>
+                              {probe.remediation ? (
+                                <button
+                                  type="button"
+                                  onClick={() => router.push(probe.remediation!.href)}
+                                  className="shrink-0 rounded-md bg-primary px-2.5 py-1 text-[10px] font-semibold text-primary-foreground hover:bg-primary/90"
+                                  title={probe.remediation.description}
+                                >
+                                  {probe.remediation.label}
+                                </button>
+                              ) : (
+                                <span className={statusBadgeClassName(probe.status === "warning" ? "amber" : "red")}>
+                                  {probe.status === "warning" ? "Check" : "Down"}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                          {platformProbeIssues.length > 3 && (
+                            <div className="px-1 text-[10px] text-muted-foreground">
+                              {platformProbeIssues.length - 3} more checks need attention.
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ) : platformProbes.length > 0 ? (
+                      <div className="mt-3 rounded-lg border border-green-500/20 bg-green-500/10 px-3 py-2 text-xs text-muted-foreground">
+                        All critical checks are ready.
+                      </div>
+                    ) : null}
+
+                    <div className="mt-2 text-right text-[10px] font-mono text-muted-foreground">
+                      Next probe: {platformProbeNextCheck}s
+                    </div>
+                  </div>
                 </div>
 
                 {/* Footer */}

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -18,6 +18,7 @@ import { useAgentRuntimeHealth } from "@/hooks/use-agent-runtime-health";
 import { useCAIPEHealth } from "@/hooks/use-caipe-health";
 import { useKeycloakHealthSummary } from "@/hooks/use-keycloak-health-summary";
 import { useMigrationStatus } from "@/hooks/use-migration-status";
+import { usePlatformHealthProbes } from "@/hooks/use-platform-health-probes";
 import { useRAGHealth } from "@/hooks/use-rag-health";
 import { useReleaseUpgradePrompt } from "@/hooks/use-release-upgrade-prompt";
 import { useVersion } from "@/hooks/use-version";
@@ -210,7 +211,6 @@ export function AppHeader() {
     url: caipeUrl,
     secondsUntilNextCheck: caipeNextCheck,
     agents,
-    tags,
     mongoDBStatus,
     storageMode
   } = useCAIPEHealth();
@@ -226,6 +226,12 @@ export function AppHeader() {
 
   // Health check for Agent Runtime (polls every 30 seconds)
   const { status: agentRuntimeStatus } = useAgentRuntimeHealth();
+  const {
+    status: platformProbeStatus,
+    probes: platformProbes,
+    summary: platformProbeSummary,
+    secondsUntilNextCheck: platformProbeNextCheck,
+  } = usePlatformHealthProbes();
 
   // Check if RAG is enabled in config
   const ragEnabled = config.ragEnabled;
@@ -256,13 +262,15 @@ export function AppHeader() {
     releasePrompt.markToastShown();
   }, [releasePrompt, session, toast]);
 
-  // Combined status: if either is checking -> checking, if supervisor is disconnected -> disconnected,
-  // if only RAG is disconnected (supervisor connected) -> rag-disconnected (amber warning), else connected
-  // Note: Only include RAG in status if it's enabled
+  // Combined status: hard failures from the supervisor or platform
+  // dependencies mark the system as disconnected; optional RAG failures are
+  // degraded so the core chat/runtime path can still show separately.
   const getCombinedStatus = () => {
     if (caipeStatus === "checking") return "checking";
     if (ragEnabled && ragStatus === "checking") return "checking";
+    if (platformProbeStatus === "checking") return "checking";
     if (caipeStatus === "disconnected") return "disconnected";
+    if (platformProbeStatus === "down") return "disconnected";
     if (ragEnabled && ragStatus === "disconnected") return "rag-disconnected";
     return "connected";
   };
@@ -804,31 +812,75 @@ export function AppHeader() {
                       </div>
                     </div>
 
-                    {/* Integrations */}
-                    {tags.length > 0 && (
-                      <div>
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                            Connected Integrations
-                          </div>
-                          <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary/10 border border-primary/20">
-                            <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-400" />
-                            <span className="text-[10px] font-bold text-primary">{tags.length}</span>
-                          </div>
+                    {/* Platform dependency probes */}
+                    <div>
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                          Platform Probes
                         </div>
-                        <div className="flex flex-wrap gap-1.5 max-h-24 overflow-y-auto pr-1">
-                          {tags.map((tag, idx) => (
-                            <span
-                              key={idx}
-                              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-semibold bg-gradient-to-br from-primary/10 to-primary/5 text-primary border border-primary/20 hover:border-primary/40 hover:bg-primary/15 transition-all"
-                            >
-                              <span className="inline-block w-1 h-1 rounded-full bg-green-400" />
-                              {tag}
-                            </span>
-                          ))}
+                        <div className={cn(
+                          "flex items-center gap-1.5 px-2 py-0.5 rounded-full border",
+                          platformProbeStatus === "healthy" && "bg-green-500/10 border-green-500/20",
+                          platformProbeStatus === "down" && "bg-red-500/10 border-red-500/20",
+                          platformProbeStatus === "checking" && "bg-muted/50 border-border"
+                        )}>
+                          {platformProbeStatus === "checking" ? (
+                            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                          ) : (
+                            <span className={cn(
+                              "inline-block w-1.5 h-1.5 rounded-full",
+                              platformProbeStatus === "healthy" && "bg-green-400",
+                              platformProbeStatus === "down" && "bg-red-400"
+                            )} />
+                          )}
+                          <span className={cn(
+                            "text-[10px] font-bold",
+                            platformProbeStatus === "healthy" && "text-green-600 dark:text-green-400",
+                            platformProbeStatus === "down" && "text-red-600 dark:text-red-400",
+                            platformProbeStatus === "checking" && "text-muted-foreground"
+                          )}>
+                            {platformProbeSummary
+                              ? `${platformProbeSummary.healthy}/${platformProbeSummary.total}`
+                              : platformProbeStatus === "checking" ? "Checking" : "Unavailable"}
+                          </span>
                         </div>
                       </div>
-                    )}
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+                        {platformProbes.length === 0 && (
+                          <div className="text-xs text-muted-foreground bg-muted/20 rounded px-2 py-1.5">
+                            Checking Keycloak, OpenFGA, AgentGateway, and bridge health...
+                          </div>
+                        )}
+                        {platformProbes.map((probe) => (
+                          <div
+                            key={probe.id}
+                            title={`${probe.target} — ${probe.detail}`}
+                            className="flex items-center justify-between gap-2 bg-muted/20 rounded px-2 py-1.5"
+                          >
+                            <div className="min-w-0">
+                              <div className="truncate text-xs font-medium text-foreground">
+                                {probe.label}
+                              </div>
+                              <div className="truncate text-[10px] text-muted-foreground">
+                                {probe.detail}
+                                {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
+                              </div>
+                            </div>
+                            <div className={cn(
+                              "px-2 py-0.5 rounded-full text-[10px] font-bold shrink-0 border",
+                              probe.status === "healthy"
+                                ? "bg-green-500/15 text-green-400 border-green-500/30"
+                                : "bg-red-500/15 text-red-400 border-red-500/30"
+                            )}>
+                              {probe.status === "healthy" ? "OK" : "DOWN"}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="mt-1.5 text-[10px] text-muted-foreground font-mono text-right">
+                        Next probe: {platformProbeNextCheck}s
+                      </div>
+                    </div>
                   </div>
 
                   {/* RAG Server Section - only show if RAG is enabled */}

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -105,6 +105,39 @@ jest.mock('@/hooks/use-rag-health', () => ({
   }),
 }))
 
+let mockPlatformProbeStatus: 'healthy' | 'down' | 'checking' = 'healthy'
+type MockPlatformProbe = {
+  id: string
+  label: string
+  status: 'healthy' | 'down'
+  detail: string
+  target: string
+  latency_ms: number
+}
+let mockPlatformProbes: MockPlatformProbe[] = [
+  {
+    id: 'keycloak',
+    label: 'Keycloak',
+    status: 'healthy',
+    detail: 'HTTP 200',
+    target: 'http://keycloak:7080',
+    latency_ms: 12,
+  },
+]
+jest.mock('@/hooks/use-platform-health-probes', () => ({
+  usePlatformHealthProbes: () => ({
+    status: mockPlatformProbeStatus,
+    probes: mockPlatformProbes,
+    summary: {
+      total: mockPlatformProbes.length,
+      healthy: mockPlatformProbes.filter((p) => p.status === 'healthy').length,
+      down: mockPlatformProbes.filter((p) => p.status === 'down').length,
+    },
+    secondsUntilNextCheck: 30,
+    checkNow: jest.fn(),
+  }),
+}))
+
 // Mock version hook
 jest.mock('@/hooks/use-version', () => ({
   useVersion: () => ({
@@ -567,6 +600,17 @@ describe('AppHeader — connection status badge', () => {
     mockRagEnabled = false
     mockCaipeStatus = 'connected'
     mockRagStatus = 'connected'
+    mockPlatformProbeStatus = 'healthy'
+    mockPlatformProbes = [
+      {
+        id: 'keycloak',
+        label: 'Keycloak',
+        status: 'healthy',
+        detail: 'HTTP 200',
+        target: 'http://keycloak:7080',
+        latency_ms: 12,
+      },
+    ]
     mockStreamingConversations = new Map()
     mockUnviewedConversations = new Set()
     mockInputRequiredConversations = new Set()
@@ -590,6 +634,8 @@ describe('AppHeader — connection status badge', () => {
       // Popover content reflects healthy state
       expect(screen.getByText('All Systems Live')).toBeInTheDocument()
       expect(screen.getByText('All systems operational')).toBeInTheDocument()
+      expect(screen.getByText('Platform Probes')).toBeInTheDocument()
+      expect(screen.getByText('Keycloak')).toBeInTheDocument()
     })
   })
 
@@ -607,6 +653,15 @@ describe('AppHeader — connection status badge', () => {
       mockCaipeStatus = 'connected'
       mockRagEnabled = true
       mockRagStatus = 'checking'
+      render(<AppHeader />)
+      const matches = screen.getAllByText('Checking')
+      expect(matches.length).toBeGreaterThan(0)
+    })
+
+    it('shows "Checking" when platform probes are still checking', () => {
+      mockCaipeStatus = 'connected'
+      mockPlatformProbeStatus = 'checking'
+      mockPlatformProbes = []
       render(<AppHeader />)
       const matches = screen.getAllByText('Checking')
       expect(matches.length).toBeGreaterThan(0)
@@ -711,6 +766,25 @@ describe('AppHeader — connection status badge', () => {
       mockCaipeStatus = 'disconnected'
       render(<AppHeader />)
       expect(screen.getByText('Disconnected')).toBeInTheDocument()
+    })
+
+    it('shows "Disconnected" when a platform dependency probe is down', () => {
+      mockCaipeStatus = 'connected'
+      mockPlatformProbeStatus = 'down'
+      mockPlatformProbes = [
+        {
+          id: 'openfga',
+          label: 'OpenFGA',
+          status: 'down',
+          detail: 'HTTP 503',
+          target: 'http://openfga:8080/healthz',
+          latency_ms: 20,
+        },
+      ]
+      render(<AppHeader />)
+      expect(screen.getByText('Disconnected')).toBeInTheDocument()
+      expect(screen.getByText('OpenFGA')).toBeInTheDocument()
+      expect(screen.getByText('DOWN')).toBeInTheDocument()
     })
 
     it('Disconnected badge has red styling', () => {

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -105,19 +105,26 @@ jest.mock('@/hooks/use-rag-health', () => ({
   }),
 }))
 
-let mockPlatformProbeStatus: 'healthy' | 'down' | 'checking' = 'healthy'
+let mockPlatformProbeStatus: 'healthy' | 'degraded' | 'down' | 'checking' = 'healthy'
 type MockPlatformProbe = {
   id: string
   label: string
-  status: 'healthy' | 'down'
+  group: 'core' | 'identity' | 'storage' | 'rag' | 'bootstrap'
+  status: 'healthy' | 'warning' | 'down'
   detail: string
   target: string
   latency_ms: number
+  remediation?: {
+    label: string
+    href: string
+    description: string
+  }
 }
 let mockPlatformProbes: MockPlatformProbe[] = [
   {
     id: 'keycloak',
     label: 'Keycloak',
+    group: 'identity',
     status: 'healthy',
     detail: 'HTTP 200',
     target: 'http://keycloak:7080',
@@ -131,6 +138,7 @@ jest.mock('@/hooks/use-platform-health-probes', () => ({
     summary: {
       total: mockPlatformProbes.length,
       healthy: mockPlatformProbes.filter((p) => p.status === 'healthy').length,
+      warning: mockPlatformProbes.filter((p) => p.status === 'warning').length,
       down: mockPlatformProbes.filter((p) => p.status === 'down').length,
     },
     secondsUntilNextCheck: 30,
@@ -605,6 +613,7 @@ describe('AppHeader — connection status badge', () => {
       {
         id: 'keycloak',
         label: 'Keycloak',
+        group: 'identity',
         status: 'healthy',
         detail: 'HTTP 200',
         target: 'http://keycloak:7080',
@@ -634,8 +643,8 @@ describe('AppHeader — connection status badge', () => {
       // Popover content reflects healthy state
       expect(screen.getByText('All Systems Live')).toBeInTheDocument()
       expect(screen.getByText('All systems operational')).toBeInTheDocument()
-      expect(screen.getByText('Platform Probes')).toBeInTheDocument()
-      expect(screen.getByText('Keycloak')).toBeInTheDocument()
+      expect(screen.getByText('Platform Health')).toBeInTheDocument()
+      expect(screen.getByText('Identity & Authz')).toBeInTheDocument()
     })
   })
 
@@ -775,6 +784,7 @@ describe('AppHeader — connection status badge', () => {
         {
           id: 'openfga',
           label: 'OpenFGA',
+          group: 'identity',
           status: 'down',
           detail: 'HTTP 503',
           target: 'http://openfga:8080/healthz',
@@ -784,7 +794,7 @@ describe('AppHeader — connection status badge', () => {
       render(<AppHeader />)
       expect(screen.getByText('Disconnected')).toBeInTheDocument()
       expect(screen.getByText('OpenFGA')).toBeInTheDocument()
-      expect(screen.getByText('DOWN')).toBeInTheDocument()
+      expect(screen.getAllByText('DOWN').length).toBeGreaterThan(0)
     })
 
     it('Disconnected badge has red styling', () => {

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -644,7 +644,7 @@ describe('AppHeader — connection status badge', () => {
       expect(screen.getByText('All Systems Live')).toBeInTheDocument()
       expect(screen.getByText('All systems operational')).toBeInTheDocument()
       expect(screen.getByText('Platform Health')).toBeInTheDocument()
-      expect(screen.getByText('Identity & Authz')).toBeInTheDocument()
+      expect(screen.getAllByText('Identity & Authz').length).toBeGreaterThan(0)
     })
   })
 
@@ -793,7 +793,7 @@ describe('AppHeader — connection status badge', () => {
       ]
       render(<AppHeader />)
       expect(screen.getByText('Disconnected')).toBeInTheDocument()
-      expect(screen.getByText('OpenFGA')).toBeInTheDocument()
+      expect(screen.getAllByText('OpenFGA').length).toBeGreaterThan(0)
       expect(screen.getAllByText('Down').length).toBeGreaterThan(0)
     })
 

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -505,8 +505,8 @@ describe('AppHeader — nav tabs', () => {
 
       render(<AppHeader />)
 
-      expect(screen.getByText('Agents')).toBeInTheDocument()
       expect(screen.getByTestId('link-/dynamic-agents')).toBeInTheDocument()
+      expect(screen.getByTestId('link-/dynamic-agents')).toHaveTextContent('Agents')
     })
   })
 
@@ -794,7 +794,7 @@ describe('AppHeader — connection status badge', () => {
       render(<AppHeader />)
       expect(screen.getByText('Disconnected')).toBeInTheDocument()
       expect(screen.getByText('OpenFGA')).toBeInTheDocument()
-      expect(screen.getAllByText('DOWN').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Down').length).toBeGreaterThan(0)
     })
 
     it('Disconnected badge has red styling', () => {

--- a/ui/src/hooks/use-platform-health-probes.ts
+++ b/ui/src/hooks/use-platform-health-probes.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback,useEffect,useRef,useState } from "react";
+
+export type PlatformProbeStatus = "checking" | "healthy" | "down";
+
+export interface PlatformHealthProbe {
+  id: string;
+  label: string;
+  status: "healthy" | "down";
+  detail: string;
+  target: string;
+  latency_ms: number | null;
+}
+
+interface PlatformHealthResponse {
+  status: "healthy" | "down";
+  checked_at: string;
+  summary: {
+    total: number;
+    healthy: number;
+    down: number;
+  };
+  probes: PlatformHealthProbe[];
+}
+
+interface UsePlatformHealthProbesResult {
+  status: PlatformProbeStatus;
+  probes: PlatformHealthProbe[];
+  summary: PlatformHealthResponse["summary"] | null;
+  secondsUntilNextCheck: number;
+  checkNow: () => void;
+}
+
+const POLL_INTERVAL_MS = 30000;
+
+export function usePlatformHealthProbes(): UsePlatformHealthProbesResult {
+  const [status, setStatus] = useState<PlatformProbeStatus>("checking");
+  const [probes, setProbes] = useState<PlatformHealthProbe[]>([]);
+  const [summary, setSummary] = useState<PlatformHealthResponse["summary"] | null>(null);
+  const [secondsUntilNextCheck, setSecondsUntilNextCheck] = useState(0);
+  const nextCheckTimeRef = useRef<number>(0);
+
+  const checkNow = useCallback(async () => {
+    if (probes.length === 0) setStatus("checking");
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const controller = new AbortController();
+      timeoutId = setTimeout(() => controller.abort(), 5000);
+      const response = await fetch("/api/platform/health", {
+        method: "GET",
+        signal: controller.signal,
+        cache: "no-store",
+      });
+      clearTimeout(timeoutId);
+
+      const body = (await response.json()) as PlatformHealthResponse;
+      setProbes(Array.isArray(body.probes) ? body.probes : []);
+      setSummary(body.summary ?? null);
+      setStatus(response.ok && body.status === "healthy" ? "healthy" : "down");
+    } catch {
+      setStatus("down");
+      setSummary(null);
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+      nextCheckTimeRef.current = Date.now() + POLL_INTERVAL_MS;
+    }
+  }, [probes.length]);
+
+  useEffect(() => {
+    void checkNow();
+    const interval = window.setInterval(checkNow, POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [checkNow]);
+
+  useEffect(() => {
+    const countdownInterval = window.setInterval(() => {
+      const remaining = Math.max(0, Math.ceil((nextCheckTimeRef.current - Date.now()) / 1000));
+      setSecondsUntilNextCheck(remaining);
+    }, 1000);
+    return () => window.clearInterval(countdownInterval);
+  }, []);
+
+  return {
+    status,
+    probes,
+    summary,
+    secondsUntilNextCheck,
+    checkNow,
+  };
+}

--- a/ui/src/hooks/use-platform-health-probes.ts
+++ b/ui/src/hooks/use-platform-health-probes.ts
@@ -2,23 +2,33 @@
 
 import { useCallback,useEffect,useRef,useState } from "react";
 
-export type PlatformProbeStatus = "checking" | "healthy" | "down";
+export type PlatformProbeStatus = "checking" | "healthy" | "degraded" | "down";
+export type PlatformProbeGroup = "core" | "identity" | "storage" | "rag" | "bootstrap";
+
+export interface PlatformProbeRemediation {
+  label: string;
+  href: string;
+  description: string;
+}
 
 export interface PlatformHealthProbe {
   id: string;
   label: string;
-  status: "healthy" | "down";
+  group: PlatformProbeGroup;
+  status: "healthy" | "warning" | "down";
   detail: string;
   target: string;
   latency_ms: number | null;
+  remediation?: PlatformProbeRemediation;
 }
 
 interface PlatformHealthResponse {
-  status: "healthy" | "down";
+  status: "healthy" | "degraded" | "down";
   checked_at: string;
   summary: {
     total: number;
     healthy: number;
+    warning: number;
     down: number;
   };
   probes: PlatformHealthProbe[];
@@ -58,7 +68,7 @@ export function usePlatformHealthProbes(): UsePlatformHealthProbesResult {
       const body = (await response.json()) as PlatformHealthResponse;
       setProbes(Array.isArray(body.probes) ? body.probes : []);
       setSummary(body.summary ?? null);
-      setStatus(response.ok && body.status === "healthy" ? "healthy" : "down");
+      setStatus(response.ok && body.status === "healthy" ? "healthy" : body.status === "degraded" ? "degraded" : "down");
     } catch {
       setStatus("down");
       setSummary(null);


### PR DESCRIPTION
## Summary
- add a server-side platform health endpoint for Keycloak, OpenFGA, OpenFGA Bridge, AgentGateway Config Bridge, and AgentGateway
- replace the status popover's Connected Integrations tag cloud with actionable platform probes
- fold platform probe failures into the header status chip

## Tests
- npm test -- --runTestsByPath src/components/layout/__tests__/AppHeader.test.tsx src/app/api/platform/health/__tests__/route.test.ts --runInBand
- npx eslint src/components/layout/AppHeader.tsx src/components/layout/__tests__/AppHeader.test.tsx src/app/api/platform/health/route.ts src/app/api/platform/health/__tests__/route.test.ts src/hooks/use-platform-health-probes.ts
- git diff --check