### PR TITLE
chore: rename single-node MCP resources from single-node-agent-{name}-mcp to mcp-{name}

### DIFF
--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -124,21 +124,6 @@ In multi-node mode reads from global.enabledSubAgents for non-A2A exports such a
 {{- end -}}
 {{- end -}}
 
-{{/*
-Prefix for single-node in-cluster MCP Kubernetes names: {prefix}-agent-<name>[-mcp].
-When global.singleNode.mcpResourcePrefix is non-empty, use it (e.g. "single-node" for readable kubectl).
-When empty, use .Release.Name so legacy DNS like <release>-agent-jira-mcp stays stable.
-*/}}
-{{- define "ai-platform-engineering.singleNodeMcpResourcePrefix" -}}
-{{- $g := .Values.global | default dict }}
-{{- $sn := index $g "singleNode" | default dict }}
-{{- $p := index $sn "mcpResourcePrefix" | default "" }}
-{{- if ne $p "" -}}
-{{- $p -}}
-{{- else -}}
-{{- .Release.Name -}}
-{{- end -}}
-{{- end -}}
 
 {{- define "ai-platform-engineering.appVersion" -}}
 {{- .Values.global.image.tag | default .Chart.AppVersion -}}
@@ -197,7 +182,7 @@ global.agentgateway.knowledgeBaseTarget, global.agentgateway.extraMcpTargets.
 {{- $mcp := $agentValues.mcp | default dict -}}
 {{- $sub := $mcp.agentgateway | default dict -}}
 {{- if $sub.enabled -}}
-{{- $entry := dict "id" $name "pathPrefix" (printf "/mcp/%s" $name) "host" (printf "%s-agent-%s-mcp.%s.svc.cluster.local" $root.Release.Name $name $ns) "port" ($mcp.port | default 8000) "protocol" ($sub.protocol | default "StreamableHTTP") -}}
+{{- $entry := dict "id" $name "pathPrefix" (printf "/mcp/%s" $name) "host" (printf "mcp-%s.%s.svc.cluster.local" $name $ns) "port" ($mcp.port | default 8000) "protocol" ($sub.protocol | default "StreamableHTTP") -}}
 {{- if eq (include "ai-platform-engineering.agentgatewayProviderTokenAuth" $sub) "true" -}}
 {{- $_ := set $entry "providerTokenAuth" true -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/templates/single-node-agent-env.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-agent-env.yaml
@@ -40,7 +40,7 @@ data:
   {{- else if $mcp.mode }}
   {{ $ENV }}_MCP_MODE: {{ $mcp.mode | quote }}
   {{- if eq $mcp.mode "http" }}
-  {{ $ENV }}_MCP_HOST: {{ printf "%s-agent-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $name | quote }}
+  {{ $ENV }}_MCP_HOST: {{ printf "mcp-%s" $name | quote }}
   {{ $ENV }}_MCP_PORT: {{ $mcp.port | default 8000 | quote }}
   {{- end }}
   {{- end }}

--- a/charts/ai-platform-engineering/templates/single-node-mcp-deployment.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-deployment.yaml
@@ -3,7 +3,7 @@ In single-node mode, agent subcharts are disabled so their mcp-deployment templa
 don't run.  This template creates MCP HTTP server Deployments at the parent chart
 level for every enabled subagent whose mcp.mode is "http" (and that isn't using a
 remote MCP server). ServiceAccounts are created by single-node-mcp-serviceaccount.yaml
-using the same naming convention as the agent subchart ({prefix}-agent-<name>); see global.singleNode.mcpResourcePrefix.
+using the mcp-<name> naming convention.
 */ -}}
 {{- if eq .Values.global.deploymentMode "single-node" }}
 {{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
@@ -20,27 +20,27 @@ using the same naming convention as the agent subchart ({prefix}-agent-<name>); 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+  name: {{ printf "mcp-%s" $name }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+    app.kubernetes.io/name: {{ printf "mcp-%s" $name }}
     app.kubernetes.io/component: mcp
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+      app.kubernetes.io/name: {{ printf "mcp-%s" $name }}
       app.kubernetes.io/component: mcp
       app.kubernetes.io/instance: {{ $.Release.Name }}
   template:
     metadata:
       labels:
         {{- include "ai-platform-engineering.labels" $ | nindent 8 }}
-        app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+        app.kubernetes.io/name: {{ printf "mcp-%s" $name }}
         app.kubernetes.io/component: mcp
     spec:
-      serviceAccountName: {{ printf "%s-%s" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+      serviceAccountName: {{ printf "mcp-%s" $name }}
       automountServiceAccountToken: {{ $mcp.automountServiceAccountToken | default false }}
       containers:
         - name: mcp

--- a/charts/ai-platform-engineering/templates/single-node-mcp-service.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-service.yaml
@@ -1,8 +1,7 @@
 {{- /*
 Companion Service for single-node MCP Deployments.
 Creates a ClusterIP Service for every enabled subagent whose mcp.mode is "http"
-so the supervisor pod can reach the MCP server at <mcpResourcePrefix>-agent-<name>-mcp:<port>
-(default prefix is the Helm release name; override with global.singleNode.mcpResourcePrefix).
+so the supervisor pod can reach the MCP server at mcp-<name>:<port>.
 */ -}}
 {{- if eq .Values.global.deploymentMode "single-node" }}
 {{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
@@ -19,10 +18,10 @@ so the supervisor pod can reach the MCP server at <mcpResourcePrefix>-agent-<nam
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+  name: {{ printf "mcp-%s" $name }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+    app.kubernetes.io/name: {{ printf "mcp-%s" $name }}
     app.kubernetes.io/component: mcp
 spec:
   type: ClusterIP
@@ -32,7 +31,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+    app.kubernetes.io/name: {{ printf "mcp-%s" $name }}
     app.kubernetes.io/component: mcp
     app.kubernetes.io/instance: {{ $.Release.Name }}
 {{- end }}

--- a/charts/ai-platform-engineering/templates/single-node-mcp-serviceaccount.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-serviceaccount.yaml
@@ -2,10 +2,8 @@
 ServiceAccounts for in-cluster HTTP MCP servers in single-node mode.
 
 The MCP Deployments are rendered by single-node-mcp-deployment.yaml while agent
-subcharts stay disabled (tags.agent-*: false). Those pods must still reference a
-ServiceAccount that matches the naming convention the supervisor and tooling use
-({prefix}-agent-<name>; prefix from global.singleNode.mcpResourcePrefix or the Helm release name), which previously only existed when the agent subchart
-created it — causing ReplicaFailure when the chart rolled forward.
+subcharts stay disabled (tags.agent-*: false). This template creates the matching
+ServiceAccount for each MCP deployment using the mcp-<name> naming convention.
 */ -}}
 {{- if eq .Values.global.deploymentMode "single-node" }}
 {{- range $name, $enabled := (include "ai-platform-engineering.enabledSubAgents" . | fromYaml) }}
@@ -22,7 +20,7 @@ created it — causing ReplicaFailure when the chart rolled forward.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ printf "%s-%s" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+  name: {{ printf "mcp-%s" $name }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
     app.kubernetes.io/component: mcp

--- a/charts/ai-platform-engineering/templates/single-node-mcp-vpa.yaml
+++ b/charts/ai-platform-engineering/templates/single-node-mcp-vpa.yaml
@@ -19,16 +19,16 @@ VPA config is resolved per-agent (mcp.vpa) falling back to global.mcp.vpa.
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+  name: {{ printf "mcp-%s" $name }}
   labels:
     {{- include "ai-platform-engineering.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+    app.kubernetes.io/name: {{ printf "mcp-%s" $name }}
     app.kubernetes.io/component: mcp
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ printf "%s-%s-mcp" (include "ai-platform-engineering.singleNodeMcpResourcePrefix" $) $agentKey }}
+    name: {{ printf "mcp-%s" $name }}
   updatePolicy:
     updateMode: {{ $vpa.updateMode | quote }}
   resourcePolicy:

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -45,11 +45,7 @@ global:
     # their MCP servers to install via broad tags such as complete.
     enabled: false
 
-  # When deploymentMode is single-node, in-cluster MCP Services/Deployments/SAs use
-  # {mcpResourcePrefix}-agent-<name>-mcp. Leave mcpResourcePrefix unset (empty) to use the
-  # Helm release name; set to "single-node" for stable, readable resource names.
-  singleNode:
-    mcpResourcePrefix: ""
+  singleNode: {}
 
   createLlmSecret: false # if true, llm secret will be created by the parent chart. Otherwise, expect existing llm secret
   llmSecrets:


### PR DESCRIPTION
## Summary

Renames in-cluster MCP Kubernetes resources from the verbose `{prefix}-agent-{name}-mcp` pattern (e.g. `single-node-agent-jira-mcp`) to the clean `mcp-{name}` pattern (e.g. `mcp-jira`).

- **Service / Deployment / VPA**: `single-node-agent-jira-mcp` → `mcp-jira`
- **ServiceAccount**: `single-node-agent-jira` → `mcp-jira`
- **Supervisor env ConfigMap**: `JIRA_MCP_HOST` now resolves to `mcp-jira` (was `single-node-agent-jira-mcp`)
- **AgentGateway MCP targets host**: `mcp-jira.<ns>.svc.cluster.local` (was using `{release}-agent-jira-mcp` — a latent bug fixed here)
- Removes the unused `singleNodeMcpResourcePrefix` helper from `_helpers.tpl`
- Removes `global.singleNode.mcpResourcePrefix` from `values.yaml` (no longer needed)

A companion PR in platform-apps-deployment updates all endpoint URLs and drops `mcpResourcePrefix: "single-node"` from every environment values file.

## Migration

On the next ArgoCD sync, old resources (`single-node-agent-*-mcp` Deployments/Services/ServiceAccounts) will be deleted and replaced with `mcp-*` equivalents. There will be a brief window during sync where MCP servers are unreachable. This is a one-time migration cost.

## Test plan

- [ ] `helm template` the chart with `global.deploymentMode: single-node` and verify resource names are `mcp-{name}`
- [ ] Verify `single-node-agent-env` ConfigMap contains `{NAME}_MCP_HOST: mcp-{name}`
- [ ] Verify AgentGateway static config contains `mcp-{name}.{ns}.svc.cluster.local` hosts
- [ ] Deploy to caipe-dev and confirm all MCP pods come up with new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)