### PR TITLE
docs(rag): clarify health proxy auth behavior

### DIFF
--- a/ui/src/app/api/rag/[...path]/route.ts
+++ b/ui/src/app/api/rag/[...path]/route.ts
@@ -42,7 +42,7 @@ import { NextRequest,NextResponse } from 'next/server';
  * authoritative source (OIDC provider's userinfo endpoint).
  *
  * Example:
- *   /api/rag/healthz -> RAG_SERVER_URL/healthz (with Bearer token)
+ *   /api/rag/healthz -> RAG_SERVER_URL/healthz (readiness probe, no Bearer token)
  *   /api/rag/v1/query -> RAG_SERVER_URL/v1/query (with Bearer token)
  *
  * The Web UI backend enforces coarse RAG access before proxying and


### PR DESCRIPTION
# Description

Clarifies that the RAG health proxy forwards `/api/rag/healthz` as an unauthenticated readiness probe, while normal RAG data/query routes still forward with the Bearer token.

Follow-up from review of #1950.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A - no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

Validation:
- `git diff --check`
- Automated tests not run; comment-only documentation cleanup.
