### PR TITLE
fix(mcp): promote custom servers to agentgateway routes

### DIFF
--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -132,6 +132,11 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
     endpoint: string;
     enabled: boolean;
     config_driven: boolean;
+    source?: "manual" | "config" | "agentgateway";
+    agentgateway_discovered?: boolean;
+    agentgateway_endpoint?: string;
+    agentgateway_target_endpoint?: string;
+    credential_sources?: unknown[];
   };
   let servers: BrowserMcpServer[] = [];
 
@@ -167,18 +172,41 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
             typeof body.id === "string" && body.id.startsWith("mcp-")
               ? body.id
               : `mcp-${String(body.id ?? "ops-tools")}`;
+          const routeThroughAgentGateway = body.route_through_agentgateway === true;
+          const upstreamEndpoint = String(
+            body.agentgateway_target_endpoint ?? body.endpoint ?? "",
+          );
+          const gatewayEndpoint = `http://agentgateway:4000/mcp/${serverId}`;
           servers = [
             {
               _id: serverId,
               name: String(body.name ?? "Ops Tools"),
               description: String(body.description ?? ""),
               transport: String(body.transport ?? "sse"),
-              endpoint: String(body.endpoint ?? ""),
+              endpoint: routeThroughAgentGateway ? gatewayEndpoint : String(body.endpoint ?? ""),
               enabled: true,
               config_driven: false,
+              ...(routeThroughAgentGateway
+                ? {
+                    source: "agentgateway" as const,
+                    agentgateway_discovered: true,
+                    agentgateway_endpoint: gatewayEndpoint,
+                    agentgateway_target_endpoint: upstreamEndpoint,
+                  }
+                : {}),
+              ...(Array.isArray(body.credential_sources)
+                ? { credential_sources: body.credential_sources }
+                : {}),
             },
           ];
           await fulfillJson(route, { success: true, data: servers[0] }, 201);
+          return true;
+        }
+
+        if (path === "/api/mcp-servers" && method === "DELETE") {
+          const id = new URL(route.request().url()).searchParams.get("id");
+          servers = servers.filter((server) => server._id !== id);
+          await fulfillJson(route, { success: true, data: { deleted: id } });
           return true;
         }
 
@@ -414,6 +442,71 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect(page.getByText("Ops Tools")).toBeVisible();
     await expect.poll(() => mocks.listRequests).toBeGreaterThanOrEqual(2);
     await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
+  });
+
+  test("custom HTTP MCP servers can be routed through AgentGateway and remain user-managed", async ({ page }) => {
+    const mocks = await installMcpServerMocks(page);
+
+    await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("No MCP Servers Yet")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add Server" }).first().click();
+    await expect(page.getByText("Add MCP Server")).toBeVisible();
+
+    await page.getByLabel(/Server ID/i).fill("gateway-tools");
+    await page.getByLabel(/Display Name/i).fill("Gateway Tools");
+    await page.getByRole("button", { name: /HTTP/i }).click();
+    await page.getByLabel(/Endpoint URL/i).fill("https://mcp.example.test/gateway/mcp");
+    await page.getByLabel(/Route through AgentGateway/i).check();
+    await page.getByRole("button", { name: /Add Credential/i }).click();
+    await page.getByLabel(/Credential name/i).fill("X-API-TOKEN");
+    await page.getByLabel(/Credential reference/i).fill("secret-ref-playwright");
+
+    await page.getByRole("button", { name: "Create Server" }).click();
+
+    await expect.poll(() => mocks.createRequests.length).toBe(1);
+    expect(mocks.createRequests[0]).toMatchObject({
+      id: "gateway-tools",
+      name: "Gateway Tools",
+      transport: "http",
+      endpoint: "https://mcp.example.test/gateway/mcp",
+      route_through_agentgateway: true,
+      agentgateway_target_endpoint: "https://mcp.example.test/gateway/mcp",
+      credential_sources: [
+        {
+          kind: "secret_ref",
+          target: "header",
+          name: "X-API-TOKEN",
+          secret_ref: "secret-ref-playwright",
+        },
+      ],
+    });
+
+    await expect(page.getByText("Gateway Tools")).toBeVisible();
+    await expect(page.getByText("mcp-gateway-tools", { exact: true })).toBeVisible();
+    await expect(page.getByTitle("Registered from AgentGateway discovery")).toBeVisible();
+    await expect(page.getByText(/Target: https:\/\/mcp\.example\.test\/gateway\/mcp/i)).toBeVisible();
+
+    const gatewayRow = page
+      .locator(".grid")
+      .filter({ hasText: "Gateway Tools" })
+      .filter({ hasText: "mcp-gateway-tools" })
+      .first();
+    await expect(gatewayRow.getByRole("button", { name: /Probe for tools/i })).toBeVisible();
+    await expect(gatewayRow.getByRole("button", { name: /Export as YAML/i })).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.accept());
+    const [deleteResponse] = await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === "DELETE" &&
+          new URL(response.url()).pathname === "/api/mcp-servers" &&
+          new URL(response.url()).searchParams.get("id") === "mcp-gateway-tools",
+      ),
+      gatewayRow.getByRole("button").last().click(),
+    ]);
+    expect(deleteResponse.status()).toBe(200);
+    await expect(page.getByText("Gateway Tools")).toHaveCount(0);
   });
 
   test("mounted MCP server list refreshes when servers change outside the tab", async ({ page }) => {

--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -541,7 +541,9 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
 
     await expect(page.getByText("knowledge-base", { exact: true })).toBeVisible();
     await expect(page.getByText("mcp-knowledge-base")).toBeVisible();
-    await expect(page.getByTitle("Registered from AgentGateway discovery")).toBeVisible();
+    await expect(
+      page.getByTitle("Routed through AgentGateway; the bridge reconciles a /mcp/<server-id> route for this server"),
+    ).toBeVisible();
     await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
   });
 

--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -484,7 +484,9 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
 
     await expect(page.getByText("Gateway Tools")).toBeVisible();
     await expect(page.getByText("mcp-gateway-tools", { exact: true })).toBeVisible();
-    await expect(page.getByTitle("Registered from AgentGateway discovery")).toBeVisible();
+    await expect(
+      page.getByTitle("Routed through AgentGateway; the bridge reconciles a /mcp/<server-id> route for this server"),
+    ).toBeVisible();
     await expect(page.getByText(/Target: https:\/\/mcp\.example\.test\/gateway\/mcp/i)).toBeVisible();
 
     const gatewayRow = page

--- a/ui/src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts
+++ b/ui/src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts
@@ -172,6 +172,55 @@ describe("POST /api/mcp-servers — endpoint normalisation", () => {
     expect(persisted.endpoint).toBe("https://mcp.example.com/mcp");
   });
 
+  it("promotes a custom HTTP server to an AgentGateway-managed route on create", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockInsertOne.mockResolvedValue({ acknowledged: true });
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          id: "custom-thing",
+          name: "Custom Thing",
+          transport: "http",
+          endpoint: "https://mcp.example.com/mcp",
+          route_through_agentgateway: true,
+          credential_sources: [
+            {
+              kind: "secret_ref",
+              target: "header",
+              name: "X-API-TOKEN",
+              secret_ref: "secret-ref-id",
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const persisted = mockInsertOne.mock.calls[0][0];
+    expect(persisted).toEqual(
+      expect.objectContaining({
+        _id: "mcp-custom-thing",
+        endpoint: "http://agentgateway:4000/mcp/mcp-custom-thing",
+        source: "agentgateway",
+        agentgateway_discovered: true,
+        agentgateway_endpoint: "http://agentgateway:4000/mcp/mcp-custom-thing",
+        agentgateway_target_endpoint: "https://mcp.example.com/mcp",
+        config_driven: false,
+        credential_sources: [
+          {
+            kind: "secret_ref",
+            target: "header",
+            name: "X-API-TOKEN",
+            secret_ref: "secret-ref-id",
+          },
+        ],
+      }),
+    );
+  });
+
   it("keeps a correctly-qualified gateway endpoint untouched on create", async () => {
     mockFindOne.mockResolvedValue(null);
     mockInsertOne.mockResolvedValue({ acknowledged: true });
@@ -294,5 +343,93 @@ describe("PUT /api/mcp-servers?id=<id> — endpoint normalisation", () => {
     expect(updatePayload.$set.endpoint).toBe(
       "http://agentgateway:4000/mcp/mcp-confluence",
     );
+  });
+
+  it("promotes a manual server to an AgentGateway-managed route on update", async () => {
+    const existing = {
+      _id: "mcp-custom-thing",
+      name: "Custom Thing",
+      transport: "http",
+      endpoint: "https://mcp.example.com/mcp",
+      config_driven: false,
+    };
+    mockFindOne.mockResolvedValue(existing);
+    mockFindOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      ...existing,
+      ...(update as { $set: Record<string, unknown> }).$set,
+    }));
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=mcp-custom-thing", {
+        method: "PUT",
+        body: JSON.stringify({
+          endpoint: "https://mcp.example.com/mcp",
+          route_through_agentgateway: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const updatePayload = mockFindOneAndUpdate.mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(updatePayload.$set).toEqual(
+      expect.objectContaining({
+        endpoint: "http://agentgateway:4000/mcp/mcp-custom-thing",
+        source: "agentgateway",
+        agentgateway_discovered: true,
+        agentgateway_endpoint: "http://agentgateway:4000/mcp/mcp-custom-thing",
+        agentgateway_target_endpoint: "https://mcp.example.com/mcp",
+        config_driven: false,
+      }),
+    );
+  });
+
+  it("detaches a user-owned AgentGateway route without making the row config-driven", async () => {
+    const existing = {
+      _id: "mcp-custom-thing",
+      name: "Custom Thing",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp/mcp-custom-thing",
+      source: "agentgateway",
+      agentgateway_discovered: true,
+      agentgateway_target_endpoint: "https://mcp.example.com/mcp",
+      config_driven: false,
+    };
+    mockFindOne.mockResolvedValue(existing);
+    mockFindOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      ...existing,
+      ...(update as { $set: Record<string, unknown> }).$set,
+    }));
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=mcp-custom-thing", {
+        method: "PUT",
+        body: JSON.stringify({
+          endpoint: "https://mcp.example.com/mcp",
+          route_through_agentgateway: false,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const updatePayload = mockFindOneAndUpdate.mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+      $unset: Record<string, "">;
+    };
+    expect(updatePayload.$set).toEqual(
+      expect.objectContaining({
+        endpoint: "https://mcp.example.com/mcp",
+        source: "manual",
+        agentgateway_discovered: false,
+        config_driven: false,
+      }),
+    );
+    expect(updatePayload.$unset).toEqual({
+      agentgateway_endpoint: "",
+      agentgateway_target_endpoint: "",
+    });
   });
 });

--- a/ui/src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts
+++ b/ui/src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts
@@ -221,6 +221,48 @@ describe("POST /api/mcp-servers — endpoint normalisation", () => {
     );
   });
 
+  it("rejects AgentGateway routing for non-HTTP transports on create", async () => {
+    mockFindOne.mockResolvedValue(null);
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          id: "custom-sse",
+          name: "Custom SSE",
+          transport: "sse",
+          endpoint: "https://mcp.example.com/sse",
+          route_through_agentgateway: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  it("rejects AgentGateway itself as the routed upstream on create", async () => {
+    mockFindOne.mockResolvedValue(null);
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          id: "loop",
+          name: "Loop",
+          transport: "http",
+          endpoint: "http://agentgateway:4000/mcp",
+          route_through_agentgateway: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
   it("keeps a correctly-qualified gateway endpoint untouched on create", async () => {
     mockFindOne.mockResolvedValue(null);
     mockInsertOne.mockResolvedValue({ acknowledged: true });
@@ -384,6 +426,31 @@ describe("PUT /api/mcp-servers?id=<id> — endpoint normalisation", () => {
         config_driven: false,
       }),
     );
+  });
+
+  it("rejects AgentGateway routing for non-HTTP transports on update", async () => {
+    const existing = {
+      _id: "mcp-custom-sse",
+      name: "Custom SSE",
+      transport: "sse",
+      endpoint: "https://mcp.example.com/sse",
+      config_driven: false,
+    };
+    mockFindOne.mockResolvedValue(existing);
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=mcp-custom-sse", {
+        method: "PUT",
+        body: JSON.stringify({
+          endpoint: "https://mcp.example.com/sse",
+          route_through_agentgateway: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
   });
 
   it("detaches a user-owned AgentGateway route without making the row config-driven", async () => {

--- a/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
@@ -121,6 +121,13 @@ describe("AgentGateway MCP server discovery API", () => {
   it("auto-imports new AgentGateway MCP targets and migrates legacy direct registrations", async () => {
     const insertOne = jest.fn();
     const updateOne = jest.fn();
+    const findOne = jest.fn().mockResolvedValue({
+      _id: "jira",
+      name: "Jira",
+      transport: "http",
+      endpoint: "http://mcp-jira:8000/mcp",
+      enabled: true,
+    });
     mockGetCollection.mockResolvedValue({
       find: jest.fn().mockReturnValue({
         toArray: jest.fn().mockResolvedValue([
@@ -135,6 +142,7 @@ describe("AgentGateway MCP server discovery API", () => {
       }),
       insertOne,
       updateOne,
+      findOne,
     });
     const { POST } = await import("../sync/route");
 
@@ -202,6 +210,61 @@ describe("AgentGateway MCP server discovery API", () => {
       conflicts: [],
       migration_warnings: [],
     });
+  });
+
+  it("preserves existing credential sources when migrating a legacy direct registration", async () => {
+    const insertOne = jest.fn();
+    const updateOne = jest.fn();
+    const existingCredentialSources = [
+      {
+        kind: "secret_ref",
+        target: "header",
+        name: "Authorization",
+        secret_ref: "jira-existing-token",
+      },
+    ];
+    mockGetCollection.mockResolvedValue({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          {
+            _id: "jira",
+            name: "Jira",
+            transport: "http",
+            endpoint: "http://mcp-jira:8000/mcp",
+            enabled: true,
+            credential_sources: existingCredentialSources,
+          },
+        ]),
+      }),
+      insertOne,
+      updateOne,
+      findOne: jest.fn().mockResolvedValue({
+        _id: "jira",
+        credential_sources: existingCredentialSources,
+      }),
+    });
+    const { POST } = await import("../sync/route");
+
+    const response = await POST(
+      request("/api/mcp-servers/agentgateway/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: ["jira"] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "jira" },
+      {
+        $set: expect.objectContaining({
+          source: "agentgateway",
+          agentgateway_target_endpoint: "http://mcp-jira:8000/mcp",
+          credential_sources: existingCredentialSources,
+        }),
+      },
+    );
+    expect(insertOne).not.toHaveBeenCalled();
   });
 
   it("repairs OpenFGA grants for existing AgentGateway-managed MCP servers during sync", async () => {

--- a/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
@@ -73,6 +73,11 @@ export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
     });
     const doc = toAgentGatewayMcpServerDocument(target);
     if (target.status === "legacy") {
+      const existing = await collection.findOne({ _id: target.id } as never);
+      const existingCredentialSources = existing?.credential_sources;
+      if (Array.isArray(existingCredentialSources) && existingCredentialSources.length > 0) {
+        doc.credential_sources = existingCredentialSources;
+      }
       await collection.updateOne({ _id: target.id } as never, { $set: doc } as never);
       migrated.push(target.id);
     } else {

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -15,7 +15,10 @@ withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection } from "@/lib/mongodb";
 import { agentGatewayMcpEndpointUrl } from "@/lib/rbac/agentgateway-mcp-discovery";
-import { normalizeMcpEndpointForServer } from "@/lib/rbac/mcp-endpoint-normalizer";
+import {
+isAgentGatewayBaseEndpoint,
+normalizeMcpEndpointForServer,
+} from "@/lib/rbac/mcp-endpoint-normalizer";
 import { caipeOrgKey } from "@/lib/rbac/organization";
 import {
 deleteAllMcpServerRelationshipTuples,
@@ -107,14 +110,28 @@ function agentGatewayEndpointForServer(serverId: string): string {
 }
 
 function wantsAgentGatewayRouting(body: Record<string, unknown>): boolean {
-  return body.route_through_agentgateway === true || normalizeString(body.agentgateway_target_endpoint) !== null;
+  return (
+    body.route_through_agentgateway === true ||
+    (body.route_through_agentgateway !== false &&
+      normalizeString(body.agentgateway_target_endpoint) !== null)
+  );
 }
 
 function agentGatewayFieldsForServer(
   body: Record<string, unknown>,
   serverId: string,
+  transport: TransportType | undefined,
 ): Record<string, unknown> | null {
+  if (
+    body.route_through_agentgateway !== undefined &&
+    typeof body.route_through_agentgateway !== "boolean"
+  ) {
+    throw new ApiError("'route_through_agentgateway' must be a boolean", 400);
+  }
   if (!wantsAgentGatewayRouting(body)) return null;
+  if (transport !== "http") {
+    throw new ApiError("AgentGateway routing is only supported for HTTP MCP servers", 400);
+  }
 
   const targetEndpoint =
     normalizeString(body.agentgateway_target_endpoint) ??
@@ -122,6 +139,12 @@ function agentGatewayFieldsForServer(
   if (!targetEndpoint) {
     throw new ApiError(
       "'agentgateway_target_endpoint' or 'endpoint' is required when routing through AgentGateway",
+      400,
+    );
+  }
+  if (isAgentGatewayBaseEndpoint(targetEndpoint, agentGatewayBaseForNormalizer())) {
+    throw new ApiError(
+      "AgentGateway-routed MCP servers must use the upstream MCP endpoint, not the AgentGateway base URL",
       400,
     );
   }
@@ -277,7 +300,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       serverId,
       agentGatewayBaseUrl: agentGatewayBaseForNormalizer(),
     });
-    const agentGatewayFields = agentGatewayFieldsForServer(body, serverId);
+    const agentGatewayFields = agentGatewayFieldsForServer(
+      body,
+      serverId,
+      body.transport as TransportType,
+    );
 
     // Build document with explicit field allowlist (Security VII)
     const now = new Date();
@@ -386,7 +413,8 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       });
     }
 
-    const agentGatewayFields = agentGatewayFieldsForServer(body, String(id));
+    const effectiveTransport = (body.transport as TransportType | undefined) ?? server.transport;
+    const agentGatewayFields = agentGatewayFieldsForServer(body, String(id), effectiveTransport);
     if (agentGatewayFields) {
       Object.assign(updateData, agentGatewayFields);
     } else if (body.route_through_agentgateway === false) {

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -102,6 +102,40 @@ function agentGatewayBaseForNormalizer(): string {
   return withMcp.replace(/\/mcp$/, "");
 }
 
+function agentGatewayEndpointForServer(serverId: string): string {
+  return agentGatewayMcpEndpointUrl(`/mcp/${serverId}`);
+}
+
+function wantsAgentGatewayRouting(body: Record<string, unknown>): boolean {
+  return body.route_through_agentgateway === true || normalizeString(body.agentgateway_target_endpoint) !== null;
+}
+
+function agentGatewayFieldsForServer(
+  body: Record<string, unknown>,
+  serverId: string,
+): Record<string, unknown> | null {
+  if (!wantsAgentGatewayRouting(body)) return null;
+
+  const targetEndpoint =
+    normalizeString(body.agentgateway_target_endpoint) ??
+    normalizeString(body.endpoint);
+  if (!targetEndpoint) {
+    throw new ApiError(
+      "'agentgateway_target_endpoint' or 'endpoint' is required when routing through AgentGateway",
+      400,
+    );
+  }
+
+  return {
+    endpoint: agentGatewayEndpointForServer(serverId),
+    source: "agentgateway",
+    agentgateway_discovered: true,
+    agentgateway_endpoint: agentGatewayEndpointForServer(serverId),
+    agentgateway_target_endpoint: targetEndpoint,
+    config_driven: false,
+  };
+}
+
 /**
  * Validate transport-specific required fields.
  *
@@ -228,7 +262,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     validateTransportConfig(
       body.transport as TransportType,
       body.command as string | undefined,
-      body.endpoint as string | undefined,
+      (body.endpoint as string | undefined) ??
+        (body.agentgateway_target_endpoint as string | undefined),
     );
 
     // Normalise AgentGateway endpoints. If the admin (or the editor)
@@ -242,6 +277,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       serverId,
       agentGatewayBaseUrl: agentGatewayBaseForNormalizer(),
     });
+    const agentGatewayFields = agentGatewayFieldsForServer(body, serverId);
 
     // Build document with explicit field allowlist (Security VII)
     const now = new Date();
@@ -263,6 +299,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       config_driven: false,
       created_at: now.toISOString(),
       updated_at: now.toISOString(),
+      ...agentGatewayFields,
     };
 
     const ownerSubjectKind =
@@ -330,6 +367,7 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
 
     // Build update with explicit field allowlist
     const updateData = pickMutableFields(body);
+    const unsetData: Record<string, ""> = {};
     if (Object.keys(updateData).length === 0) {
       // No fields to update — return current state
       return successResponse(server);
@@ -348,11 +386,25 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       });
     }
 
+    const agentGatewayFields = agentGatewayFieldsForServer(body, String(id));
+    if (agentGatewayFields) {
+      Object.assign(updateData, agentGatewayFields);
+    } else if (body.route_through_agentgateway === false) {
+      updateData.source = "manual";
+      updateData.agentgateway_discovered = false;
+      updateData.config_driven = false;
+      unsetData.agentgateway_endpoint = "";
+      unsetData.agentgateway_target_endpoint = "";
+    }
+
     updateData.updated_at = new Date().toISOString();
 
     const updated = await collection.findOneAndUpdate(
       { _id: id },
-      { $set: updateData },
+      {
+        $set: updateData,
+        ...(Object.keys(unsetData).length > 0 ? { $unset: unsetData } : {}),
+      },
       { returnDocument: "after" },
     );
 

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -464,9 +464,8 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 {gatewayDiscoveryLoaded && agentGatewayTargets.length > 0 ? (
                   <div className="space-y-1">
                     <p className="text-xs text-muted-foreground">
-                      Or pick an AgentGateway target — this fills the endpoint with the
-                      target-qualified URL (<code className="font-mono">/mcp/&lt;target&gt;</code>) so the
-                      gateway can route this server correctly.
+                      Or pick an AgentGateway target — this fills the upstream URL and enables
+                      AgentGateway routing.
                     </p>
                     <div className="flex flex-wrap gap-2">
                       {agentGatewayTargets.map((target) => (

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -37,7 +37,14 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
   const [name, setName] = React.useState(server?.name || "");
   const [description, setDescription] = React.useState(server?.description || "");
   const [transport, setTransport] = React.useState<TransportType>(server?.transport || "sse");
-  const [endpoint, setEndpoint] = React.useState(server?.endpoint || "");
+  const [routeThroughAgentGateway, setRouteThroughAgentGateway] = React.useState(
+    server?.source === "agentgateway"
+  );
+  const [endpoint, setEndpoint] = React.useState(
+    server?.source === "agentgateway"
+      ? server.agentgateway_target_endpoint || server.endpoint || ""
+      : server?.endpoint || ""
+  );
   const [command, setCommand] = React.useState(server?.command || "");
   const [args, setArgs] = React.useState<string[]>(server?.args || []);
   const [envVars, setEnvVars] = React.useState<{ key: string; value: string }[]>(
@@ -162,6 +169,9 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
           description: description || undefined,
           transport,
           endpoint: transport !== "stdio" ? endpoint : undefined,
+          route_through_agentgateway: transport !== "stdio" ? routeThroughAgentGateway : false,
+          agentgateway_target_endpoint:
+            transport !== "stdio" && routeThroughAgentGateway ? endpoint : undefined,
           command: transport === "stdio" ? command : undefined,
           args: transport === "stdio" ? args : undefined,
           env: transport === "stdio" && Object.keys(env).length > 0 ? env : undefined,
@@ -186,6 +196,9 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
           description: description || undefined,
           transport,
           endpoint: transport !== "stdio" ? endpoint : undefined,
+          route_through_agentgateway: transport !== "stdio" ? routeThroughAgentGateway : false,
+          agentgateway_target_endpoint:
+            transport !== "stdio" && routeThroughAgentGateway ? endpoint : undefined,
           command: transport === "stdio" ? command : undefined,
           args: transport === "stdio" ? args : undefined,
           env: transport === "stdio" && Object.keys(env).length > 0 ? env : undefined,
@@ -421,18 +434,33 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 </div>
               </>
             ) : (
-              <div className="space-y-2">
-                <Label htmlFor="endpoint">
-                  Endpoint URL <span className="text-destructive">*</span>
-                </Label>
-                <Input
-                  id="endpoint"
-                  placeholder={`e.g., http://localhost:3000/${transport === "sse" ? "sse" : "mcp"}`}
-                  value={endpoint}
-                  onChange={(e) => setEndpoint(e.target.value)}
-                  disabled={loading || readOnly}
-                  className="font-mono"
-                />
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <Label htmlFor="endpoint">
+                    {routeThroughAgentGateway ? "Upstream URL" : "Endpoint URL"}{" "}
+                    <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="endpoint"
+                    placeholder={`e.g., http://localhost:3000/${transport === "sse" ? "sse" : "mcp"}`}
+                    value={endpoint}
+                    onChange={(e) => setEndpoint(e.target.value)}
+                    disabled={loading || readOnly}
+                    className="font-mono"
+                  />
+                </div>
+                {transport === "http" && (
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={routeThroughAgentGateway}
+                      onChange={(event) => setRouteThroughAgentGateway(event.target.checked)}
+                      disabled={loading || readOnly}
+                      className="h-4 w-4 rounded border-input"
+                    />
+                    Route through AgentGateway
+                  </label>
+                )}
                 {gatewayDiscoveryLoaded && agentGatewayTargets.length > 0 ? (
                   <div className="space-y-1">
                     <p className="text-xs text-muted-foreground">
@@ -448,7 +476,10 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           variant="outline"
                           size="sm"
                           disabled={loading || readOnly}
-                          onClick={() => setEndpoint(target.endpoint)}
+                          onClick={() => {
+                            setEndpoint(target.target_endpoint || target.endpoint);
+                            setRouteThroughAgentGateway(true);
+                          }}
                           title={
                             target.target_endpoint
                               ? `${target.endpoint} → ${target.target_endpoint}`

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -462,13 +462,21 @@ export function MCPServersTab() {
                         <div>
                           <div className="flex items-center gap-2">
                             <div className="font-medium text-sm">{server.name}</div>
-                            {server.source === "agentgateway" && (
+                            {server.source === "agentgateway" ? (
                               <Badge
                                 variant="outline"
                                 className="gap-1 bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/30"
-                                title="Registered from AgentGateway discovery"
+                                title="Routed through AgentGateway; the bridge reconciles a /mcp/<server-id> route for this server"
                               >
                                 AgentGateway
+                              </Badge>
+                            ) : (
+                              <Badge
+                                variant="outline"
+                                className="gap-1 bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/30"
+                                title="Direct/manual MCP server; AgentGateway does not reconcile a route for this row"
+                              >
+                                Direct
                               </Badge>
                             )}
                           </div>
@@ -507,7 +515,13 @@ export function MCPServersTab() {
                         onClick={(e) => { e.stopPropagation(); if (!server.config_driven) handleToggleEnabled(server); }}
                         className={`flex items-center gap-1.5 ${server.config_driven ? "cursor-not-allowed opacity-60" : ""}`}
                         disabled={server.config_driven}
-                        title={server.config_driven ? "Config-driven servers cannot be modified" : undefined}
+                        title={
+                          server.config_driven
+                            ? server.source === "agentgateway"
+                              ? "AgentGateway-managed route status is controlled by AgentGateway sync"
+                              : "Config-driven servers cannot be modified"
+                            : undefined
+                        }
                       >
                         {server.enabled ? (
                           <>

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -43,4 +43,33 @@ describe("MCPServerEditor credential sources", () => {
     expect(createCall).toBeDefined();
     expect(createCall?.[1]?.body).toContain("conn-1");
   });
+
+  it("sends AgentGateway routing metadata for custom HTTP MCP servers", async () => {
+    const user = userEvent.setup();
+    render(<MCPServerEditor server={null} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/server id/i), "custom");
+    await user.type(screen.getByLabelText(/display name/i), "Custom MCP");
+    await user.click(screen.getByRole("button", { name: /HTTP/i }));
+    await user.type(screen.getByLabelText(/endpoint url/i), "https://mcp.example.com/mcp");
+    await user.click(screen.getByLabelText(/route through agentgateway/i));
+    await user.click(screen.getByRole("button", { name: /create server/i }));
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    const createCall = calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        url === "/api/mcp-servers" && init?.method === "POST",
+    );
+    expect(createCall).toBeDefined();
+    const body = JSON.parse(String(createCall?.[1]?.body));
+    expect(body).toEqual(
+      expect.objectContaining({
+        id: "custom",
+        transport: "http",
+        endpoint: "https://mcp.example.com/mcp",
+        route_through_agentgateway: true,
+        agentgateway_target_endpoint: "https://mcp.example.com/mcp",
+      }),
+    );
+  });
 });

--- a/ui/src/types/dynamic-agent.ts
+++ b/ui/src/types/dynamic-agent.ts
@@ -80,6 +80,8 @@ export interface MCPServerConfigCreate {
   description?: string;
   transport: TransportType;
   endpoint?: string;
+  route_through_agentgateway?: boolean;
+  agentgateway_target_endpoint?: string;
   command?: string;
   args?: string[];
   env?: Record<string, string>;
@@ -93,6 +95,8 @@ export interface MCPServerConfigUpdate {
   description?: string;
   transport?: TransportType;
   endpoint?: string;
+  route_through_agentgateway?: boolean;
+  agentgateway_target_endpoint?: string;
   command?: string;
   args?: string[];
   env?: Record<string, string>;


### PR DESCRIPTION
## Summary

Fixes #1921.

This PR adds an explicit AgentGateway routing path for custom HTTP MCP servers created or edited in the Dynamic Agents MCP server UI.

## What changed

- Adds `route_through_agentgateway` and `agentgateway_target_endpoint` to MCP server create/update payloads.
- Persists user-created AgentGateway-routed MCP servers with:
  - `source: "agentgateway"`
  - `agentgateway_discovered: true`
  - `endpoint: <agentgateway>/mcp/<server-id>`
  - `agentgateway_target_endpoint: <original upstream URL>`
  - `config_driven: false`
- Keeps user-created gateway routes editable/deletable by not marking them config-driven.
- Allows detaching a user-owned MCP server from AgentGateway routing by clearing the gateway metadata.
- Updates the MCP server editor so admins can opt into AgentGateway routing and edit the upstream URL for gateway-routed servers.

## Root cause

Custom HTTP MCP servers were saved as direct/manual rows. The AgentGateway config bridge only publishes rows with `source: "agentgateway"` and a valid `agentgateway_target_endpoint`, so these custom servers appeared in the UI but never became AgentGateway routes.

## Validation

- `npm test -- --runTestsByPath src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx --runInBand`
- `npm test -- --runTestsByPath src/app/api/internal/agentgateway/mcp-targets/__tests__/route.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
