### PR TITLE
docs(blog): What's New in 0.5 — end-user feature overview

### DIFF
--- a/docs/blog/2026-06-18-whats-new-in-0-5.md
+++ b/docs/blog/2026-06-18-whats-new-in-0-5.md
@@ -1,0 +1,199 @@
+---
+slug: whats-new-in-0-5
+title: "What's New in 0.5 — Enterprise RBAC, Webex, Smart Gateways, and a Redesigned Admin Experience"
+date: 2026-06-18
+authors: [sriaradhyula]
+tags: [articles, release]
+---
+
+The 0.5 series is the biggest leap since the initial release. In a single minor version, CAIPE gained a full enterprise authorization stack, a brand-new Webex bot, fine-grained access control across every resource type, a configurable MCP gateway, and a dramatically improved admin experience. If you have been running 0.4.x and wondering what to expect — this post covers it all.
+
+<!-- truncate -->
+
+> **Current stable:** 0.5.16 · [Upgrade guide →](/blog/releases/release-0.5.0)
+
+---
+
+## The headline: Authorization that actually scales
+
+In 0.4.x, access control was coarse — you were either an admin or you weren't. Teams existed as a concept but weren't enforced. In 0.5, that changes completely.
+
+CAIPE now ships with [OpenFGA](https://openfga.dev/)-backed **relationship-based access control (ReBAC)**. Every resource — agents, knowledge bases, skills, MCP tools — has an owner team, can be shared with other teams, and enforces access at the API, BFF, and RAG server layers consistently. The authorization model looks like this:
+
+```
+organization
+  └── teams (owned by team admins)
+        ├── members
+        ├── agents    (shared or team-owned)
+        ├── knowledge bases
+        ├── skills
+        └── MCP tools
+```
+
+This is opt-in: if you upgrade from 0.4.18 and don't enable Keycloak/OpenFGA, the entire RBAC stack stays disabled and your deployment just works. No `values.yaml` changes required.
+
+---
+
+## Five things you'll notice immediately
+
+### 1. A new Webex bot
+
+CAIPE now ships a first-class **Webex bot** alongside the Slack bot. It supports spaces, direct messages, thread context (the bot remembers your conversation), identity linking, and the same OpenFGA authorization decisions as the web UI.
+
+Set up Webex routing from **Admin → Webex Spaces** — you'll see the same channel management experience you know from Slack, now unified into a single `ConnectorAdminPanel` shared by both bots.
+
+```yaml
+# Enable in Helm:
+tags:
+  webex-bot: true
+```
+
+### 2. Slack channels now route by agent, not just team
+
+In 0.4.x, Slack channels were mapped to a team and any agent would respond. In 0.5, **each channel gets a dedicated agent assignment**. Channel access requires an explicit agent assignment — no more phantom channel entries from team membership alone.
+
+From **Admin → Slack Channels** you can:
+- Assign (or swap) the agent for any channel in-place
+- Delete a channel binding without removing the team
+- Import bindings from a config file with `config_team` field support
+- Use the new route editor for quick agent swaps
+
+The bot's slash-command prefix is now derived from `APP_NAME`, so multi-tenant installs can namespace `/myorg-caipe` instead of `/caipe`.
+
+### 3. Fine-grained sharing for everything
+
+In 0.4.x, knowledge bases, agents, and skills were visible globally or not at all. In 0.5, every resource type supports **team sharing**:
+
+| Resource | What changed |
+|----------|-------------|
+| **Agents** | Owner team + optional team shares; `user:*` wildcard for org-wide visibility |
+| **Knowledge Bases** | Shared-with-teams via OpenFGA; each KB tab (Search, Data Sources, Graph, MCP Tools) gated separately |
+| **Skills** | Team shares via Skill Builder using the same picker as agents and KBs |
+| **MCP Tools** | First-class `mcp_tool` resource type in OpenFGA |
+
+Team members see only what their teams have access to. Org admins retain full access as a super-grant. The RAG server, BFF, and UI all enforce the same OpenFGA decision — no more inconsistent access across surfaces.
+
+### 4. A completely redesigned admin experience
+
+The admin UI grew substantially in 0.5:
+
+**Teams panel**
+- Team cards now show knowledge-base, agent, and tool counts at a glance
+- Searchable `TeamPicker` and `TeamMultiPicker` replace native `<select>` dropdowns everywhere
+- Canonical team membership from a single source of truth (`team_membership_sources` collection) — no more drift between what the API says and what the UI shows
+
+**Identity & Directory Sync**
+- **Okta directory sync** (0.5.10) — full SDK-based group sync with JIT user provisioning. Map Okta groups to CAIPE teams with live preview from **Admin → Identity Group Sync → Okta**
+- **Generic OIDC IdP broker** — federate any Okta, Azure AD, Duo, or enterprise SSO into Keycloak with the `idp` subchart values
+
+**RBAC Migrations panel**
+- Admin-runnable backfill migrations for every resource type (agents, skills, knowledge bases)
+- Keycloak migration health summary and invariant list with amber warning consolidation
+
+**Onboarding defaults**
+- Admins can set the default team and agent for new users with an explicit Save flow and pending-changes indicator
+- Fresh installs seed a working Hello-World agent automatically
+
+### 5. AgentGateway MCP routing — no CRDs required
+
+MCP traffic can now be proxied through **AgentGateway** without needing Kubernetes CRDs or a Gateway controller. The default mode (`routingMode: static`) writes routes directly into the proxy's static config:
+
+- One `/mcp/<id>` route per agent (rendered automatically from Helm)
+- A built-in `/mcp/knowledge-base` route for the RAG server
+- Dynamic route updates via the config-bridge sidecar (no pod restarts)
+- Optional listener-level JWT validation
+
+Enable with a single values flag:
+```yaml
+global:
+  agentgateway:
+    enabled: true
+    # routingMode: static (default, no CRDs)
+    # routingMode: gateway-api (opt-in, requires CRDs + controller)
+```
+
+---
+
+## What else changed
+
+### Connections & Credentials (opt-in)
+An **envelope-encrypted credential store** backs OAuth connectors for agents. Credentials are stored with AES-GCM and KMS-style data-key wrapping. For production, use `aws-kms`; `local-cmk` is for non-production testing only.
+
+```yaml
+caipe-ui:
+  config:
+    CAIPE_CREDENTIALS_ENABLED: "true"
+    CREDENTIAL_KEY_PROVIDER: "aws-kms"
+```
+
+### Dynamic agents got smarter
+- **Owner team requirement** — dynamic agents must have an owner team; the editor surfaces a required-field message with ARIA hooks instead of a silent save failure
+- **Protected platform default agent** — the platform default agent is now protected from deletion/misconfiguration
+- **Blocker hints** — the editor surfaces actionable hints when an agent can't be published (missing LLM config, missing team, etc.)
+- **MCP URL normalization** — canonicalizes trailing slashes, `/mcp` suffixes, and scheme inference so copy-pasted URLs work the first time
+- **LLM errors surface over SSE** — LLM config errors now appear as actionable messages in the Slack/Webex/UI response instead of generic "something went wrong"
+
+### UI quality of life
+- **Responsive nav overflow** — the top navigation bar gracefully collapses on narrow viewports with a labeled menu
+- **Compact header** — user menu and notifications are condensed for more content space
+- **Screenshot in feedback dialog** — the feedback/report dialog now accepts an optional screenshot attachment
+- **Expandable agent panels** — config-driven agent sidebar panels expand to show full descriptions
+
+### Setup script overhaul (0.5.7)
+`setup-caipe.sh` grew several new capabilities:
+- `--litellm` — a single LiteLLM proxy front for both chat and embeddings
+- `--postgres` — shared Postgres for Keycloak and OpenFGA
+- `--github-client-id` / `--github-client-secret` — GitHub social login
+- `setup-caipe.sh creds` — reprint local credentials without re-running setup
+- Embeddings model is preserved across non-interactive upgrades
+
+### AI Review rubric expansion
+The default review rubric for agent system prompts grew from 7 to **11 criteria**, adding:
+- Negative-constraints coverage
+- Failure-mode handling
+- Prompt-injection resistance
+- Bounded scope evaluation
+
+The SKILL.md rubric also expanded to 11 criteria with emphasis on trigger conditions and actionable instructions.
+
+---
+
+## Production hardening
+
+Several security improvements shipped in 0.5 that are worth calling out:
+
+- **Keycloak client-secret reconciliation** — dev placeholder secrets for service-account clients are rotated on every install/upgrade; a `strictClientSecrets` gate fails the install if any placeholder is still in use
+- **MongoDB strict-password gate** — `mongodb.auth.strictPasswords: true` makes `helm install` fail-fast on placeholder `rootPassword` values
+- **SSRF protection in RAG web loader** — non-public start and redirect URLs are blocked
+- **HMAC-SHA256 for catalog API keys** (0.5.8) — keys stored at rest use HMAC-SHA256 instead of plain SHA-256; existing keys need rotation after upgrade
+
+---
+
+## Is this a breaking upgrade from 0.4.x?
+
+**For most deployments: no.** If you are on 0.4.18 with a default `values.yaml`, this is a drop-in upgrade. Every new subchart (Keycloak, OpenFGA, Webex bot, AgentGateway) defaults to `enabled: false`. The RBAC stack is additive.
+
+The only behavioral change that may affect you:
+
+| Change | Impact | Action |
+|--------|--------|--------|
+| `active_team` JWT claim removed | Only matters if external code read this claim | None — claim was never issued in 0.4.x |
+| AgentGateway `routingMode` defaults to `static` (0.5.3) | Only if you had `agentgateway.enabled: true` with CRD-based routing | Set `routingMode: gateway-api` explicitly |
+| Catalog API key hash changed to HMAC-SHA256 (0.5.8) | Keys minted before 0.5.8 will fail verification | Revoke old keys and mint new ones after upgrade |
+
+---
+
+## Upgrade
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.16 \
+  -f your-values.yaml
+```
+
+See the full series of [per-release upgrade guides](/blog/releases) for step-by-step instructions, Helm values diffs, and data migrations for each 0.5.x patch.
+
+---
+
+*This post covers 0.5.0 through 0.5.16. The 0.5 series is actively maintained — check the [releases blog](/blog/releases) for the latest patches.*

--- a/docs/blog/2026-06-18-whats-new-in-0-5.md
+++ b/docs/blog/2026-06-18-whats-new-in-0-5.md
@@ -6,11 +6,13 @@ authors: [sriaradhyula]
 tags: [articles, release]
 ---
 
+<!-- assisted-by Codex Codex-sonnet-4-6 -->
+
 The 0.5 series is the biggest leap since the initial release. In a single minor version, CAIPE gained a full enterprise authorization stack, a brand-new Webex bot, fine-grained access control across every resource type, a configurable MCP gateway, and a dramatically improved admin experience. If you have been running 0.4.x and wondering what to expect — this post covers it all.
 
 <!-- truncate -->
 
-> **Current stable:** 0.5.16 · [Upgrade guide →](/blog/releases/release-0.5.0)
+> **Latest release:** use the [releases page](/blog/releases) for the current 0.5.x patch, per-release upgrade guides, and Helm values diffs.
 
 ---
 
@@ -96,7 +98,7 @@ The admin UI grew substantially in 0.5:
 
 ### 5. AgentGateway MCP routing — no CRDs required
 
-MCP traffic can now be proxied through **AgentGateway** without needing Kubernetes CRDs or a Gateway controller. The default mode (`routingMode: static`) writes routes directly into the proxy's static config:
+MCP traffic is now proxied through **AgentGateway** without needing Kubernetes CRDs or a Gateway controller. The default mode (`routingMode: static`) writes routes directly into the proxy's static config:
 
 - One `/mcp/<id>` route per agent (rendered automatically from Helm)
 - A built-in `/mcp/knowledge-base` route for the RAG server
@@ -126,6 +128,9 @@ caipe-ui:
     CREDENTIAL_KEY_PROVIDER: "aws-kms"
 ```
 
+### Service accounts for automation
+Teams can create **service accounts** for external systems and automation. These are team-owned bot identities with scoped access to selected agents and tools, one-time credentials, rotation/revocation flows, and caller-keyed tool authorization at the AgentGateway layer. Slack routes can also run as a selected user or service account for unlinked-user fallback and controlled bot-operated channels.
+
 ### Dynamic agents got smarter
 - **Owner team requirement** — dynamic agents must have an owner team; the editor surfaces a required-field message with ARIA hooks instead of a silent save failure
 - **Protected platform default agent** — the platform default agent is now protected from deletion/misconfiguration
@@ -138,6 +143,8 @@ caipe-ui:
 - **Compact header** — user menu and notifications are condensed for more content space
 - **Screenshot in feedback dialog** — the feedback/report dialog now accepts an optional screenshot attachment
 - **Expandable agent panels** — config-driven agent sidebar panels expand to show full descriptions
+- **Platform health probes** — admins can inspect core component health, expected versions, and AgentGateway/config-bridge readiness from the UI
+- **Admin scale improvements** — teams, members, and IdP-sync history are paginated, and OpenFGA drift can self-heal during normal admin operations
 
 ### Setup script overhaul (0.5.7)
 `setup-caipe.sh` grew several new capabilities:
@@ -171,7 +178,7 @@ Several security improvements shipped in 0.5 that are worth calling out:
 
 ## Is this a breaking upgrade from 0.4.x?
 
-**For most deployments: no.** If you are on 0.4.18 with a default `values.yaml`, this is a drop-in upgrade. Every new subchart (Keycloak, OpenFGA, Webex bot, AgentGateway) defaults to `enabled: false`. The RBAC stack is additive.
+**For most deployments: no.** If you are on 0.4.18 with a default `values.yaml`, this is a drop-in upgrade. Keycloak, OpenFGA, and the Webex bot remain opt-in. AgentGateway is enabled by default in CRD-free static routing mode, while JWT validation and OpenFGA ext_authz enforcement remain disabled unless configured. The RBAC stack is additive.
 
 The only behavioral change that may affect you:
 
@@ -185,15 +192,8 @@ The only behavioral change that may affect you:
 
 ## Upgrade
 
-```bash
-helm upgrade ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
-  --version 0.5.16 \
-  -f your-values.yaml
-```
-
-See the full series of [per-release upgrade guides](/blog/releases) for step-by-step instructions, Helm values diffs, and data migrations for each 0.5.x patch.
+Pick the current patch from the [releases page](/blog/releases) and use the Helm command in that release post. Each release post includes step-by-step upgrade notes, Helm values diffs, and data migrations when a patch needs them.
 
 ---
 
-*This post covers 0.5.0 through 0.5.16. The 0.5 series is actively maintained — check the [releases blog](/blog/releases) for the latest patches.*
+*This post covers the 0.5 series at a feature level. The 0.5 series is actively maintained — check the [releases blog](/blog/releases) for the latest patch-specific changes.*


### PR DESCRIPTION
## Summary

- Adds a new blog post at `docs/blog/2026-06-18-whats-new-in-0-5.md` summarizing the full 0.5.x series for end users upgrading from 0.4.x
- Covers the five most user-visible changes: enterprise RBAC/OpenFGA, Webex bot, fine-grained resource sharing, redesigned admin experience, and AgentGateway CRD-free routing
- Includes a concise breaking-changes table (3 items, most users unaffected) and a direct upgrade command

## What this post covers

- **Authorization** — OpenFGA ReBAC model, opt-in Keycloak, team-scoped access
- **Webex bot** — new first-class Webex integration with spaces, DMs, thread context
- **Slack improvements** — agent-per-channel routing, in-place agent swap, delete binding, slash-command prefix from APP_NAME
- **Fine-grained sharing** — agents, knowledge bases, skills, MCP tools all support team sharing
- **Admin UX redesign** — Okta directory sync, team cards with resource counts, searchable TeamPicker, RBAC migrations panel
- **AgentGateway** — CRD-free static routing, config-bridge sidecar, secret-backed backend auth
- **Dynamic agents** — owner team requirement, blocker hints, MCP URL normalization, LLM errors over SSE
- **UI quality of life** — responsive nav, compact header, screenshot in feedback dialog
- **Production hardening** — Keycloak strict-secrets gate, MongoDB password gate, SSRF block, HMAC-SHA256 catalog keys

## Test plan

- [ ] Verify Docusaurus renders the blog post at `/blog/whats-new-in-0-5`
- [ ] Check `<!-- truncate -->` produces the correct preview on the blog list page
- [ ] Confirm all internal links (`/blog/releases/release-0.5.0`, `/blog/releases`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)