### PR TITLE
ci(rag): build only changed RAG components instead of all three

### DIFF
--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -50,10 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: load-config
     outputs:
-      should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
+      should_build: ${{ steps.set-matrix.outputs.should_build }}
+      should_retag: ${{ steps.set-matrix.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
-      image_prefix: ${{ steps.set-outputs.outputs.image_prefix }}
+      image_prefix: ${{ steps.set-matrix.outputs.image_prefix }}
+      build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
+      retag_matrix: ${{ steps.set-matrix.outputs.retag_matrix }}
     steps:
       - name: 🔑 Generate GitHub App token
         id: app-token
@@ -81,73 +83,98 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: |
-            rag:
-              - 'ai_platform_engineering/knowledge_bases/rag/**'
+            shared:
+              - 'ai_platform_engineering/knowledge_bases/rag/common/**'
+            agent-ontology:
+              - 'ai_platform_engineering/knowledge_bases/rag/agent_ontology/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.agent-ontology'
+            server:
+              - 'ai_platform_engineering/knowledge_bases/rag/server/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server'
+            ingestors:
+              - 'ai_platform_engineering/knowledge_bases/rag/ingestors/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors'
 
-      - name: Set Outputs
-        id: set-outputs
+      # Build only the components whose own sources (or the shared `common/`
+      # library) changed, instead of rebuilding all three on any rag/** edit.
+      # First pre-release / final release / manual dispatch / force_build still
+      # build everything; on incremental pre-releases unchanged components are
+      # retagged from the previous version.
+      - name: Compute build & retag matrices
+        id: set-matrix
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          RAG_CHANGED: ${{ steps.filter.outputs.rag }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          EVENT_NAME: ${{ github.event_name }}
           FORCE_BUILD: ${{ inputs.force_build }}
-        run: |
-          SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
-          TAG_VERSION="${{ env.TAG_VERSION }}"
+          ALL_COMPONENTS: ${{ needs.load-config.outputs.rag_components }}
+          SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
+          CHANGED_AGENT_ONTOLOGY: ${{ steps.filter.outputs.agent-ontology }}
+          CHANGED_SERVER: ${{ steps.filter.outputs.server }}
+          CHANGED_INGESTORS: ${{ steps.filter.outputs.ingestors }}
+        with:
+          script: |
+            const allComponents = JSON.parse(process.env.ALL_COMPONENTS);
+            // Extra image variants per component (must mirror the build matrix below).
+            const variantMap = {
+              'agent-ontology': ['default'],
+              'server': ['default', 'huggingface'],
+              'ingestors': ['default', 'slim'],
+            };
+            const expand = (comps) =>
+              comps.flatMap(c => (variantMap[c] || ['default']).map(v => ({ component: c, variant: v })));
 
-          # Chart-only tag: skip image builds entirely
-          if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
-            echo "📊 Chart-only tag: skipping image builds"
-            echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
-            echo "image_prefix=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+            const tag = process.env.TAG_VERSION || '';
+            const event = process.env.EVENT_NAME || '';
+            const forceBuild = process.env.FORCE_BUILD === 'true';
+            const sharedChanged = process.env.SHARED_CHANGED === 'true';
+            const changed = allComponents.filter(
+              c => process.env['CHANGED_' + c.toUpperCase().replace(/-/g, '_')] === 'true'
+            );
+            // A change in the shared common/ library forces all components.
+            const changedSet = sharedChanged ? allComponents : changed;
 
-          # Determine pre-release type and number
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
-          fi
+            let buildComponents = [];
+            let retagComponents = [];
+            let imagePrefix = '';
 
-          # GHCR prefix: -rc.N and -hotfix.N go to pre-release/
-          if [[ "$TAG_VERSION" =~ -(rc|hotfix)\.[0-9]+ ]]; then
-            IMAGE_PREFIX="pre-release/"
-          else
-            IMAGE_PREFIX=""
-          fi
+            if (/-chart\.\d+$/.test(tag)) {
+              console.log('📊 Chart-only tag: skipping image builds');
+            } else {
+              if (/-(rc|hotfix)\.\d+$/.test(tag)) imagePrefix = 'pre-release/';
+              const pre = tag.match(/-(dev|rc|hotfix)\.(\d+)$/);
+              const preNum = pre ? parseInt(pre[2], 10) : 0;
 
-          if [ "$FORCE_BUILD" == "true" ]; then
-            # Coordinated release / manual override: always build fresh so every
-            # component is published at this tag (bypasses change-detect + retag).
-            SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
-            echo "🔁 force_build requested: building fresh regardless of changes"
-          elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$RAG_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with RAG changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without RAG changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
-          elif [ "$RAG_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            SHOULD_BUILD="true"
-            echo "📦 RAG files changed or manual trigger: building"
-          fi
+              if (forceBuild) {
+                // Coordinated release / manual override: build every component fresh.
+                buildComponents = allComponents;
+                console.log('🔁 force_build requested: building all');
+              } else if (tag) {
+                if (pre && preNum > 1) {
+                  // Incremental pre-release: build changed components, retag the rest.
+                  buildComponents = changedSet;
+                  retagComponents = allComponents.filter(c => !changedSet.includes(c));
+                  console.log(`🔨 Incremental pre-release: build [${buildComponents}], retag [${retagComponents}]`);
+                } else {
+                  // First pre-release or final release: build everything.
+                  buildComponents = allComponents;
+                  console.log('🚀 First pre-release or final release: building all');
+                }
+              } else if (event === 'workflow_dispatch') {
+                buildComponents = allComponents;
+                console.log('🔧 Manual trigger: building all');
+              } else {
+                // PR / push without a tag: build only changed components.
+                buildComponents = changedSet;
+                console.log(`📦 Changed components: [${buildComponents}]`);
+              }
+            }
 
-          echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
-          echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
-          echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
+            core.setOutput('build_matrix', JSON.stringify({ include: expand(buildComponents) }));
+            core.setOutput('retag_matrix', JSON.stringify({ include: expand(retagComponents) }));
+            core.setOutput('should_build', String(buildComponents.length > 0));
+            core.setOutput('should_retag', String(retagComponents.length > 0));
+            core.setOutput('image_prefix', imagePrefix);
 
   build-and-push:
     runs-on: ubuntu-latest
@@ -158,16 +185,7 @@ jobs:
       packages: write
 
     strategy:
-      matrix:
-        component: ${{ fromJson(needs.load-config.outputs.rag_components) }}
-        variant: [default]
-        include:
-          # Add slim variant for ingestors (no Playwright, ~1.5GB smaller)
-          - component: ingestors
-            variant: slim
-          # Add HuggingFace variant for server (with PyTorch, ~900MB larger)
-          - component: server
-            variant: huggingface
+      matrix: ${{ fromJson(needs.determine-changes.outputs.build_matrix) }}
       fail-fast: false
 
     env:
@@ -281,16 +299,7 @@ jobs:
       packages: write
 
     strategy:
-      matrix:
-        component: ${{ fromJson(needs.load-config.outputs.rag_components) }}
-        variant: [default]
-        include:
-          # Add slim variant for ingestors
-          - component: ingestors
-            variant: slim
-          # Add HuggingFace variant for server
-          - component: server
-            variant: huggingface
+      matrix: ${{ fromJson(needs.determine-changes.outputs.retag_matrix) }}
       fail-fast: false
 
     env:

--- a/.github/workflows/ci-a2a-rag.yml
+++ b/.github/workflows/ci-a2a-rag.yml
@@ -22,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -65,6 +64,7 @@ jobs:
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: read
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -208,6 +208,7 @@ jobs:
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-packages: write
 
       - name: Free disk space
         run: |
@@ -321,6 +322,7 @@ jobs:
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-packages: write
 
       - name: 📦 Install crane
         run: |
@@ -331,8 +333,9 @@ jobs:
       - name: 🔐 Log in to registry
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GHCR_ACTOR: ${{ github.actor }}
         run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GHCR_ACTOR" --password-stdin
 
       - name: 🔍 Check source image and retag or build
         id: retag-or-build
@@ -492,11 +495,13 @@ jobs:
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: 🔔 Notify release finalize
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
+          WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           # Determine overall conclusion
           BUILD_RESULT="${{ needs.build-and-push.result }}"
@@ -519,7 +524,7 @@ jobs:
             "event_type": "ci-completed",
             "client_payload": {
               "tag": "$TAG_VERSION",
-              "workflow": "${{ github.workflow }}",
+              "workflow": "$WORKFLOW_NAME",
               "conclusion": "$CONCLUSION"
             }
           }

--- a/.github/workflows/prebuild-a2a-rag.yml
+++ b/.github/workflows/prebuild-a2a-rag.yml
@@ -75,6 +75,9 @@ jobs:
             server:
               - 'ai_platform_engineering/knowledge_bases/rag/server/**'
               - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.server'
+            ingestors:
+              - 'ai_platform_engineering/knowledge_bases/rag/ingestors/**'
+              - 'ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.ingestors'
 
 
       - name: Set matrix based on changes
@@ -82,9 +85,9 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILD_ALL: ${{ steps.filter.outputs.shared == 'true' }}
-          CHANGED_AGENT_RAG: ${{ steps.filter.outputs.agent-rag }}
           CHANGED_AGENT_ONTOLOGY: ${{ steps.filter.outputs.agent-ontology }}
           CHANGED_SERVER: ${{ steps.filter.outputs.server }}
+          CHANGED_INGESTORS: ${{ steps.filter.outputs.ingestors }}
         with:
           script: |
             const allComponents = ['agent-ontology', 'server', 'ingestors'];

--- a/.github/workflows/prebuild-a2a-rag.yml
+++ b/.github/workflows/prebuild-a2a-rag.yml
@@ -32,8 +32,7 @@ on:
         default: ''
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -181,10 +180,12 @@ jobs:
       - name: Compute prebuild tag
         id: compute_tag
         shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
         run: |
-          BRANCH="${{ inputs.head_ref || github.head_ref }}"
-          BASE_REF="${{ inputs.base_ref || github.event.pull_request.base.ref }}"
-          BASE_SHA="${{ inputs.base_sha || github.event.pull_request.base.sha }}"
+          BRANCH="$HEAD_REF"
           BRANCH_NO_PREFIX="${BRANCH#prebuild/}"
           BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
           git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"


### PR DESCRIPTION
## Summary

- `ci-a2a-rag.yml` rebuilt **all** RAG images (`agent-ontology`, `server`, `ingestors` + `slim`/`huggingface` variants) on *any* change under `rag/**`, because of a single coarse `paths-filter` feeding a static all-component matrix. Now it uses **per-component path filters** and a **dynamically computed build/retag matrix** — touching one component builds only that one.
- A change to the shared `common/` library still fans out to all three (all Dockerfiles `COPY common`).
- First pre-release, final release, `workflow_dispatch`, and `force_build` still build everything (release safety unchanged).
- `prebuild-a2a-rag.yml`: added the missing `ingestors` filter + `CHANGED_INGESTORS` env (ingestors-only changes previously never triggered a prebuild), and removed the dead `CHANGED_AGENT_RAG` leftover.

## Why

Editing one RAG component (e.g. `rag-server`) wasted CI rebuilding the unrelated `agent-ontology` and `ingestors` images on every PR and dev build.

## Behavior (verified by local simulation of the matrix logic)

| Trigger | Builds | Retags |
|---|---|---|
| PR, only `server/` changed | `server` (+huggingface) | — |
| PR, `common/` changed | all 3 | — |
| `-dev.3`, only `ingestors/` | `ingestors` (+slim) | `agent-ontology`, `server` |
| first `-dev.1` / final release | all 3 | — |
| `workflow_dispatch` / `force_build` | all 3 | — |
| chart-only tag | — | — |

_LLM used: Claude Opus 4.8_