### PR TITLE
fix(ci): satisfy zizmor security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_SECURITY_APP_ID }}
           private-key: ${{ secrets.CI_SECURITY_APP_PRIVATE_KEY }}
+          permission-security-events: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -158,14 +159,17 @@ jobs:
         with:
           app-id: ${{ secrets.CI_SECURITY_APP_ID }}
           private-key: ${{ secrets.CI_SECURITY_APP_PRIVATE_KEY }}
+          permission-security-events: write
 
       - name: Determine image tag
         id: tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            printf 'tag=%s\n' "$DISPATCH_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            printf 'tag=%s\n' "${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Grype scan on container image


### PR DESCRIPTION
## Summary
- scope `actions/create-github-app-token` outputs to `security-events: write` in the Grype scan workflow
- avoid direct workflow input template expansion inside the image tag shell step

## Why
- `zizmor` flagged the workflow for unscoped GitHub App tokens and template injection when `security-scan.yml` was touched by PR #1721
- the scan only needs the generated token for SARIF upload to GitHub Code Scanning

## Validation
- `uvx --from "zizmor==1.25.2" zizmor --min-severity high --min-confidence high .github/workflows/security-scan.yml`
