### PR TITLE
fix(compose): use canonical caipe-ui image tag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -411,7 +411,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.16}-prod
+    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.16}
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -486,7 +486,7 @@ services:
         condition: service_healthy
         required: false
     profiles:
-      - caipe-ui-prod
+      - caipe-ui
 
   ####################################################################################################
   #                                      Audit Service                                               #
@@ -537,7 +537,7 @@ services:
     profiles:
       - audit-service
       - caipe-supervisor
-      - caipe-ui-prod
+      - caipe-ui
       - dynamic-agents
       - slack-bot
       - webex-bot


### PR DESCRIPTION
# Description

Updates the root Docker Compose UI service to use the canonical `ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.16}` image tag instead of the non-published `-prod` variant.

This also moves the dependent profile references from `caipe-ui-prod` back to `caipe-ui`, matching the root compose service/profile naming.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `docker compose -f docker-compose.yaml config --quiet`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
