### PR TITLE
fix(identity-sync): remove proactive Okta credential health check on page load

### DIFF
--- a/ui/e2e/rbac/identity-sync-regression.spec.ts
+++ b/ui/e2e/rbac/identity-sync-regression.spec.ts
@@ -162,7 +162,7 @@ test.describe("mocked identity sync browser regression", () => {
       "true",
     );
     await expect(page.getByText("Okta Connector Status")).toBeVisible();
-    await expect(page.getByText("Verified")).toBeVisible();
+    await expect(page.getByText("Configured")).toBeVisible();
     await expect(page.getByText("Every hour").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Run sync now" }).click();

--- a/ui/src/app/api/admin/identity-group-sync/directory-sync/status/route.ts
+++ b/ui/src/app/api/admin/identity-group-sync/directory-sync/status/route.ts
@@ -3,10 +3,8 @@ import { NextRequest,NextResponse } from "next/server";
 import { successResponse,withErrorHandler } from "@/lib/api-middleware";
 import { isMongoDBConfigured } from "@/lib/mongodb";
 import {
-checkConnectorHealthForProvider,
 isConnectorConfigured,
 listIdpConnectors,
-type IdpConnectorHealth,
 } from "@/lib/rbac/idp-connectors";
 import { getIdpSyncSettings,listIdpSyncRuns,reapStaleIdpSyncRuns } from "@/lib/rbac/idp-sync-store";
 
@@ -31,28 +29,12 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       listIdpSyncRuns(provider, 20),
     ]);
 
-    // One-shot credential probe so the page can flag bad creds up front.
-    // Best-effort: never let the health check sink the whole status response.
-    let health: IdpConnectorHealth | null = null;
-    if (configured) {
-      try {
-        health = await checkConnectorHealthForProvider(provider);
-      } catch (err) {
-        health = {
-          ok: false,
-          mode: provider,
-          error: err instanceof Error ? err.message : "Connectivity check failed.",
-        };
-      }
-    }
-
     return successResponse({
       provider,
       connectors: listIdpConnectors(),
       settings,
       recent_runs: recentRuns,
       provider_configured: configured,
-      health,
     });
   });
 });

--- a/ui/src/components/admin/teams/IdentitySyncPanel.tsx
+++ b/ui/src/components/admin/teams/IdentitySyncPanel.tsx
@@ -17,19 +17,12 @@ interface IdpConnectorDescriptor {
   implemented: boolean;
 }
 
-interface IdpSyncHealth {
-  ok: boolean;
-  mode: string;
-  error?: string;
-}
-
 interface IdpSyncStatus {
   provider: string;
   connectors: IdpConnectorDescriptor[];
   settings: IdpSyncSettings;
   recent_runs: IdpSyncRun[];
   provider_configured: boolean;
-  health: IdpSyncHealth | null;
 }
 
 function formatDuration(startedAt: string, completedAt?: string): string {
@@ -370,18 +363,6 @@ export function IdentitySyncPanel({ isAdmin }: IdentitySyncPanelProps) {
             </div>
           )}
 
-          {/* Credential health: creds present but a live probe failed
-              (bad token / expired key / missing scopes / network). */}
-          {status?.provider_configured && status.health && !status.health.ok && (
-            <div className="flex items-start gap-2 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900">
-              <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <div>
-                <span className="font-medium">{connectorLabel} credential check failed.</span>{" "}
-                {status.health.error ?? "The configured credentials could not authenticate."}
-              </div>
-            </div>
-          )}
-
           {/* Connector status */}
           <Card>
             <CardHeader>
@@ -401,12 +382,6 @@ export function IdentitySyncPanel({ isAdmin }: IdentitySyncPanelProps) {
                   <div className="mt-1 font-medium text-sm">
                     {!status?.provider_configured ? (
                       <span className="text-amber-600">Not set</span>
-                    ) : status.health?.ok === false ? (
-                      <span className="text-red-600">Invalid</span>
-                    ) : status.health?.ok ? (
-                      <span className="text-green-600">
-                        Verified{status.health.mode === "oauth" ? " (OAuth)" : ""}
-                      </span>
                     ) : (
                       <span className="text-green-600">Configured</span>
                     )}


### PR DESCRIPTION
# Description

Removes the proactive Okta credential health check that fired on every page load of the Identity Sync tab. The check called `GET /api/v1/groups?limit=1` against Okta each time the page was opened, contributing to rate limit violations on shared API tokens (we observed a `system.operation.rate_limit.violation` event in Okta audit logs for the shared token).

Credential errors will still surface naturally when a sync run fails — the error is recorded on the run row and shown in Sync History. The Credentials stat box now shows **"Not set"** (unconfigured) or **"Configured"** (env vars present), which is a local check with no Okta API call.

**Changes:**
- `status/route.ts`: removed `checkConnectorHealthForProvider` call and `health` field from response
- `IdentitySyncPanel.tsx`: removed `IdpSyncHealth` interface, `health` field from `IdpSyncStatus`, credential error banner, and "Invalid"/"Verified" badge states

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass