### PR TITLE
fix(workflows): allow non-admins to create and save workflows

### DIFF
--- a/docs/docs/security/rbac/pdp-coverage-audit.md
+++ b/docs/docs/security/rbac/pdp-coverage-audit.md
@@ -54,6 +54,7 @@ return withAuth(request, async (req, user, session) => { ... });
 | `/api/ai`                                             | `ai_assist#invoke`             |
 | `/api/credentials`                                    | `credential_vault#use` plus concrete `secret_ref` checks |
 | `/api/task-configs` (`GET` / non-`GET`)               | `dynamic_agent#view` / `manage` |
+| `/api/workflow-configs` (all methods)                 | `dynamic_agent#view` |
 | `/api/workflow-runs` (`GET` / non-`GET`)              | `dynamic_agent#view` / `invoke` |
 | `/api/catalog-api-keys`                               | `skill#configure`              |
 | `/api/skills/seed`                                    | `admin_ui#admin`               |

--- a/docs/docs/security/rbac/workflows.md
+++ b/docs/docs/security/rbac/workflows.md
@@ -1577,7 +1577,7 @@ Workflow authorization is the first end-to-end migration onto the **Centralized 
 * **List filtering** — config lists use batched `authorizeMany` against CAS instead of per-row OpenFGA calls.
 * **Clean errors** — denials return stable reason codes (`WORKFLOW_FORBIDDEN`, `WORKFLOW_RUN_FORBIDDEN`, `AUTHZ_UNAVAILABLE`) without leaking OpenFGA relation strings in response bodies.
 
-The coarse session gate in `ui/src/lib/api-middleware.ts` still maps these paths to Keycloak scopes (`dynamic_agent#view` for `GET`, `dynamic_agent#manage` / `#invoke` for mutations) before the CAS PEP runs.
+The coarse session gate in `ui/src/lib/api-middleware.ts` maps workflow-config routes to **`dynamic_agent#view`** for all methods (`GET`/`POST`/`PUT`/`DELETE`). Create/update/delete ownership and `task#write` checks run in `workflow-configs/route.ts` (`requireWorkflowConfigWriteAccess`). Workflow **runs** still use `dynamic_agent#invoke` for mutations via the same legacy resolver.
 
 ```mermaid
 sequenceDiagram

--- a/ui/e2e/rbac/README.md
+++ b/ui/e2e/rbac/README.md
@@ -12,7 +12,7 @@ CAIPE + Keycloak stack:
 | `pdp-down.spec.ts` | When Keycloak is unreachable, the UI shows a 503 toast (no silent allow). |
 | `credential-team-sharing.spec.ts` | Live credential Team Access keeps concurrent share responses from dropping successful grants. |
 | `workflow-agent-access.spec.ts` | Mocked browser regression for workflow run access and denied agent-access grants. |
-| `workflows-rbac-regression.spec.ts` | Mocked browser regression for team/global/private workflow visibility, MCP step tool overrides, grant/save paths, and non-admin run access. |
+| `workflows-rbac-regression.spec.ts` | Mocked browser regression for team/global/private workflow visibility, MCP step tool overrides, grant/save paths, save-as-private fallback when agent grants are denied, and non-admin run access. |
 | `webex-workflow-agent-routes.spec.ts` | Mocked browser regression for Webex space onboarding and routing to workflow/MCP agents (bot dispatch path). |
 | `workflow-agent-service-auth.spec.ts` | Mocked regression for agent→BFF workflow run auth (401 without Bearer, 201 with Bearer) and agent workflow wiring. |
 | `workflow-agent-user-delegation.spec.ts` | Mocked regression for run-as-user workflow delegation (user OBO bearer vs service account on team/global/private workflows). |

--- a/ui/e2e/rbac/workflows-rbac-regression.spec.ts
+++ b/ui/e2e/rbac/workflows-rbac-regression.spec.ts
@@ -209,6 +209,52 @@ test.describe("mocked workflows RBAC and MCP regression", () => {
     await expect.poll(() => mocks.saveRequests.length).toBe(0);
   });
 
+  test("saves as private when a non-manager cannot grant global agent access", async ({ page }) => {
+    const privateAgent = buildPrivateAgentFixture();
+    const scenario: WorkflowScenario = {
+      workflowId: "wf-playwright-global-save-private",
+      workflowName: "Global workflow save private fallback",
+      visibility: "global",
+      gapTarget: GLOBAL_ACCESS_LABEL,
+      expectedGrant: {
+        resource: { type: "agent", id: privateAgent.id },
+        grantee: { type: "everyone" },
+        capability: "use",
+      },
+    };
+
+    const mocks = await installWorkflowBrowserMocks(page, {
+      session: WORKFLOW_TEAM_MEMBER_SESSION,
+      teamSlugs: [WORKFLOW_PLATFORM_TEAM.slug],
+      workflows: [
+        workflowFixtureFromScenario(
+          scenario,
+          privateAgent.id,
+          WORKFLOW_TEAM_MEMBER_SESSION.email,
+        ),
+      ],
+      agents: [privateAgent],
+      agentAccessGaps: [
+        {
+          agentId: privateAgent.id,
+          agentName: privateAgent.name,
+          teamsWithoutAccess: [GLOBAL_ACCESS_LABEL],
+        },
+      ],
+    });
+
+    await openWorkflowEditor(page, scenario.workflowName);
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    const dialog = page.getByRole("dialog", { name: /agent access required/i });
+    await expect(dialog).toBeVisible();
+    await page.getByRole("button", { name: /save as private instead/i }).click();
+
+    await expect.poll(() => mocks.saveRequests.length).toBe(1);
+    expect(mocks.saveRequests[0]).toMatchObject({ visibility: "private" });
+    await expect(dialog).toHaveCount(0);
+  });
+
   test("lists MCP-backed and team workflows together for org admins", async ({ page }) => {
     await installWorkflowBrowserMocks(page, {
       session: WORKFLOW_ORG_ADMIN_SESSION,

--- a/ui/src/app/api/workflow-configs/route.ts
+++ b/ui/src/app/api/workflow-configs/route.ts
@@ -200,7 +200,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     }
 
     validateSteps(body.steps);
-    const visibility: WorkflowConfigVisibility = body.visibility || "global";
+    const visibility: WorkflowConfigVisibility = body.visibility || "private";
     const sharedWithTeams =
       visibility === "team"
         ? await normalizeSharedWithTeamSlugs(body.shared_with_teams)

--- a/ui/src/components/workflows/WorkflowAgentAccessModal.tsx
+++ b/ui/src/components/workflows/WorkflowAgentAccessModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { AlertTriangle, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Lock, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,16 +15,22 @@ import type { AgentAccessGap } from "@/app/api/workflow-configs/check-agent-acce
 
 interface WorkflowAgentAccessModalProps {
   gaps: AgentAccessGap[];
+  visibility: "private" | "team" | "global";
   onGrantAndSave: () => Promise<void>;
+  onSaveAsPrivate: () => Promise<void>;
   onCancel: () => void;
 }
 
 export function WorkflowAgentAccessModal({
   gaps,
+  visibility,
   onGrantAndSave,
+  onSaveAsPrivate,
   onCancel,
 }: WorkflowAgentAccessModalProps) {
   const [isGranting, setIsGranting] = useState(false);
+  const [isSavingPrivate, setIsSavingPrivate] = useState(false);
+  const busy = isGranting || isSavingPrivate;
 
   const handleGrant = async () => {
     setIsGranting(true);
@@ -35,6 +41,20 @@ export function WorkflowAgentAccessModal({
     }
   };
 
+  const handleSaveAsPrivate = async () => {
+    setIsSavingPrivate(true);
+    try {
+      await onSaveAsPrivate();
+    } finally {
+      setIsSavingPrivate(false);
+    }
+  };
+
+  const sharingLabel =
+    visibility === "global"
+      ? "everyone in the organization"
+      : "the teams this workflow is shared with";
+
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
       <DialogContent className="max-w-md">
@@ -44,8 +64,9 @@ export function WorkflowAgentAccessModal({
             Agent access required
           </DialogTitle>
           <DialogDescription>
-            The following agents are not accessible to all teams this workflow is shared with.
-            Grant access to let those teams run this workflow.
+            To share this workflow with {sharingLabel}, each step agent must be accessible
+            to those users. Granting that access requires manage permission on each agent.
+            If you only need a personal workflow, save as private instead.
           </DialogDescription>
         </DialogHeader>
 
@@ -61,13 +82,22 @@ export function WorkflowAgentAccessModal({
           ))}
         </div>
 
-        <DialogFooter className="gap-2">
-          <Button variant="outline" onClick={onCancel} disabled={isGranting}>
-            Cancel
-          </Button>
-          <Button onClick={handleGrant} disabled={isGranting} className="gap-2">
+        <DialogFooter className="flex-col gap-2 sm:flex-col sm:space-x-0">
+          <Button onClick={handleGrant} disabled={busy} className="gap-2 w-full sm:w-auto">
             <ShieldCheck className="h-4 w-4" />
             {isGranting ? "Granting access…" : "Grant access and save"}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleSaveAsPrivate}
+            disabled={busy}
+            className="gap-2 w-full sm:w-auto"
+          >
+            <Lock className="h-4 w-4" />
+            {isSavingPrivate ? "Saving…" : "Save as private instead"}
+          </Button>
+          <Button variant="outline" onClick={onCancel} disabled={busy} className="w-full sm:w-auto">
+            Cancel
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/ui/src/components/workflows/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/WorkflowCanvas.tsx
@@ -328,7 +328,7 @@ function WorkflowCanvasInner({
 
   // Visibility & sharing
   const [visibility, setVisibility] = useState<"private" | "team" | "global">(
-    existingConfig?.visibility || "global",
+    existingConfig?.visibility || "private",
   );
   const [sharedWithTeams, setSharedWithTeams] = useState<string[]>(
     existingConfig?.shared_with_teams || [],
@@ -562,19 +562,27 @@ function WorkflowCanvasInner({
   // Save
   // -----------------------------------------------------------------------
 
-  const persistWorkflow = useCallback(async (): Promise<string | null> => {
+  const persistWorkflow = useCallback(async (
+    overrides?: Pick<CreateWorkflowConfigInput, "visibility" | "shared_with_teams">,
+  ): Promise<string | null> => {
     if (!name || steps.length === 0) {
       toast("Workflow name and at least one step are required", "error");
       return null;
     }
+
+    const effectiveVisibility = overrides?.visibility ?? visibility;
+    const effectiveSharedWithTeams =
+      effectiveVisibility === "team"
+        ? overrides?.shared_with_teams ?? sharedWithTeams
+        : undefined;
 
     if (existingConfig?.config_driven) {
       const input: CreateWorkflowConfigInput = {
         name: `${name.trim()} (editable)`,
         description: description.trim() || undefined,
         steps,
-        visibility,
-        shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+        visibility: effectiveVisibility,
+        shared_with_teams: effectiveSharedWithTeams,
       };
       const newId = await createConfig(input);
       openEditor("edit", newId);
@@ -586,8 +594,8 @@ function WorkflowCanvasInner({
         name: name.trim(),
         description: description.trim() || undefined,
         steps,
-        visibility,
-        shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+        visibility: effectiveVisibility,
+        shared_with_teams: effectiveSharedWithTeams,
       };
       await updateConfig(existingConfig._id, updates);
       return existingConfig._id;
@@ -597,8 +605,8 @@ function WorkflowCanvasInner({
       name: name.trim(),
       description: description.trim() || undefined,
       steps,
-      visibility,
-      shared_with_teams: visibility === "team" ? sharedWithTeams : undefined,
+      visibility: effectiveVisibility,
+      shared_with_teams: effectiveSharedWithTeams,
     };
     const newId = await createConfig(input);
     openEditor("edit", newId);
@@ -677,6 +685,29 @@ function WorkflowCanvasInner({
       );
     }
   }, [agentAccessGaps, doSave, toast]);
+
+  const handleSaveAsPrivate = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const savedId = await persistWorkflow({ visibility: "private", shared_with_teams: [] });
+      if (!savedId) return;
+      setVisibility("private");
+      setSharedWithTeams([]);
+      setShowAccessModal(false);
+      setAgentAccessGaps([]);
+      isDirtyRef.current = false;
+      setUnsaved(false);
+      toast("Workflow saved as private", "success");
+    } catch (error) {
+      console.error("Failed to save workflow as private:", error);
+      toast(
+        error instanceof Error ? error.message : "Failed to save workflow",
+        "error",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }, [persistWorkflow, setUnsaved, toast]);
 
   // -----------------------------------------------------------------------
   // Run workflow
@@ -931,7 +962,9 @@ function WorkflowCanvasInner({
       {showAccessModal && agentAccessGaps.length > 0 && (
         <WorkflowAgentAccessModal
           gaps={agentAccessGaps}
+          visibility={visibility}
           onGrantAndSave={handleGrantAndSave}
+          onSaveAsPrivate={handleSaveAsPrivate}
           onCancel={() => { setShowAccessModal(false); setAgentAccessGaps([]); }}
         />
       )}

--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -1170,7 +1170,8 @@ describe('withAuth', () => {
 
     it.each([
       ['/api/workflow-configs', 'GET', 'can_use', 'dynamic_agent#view'],
-      ['/api/workflow-configs', 'POST', 'can_manage', 'dynamic_agent#manage'],
+      ['/api/workflow-configs', 'POST', 'can_use', 'dynamic_agent#view'],
+      ['/api/workflow-configs', 'PUT', 'can_use', 'dynamic_agent#view'],
       ['/api/workflow-runs', 'GET', 'can_use', 'dynamic_agent#view'],
       ['/api/unclassified-feature', 'GET', 'can_audit', 'admin_ui#view'],
       ['/api/unclassified-feature', 'POST', 'can_manage', 'admin_ui#manage'],

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -343,9 +343,10 @@ function resolveLegacyWithAuthRbacPolicy(request: NextRequest): RouteRbacPolicy 
       : { resource: 'dynamic_agent', scope: 'manage' };
   }
   if (pathname.startsWith('/api/workflow-configs')) {
-    return method === 'GET'
-      ? { resource: 'dynamic_agent', scope: 'view' }
-      : { resource: 'dynamic_agent', scope: 'manage' };
+    // Workflow CRUD is gated in route handlers (owner / task#write). The legacy
+    // gate only requires workflow discovery access so non-admin users can create
+    // and edit their own private workflows without dynamic_agent#manage.
+    return { resource: 'dynamic_agent', scope: 'view' };
   }
   if (pathname.startsWith('/api/workflow-runs')) {
     return method === 'GET'

--- a/ui/src/store/workflow-config-store.ts
+++ b/ui/src/store/workflow-config-store.ts
@@ -57,6 +57,12 @@ function parseWorkflowConfigList(data: unknown): WorkflowConfig[] {
   return [];
 }
 
+function workflowConfigApiError(payload: Record<string, unknown>, fallback: string): string {
+  const message = typeof payload.message === "string" ? payload.message.trim() : "";
+  const error = typeof payload.error === "string" ? payload.error.trim() : "";
+  return message || error || fallback;
+}
+
 export const useWorkflowConfigStore = create<WorkflowConfigState>()((set, get) => ({
   configs: [],
   isLoading: false,
@@ -104,8 +110,10 @@ export const useWorkflowConfigStore = create<WorkflowConfigState>()((set, get) =
     });
 
     if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.error || `Failed to create workflow config: ${response.status}`);
+      const err = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      throw new Error(
+        workflowConfigApiError(err, `Failed to create workflow config: ${response.status}`),
+      );
     }
 
     const result = await response.json();
@@ -121,8 +129,10 @@ export const useWorkflowConfigStore = create<WorkflowConfigState>()((set, get) =
     });
 
     if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      throw new Error(err.error || `Failed to update workflow config: ${response.status}`);
+      const err = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      throw new Error(
+        workflowConfigApiError(err, `Failed to update workflow config: ${response.status}`),
+      );
     }
 
     await get().loadConfigs();


### PR DESCRIPTION
## Summary

Fixes workflow save failures for non-admin users (e.g. generic user **GU** saving a **Private** workflow with a team-scoped agent like **Jira GU**).

### Root cause

The BFF `withAuth` legacy gate required **`dynamic_agent#manage`** for all `/api/workflow-configs` mutations (`POST`/`PUT`/`DELETE`). Non-admins were denied with *"You do not have permission to perform this action."* **before** route-level owner checks ran — including creating a new private workflow.

### Changes

1. **Middleware (`api-middleware.ts`)** — Require only `dynamic_agent#view` for workflow-config routes; keep fine-grained write/delete checks in the route handler (`requireWorkflowConfigWriteAccess`).
2. **Default visibility** — New workflows default to **private** (UI + POST API) instead of global.
3. **Agent access modal** — When global/team save needs agent grants the caller cannot authorize, offer **Save as private instead**.
4. **Error surfacing** — Workflow config store prefers API `message` over opaque error codes.

Follow-up to workflow save issues observed after [#1967](https://github.com/cnoe-io/ai-platform-engineering/pull/1967).

## Commits

- `fix(workflows): let non-admins save workflows without global agent grants` — UX defaults, save-as-private modal, E2E
- `fix(workflows): allow workflow CRUD with view permission at BFF gate` — middleware fix for private workflow create/update

## Test plan

- [x] `npm test -- --runInBand src/lib/__tests__/api-middleware.test.ts`
- [x] `npm test -- --runInBand src/lib/rbac/__tests__/workflow-config-rebac.test.ts`
- [ ] `npm run test:e2e:rbac-regression` (`workflows-rbac-regression.spec.ts` — save-as-private case)
- [x] Manual: generic user → **New Workflow** → Jira GU step → **Private** → **Save** succeeds
- [ ] Manual: global workflow with private agent → modal → **Save as private instead** succeeds
- [ ] Manual: non-owner editing another user's global workflow still read-only / denied on PUT
