### PR TITLE
fix(helm): keep MCP servers while disabling A2A agents

### DIFF
--- a/charts/ai-platform-engineering/charts/agent/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/agent/templates/_helpers.tpl
@@ -266,6 +266,20 @@ Get agentSecrets.externalSecrets.name - if empty assume no secret, if not append
 {{- end -}}
 
 {{/*
+Determine whether to render the A2A agent Deployment and Service.
+Per-agent .Values.a2a.enabled overrides global.a2aAgents.enabled.
+*/}}
+{{- define "agent.a2a.enabled" -}}
+    {{- if and (hasKey .Values "a2a") (hasKey .Values.a2a "enabled") -}}
+        {{- .Values.a2a.enabled -}}
+    {{- else if and (hasKey .Values "global") (hasKey .Values.global "a2aAgents") (hasKey .Values.global.a2aAgents "enabled") -}}
+        {{- .Values.global.a2aAgents.enabled -}}
+    {{- else -}}
+        {{- true -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
 Determine MCP mode
 */}}
 {{- define "agent.createMcpHttpServer" -}}
@@ -387,4 +401,3 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $repository -}}
 {{- end -}}
 {{- end -}}
-

--- a/charts/ai-platform-engineering/charts/agent/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or (ne .Values.global.deploymentMode "single-node") .Values.remoteAgent }}
+{{- if and (include "agent.a2a.enabled" . | eq "true") (or (ne .Values.global.deploymentMode "single-node") .Values.remoteAgent) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/ai-platform-engineering/charts/agent/templates/service.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (ne .Values.global.deploymentMode "single-node") .Values.remoteAgent }}
+{{- if and (include "agent.a2a.enabled" . | eq "true") (or (ne .Values.global.deploymentMode "single-node") .Values.remoteAgent) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/ai-platform-engineering/charts/agent/templates/vpa.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/vpa.yaml
@@ -6,7 +6,7 @@
 */ -}}
 {{- $globalVpa := dig "vpa" dict .Values.global }}
 {{- $vpaEnabled := or .Values.vpa.enabled (and $globalVpa $globalVpa.enabled) }}
-{{- if and $vpaEnabled (or (ne .Values.global.deploymentMode "single-node") .Values.remoteAgent) }}
+{{- if and $vpaEnabled (include "agent.a2a.enabled" . | eq "true") (or (ne .Values.global.deploymentMode "single-node") .Values.remoteAgent) }}
 {{- if .Values.autoscaling.enabled }}
 {{- fail "vpa.enabled and autoscaling.enabled cannot both be true - VPA conflicts with HPA on both CPU-based and memory-based scaling" }}
 {{- end }}

--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -114,7 +114,7 @@ Get llmSecrets.externalSecrets.secretStoreRef with global fallback
 {{/*
 Returns the enabledSubAgents dict as YAML.
 In single-node mode reads from supervisor-agent.singleNode.enabledSubAgents.
-In multi-node mode reads from global.enabledSubAgents (populated by Chart.yaml import-values e.g. global.enabledSubAgents.backstage.enabled: true).
+In multi-node mode reads from global.enabledSubAgents for non-A2A exports such as RAG.
 */}}
 {{- define "ai-platform-engineering.enabledSubAgents" -}}
 {{- if eq .Values.global.deploymentMode "single-node" -}}

--- a/charts/ai-platform-engineering/templates/multi-node-supervisor-agent-env.yaml
+++ b/charts/ai-platform-engineering/templates/multi-node-supervisor-agent-env.yaml
@@ -8,10 +8,28 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-supervisor-agent-env" .Release.Name }}
 data:
-  DISTRIBUTED_AGENTS: "all"
   {{- $port := (index .Values "supervisor-agent" "multiAgentConfig" "port" | default "8000") -}}
+  {{- $a2aAgents := list "argocd" "aws" "backstage" "confluence" "github" "gitlab" "jira" "komodor" "pagerduty" "slack" "splunk" "victorops" "webex" "netutils" "weather" "petstore" -}}
+  {{- $globalA2aEnabled := dig "a2aAgents" "enabled" true .Values.global -}}
+  {{- $distributedAgents := list -}}
   {{- range $name, $enabled := (default dict .Values.global.enabledSubAgents) }}
-  {{- if $enabled }}
+  {{- $agentValues := index $.Values (printf "agent-%s" $name) | default dict -}}
+  {{- $agentA2aEnabled := $globalA2aEnabled -}}
+  {{- if and (hasKey $agentValues "a2a") (hasKey $agentValues.a2a "enabled") -}}
+  {{- $agentA2aEnabled = $agentValues.a2a.enabled -}}
+  {{- end -}}
+  {{- if and $enabled $agentA2aEnabled (has $name $a2aAgents) }}
+  {{- $distributedAgents = append $distributedAgents $name -}}
+  {{- end }}
+  {{- end }}
+  DISTRIBUTED_AGENTS: {{ join "," $distributedAgents | quote }}
+  {{- range $name, $enabled := (default dict .Values.global.enabledSubAgents) }}
+  {{- $agentValues := index $.Values (printf "agent-%s" $name) | default dict -}}
+  {{- $agentA2aEnabled := $globalA2aEnabled -}}
+  {{- if and (hasKey $agentValues "a2a") (hasKey $agentValues.a2a "enabled") -}}
+  {{- $agentA2aEnabled = $agentValues.a2a.enabled -}}
+  {{- end -}}
+  {{- if and $enabled $agentA2aEnabled (has $name $a2aAgents) }}
   {{- $ENV := upper $name }}
   {{ $ENV }}_AGENT_HOST: {{ printf "%s-agent-%s" $.Release.Name $name | quote }}
   {{ $ENV }}_AGENT_PORT: {{ printf "%v" $port | quote }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -40,6 +40,10 @@ global:
 
   # Deployment mode: "single-node" (all agents in-process) or "multi-node" (each agent as a separate pod)
   deploymentMode: "multi-node"
+  a2aAgents:
+    # Keep bundled A2A agent pods disabled by default while still allowing
+    # their MCP servers to install via broad tags such as complete.
+    enabled: false
 
   # When deploymentMode is single-node, in-cluster MCP Services/Deployments/SAs use
   # {mcpResourcePrefix}-agent-<name>-mcp. Leave mcpResourcePrefix unset (empty) to use the

--- a/scripts/validate-helm-image-channel.py
+++ b/scripts/validate-helm-image-channel.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 PARENT_EXPECTED_IMAGE_NAMES = (
     "ai-platform-engineering",
-    "agent-argocd",
     "mcp-argocd",
     "caipe-ui",
     "caipe-dynamic-agents",
@@ -26,6 +25,10 @@ PARENT_EXPECTED_IMAGE_NAMES = (
     "keycloak-init",
     "openfga-authz-bridge",
     "skill-scanner",
+)
+
+A2A_AGENT_EXPECTED_IMAGE_NAMES = (
+    "agent-argocd",
 )
 
 RAG_EXPECTED_IMAGE_NAMES = (
@@ -60,6 +63,12 @@ PARENT_HELM_ARGS = (
     "openfga-authz-bridge.tokenValidation.audiences[0]=agentgateway",
 )
 
+A2A_AGENT_HELM_ARGS = (
+    *PARENT_HELM_ARGS,
+    "--set",
+    "agent-argocd.a2a.enabled=true",
+)
+
 RAG_SUBCHART_HELM_ARGS = (
     "--set",
     "global.vpa.enabled=false",
@@ -85,6 +94,27 @@ def render_chart(chart: Path, helm_args: tuple[str, ...], *extra_args: str) -> s
         stderr=subprocess.PIPE,
     )
     return result.stdout
+
+
+def chart_app_version(chart: Path) -> str:
+    chart_yaml = chart / "Chart.yaml"
+    for line in chart_yaml.read_text().splitlines():
+        if line.startswith("appVersion:"):
+            return line.split(":", 1)[1].split("#", 1)[0].strip().strip('"')
+    raise ValueError(f"appVersion not found in {chart_yaml}")
+
+
+def default_image_prefix(chart: Path) -> str:
+    app_version = chart_app_version(chart)
+    if re.search(r"(?:^|[-.])(dev|rc|hotfix)(?:[-.]|$)", app_version):
+        return "ghcr.io/cnoe-io/pre-release"
+    return "ghcr.io/cnoe-io"
+
+
+def opposite_image_prefix(prefix: str) -> str:
+    if prefix == "ghcr.io/cnoe-io":
+        return "ghcr.io/cnoe-io/pre-release"
+    return "ghcr.io/cnoe-io"
 
 
 def rendered_images(manifest: str) -> set[str]:
@@ -142,32 +172,49 @@ def main() -> int:
     args = parser.parse_args()
 
     default_images = rendered_images(render_chart(args.chart, PARENT_HELM_ARGS))
+    default_a2a_images = rendered_images(render_chart(args.chart, A2A_AGENT_HELM_ARGS))
     auto_images = rendered_images(
         render_chart(args.chart, PARENT_HELM_ARGS, "--set", "global.image.channel=auto")
+    )
+    auto_a2a_images = rendered_images(
+        render_chart(args.chart, A2A_AGENT_HELM_ARGS, "--set", "global.image.channel=auto")
     )
     release_images = rendered_images(
         render_chart(args.chart, PARENT_HELM_ARGS, "--set", "global.image.channel=release")
     )
+    release_a2a_images = rendered_images(
+        render_chart(args.chart, A2A_AGENT_HELM_ARGS, "--set", "global.image.channel=release")
+    )
     default_rag_images = render_rag_subcharts(args.rag_chart)
     auto_rag_images = render_rag_subcharts(args.rag_chart, "--set", "global.image.channel=auto")
     release_rag_images = render_rag_subcharts(args.rag_chart, "--set", "global.image.channel=release")
+    default_prefix = default_image_prefix(args.chart)
+    forbidden_default_prefix = opposite_image_prefix(default_prefix)
 
     missing_default = require_images(
         default_images,
-        "ghcr.io/cnoe-io/pre-release",
+        default_prefix,
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + require_images(
+        default_a2a_images,
+        default_prefix,
+        A2A_AGENT_EXPECTED_IMAGE_NAMES,
+    ) + require_images(
         default_rag_images,
-        "ghcr.io/cnoe-io/pre-release",
+        default_prefix,
         RAG_EXPECTED_IMAGE_NAMES,
     )
     missing_auto = require_images(
         auto_images,
-        "ghcr.io/cnoe-io/pre-release",
+        default_prefix,
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + require_images(
+        auto_a2a_images,
+        default_prefix,
+        A2A_AGENT_EXPECTED_IMAGE_NAMES,
+    ) + require_images(
         auto_rag_images,
-        "ghcr.io/cnoe-io/pre-release",
+        default_prefix,
         RAG_EXPECTED_IMAGE_NAMES,
     )
     missing_release = require_images(
@@ -175,32 +222,48 @@ def main() -> int:
         "ghcr.io/cnoe-io",
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + require_images(
+        release_a2a_images,
+        "ghcr.io/cnoe-io",
+        A2A_AGENT_EXPECTED_IMAGE_NAMES,
+    ) + require_images(
         release_rag_images,
         "ghcr.io/cnoe-io",
         RAG_EXPECTED_IMAGE_NAMES,
     )
     forbidden_default = forbid_images(
         default_images,
-        "ghcr.io/cnoe-io",
+        forbidden_default_prefix,
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + forbid_images(
+        default_a2a_images,
+        forbidden_default_prefix,
+        A2A_AGENT_EXPECTED_IMAGE_NAMES,
+    ) + forbid_images(
         default_rag_images,
-        "ghcr.io/cnoe-io",
+        forbidden_default_prefix,
         RAG_EXPECTED_IMAGE_NAMES,
     )
     forbidden_auto = forbid_images(
         auto_images,
-        "ghcr.io/cnoe-io",
+        forbidden_default_prefix,
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + forbid_images(
+        auto_a2a_images,
+        forbidden_default_prefix,
+        A2A_AGENT_EXPECTED_IMAGE_NAMES,
+    ) + forbid_images(
         auto_rag_images,
-        "ghcr.io/cnoe-io",
+        forbidden_default_prefix,
         RAG_EXPECTED_IMAGE_NAMES,
     )
     forbidden_release = forbid_images(
         release_images,
         "ghcr.io/cnoe-io/pre-release",
         PARENT_EXPECTED_IMAGE_NAMES,
+    ) + forbid_images(
+        release_a2a_images,
+        "ghcr.io/cnoe-io/pre-release",
+        A2A_AGENT_EXPECTED_IMAGE_NAMES,
     ) + forbid_images(
         release_rag_images,
         "ghcr.io/cnoe-io/pre-release",
@@ -216,19 +279,19 @@ def main() -> int:
         or forbidden_release
     ):
         if missing_default:
-            print("Missing default pre-release images:", file=sys.stderr)
+            print("Missing default-channel images:", file=sys.stderr)
             print("\n".join(f"  - {image}" for image in missing_default), file=sys.stderr)
         if missing_auto:
-            print("Missing auto-channel pre-release images:", file=sys.stderr)
+            print("Missing auto-channel images:", file=sys.stderr)
             print("\n".join(f"  - {image}" for image in missing_auto), file=sys.stderr)
         if missing_release:
             print("Missing release-channel images:", file=sys.stderr)
             print("\n".join(f"  - {image}" for image in missing_release), file=sys.stderr)
         if forbidden_default:
-            print("Default channel rendered release images:", file=sys.stderr)
+            print("Default channel rendered wrong-channel images:", file=sys.stderr)
             print("\n".join(f"  - {image}" for image in forbidden_default), file=sys.stderr)
         if forbidden_auto:
-            print("Auto channel rendered release images:", file=sys.stderr)
+            print("Auto channel rendered wrong-channel images:", file=sys.stderr)
             print("\n".join(f"  - {image}" for image in forbidden_auto), file=sys.stderr)
         if forbidden_release:
             print("Release channel rendered pre-release images:", file=sys.stderr)


### PR DESCRIPTION
## Summary

- keep bundled MCP server Deployments/Services available through existing broad tags such as `complete`
- add an A2A-only render gate so bundled A2A agent pods stay disabled by default
- wire supervisor remote-agent env only when the corresponding A2A agent is explicitly enabled
- update the Helm image-channel validator for MCP-only broad tags and explicit A2A opt-in renders

## Why

Broad Helm installs still need MCP servers for dynamic agents and AgentGateway routing, but they should not start first-party A2A agent pods by default. This separates MCP server availability from A2A agent pod startup while preserving explicit opt-in for legacy/full A2A agent installs.

## Behavior

- `--set tags.complete=true` renders MCP servers such as `agent-jira-mcp`, but not `agent-jira` A2A pods.
- `--set tags.agent-jira=true` renders only the JIRA MCP server by default.
- `--set tags.agent-jira=true --set agent-jira.a2a.enabled=true` renders both the JIRA MCP server and JIRA A2A agent, and wires supervisor env for JIRA.

## Validation

- `python3 scripts/validate-helm-image-channel.py`
- `helm lint charts/ai-platform-engineering`
- `helm template test charts/ai-platform-engineering --set tags.complete=true | rg -n "DISTRIBUTED_AGENTS|ghcr.io/cnoe-io/agent-jira|ghcr.io/cnoe-io/mcp-jira|name: test-agent-jira-mcp|ENABLE_JIRA|JIRA_AGENT_HOST"`
- `helm template test charts/ai-platform-engineering --set tags.agent-jira=true | rg -n "DISTRIBUTED_AGENTS|ghcr.io/cnoe-io/agent-jira|ghcr.io/cnoe-io/mcp-jira|name: test-agent-jira-mcp|ENABLE_JIRA|JIRA_AGENT_HOST"`
- `helm template test charts/ai-platform-engineering --set tags.agent-jira=true --set agent-jira.a2a.enabled=true | rg -n "DISTRIBUTED_AGENTS|ghcr.io/cnoe-io/agent-jira|ghcr.io/cnoe-io/mcp-jira|name: test-agent-jira-mcp|ENABLE_JIRA|JIRA_AGENT_HOST"`
