### PR TITLE
fix(security): reduce container scan surface

### DIFF
--- a/ai_platform_engineering/agents/aws/agent_aws/agent_langgraph.py
+++ b/ai_platform_engineering/agents/aws/agent_aws/agent_langgraph.py
@@ -1,5 +1,6 @@
 # Copyright 2025 CNOE
 # SPDX-License-Identifier: Apache-2.0
+# assisted-by Codex Codex-sonnet-4-6
 
 """LangGraph-based AWS Agent with AWS CLI tool support."""
 
@@ -111,7 +112,9 @@ Use `aws ce` commands for cost analysis:
 
 Example - Get last month's costs by service:
 ```
-ce get-cost-and-usage --time-period Start=2024-11-01,End=2024-12-01 --granularity MONTHLY --metrics BlendedCost --group-by Type=DIMENSION,Key=SERVICE
+ce get-cost-and-usage --time-period Start=2024-11-01,End=2024-12-01 \
+  --granularity MONTHLY --metrics BlendedCost \
+  --group-by Type=DIMENSION,Key=SERVICE
 ```
 
 **⏰ WHEN TO USE CURRENT DATE:**
@@ -869,7 +872,8 @@ When listing ANY AWS resources, ALWAYS include these columns:
 
 **HOW TO GET INSTANCE NAME:**
 - Name is stored in Tags: `.Tags[] | select(.Key=="Name") | .Value`
-- Use jq_filter to extract: `jq_filter: ".Reservations[].Instances[] | {{Name: (.Tags[]? | select(.Key==\"Name\") | .Value), ID: .InstanceId}}"`
+- Use jq_filter to extract names and IDs:
+  `jq_filter: ".Reservations[].Instances[] | {{Name: (.Tags[]? | select(.Key==\"Name\") | .Value), ID: .InstanceId}}"`
 - If no Name tag exists, show "unnamed" or the Instance ID
 
 **HOW TO GET ACCOUNT INFO:**
@@ -891,7 +895,7 @@ When listing ANY AWS resources, ALWAYS include these columns:
 Large outputs cause context overflow! ALWAYS use --query to get only needed fields:
 
 **GOOD (filtered - small output):**
-`ec2 describe-instances --query 'Reservations[].Instances[].{{Name:Tags[?Key==Name].Value|[0],ID:InstanceId,State:State.Name,Type:InstanceType}}'`
+`ec2 describe-instances --query 'Reservations[].Instances[].{{Name:Tags[?Key==Name].Value|[0],ID:InstanceId,State:State.Name}}'`
 `eks list-clusters --query 'clusters'`
 `eks describe-cluster --name CLUSTER --query 'cluster.{{Name:name,Status:status,Version:version,Endpoint:endpoint}}'`
 `ecr describe-repositories --query 'repositories[].repositoryName'`
@@ -1061,7 +1065,8 @@ Other repositories containing 'myapp': services/myapp-api, tools/myapp-helper"
    `ecr describe-images --profile <account-name> --region <region> --repository-name REPO_NAME`
 
 4. **Find latest images (sorted by push date):**
-   `ecr describe-images --profile <account-name> --region <region> --repository-name REPO_NAME --query 'sort_by(imageDetails, &imagePushedAt)[-5:]'`
+   `ecr describe-images --profile <account-name> --region <region> --repository-name REPO_NAME \
+     --query 'sort_by(imageDetails, &imagePushedAt)[-5:]'`
 
 5. **Get specific image by tag:**
    `ecr describe-images --profile <account-name> --region <region> --repository-name REPO_NAME --image-ids imageTag=latest`
@@ -1322,7 +1327,10 @@ Always structure your final answer with:
             tools.append(aws_cli_tool)
             logger.info(f"✅ {agent_name}: Added AWS CLI tool (aws_cli_execute)")
         else:
-            logger.warning(f"⚠️  {agent_name}: AWS CLI tool not enabled. Set USE_AWS_CLI_AS_TOOL=true to enable.")
+            logger.warning(
+                f"⚠️  {agent_name}: AWS CLI tool unavailable. "
+                "Set USE_AWS_CLI_AS_TOOL=true and ensure aws is installed on PATH to enable it."
+            )
 
         # Add EKS kubectl tool for Kubernetes resource inspection
         eks_kubectl_tool = get_eks_kubectl_tool()
@@ -1333,7 +1341,7 @@ Always structure your final answer with:
         if not tools:
             raise RuntimeError(
                 f"{agent_name}: No tools available. "
-                "Please set USE_AWS_CLI_AS_TOOL=true to enable the AWS CLI tool."
+                "Please set USE_AWS_CLI_AS_TOOL=true and ensure aws is installed on PATH."
             )
 
         logger.info(f"✅ {agent_name}: Total tools available: {len(tools)}")

--- a/ai_platform_engineering/agents/aws/agent_aws/tools.py
+++ b/ai_platform_engineering/agents/aws/agent_aws/tools.py
@@ -1,5 +1,6 @@
 # Copyright 2025 CNOE
 # SPDX-License-Identifier: Apache-2.0
+# assisted-by Codex Codex-sonnet-4-6
 
 """Custom tools for AWS Agent including AWS CLI execution."""
 
@@ -8,6 +9,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 from typing import Any, Optional
 
 from langchain_core.tools import BaseTool
@@ -115,6 +117,15 @@ _kubectl_semaphore = asyncio.Semaphore(MAX_CONCURRENT_KUBECTL_CALLS)
 
 # AWS profiles configuration
 _aws_profiles_configured = False
+
+
+def _has_executable(name: str) -> bool:
+    """Return whether a required local CLI is available on PATH."""
+    if shutil.which(name):
+        return True
+
+    logger.warning("%s executable is not installed or not on PATH", name)
+    return False
 
 
 def setup_aws_profiles() -> list[dict]:
@@ -256,7 +267,8 @@ class AWSCLIToolInput(BaseModel):
         default=None,
         description=(
             "Optional jq filter to process JSON output. Use this to extract specific fields. "
-            "Examples: '.Reservations[].Instances[] | {Name: .Tags[]? | select(.Key==\"Name\") | .Value, ID: .InstanceId, State: .State.Name}', "
+            "Examples: '.Reservations[].Instances[] | {Name: .Tags[]? | "
+            "select(.Key==\"Name\") | .Value, ID: .InstanceId, State: .State.Name}', "
             "'.clusters[]', '.DBInstances[] | {Name: .DBInstanceIdentifier, Status: .DBInstanceStatus}'. "
             "The filter is applied to the raw JSON output from AWS CLI."
         )
@@ -551,6 +563,10 @@ def get_aws_cli_tool() -> Optional[AWSCLITool]:
 
     if not use_aws_cli:
         logger.info("AWS CLI tool is disabled (USE_AWS_CLI_AS_TOOL=false)")
+        return None
+
+    if not _has_executable("aws"):
+        logger.info("AWS CLI tool is disabled because the aws executable is unavailable")
         return None
 
     # Setup AWS profiles for cross-account access
@@ -975,12 +991,18 @@ class EKSKubectlTool(BaseTool):
             )
 
 
-def get_eks_kubectl_tool() -> EKSKubectlTool:
+def get_eks_kubectl_tool() -> Optional[EKSKubectlTool]:
     """Get the EKS kubectl tool instance."""
+    if not _has_executable("aws"):
+        logger.info("EKS kubectl tool is disabled because the aws executable is unavailable")
+        return None
+    if not _has_executable("kubectl"):
+        logger.info("EKS kubectl tool is disabled because the kubectl executable is unavailable")
+        return None
+
     return EKSKubectlTool()
 
 
 def get_reflection_tool() -> ReflectionTool:
     """Get the reflection tool instance."""
     return ReflectionTool()
-

--- a/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors
+++ b/ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors
@@ -10,7 +10,7 @@ ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 # for an example.
 ENV UV_PYTHON_DOWNLOADS=0
 
-# Build variant: "default" (with Playwright/Chromium for JS rendering) or "slim" (no Playwright, smaller image)
+# Build variant: "default" or "slim" (browserless) or "browser" (with Playwright/Chromium for JS rendering)
 ARG VARIANT=default
 
 # Copy over the local dependencies (excluding .venv directories)
@@ -19,23 +19,23 @@ COPY common /app/common
 RUN rm -rf /app/common/.venv
 
 WORKDIR /app/ingestors
-# Install dependencies based on variant
-# Default includes Playwright for JS rendering; slim variant excludes it for smaller image
+# Install dependencies based on variant.
+# Default is browserless so the published image does not ship Chromium CVEs.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=ingestors/uv.lock,target=uv.lock \
     --mount=type=bind,source=ingestors/pyproject.toml,target=pyproject.toml \
-    if [ "$VARIANT" = "slim" ]; then \
-        UV_HTTP_TIMEOUT=900 uv sync --locked --no-install-project --no-dev; \
-    else \
+    if [ "$VARIANT" = "browser" ]; then \
         UV_HTTP_TIMEOUT=900 uv sync --locked --no-install-project --no-dev --extra playwright; \
+    else \
+        UV_HTTP_TIMEOUT=900 uv sync --locked --no-install-project --no-dev; \
     fi
 
 COPY ingestors .
 RUN --mount=type=cache,target=/root/.cache/uv \
-    if [ "$VARIANT" = "slim" ]; then \
-        UV_HTTP_TIMEOUT=900 uv sync --locked --no-dev; \
-    else \
+    if [ "$VARIANT" = "browser" ]; then \
         UV_HTTP_TIMEOUT=900 uv sync --locked --no-dev --extra playwright; \
+    else \
+        UV_HTTP_TIMEOUT=900 uv sync --locked --no-dev; \
     fi
 
 # Clean up .venv to reduce image size (remove ~100MB of unnecessary files)
@@ -55,14 +55,14 @@ FROM cgr.dev/chainguard/wolfi-base
 
 # Re-declare ARG after FROM to make it available in this stage
 ARG VARIANT=default
+ARG INSTALL_AWS_CLI=false
 
 # Install system dependencies from the Wolfi package repository:
 # - python-3.13            : system CPython matching the builder
 # - ca-certificates-bundle : TLS trust store
-# - curl / unzip           : AWS CLI v2 download + extraction
 # - bash                   : login shell for the non-root user
 # - shadow                 : provides groupadd/useradd for non-root user creation
-# - chromium (default var) : distro browser for Playwright full-browser launches.
+# - chromium (browser var) : distro browser for Playwright full-browser launches.
 #                            Wolfi's chromium apk resolves its own runtime libs,
 #                            so the long manual Debian lib list is no longer needed.
 RUN echo "https://packages.wolfi.dev/os" > /etc/apk/repositories && \
@@ -70,29 +70,38 @@ RUN echo "https://packages.wolfi.dev/os" > /etc/apk/repositories && \
     apk add --no-cache \
         python-3.13 \
         ca-certificates-bundle \
-        curl \
-        unzip \
         bash \
         shadow && \
-    if [ "$VARIANT" != "slim" ]; then \
+    if [ "$VARIANT" = "browser" ]; then \
         apk add --no-cache chromium; \
     fi && \
-    # Ensure /usr/local/bin/python3 (the path baked into the builder venv) exists
+    if [ "$INSTALL_AWS_CLI" = "true" ]; then \
+        apk add --no-cache curl unzip; \
+    fi
+
+# Ensure /usr/local/bin/python3 (the path baked into the builder venv) exists.
+RUN \
     if [ ! -e /usr/local/bin/python3 ]; then \
         mkdir -p /usr/local/bin && \
         ln -sf "$(command -v python3.13 || command -v python3)" /usr/local/bin/python3; \
     fi && \
     ln -sf /usr/local/bin/python3 /usr/local/bin/python && \
-    # Install AWS CLI v2 (detect architecture) for EKS authentication (k8s ingestor)
-    ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ]; then \
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
-    else \
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    apk upgrade --no-cache
+
+# AWS CLI v2 is opt-in for EKS kubeconfigs that shell out to `aws eks get-token`.
+RUN \
+    if [ "$INSTALL_AWS_CLI" = "true" ]; then \
+        ARCH=$(uname -m) && \
+        if [ "$ARCH" = "aarch64" ]; then \
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+        else \
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+        fi && \
+        unzip -q awscliv2.zip && \
+        ./aws/install && \
+        rm -rf awscliv2.zip aws; \
     fi && \
-    unzip -q awscliv2.zip && \
-    ./aws/install && \
-    rm -rf awscliv2.zip aws
+    true
 
 # Create a non-root user
 RUN groupadd --gid 1001 app && \
@@ -111,7 +120,7 @@ ENV PATH="/app/ingestors/.venv/bin:$PATH"
 # use the distro browser. A fixed symlink /opt/chrome/chrome makes the ENV path
 # arch-independent and decoupled from the exact Wolfi chromium install location.
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
-RUN if [ "$VARIANT" != "slim" ]; then \
+RUN if [ "$VARIANT" = "browser" ]; then \
         mkdir -p /opt/chrome && \
         ln -sf "$(command -v chromium || echo /usr/bin/chromium)" /opt/chrome/chrome && \
         playwright install chromium && \
@@ -123,5 +132,5 @@ ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/opt/chrome/chrome
 # Use a non-root user to run the application
 USER app
 
-# Run the application by default - use shell form to enable variable expansion
-CMD python3 src/ingestors/${INGESTOR_TYPE}/ingestor.py
+# Run the application by default through sh so INGESTOR_TYPE expands at runtime.
+CMD ["sh", "-c", "exec python3 src/ingestors/${INGESTOR_TYPE}/ingestor.py"]

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/k8s/README.md
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/k8s/README.md
@@ -87,13 +87,24 @@ docker compose --profile k8s up --build k8s_ingestor
 
 ### Running with EKS clusters (requires AWS authentication)
 
-EKS clusters use AWS IAM for authentication, which requires the AWS CLI to be available in the container. To run the K8s ingestor with EKS:
+EKS clusters use AWS IAM for authentication, which requires the AWS CLI to be available in the container. The default published ingestors image does not include AWS CLI because the upstream installer ships a bundled Python runtime with separate security findings. Build an EKS-specific image when your kubeconfig uses `aws eks get-token`:
+
+```bash
+docker build \
+  -f build/Dockerfile.ingestors \
+  --build-arg INSTALL_AWS_CLI=true \
+  -t caipe-rag-ingestors:eks \
+  .
+```
+
+To run the K8s ingestor with EKS:
 
 1. Create a `docker-compose.override.yaml` file:
 
 ```yaml
 services:
   k8s_ingestor:
+    image: caipe-rag-ingestors:eks
     volumes:
       # Mount AWS credentials for EKS authentication
       - ~/.aws:/home/app/.aws:ro
@@ -129,4 +140,3 @@ The K8s ingestor requires:
 - Entity types are created in Pascal case format (e.g., `K8sDeployment`, `K8sService`, `K8sCustomResource`)
 - When running in-cluster, ensure the ServiceAccount has proper RBAC permissions
 - **For EKS clusters:** AWS credentials must be available in the container (see EKS-specific instructions above)
-

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/README.md
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/README.md
@@ -90,6 +90,15 @@ In addition to `ScrapySettings`, the URL ingestion request supports:
 - Enable `render_javascript: true` for JavaScript-heavy sites (SPAs)
 - Uses Playwright for headless browser rendering
 - Supports waiting for specific selectors before extraction
+- The default published ingestors image is browserless. Build a browser-enabled image when JavaScript rendering is required:
+
+```bash
+docker build \
+  -f build/Dockerfile.ingestors \
+  --build-arg VARIANT=browser \
+  -t caipe-rag-ingestors:browser \
+  .
+```
 
 ### 4. Specialized Parsers
 - **Docusaurus**: Optimized for Docusaurus documentation sites
@@ -206,4 +215,3 @@ INFO: Completed URL ingestion for https://example.com
 - Failed URLs are logged and can be retried via reload commands
 - The ingestor automatically manages task concurrency to prevent resource exhaustion
 - Periodic reloads ensure documentation stays current without manual intervention
-

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,6 +41,7 @@ RUN BEDROCK_PY=".venv/lib/python3.13/site-packages/langchain_aws/chat_models/bed
 FROM cgr.dev/chainguard/wolfi-base
 
 ARG TERRAFORM_VERSION=1.15.4
+ARG INSTALL_AWS_CLI=false
 
 # Override APK repo to public Wolfi OS packages (no auth required).
 RUN echo "https://packages.wolfi.dev/os" > /etc/apk/repositories
@@ -65,16 +66,20 @@ RUN mkdir -p /usr/local/bin \
     && ln -sf /usr/bin/python3.13 /usr/local/bin/python3 \
     && ln -sf /usr/bin/python3.13 /usr/local/bin/python
 
-# AWS CLI v2 — used by aws_cli_execute tool in single-node AWS subagent
+# AWS CLI v2 is opt-in because the upstream installer bundles its own Python
+# runtime, which shows up as separate binary CVEs in the default image.
 RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
-        curl -sfL --retry 5 --retry-delay 3 "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
-    else \
-        curl -sfL --retry 5 --retry-delay 3 "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    if [ "$INSTALL_AWS_CLI" = "true" ]; then \
+        if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+            curl -sfL --retry 5 --retry-delay 3 "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+        else \
+            curl -sfL --retry 5 --retry-delay 3 "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+        fi && \
+        unzip -q awscliv2.zip && \
+        ./aws/install && \
+        rm -rf awscliv2.zip aws; \
     fi && \
-    unzip -q awscliv2.zip && \
-    ./aws/install && \
-    rm -rf awscliv2.zip aws
+    true
 
 # Terraform CLI — used by terraform_fmt tool for HCL formatting in self-service tasks
 RUN ARCH=$(uname -m) && \
@@ -94,6 +99,7 @@ WORKDIR /app
 # imports like 'from agent_github.tools import ...' work in single-node mode.
 # Only include dirs with agent_* packages; pure MCP-server dirs (e.g. agents/litellm/)
 # must be omitted to avoid shadowing PyPI packages with same-named subdirectories.
+ENV PYTHONPATH=""
 ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     GOPATH="/home/appuser/go" \
     PATH="/app/.venv/bin:/home/appuser/go/bin:${PATH}" \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,7 +41,7 @@ RUN BEDROCK_PY=".venv/lib/python3.13/site-packages/langchain_aws/chat_models/bed
 FROM cgr.dev/chainguard/wolfi-base
 
 ARG TERRAFORM_VERSION=1.15.4
-ARG INSTALL_AWS_CLI=false
+ARG INSTALL_AWS_CLI=true
 
 # Override APK repo to public Wolfi OS packages (no auth required).
 RUN echo "https://packages.wolfi.dev/os" > /etc/apk/repositories
@@ -66,8 +66,9 @@ RUN mkdir -p /usr/local/bin \
     && ln -sf /usr/bin/python3.13 /usr/local/bin/python3 \
     && ln -sf /usr/bin/python3.13 /usr/local/bin/python
 
-# AWS CLI v2 is opt-in because the upstream installer bundles its own Python
-# runtime, which shows up as separate binary CVEs in the default image.
+# AWS CLI v2 is installed by default because the all-in-one image currently
+# exposes AWS agent tools that depend on it. Custom hardened builds can opt out
+# because the upstream installer bundles its own Python runtime with binary CVEs.
 RUN ARCH=$(uname -m) && \
     if [ "$INSTALL_AWS_CLI" = "true" ]; then \
         if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \


### PR DESCRIPTION
# Description

Reduce the current container code-scanning surface by removing default RAG ingestor image contents that are producing large alert buckets, while preserving the current all-in-one runtime contract.

Changes:
- Make the published RAG ingestors default image browserless; `slim` remains a browserless compatibility tag.
- Keep Playwright/Chromium available only for custom ingestors builds with `VARIANT=browser`.
- Make AWS CLI v2 opt-in for the RAG ingestors image with `INSTALL_AWS_CLI=true`.
- Keep AWS CLI v2 installed by default in the all-in-one `ai-platform-engineering` image because the current AWS agent runtime still depends on it.
- Allow custom hardened all-in-one builds to opt out with `INSTALL_AWS_CLI=false`.
- Hide local AWS CLI/EKS kubectl tools when their required binaries are not present on `PATH`.
- Document the EKS and JavaScript-rendering opt-in image builds.

Security impact from the current open code-scanning view:
- Current open alerts: 269.
- Expected to clear after image rebuild/rescan: 183.
- Breakdown: 183 `caipe-rag-ingestors` Chromium/AWS CLI bundled-Python findings.
- Expected remaining: 86 findings: 13 all-in-one `ai-platform-engineering` AWS CLI bundled-Python findings, plus 73 upstream package findings for Wolfi `python-3.13` at `3.13.14-r0`, Alpine BusyBox at `1.37.0-r31`, and Wolfi `kubectl-1.36-default` at `1.36.2-r0`.

Operator impact:
- Default ingestors images no longer support JavaScript rendering unless rebuilt with `VARIANT=browser`.
- Default ingestors images no longer include AWS CLI v2 unless rebuilt with `INSTALL_AWS_CLI=true`.
- Default all-in-one images still include AWS CLI v2.
- AWS A2A/MCP images still opt into AWS CLI/kubectl through the existing per-agent build args because those tools are their runtime surface.

Follow-up design note:
- The all-in-one image still carries AWS CLI because the current AWS agent exposes CLI-backed tools from that runtime.
- To clear the remaining all-in-one AWS CLI alerts without changing behavior, we should split that dependency out of the default all-in-one path: for example an AWS-specific agent image, sidecar/tool-runner, or an explicit deployment profile that only enables AWS CLI where the AWS agent is deployed.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `git diff --check`
- `uv run ruff check ai_platform_engineering/agents/aws/agent_aws/tools.py ai_platform_engineering/agents/aws/agent_aws/agent_langgraph.py`
- `uv run pytest tests/test_aws_agent_tools.py`
- `docker buildx build --check -f build/Dockerfile .`
- `docker buildx build --check -f build/Dockerfile --build-arg INSTALL_AWS_CLI=false .`
- `docker buildx build --check -f ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors --build-arg VARIANT=default --build-arg INSTALL_AWS_CLI=false ai_platform_engineering/knowledge_bases/rag`
- `docker buildx build --check -f ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors --build-arg VARIANT=browser --build-arg INSTALL_AWS_CLI=true ai_platform_engineering/knowledge_bases/rag`
- `docker build -f ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors --build-arg VARIANT=default --build-arg INSTALL_AWS_CLI=false -t caipe-rag-ingestors:security-check ai_platform_engineering/knowledge_bases/rag`
- `docker run --rm --entrypoint sh caipe-rag-ingestors:security-check -c 'set -eu; ! command -v aws; ! command -v chromium; ! command -v chromium-browser; python3 - <<"PY" ... PY; python3 --version'`
