### PR TITLE
fix(rbac): replace unsupported $facet in team members pagination for DocumentDB

### DIFF
--- a/ui/src/lib/rbac/__tests__/team-membership-store.test.ts
+++ b/ui/src/lib/rbac/__tests__/team-membership-store.test.ts
@@ -102,6 +102,7 @@ import {
   findUserRoleInTeam,
   isUserInTeam,
   loadActiveTeamMembers,
+  loadActiveTeamMembersPage,
   loadTeamMemberCounts,
   loadTeamMembersForSlugs,
 } from "../team-membership-store";
@@ -365,6 +366,49 @@ describe("isUserInTeam", () => {
 
   it("returns false otherwise", async () => {
     expect(await isUserInTeam("platform", { user_subject: "kc-Z" })).toBe(false);
+  });
+});
+
+describe("loadActiveTeamMembersPage — DocumentDB compatibility", () => {
+  // Amazon DocumentDB (our deploy target) does NOT support the $facet
+  // aggregation stage; using it fails at runtime with
+  // "Aggregation stage not supported: '$facet'". The page+count must be
+  // computed as two pipelines sharing a prefix instead. These tests pin that.
+  it("issues two aggregations (count + page) and never uses $facet", async () => {
+    await loadActiveTeamMembersPage("platform", { page: 2, pageSize: 10 });
+
+    // Two separate aggregate calls — one to count, one to fetch the page.
+    expect(collectionStub.aggregate).toHaveBeenCalledTimes(2);
+
+    const pipelines = collectionStub.aggregate.mock.calls.map((call) => call[0]);
+    for (const pipeline of pipelines) {
+      expect(pipeline.find((s: Record<string, unknown>) => "$facet" in s)).toBeUndefined();
+    }
+
+    // Exactly one pipeline counts; exactly one pages with $skip/$limit.
+    const countPipeline = pipelines.find((p) =>
+      p.some((s: Record<string, unknown>) => "$count" in s),
+    );
+    const pagePipeline = pipelines.find((p) =>
+      p.some((s: Record<string, unknown>) => "$limit" in s),
+    );
+    expect(countPipeline).toBeDefined();
+    expect(pagePipeline).toBeDefined();
+
+    const skipStage = pagePipeline!.find((s: Record<string, unknown>) => "$skip" in s);
+    const limitStage = pagePipeline!.find((s: Record<string, unknown>) => "$limit" in s);
+    expect(skipStage.$skip).toBe(10); // (page 2 - 1) * pageSize 10
+    expect(limitStage.$limit).toBe(10);
+  });
+
+  it("clamps page_size to [1,100] before building the $limit stage", async () => {
+    await loadActiveTeamMembersPage("platform", { page: 1, pageSize: 9999 });
+    const pipelines = collectionStub.aggregate.mock.calls.map((call) => call[0]);
+    const pagePipeline = pipelines.find((p) =>
+      p.some((s: Record<string, unknown>) => "$limit" in s),
+    );
+    const limitStage = pagePipeline!.find((s: Record<string, unknown>) => "$limit" in s);
+    expect(limitStage.$limit).toBe(100);
   });
 });
 

--- a/ui/src/lib/rbac/team-membership-store.ts
+++ b/ui/src/lib/rbac/team-membership-store.ts
@@ -317,39 +317,41 @@ export async function loadActiveTeamMembersPage(
     ? { $cond: [{ $eq: [{ $toLower: { $ifNull: ["$user_email", ""] } }, ownerEmail] }, 0, 1] }
     : 1;
 
-  const docs = await collection
-    .aggregate<{
-      total: { count: number }[];
-      rows: Array<{
+  // Run count and page as two pipelines sharing this prefix, NOT one $facet:
+  // $facet is unsupported on Amazon DocumentDB (our deploy target). The count
+  // runs over grouped identities, not the raw match, so members with multiple
+  // source rows are counted once.
+  const prefix: Record<string, unknown>[] = [
+    { $match: match },
+    groupStage,
+    { $match: { _id: { $ne: null } } },
+    { $addFields: { owner_rank: ownerRank, email_sort: { $toLower: { $ifNull: ["$user_email", ""] } } } },
+  ];
+
+  const [countDocs, rows] = await Promise.all([
+    collection
+      .aggregate<{ count: number }>([...prefix, { $count: "count" }])
+      .toArray(),
+    collection
+      .aggregate<{
         _id: string | null;
         user_subject?: string;
         user_email?: string;
         is_admin: number;
         source_types: TeamMembershipSource["source_type"][];
         added_at?: string;
-      }>;
-    }>([
-      { $match: match },
-      groupStage,
-      { $match: { _id: { $ne: null } } },
-      { $addFields: { owner_rank: ownerRank, email_sort: { $toLower: { $ifNull: ["$user_email", ""] } } } },
-      {
-        $facet: {
-          total: [{ $count: "count" }],
-          rows: [
-            { $sort: { owner_rank: 1, email_sort: 1, _id: 1 } },
-            { $skip: (page - 1) * pageSize },
-            { $limit: pageSize },
-          ],
-        },
-      },
-    ])
-    .toArray();
+      }>([
+        ...prefix,
+        { $sort: { owner_rank: 1, email_sort: 1, _id: 1 } },
+        { $skip: (page - 1) * pageSize },
+        { $limit: pageSize },
+      ])
+      .toArray(),
+  ]);
 
-  const facet = docs[0] ?? { total: [], rows: [] };
-  const total = facet.total[0]?.count ?? 0;
+  const total = countDocs[0]?.count ?? 0;
 
-  const members: TeamMemberPageRow[] = facet.rows.map((row) => {
+  const members: TeamMemberPageRow[] = rows.map((row) => {
     const sourceTypes = Array.isArray(row.source_types) ? row.source_types : [];
     const isOwner = Boolean(ownerEmail && (row.user_email ?? "").toLowerCase() === ownerEmail);
     return {


### PR DESCRIPTION
# Description

`GET /api/admin/teams/[id]/members` failed on our Amazon DocumentDB deploy with `Aggregation stage not supported: '$facet'`. `loadActiveTeamMembersPage` used a single `$facet` aggregation to compute the page rows and the total count in one round trip, but DocumentDB does not support `$facet`.

This replaces the `$facet` with two aggregations that share a common prefix (`$match` → dedupe `$group` → drop-null `$match` → `$addFields` sort keys), run concurrently via `Promise.all`:
- one ends in `$count` for the distinct-identity total
- one ends in `$sort`/`$skip`/`$limit` for the requested page

The count is computed over the **grouped** identities (post-dedupe), so members with multiple source rows (e.g. manual + Okta) are still counted once — matching the previous `$facet` behavior. No change to the returned shape, sort order, or pagination semantics.

The repo already bans `$facet` (and sub-pipeline `$lookup`) in the audit-logs and dynamic-agents conversation routes for the same DocumentDB reason; this brings the team-members pager in line.

Added unit tests in `team-membership-store.test.ts` that exercise the real `loadActiveTeamMembersPage` and assert: two aggregations are issued, neither pipeline contains `$facet`, the count/page split is correct, and `page_size` clamping flows into `$limit`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass