### PR TITLE
fix(ui,chart): handle Kubernetes tcp:// port env vars and wire platform health probe hosts

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -132,6 +132,20 @@ spec:
             - name: AGENT_GATEWAY_URL
               value: {{ index .Values.config "AGENT_GATEWAY_URL" | default (printf "http://%s:%v" $agwMcpHost $agwMcpPort) | quote }}
             {{- end }}
+            {{- /* Platform health probe env vars — wire Kubernetes service names so the
+                   /api/platform/health route resolves hosts without docker-compose defaults. */}}
+            - name: AGENTGATEWAY_ADMIN_CONFIG_URL
+              value: {{ index .Values.config "AGENTGATEWAY_ADMIN_CONFIG_URL" | default (printf "http://%s-agentgateway:15000/config" .Release.Name) | quote }}
+            - name: AGENTGATEWAY_TARGETS_URL
+              value: {{ index .Values.config "AGENTGATEWAY_TARGETS_URL" | default (printf "http://%s-caipe-ui:3000/api/internal/agentgateway/mcp-targets" .Release.Name) | quote }}
+            - name: OPENFGA_AUTHZ_BRIDGE_HOST
+              value: {{ index .Values.config "OPENFGA_AUTHZ_BRIDGE_HOST" | default (printf "%s-openfga-authz-bridge" .Release.Name) | quote }}
+            - name: ETCD_HOST
+              value: {{ index .Values.config "ETCD_HOST" | default (printf "%s-etcd" .Release.Name) | quote }}
+            - name: MILVUS_HEALTH_URL
+              value: {{ index .Values.config "MILVUS_HEALTH_URL" | default (printf "http://%s-milvus:9091/healthz" .Release.Name) | quote }}
+            - name: MILVUS_MINIO_HOST
+              value: {{ index .Values.config "MILVUS_MINIO_HOST" | default (printf "%s-minio" .Release.Name) | quote }}
           envFrom:
             # Mount ConfigMap as environment variables (non-sensitive config)
             - configMapRef:

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -40,6 +40,16 @@ function env(name: string): string | undefined {
   return process.env[name] || process.env[`NEXT_PUBLIC_${name}`] || undefined;
 }
 
+// Kubernetes auto-injects {SERVICE}_PORT as "tcp://host:port" (a connection URL,
+// not a bare port number). Number("tcp://...") is NaN, which crashes net.createConnection.
+function envPort(name: string, defaultPort: number): number {
+  const raw = env(name);
+  if (!raw) return defaultPort;
+  const tcpMatch = raw.match(/^tcp:\/\/[^:]+:(\d+)/);
+  if (tcpMatch) return Number(tcpMatch[1]);
+  return Number(raw) || defaultPort;
+}
+
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/$/, "");
 }
@@ -461,7 +471,7 @@ async function getPlatformHealth(): Promise<NextResponse> {
       label: "OpenFGA Bridge",
       group: "identity",
       host: env("OPENFGA_AUTHZ_BRIDGE_HOST") || "openfga-authz-bridge",
-      port: Number(env("OPENFGA_AUTHZ_BRIDGE_PORT") || 9100),
+      port: envPort("OPENFGA_AUTHZ_BRIDGE_PORT", 9100),
       remediation: {
         label: "OpenFGA",
         href: "/admin?cat=security&tab=openfga",
@@ -498,7 +508,7 @@ async function getPlatformHealth(): Promise<NextResponse> {
       label: "MongoDB",
       group: "storage",
       host: env("MONGODB_HOST") || "caipe-mongodb",
-      port: Number(env("MONGODB_PORT") || 27017),
+      port: envPort("MONGODB_PORT", 27017),
     }),
     auditProbe,
     probeTcp({
@@ -506,14 +516,14 @@ async function getPlatformHealth(): Promise<NextResponse> {
       label: "Keycloak Postgres",
       group: "storage",
       host: env("KEYCLOAK_POSTGRES_HOST") || "keycloak-postgres",
-      port: Number(env("KEYCLOAK_POSTGRES_PORT") || 5432),
+      port: envPort("KEYCLOAK_POSTGRES_PORT", 5432),
     }),
     probeTcp({
       id: "openfga-postgres",
       label: "OpenFGA Postgres",
       group: "storage",
       host: env("OPENFGA_POSTGRES_HOST") || "openfga-postgres",
-      port: Number(env("OPENFGA_POSTGRES_PORT") || 5432),
+      port: envPort("OPENFGA_POSTGRES_PORT", 5432),
     }),
     probeHttp({
       id: "rag-server",
@@ -531,7 +541,7 @@ async function getPlatformHealth(): Promise<NextResponse> {
       label: "RAG Redis",
       group: "rag",
       host: env("RAG_REDIS_HOST") || "rag-redis",
-      port: Number(env("RAG_REDIS_PORT") || 6379),
+      port: envPort("RAG_REDIS_PORT", 6379),
     }),
     probeHttp({
       id: "milvus",
@@ -544,14 +554,14 @@ async function getPlatformHealth(): Promise<NextResponse> {
       label: "Milvus MinIO",
       group: "rag",
       host: env("MILVUS_MINIO_HOST") || "milvus-minio",
-      port: Number(env("MILVUS_MINIO_PORT") || 9000),
+      port: envPort("MILVUS_MINIO_PORT", 9000),
     }),
     probeTcp({
       id: "etcd",
       label: "etcd",
       group: "rag",
       host: env("ETCD_HOST") || "etcd",
-      port: Number(env("ETCD_PORT") || 2379),
+      port: envPort("ETCD_PORT", 2379),
     }),
     probeOpenFgaBootstrap(openfgaUrl),
     probeKeycloakBootstrap(),

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -417,6 +417,7 @@ async function getPlatformHealth(): Promise<NextResponse> {
   const keycloakRealm = env("KEYCLOAK_REALM") || "caipe";
   const openfgaUrl = trimTrailingSlash(env("OPENFGA_HTTP") || "http://openfga:8080");
   const ragServerUrl = trimTrailingSlash(env("RAG_SERVER_URL") || "http://rag-server:9446");
+  const dynamicAgentsUrl = trimTrailingSlash(env("DYNAMIC_AGENTS_URL") || env("DA_SERVER_BASE_URL") || "http://dynamic-agents:8001");
   const agentgatewayAdminUrl = trimTrailingSlash(
     env("AGENTGATEWAY_ADMIN_CONFIG_URL") || "http://agentgateway:15000/config",
   );
@@ -476,6 +477,17 @@ async function getPlatformHealth(): Promise<NextResponse> {
         label: "OpenFGA",
         href: "/admin?cat=security&tab=openfga",
         description: "Check OpenFGA bridge logs and authz configuration.",
+      },
+    }),
+    probeHttp({
+      id: "dynamic-agents",
+      label: "Dynamic Agents",
+      group: "core",
+      target: `${dynamicAgentsUrl}/health`,
+      remediation: {
+        label: "Dynamic Agents",
+        href: "/agents",
+        description: "Check dynamic agents service logs and dependencies.",
       },
     }),
     probeHttp({


### PR DESCRIPTION
Closes #1959

## Summary

PR #1949 (`perf(ui): cache health and RBAC gate checks`) rewrote `route.ts` and accidentally dropped the `envPort()` helper that was added in #1927, reverting the fix and re-introducing the bug in `0.5.19`.

**Root cause:** Kubernetes auto-injects `{SERVICE}_PORT` env vars as `tcp://host:port` strings (e.g. `RAG_REDIS_PORT=tcp://172.20.x.x:6379`). Passing these directly to `Number()` yields `NaN`, which causes `net.createConnection` to throw `RangeError: Port should be >= 0 and < 65536` and crash the entire `/api/platform/health` route with HTTP 500.

The Platform Health widget then shows **Down** and the UI pod logs fill with `RangeError: Port should be >= 0 and < 65536. Received type number (NaN)` every 30 seconds.

**Fix:** Re-add the `envPort()` helper from #1927 that strips the `tcp://host:` prefix before converting to a number.

## Test plan

- [ ] Deploy to caipe-dev and confirm `/api/platform/health` returns 200/503 (not 500)
- [ ] Verify `RangeError` no longer appears in UI pod logs
- [ ] Verify Platform Health widget shows individual probe statuses instead of generic Down

🤖 Generated with [Claude Code](https://claude.com/claude-code)