### PR TITLE
fix(setup-caipe): Missing AGENTGATEWAY_TARGETS_TOKEN

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -3646,6 +3646,20 @@ create_namespace_and_secrets() {
     log "caipe-ui-secret ready (NextAuth secret + caipe-ui client id/secret; default SSO)"
   fi
 
+  # Inject AGENTGATEWAY_TARGETS_TOKEN into caipe-ui-secret so the config-bridge
+  # sidecar and the BFF share the same bearer token. Generated once and persisted
+  # (idempotent re-runs). Both code paths above (--ui-env-file and default SSO)
+  # produce caipe-ui-secret before this point.
+  if $ENABLE_AGENTGATEWAY; then
+    local _ag_token
+    _ag_token=$(kubectl get secret caipe-ui-secret -n caipe \
+      -o jsonpath='{.data.AGENTGATEWAY_TARGETS_TOKEN}' 2>/dev/null | base64 -d 2>/dev/null || true)
+    [[ -z "$_ag_token" ]] && _ag_token="$(openssl rand -hex 32)"
+    kubectl patch secret caipe-ui-secret -n caipe --type='json' \
+      -p="[{\"op\":\"add\",\"path\":\"/data/AGENTGATEWAY_TARGETS_TOKEN\",\"value\":\"$(echo -n "$_ag_token" | base64 -w0)\"}]" &>/dev/null
+    log "AGENTGATEWAY_TARGETS_TOKEN patched into caipe-ui-secret"
+  fi
+
   # Chat-bot surfaces (slack-bot / webex-bot). Token secrets are created here;
   # the Helm tags + in-cluster config (incl. MONGODB_URI built from the resolved
   # cluster password) are written by _write_bot_values and applied in deploy_caipe.
@@ -6361,6 +6375,15 @@ deploy_caipe() {
     if _local_admin_active; then
       helm_args+=(--set "caipe-ui.config.BOOTSTRAP_ADMIN_EMAILS=${LOCAL_ADMIN_EMAIL}")
     fi
+  fi
+
+  # Wire the config-bridge bearer token secret so the sidecar can authenticate
+  # to the BFF's internal MCP-targets endpoint. caipe-ui-secret holds the same
+  # key (patched in create_namespace_and_secrets), so both sides share the token.
+  if $ENABLE_AGENTGATEWAY; then
+    helm_args+=(
+      --set "global.agentgateway.static.configBridge.bff.existingSecret.name=caipe-ui-secret"
+    )
   fi
 
   # ── Deployment mode ──────────────────────────────────────────────────────


### PR DESCRIPTION
# Description

PR #1852 introduced a bearer token requirement for the config-bridge sidecar to authenticate against the BFF's internal MCP-targets endpoint, but did not update setup-caipe.sh. This caused the config-bridge container in the caipe-agentgateway deployment to crash on startup (missing env var).

- Generate AGENTGATEWAY_TARGETS_TOKEN idempotently and patch it into caipe-ui-secret (covers both --ui-env-file and default SSO paths)
- Pass global.agentgateway.static.configBridge.bff.existingSecret.name=caipe-ui-secret so the Helm chart injects the token into the config-bridge container

Both the BFF (caipe-ui) and config-bridge now read the token from the same secret, matching the design described in PR #1852.

Fixes https://github.com/cnoe-io/ai-platform-engineering/issues/1913

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
