### PR TITLE
feat(ui): paginate admin teams + member lists and split sync-source labels

### DIFF
--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -58,7 +58,7 @@ import { getConfig } from "@/lib/config";
 import { cn } from "@/lib/utils";
 import type { SkillMetricsAdmin } from "@/types/agent-skill";
 import type { Team as TeamType } from "@/types/teams";
-import { Activity,Bot,Bug,Calendar,CheckCircle2,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,HelpCircle,Layers,Loader2,MessageSquare,Plus,RefreshCw,Search,Settings,Share2,Shield,ShieldCheck,Star,ThumbsDown,ThumbsUp,Trash2,TrendingUp,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
+import { Activity,Bot,Bug,Calendar,CheckCircle2,ChevronLeft,ChevronRight,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,HelpCircle,Layers,Loader2,MessageSquare,Plus,RefreshCw,Search,Settings,Share2,Shield,ShieldCheck,Star,ThumbsDown,ThumbsUp,Trash2,TrendingUp,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { usePathname,useRouter,useSearchParams } from "next/navigation";
 import React,{ useCallback,useEffect,useMemo,useRef,useState } from "react";
@@ -364,6 +364,10 @@ function categoryForTab(tab: string): CategoryKey {
   return DEFAULT_ADMIN_CATEGORY;
 }
 
+// Admin Teams grid page size. The grid is server-paginated (`?page=`) so the
+// browser only ever holds one page of teams regardless of directory size.
+const TEAMS_PAGE_SIZE = 24;
+
 // IdP membership source types (okta / oidc_claim / active_directory) → display
 // label + optional logo asset, for the "synced from <IdP>" team badge.
 const IDP_SOURCE_META: Record<string, { label: string; logo?: string }> = {
@@ -372,29 +376,39 @@ const IDP_SOURCE_META: Record<string, { label: string; logo?: string }> = {
   active_directory: { label: 'Active Directory' },
 };
 
-// Badge shown on a team card when its membership was synced from an IdP. Renders
-// the provider logo (e.g. Okta) when available, falling back to a label, with a
+// Badges shown on a team card when its membership was synced from an IdP. A
+// team can be synced from more than one source (e.g. some members from Okta,
+// others from a raw OIDC claim), so we render one pill PER source type rather
+// than collapsing them into a single combined label. Each pill shows the
+// provider logo (e.g. Okta) when available plus its label, with a
 // "Synced with <IdP>" tooltip.
 function IdpSyncedBadge({ sourceTypes }: { sourceTypes: string[] }) {
-  const metas = sourceTypes.map((t) => IDP_SOURCE_META[t] ?? { label: t });
-  const labels = metas.map((m) => m.label).join(', ');
-  const title = `Synced with ${labels}`;
+  // Dedupe defensively — the backend $addToSet already returns distinct types,
+  // but a stray duplicate would otherwise render two identical pills.
+  const seen = new Set<string>();
+  const types = sourceTypes.filter((t) => (seen.has(t) ? false : (seen.add(t), true)));
   return (
-    <span
-      className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 border border-border"
-      title={title}
-      aria-label={title}
-    >
-      {metas.map((m, i) =>
-        m.logo ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img key={i} src={m.logo} alt={m.label} className="h-3.5 w-3.5" />
-        ) : (
-          <span key={i} className="text-[10px] font-medium text-muted-foreground">
-            {m.label}
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {types.map((t) => {
+        const meta = IDP_SOURCE_META[t] ?? { label: t };
+        const title = `Synced with ${meta.label}`;
+        return (
+          <span
+            key={t}
+            className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 border border-border"
+            title={title}
+            aria-label={title}
+          >
+            {meta.logo && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={meta.logo} alt="" aria-hidden="true" className="h-3.5 w-3.5" />
+            )}
+            <span className="text-[10px] font-medium text-muted-foreground">
+              {meta.label}
+            </span>
           </span>
-        )
-      )}
+        );
+      })}
     </span>
   );
 }
@@ -511,9 +525,20 @@ function AdminPage() {
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [globalOverview, setGlobalOverview] = useState<AdminStats['overview'] | null>(null);
   const [skillStats, setSkillStats] = useState<SkillMetricsAdmin | null>(null);
+  // `teams` is the FULL team list, used only by the shared Stats/Feedback
+  // team-filter dropdowns and the access-simulation team picker (which need
+  // every team available for selection). The Teams grid below does NOT read
+  // from this — it has its own server-paginated state (`gridTeams`) so the
+  // grid only ever renders one page of cards.
   const [teams, setTeams] = useState<Team[]>([]);
   const [teamSearch, setTeamSearch] = useState("");
-  const [teamsRefreshing, setTeamsRefreshing] = useState(false);
+  // Server-paginated Teams grid state. `gridTeams` holds only the current
+  // page; `gridSearch` is the debounced query sent to the server.
+  const [gridTeams, setGridTeams] = useState<Team[]>([]);
+  const [gridTotal, setGridTotal] = useState(0);
+  const [gridPage, setGridPage] = useState(1);
+  const [gridLoading, setGridLoading] = useState(false);
+  const [gridLoaded, setGridLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedUserEmail, setSelectedUserEmail] = useState<string | null>(null);
@@ -872,40 +897,78 @@ function AdminPage() {
     return result.data?.teams || [];
   };
 
+  // Refresh the FULL team list backing the shared filter dropdowns. The Teams
+  // grid has its own paginated loader (`fetchTeamsGridPage`) and does not use
+  // this. Runs quietly in the background — no visible spinner.
   const loadTeams = async () => {
-    setTeamsRefreshing(true);
     try {
       setTeams(await fetchTeamsFromDb());
     } catch (err: any) {
       console.error('[Admin] Failed to refresh teams:', err);
-      alert(`Failed to refresh teams: ${err.message || 'Unknown error'}`);
-    } finally {
-      setTeamsRefreshing(false);
     }
   };
 
-  const filteredTeams = useMemo(() => {
-    const query = teamSearch.trim().toLowerCase();
-    if (!query) return teams;
+  // Fetch one page of the Teams grid from the server. Search is applied
+  // server-side so the browser never holds more than a page of rows. The
+  // request is the source of truth for `gridTotal`, which drives the pager.
+  const fetchTeamsGridPage = useCallback(async (page: number, search: string) => {
+    setGridLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(page),
+        page_size: String(TEAMS_PAGE_SIZE),
+        fresh: String(Date.now()),
+      });
+      if (search.trim()) params.set('search', search.trim());
+      const response = await fetch(`/api/admin/teams?${params.toString()}`, {
+        cache: 'no-store',
+      });
+      const result = await response.json();
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'Failed to load teams');
+      }
+      setGridTeams(result.data?.teams ?? []);
+      setGridTotal(result.data?.total ?? 0);
+      setGridPage(result.data?.page ?? page);
+      setGridLoaded(true);
+    } catch (err: any) {
+      console.error('[Admin] Failed to load teams page:', err);
+    } finally {
+      setGridLoading(false);
+    }
+  }, []);
 
-    return teams.filter((team) => {
-      const searchableValues = [
-        team.name,
-        team.slug,
-        team.description,
-        team.owner_id,
-        // Defensive read: post Commit 6/8 of the canonical-team-membership
-        // refactor the embedded `members[]` array goes away. Until the
-        // search-by-member-email UX is reworked to lazily fetch rosters
-        // via `/api/admin/teams/[id]` we still consult the embedded list
-        // when it's present, but never crash if it's absent.
-        ...(team.members ?? []).map((member) => member.user_id),
-      ];
-      return searchableValues
-        .filter(Boolean)
-        .some((value) => String(value).toLowerCase().includes(query));
-    });
-  }, [teams, teamSearch]);
+  // Debounced server-side search for the Teams grid. Typing resets to page 1
+  // and re-queries the server (~250ms after the last keystroke), matching the
+  // discovery-search pattern used elsewhere in the admin dialogs. We only run
+  // this while the Teams tab is active so other tabs don't trigger team
+  // queries on every keystroke.
+  useEffect(() => {
+    if (activeTab !== 'teams') return;
+    const handle = setTimeout(() => {
+      void fetchTeamsGridPage(1, teamSearch);
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [teamSearch, activeTab, fetchTeamsGridPage]);
+
+  const gridTotalPages = Math.max(1, Math.ceil(gridTotal / TEAMS_PAGE_SIZE));
+  const gridHasMore = gridPage * TEAMS_PAGE_SIZE < gridTotal;
+
+  const goToTeamsPage = (page: number) => {
+    const clamped = Math.min(Math.max(1, page), gridTotalPages);
+    void fetchTeamsGridPage(clamped, teamSearch);
+  };
+
+  // Refresh after a team mutation (create/edit/delete/member change). Always
+  // re-fetches the visible grid page. Also refreshes the full team list — but
+  // only when it has already been loaded — so the shared filter dropdowns stay
+  // current without forcing a full fetch for users who never opened those tabs.
+  const refreshAfterTeamMutation = (page?: number) => {
+    void fetchTeamsGridPage(page ?? gridPage, teamSearch);
+    if (visitedTabsRef.current.has('_teams-loaded')) {
+      void loadTeams();
+    }
+  };
 
   // Expand team: prefixed selections to member emails
   // See `filteredTeams` above for the canonical-team-membership refactor note —
@@ -1079,11 +1142,13 @@ function AdminPage() {
 
     // Map of tab key → loader. Tabs not listed here have no upfront data to
     // load and should not block render (loading is initialized to false).
+    // The Teams tab is NOT listed here: its grid is server-paginated and
+    // self-loads via a debounced effect, so it must not pull the full team
+    // list. The full list (`loadTeamsIfNeeded`) is only needed by tabs whose
+    // dropdowns offer every team for selection (stats/slack/feedback).
     const loaders: Record<string, () => Promise<void>> = {
       stats: async () => { await Promise.all([loadStatsIfNeeded(), loadTeamsIfNeeded()]); },
       slack: async () => { await Promise.all([loadStatsIfNeeded(), loadTeamsIfNeeded()]); },
-      teams: () => loadTeamsIfNeeded(),
-      'identity-sync': () => loadTeamsIfNeeded(),
       skills: loadSkillStats,
       feedback: async () => { await Promise.all([loadFeedbackOnce(), loadTeamsIfNeeded()]); },
       nps: loadNpsDataOnce,
@@ -1242,8 +1307,13 @@ function AdminPage() {
         throw new Error(result.error || 'Failed to delete team');
       }
 
-      // Remove from local state
-      setTeams(teams.filter(t => t._id !== team._id));
+      // Drop from both local lists, then re-fetch the grid page so a team
+      // from the next page backfills the now-empty slot (and the pager total
+      // stays correct). If the deletion emptied the current page, step back.
+      setTeams((prev) => prev.filter((t) => t._id !== team._id));
+      setGridTeams((prev) => prev.filter((t) => t._id !== team._id));
+      const nextPage = gridTeams.length === 1 && gridPage > 1 ? gridPage - 1 : gridPage;
+      refreshAfterTeamMutation(nextPage);
       setTeamPendingDelete(null);
       console.log(`[Admin] Team deleted: ${team.name}`);
     } catch (err: any) {
@@ -1622,10 +1692,10 @@ function AdminPage() {
                       type="button"
                       variant="outline"
                       className="gap-2"
-                      onClick={loadTeams}
-                      disabled={teamsRefreshing}
+                      onClick={() => fetchTeamsGridPage(gridPage, teamSearch)}
+                      disabled={gridLoading}
                     >
-                      {teamsRefreshing ? (
+                      {gridLoading ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       ) : (
                         <RefreshCw className="h-4 w-4" />
@@ -1640,11 +1710,11 @@ function AdminPage() {
                     )}
                   </div>
                 </div>
-                {teamsRefreshing && teams.length === 0 ? (
+                {(!gridLoaded && gridLoading) || (gridLoading && gridTeams.length === 0) ? (
                   <div className="flex justify-center py-12">
                     <CAIPESpinner />
                   </div>
-                ) : teams.length === 0 ? (
+                ) : gridTeams.length === 0 && !teamSearch.trim() ? (
                   <div className="text-center py-12">
                     <UsersIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                     <h3 className="text-lg font-semibold mb-2">No Teams Yet</h3>
@@ -1660,12 +1730,12 @@ function AdminPage() {
                       </Button>
                     )}
                   </div>
-                ) : filteredTeams.length === 0 ? (
+                ) : gridTeams.length === 0 ? (
                   <div className="rounded-lg border border-dashed py-12 text-center">
                     <Search className="h-10 w-10 text-muted-foreground mx-auto mb-4" />
                     <h3 className="text-lg font-semibold mb-2">No teams match &quot;{teamSearch}&quot;</h3>
                     <p className="text-muted-foreground mb-4">
-                      Try a team name, owner email, member email, or description.
+                      Try a team name, owner email, or description.
                     </p>
                     <Button type="button" variant="outline" onClick={() => setTeamSearch("")}>
                       Clear team search
@@ -1673,7 +1743,7 @@ function AdminPage() {
                   </div>
                 ) : (
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {filteredTeams.map((team) => {
+                    {gridTeams.map((team) => {
                       const chatIntegrationCount =
                         (team.slack_channels?.length ?? 0) + (team.webex_spaces?.length ?? 0);
 
@@ -1790,6 +1860,36 @@ function AdminPage() {
                       </Card>
                       );
                     })}
+                  </div>
+                )}
+                {/* Pager — shown whenever the result set spans more than one
+                    page. Prev/Next drive a server fetch; the page indicator
+                    reflects server-reported totals. */}
+                {gridTotal > TEAMS_PAGE_SIZE && (
+                  <div className="flex items-center justify-between pt-2 text-sm">
+                    <span className="text-muted-foreground">
+                      Page {gridPage} of {gridTotalPages} · {gridTotal} team{gridTotal === 1 ? "" : "s"}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => goToTeamsPage(gridPage - 1)}
+                        disabled={gridPage <= 1 || gridLoading}
+                        aria-label="Previous page"
+                      >
+                        <ChevronLeft className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => goToTeamsPage(gridPage + 1)}
+                        disabled={!gridHasMore || gridLoading}
+                        aria-label="Next page"
+                      >
+                        <ChevronRight className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
                 )}
               </TabsContent>
@@ -3265,7 +3365,9 @@ function AdminPage() {
       <CreateTeamDialog
         open={createTeamDialogOpen}
         onOpenChange={setCreateTeamDialogOpen}
-        onSuccess={loadTeams}
+        // New teams sort to the top (newest-first), so jump to page 1 to
+        // reveal the just-created team.
+        onSuccess={() => refreshAfterTeamMutation(1)}
       />
 
       {/* Team Details / Member Management Dialog */}
@@ -3274,25 +3376,23 @@ function AdminPage() {
         mode={teamDialogMode}
         open={teamDetailsOpen}
         onOpenChange={setTeamDetailsOpen}
-        onTeamUpdated={loadTeams}
+        onTeamUpdated={() => refreshAfterTeamMutation()}
         onTeamMutated={(updatedTeam) => {
-          // In-place patch of the teams[] state so the row in the
-          // background list re-renders with the new member count /
-          // attributes — without triggering loadAdminData() (which
-          // sets loading=true and re-fetches the entire dashboard).
+          // In-place patch of the grid + full team lists so the row in the
+          // background re-renders with the new member count / attributes —
+          // without triggering a full dashboard reload.
           //
           // The Team shape used by this page is a structural superset
           // of the one returned by /api/admin/teams/[id]/* mutation
           // endpoints; we merge so any locally-known fields the API
           // doesn't echo back (e.g. denormalised StatChip counters)
           // survive the patch.
-          setTeams((prev) =>
-            prev.map((t) =>
-              t._id === updatedTeam._id
-                ? ({ ...t, ...(updatedTeam as Partial<Team>) } as Team)
-                : t,
-            ),
-          );
+          const patch = (t: Team) =>
+            t._id === updatedTeam._id
+              ? ({ ...t, ...(updatedTeam as Partial<Team>) } as Team)
+              : t;
+          setGridTeams((prev) => prev.map(patch));
+          setTeams((prev) => prev.map(patch));
           // Also keep `selectedTeam` (the prop the dialog reads from)
           // in sync so its `useEffect(() => setCurrentTeam(team), [team])`
           // can pick up the patched payload if the dialog re-opens

--- a/ui/src/app/api/admin/teams/[id]/members/__tests__/members-pagination.test.ts
+++ b/ui/src/app/api/admin/teams/[id]/members/__tests__/members-pagination.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for GET /api/admin/teams/[id]/members — the paginated, search-filtered
+ * member list. Mocks `loadActiveTeamMembersPage` so we assert param parsing
+ * (page / page_size / search), the owner_email passthrough, and the
+ * `{ members, total, page, page_size, has_more }` response envelope without a
+ * real MongoDB aggregation.
+ */
+
+import { NextRequest } from "next/server";
+import { ObjectId } from "mongodb";
+
+const mockGetServerSession = jest.fn();
+const mockCheckPermission = jest.fn();
+const mockLoadActiveTeamMembersPage = jest.fn();
+
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+jest.mock("@/lib/auth-config", () => ({
+  authOptions: {},
+  isBootstrapAdmin: jest.fn().mockReturnValue(false),
+  REQUIRED_ADMIN_GROUP: "",
+}));
+
+jest.mock("@/lib/config", () => ({
+  getConfig: (key: string) => key === "ssoEnabled",
+}));
+
+jest.mock("@/lib/rbac/keycloak-authz", () => ({
+  checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
+}));
+
+jest.mock("@/lib/rbac/audit", () => ({
+  logAuthzDecision: jest.fn(),
+}));
+
+// The route's other imports are only exercised by POST/DELETE; stub them so
+// importing the module doesn't drag in real implementations.
+jest.mock("@/lib/rbac/keycloak-admin", () => ({
+  searchRealmUsers: jest.fn(),
+  isValidTeamSlug: jest.fn(() => true),
+}));
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  writeOpenFgaTuples: jest.fn(),
+  isOpenFgaConfigured: jest.fn(() => true),
+}));
+
+jest.mock("@/lib/rbac/team-openfga-sync-status", () => ({
+  readTeamOpenFgaTuples: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/team-membership-source-store", () => ({
+  upsertTeamMembershipSource: jest.fn(),
+  markTeamMembershipSourceRemoved: jest.fn(),
+  listActiveTeamMembershipSourcesForTeamUser: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/team-membership-store", () => ({
+  findUserRoleInTeam: jest.fn(),
+  loadActiveTeamMembersPage: (...args: unknown[]) => mockLoadActiveTeamMembersPage(...args),
+}));
+
+const mockCollections: Record<string, any> = {};
+let mockIsMongoDBConfigured = true;
+
+jest.mock("@/lib/mongodb", () => ({
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+  getCollection: jest.fn(async (name: string) => mockCollections[name] ?? createMockCollection()),
+}));
+
+const TEAM_ID = "507f1f77bcf86cd799439011";
+
+function createMockCollection() {
+  return {
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    findOne: jest.fn().mockResolvedValue(null),
+  };
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost:3000"));
+}
+
+function accessTokenWithRoles(roles: string[]): string {
+  const payload = Buffer.from(JSON.stringify({ realm_access: { roles } }), "utf8").toString(
+    "base64url",
+  );
+  return `h.${payload}.s`;
+}
+
+function adminSession() {
+  return {
+    user: { email: "admin@example.com", name: "Admin" },
+    role: "admin",
+    sub: "admin-sub",
+    accessToken: accessTokenWithRoles(["admin"]),
+  };
+}
+
+function seedTeam(extra: Record<string, unknown> = {}) {
+  const teamsCol = createMockCollection();
+  teamsCol.findOne.mockResolvedValue({
+    _id: new ObjectId(TEAM_ID),
+    slug: "platform",
+    name: "Platform",
+    owner_id: "owner@example.com",
+    ...extra,
+  });
+  mockCollections.teams = teamsCol;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsMongoDBConfigured = true;
+  Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
+  mockCheckPermission.mockResolvedValue({ allowed: true, reason: "OK" });
+  mockGetServerSession.mockResolvedValue(adminSession());
+  mockLoadActiveTeamMembersPage.mockResolvedValue({
+    members: [
+      {
+        identity_key: "owner@example.com",
+        user_email: "owner@example.com",
+        role: "owner",
+        source_types: ["manual"],
+        idp_managed: false,
+        added_at: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    total: 60,
+  });
+});
+
+async function callGet(url: string) {
+  const { GET } = await import("../route");
+  const response = await GET(makeRequest(url), {
+    params: Promise.resolve({ id: TEAM_ID }),
+  });
+  return { response, body: await response.json() };
+}
+
+describe("GET /api/admin/teams/[id]/members", () => {
+  it("returns a paginated envelope and passes page/size/search/owner to the store", async () => {
+    seedTeam();
+    const { response, body } = await callGet(
+      `/api/admin/teams/${TEAM_ID}/members?page=2&page_size=25&search=ali`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(body.data.members).toHaveLength(1);
+    expect(body.data.total).toBe(60);
+    expect(body.data.page).toBe(2);
+    expect(body.data.page_size).toBe(25);
+    // 2 * 25 = 50 < 60, so there is another page.
+    expect(body.data.has_more).toBe(true);
+
+    expect(mockLoadActiveTeamMembersPage).toHaveBeenCalledWith("platform", {
+      page: 2,
+      pageSize: 25,
+      search: "ali",
+      ownerEmail: "owner@example.com",
+    });
+  });
+
+  it("defaults to page 1, size 25, empty search when params are absent", async () => {
+    seedTeam();
+    await callGet(`/api/admin/teams/${TEAM_ID}/members`);
+
+    expect(mockLoadActiveTeamMembersPage).toHaveBeenCalledWith("platform", {
+      page: 1,
+      pageSize: 25,
+      search: "",
+      ownerEmail: "owner@example.com",
+    });
+  });
+
+  it("clamps page_size to the 1..100 range", async () => {
+    seedTeam();
+    await callGet(`/api/admin/teams/${TEAM_ID}/members?page_size=9999`);
+
+    expect(mockLoadActiveTeamMembersPage).toHaveBeenCalledWith(
+      "platform",
+      expect.objectContaining({ pageSize: 100 }),
+    );
+  });
+
+  it("404s when the team does not exist", async () => {
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue(null);
+    mockCollections.teams = teamsCol;
+
+    const { response } = await callGet(`/api/admin/teams/${TEAM_ID}/members`);
+    expect(response.status).toBe(404);
+    expect(mockLoadActiveTeamMembersPage).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty page (no store call) when the team has no slug", async () => {
+    seedTeam({ slug: "" });
+    const { response, body } = await callGet(`/api/admin/teams/${TEAM_ID}/members`);
+
+    expect(response.status).toBe(200);
+    expect(body.data.members).toEqual([]);
+    expect(body.data.total).toBe(0);
+    expect(mockLoadActiveTeamMembersPage).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/admin/teams/[id]/members/route.ts
+++ b/ui/src/app/api/admin/teams/[id]/members/route.ts
@@ -4,6 +4,7 @@
 import {
 ApiError,
 getAuthFromBearerOrSession,
+requireRbacPermission,
 successResponse,
 validateEmail,
 withErrorHandler,
@@ -16,7 +17,7 @@ listActiveTeamMembershipSourcesForTeamUser,
 markTeamMembershipSourceRemoved,
 upsertTeamMembershipSource,
 } from '@/lib/rbac/team-membership-source-store';
-import { findUserRoleInTeam } from '@/lib/rbac/team-membership-store';
+import { findUserRoleInTeam, loadActiveTeamMembersPage } from '@/lib/rbac/team-membership-store';
 import {
 buildTeamMembershipTuples,
 mongoRoleToOpenFgaRelations,
@@ -159,6 +160,57 @@ function manualMembershipSource(input: {
     created_at: timestamp,
   };
 }
+
+// GET /api/admin/teams/[id]/members — paginated, search-filtered member list.
+//
+// Returns one page of the team's deduplicated members so the Admin team
+// dialog can show large rosters without loading every membership-source row.
+// Query params: `page` (1-based), `page_size` (1–100, default 25), `search`
+// (case-insensitive email substring). Each member carries `source_types`
+// (e.g. ["okta"]) and `idp_managed` so the UI can badge provenance and lock
+// the remove action for directory-managed members.
+export const GET = withErrorHandler(async (
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) => {
+  const mongoCheck = requireMongoDB();
+  if (mongoCheck) return mongoCheck;
+
+  const { session } = await getAuthFromBearerOrSession(request);
+  await requireRbacPermission(session, 'team', 'view');
+
+  const params = await context.params;
+  const teamId = parseTeamId(params.id);
+  const teams = await getCollection<TeamDocument>('teams');
+  const team = await teams.findOne({ _id: teamId });
+  if (!team) {
+    throw new ApiError('Team not found', 404);
+  }
+
+  const teamSlug = String(team.slug || '').trim();
+  const url = new URL(request.url);
+  const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10) || 1);
+  const pageSizeRaw = parseInt(url.searchParams.get('page_size') || '25', 10) || 25;
+  const pageSize = Math.min(100, Math.max(1, pageSizeRaw));
+  const search = (url.searchParams.get('search') || '').trim();
+
+  const { members, total } = teamSlug
+    ? await loadActiveTeamMembersPage(teamSlug, {
+        page,
+        pageSize,
+        search,
+        ownerEmail: typeof team.owner_id === 'string' ? team.owner_id : undefined,
+      })
+    : { members: [], total: 0 };
+
+  return successResponse({
+    members,
+    total,
+    page,
+    page_size: pageSize,
+    has_more: page * pageSize < total,
+  });
+});
 
 // POST /api/admin/teams/[id]/members
 export const POST = withErrorHandler(async (

--- a/ui/src/app/api/admin/teams/__tests__/teams-list-pagination.test.ts
+++ b/ui/src/app/api/admin/teams/__tests__/teams-list-pagination.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for GET /api/admin/teams pagination. Pagination + server-side search
+ * are opt-in via the `page` query param: with it, the route returns a
+ * `{ teams, total, page, page_size, has_more }` envelope and pushes
+ * skip/limit + a search filter into Mongo; without it, the route returns the
+ * full list exactly as before (so the shared filter dropdowns keep working).
+ */
+
+import { NextRequest } from "next/server";
+import { ObjectId } from "mongodb";
+
+const mockGetServerSession = jest.fn();
+const mockCheckPermission = jest.fn();
+const mockRequireBaselineAdminSurfaceRead = jest.fn();
+const mockLoadTeamMemberCounts = jest.fn();
+const mockLoadTeamIdpSourceTypes = jest.fn();
+const mockListOpenFgaObjects = jest.fn();
+
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+jest.mock("@/lib/auth-config", () => ({
+  authOptions: {},
+  isBootstrapAdmin: jest.fn().mockReturnValue(false),
+  REQUIRED_ADMIN_GROUP: "",
+}));
+
+jest.mock("@/lib/config", () => ({
+  getConfig: (key: string) => key === "ssoEnabled",
+}));
+
+jest.mock("@/lib/rbac/keycloak-authz", () => ({
+  checkPermission: (...args: unknown[]) => mockCheckPermission(...args),
+}));
+
+jest.mock("@/lib/rbac/audit", () => ({ logAuthzDecision: jest.fn() }));
+
+jest.mock("@/lib/rbac/require-openfga", () => ({
+  requireBaselineAdminSurfaceRead: (...args: unknown[]) =>
+    mockRequireBaselineAdminSurfaceRead(...args),
+  requireAdminSurfaceManage: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  listOpenFgaObjects: (...args: unknown[]) => mockListOpenFgaObjects(...args),
+}));
+
+jest.mock("@/lib/rbac/team-membership-store", () => ({
+  loadTeamMemberCounts: (...args: unknown[]) => mockLoadTeamMemberCounts(...args),
+  loadTeamIdpSourceTypes: (...args: unknown[]) => mockLoadTeamIdpSourceTypes(...args),
+}));
+
+jest.mock("@/lib/rbac/team-membership-source-store", () => ({
+  upsertTeamMembershipSource: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/team-membership-sync", () => ({
+  mongoRoleToOpenFgaRelations: jest.fn(() => []),
+  resolveKeycloakUserSubject: jest.fn(),
+  writeTeamMembershipTuples: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/keycloak-admin", () => ({
+  isValidTeamSlug: jest.fn(() => true),
+}));
+
+const mockCollections: Record<string, any> = {};
+let mockIsMongoDBConfigured = true;
+
+jest.mock("@/lib/mongodb", () => ({
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+  getCollection: jest.fn(async (name: string) => mockCollections[name] ?? createMockCollection()),
+}));
+
+function createMockCollection() {
+  return {
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    findOne: jest.fn().mockResolvedValue(null),
+    countDocuments: jest.fn().mockResolvedValue(0),
+  };
+}
+
+// A teams collection that records the query/skip/limit it was asked for and
+// supports BOTH the paginated chain (find().sort().skip().limit().toArray())
+// and the unpaginated chain (find().sort().toArray()).
+function seedTeamsCollection(rows: Array<Record<string, unknown>>, total: number) {
+  const calls: { query?: Record<string, unknown>; skip?: number; limit?: number } = {};
+  const cursor: any = {
+    sort: jest.fn().mockReturnValue(cursorChain()),
+  };
+  function cursorChain() {
+    const chain: any = {
+      skip: jest.fn((n: number) => {
+        calls.skip = n;
+        return chain;
+      }),
+      limit: jest.fn((n: number) => {
+        calls.limit = n;
+        return chain;
+      }),
+      toArray: jest.fn().mockResolvedValue(rows),
+    };
+    return chain;
+  }
+  const teamsCol = {
+    find: jest.fn((query: Record<string, unknown>) => {
+      calls.query = query;
+      return cursor;
+    }),
+    countDocuments: jest.fn().mockResolvedValue(total),
+    findOne: jest.fn().mockResolvedValue(null),
+  };
+  mockCollections.teams = teamsCol;
+  mockCollections.team_kb_ownership = createMockCollection();
+  return { teamsCol, calls };
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost:3000"));
+}
+
+function accessTokenWithRoles(roles: string[]): string {
+  const payload = Buffer.from(JSON.stringify({ realm_access: { roles } }), "utf8").toString(
+    "base64url",
+  );
+  return `h.${payload}.s`;
+}
+
+function adminSession() {
+  return {
+    user: { email: "admin@example.com", name: "Admin" },
+    role: "admin",
+    sub: "admin-sub",
+    accessToken: accessTokenWithRoles(["admin"]),
+  };
+}
+
+const teamRow = (slug: string) => ({
+  _id: new ObjectId(),
+  slug,
+  name: slug,
+  owner_id: "owner@example.com",
+  created_at: new Date(),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsMongoDBConfigured = true;
+  Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
+  mockGetServerSession.mockResolvedValue(adminSession());
+  mockCheckPermission.mockResolvedValue({ allowed: true, reason: "OK" });
+  mockRequireBaselineAdminSurfaceRead.mockResolvedValue(undefined);
+  // hasAdminView is probed via requireRbacPermission(admin_ui, view) →
+  // checkPermission. Default allow so the admin sees the unscoped list.
+  mockLoadTeamMemberCounts.mockResolvedValue(new Map());
+  mockLoadTeamIdpSourceTypes.mockResolvedValue(new Map());
+  mockListOpenFgaObjects.mockResolvedValue({ objects: [] });
+});
+
+async function callGet(url: string) {
+  const { GET } = await import("../route");
+  const response = await GET(makeRequest(url));
+  return { response, body: await response.json() };
+}
+
+describe("GET /api/admin/teams pagination", () => {
+  it("returns a paginated envelope and pushes skip/limit + search into Mongo", async () => {
+    const { calls } = seedTeamsCollection([teamRow("alpha")], 60);
+
+    const { response, body } = await callGet(
+      "/api/admin/teams?page=2&page_size=24&search=alp",
+    );
+
+    expect(response.status).toBe(200);
+    expect(body.data.page).toBe(2);
+    expect(body.data.page_size).toBe(24);
+    expect(body.data.total).toBe(60);
+    expect(body.data.has_more).toBe(true); // 2*24=48 < 60
+    expect(body.data.teams).toHaveLength(1);
+
+    // skip = (page-1)*pageSize, limit = pageSize
+    expect(calls.skip).toBe(24);
+    expect(calls.limit).toBe(24);
+    // search builds a case-insensitive $or over name/slug/description/owner_id.
+    // The clauses hold RegExp objects (which JSON.stringify flattens to {}),
+    // so assert on the structure + the compiled regex source/flags directly.
+    const and = (calls.query as { $and?: Array<{ $or?: Array<Record<string, RegExp>> }> })?.$and;
+    const orClause = and?.find((clause) => Array.isArray(clause.$or))?.$or;
+    expect(orClause).toBeDefined();
+    const fields = orClause!.map((entry) => Object.keys(entry)[0]);
+    expect(fields).toEqual(["name", "slug", "description", "owner_id"]);
+    const nameRx = orClause!.find((entry) => entry.name)!.name;
+    expect(nameRx).toBeInstanceOf(RegExp);
+    expect(nameRx.source).toBe("alp");
+    expect(nameRx.flags).toContain("i");
+  });
+
+  it("returns the full list (no pagination fields) when `page` is absent", async () => {
+    seedTeamsCollection([teamRow("alpha"), teamRow("beta")], 2);
+
+    const { response, body } = await callGet("/api/admin/teams");
+
+    expect(response.status).toBe(200);
+    expect(body.data.teams).toHaveLength(2);
+    expect(body.data.total).toBe(2);
+    // The legacy (unpaginated) envelope omits page / page_size / has_more.
+    expect(body.data.page).toBeUndefined();
+    expect(body.data.has_more).toBeUndefined();
+  });
+});

--- a/ui/src/app/api/admin/teams/route.ts
+++ b/ui/src/app/api/admin/teams/route.ts
@@ -38,6 +38,11 @@ interface CreateTeamRequest {
  * rather fail loudly so the admin notices) — names that produce an empty
  * slug after stripping are rejected with a 400.
  */
+/** Escape user-supplied text for safe use inside a `new RegExp(...)`. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function deriveSlug(name: string): string {
   return name
     .toLowerCase()
@@ -97,27 +102,63 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
   const teams = await getCollection('teams');
 
-  const allTeams = await teams
-    .find({})
-    .sort({ created_at: -1 })
-    .toArray();
+  // Pagination + server-side search are OPT-IN via the `page` query param.
+  // The Admin Teams grid sends `?page=&page_size=&search=` so it only ever
+  // pulls one page of rows into the browser. Callers that omit `page` (the
+  // shared Stats/Feedback team-filter dropdowns and the access-simulation
+  // team picker) still get the full list, exactly as before.
+  const url = new URL(request.url);
+  const paginated = url.searchParams.has('page');
+  const page = paginated ? Math.max(1, parseInt(url.searchParams.get('page') || '1', 10) || 1) : 1;
+  const pageSizeRaw = parseInt(url.searchParams.get('page_size') || '24', 10) || 24;
+  const pageSize = Math.min(100, Math.max(1, pageSizeRaw));
+  const search = (url.searchParams.get('search') || '').trim();
 
-  const visibleTeams = hasAdminView
-    ? allTeams
-    : allTeams.filter((team) => {
-        const slug = typeof team.slug === 'string' ? team.slug : '';
-        return slug ? memberSlugs.has(slug) : false;
-      });
+  // Build the Mongo query honoring per-row access control + search so the
+  // skip/limit and the aggregations only ever touch matching rows.
+  const andClauses: Record<string, unknown>[] = [];
+  if (!hasAdminView) {
+    const allowedSlugs = Array.from(memberSlugs);
+    if (allowedSlugs.length === 0) {
+      // Fail-closed: a non-admin with no team memberships sees nothing.
+      const empty = paginated
+        ? successResponse({ teams: [], total: 0, page, page_size: pageSize, has_more: false })
+        : successResponse({ teams: [], total: 0 });
+      empty.headers.set('Cache-Control', 'no-store, max-age=0');
+      return empty;
+    }
+    andClauses.push({ slug: { $in: allowedSlugs } });
+  }
+  if (search) {
+    const rx = new RegExp(escapeRegExp(search), 'i');
+    andClauses.push({ $or: [{ name: rx }, { slug: rx }, { description: rx }, { owner_id: rx }] });
+  }
+  const query: Record<string, unknown> = andClauses.length > 0 ? { $and: andClauses } : {};
+
+  // The page (or full set) of team documents to decorate + return.
+  let pageTeams: Record<string, any>[];
+  let total: number;
+  if (paginated) {
+    total = await teams.countDocuments(query);
+    pageTeams = await teams
+      .find(query)
+      .sort({ created_at: -1 })
+      .skip((page - 1) * pageSize)
+      .limit(pageSize)
+      .toArray();
+  } else {
+    pageTeams = await teams.find(query).sort({ created_at: -1 }).toArray();
+    total = pageTeams.length;
+  }
 
   // Commit 4/8 of the canonical-team-membership refactor (spec
   // 2026-05-26-canonical-team-membership): instead of returning
   // team.members[] (which the Admin UI used to read .length on for the
   // Members badge), decorate every row with `member_count` derived from
   // the canonical team_membership_sources store via a single aggregation
-  // query. This is a tracer-bullet step — the legacy team.members[]
-  // payload is still emitted so older UI revisions and integration
-  // tests keep working until commit 5/8 drops the embedded array.
-  const slugs = visibleTeams
+  // query. With pagination this only spans the current page's slugs, so
+  // the aggregation stays cheap even with thousands of teams.
+  const slugs = pageTeams
     .map((team) => (typeof team.slug === 'string' ? team.slug : ''))
     .filter((slug): slug is string => slug.length > 0);
   const memberCounts = slugs.length > 0 ? await loadTeamMemberCounts(slugs) : new Map<string, number>();
@@ -133,7 +174,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   // has KBs assigned (issue #1642 follow-up). We count distinct kb_ids per
   // team in a single query, falling back to the legacy doc field when no
   // ownership row exists yet.
-  const teamIdStrings = visibleTeams.map((team) => team._id.toString());
+  const teamIdStrings = pageTeams.map((team) => team._id.toString());
   const kbCounts = new Map<string, number>();
   if (teamIdStrings.length > 0) {
     const ownership = await getCollection<{ team_id?: string; kb_ids?: string[] }>('team_kb_ownership');
@@ -147,7 +188,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
   }
 
-  const teamsWithCounts = visibleTeams.map((team) => {
+  const teamsWithCounts = pageTeams.map((team) => {
     const slug = typeof team.slug === 'string' ? team.slug : '';
     const idStr = team._id.toString();
     const legacyKbCount = Array.isArray(team.resources?.knowledge_bases)
@@ -162,10 +203,18 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     };
   });
 
-  const response = successResponse({
-    teams: teamsWithCounts,
-    total: teamsWithCounts.length,
-  });
+  const response = paginated
+    ? successResponse({
+        teams: teamsWithCounts,
+        total,
+        page,
+        page_size: pageSize,
+        has_more: page * pageSize < total,
+      })
+    : successResponse({
+        teams: teamsWithCounts,
+        total,
+      });
   response.headers.set('Cache-Control', 'no-store, max-age=0');
   return response;
 });

--- a/ui/src/components/admin/teams/TeamDetailsDialog.tsx
+++ b/ui/src/components/admin/teams/TeamDetailsDialog.tsx
@@ -19,9 +19,11 @@ import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import type { TeamMembershipSource } from "@/types/identity-group-sync";
-import type { Team,TeamMember } from "@/types/teams";
+import type { Team } from "@/types/teams";
 import {
 Check,
+ChevronLeft,
+ChevronRight,
 Clock3,
 Crown,
 Hash,
@@ -155,6 +157,27 @@ interface WebexDiscoveryPayload {
   query: { q: string; limit: number };
 }
 
+// One row of the paginated member list (GET /api/admin/teams/[id]/members).
+interface TeamMemberPageRow {
+  identity_key: string;
+  user_subject?: string;
+  user_email?: string;
+  role: "owner" | "admin" | "member";
+  source_types: TeamMembershipSource["source_type"][];
+  idp_managed: boolean;
+  added_at?: string;
+}
+
+interface TeamMembersPagePayload {
+  members: TeamMemberPageRow[];
+  total: number;
+  page: number;
+  page_size: number;
+  has_more: boolean;
+}
+
+const TEAM_MEMBERS_PAGE_SIZE = 25;
+
 interface TeamDetailsDialogProps {
   team: Team | null;
   mode: DialogMode;
@@ -195,18 +218,18 @@ function getRoleBadgeVariant(role: string) {
   }
 }
 
-function getSourceLabel(source: TeamMembershipSource): string {
-  if (source.source_type === "manual") return "Manual";
-  if (source.source_type === "oidc_claim") return "OIDC claim";
-  if (source.source_type === "active_directory") return "AD";
-  if (source.source_type === "okta") return "Okta";
-  return source.source_type.replace(/_/g, " ");
+function getSourceLabel(sourceType: TeamMembershipSource["source_type"]): string {
+  if (sourceType === "manual") return "Manual";
+  if (sourceType === "oidc_claim") return "OIDC claim";
+  if (sourceType === "active_directory") return "AD";
+  if (sourceType === "okta") return "Okta";
+  return sourceType.replace(/_/g, " ");
 }
 
-function getSourceBadgeVariant(source: TeamMembershipSource) {
-  if (source.status === "active" && source.source_type === "manual") return "secondary" as const;
-  if (source.status === "active") return "outline" as const;
-  return "destructive" as const;
+function getSourceBadgeVariant(sourceType: TeamMembershipSource["source_type"]) {
+  // Members from the paginated list are always active; only the manual source
+  // gets the filled "secondary" treatment, IdP sources get the "outline".
+  return sourceType === "manual" ? ("secondary" as const) : ("outline" as const);
 }
 
 // Render-helpers for the OpenFGA sync diagnostic. Kept colocated so the
@@ -260,34 +283,6 @@ function syncBadgeAppearance(status: TeamMembershipSyncState): {
   }
 }
 
-function memberFromSource(source: TeamMembershipSource, fallbackDate: Date): TeamMember | null {
-  if (source.status !== "active") return null;
-  const userId = (source.user_email ?? source.user_subject ?? "").trim();
-  if (!userId) return null;
-
-  return {
-    user_id: userId,
-    role: source.relationship === "admin" ? "admin" : "member",
-    added_at: new Date(source.first_seen_at ?? source.created_at ?? source.last_seen_at ?? fallbackDate),
-    added_by: source.created_by ?? "identity-sync",
-  };
-}
-
-function membersFromSources(sources: TeamMembershipSource[], fallbackDate: Date): TeamMember[] {
-  const byUser = new Map<string, TeamMember>();
-  for (const source of sources) {
-    const member = memberFromSource(source, fallbackDate);
-    if (!member) continue;
-
-    const key = member.user_id.toLowerCase();
-    const existing = byUser.get(key);
-    if (!existing || existing.role === "member") {
-      byUser.set(key, member);
-    }
-  }
-  return Array.from(byUser.values());
-}
-
 export function TeamDetailsDialog({
   team,
   mode,
@@ -336,6 +331,16 @@ export function TeamDetailsDialog({
   );
   const [removingMember, setRemovingMember] = useState<string | null>(null);
 
+  // Paginated member list (GET /api/admin/teams/[id]/members). The Members tab
+  // renders from this — NOT from the full `membershipSources` array — so a team
+  // with a very large roster loads one page at a time instead of all at once.
+  // `memberSearch` is debounced into a server-side email filter.
+  const [memberPage, setMemberPage] = useState<TeamMemberPageRow[]>([]);
+  const [memberTotal, setMemberTotal] = useState(0);
+  const [memberPageNum, setMemberPageNum] = useState(1);
+  const [memberSearch, setMemberSearch] = useState("");
+  const [membersLoading, setMembersLoading] = useState(false);
+
   // Spec 104 — Resources tab state
   const [resourcesData, setResourcesData] = useState<ResourcesPayload | null>(null);
   const [selectedAgents, setSelectedAgents] = useState<Set<string>>(new Set());
@@ -379,7 +384,6 @@ export function TeamDetailsDialog({
 
   // Current team data (may be refreshed after mutations)
   const [currentTeam, setCurrentTeam] = useState<Team | null>(team);
-  const [membershipSources, setMembershipSources] = useState<TeamMembershipSource[]>([]);
   // OpenFGA sync diagnostic — populated from the GET /api/admin/teams/[id]
   // response (top-level `openfga_sync` field). `canReconcile` controls
   // visibility of the Reconcile button; we only know that the request
@@ -405,6 +409,11 @@ export function TeamDetailsDialog({
       setMemberSearchLoading(false);
       setMemberSearchOpen(false);
       setPendingRemoveMember(null);
+      setMemberPage([]);
+      setMemberTotal(0);
+      setMemberPageNum(1);
+      setMemberSearch("");
+      setMembersLoading(false);
       setResourcesData(null);
       setResourcesNotice(null);
       setChannelsData(null);
@@ -425,7 +434,6 @@ export function TeamDetailsDialog({
       setWebexDiscoverySearch("");
       setManualSpaceId("");
       setManualSpaceName("");
-      setMembershipSources(team.membership_sources ?? []);
       setOpenFgaSync(null);
       setReconcileError(null);
       setReconcileNotice(null);
@@ -445,12 +453,6 @@ export function TeamDetailsDialog({
         if (cancelled || !data.success) return;
         if (data.data?.openfga_sync) {
           setOpenFgaSync(data.data.openfga_sync as TeamMembershipSyncReport);
-        }
-        // Canonical team route also returns the membership sources, so we
-        // hydrate them here instead of from the (now-removed) identity-group
-        // -sync membership-sources endpoint.
-        if (Array.isArray(data.data?.membership_sources)) {
-          setMembershipSources(data.data.membership_sources as TeamMembershipSource[]);
         }
       })
       .catch((err: unknown) => {
@@ -1006,11 +1008,6 @@ export function TeamDetailsDialog({
       if (payload.team) {
         setCurrentTeam(payload.team);
       }
-      setMembershipSources(
-        Array.isArray(payload.membership_sources)
-          ? (payload.membership_sources as TeamMembershipSource[])
-          : []
-      );
       setOpenFgaSync(
         payload.openfga_sync
           ? (payload.openfga_sync as TeamMembershipSyncReport)
@@ -1023,6 +1020,64 @@ export function TeamDetailsDialog({
       setRefreshingTeam(false);
     }
   }, [currentTeam]);
+
+  // Fetch one page of the member list from the server. Search is applied
+  // server-side (email substring) so the browser only ever holds a page of
+  // members regardless of roster size.
+  const fetchMembersPage = useCallback(
+    async (teamId: string, page: number, search: string) => {
+      setMembersLoading(true);
+      try {
+        const params = new URLSearchParams({
+          page: String(page),
+          page_size: String(TEAM_MEMBERS_PAGE_SIZE),
+        });
+        if (search.trim()) params.set("search", search.trim());
+        const res = await fetch(
+          `/api/admin/teams/${teamId}/members?${params.toString()}`,
+        );
+        const data = await res.json();
+        if (!data.success) {
+          throw new Error(data.error || `Failed to load members (${res.status})`);
+        }
+        const payload = data.data as TeamMembersPagePayload;
+        setMemberPage(payload.members ?? []);
+        setMemberTotal(payload.total ?? 0);
+        setMemberPageNum(payload.page ?? page);
+      } catch (err: unknown) {
+        console.error("[TeamDetails] Failed to load members:", err);
+        setError(err instanceof Error ? err.message : "Failed to load members");
+      } finally {
+        setMembersLoading(false);
+      }
+    },
+    [],
+  );
+
+  // Load + debounced search for the Members tab. Typing resets to page 1 and
+  // re-queries the server (~250ms after the last keystroke). Only runs while
+  // the Members tab is active so other tabs don't trigger member queries.
+  useEffect(() => {
+    if (!open || activeMode !== "members" || !currentTeam?._id) return;
+    const teamId = currentTeam._id;
+    const handle = setTimeout(() => {
+      void fetchMembersPage(teamId, 1, memberSearch);
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [open, activeMode, currentTeam?._id, memberSearch, fetchMembersPage]);
+
+  const memberTotalPages = Math.max(1, Math.ceil(memberTotal / TEAM_MEMBERS_PAGE_SIZE));
+  const memberHasMore = memberPageNum * TEAM_MEMBERS_PAGE_SIZE < memberTotal;
+  const goToMembersPage = (page: number) => {
+    if (!currentTeam?._id) return;
+    const clamped = Math.min(Math.max(1, page), memberTotalPages);
+    void fetchMembersPage(currentTeam._id, clamped, memberSearch);
+  };
+  // Re-fetch the current member page after an add/remove mutation.
+  const reloadMembersPage = useCallback(() => {
+    if (!currentTeam?._id) return;
+    void fetchMembersPage(currentTeam._id, memberPageNum, memberSearch);
+  }, [currentTeam?._id, fetchMembersPage, memberPageNum, memberSearch]);
 
   const handleSaveEdit = async () => {
     if (!currentTeam) return;
@@ -1087,10 +1142,9 @@ export function TeamDetailsDialog({
       setNewMemberRole("member");
       setMemberSearchResults([]);
       setMemberSearchOpen(false);
-      // Re-fetch in the background so badges (membership sources,
-      // OpenFGA sync status) reflect the post-write reality. The
-      // primary list update above already shows the new member; this
-      // is a follow-up that hydrates secondary metadata.
+      // Reload the member page so the new member shows up, and refresh the
+      // OpenFGA sync diagnostic (Details-tab banner) in the background.
+      reloadMembersPage();
       void refreshTeam();
       // Prefer the lightweight callback so the parent admin page can
       // patch its `teams[]` state in place — no full dashboard reload,
@@ -1138,6 +1192,13 @@ export function TeamDetailsDialog({
 
       const updatedTeam = data.data.team as Team;
       setCurrentTeam(updatedTeam);
+      // Optimistically drop the removed row, then reload the page so a member
+      // from the next page backfills the slot and the total stays correct.
+      setMemberPage((prev) =>
+        prev.filter((m) => (m.user_email ?? "").toLowerCase() !== email.toLowerCase()),
+      );
+      setMemberTotal((prev) => Math.max(0, prev - 1));
+      reloadMembersPage();
       void refreshTeam();
       if (onTeamMutated) {
         onTeamMutated(updatedTeam);
@@ -1203,26 +1264,16 @@ export function TeamDetailsDialog({
 
   if (!currentTeam) return null;
 
-  const canonicalMembers = membersFromSources(
-    membershipSources,
-    new Date(currentTeam.created_at),
-  );
-  const members = canonicalMembers.length > 0 ? canonicalMembers : currentTeam.members || [];
-  const sourcesByMember = membershipSources.reduce<Record<string, TeamMembershipSource[]>>(
-    (acc, source) => {
-      const key = (source.user_email ?? source.user_subject ?? "").toLowerCase();
-      if (!key) return acc;
-      acc[key] = acc[key] ?? [];
-      acc[key].push(source);
-      return acc;
-    },
-    {}
-  );
+  // Member count for the tab/Details badges. Prefer the server total from the
+  // paginated members endpoint once loaded; fall back to the count decorated
+  // onto the team by GET /api/admin/teams before the first page loads.
+  const memberCount = memberTotal || currentTeam.member_count || 0;
+
   // Pick the "worst" sync entry per member email so the Members tab can
   // show a single badge instead of one per identity source. Ordering of
-  // severity: drifted > unknown > pending > synced. If no entry exists
-  // for the user (no source row yet), we render no badge — silence is
-  // accurate because there's literally nothing to sync.
+  // severity: drifted > unknown > pending > synced. Sourced from the
+  // OpenFGA sync report (Details-tab diagnostic); members not covered by
+  // the report simply render no sync badge.
   const syncByMember = (openFgaSync?.entries ?? []).reduce<
     Record<string, TeamMembershipSyncEntry>
   >((acc, entry) => {
@@ -1234,11 +1285,6 @@ export function TeamDetailsDialog({
     }
     return acc;
   }, {});
-  const sortedMembers = [...members].sort((a, b) => {
-    const roleOrder = { owner: 0, admin: 1, member: 2 };
-    return (roleOrder[a.role as keyof typeof roleOrder] ?? 2) -
-           (roleOrder[b.role as keyof typeof roleOrder] ?? 2);
-  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -1270,7 +1316,7 @@ export function TeamDetailsDialog({
             onClick={() => setActiveMode("members")}
             className="text-xs"
           >
-            Members ({members.length})
+            Members ({memberCount})
           </Button>
           <Button
             variant={activeMode === "resources" ? "default" : "ghost"}
@@ -1400,7 +1446,7 @@ export function TeamDetailsDialog({
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-muted-foreground">Members</span>
-                    <span className="text-sm">{members.length}</span>
+                    <span className="text-sm">{memberCount}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-muted-foreground">Created</span>
@@ -1572,8 +1618,13 @@ export function TeamDetailsDialog({
                           .filter(Boolean)
                           .join(" ")
                           .trim();
-                        const alreadyMember = members.some(
-                          (m) => m.user_id.toLowerCase() === u.email.toLowerCase()
+                        // Best-effort hint only: the member list is paginated,
+                        // so we can confidently flag matches on the loaded page
+                        // but cannot prove non-membership client-side. The add
+                        // endpoint is authoritative and rejects true duplicates
+                        // with a 400.
+                        const alreadyMember = memberPage.some(
+                          (m) => (m.user_email ?? "").toLowerCase() === u.email.toLowerCase()
                         );
                         return (
                           <button
@@ -1642,34 +1693,44 @@ export function TeamDetailsDialog({
               </Button>
             </form>
 
+            {/* Filter the roster by email. Debounced into a server-side
+                query so it works regardless of how large the team is. */}
+            <div className="relative">
+              <Search className="h-3.5 w-3.5 text-muted-foreground absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+              <Input
+                placeholder="Filter members by email…"
+                value={memberSearch}
+                onChange={(e) => setMemberSearch(e.target.value)}
+                className="pl-8 h-9"
+                type="search"
+                aria-label="Filter members by email"
+              />
+            </div>
+
             {/* Members List */}
             <ScrollArea className="flex-1 -mx-1 px-1" style={{ maxHeight: "320px" }}>
               <div className="space-y-1">
-                {sortedMembers.length === 0 ? (
+                {membersLoading && memberPage.length === 0 ? (
+                  <div className="flex justify-center py-8">
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : memberPage.length === 0 ? (
                   <p className="text-sm text-muted-foreground text-center py-8">
-                    No members yet. Add members above.
+                    {memberSearch.trim()
+                      ? `No members match "${memberSearch.trim()}".`
+                      : "No members yet. Add members above."}
                   </p>
                 ) : (
-                  sortedMembers.map((member) => {
-                    // Only surface currently-active provenance to operators. Non-active
-                    // rows (status="removed") are an audit-trail artefact: when a user is
-                    // removed and later re-added they otherwise show up next to the active
-                    // badge as a confusing "Manual: Removed" pill alongside "Manual".
-                    // See team-membership-source-store.markTeamMembershipSourceRemoved.
-                    const memberSources = (sourcesByMember[member.user_id.toLowerCase()] ?? [])
-                      .filter((source) => source.status === "active");
-                    const isIdpManaged =
-                      memberSources.length > 0 &&
-                      memberSources.every((s) => s.source_type !== "manual");
-                    const syncEntry = syncByMember[member.user_id.toLowerCase()];
+                  memberPage.map((member) => {
+                    const email = member.user_email ?? member.identity_key;
+                    const syncEntry = syncByMember[email.toLowerCase()];
                     const syncBadge = syncEntry
                       ? syncBadgeAppearance(syncEntry.status)
                       : null;
-                    const isPendingRemove =
-                      pendingRemoveMember === member.user_id;
+                    const isPendingRemove = pendingRemoveMember === email;
                     return (
                       <div
-                        key={member.user_id}
+                        key={member.identity_key}
                         className={`flex items-center justify-between py-2 px-3 rounded-md group ${
                           isPendingRemove
                             ? "bg-destructive/5 ring-1 ring-destructive/20"
@@ -1678,23 +1739,24 @@ export function TeamDetailsDialog({
                       >
                         <div className="flex items-center gap-3 min-w-0">
                           <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-medium text-sm shrink-0">
-                            {member.user_id.charAt(0).toUpperCase()}
+                            {email.charAt(0).toUpperCase()}
                           </div>
                           <div className="min-w-0">
-                            <p className="text-sm truncate">{member.user_id}</p>
-                            <p className="text-xs text-muted-foreground">
-                              Added {new Date(member.added_at).toLocaleDateString()}
-                            </p>
-                            {(memberSources.length > 0 || syncBadge) && (
+                            <p className="text-sm truncate">{email}</p>
+                            {member.added_at && (
+                              <p className="text-xs text-muted-foreground">
+                                Added {new Date(member.added_at).toLocaleDateString()}
+                              </p>
+                            )}
+                            {(member.source_types.length > 0 || syncBadge) && (
                               <div className="mt-1 flex flex-wrap gap-1">
-                                {memberSources.map((source) => (
+                                {member.source_types.map((sourceType) => (
                                   <Badge
-                                    key={`${source.source_type}-${source.provider_id ?? "local"}-${source.external_group_id ?? "manual"}-${source.relationship}-${source.status}`}
-                                    variant={getSourceBadgeVariant(source)}
+                                    key={sourceType}
+                                    variant={getSourceBadgeVariant(sourceType)}
                                     className="text-[10px] capitalize"
                                   >
-                                    {getSourceLabel(source)}
-                                    {source.status !== "active" ? `: ${source.status}` : ""}
+                                    {getSourceLabel(sourceType)}
                                   </Badge>
                                 ))}
                                 {syncBadge && (
@@ -1717,7 +1779,7 @@ export function TeamDetailsDialog({
                             {member.role}
                           </Badge>
                           {member.role !== "owner" && (
-                            isIdpManaged ? (
+                            member.idp_managed ? (
                               <span
                                 title="Managed by identity sync — edit membership in your IDP"
                                 className="flex h-7 w-7 items-center justify-center text-muted-foreground/50"
@@ -1726,8 +1788,8 @@ export function TeamDetailsDialog({
                                 <Lock className="h-3.5 w-3.5" />
                               </span>
                             ) : (
-                              pendingRemoveMember === member.user_id &&
-                              removingMember !== member.user_id ? (
+                              pendingRemoveMember === email &&
+                              removingMember !== email ? (
                                 // Inline confirm row — replaces the previous
                                 // window.confirm() blocking prompt. Stays on
                                 // the same row so focus, scroll position, and
@@ -1735,7 +1797,7 @@ export function TeamDetailsDialog({
                                 <div
                                   className="flex items-center gap-1"
                                   role="group"
-                                  aria-label={`Confirm removal of ${member.user_id}`}
+                                  aria-label={`Confirm removal of ${email}`}
                                   onKeyDown={(e) => {
                                     if (e.key === "Escape") {
                                       e.stopPropagation();
@@ -1753,11 +1815,9 @@ export function TeamDetailsDialog({
                                     variant="destructive"
                                     size="sm"
                                     className="h-7 px-2 text-xs"
-                                    onClick={() =>
-                                      handleRemoveMember(member.user_id)
-                                    }
+                                    onClick={() => handleRemoveMember(email)}
                                     autoFocus
-                                    aria-label={`Confirm remove ${member.user_id}`}
+                                    aria-label={`Confirm remove ${email}`}
                                   >
                                     <Check className="h-3.5 w-3.5 mr-1" />
                                     Remove
@@ -1777,17 +1837,15 @@ export function TeamDetailsDialog({
                                   variant="ghost"
                                   size="sm"
                                   className={`h-7 w-7 p-0 text-muted-foreground hover:text-destructive ${
-                                    removingMember === member.user_id
+                                    removingMember === email
                                       ? "opacity-100"
                                       : "opacity-0 group-hover:opacity-100"
                                   }`}
-                                  onClick={() =>
-                                    setPendingRemoveMember(member.user_id)
-                                  }
-                                  disabled={removingMember === member.user_id}
-                                  aria-label={`Remove ${member.user_id}`}
+                                  onClick={() => setPendingRemoveMember(email)}
+                                  disabled={removingMember === email}
+                                  aria-label={`Remove ${email}`}
                                 >
-                                  {removingMember === member.user_id ? (
+                                  {removingMember === email ? (
                                     <Loader2 className="h-3.5 w-3.5 animate-spin" />
                                   ) : (
                                     <Trash2 className="h-3.5 w-3.5" />
@@ -1803,6 +1861,38 @@ export function TeamDetailsDialog({
                 )}
               </div>
             </ScrollArea>
+
+            {/* Member pager — shown when the roster spans more than one page. */}
+            {memberTotal > TEAM_MEMBERS_PAGE_SIZE && (
+              <div className="flex items-center justify-between pt-1 text-xs">
+                <span className="text-muted-foreground">
+                  Page {memberPageNum} of {memberTotalPages} · {memberTotal} member
+                  {memberTotal === 1 ? "" : "s"}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7"
+                    onClick={() => goToMembersPage(memberPageNum - 1)}
+                    disabled={memberPageNum <= 1 || membersLoading}
+                    aria-label="Previous page"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7"
+                    onClick={() => goToMembersPage(memberPageNum + 1)}
+                    disabled={!memberHasMore || membersLoading}
+                    aria-label="Next page"
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/ui/src/components/admin/teams/__tests__/TeamDetailsDialog.members.test.tsx
+++ b/ui/src/components/admin/teams/__tests__/TeamDetailsDialog.members.test.tsx
@@ -35,50 +35,60 @@ function jsonResponse(payload: unknown): Response {
   } as Response;
 }
 
+// Build a paginated members payload mirroring GET /api/admin/teams/[id]/members.
+function membersPayload(
+  members: Array<{
+    user_email: string;
+    role: "owner" | "admin" | "member";
+    source_types?: string[];
+    idp_managed?: boolean;
+  }>,
+): Response {
+  return jsonResponse({
+    success: true,
+    data: {
+      members: members.map((m) => ({
+        identity_key: m.user_email,
+        user_email: m.user_email,
+        role: m.role,
+        source_types: m.source_types ?? ["manual"],
+        idp_managed: m.idp_managed ?? false,
+        added_at: "2026-01-02T00:00:00.000Z",
+      })),
+      total: members.length,
+      page: 1,
+      page_size: 25,
+      has_more: false,
+    },
+  });
+}
+
+function isMembersGet(url: string, init?: RequestInit): boolean {
+  return (
+    url.startsWith("/api/admin/teams/team-1/members") &&
+    (!init?.method || init.method === "GET")
+  );
+}
+
 beforeEach(() => {
   fetchMock.mockReset();
   global.fetch = fetchMock as unknown as typeof fetch;
 });
 
-it("renders active canonical membership sources when embedded team members are empty", async () => {
-  const teamWithoutEmbeddedMembers: Team = {
-    ...baseTeam,
-    members: [],
-    membership_sources: [
-      {
-        team_id: "team-1",
-        team_slug: "platform",
-        user_email: "alice@example.com",
-        relationship: "member",
-        source_type: "active_directory",
-        managed: true,
-        status: "active",
-        created_at: "2026-01-02T00:00:00.000Z",
-      },
-    ],
-  };
-
-  fetchMock.mockImplementation(async (url: string) => {
-    if (url === "/api/admin/identity-group-sync/teams/team-1/membership-sources") {
-      return jsonResponse({
-        success: true,
-        data: {
-          sources: teamWithoutEmbeddedMembers.membership_sources,
-        },
-      });
+it("renders members from the paginated members endpoint", async () => {
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (isMembersGet(url, init)) {
+      return membersPayload([
+        { user_email: "alice@example.com", role: "member", source_types: ["active_directory"], idp_managed: true },
+      ]);
     }
-    return jsonResponse({
-      success: true,
-      data: {
-        team: teamWithoutEmbeddedMembers,
-        membership_sources: teamWithoutEmbeddedMembers.membership_sources,
-      },
-    });
+    // Team detail (OpenFGA diagnostic) — harmless empty.
+    return jsonResponse({ success: true, data: { team: baseTeam } });
   });
 
   render(
     <TeamDetailsDialog
-      team={teamWithoutEmbeddedMembers}
+      team={baseTeam}
       mode="members"
       open
       onOpenChange={jest.fn()}
@@ -95,23 +105,24 @@ it("calls onTeamMutated (not onTeamUpdated) when a member is added", async () =>
   const onTeamMutated = jest.fn();
   const onTeamUpdated = jest.fn();
 
-  // Server returns the patched team document.
-  const updatedTeam: Team = {
-    ...baseTeam,
-    members: [
-      ...baseTeam.members,
-      {
-        user_id: "bob@example.com",
-        role: "member",
-        added_at: new Date("2026-01-03"),
-      },
-    ],
-  };
+  const updatedTeam: Team = { ...baseTeam };
+  let added = false;
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url === "/api/admin/teams/team-1/members" && init?.method === "POST") {
+      added = true;
       return jsonResponse({ success: true, data: { team: updatedTeam } });
     }
-    // Secondary background hydrate calls (refreshTeam) — return harmless empties.
+    if (isMembersGet(url, init)) {
+      // Bob shows up once the add has gone through.
+      return membersPayload(
+        added
+          ? [
+              { user_email: "alice@example.com", role: "member" },
+              { user_email: "bob@example.com", role: "member" },
+            ]
+          : [{ user_email: "alice@example.com", role: "member" }],
+      );
+    }
     return jsonResponse({ success: true, data: { team: updatedTeam } });
   });
 
@@ -156,16 +167,21 @@ it("shows an inline confirm row instead of window.confirm when removing a member
   const onTeamMutated = jest.fn();
   const onTeamUpdated = jest.fn();
 
-  const updatedTeam: Team = {
-    ...baseTeam,
-    members: baseTeam.members.filter((m) => m.user_id !== "alice@example.com"),
-  };
+  const updatedTeam: Team = { ...baseTeam };
+  let removed = false;
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
     if (
       url.startsWith("/api/admin/teams/team-1/members") &&
       init?.method === "DELETE"
     ) {
+      removed = true;
       return jsonResponse({ success: true, data: { team: updatedTeam } });
+    }
+    if (isMembersGet(url, init)) {
+      // After the delete, the server no longer returns alice.
+      return membersPayload(
+        removed ? [] : [{ user_email: "alice@example.com", role: "member" }],
+      );
     }
     return jsonResponse({ success: true, data: { team: updatedTeam } });
   });
@@ -191,7 +207,7 @@ it("shows an inline confirm row instead of window.confirm when removing a member
   );
 
   // First click: stages the inline confirm row, does NOT fire the API.
-  const removeButton = screen.getByRole("button", {
+  const removeButton = await screen.findByRole("button", {
     name: /^Remove alice@example.com$/i,
   });
   fireEvent.click(removeButton);
@@ -237,9 +253,14 @@ it("cancels the inline confirm row without calling the API", async () => {
   const onTeamMutated = jest.fn();
   const onTeamUpdated = jest.fn();
 
-  fetchMock.mockImplementation(async () =>
-    jsonResponse({ success: true, data: {} }),
-  );
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (isMembersGet(url, init)) {
+      return membersPayload([
+        { user_email: "alice@example.com", role: "member" },
+      ]);
+    }
+    return jsonResponse({ success: true, data: {} });
+  });
 
   render(
     <TeamDetailsDialog
@@ -253,7 +274,7 @@ it("cancels the inline confirm row without calling the API", async () => {
   );
 
   fireEvent.click(
-    screen.getByRole("button", { name: /^Remove alice@example.com$/i }),
+    await screen.findByRole("button", { name: /^Remove alice@example.com$/i }),
   );
 
   // Confirm row visible.
@@ -293,20 +314,15 @@ it("cancels the inline confirm row without calling the API", async () => {
 it("falls back to onTeamUpdated when onTeamMutated is not provided (legacy behaviour)", async () => {
   const onTeamUpdated = jest.fn();
 
-  const updatedTeam: Team = {
-    ...baseTeam,
-    members: [
-      ...baseTeam.members,
-      {
-        user_id: "charlie@example.com",
-        role: "member",
-        added_at: new Date("2026-01-04"),
-      },
-    ],
-  };
+  const updatedTeam: Team = { ...baseTeam };
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url === "/api/admin/teams/team-1/members" && init?.method === "POST") {
       return jsonResponse({ success: true, data: { team: updatedTeam } });
+    }
+    if (isMembersGet(url, init)) {
+      return membersPayload([
+        { user_email: "alice@example.com", role: "member" },
+      ]);
     }
     return jsonResponse({ success: true, data: { team: updatedTeam } });
   });

--- a/ui/src/lib/rbac/team-membership-store.ts
+++ b/ui/src/lib/rbac/team-membership-store.ts
@@ -228,6 +228,147 @@ export async function loadTeamMembersForSlugs(
 }
 
 /**
+ * One page of a team's deduplicated, role-escalated members, plus the total
+ * distinct member count for the (optionally search-filtered) set.
+ *
+ * `source_types` lists every active source that contributed a row for the
+ * member (e.g. `["okta", "manual"]`). `idp_managed` is true when the member
+ * has at least one source and ALL of them are non-manual — i.e. the member is
+ * managed entirely by directory sync and cannot be removed by hand.
+ */
+export interface TeamMemberPageRow {
+  identity_key: string;
+  user_subject?: string;
+  user_email?: string;
+  // UI-facing role. The canonical store only tracks member/admin; "owner" is
+  // derived from the team document's owner_id for display + sort purposes.
+  role: "owner" | "admin" | "member";
+  source_types: TeamMembershipSource["source_type"][];
+  idp_managed: boolean;
+  added_at?: string;
+}
+
+export interface TeamMemberPage {
+  members: TeamMemberPageRow[];
+  total: number;
+}
+
+export interface LoadTeamMembersPageOptions extends QueryOptions {
+  /** 1-based page index. Defaults to 1. */
+  page?: number;
+  /** Rows per page. Clamped to [1, 100]. Defaults to 25. */
+  pageSize?: number;
+  /** Case-insensitive substring match against `user_email`. */
+  search?: string;
+  /**
+   * Team owner's email. When provided, the matching member is reported with
+   * role `"owner"` and sorted to the very top so it leads page 1.
+   */
+  ownerEmail?: string;
+}
+
+/**
+ * Paginated, search-filtered companion to `loadActiveTeamMembers`. Dedupe +
+ * role escalation happen server-side via aggregation, and only one page of
+ * rows crosses the wire — so this stays cheap for teams with very large
+ * rosters where loading the full member list would be prohibitive.
+ *
+ * Pagination is stable: members are sorted owner-first, then by email, then
+ * identity_key as a tiebreak.
+ */
+export async function loadActiveTeamMembersPage(
+  teamSlug: string,
+  opts?: LoadTeamMembersPageOptions,
+): Promise<TeamMemberPage> {
+  if (!teamSlug || typeof teamSlug !== "string") return { members: [], total: 0 };
+
+  const page = Math.max(1, opts?.page ?? 1);
+  const pageSize = Math.min(100, Math.max(1, opts?.pageSize ?? 25));
+  const search = (opts?.search ?? "").trim();
+  const ownerEmail = opts?.ownerEmail?.trim().toLowerCase() || null;
+
+  const collection = await getRbacCollection<TeamMembershipSource>("teamMembershipSources");
+
+  const match: Record<string, unknown> = {
+    team_slug: teamSlug,
+    ...buildStatusFilter(opts),
+  };
+  if (search) {
+    // Escape regex metacharacters so a user typing e.g. "a.b" doesn't match
+    // unexpectedly. Email matching only — that's what the UI displays.
+    const escaped = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    match.user_email = { $regex: escaped, $options: "i" };
+  }
+
+  const groupStage = {
+    $group: {
+      _id: { $ifNull: ["$user_subject", { $toLower: "$user_email" }] },
+      user_subject: { $first: "$user_subject" },
+      user_email: { $first: "$user_email" },
+      // Escalate to admin if ANY contributing row is an admin grant.
+      is_admin: { $max: { $cond: [{ $eq: ["$relationship", "admin"] }, 1, 0] } },
+      source_types: { $addToSet: "$source_type" },
+      // Earliest provenance timestamp wins as "added" date.
+      added_at: { $min: { $ifNull: ["$first_seen_at", "$created_at"] } },
+    },
+  };
+
+  const ownerRank = ownerEmail
+    ? { $cond: [{ $eq: [{ $toLower: { $ifNull: ["$user_email", ""] } }, ownerEmail] }, 0, 1] }
+    : 1;
+
+  const docs = await collection
+    .aggregate<{
+      total: { count: number }[];
+      rows: Array<{
+        _id: string | null;
+        user_subject?: string;
+        user_email?: string;
+        is_admin: number;
+        source_types: TeamMembershipSource["source_type"][];
+        added_at?: string;
+      }>;
+    }>([
+      { $match: match },
+      groupStage,
+      { $match: { _id: { $ne: null } } },
+      { $addFields: { owner_rank: ownerRank, email_sort: { $toLower: { $ifNull: ["$user_email", ""] } } } },
+      {
+        $facet: {
+          total: [{ $count: "count" }],
+          rows: [
+            { $sort: { owner_rank: 1, email_sort: 1, _id: 1 } },
+            { $skip: (page - 1) * pageSize },
+            { $limit: pageSize },
+          ],
+        },
+      },
+    ])
+    .toArray();
+
+  const facet = docs[0] ?? { total: [], rows: [] };
+  const total = facet.total[0]?.count ?? 0;
+
+  const members: TeamMemberPageRow[] = facet.rows.map((row) => {
+    const sourceTypes = Array.isArray(row.source_types) ? row.source_types : [];
+    const isOwner = Boolean(ownerEmail && (row.user_email ?? "").toLowerCase() === ownerEmail);
+    return {
+      identity_key: row._id ?? "",
+      user_subject: row.user_subject || undefined,
+      user_email: row.user_email || undefined,
+      // Owner is a UI-only role label; the canonical store only tracks
+      // member/admin. The owner is always at least an admin in OpenFGA.
+      role: isOwner ? "owner" : row.is_admin ? "admin" : "member",
+      source_types: sourceTypes,
+      idp_managed: sourceTypes.length > 0 && sourceTypes.every((t) => t !== "manual"),
+      added_at: row.added_at,
+    };
+  });
+
+  return { members, total };
+}
+
+/**
  * Bulk variant of `countActiveTeamMembers` for the admin teams list
  * endpoint. Returns a map keyed by team_slug. Slugs with zero members
  * are present in the map with value 0 (so callers don't have to check

--- a/ui/src/types/teams.ts
+++ b/ui/src/types/teams.ts
@@ -29,6 +29,12 @@ export interface Team {
   updated_at: Date;
   members: TeamMember[];
   membership_sources?: TeamMembershipSource[];
+  /**
+   * Distinct active member count, decorated by GET /api/admin/teams from the
+   * canonical `team_membership_sources` store. Optional because locally-built
+   * Team objects (pre server round-trip) won't have it.
+   */
+  member_count?: number;
   keycloak_roles?: string[];
   /**
    * Optional Baseline FGA profile overrides. When present, login and admin


### PR DESCRIPTION
# Description

Improves the Admin → **Teams & Users → Teams** page for large directories (e.g. tens of thousands of synced groups/members):

- **Teams list pagination** — `GET /api/admin/teams` now supports opt-in server-side pagination + search via `?page=&page_size=&search=`, returning a `{ teams, total, page, page_size, has_more }` envelope. The grid holds only one page at a time and uses a debounced (250ms) server-side search. The unpaginated path is preserved (no `page` param) so the shared filter dropdowns (Stats/Feedback/NPS + simulation picker) keep getting the full team list.
- **Member list pagination** — new paginated `GET /api/admin/teams/[id]/members` endpoint backed by `loadActiveTeamMembersPage` (Mongo `$facet` dedupe-by-identity + paginate). `TeamDetailsDialog` renders one page of members at a time with debounced search, fixing the hang when opening teams with very large membership.
- **Split sync-source labels** — `IdpSyncedBadge` and member-row source badges now render one deduped pill per source type (e.g. Okta, OIDC) instead of a single combined label.

All changes are additive/opt-in; access control (per-row `slug $in` scoping, fail-closed for non-admins) and identity dedupe (`COALESCE(user_subject, user_email)`, admin-wins role escalation) are preserved.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A — no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass