### PR TITLE
fix(ui): allow AgentGateway MCP credential rotation

### DIFF
--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -102,6 +102,7 @@ async function installTeamResourceMocks(page: Page): Promise<InstalledTeamMocks>
 
 type InstalledMcpMocks = {
   createRequests: Array<Record<string, unknown>>;
+  updateRequests: Array<{ id: string | null; body: Record<string, unknown> }>;
   listRequests: number;
   addExternalServer: (server: {
     _id: string;
@@ -111,6 +112,9 @@ type InstalledMcpMocks = {
     endpoint?: string;
     enabled?: boolean;
     config_driven?: boolean;
+    source?: string;
+    agentgateway_target_endpoint?: string;
+    credential_sources?: Array<Record<string, unknown>>;
   }) => void;
 };
 
@@ -123,6 +127,7 @@ type InstalledRagFileMocks = {
 
 async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
   const createRequests: Array<Record<string, unknown>> = [];
+  const updateRequests: Array<{ id: string | null; body: Record<string, unknown> }> = [];
   let listRequests = 0;
   type BrowserMcpServer = {
     _id: string;
@@ -132,6 +137,9 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
     endpoint: string;
     enabled: boolean;
     config_driven: boolean;
+    source?: string;
+    agentgateway_target_endpoint?: string;
+    credential_sources?: Array<Record<string, unknown>>;
   };
   let servers: BrowserMcpServer[] = [];
 
@@ -139,7 +147,7 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
     isAdmin: true,
     session: adminSession,
     handlers: [
-      async ({ route, path, method }) => {
+      async ({ route, path, method, url }) => {
         if (path === "/api/mcp-servers/agentgateway/discover" && method === "GET") {
           await fulfillJson(route, { success: true, data: { targets: [] } });
           return true;
@@ -182,6 +190,25 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
           return true;
         }
 
+        if (path === "/api/mcp-servers" && method === "PUT") {
+          const body = ((await postJson(route)) ?? {}) as Record<string, unknown>;
+          const id = url.searchParams.get("id");
+          updateRequests.push({ id, body });
+          servers = servers.map((server) =>
+            server._id === id
+              ? {
+                  ...server,
+                  credential_sources: Array.isArray(body.credential_sources)
+                    ? (body.credential_sources as Array<Record<string, unknown>>)
+                    : server.credential_sources,
+                }
+              : server,
+          );
+          const updated = servers.find((server) => server._id === id);
+          await fulfillJson(route, { success: true, data: updated ?? null });
+          return true;
+        }
+
         return false;
       },
     ],
@@ -190,6 +217,9 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
   return {
     get createRequests() {
       return createRequests;
+    },
+    get updateRequests() {
+      return updateRequests;
     },
     get listRequests() {
       return listRequests;
@@ -205,6 +235,9 @@ async function installMcpServerMocks(page: Page): Promise<InstalledMcpMocks> {
           endpoint: server.endpoint ?? "",
           enabled: server.enabled ?? true,
           config_driven: server.config_driven ?? false,
+          source: server.source,
+          agentgateway_target_endpoint: server.agentgateway_target_endpoint,
+          credential_sources: server.credential_sources,
         },
       ];
     },
@@ -448,6 +481,65 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect(page.getByText("mcp-knowledge-base")).toBeVisible();
     await expect(page.getByTitle("Registered from AgentGateway discovery")).toBeVisible();
     await expect(page.getByText("No MCP Servers Yet")).toHaveCount(0);
+  });
+
+  test("rotates credentials for AgentGateway-managed MCP servers without editing routing metadata", async ({
+    page,
+  }) => {
+    const mocks = await installMcpServerMocks(page);
+    mocks.addExternalServer({
+      _id: "rag",
+      name: "RAG",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp",
+      enabled: true,
+      config_driven: true,
+      source: "agentgateway",
+      agentgateway_target_endpoint: "http://rag-server:9446/mcp",
+      credential_sources: [
+        {
+          kind: "secret_ref",
+          target: "header",
+          name: "Authorization",
+          secret_ref: "old-secret",
+        },
+      ],
+    });
+
+    await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("RAG", { exact: true })).toBeVisible();
+    await expect(page.getByTitle(/Delete unavailable: AgentGateway manages this route/i)).toBeDisabled();
+    await expect(page.getByTitle(/AgentGateway manages enablement for this route/i)).toBeDisabled();
+
+    await page.getByText("RAG", { exact: true }).click();
+
+    await expect(page.getByText("Manage AgentGateway MCP Server")).toBeVisible();
+    await expect(page.getByText(/Credential references can be rotated here/i)).toBeVisible();
+    await expect(page.getByLabel(/Display Name/i)).toBeDisabled();
+    await expect(page.getByLabel(/Endpoint URL/i)).toBeDisabled();
+
+    const credentialReference = page.getByLabel(/Credential reference/i);
+    await expect(credentialReference).toBeEnabled();
+    await credentialReference.fill("rotated-secret");
+
+    await page.getByRole("button", { name: /Save Credential Sources/i }).click();
+
+    await expect.poll(() => mocks.updateRequests.length).toBe(1);
+    expect(mocks.updateRequests[0]).toEqual({
+      id: "rag",
+      body: {
+        credential_sources: [
+          {
+            kind: "secret_ref",
+            target: "header",
+            name: "Authorization",
+            secret_ref: "rotated-secret",
+          },
+        ],
+      },
+    });
+    expect(mocks.updateRequests[0].body).not.toHaveProperty("endpoint");
+    expect(mocks.updateRequests[0].body).not.toHaveProperty("agentgateway_target_endpoint");
   });
 
   test("uploads multiple local files as multipart FormData from the ingest UI", async ({ page }) => {

--- a/ui/src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts
+++ b/ui/src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts
@@ -83,7 +83,7 @@ jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
     mockDeleteAllMcpServerRelationshipTuples(...args),
 }));
 
-function request(path: string, init: RequestInit & { body: string }): NextRequest {
+function request(path: string, init?: RequestInit): NextRequest {
   return new NextRequest(new URL(path, "http://localhost:3000"), init);
 }
 
@@ -294,5 +294,147 @@ describe("PUT /api/mcp-servers?id=<id> — endpoint normalisation", () => {
     expect(updatePayload.$set.endpoint).toBe(
       "http://agentgateway:4000/mcp/mcp-confluence",
     );
+  });
+});
+
+describe("managed AgentGateway MCP servers", () => {
+  it("allows credential source rotation without changing AgentGateway routing metadata", async () => {
+    const existing = {
+      _id: "rag",
+      name: "RAG",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp",
+      config_driven: true,
+      source: "agentgateway",
+      agentgateway_discovered: true,
+      agentgateway_target_endpoint: "http://rag-server:9446/mcp",
+      credential_sources: [
+        { kind: "secret_ref", target: "header", name: "Authorization", secret_ref: "old-secret" },
+      ],
+    };
+    mockFindOne.mockResolvedValue(existing);
+    mockFindOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      ...existing,
+      ...(update as { $set: Record<string, unknown> }).$set,
+    }));
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=rag", {
+        method: "PUT",
+        body: JSON.stringify({
+          credential_sources: [
+            {
+              kind: "secret_ref",
+              target: "header",
+              name: "Authorization",
+              secret_ref: "rotated-secret",
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+    const updatePayload = mockFindOneAndUpdate.mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(updatePayload.$set).toMatchObject({
+      credential_sources: [
+        {
+          kind: "secret_ref",
+          target: "header",
+          name: "Authorization",
+          secret_ref: "rotated-secret",
+        },
+      ],
+    });
+    expect(updatePayload.$set).not.toHaveProperty("endpoint");
+    expect(updatePayload.$set).not.toHaveProperty("source");
+    expect(updatePayload.$set).not.toHaveProperty("agentgateway_target_endpoint");
+  });
+
+  it("allows clearing credential sources from an AgentGateway-managed MCP server", async () => {
+    const existing = {
+      _id: "rag",
+      name: "RAG",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp",
+      config_driven: true,
+      source: "agentgateway",
+      credential_sources: [
+        { kind: "secret_ref", target: "header", name: "Authorization", secret_ref: "old-secret" },
+      ],
+    };
+    mockFindOne.mockResolvedValue(existing);
+    mockFindOneAndUpdate.mockImplementation(async (_filter, update) => ({
+      ...existing,
+      ...(update as { $set: Record<string, unknown> }).$set,
+    }));
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=rag", {
+        method: "PUT",
+        body: JSON.stringify({ credential_sources: [] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const updatePayload = mockFindOneAndUpdate.mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(updatePayload.$set.credential_sources).toEqual([]);
+  });
+
+  it("rejects non-credential changes to AgentGateway-managed MCP servers", async () => {
+    mockFindOne.mockResolvedValue({
+      _id: "rag",
+      name: "RAG",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp",
+      config_driven: true,
+      source: "agentgateway",
+    });
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=rag", {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "RAG renamed",
+          credential_sources: [],
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toMatch(/only allow credential source updates/i);
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("explains why AgentGateway-managed MCP servers cannot be deleted from the UI", async () => {
+    mockFindOne.mockResolvedValue({
+      _id: "rag",
+      name: "RAG",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp",
+      config_driven: true,
+      source: "agentgateway",
+    });
+    const { DELETE } = await import("../route");
+
+    const response = await DELETE(
+      request("/api/mcp-servers?id=rag", {
+        method: "DELETE",
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toMatch(/AgentGateway-managed MCP servers cannot be deleted/i);
+    expect(mockDeleteAllMcpServerRelationshipTuples).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -88,6 +88,16 @@ function pickMutableFields(
   return result;
 }
 
+function isAgentGatewayManagedServer(server: MCPServerConfig): boolean {
+  return server.config_driven === true && server.source === "agentgateway";
+}
+
+function validateCredentialSources(value: unknown): void {
+  if (value !== undefined && !Array.isArray(value)) {
+    throw new ApiError("'credential_sources' must be an array", 400);
+  }
+}
+
 /**
  * Resolve the AgentGateway base URL for endpoint normalisation. Returns
  * just the origin (protocol://host:port), with no `/mcp` suffix —
@@ -293,7 +303,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 /**
  * PUT /api/mcp-servers?id=<server_id>
  * Update an MCP server configuration.
- * Requires resource write access. Config-driven servers cannot be modified.
+ * Requires resource write access. Config-driven servers cannot be modified,
+ * except AgentGateway-managed rows may update credential_sources.
  */
 export const PUT = withErrorHandler(async (request: NextRequest) => {
   const { searchParams } = new URL(request.url);
@@ -320,16 +331,29 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     };
     await requireResourcePermission(session, updateTarget);
 
-    // Config-driven guard
-    if (server.config_driven) {
+    // Build update with explicit field allowlist
+    const updateData = pickMutableFields(body);
+    validateCredentialSources(updateData.credential_sources);
+
+    if (server.config_driven && !isAgentGatewayManagedServer(server)) {
       throw new ApiError(
         "Config-driven MCP servers cannot be modified. Update config.yaml instead.",
         403,
       );
     }
 
-    // Build update with explicit field allowlist
-    const updateData = pickMutableFields(body);
+    if (isAgentGatewayManagedServer(server)) {
+      const disallowedFields = Object.keys(updateData).filter(
+        (field) => field !== "credential_sources",
+      );
+      if (disallowedFields.length > 0) {
+        throw new ApiError(
+          "AgentGateway-managed MCP servers only allow credential source updates. Routing metadata is managed by AgentGateway.",
+          403,
+        );
+      }
+    }
+
     if (Object.keys(updateData).length === 0) {
       // No fields to update — return current state
       return successResponse(server);
@@ -396,8 +420,13 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
     };
     await requireResourcePermission(session, deleteTarget);
 
-    // Config-driven guard
     if (server.config_driven) {
+      if (isAgentGatewayManagedServer(server)) {
+        throw new ApiError(
+          "AgentGateway-managed MCP servers cannot be deleted from this UI. Remove or disable the route in AgentGateway, then sync MCP servers again.",
+          403,
+        );
+      }
       throw new ApiError(
         "Config-driven MCP servers cannot be deleted. Remove from config.yaml instead.",
         403,

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -19,6 +19,7 @@ import React from "react";
 interface MCPServerEditorProps {
   server: MCPServerConfig | null; // null = creating new
   readOnly?: boolean;
+  managedByAgentGateway?: boolean;
   onSave: () => void;
   onCancel: () => void;
 }
@@ -29,8 +30,18 @@ const TRANSPORT_OPTIONS: { value: TransportType; label: string; description: str
   { value: "http", label: "HTTP", description: "HTTP/REST endpoint" },
 ];
 
-export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServerEditorProps) {
+export function MCPServerEditor({
+  server,
+  readOnly,
+  managedByAgentGateway,
+  onSave,
+  onCancel,
+}: MCPServerEditorProps) {
   const isEditing = !!server;
+  // assisted-by Codex Codex-sonnet-4-6
+  const credentialOnly = Boolean(isEditing && managedByAgentGateway && !readOnly);
+  const metadataReadOnly = Boolean(readOnly || credentialOnly);
+  const credentialReadOnly = Boolean(readOnly);
 
   // Form state
   const [id, setId] = React.useState(server?._id || "");
@@ -157,16 +168,22 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
 
       if (isEditing) {
         // Update existing server
-        const updateData: MCPServerConfigUpdate = {
-          name,
-          description: description || undefined,
-          transport,
-          endpoint: transport !== "stdio" ? endpoint : undefined,
-          command: transport === "stdio" ? command : undefined,
-          args: transport === "stdio" ? args : undefined,
-          env: transport === "stdio" && Object.keys(env).length > 0 ? env : undefined,
-          credential_sources: credentialSources.length > 0 ? credentialSources : undefined,
-        };
+        const shouldSendCredentialSources =
+          credentialOnly || credentialSources.length > 0 || Boolean(server.credential_sources?.length);
+        const updateData: MCPServerConfigUpdate = credentialOnly
+          ? {
+              credential_sources: credentialSources,
+            }
+          : {
+              name,
+              description: description || undefined,
+              transport,
+              endpoint: transport !== "stdio" ? endpoint : undefined,
+              command: transport === "stdio" ? command : undefined,
+              args: transport === "stdio" ? args : undefined,
+              env: transport === "stdio" && Object.keys(env).length > 0 ? env : undefined,
+              credential_sources: shouldSendCredentialSources ? credentialSources : undefined,
+            };
 
         const response = await fetch(`/api/mcp-servers?id=${server._id}`, {
           method: "PUT",
@@ -213,9 +230,10 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
   };
 
   const isValid =
-    name.trim() &&
-    (isEditing || id.trim()) &&
-    (transport === "stdio" ? command.trim() : endpoint.trim());
+    credentialOnly ||
+    (name.trim() &&
+      (isEditing || id.trim()) &&
+      (transport === "stdio" ? command.trim() : endpoint.trim()));
 
   return (
     <Card>
@@ -225,10 +243,20 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
-            <CardTitle>{readOnly ? "View MCP Server" : isEditing ? "Edit MCP Server" : "Add MCP Server"}</CardTitle>
+            <CardTitle>
+              {readOnly
+                ? "View MCP Server"
+                : credentialOnly
+                ? "Manage AgentGateway MCP Server"
+                : isEditing
+                ? "Edit MCP Server"
+                : "Add MCP Server"}
+            </CardTitle>
             <CardDescription>
               {readOnly
                 ? "This server is managed by configuration and cannot be edited."
+                : credentialOnly
+                ? "AgentGateway manages routing metadata. Credential references can be rotated here."
                 : isEditing
                 ? "Update the server configuration"
                 : "Configure a new MCP server connection"}
@@ -253,7 +281,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   placeholder="e.g., github, filesystem, postgres"
                   value={id}
                   onChange={(e) => setId(e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ""))}
-                  disabled={loading || readOnly}
+                  disabled={loading || metadataReadOnly}
                   className="font-mono"
                 />
                 <p className="text-xs text-muted-foreground">
@@ -274,7 +302,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 placeholder="e.g., GitHub MCP Server"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                disabled={loading || readOnly}
+                disabled={loading || metadataReadOnly}
               />
             </div>
 
@@ -285,7 +313,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 placeholder="What does this server provide?"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                disabled={loading || readOnly}
+                disabled={loading || metadataReadOnly}
                 rows={2}
               />
             </div>
@@ -308,7 +336,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                         ? "border-primary bg-primary/5"
                         : "border-muted hover:border-primary/50"
                     }`}
-                    disabled={loading || readOnly}
+                    disabled={loading || metadataReadOnly}
                   >
                     <div className="font-medium text-sm">{opt.label}</div>
                     <div className="text-xs text-muted-foreground">{opt.description}</div>
@@ -329,7 +357,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                     placeholder="e.g., npx, uvx, python"
                     value={command}
                     onChange={(e) => setCommand(e.target.value)}
-                    disabled={loading || readOnly}
+                    disabled={loading || metadataReadOnly}
                     className="font-mono"
                   />
                 </div>
@@ -347,10 +375,10 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           handleAddArg();
                         }
                       }}
-                      disabled={loading || readOnly}
+                      disabled={loading || metadataReadOnly}
                       className="font-mono"
                     />
-                    <Button type="button" variant="outline" onClick={handleAddArg} disabled={loading || readOnly}>
+                    <Button type="button" variant="outline" onClick={handleAddArg} disabled={loading || metadataReadOnly}>
                       <Plus className="h-4 w-4" />
                     </Button>
                   </div>
@@ -362,7 +390,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           <button
                             type="button"
                             onClick={() => handleRemoveArg(i)}
-                            disabled={readOnly}
+                            disabled={metadataReadOnly}
                             className="ml-1 hover:text-destructive"
                           >
                             <X className="h-3 w-3" />
@@ -381,7 +409,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       variant="ghost"
                       size="sm"
                       onClick={handleAddEnvVar}
-                      disabled={loading || readOnly}
+                      disabled={loading || metadataReadOnly}
                     >
                       <Plus className="h-4 w-4 mr-1" />
                       Add
@@ -395,14 +423,14 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                             placeholder="KEY"
                             value={env.key}
                             onChange={(e) => handleUpdateEnvVar(i, "key", e.target.value)}
-                            disabled={loading || readOnly}
+                            disabled={loading || metadataReadOnly}
                             className="font-mono flex-1"
                           />
                           <Input
                             placeholder="value"
                             value={env.value}
                             onChange={(e) => handleUpdateEnvVar(i, "value", e.target.value)}
-                            disabled={loading || readOnly}
+                            disabled={loading || metadataReadOnly}
                             className="font-mono flex-[2]"
                           />
                           <Button
@@ -410,7 +438,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                             variant="ghost"
                             size="icon"
                             onClick={() => handleRemoveEnvVar(i)}
-                            disabled={loading || readOnly}
+                            disabled={loading || metadataReadOnly}
                           >
                             <X className="h-4 w-4" />
                           </Button>
@@ -430,7 +458,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   placeholder={`e.g., http://localhost:3000/${transport === "sse" ? "sse" : "mcp"}`}
                   value={endpoint}
                   onChange={(e) => setEndpoint(e.target.value)}
-                  disabled={loading || readOnly}
+                  disabled={loading || metadataReadOnly}
                   className="font-mono"
                 />
                 {gatewayDiscoveryLoaded && agentGatewayTargets.length > 0 ? (
@@ -447,7 +475,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           type="button"
                           variant="outline"
                           size="sm"
-                          disabled={loading || readOnly}
+                          disabled={loading || metadataReadOnly}
                           onClick={() => setEndpoint(target.endpoint)}
                           title={
                             target.target_endpoint
@@ -479,7 +507,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 variant="ghost"
                 size="sm"
                 onClick={handleAddCredentialSource}
-                disabled={loading || readOnly}
+                disabled={loading || credentialReadOnly}
               >
                 <Plus className="h-4 w-4 mr-1" />
                 Add Credential
@@ -494,7 +522,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       className="rounded-md border border-input bg-background px-3 py-2 text-sm"
                       value={source.kind}
                       onChange={(event) => handleUpdateCredentialSource(i, "kind", event.target.value)}
-                      disabled={readOnly}
+                      disabled={credentialReadOnly}
                     >
                       <option value="secret_ref">Secret ref</option>
                       <option value="provider_connection">Provider connection</option>
@@ -504,7 +532,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       className="rounded-md border border-input bg-background px-3 py-2 text-sm"
                       value={source.target}
                       onChange={(event) => handleUpdateCredentialSource(i, "target", event.target.value)}
-                      disabled={readOnly}
+                      disabled={credentialReadOnly}
                     >
                       <option value="env">Environment</option>
                       <option value="header">Header</option>
@@ -514,7 +542,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                       placeholder={source.target === "env" ? "GITHUB_TOKEN" : "Authorization"}
                       value={source.name}
                       onChange={(event) => handleUpdateCredentialSource(i, "name", event.target.value)}
-                      disabled={readOnly}
+                      disabled={credentialReadOnly}
                     />
                     <Input
                       aria-label="Credential reference"
@@ -527,14 +555,14 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                           event.target.value,
                         )
                       }
-                      disabled={readOnly}
+                      disabled={credentialReadOnly}
                     />
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
                       onClick={() => handleRemoveCredentialSource(i)}
-                      disabled={loading || readOnly}
+                      disabled={loading || credentialReadOnly}
                     >
                       <X className="h-4 w-4" />
                     </Button>
@@ -559,6 +587,11 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 Config-driven — managed by configuration file
               </span>
             )}
+            {credentialOnly && (
+              <span className="text-xs text-muted-foreground mr-auto">
+                AgentGateway-managed — route changes must be made in AgentGateway
+              </span>
+            )}
             <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
               {readOnly ? "Close" : "Cancel"}
             </Button>
@@ -569,6 +602,8 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                     {isEditing ? "Saving..." : "Creating..."}
                   </>
+                ) : credentialOnly ? (
+                  "Save Credential Sources"
                 ) : isEditing ? (
                   "Save Changes"
                 ) : (

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -52,6 +52,10 @@ function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback;
 }
 
+function isAgentGatewayManagedServer(server: MCPServerConfig): boolean {
+  return server.config_driven === true && server.source === "agentgateway";
+}
+
 export function MCPServersTab() {
   const [servers, setServers] = React.useState<MCPServerConfig[]>([]);
   const [loading, setLoading] = React.useState(true);
@@ -308,10 +312,14 @@ export function MCPServersTab() {
   };
 
   if (isCreating || editingServer) {
+    const editingServerIsAgentGatewayManaged = editingServer
+      ? isAgentGatewayManagedServer(editingServer)
+      : false;
     return (
       <MCPServerEditor
         server={editingServer}
-        readOnly={editingServer?.config_driven}
+        readOnly={Boolean(editingServer?.config_driven && !editingServerIsAgentGatewayManaged)}
+        managedByAgentGateway={editingServerIsAgentGatewayManaged}
         onSave={() => {
           setEditingServer(null);
           setIsCreating(false);
@@ -448,6 +456,7 @@ export function MCPServersTab() {
             {/* Server rows */}
             {servers.map((server) => {
               const probe = probeResults[server._id];
+              const isAgentGatewayManaged = isAgentGatewayManagedServer(server);
               return (
                 <div key={server._id} className="space-y-2">
                   <div
@@ -507,7 +516,13 @@ export function MCPServersTab() {
                         onClick={(e) => { e.stopPropagation(); if (!server.config_driven) handleToggleEnabled(server); }}
                         className={`flex items-center gap-1.5 ${server.config_driven ? "cursor-not-allowed opacity-60" : ""}`}
                         disabled={server.config_driven}
-                        title={server.config_driven ? "Config-driven servers cannot be modified" : undefined}
+                        title={
+                          isAgentGatewayManaged
+                            ? "AgentGateway manages enablement for this route. Update AgentGateway, then sync MCP servers."
+                            : server.config_driven
+                            ? "Config-driven servers cannot be modified"
+                            : undefined
+                        }
                       >
                         {server.enabled ? (
                           <>
@@ -557,6 +572,17 @@ export function MCPServersTab() {
                         >
                           Config
                         </Badge>
+                      )}
+                      {isAgentGatewayManaged && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-muted-foreground"
+                          disabled
+                          title="Delete unavailable: AgentGateway manages this route. Remove or disable it in AgentGateway, then sync MCP servers."
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
                       )}
                       {!server.config_driven && (
                         <Button

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { MCPServerEditor } from "../MCPServerEditor";
@@ -42,5 +42,120 @@ describe("MCPServerEditor credential sources", () => {
     );
     expect(createCall).toBeDefined();
     expect(createCall?.[1]?.body).toContain("conn-1");
+  });
+
+  it("rotates credential references for AgentGateway-managed servers without sending route metadata", async () => {
+    const user = userEvent.setup();
+    render(
+      <MCPServerEditor
+        server={{
+          _id: "rag",
+          name: "RAG",
+          transport: "http",
+          endpoint: "http://agentgateway:4000/mcp",
+          enabled: true,
+          config_driven: true,
+          source: "agentgateway",
+          agentgateway_target_endpoint: "http://rag-server:9446/mcp",
+          credential_sources: [
+            {
+              kind: "secret_ref",
+              target: "header",
+              name: "Authorization",
+              secret_ref: "old-secret",
+            },
+          ],
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        }}
+        managedByAgentGateway
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/display name/i)).toBeDisabled();
+    expect(screen.getByLabelText(/endpoint url/i)).toBeDisabled();
+
+    const credentialReference = screen.getByLabelText(/credential reference/i);
+    expect(credentialReference).not.toBeDisabled();
+    await user.clear(credentialReference);
+    await user.type(credentialReference, "rotated-secret");
+    await user.click(screen.getByRole("button", { name: /save credential sources/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/mcp-servers?id=rag",
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    const updateCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        url === "/api/mcp-servers?id=rag" && init?.method === "PUT",
+    );
+    const body = JSON.parse(String(updateCall?.[1]?.body));
+
+    expect(body).toEqual({
+      credential_sources: [
+        {
+          kind: "secret_ref",
+          target: "header",
+          name: "Authorization",
+          secret_ref: "rotated-secret",
+        },
+      ],
+    });
+    expect(body).not.toHaveProperty("endpoint");
+    expect(body).not.toHaveProperty("agentgateway_target_endpoint");
+  });
+
+  it("adds a missing credential reference for AgentGateway-managed servers", async () => {
+    const user = userEvent.setup();
+    render(
+      <MCPServerEditor
+        server={{
+          _id: "rag",
+          name: "RAG",
+          transport: "http",
+          endpoint: "http://agentgateway:4000/mcp",
+          enabled: true,
+          config_driven: true,
+          source: "agentgateway",
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        }}
+        managedByAgentGateway
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add credential/i }));
+    await user.type(screen.getByLabelText(/credential name/i), "Authorization");
+    await user.type(screen.getByLabelText(/credential reference/i), "secret-1");
+    await user.click(screen.getByRole("button", { name: /save credential sources/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/mcp-servers?id=rag",
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    const updateCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        url === "/api/mcp-servers?id=rag" && init?.method === "PUT",
+    );
+    const body = JSON.parse(String(updateCall?.[1]?.body));
+
+    expect(body.credential_sources).toEqual([
+      {
+        kind: "secret_ref",
+        target: "header",
+        name: "Authorization",
+        secret_ref: "secret-1",
+      },
+    ]);
   });
 });

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -67,6 +67,15 @@ describe("MCPServersTab AgentGateway sync", () => {
           }),
         } as Response);
       }
+      if (url === "/api/mcp-servers/agentgateway/discover") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: { targets: [] },
+          }),
+        } as Response);
+      }
       throw new Error(`Unexpected fetch: ${url}`);
     }) as unknown as typeof fetch;
   });
@@ -109,6 +118,23 @@ describe("MCPServersTab AgentGateway sync", () => {
 
     expect(screen.getByText("AgentGateway")).toBeInTheDocument();
     expect(screen.getByText(/Target: http:\/\/rag-server:9446\/mcp/i)).toBeInTheDocument();
+  });
+
+  it("explains managed AgentGateway lifecycle actions and opens credential-only editing", async () => {
+    serverItems = [agentGatewayRagServer];
+    render(<MCPServersTab />);
+
+    await screen.findByText("RAG");
+
+    expect(screen.getByTitle(/Delete unavailable: AgentGateway manages this route/i)).toBeDisabled();
+    expect(screen.getByTitle(/AgentGateway manages enablement for this route/i)).toBeDisabled();
+
+    fireEvent.click(screen.getByText("RAG"));
+
+    expect(await screen.findByText("Manage AgentGateway MCP Server")).toBeInTheDocument();
+    expect(screen.getByText(/Credential references can be rotated here/i)).toBeInTheDocument();
+    expect(screen.getByText(/route changes must be made in AgentGateway/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add credential/i })).toBeEnabled();
   });
 
   it("refreshes the mounted list when servers are added outside the tab", async () => {


### PR DESCRIPTION
# Description

Fixes #1930.

AgentGateway-managed MCP server rows were treated as fully config-driven, which disabled credential editing and hid the practical lifecycle path from admins. This PR adds a narrow credential-only edit path for AgentGateway-managed MCP servers while preserving AgentGateway-owned routing metadata.

What changed:
- Allows `credential_sources` updates for MCP rows with `config_driven: true` and `source: \"agentgateway\"`.
- Rejects non-credential edits on AgentGateway-managed rows so endpoint/source/target metadata remains sync-owned.
- Shows a credential-only editor for AgentGateway-managed rows in the MCP Servers tab.
- Keeps toggle/delete disabled for managed rows, but surfaces explicit remediation copy instead of leaving the action hidden.
- Adds Jest and Playwright coverage for credential rotation, missing credential refs, routing metadata preservation, and lifecycle explanations.

User impact:
- Admins can rotate, replace, add, or clear credential references for AgentGateway-managed MCP servers without direct database edits.
- Managed rows explain that route enable/delete changes must happen in AgentGateway followed by an MCP sync.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `npx jest src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx --runInBand`
- `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3000 npx playwright test e2e/rbac/mcp-openfga-tuples.spec.ts --config=playwright.rbac.config.ts`
- `npx eslint e2e/rbac/mcp-openfga-tuples.spec.ts src/app/api/mcp-servers/route.ts src/components/dynamic-agents/MCPServerEditor.tsx src/components/dynamic-agents/MCPServersTab.tsx src/app/api/mcp-servers/__tests__/endpoint-normalization.test.ts src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx`
- `git diff --check`
- `npm run lint` (0 errors; existing repo warnings remain)
- `npm run build`