### PR TITLE
docs: document AGENTGATEWAY_TARGETS_TOKEN in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,11 @@ NEXT_PUBLIC_RAG_WEBUI_URL=http://localhost:9447
 # Set to enable AG routing for supervisor and dynamic agent MCP calls.
 # Leave empty to fall back to direct MCP connections (no AG).
 AGENT_GATEWAY_URL=
+# Bearer token used by the agentgateway config-bridge to authenticate to the
+# caipe-ui BFF (/api/internal/agentgateway/mcp-targets). Must match the value
+# stored in caipe-ui's AGENTGATEWAY_TARGETS_TOKEN env var. Defaults to a dev
+# placeholder when unset; set a strong random value in production.
+AGENTGATEWAY_TARGETS_TOKEN=agentgateway-config-bridge-dev-token
 
 # RAG RBAC Configuration
 # Map OIDC groups to RAG server roles (comma-separated)


### PR DESCRIPTION
## Summary
- Adds `AGENTGATEWAY_TARGETS_TOKEN` to `.env.example` alongside `AGENT_GATEWAY_URL`
- The token was already used in `docker-compose.yaml` and `docker-compose.dev.yaml` with a dev default (`agentgateway-config-bridge-dev-token`) but was undocumented in the example env file
- Operators deploying to non-local environments need to know to set this to a strong random value

## Context
`AGENTGATEWAY_TARGETS_TOKEN` is the bearer token the `agentgateway-config-bridge` sidecar uses to authenticate to the caipe-ui BFF at `/api/internal/agentgateway/mcp-targets`. It must match the value configured in caipe-ui environment.

Generated with [Claude Code](https://claude.com/claude-code)