### PR TITLE
fix(rbac): address admin and chat regressions

### DIFF
--- a/tests/rbac/unit/py/conftest.py
+++ b/tests/rbac/unit/py/conftest.py
@@ -10,14 +10,8 @@ What this file provides
   pair from `tests/rbac/unit/py/matrix_driver.py:expand_matrix()`. Used
   by the auto-generated `test_matrix.py` (and by ad-hoc phase tests that
   want to drive a single row).
-* `audit_collection` — pymongo collection handle pointed at the e2e Mongo
-  (read from `MONGODB_URI` / `AUDIT_COLLECTION` env vars). Skips the test
-  if pymongo isn't installed *or* if Mongo is unreachable. Tests use this
-  to assert the audit-log row written by `logAuthzDecision` /
-  `log_authz_decision` (FR-007).
-* `clean_authz_decisions` — autouse, function-scoped fixture that drops
-  the `authz_decisions` collection between tests so per-route
-  audit-log assertions don't see stale rows from earlier tests.
+* Audit assertions live in `tests/rbac/fixtures/audit.py` and query
+  audit-service. Audit storage is append-only from these tests.
 
 Notes
 -----
@@ -33,17 +27,9 @@ Notes
 
 from __future__ import annotations
 
-import os
-from collections.abc import Iterator
-from typing import Any
-
 import pytest
 
 from tests.rbac.unit.py.matrix_driver import MatrixRow, matrix_param_set
-
-DEFAULT_MONGODB_URI = "mongodb://localhost:28017"  # e2e port band (T032)
-DEFAULT_AUDIT_DB = "caipe_audit"
-DEFAULT_AUDIT_COLLECTION = "authz_decisions"
 
 
 @pytest.fixture(params=list(matrix_param_set()))
@@ -56,57 +42,6 @@ def matrix_driver_row(request: pytest.FixtureRequest) -> MatrixRow:
     return request.param
 
 
-@pytest.fixture(scope="session")
-def _pymongo_module() -> Any:
-    """Lazily import pymongo. Returns the module or skips if unavailable."""
-    try:
-        import pymongo  # noqa: PLC0415
-
-        return pymongo
-    except Exception as exc:  # pragma: no cover - import-time check
-        pytest.skip(f"pymongo not installed; skipping audit-log tests ({exc})")
-
-
-@pytest.fixture(scope="session")
-def audit_collection(_pymongo_module: Any) -> Any:
-    """Return the live `authz_decisions` collection used for FR-007 assertions.
-
-    Skips the test if Mongo is unreachable. The e2e lane in `make test-rbac-up`
-    publishes Mongo on `localhost:28017` (via `MONGODB_HOST_PORT=28017` injected
-    into `docker-compose.dev.yaml`); override via `MONGODB_URI=…`.
-    """
-    uri = os.environ.get("MONGODB_URI", DEFAULT_MONGODB_URI)
-    db_name = os.environ.get("AUDIT_DB", DEFAULT_AUDIT_DB)
-    coll_name = os.environ.get("AUDIT_COLLECTION", DEFAULT_AUDIT_COLLECTION)
-    client = _pymongo_module.MongoClient(uri, serverSelectionTimeoutMS=2000)
-    try:
-        client.admin.command("ping")
-    except Exception as exc:
-        pytest.skip(f"Mongo unreachable at {uri}; skipping audit-log assertions ({exc})")
-    return client[db_name][coll_name]
-
-
-@pytest.fixture(autouse=True)
-def clean_authz_decisions(request: pytest.FixtureRequest) -> Iterator[None]:
-    """Drop the audit collection before/after each test that uses it.
-
-    Implemented as autouse so individual tests don't have to remember; only
-    actually fires when `audit_collection` is in the test's fixture closure
-    (avoids hitting Mongo for tests that don't need it).
-    """
-    needs_audit = "audit_collection" in request.fixturenames
-    if not needs_audit:
-        yield
-        return
-
-    coll = request.getfixturevalue("audit_collection")
-    coll.delete_many({})
-    yield
-    coll.delete_many({})
-
-
 __all__ = [
-    "audit_collection",
-    "clean_authz_decisions",
     "matrix_driver_row",
 ]

--- a/tests/rbac/unit/py/test_audit.py
+++ b/tests/rbac/unit/py/test_audit.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -26,6 +27,23 @@ _SCHEMA_PATH = (
 )
 
 
+def _call_log(**overrides: Any) -> None:
+    kwargs: dict[str, Any] = {
+        "user_id": "alice-sub",
+        "resource": "admin_ui",
+        "scope": "view",
+        "allowed": True,
+        "reason": "OK",
+        "service": "ui",
+        "user_email": "alice@example.com",
+        "route": "GET /api/admin/users",
+        "request_id": "req-123",
+        "pdp": "keycloak",
+    }
+    kwargs.update(overrides)
+    audit.log_authz_decision(**kwargs)
+
+
 def test_successful_write_posts_service_event(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AUDIT_LOG_BACKEND", "service")
     monkeypatch.setenv("AUDIT_SERVICE_URL", "http://audit-service:8010")
@@ -33,18 +51,7 @@ def test_successful_write_posts_service_event(monkeypatch: pytest.MonkeyPatch) -
     mock_client.__enter__.return_value = mock_client
 
     with patch("httpx.Client", return_value=mock_client):
-        audit.log_authz_decision(
-            user_id="alice-sub",
-            resource="admin_ui",
-            scope="view",
-            allowed=True,
-            reason="OK",
-            service="ui",
-            user_email="alice@example.com",
-            route="GET /api/admin/users",
-            request_id="req-123",
-            pdp="keycloak",
-        )
+        _call_log()
 
     mock_client.post.assert_called_once()
     url, = mock_client.post.call_args.args
@@ -81,60 +88,42 @@ def test_service_failure_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None
     mock_client.post.side_effect = RuntimeError("audit-service down")
 
     with patch("httpx.Client", return_value=mock_client):
-        # Must NOT raise — FR-007.
-        audit.log_authz_decision(
+        _call_log(
             user_id="bob-sub",
             resource="rag",
             scope="retrieve",
             allowed=False,
             reason="DENY_NO_CAPABILITY",
             service="rag_server",
+            user_email=None,
+            route=None,
+            request_id=None,
+            pdp=None,
         )
 
 
-def test_invalid_reason_is_silently_dropped() -> None:
+def test_invalid_reason_is_silently_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUDIT_SERVICE_URL", "http://audit-service:8010")
+
     with patch("httpx.Client") as mock_client_cls:
-        audit.log_authz_decision(
-            user_id="carol-sub",
-            resource="rag",
-            scope="ingest",
-            allowed=False,
-            reason="GIBBERISH",  # not in the closed enum
-            service="rag_server",
-        )
+        _call_log(reason="GIBBERISH")
 
     mock_client_cls.assert_not_called()
 
 
-def test_document_validates_against_schema() -> None:
-    """Sanity check that what we write matches the contract schema."""
+def test_document_validates_against_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity check that the legacy-compatible payload still matches the contract schema."""
     pytest.importorskip("jsonschema")
     import json
     import jsonschema  # type: ignore[import-untyped]
 
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    monkeypatch.setenv("AUDIT_SERVICE_URL", "http://audit-service:8010")
 
     captured: dict[str, Any] = {}
 
     with patch.object(audit, "_write_service_event", side_effect=lambda doc: captured.update(doc)):
-        audit.log_authz_decision(
-            user_id="alice-sub",
-            resource="admin_ui",
-            scope="view",
-            allowed=True,
-            reason="OK",
-            service="ui",
-            user_email="alice@example.com",
-            route="GET /api/admin/users",
-            pdp="keycloak",
-        )
-
-    # The contract schema declares `ts` as either an ISO-8601 string (when
-    # serialized) or a BSON Date object (when stored in Mongo). For the in-memory
-    # validator we serialize datetime to ISO-8601 before checking — this mirrors
-    # what bson.json_util would emit for any consumer reading `authz_decisions`
-    # over the network.
-    from datetime import datetime
+        _call_log()
 
     if isinstance(captured.get("ts"), datetime):
         captured["ts"] = captured["ts"].isoformat().replace("+00:00", "Z")

--- a/ui/src/app/api/__tests__/rag-rbac.test.ts
+++ b/ui/src/app/api/__tests__/rag-rbac.test.ts
@@ -105,6 +105,32 @@ describe('RAG RBAC Integration', () => {
     ) as jest.Mock;
   });
 
+  describe('RAG health proxy', () => {
+    it('allows GET /api/rag/healthz without a browser session or RBAC check', async () => {
+      jest.mocked(getServerSession).mockResolvedValue(null);
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'healthy', config: { graph_rag_enabled: true } }),
+      } as Response);
+
+      const { GET } = await import('@/app/api/rag/[...path]/route');
+      const response = await GET(
+        ragRequest('/api/rag/healthz', { method: 'GET' }),
+        { params: Promise.resolve({ path: ['healthz'] }) },
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('healthy');
+      expect(mockRequireRbacPermission).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/healthz'),
+        { method: 'GET' },
+      );
+    });
+  });
+
   describe('User Info API', () => {
     it('should return unauthenticated for no session', async () => {
       jest.mocked(getServerSession).mockResolvedValue(null);

--- a/ui/src/app/api/admin/rebac/__tests__/change-sets-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/change-sets-route.test.ts
@@ -103,7 +103,6 @@ beforeEach(() => {
   mockCollections.policy_change_sets = createMockCollection([]);
   mockCollections.rebac_relationships = createMockCollection([]);
   mockCollections.policy_rules = createMockCollection([]);
-  mockCollections.audit_events = createMockCollection([]);
 });
 
 describe("ReBAC change-set routes", () => {

--- a/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
+++ b/ui/src/app/api/admin/rebac/__tests__/migrations-route.test.ts
@@ -262,6 +262,53 @@ describe("admin ReBAC migrations API", () => {
     );
   });
 
+  it("keeps a completed run actionable when the schema version is still behind", async () => {
+    collections.schema_migrations = createCollection([
+      {
+        _id: "rbac_indexes_v1",
+        release: "0.5.1",
+        schema_area: "rbac_indexes",
+        status: "completed",
+        completed_at: "2026-06-19T12:00:00.000Z",
+      },
+    ]);
+    collections.data_schema_versions = createCollection([
+      { _id: "rbac_indexes", version: 1, last_migration_id: "schema_version_bootstrap_v1" },
+    ]);
+    const { GET } = await import("../migrations/route");
+
+    const response = await GET(request("/api/admin/rebac/migrations"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.migrations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "rbac_indexes_v1",
+          schema_area: "rbac_indexes",
+          current_version: 1,
+          target_version: 2,
+          status: "not_started",
+        }),
+      ]),
+    );
+    expect(body.data.completed_migrations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "rbac_indexes_v1" }),
+      ]),
+    );
+    expect(body.data.schema_versions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          schema_area: "rbac_indexes",
+          current_version: 1,
+          target_version: 2,
+          status: "behind",
+        }),
+      ]),
+    );
+  });
+
   it("returns blocking migration status and records super-admin overrides", async () => {
     collections.data_schema_versions = createCollection([{ _id: "conversations", version: 1 }]);
     const statusRoute = await import("../migrations/status/route");
@@ -694,7 +741,7 @@ describe("admin ReBAC migrations API", () => {
     const response = await POST(
       request("/api/admin/rebac/migrations/rbac_indexes_v1/apply", {
         method: "POST",
-        body: JSON.stringify({ confirmation: "MIGRATE audit_events TO v2" }),
+        body: JSON.stringify({ confirmation: "MIGRATE rbac_indexes TO v2" }),
       }),
       { params: Promise.resolve({ migrationId: "rbac_indexes_v1" }) },
     );

--- a/ui/src/app/api/rag/[...path]/route.ts
+++ b/ui/src/app/api/rag/[...path]/route.ts
@@ -820,6 +820,16 @@ export async function GET(
       targetUrl.searchParams.append(key, value);
     });
 
+    if (request.method === 'GET' && targetPath === 'healthz') {
+      // assisted-by Codex Codex-sonnet-4-6
+      // Health is a readiness probe, not a data operation. Keep KB/query/admin
+      // routes RBAC-gated, but let UI status checks verify that RAG is up even
+      // when the browser session has no downstream Keycloak access token.
+      const response = await fetch(targetUrl.toString(), { method: 'GET' });
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    }
+
     const { headers, session } = await getAuthorizedRagContext('GET', path, request);
     const response = await fetch(targetUrl.toString(), {
       method: 'GET',

--- a/ui/src/components/admin/security/__tests__/MigrationTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/MigrationTab.test.tsx
@@ -229,7 +229,7 @@ describe("MigrationTab", () => {
               { schema_area: "conversations", current_version: 1, target_version: 2, status: "behind" },
               { schema_area: "messaging_rebac_indexes", current_version: null, target_version: 2, status: "unknown" },
               { schema_area: "conversation_bookmarks", current_version: 2, target_version: 2, status: "current" },
-              { schema_area: "audit_events", current_version: null, target_version: null, status: "unknown" },
+              { schema_area: "rbac_indexes", current_version: null, target_version: null, status: "unknown" },
             ],
             migrations: [],
             completed_migrations: [],
@@ -259,12 +259,12 @@ describe("MigrationTab", () => {
     const messagingCard = screen.getByText("messaging_rebac_indexes").closest(".rounded-lg");
     expect(messagingCard?.querySelector("svg")).toHaveClass("text-amber-600");
     expect(screen.queryByText("conversation_bookmarks")).not.toBeInTheDocument();
-    expect(screen.queryByText("audit_events")).not.toBeInTheDocument();
+    expect(screen.queryByText("rbac_indexes")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText(/Show collections without pending migrations/i));
 
     expect(await screen.findByText("conversation_bookmarks")).toBeInTheDocument();
-    expect(screen.getByText("audit_events")).toBeInTheDocument();
+    expect(screen.getByText("rbac_indexes")).toBeInTheDocument();
   });
 
   it("lets admins initialize all version-only schema areas to v1", async () => {

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -246,6 +246,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
   const isThisConversationStreaming = activeConversationId
     ? isConversationStreaming(activeConversationId)
     : false;
+  const hasAssistantMessageForInterruptCheck = conversation?.messages?.some((message) => message.role === "assistant") ?? false;
 
   // Check if user is near the bottom of the scroll area
   const isNearBottom = useCallback(() => {
@@ -357,7 +358,11 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
     // this effect can fire before ChatContainer finishes loading messages
     // from MongoDB, causing lastMsg to be undefined and recovery to fail)
     if (isLoadingMessages) return;
-    
+    if (isThisConversationStreaming) return;
+    // assisted-by Codex Codex-sonnet-4-6
+    // Empty chats have no assistant turn to attach restored HITL state to.
+    if (!hasAssistantMessageForInterruptCheck) return;
+
     // Skip if already checked this conversation
     if (interruptCheckedRef.current.has(conversationId)) return;
     
@@ -366,11 +371,14 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
 
     const checkInterruptState = async () => {
       setCheckingInterrupt(true);
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), 5000);
       try {
         // Check for pending HITL interrupt state (lightweight call to checkpointer)
         // Messages are already loaded by ChatContainer - we only check interrupt state here
         const interruptResponse = await fetch(
-          `/api/dynamic-agents/conversations/${conversationId}/interrupt-state?agent_id=${encodeURIComponent(agentId)}`
+          `/api/dynamic-agents/conversations/${conversationId}/interrupt-state?agent_id=${encodeURIComponent(agentId)}`,
+          { signal: controller.signal },
         );
         
         if (interruptResponse.ok) {
@@ -439,12 +447,13 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
         // Non-fatal: HITL state check failed
         console.warn("[ChatPanel] Failed to check interrupt state:", interruptError);
       } finally {
+        window.clearTimeout(timeoutId);
         setCheckingInterrupt(false);
       }
     };
 
     checkInterruptState();
-  }, [conversationId, agentId, isLoadingMessages]);
+  }, [conversationId, agentId, isLoadingMessages, isThisConversationStreaming, hasAssistantMessageForInterruptCheck]);
 
   // ═══════════════════════════════════════════════════════════════
   // FILES & TASKS FETCH (for timeline display in latest message)

--- a/ui/src/lib/rbac/__tests__/conversation-implicit-authz.test.ts
+++ b/ui/src/lib/rbac/__tests__/conversation-implicit-authz.test.ts
@@ -11,7 +11,8 @@ jest.mock("../resource-authz", () => ({
   requireResourcePermission: jest.fn(async () => undefined),
 }));
 
-const { requireResourcePermission } = jest.requireMock("../resource-authz") as {
+const { filterResourcesByPermission, requireResourcePermission } = jest.requireMock("../resource-authz") as {
+  filterResourcesByPermission: jest.Mock;
   requireResourcePermission: jest.Mock;
 };
 
@@ -50,6 +51,18 @@ describe("conversation implicit authorization", () => {
     );
 
     expect(visible.map((conversation) => conversation._id)).toEqual(["owned-sub", "owned-email", "shared"]);
+    expect(filterResourcesByPermission).toHaveBeenCalledWith(
+      { sub: "alice-sub" },
+      [
+        { _id: "shared", owner_id: "carol@example.com" },
+        { _id: "denied", owner_id: "dave@example.com" },
+      ],
+      expect.objectContaining({
+        type: "conversation",
+        action: "discover",
+      }),
+      { bypassForOrgAdmin: true },
+    );
   });
 
   it("requires OpenFGA only when caller is not the implicit owner", async () => {
@@ -70,6 +83,7 @@ describe("conversation implicit authorization", () => {
     expect(requireResourcePermission).toHaveBeenCalledWith(
       { sub: "bob-sub" },
       { type: "conversation", id: "shared", action: "write" },
+      { bypassForOrgAdmin: true },
     );
   });
 });

--- a/ui/src/lib/rbac/conversation-implicit-authz.ts
+++ b/ui/src/lib/rbac/conversation-implicit-authz.ts
@@ -32,11 +32,15 @@ export async function requireConversationResourcePermission(
   action: ResourcePermissionAction,
 ): Promise<void> {
   if (isImplicitConversationOwner(session, userEmail, conversation)) return;
-  await requireResourcePermission(session, {
-    type: "conversation",
-    id: conversation._id,
-    action,
-  });
+  await requireResourcePermission(
+    session,
+    {
+      type: "conversation",
+      id: conversation._id,
+      action,
+    },
+    { bypassForOrgAdmin: true },
+  );
 }
 
 export async function filterConversationsByImplicitOrExplicitPermission<T extends Conversation>(
@@ -51,11 +55,16 @@ export async function filterConversationsByImplicitOrExplicitPermission<T extend
       .map((conversation) => conversation._id),
   );
   const explicitCandidates = conversations.filter((conversation) => !implicitIds.has(conversation._id));
-  const explicitVisible = await filterResourcesByPermission(session, explicitCandidates, {
-    type: "conversation",
-    action,
-    id: (conversation) => conversation._id,
-  });
+  const explicitVisible = await filterResourcesByPermission(
+    session,
+    explicitCandidates,
+    {
+      type: "conversation",
+      action,
+      id: (conversation) => conversation._id,
+    },
+    { bypassForOrgAdmin: true },
+  );
   const explicitIds = new Set(explicitVisible.map((conversation) => conversation._id));
   return conversations.filter((conversation) => implicitIds.has(conversation._id) || explicitIds.has(conversation._id));
 }

--- a/ui/src/lib/rbac/migrations/registry.ts
+++ b/ui/src/lib/rbac/migrations/registry.ts
@@ -427,13 +427,13 @@ export const MIGRATION_DEFINITIONS: MigrationDefinition[] = [
   {
     id: "rbac_indexes_v1",
     release: RELEASE_051,
-    schema_area: "audit_events",
+    schema_area: "rbac_indexes",
     from_version: 1,
     to_version: 2,
     kind: "index",
-    title: "RBAC audit and migration indexes",
-    description: "Ensure RBAC audit, schema migration, and provenance indexes exist.",
-    confirmation: "MIGRATE audit_events TO v2",
+    title: "RBAC migration indexes",
+    description: "Ensure RBAC schema migration and provenance indexes exist.",
+    confirmation: "MIGRATE rbac_indexes TO v2",
     required: true,
     implemented: true,
   },
@@ -2012,7 +2012,6 @@ const RBAC_INDEX_SPECS: NonNullable<MigrationRuntimePlan["indexes"]> = [
   { collection: "schema_migrations", keys: { release: 1, status: 1 } },
   { collection: "rebac_relationships", keys: { "resource.type": 1, "resource.id": 1, action: 1, status: 1 } },
   { collection: "team_membership_sources", keys: { team_slug: 1, user_subject: 1, relationship: 1 } },
-  { collection: "audit_events", keys: { type: 1, ts: -1 } },
 ];
 
 const MESSAGING_REBAC_INDEX_SPECS: NonNullable<MigrationRuntimePlan["indexes"]> = [
@@ -2042,7 +2041,7 @@ function deriveIndexPlan(): MigrationRuntimePlan {
   return {
     migration_id: RBAC_INDEXES_MIGRATION_ID,
     release: RELEASE_051,
-    schema_area: "audit_events",
+    schema_area: "rbac_indexes",
     kind: "index",
     from_version: 1,
     to_version: 2,
@@ -2055,7 +2054,7 @@ function deriveIndexPlan(): MigrationRuntimePlan {
       after: { keys: spec.keys, options: spec.options ?? {} },
     })),
     tuple_writes_planned: 0,
-    confirmation: "MIGRATE audit_events TO v2",
+    confirmation: "MIGRATE rbac_indexes TO v2",
     indexes: RBAC_INDEX_SPECS,
   };
 }
@@ -2400,7 +2399,20 @@ function manifestDefinition(doc: MigrationManifestDoc): MigrationDefinition {
 }
 
 function isMigrationComplete(definition: MigrationDefinition, version?: SchemaVersionDoc, run?: SchemaMigrationDoc): boolean {
-  return run?.status === "completed" || (version?.version ?? 0) >= definition.to_version;
+  return (version?.version ?? 0) >= definition.to_version;
+}
+
+function migrationListStatus(
+  definition: MigrationDefinition,
+  version?: SchemaVersionDoc,
+  run?: SchemaMigrationDoc,
+): MigrationListItem["status"] {
+  // assisted-by Codex Codex-sonnet-4-6
+  // data_schema_versions is the source of truth; completed run rows can drift
+  // and must not hide a repairable version mismatch from the admin UI.
+  if (isMigrationComplete(definition, version, run)) return "completed";
+  if (run?.status && run.status !== "completed") return run.status;
+  return "not_started";
 }
 
 async function seedMigrationManifest(now = new Date().toISOString()): Promise<void> {
@@ -2502,13 +2514,13 @@ export async function listReleaseMigrations(options: { includeCompleted?: boolea
   const migrations = definitions.map((definition) => {
     const version = versionByArea.get(definition.schema_area);
     const run = runById.get(definition.id);
-    const completed = isMigrationComplete(definition, version, run);
+    const status = migrationListStatus(definition, version, run);
     return {
       ...definition,
       blocking: definition.blocking ?? definition.required,
       current_version: version?.version ?? null,
       target_version: definition.to_version,
-      status: completed ? "completed" : run?.status ?? "not_started",
+      status,
       last_run_at: run?.completed_at ?? run?.updated_at,
     };
   });

--- a/ui/src/lib/rbac/migrations/schema-area-classifications.ts
+++ b/ui/src/lib/rbac/migrations/schema-area-classifications.ts
@@ -16,10 +16,6 @@ export const SCHEMA_AREA_CLASSIFICATIONS: Record<string, SchemaAreaClassificatio
     description:
       "Skill catalog/config records. `agent_skill_openfga_reconcile_v1` aligns OpenFGA grants with Mongo `visibility` (team slugs from FGA) and revokes stale team shares on private skills.",
   },
-  audit_events: {
-    classification: "migration",
-    description: "RBAC index migration target.",
-  },
   channel_team_mappings: {
     classification: "baseline_v1",
     description: "Slack channel team mapping metadata.",
@@ -113,6 +109,10 @@ export const SCHEMA_AREA_CLASSIFICATIONS: Record<string, SchemaAreaClassificatio
   rebac_relationships: {
     classification: "baseline_v1",
     description: "Universal ReBAC relationship provenance records.",
+  },
+  rbac_indexes: {
+    classification: "migration",
+    description: "RBAC schema migration and provenance index migration target.",
   },
   schema_migrations: {
     classification: "metadata",


### PR DESCRIPTION
# Description

Collects the focused behavior fixes that came out of validating the audit-service/performance branch.

This PR includes:
- super-admin bypass for explicit conversation OpenFGA checks
- chat interrupt-state guard so empty conversations do not stay in loading/checking state
- RAG health proxy bypass for unauthenticated health checks
- migration status repair so completed run rows do not hide a behind schema version
- RBAC migration target cleanup now that audit storage is no longer Mongo-backed
- Python audit unit test cleanup from Mongo fixtures to audit-service writes

Stacked on #1949.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- `cd ui && npm test -- --runTestsByPath src/app/api/__tests__/rag-rbac.test.ts src/lib/rbac/__tests__/conversation-implicit-authz.test.ts src/app/api/admin/rebac/__tests__/migrations-route.test.ts src/components/admin/security/__tests__/MigrationTab.test.tsx`
- `PYTHONPATH=. uv run pytest tests/rbac/unit/py/test_audit.py`
- `git diff --check`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
