### PR TITLE
fix(mcp): route Confluence provider tokens through AgentGateway

### DIFF
--- a/deploy/agentgateway/config.caipe-rbac.yaml
+++ b/deploy/agentgateway/config.caipe-rbac.yaml
@@ -49,7 +49,26 @@ binds:
           - name: backstage
             mcp: { host: http://mcp-backstage:8000/mcp }
     - matches: [{ path: { pathPrefix: /mcp/confluence } }]
-      policies: *mcpAuthzPolicy
+      policies:
+        extAuthz:
+          host: openfga-authz-bridge:9100
+          failureMode: { denyWithStatus: 403 }
+          includeRequestBody:
+            maxRequestBytes: 65536
+            allowPartialMessage: false
+            packAsBytes: true
+          protocol:
+            grpc:
+              metadata:
+                caipe.auth: '{"sub": jwt.sub, "preferred_username": jwt.preferred_username}'
+        authorization:
+          rules:
+          - allow: 'true'
+        transformations:
+          request:
+            set:
+              authorization: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+              x-caipe-provider-token: 'default(request.headers["x-caipe-provider-token"], "")'
       backends:
       - mcp:
           targets:

--- a/deploy/agentgateway/config.yaml
+++ b/deploy/agentgateway/config.yaml
@@ -64,7 +64,26 @@ binds:
           - name: backstage
             mcp: { host: http://mcp-backstage:8000/mcp }
     - matches: [{ path: { pathPrefix: /mcp/confluence } }]
-      policies: *mcpAuthzPolicy
+      policies:
+        extAuthz:
+          host: openfga-authz-bridge:9100
+          failureMode: { denyWithStatus: 403 }
+          includeRequestBody:
+            maxRequestBytes: 65536
+            allowPartialMessage: false
+            packAsBytes: true
+          protocol:
+            grpc:
+              metadata:
+                caipe.auth: '{"sub": jwt.sub, "preferred_username": jwt.preferred_username}'
+        authorization:
+          rules:
+          - allow: 'true'
+        transformations:
+          request:
+            set:
+              authorization: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+              x-caipe-provider-token: 'default(request.headers["x-caipe-provider-token"], "")'
       backends:
       - mcp:
           targets:

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -101,7 +101,8 @@ PROVIDER_TOKEN_BEARER_TRANSFORM: dict[str, Any] = {
                     '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
                 ),
                 # Jira MCP reads Atlassian OAuth from this header directly; GitHub/GitLab
-                # consume Authorization. Forward the provider token for both patterns.
+                # and sooperset/mcp-atlassian (Confluence) consume Authorization. Forward
+                # the provider token for both patterns.
                 "x-caipe-provider-token": (
                     'default(request.headers["x-caipe-provider-token"], "")'
                 ),
@@ -115,6 +116,7 @@ PROVIDER_TOKEN_BEARER_TRANSFORM: dict[str, Any] = {
 # per-user RAG group RBAC) or a caipe-platform service token (non-user contexts) on
 # X-CAIPE-Provider-Token, which this rewrites into the upstream Authorization header.
 DEFAULT_MCP_ROUTE_POLICY_OVERRIDES: dict[str, dict[str, Any]] = {
+    "confluence": PROVIDER_TOKEN_BEARER_TRANSFORM,
     "github": PROVIDER_TOKEN_BEARER_TRANSFORM,
     "gitlab": PROVIDER_TOKEN_BEARER_TRANSFORM,
     "jira": PROVIDER_TOKEN_BEARER_TRANSFORM,

--- a/deploy/agentgateway/tests/test_config_bridge.py
+++ b/deploy/agentgateway/tests/test_config_bridge.py
@@ -655,7 +655,7 @@ def test_load_builtin_mcp_routes_parses_shipped_config() -> None:
     builtins = bridge.load_builtin_mcp_routes(SHIPPED_CONFIG_PATH)
 
     # Every shipped /mcp/<id> route must be recognised as a protected built-in.
-    assert {"argocd", "gitlab", "jira", "knowledge-base", "slack"} <= set(builtins)
+    assert {"argocd", "confluence", "gitlab", "jira", "knowledge-base", "slack"} <= set(builtins)
     assert "github" not in builtins
     # gitlab carries its per-request provider-token transform straight from the
     # bootstrap definition (YAML anchors/aliases resolved by the parser).
@@ -671,6 +671,10 @@ def test_load_builtin_mcp_routes_parses_shipped_config() -> None:
     assert jira_transform["x-caipe-provider-token"] == (
         'default(request.headers["x-caipe-provider-token"], "")'
     )
+    confluence = builtins["confluence"]
+    confluence_transform = confluence["policies"]["transformations"]["request"]["set"]
+    assert confluence_transform["authorization"] == jira_transform["authorization"]
+    assert confluence_transform["x-caipe-provider-token"] == jira_transform["x-caipe-provider-token"]
 
 
 def test_load_builtin_mcp_routes_missing_path_returns_empty() -> None:

--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -702,7 +702,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect(page.getByLabel(/Endpoint URL/i)).toHaveValue("http://mcp-netutils:8000/mcp");
 
     await page.getByRole("button", { name: "Add Credential" }).click();
-    await page.getByLabel(/Credential header/i).selectOption("X-CAIPE-Token");
+    await page.getByLabel(/Credential header/i).selectOption("X-CAIPE-Provider-Token");
     await page.getByLabel(/^Secret$/).selectOption("secret-netutils-token");
     await expect(page.getByText("Preview net_...oken")).toBeVisible();
 
@@ -720,7 +720,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
       {
         kind: "secret_ref",
         target: "header",
-        name: "X-CAIPE-Token",
+        name: "X-CAIPE-Provider-Token",
         secret_ref: "secret-netutils-token",
       },
     ]);

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -48,8 +48,31 @@ const TRANSPORT_OPTIONS: { value: TransportType; label: string; description: str
   { value: "http", label: "HTTP", description: "HTTP/REST endpoint" },
 ];
 
-const HEADER_NAME_OPTIONS = ["Authorization", "X-CAIPE-Token"] as const;
+const MCP_PROVIDER_CREDENTIAL_HEADER = "X-CAIPE-Provider-Token";
+const HEADER_NAME_OPTIONS = [MCP_PROVIDER_CREDENTIAL_HEADER, "Authorization"] as const;
 const CUSTOM_HEADER_VALUE = "__custom__";
+
+function normalizeCredentialHeaderName(name: string): string {
+  const trimmed = name.trim();
+  if (/^(authorization|x-caipe-token)$/i.test(trimmed)) {
+    return MCP_PROVIDER_CREDENTIAL_HEADER;
+  }
+  return trimmed;
+}
+
+function normalizeCredentialSourcesForEditor(
+  sources: MCPCredentialSource[] | undefined,
+): MCPCredentialSource[] {
+  return (sources ?? []).map((source) =>
+    source.target === "header"
+      ? { ...source, name: normalizeCredentialHeaderName(source.name) }
+      : source,
+  );
+}
+
+function usesAgentGatewayRouting(transportType: TransportType): boolean {
+  return transportType !== "stdio";
+}
 
 interface EndpointProbeAttempt {
   url: string;
@@ -200,7 +223,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
     server?.env ? Object.entries(server.env).map(([key, value]) => ({ key, value })) : []
   );
   const [credentialSources, setCredentialSources] = React.useState<MCPCredentialSource[]>(
-    server?.credential_sources || []
+    normalizeCredentialSourcesForEditor(server?.credential_sources),
   );
 
   const [loading, setLoading] = React.useState(false);
@@ -334,7 +357,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
       {
         kind: "secret_ref",
         target: transport === "stdio" ? "env" : "header",
-        name: transport === "stdio" ? "" : "Authorization",
+        name: transport === "stdio" ? "" : MCP_PROVIDER_CREDENTIAL_HEADER,
         secret_ref: "",
       },
     ]);
@@ -363,7 +386,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
         name: nextTarget === "env" && currentNameIsDefaultHeader
           ? ""
           : nextTarget === "header" && !current.name.trim()
-          ? "Authorization"
+          ? MCP_PROVIDER_CREDENTIAL_HEADER
           : current.name,
       });
       return;
@@ -967,6 +990,15 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 <p className="text-xs text-muted-foreground">
                   Choose saved secrets or connected apps. Secret values stay on the server.
                 </p>
+                {usesAgentGatewayRouting(transport) ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    HTTP and SSE MCP servers route through AgentGateway. The{" "}
+                    <code className="font-mono">Authorization</code> header is reserved for the
+                    caller JWT — use{" "}
+                    <code className="font-mono">{MCP_PROVIDER_CREDENTIAL_HEADER}</code> for provider
+                    OAuth tokens, API keys, and saved secrets.
+                  </p>
+                ) : null}
               </div>
               <Button
                 type="button"
@@ -1038,6 +1070,13 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                             disabled={readOnly}
                             {...SUPPRESS_PASSWORD_MANAGER_INPUT_PROPS}
                           />
+                        ) : null}
+                        {usesAgentGatewayRouting(transport) &&
+                        source.name.trim().toLowerCase() === "authorization" ? (
+                          <p className="text-xs text-amber-700 dark:text-amber-400">
+                            Authorization is not forwarded to the upstream MCP server via
+                            AgentGateway. Use {MCP_PROVIDER_CREDENTIAL_HEADER} instead.
+                          </p>
                         ) : null}
                       </div>
                     ) : (

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -100,7 +100,7 @@ describe("MCPServerEditor credential sources", () => {
     expect(screen.queryByRole("option", { name: /bearer_token|fingerprint|preview/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Preview j\.\.\.a/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /create server/i })).toBeDisabled();
-    expect(screen.getByLabelText(/credential header/i)).toHaveValue("Authorization");
+    expect(screen.getByLabelText(/credential header/i)).toHaveValue("X-CAIPE-Provider-Token");
     await user.selectOptions(screen.getByLabelText(/^secret$/i), "secret-jira");
     expect(screen.getByText("Preview j...a")).toBeInTheDocument();
 
@@ -116,7 +116,7 @@ describe("MCPServerEditor credential sources", () => {
       {
         kind: "secret_ref",
         target: "header",
-        name: "Authorization",
+        name: "X-CAIPE-Provider-Token",
         secret_ref: "secret-jira",
       },
       {
@@ -138,16 +138,32 @@ describe("MCPServerEditor credential sources", () => {
     await user.click(screen.getByRole("button", { name: /add credential/i }));
     await screen.findByRole("option", { name: "Jira token" });
 
-    await user.selectOptions(screen.getByLabelText(/credential header/i), "X-CAIPE-Token");
+    await user.selectOptions(screen.getByLabelText(/credential header/i), "X-CAIPE-Provider-Token");
     await user.selectOptions(screen.getByLabelText(/^secret$/i), "secret-jira");
     await user.click(screen.getByRole("button", { name: /create server/i }));
 
     await waitFor(() => expect(createBody().credential_sources).toEqual([
       expect.objectContaining({
         target: "header",
-        name: "X-CAIPE-Token",
+        name: "X-CAIPE-Provider-Token",
       }),
     ]));
+  });
+
+  it("warns when Authorization is selected for AgentGateway-routed servers", async () => {
+    const user = userEvent.setup();
+    render(<MCPServerEditor server={null} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/display name/i), "Auth Warning Test");
+    await user.type(screen.getByLabelText(/upstream url|endpoint url/i), "https://mcp.example.com/mcp");
+    await user.click(screen.getByRole("button", { name: /add credential/i }));
+
+    expect(screen.getByText(/route through AgentGateway/i)).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText(/credential header/i), "Authorization");
+    expect(
+      screen.getByText(/Authorization is not forwarded to the upstream MCP server via AgentGateway/i),
+    ).toBeInTheDocument();
   });
 
   it("lets users type a custom header name", async () => {
@@ -330,7 +346,7 @@ describe("MCPServerEditor credential sources", () => {
         {
           kind: "provider_connection",
           target: "header",
-          name: "Authorization",
+          name: "X-CAIPE-Provider-Token",
           connection_scope: "caller",
           provider: "atlassian",
         },
@@ -348,7 +364,7 @@ describe("MCPServerEditor credential sources", () => {
 
     await user.selectOptions(screen.getByLabelText(/credential kind/i), "provider_connection");
     await screen.findByRole("option", { name: /Atlassian Cloud/ });
-    expect(screen.getByLabelText(/credential header/i)).toHaveValue("Authorization");
+    expect(screen.getByLabelText(/credential header/i)).toHaveValue("X-CAIPE-Provider-Token");
     await user.selectOptions(screen.getByLabelText(/provider connection/i), "conn-atlassian");
     await user.click(screen.getByRole("button", { name: /create server/i }));
 
@@ -356,7 +372,7 @@ describe("MCPServerEditor credential sources", () => {
       {
         kind: "provider_connection",
         target: "header",
-        name: "Authorization",
+        name: "X-CAIPE-Provider-Token",
         connection_scope: "pinned",
         provider_connection_id: "conn-atlassian",
       },

--- a/ui/src/lib/rbac/__tests__/agentgateway-mcp-discovery.test.ts
+++ b/ui/src/lib/rbac/__tests__/agentgateway-mcp-discovery.test.ts
@@ -302,6 +302,17 @@ describe("AgentGateway MCP discovery", () => {
     ]);
   });
 
+  it("attaches built-in provider_connection credential source for confluence", () => {
+    expect(builtinCredentialSourcesFor("confluence")).toEqual([
+      {
+        kind: "provider_connection",
+        name: "X-CAIPE-Provider-Token",
+        provider: "atlassian",
+        target: "header",
+      },
+    ]);
+  });
+
   it("omits credential_sources for targets with no built-in mapping", () => {
     const target: AgentGatewayMcpDiscoveryTarget = {
       id: "argocd",

--- a/ui/src/lib/rbac/agentgateway-mcp-discovery.ts
+++ b/ui/src/lib/rbac/agentgateway-mcp-discovery.ts
@@ -42,6 +42,14 @@ export const BUILTIN_MCP_CREDENTIAL_SOURCES: Record<string, MCPCredentialSource[
       target: "header",
     },
   ],
+  confluence: [
+    {
+      kind: "provider_connection",
+      name: "X-CAIPE-Provider-Token",
+      provider: "atlassian",
+      target: "header",
+    },
+  ],
   pagerduty: [
     {
       kind: "provider_connection",


### PR DESCRIPTION
## Summary

- Add AgentGateway provider-token rewrite for the `/mcp/confluence` route (same pattern as Jira/GitLab) so `X-CAIPE-Provider-Token` becomes upstream `Authorization: Bearer <atlassian_token>` for sooperset/mcp-atlassian.
- Register built-in `confluence` credential sources (`provider_connection` / `atlassian`) for AgentGateway discovery and Mongo backfill.
- Update MCP server editor: default header to `X-CAIPE-Provider-Token`, normalize legacy `X-CAIPE-Token`/`Authorization` values, and warn that `Authorization` is reserved for the caller JWT on AgentGateway-routed HTTP/SSE servers.

## Motivation

Confluence MCP tool tests were returning Confluence API 403s even when credential resolution showed a valid Atlassian Connected App token. AgentGateway was forwarding the caller Keycloak JWT on `Authorization` while the provider OAuth token sat unused on `X-CAIPE-Provider-Token`.

## Test plan

- [x] `pytest deploy/agentgateway/tests/test_config_bridge.py::test_load_builtin_mcp_routes_parses_shipped_config`
- [x] `npm test -- --testPathPatterns=MCPServerEditor.credentials.test.ts|agentgateway-mcp-discovery.test.ts`
- [ ] Restart AgentGateway / config-bridge locally and re-test a Confluence MCP tool with a connected Atlassian account
- [ ] Confirm Jira and other MCP routes still probe successfully


Made with [Cursor](https://cursor.com)