### PR TITLE
feat(admin): expand platform health diagnostics

### DIFF
--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -467,6 +467,39 @@ test.describe("platform health probes", () => {
     await expect(page).toHaveURL(/\/admin\?cat=security&tab=openfga/);
   });
 
+  test("AgentGateway remediation opens MCP Servers, not Skills Gateway", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "agentgateway"
+        ? {
+            ...probe,
+            status: "down" as const,
+            detail: "connection refused",
+            latency_ms: 31,
+            remediation: {
+              label: "MCP Servers",
+              href: "/dynamic-agents?tab=mcp-servers",
+              description: "Open MCP Servers to sync AgentGateway routes.",
+            },
+          }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+    await openSystemStatus(page);
+
+    await page.locator('button[title="Open MCP Servers to sync AgentGateway routes."]').click();
+    await expect(page).toHaveURL(/\/dynamic-agents\?tab=mcp-servers/);
+  });
+
   test("long probe output scrolls inside the status popover", async ({ page }) => {
     const env = rbacEnvOrSkip({ requireUserSub: true });
     await installStableHeaderHealthMocks(page);

--- a/ui/src/app/api/admin/webex/available-spaces/route.ts
+++ b/ui/src/app/api/admin/webex/available-spaces/route.ts
@@ -41,6 +41,10 @@ interface NormalizedSpace {
 interface CacheEntry {
   spaces: NormalizedSpace[];
   fetched_at: number;
+  refreshing?: Promise<NormalizedSpace[]>;
+  last_error?: string;
+  started_at?: number;
+  updated_at?: number;
 }
 
 // Webex space lists rarely change between admin actions. The TTL is
@@ -54,6 +58,89 @@ const MAX_WEBEX_PAGES = 50;
 const cache = new Map<string, CacheEntry>();
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function tokenCacheKey(token: string): string {
+  return token.slice(-12);
+}
+
+export function __resetWebexSpaceDiscoveryCacheForTests(): void {
+  cache.clear();
+}
+
+function refreshWebexSpaceCache(token: string): Promise<NormalizedSpace[]> {
+  const cacheKey = tokenCacheKey(token);
+  const existing = cache.get(cacheKey);
+  if (existing?.refreshing) return existing.refreshing;
+
+  const refreshing = listAllRooms(token)
+    .then((spaces) => {
+      cache.set(cacheKey, {
+        spaces,
+        fetched_at: Date.now(),
+        started_at: existing?.started_at,
+        updated_at: Date.now(),
+      });
+      return spaces;
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      cache.set(cacheKey, {
+        spaces: existing?.spaces ?? [],
+        fetched_at: existing?.fetched_at ?? 0,
+        last_error: message,
+        started_at: existing?.started_at,
+        updated_at: Date.now(),
+      });
+      throw err;
+    });
+
+  cache.set(cacheKey, {
+    spaces: existing?.spaces ?? [],
+    fetched_at: existing?.fetched_at ?? 0,
+    refreshing,
+    last_error: existing?.last_error,
+    started_at: Date.now(),
+    updated_at: Date.now(),
+  });
+  return refreshing;
+}
+
+export function warmWebexSpaceDiscovery(token: string): void {
+  void getDiscoveryCacheTtlMs()
+    .then((cacheTtlMs) => {
+      const cacheKey = tokenCacheKey(token);
+      const cached = cache.get(cacheKey);
+      const fresh =
+        cacheTtlMs > 0 &&
+        Boolean(cached?.spaces.length) &&
+        Date.now() - (cached?.fetched_at ?? 0) < cacheTtlMs;
+      if (!fresh) {
+        void refreshWebexSpaceCache(token).catch((err) => {
+          console.warn("[Admin WebexSpaces] background refresh failed", err);
+        });
+      }
+    })
+    .catch((err) => {
+      console.warn("[Admin WebexSpaces] failed to read discovery cache TTL", err);
+    });
+}
+
+export async function getWebexSpaceDiscoveryStatus(token: string) {
+  const cacheTtlMs = await getDiscoveryCacheTtlMs();
+  const cached = cache.get(tokenCacheKey(token));
+  const now = Date.now();
+  const hasSnapshot = Boolean(cached?.spaces.length);
+  const fresh = Boolean(hasSnapshot && cacheTtlMs > 0 && cached && now - cached.fetched_at < cacheTtlMs);
+  return {
+    status: cached?.refreshing ? ("warming" as const) : fresh ? ("ready" as const) : hasSnapshot ? ("stale" as const) : ("empty" as const),
+    spaces_indexed: cached?.spaces.length ?? 0,
+    fetched_at: cached?.fetched_at || null,
+    updated_at: cached?.updated_at || null,
+    started_at: cached?.started_at || null,
+    ttl_seconds: Math.floor(cacheTtlMs / 1000),
+    last_error: cached?.last_error,
+  };
+}
 
 export function isSafeWebexPaginationUrl(url: string): boolean {
   try {
@@ -159,7 +246,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       : DEFAULT_UI_LIMIT;
 
   const now = Date.now();
-  const cacheKey = token.slice(-12);
+  const cacheKey = tokenCacheKey(token);
   const cached = cache.get(cacheKey);
   const cacheTtlMs = await getDiscoveryCacheTtlMs();
 

--- a/ui/src/app/api/admin/webex/directory/status/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/webex/directory/status/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+
+const mockRequireRbacPermission = jest.fn();
+const mockCallWebexBotAdmin = jest.fn();
+const mockGetWebexSpaceDiscoveryStatus = jest.fn();
+const mockWarmWebexSpaceDiscovery = jest.fn();
+const mockCountDocuments = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => ({
+  getAuthFromBearerOrSession: jest.fn(async () => ({ session: { user: { email: "admin@test" } } })),
+  requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
+  successResponse: (data: unknown) => Response.json({ success: true, data }),
+  withErrorHandler: (handler: (req: NextRequest) => Promise<Response>) => handler,
+}));
+
+jest.mock("@/lib/webex-bot-admin", () => ({
+  callWebexBotAdmin: (...args: unknown[]) => mockCallWebexBotAdmin(...args),
+}));
+
+jest.mock("@/lib/rbac/mongo-collections", () => ({
+  getRbacCollection: jest.fn(async () => ({
+    countDocuments: (...args: unknown[]) => mockCountDocuments(...args),
+  })),
+}));
+
+jest.mock("../../../available-spaces/route", () => ({
+  warmWebexSpaceDiscovery: (...args: unknown[]) => mockWarmWebexSpaceDiscovery(...args),
+  getWebexSpaceDiscoveryStatus: (...args: unknown[]) => mockGetWebexSpaceDiscoveryStatus(...args),
+}));
+
+import { GET } from "../route";
+
+describe("GET /api/admin/webex/directory/status", () => {
+  const originalToken = process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCountDocuments
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(3);
+    mockCallWebexBotAdmin.mockResolvedValue({
+      route_mode: "db_prefer",
+      static_config: { spaces: 2, routes: 3 },
+      route_cache: { cache_size: 2 },
+    });
+    mockGetWebexSpaceDiscoveryStatus.mockResolvedValue({
+      status: "ready",
+      spaces_indexed: 5,
+      fetched_at: 1,
+      updated_at: 2,
+      started_at: 1,
+      ttl_seconds: 3600,
+      last_error: undefined,
+    });
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN;
+    } else {
+      process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN = originalToken;
+    }
+  });
+
+  it("returns bot admin runtime and space discovery status when configured", async () => {
+    process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN = "integration-token";
+
+    const res = await GET(new NextRequest("http://localhost/api/admin/webex/directory/status"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.configured).toBe(true);
+    expect(body.data.bot_admin.reachable).toBe(true);
+    expect(body.data.bot_admin.runtime).toEqual({
+      route_mode: "db_prefer",
+      static_spaces: 2,
+      static_routes: 3,
+      cache_size: 2,
+    });
+    expect(body.data.space_discovery).toMatchObject({
+      configured: true,
+      status: "ready",
+      spaces_indexed: 5,
+    });
+    expect(body.data.platform).toEqual({
+      reachable: true,
+      spaces_onboarded: 2,
+      routes_configured: 3,
+    });
+    expect(mockWarmWebexSpaceDiscovery).toHaveBeenCalledWith("integration-token");
+  });
+
+  it("reports configured when platform routes exist without integration token", async () => {
+    delete process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN;
+    mockCallWebexBotAdmin.mockRejectedValue(new Error("Webex bot admin request failed: 502"));
+
+    const res = await GET(new NextRequest("http://localhost/api/admin/webex/directory/status"));
+    const body = await res.json();
+
+    expect(body.data.configured).toBe(true);
+    expect(body.data.platform.spaces_onboarded).toBe(2);
+    expect(body.data.bot_admin.reachable).toBe(false);
+  });
+
+  it("returns partial status when integration token is unset but bot admin is reachable", async () => {
+    delete process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN;
+
+    const res = await GET(new NextRequest("http://localhost/api/admin/webex/directory/status"));
+    const body = await res.json();
+
+    expect(body.data.configured).toBe(true);
+    expect(body.data.space_discovery.configured).toBe(false);
+    expect(body.data.space_discovery.status).toBe("empty");
+    expect(mockWarmWebexSpaceDiscovery).not.toHaveBeenCalled();
+  });
+
+  it("surfaces bot admin errors without failing the whole response", async () => {
+    delete process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN;
+    mockCallWebexBotAdmin.mockRejectedValue(
+      new Error("WEBEX_BOT_ADMIN_CLIENT_SECRET (or OIDC_CLIENT_SECRET) is not configured")
+    );
+    mockCountDocuments.mockReset();
+    mockCountDocuments.mockResolvedValue(0);
+
+    const res = await GET(new NextRequest("http://localhost/api/admin/webex/directory/status"));
+    const body = await res.json();
+
+    expect(body.data.configured).toBe(false);
+    expect(body.data.bot_admin).toEqual({
+      reachable: false,
+      error: "WEBEX_BOT_ADMIN_CLIENT_SECRET (or OIDC_CLIENT_SECRET) is not configured",
+    });
+  });
+});

--- a/ui/src/app/api/admin/webex/directory/status/route.ts
+++ b/ui/src/app/api/admin/webex/directory/status/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest } from "next/server";
+
+import {
+  getAuthFromBearerOrSession,
+  requireRbacPermission,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { callWebexBotAdmin } from "@/lib/webex-bot-admin";
+import { getRbacCollection } from "@/lib/rbac/mongo-collections";
+
+import {
+  getWebexSpaceDiscoveryStatus,
+  warmWebexSpaceDiscovery,
+} from "../../available-spaces/route";
+
+interface WebexBotRuntimeStatus {
+  route_mode?: string;
+  static_spaces?: number;
+  static_routes?: number;
+  cache_size?: number;
+}
+
+async function webexPlatformConfigSummary(): Promise<{
+  reachable: boolean;
+  spaces_onboarded: number;
+  routes_configured: number;
+  error?: string;
+}> {
+  try {
+    const [mappings, routes] = await Promise.all([
+      getRbacCollection<{ active?: boolean }>("webexSpaceTeamMappings"),
+      getRbacCollection<{ enabled?: boolean }>("webexSpaceAgentRoutes"),
+    ]);
+    const [spaces_onboarded, routes_configured] = await Promise.all([
+      mappings.countDocuments({ active: { $ne: false } }),
+      routes.countDocuments({ enabled: { $ne: false } }),
+    ]);
+    return { reachable: true, spaces_onboarded, routes_configured };
+  } catch (err) {
+    return {
+      reachable: false,
+      spaces_onboarded: 0,
+      routes_configured: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function webexBotAdminStatus(): Promise<{
+  reachable: boolean;
+  error?: string;
+  runtime?: WebexBotRuntimeStatus;
+}> {
+  try {
+    const status = (await callWebexBotAdmin("/admin/webex/routes/status")) as {
+      route_mode?: string;
+      static_config?: { spaces?: number; routes?: number };
+      route_cache?: { cache_size?: number };
+    };
+    return {
+      reachable: true,
+      runtime: {
+        route_mode: status.route_mode,
+        static_spaces: status.static_config?.spaces,
+        static_routes: status.static_config?.routes,
+        cache_size: status.route_cache?.cache_size,
+      },
+    };
+  } catch (err) {
+    return { reachable: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const { session } = await getAuthFromBearerOrSession(request);
+  await requireRbacPermission(session, "admin_ui", "view");
+
+  const integrationToken = process.env.WEBEX_INTEGRATION_BOT_ACCESS_TOKEN?.trim();
+  if (integrationToken) {
+    warmWebexSpaceDiscovery(integrationToken);
+  }
+
+  const bot_admin = await webexBotAdminStatus();
+  const platform = await webexPlatformConfigSummary();
+  const space_discovery = integrationToken
+    ? {
+        configured: true,
+        ...(await getWebexSpaceDiscoveryStatus(integrationToken)),
+      }
+    : {
+        configured: false,
+        status: "empty" as const,
+        spaces_indexed: 0,
+        fetched_at: null,
+        updated_at: null,
+        started_at: null,
+        ttl_seconds: 0,
+        last_error: undefined,
+      };
+
+  return successResponse({
+    configured: Boolean(
+      integrationToken ||
+        bot_admin.reachable ||
+        platform.spaces_onboarded > 0 ||
+        platform.routes_configured > 0
+    ),
+    bot_admin,
+    platform,
+    space_discovery,
+  });
+});

--- a/ui/src/app/api/platform/health/__tests__/route.test.ts
+++ b/ui/src/app/api/platform/health/__tests__/route.test.ts
@@ -128,6 +128,40 @@ describe("/api/platform/health", () => {
     );
   });
 
+  it("routes AgentGateway remediation to MCP Servers when probes fail", async () => {
+    (global.fetch as jest.Mock) = jest.fn(async (url: string) => {
+      if (url.endsWith("/stores")) {
+        return new Response(JSON.stringify({ stores: [{ id: "store-1", name: "caipe-openfga" }] }), { status: 200 });
+      }
+      if (url.endsWith("/authorization-models")) {
+        return new Response(JSON.stringify({ authorization_models: [{ id: "model-1" }] }), { status: 200 });
+      }
+      if (url.includes("agentgateway")) {
+        return new Response("unavailable", { status: 503 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    mockTcpConnect();
+
+    const { GET } = await import("../route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.probes.find((probe: { id: string }) => probe.id === "agentgateway")).toMatchObject({
+      status: "down",
+      remediation: {
+        href: "/dynamic-agents?tab=mcp-servers",
+        label: "MCP Servers",
+      },
+    });
+    expect(body.probes.find((probe: { id: string }) => probe.id === "agentgateway-config-bridge")).toMatchObject({
+      remediation: {
+        href: "/dynamic-agents?tab=mcp-servers",
+        label: "MCP Servers",
+      },
+    });
+  });
+
   it("returns 503 and marks failed probes down", async () => {
     (global.fetch as jest.Mock) = jest.fn((url: string) =>
       Promise.resolve(new Response(JSON.stringify({ stores: [] }), { status: url.includes("healthz") && url.includes("openfga") ? 503 : 200 })),

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -7,6 +7,7 @@ createJsonResponseCacheStore,
 envTtlMs,
 withJsonResponseCache,
 } from "@/lib/server-response-cache";
+import { AGENTGATEWAY_HEALTH_REMEDIATION } from "@/lib/platform-health-remediation";
 import { getKeycloakMigrationHealth } from "@/lib/rbac/keycloak-migration-health";
 import { getMigrationBlockingStatus } from "@/lib/rbac/migrations/registry";
 
@@ -476,22 +477,14 @@ async function getPlatformHealth(): Promise<NextResponse> {
       headers: {
         authorization: `Bearer ${agentgatewayTargetsToken}`,
       },
-      remediation: {
-        label: "AgentGateway",
-        href: "/skills/gateway",
-        description: "Check AgentGateway target discovery and bridge token configuration.",
-      },
+      remediation: AGENTGATEWAY_HEALTH_REMEDIATION,
     }),
     probeHttp({
       id: "agentgateway",
       label: "AgentGateway",
       group: "core",
       target: agentgatewayAdminUrl,
-      remediation: {
-        label: "AgentGateway",
-        href: "/skills/gateway",
-        description: "Check AgentGateway admin API and compose service logs.",
-      },
+      remediation: AGENTGATEWAY_HEALTH_REMEDIATION,
     }),
     probeTcp({
       id: "caipe-mongodb",

--- a/ui/src/components/admin/platform/HealthTab.tsx
+++ b/ui/src/components/admin/platform/HealthTab.tsx
@@ -261,7 +261,7 @@ export function HealthTab({
               size="sm"
               className="gap-1.5"
               onClick={refreshAll}
-              disabled={loading || platformProbeStatus === "checking"}
+              disabled={loading}
             >
               {loading ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/ui/src/components/admin/platform/HealthTab.tsx
+++ b/ui/src/components/admin/platform/HealthTab.tsx
@@ -2,13 +2,21 @@
 
 import { Button } from "@/components/ui/button";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
+import { usePlatformHealthProbes,type PlatformHealthProbe } from "@/hooks/use-platform-health-probes";
 import { useServiceHealth,type HealthStatus } from "@/hooks/use-service-health";
+import {
+PROMETHEUS_SETUP_GUIDANCE,
+PROMETHEUS_UNAVAILABLE_MESSAGE,
+type PlatformHealthRemediationLink,
+} from "@/lib/platform-health-remediation";
 import { cn } from "@/lib/utils";
 import {
 AlertTriangle,
 CheckCircle2,
 Database,
+ExternalLink,
 HelpCircle,
+Info,
 Loader2,
 MessageSquare,
 RefreshCw,
@@ -16,7 +24,8 @@ Server,
 Shield,
 XCircle,
 } from "lucide-react";
-import React,{ useCallback,useEffect,useState } from "react";
+import { useRouter } from "next/navigation";
+import React,{ useCallback,useEffect,useMemo,useState } from "react";
 
 const STATUS_CONFIG: Record<
   HealthStatus,
@@ -78,19 +87,78 @@ interface SlackDirectoryStatus {
   };
 }
 
+interface WebexDirectoryStatus {
+  configured: boolean;
+  bot_admin: {
+    reachable: boolean;
+    error?: string;
+    runtime?: {
+      route_mode?: string;
+      static_spaces?: number;
+      static_routes?: number;
+      cache_size?: number;
+    };
+  };
+  platform: {
+    reachable: boolean;
+    spaces_onboarded: number;
+    routes_configured: number;
+    error?: string;
+  };
+  space_discovery: {
+    configured: boolean;
+    status: "warming" | "ready" | "stale" | "empty";
+    spaces_indexed: number;
+    fetched_at: number | null;
+    updated_at: number | null;
+    started_at: number | null;
+    ttl_seconds?: number;
+    last_error?: string;
+  };
+}
+
 export function HealthTab({
   ssoEnabled = true,
   mongodbEnabled = true,
   ragEnabled = true,
 }: HealthTabProps) {
+  const router = useRouter();
   const { services, overall, loading, error, configured, refetch } =
     useServiceHealth({ refreshInterval: 30_000 });
+  const {
+    probes: platformProbes,
+    summary: platformProbeSummary,
+    status: platformProbeStatus,
+    checkNow: refreshPlatformProbes,
+    secondsUntilNextCheck: platformProbeNextCheck,
+  } = usePlatformHealthProbes();
 
-  const overallConfig = STATUS_CONFIG[overall];
+  const prometheusUnavailable = !configured || error === "Prometheus not configured";
+  const operationalError =
+    error && error !== "Prometheus not configured" ? error : null;
+
+  const systemStatus = useMemo((): HealthStatus => {
+    if (platformProbeStatus === "checking") return "unknown";
+    if (platformProbeStatus === "down") return "down";
+    if (platformProbeStatus === "degraded") return "degraded";
+    if (platformProbeStatus === "healthy") {
+      if (!prometheusUnavailable && overall !== "unknown") {
+        if (overall === "down") return "down";
+        if (overall === "degraded") return "degraded";
+      }
+      return "healthy";
+    }
+    return overall;
+  }, [platformProbeStatus, prometheusUnavailable, overall]);
+
+  const overallConfig = STATUS_CONFIG[systemStatus];
   const OverallIcon = overallConfig.icon;
   const [slackStatus, setSlackStatus] = useState<SlackDirectoryStatus | null>(null);
   const [slackLoading, setSlackLoading] = useState(false);
   const [slackError, setSlackError] = useState<string | null>(null);
+  const [webexStatus, setWebexStatus] = useState<WebexDirectoryStatus | null>(null);
+  const [webexLoading, setWebexLoading] = useState(false);
+  const [webexError, setWebexError] = useState<string | null>(null);
 
   const loadSlackStatus = useCallback(async () => {
     setSlackLoading(true);
@@ -107,9 +175,28 @@ export function HealthTab({
     }
   }, []);
 
+  const loadWebexStatus = useCallback(async () => {
+    setWebexLoading(true);
+    setWebexError(null);
+    try {
+      const res = await fetch("/api/admin/webex/directory/status");
+      const payload = await res.json();
+      if (res.status === 404) {
+        throw new Error("Webex health API is unavailable. Rebuild or restart the UI service to pick up the latest Health tab.");
+      }
+      if (!res.ok || !payload.success) throw new Error(payload?.error || "Failed to load Webex status");
+      setWebexStatus(payload.data);
+    } catch (err) {
+      setWebexError(err instanceof Error ? err.message : "Failed to load Webex status");
+    } finally {
+      setWebexLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     void loadSlackStatus();
-  }, [loadSlackStatus]);
+    void loadWebexStatus();
+  }, [loadSlackStatus, loadWebexStatus]);
 
   useEffect(() => {
     if (!slackStatus || (slackStatus.users.status !== "warming" && slackStatus.emoji.status !== "warming")) return;
@@ -117,20 +204,34 @@ export function HealthTab({
     return () => window.clearInterval(id);
   }, [loadSlackStatus, slackStatus]);
 
+  useEffect(() => {
+    if (!webexStatus || webexStatus.space_discovery.status !== "warming") return;
+    const id = window.setInterval(() => void loadWebexStatus(), 5000);
+    return () => window.clearInterval(id);
+  }, [loadWebexStatus, webexStatus]);
+
   // Separate agent-specific services from platform services
   const agentServices = services.filter((s) => s.name.startsWith("Agent: "));
-  const platformServices = services.filter((s) => !s.name.startsWith("Agent: "));
+  const platformMetricServices = services.filter((s) => !s.name.startsWith("Agent: "));
+  const platformProbeIssues = platformProbes.filter((probe) => probe.status !== "healthy");
+
+  const refreshAll = useCallback(() => {
+    void refetch();
+    refreshPlatformProbes();
+    void loadSlackStatus();
+    void loadWebexStatus();
+  }, [refetch, refreshPlatformProbes, loadSlackStatus, loadWebexStatus]);
 
   return (
     <div className="space-y-4">
       {/* Overall Status Banner */}
-      {configured && !loading && (
+      {(platformProbeSummary || !prometheusUnavailable) && platformProbeStatus !== "checking" && (
         <Card className={cn(
           "border-l-4",
-          overall === "healthy" && "border-l-green-500",
-          overall === "degraded" && "border-l-yellow-500",
-          overall === "down" && "border-l-red-500",
-          overall === "unknown" && "border-l-muted-foreground",
+          systemStatus === "healthy" && "border-l-green-500",
+          systemStatus === "degraded" && "border-l-yellow-500",
+          systemStatus === "down" && "border-l-red-500",
+          systemStatus === "unknown" && "border-l-muted-foreground",
         )}>
           <CardContent className="flex items-center justify-between py-4">
             <div className="flex items-center gap-3">
@@ -138,12 +239,20 @@ export function HealthTab({
               <div>
                 <p className="font-medium">System Status: {overallConfig.label}</p>
                 <p className="text-xs text-muted-foreground">
-                  {platformServices.filter((s) => s.status === "healthy").length} of{" "}
-                  {platformServices.length} platform services healthy
+                  {platformProbeSummary
+                    ? `${platformProbeSummary.healthy} of ${platformProbeSummary.total} dependency checks passing`
+                    : "Running dependency checks"}
+                  {configured && !prometheusUnavailable && platformMetricServices.length > 0 && (
+                    <> · {platformMetricServices.filter((s) => s.status === "healthy").length} of{" "}
+                    {platformMetricServices.length} Prometheus metrics healthy</>
+                  )}
                   {agentServices.length > 0 && (
                     <> · {agentServices.filter((s) => s.status === "healthy").length} of{" "}
                     {agentServices.length} agents enabled</>
                   )}
+                  {prometheusUnavailable && platformProbeSummary ? (
+                    <> · optional Prometheus metrics not configured</>
+                  ) : null}
                 </p>
               </div>
             </div>
@@ -151,8 +260,8 @@ export function HealthTab({
               variant="outline"
               size="sm"
               className="gap-1.5"
-              onClick={refetch}
-              disabled={loading}
+              onClick={refreshAll}
+              disabled={loading || platformProbeStatus === "checking"}
             >
               {loading ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -170,61 +279,178 @@ export function HealthTab({
         <CardHeader>
           <CardTitle>Platform Services</CardTitle>
           <CardDescription>
-            {configured
-              ? "Live health status from Prometheus metrics"
-              : "Set PROMETHEUS_URL to enable live health monitoring"}
+            {configured && !prometheusUnavailable
+              ? "Live dependency checks plus Prometheus-backed agent metrics"
+              : PROMETHEUS_UNAVAILABLE_MESSAGE}
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {/* Static services (always shown) */}
-            <ServiceRow
-              name="MongoDB"
-              description="Database connection"
-              icon={<Database className="h-4 w-4 text-muted-foreground" />}
-              status={mongodbEnabled ? "healthy" : "unknown"}
-              detail={mongodbEnabled ? "Connected" : "Not configured"}
-            />
-            <ServiceRow
-              name="Authentication"
-              description="OIDC SSO"
-              icon={<Shield className="h-4 w-4 text-muted-foreground" />}
-              status={ssoEnabled ? "healthy" : "unknown"}
-              detail={ssoEnabled ? "Active" : "Disabled"}
-            />
-            <ServiceRow
-              name="RAG Server"
-              description="Knowledge base operations"
-              icon={<Server className="h-4 w-4 text-muted-foreground" />}
-              status={ragEnabled ? "healthy" : "unknown"}
-              detail={ragEnabled ? "Operational" : "Disabled"}
-            />
-            <SlackIntegrationStatus
-              status={slackStatus}
-              loading={slackLoading}
-              error={slackError}
-              onRefresh={loadSlackStatus}
-            />
+        <CardContent className="space-y-5">
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium">Dependency checks</p>
+                <p className="text-xs text-muted-foreground">
+                  Keycloak, OpenFGA, AgentGateway, databases, RAG stack, and bootstrap migrations
+                </p>
+              </div>
+              {platformProbeSummary ? (
+                <span className="text-xs text-muted-foreground">
+                  {platformProbeSummary.healthy}/{platformProbeSummary.total} OK · next in {platformProbeNextCheck}s
+                </span>
+              ) : null}
+            </div>
 
-            {/* Prometheus-sourced platform services */}
-            {configured && platformServices.map((svc) => (
-              <ServiceRow
-                key={svc.name}
-                name={svc.name}
-                status={svc.status}
-                detail={svc.detail}
-              />
-            ))}
-
-            {loading && services.length === 0 && (
+            {platformProbeStatus === "checking" && platformProbes.length === 0 ? (
               <div className="flex items-center justify-center py-4">
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                <span className="text-sm text-muted-foreground ml-2">
-                  Loading metrics...
-                </span>
+                <span className="text-sm text-muted-foreground ml-2">Checking platform dependencies...</span>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {platformProbes.map((probe) => (
+                  <PlatformProbeRow
+                    key={probe.id}
+                    probe={probe}
+                    onNavigate={(href) => router.push(href)}
+                  />
+                ))}
               </div>
             )}
-          </div>
+
+            {platformProbeIssues.length > 0 ? (
+              <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-3 text-xs text-amber-800 dark:text-amber-200">
+                <p className="font-semibold">Remediation tips</p>
+                <ul className="mt-2 list-disc space-y-1 pl-4 text-amber-900/90 dark:text-amber-100/90">
+                  {platformProbeIssues.slice(0, 4).map((probe) => (
+                    <li key={probe.id}>
+                      <span className="font-medium">{probe.label}:</span>{" "}
+                      {probe.remediation?.description ?? probe.detail}
+                    </li>
+                  ))}
+                  {platformProbeIssues.length > 4 ? (
+                    <li>{platformProbeIssues.length - 4} more checks need attention.</li>
+                  ) : null}
+                </ul>
+              </div>
+            ) : platformProbes.length > 0 ? (
+              <div className="rounded-lg border border-green-500/20 bg-green-500/10 px-3 py-2 text-xs text-muted-foreground">
+                All dependency checks are passing.
+              </div>
+            ) : null}
+          </section>
+
+          <section className="space-y-3">
+            <div>
+              <p className="text-sm font-medium">Configured integrations</p>
+              <p className="text-xs text-muted-foreground">
+                Feature flags and integration caches for this deployment
+              </p>
+            </div>
+            <div className="space-y-3">
+              <ServiceRow
+                name="MongoDB"
+                description="Database connection"
+                icon={<Database className="h-4 w-4 text-muted-foreground" />}
+                status={mongodbEnabled ? "healthy" : "unknown"}
+                detail={mongodbEnabled ? "Configured" : "Not configured"}
+                remediation={
+                  mongodbEnabled
+                    ? undefined
+                    : {
+                        label: "Docs",
+                        href: "/admin?cat=metrics&tab=health",
+                        description: "Set MONGODB_URI on the UI service and verify the caipe-mongodb container is running.",
+                      }
+                }
+                onNavigate={(href) => router.push(href)}
+              />
+              <ServiceRow
+                name="Authentication"
+                description="OIDC SSO"
+                icon={<Shield className="h-4 w-4 text-muted-foreground" />}
+                status={ssoEnabled ? "healthy" : "unknown"}
+                detail={ssoEnabled ? "SSO enabled" : "Disabled"}
+                remediation={
+                  ssoEnabled
+                    ? {
+                        label: "Keycloak",
+                        href: "/admin?cat=security&tab=keycloak",
+                        description: "Review realm reconciliation, IdP mappers, and admin credentials.",
+                      }
+                    : {
+                        label: "Enable SSO",
+                        href: "/admin?cat=security&tab=keycloak",
+                        description: "Configure OIDC_CLIENT_ID, OIDC_ISSUER, and OIDC_CLIENT_SECRET on the UI service.",
+                      }
+                }
+                onNavigate={(href) => router.push(href)}
+              />
+              <ServiceRow
+                name="RAG Server"
+                description="Knowledge base operations"
+                icon={<Server className="h-4 w-4 text-muted-foreground" />}
+                status={ragEnabled ? "healthy" : "unknown"}
+                detail={ragEnabled ? "Enabled" : "Disabled"}
+                remediation={
+                  ragEnabled
+                    ? {
+                        label: "Knowledge Bases",
+                        href: "/knowledge-bases",
+                        description: "Open knowledge bases to verify ingest jobs and retrieval.",
+                      }
+                    : {
+                        label: "Setup",
+                        href: "/knowledge-bases/ingest",
+                        description: "Start the rag compose profile and set RAG_SERVER_URL on the UI service.",
+                      }
+                }
+                onNavigate={(href) => router.push(href)}
+              />
+              <SlackIntegrationStatus
+                status={slackStatus}
+                loading={slackLoading}
+                error={slackError}
+                onRefresh={loadSlackStatus}
+                onNavigate={(href) => router.push(href)}
+              />
+              <WebexIntegrationStatus
+                status={webexStatus}
+                loading={webexLoading}
+                error={webexError}
+                onRefresh={loadWebexStatus}
+                onNavigate={(href) => router.push(href)}
+              />
+            </div>
+          </section>
+
+          {prometheusUnavailable ? (
+            <section className="rounded-lg border border-border/70 bg-muted/20 p-4">
+              <div className="flex items-start gap-3">
+                <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">{PROMETHEUS_SETUP_GUIDANCE.title}</p>
+                  <p className="text-xs text-muted-foreground">{PROMETHEUS_SETUP_GUIDANCE.body}</p>
+                </div>
+              </div>
+            </section>
+          ) : (
+            <>
+              {loading && platformMetricServices.length === 0 ? (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground ml-2">Loading Prometheus metrics...</span>
+                </div>
+              ) : null}
+              {platformMetricServices.map((svc) => (
+                <ServiceRow
+                  key={svc.name}
+                  name={svc.name}
+                  status={svc.status}
+                  detail={svc.detail}
+                />
+              ))}
+            </>
+          )}
         </CardContent>
       </Card>
 
@@ -260,10 +486,10 @@ export function HealthTab({
         </Card>
       )}
 
-      {error && (
+      {operationalError && (
         <Card className="border-destructive/50">
           <CardContent className="py-4">
-            <p className="text-sm text-destructive">{error}</p>
+            <p className="text-sm text-destructive">{operationalError}</p>
           </CardContent>
         </Card>
       )}
@@ -275,35 +501,102 @@ export function HealthTab({
 // ServiceRow — single service status row
 // ────────────────────────────────────────────────────────────────
 
+function probeStatusToHealth(status: PlatformHealthProbe["status"]): HealthStatus {
+  if (status === "healthy") return "healthy";
+  if (status === "warning") return "degraded";
+  return "down";
+}
+
+function PlatformProbeRow({
+  probe,
+  onNavigate,
+}: {
+  probe: PlatformHealthProbe;
+  onNavigate: (href: string) => void;
+}) {
+  const status = probeStatusToHealth(probe.status);
+  const cfg = STATUS_CONFIG[status];
+
+  return (
+    <div className="rounded-lg bg-muted/50 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium">{probe.label}</p>
+          <p className="text-xs text-muted-foreground">
+            {probe.detail}
+            {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
+          </p>
+          <p className="mt-1 break-all font-mono text-[10px] text-muted-foreground">{probe.target}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <div className={cn("h-2 w-2 rounded-full", cfg.bg)} />
+          <span className="text-xs font-medium">{cfg.label}</span>
+          {probe.remediation ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 px-2 text-[10px]"
+              title={probe.remediation.description}
+              onClick={() => onNavigate(probe.remediation!.href)}
+            >
+              {probe.remediation.label}
+              <ExternalLink className="h-3 w-3" />
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ServiceRow({
   name,
   description,
   icon,
   status,
   detail,
+  remediation,
+  onNavigate,
 }: {
   name: string;
   description?: string;
   icon?: React.ReactNode;
   status: HealthStatus;
   detail: string;
+  remediation?: PlatformHealthRemediationLink;
+  onNavigate?: (href: string) => void;
 }) {
   const cfg = STATUS_CONFIG[status];
 
   return (
-    <div className="flex items-center justify-between p-4 bg-muted/50 rounded-lg">
-      <div className="flex items-center gap-3">
+    <div className="flex items-center justify-between gap-3 p-4 bg-muted/50 rounded-lg">
+      <div className="flex min-w-0 items-center gap-3">
         {icon}
-        <div>
+        <div className="min-w-0">
           <p className="text-sm font-medium">{name}</p>
           {description && (
             <p className="text-xs text-muted-foreground">{description}</p>
           )}
+          {remediation && (
+            <p className="mt-1 line-clamp-2 text-[10px] text-muted-foreground">{remediation.description}</p>
+          )}
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         <div className={cn("h-2 w-2 rounded-full", cfg.bg)} />
         <span className="text-sm">{detail}</span>
+        {remediation && onNavigate ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 px-2 text-[10px]"
+            onClick={() => onNavigate(remediation.href)}
+          >
+            {remediation.label}
+          </Button>
+        ) : null}
       </div>
     </div>
   );
@@ -326,11 +619,13 @@ function SlackIntegrationStatus({
   loading,
   error,
   onRefresh,
+  onNavigate,
 }: {
   status: SlackDirectoryStatus | null;
   loading: boolean;
   error: string | null;
   onRefresh: () => void | Promise<void>;
+  onNavigate?: (href: string) => void;
 }) {
   if (error && !status) {
     return (
@@ -340,19 +635,25 @@ function SlackIntegrationStatus({
         icon={<MessageSquare className="h-4 w-4 text-muted-foreground" />}
         status="degraded"
         detail={error}
+        remediation={{
+          label: "Slack Admin",
+          href: "/admin?cat=integrations&tab=slack",
+          description: "Verify SLACK_BOT_ADMIN_TOKEN_URL, bot credentials, and directory sync permissions.",
+        }}
+        onNavigate={onNavigate}
       />
     );
   }
 
   const botStatus: HealthStatus = status?.bot_admin.reachable ? "healthy" : status ? "degraded" : "unknown";
   const userStatus = status ? cacheStateToHealth(status.users.status, status.users.last_error) : "unknown";
-  const emojiStatus = status ? cacheStateToHealth(status.emoji.status, status.emoji.last_error) : "unknown";
   const overallStatus: HealthStatus =
-    [botStatus, userStatus, emojiStatus].includes("down") ? "down"
-      : [botStatus, userStatus, emojiStatus].includes("degraded") ? "degraded"
-        : [botStatus, userStatus, emojiStatus].every((s) => s === "healthy") ? "healthy"
+    [botStatus, userStatus].includes("down") ? "down"
+      : [botStatus, userStatus].includes("degraded") ? "degraded"
+        : [botStatus, userStatus].every((s) => s === "healthy") ? "healthy"
           : "unknown";
   const cfg = STATUS_CONFIG[overallStatus];
+  const emojiReady = status?.emoji.status === "ready" && !status.emoji.last_error;
 
   return (
     <div className="rounded-lg bg-muted/50 p-4">
@@ -361,11 +662,22 @@ function SlackIntegrationStatus({
           <MessageSquare className="mt-0.5 h-4 w-4 text-muted-foreground" />
           <div>
             <p className="text-sm font-medium">Slack Integration</p>
-            <p className="text-xs text-muted-foreground">Bot admin API and Slack directory caches</p>
+            <p className="text-xs text-muted-foreground">Bot admin API, user directory, and optional emoji picker cache</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
           <div className={cn("h-2 w-2 rounded-full", cfg.bg)} />
+          {onNavigate ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 px-2 text-[10px]"
+              onClick={() => onNavigate("/admin?cat=integrations&tab=slack")}
+            >
+              Slack Admin
+            </Button>
+          ) : null}
           <Button type="button" variant="ghost" size="sm" onClick={() => void onRefresh()} disabled={loading}>
             {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
           </Button>
@@ -391,13 +703,165 @@ function SlackIntegrationStatus({
           )}
           {status?.users.last_error && <div className="mt-1 text-amber-700 dark:text-amber-400 line-clamp-2">{status.users.last_error}</div>}
         </div>
-        <div className="rounded-md border bg-background/60 p-2">
-          <div className="font-medium">Emoji cache</div>
-          <div className="text-muted-foreground">
-            {status ? `${status.emoji.status}: ${status.emoji.emoji_indexed} emoji indexed` : "checking"}
+        <div className="rounded-md border border-dashed bg-background/60 p-2">
+          <div className="font-medium">
+            Emoji cache <span className="font-normal text-muted-foreground">(optional)</span>
           </div>
-          {status && <div className="text-muted-foreground">updated {formatTime(status.emoji.updated_at)}</div>}
-          {status?.emoji.last_error && <div className="mt-1 text-amber-700 dark:text-amber-400 line-clamp-2">{status.emoji.last_error}</div>}
+          <div className={emojiReady ? "text-emerald-700 dark:text-emerald-400" : "text-muted-foreground"}>
+            {status
+              ? status.emoji.last_error
+                ? "Not loaded · bot messaging unaffected"
+                : `${status.emoji.status}: ${status.emoji.emoji_indexed} emoji indexed`
+              : "checking"}
+          </div>
+          {status && !status.emoji.last_error && (
+            <div className="text-muted-foreground">updated {formatTime(status.emoji.updated_at)}</div>
+          )}
+          {status?.emoji.last_error ? (
+            <div className="mt-1 text-muted-foreground line-clamp-3">{status.emoji.last_error}</div>
+          ) : (
+            <div className="text-muted-foreground">
+              Suggests custom workspace emoji in Slack Admin escalation config · requires <code className="text-[10px]">emoji:read</code>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WebexIntegrationStatus({
+  status,
+  loading,
+  error,
+  onRefresh,
+  onNavigate,
+}: {
+  status: WebexDirectoryStatus | null;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void | Promise<void>;
+  onNavigate?: (href: string) => void;
+}) {
+  if (error && !status) {
+    return (
+      <ServiceRow
+        name="Webex Integration"
+        description="Bot admin API and Webex space discovery"
+        icon={<MessageSquare className="h-4 w-4 text-muted-foreground" />}
+        status="degraded"
+        detail={error}
+        remediation={{
+          label: "Webex Admin",
+          href: "/admin?cat=integrations&tab=webex",
+          description: "Verify WEBEX_BOT_ADMIN_CLIENT_SECRET, WEBEX_INTEGRATION_BOT_ACCESS_TOKEN, and webex-bot connectivity.",
+        }}
+        onNavigate={onNavigate}
+      />
+    );
+  }
+
+  const botStatus: HealthStatus = status?.bot_admin.reachable ? "healthy" : status ? "degraded" : "unknown";
+  const platformStatus: HealthStatus = status
+    ? status.platform.reachable && (status.platform.spaces_onboarded > 0 || status.platform.routes_configured > 0)
+      ? "healthy"
+      : status.platform.reachable
+        ? "unknown"
+        : "degraded"
+    : "unknown";
+  const discoveryStatus = status
+    ? status.space_discovery.configured
+      ? cacheStateToHealth(status.space_discovery.status, status.space_discovery.last_error)
+      : "unknown"
+    : "unknown";
+  const overallStatus: HealthStatus =
+    [botStatus, platformStatus, discoveryStatus].includes("down") ? "down"
+      : [botStatus, platformStatus, discoveryStatus].includes("degraded") ? "degraded"
+        : [botStatus, platformStatus, discoveryStatus].some((s) => s === "healthy") ? "healthy"
+          : status?.configured ? "degraded" : "unknown";
+  const cfg = STATUS_CONFIG[overallStatus];
+  const runtime = status?.bot_admin.runtime;
+  const platform = status?.platform;
+
+  return (
+    <div className="rounded-lg bg-muted/50 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <MessageSquare className="mt-0.5 h-4 w-4 text-muted-foreground" />
+          <div>
+            <p className="text-sm font-medium">Webex Integration</p>
+            <p className="text-xs text-muted-foreground">Bot admin API and Webex space discovery</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className={cn("h-2 w-2 rounded-full", cfg.bg)} />
+          {onNavigate ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 px-2 text-[10px]"
+              onClick={() => onNavigate("/admin?cat=integrations&tab=webex")}
+            >
+              Webex Admin
+            </Button>
+          ) : null}
+          <Button type="button" variant="ghost" size="sm" onClick={() => void onRefresh()} disabled={loading}>
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+          </Button>
+        </div>
+      </div>
+      <div className="mt-3 grid gap-2 text-xs md:grid-cols-3">
+        <div className="rounded-md border bg-background/60 p-2">
+          <div className="font-medium">Bot admin API</div>
+          <div className={status?.bot_admin.reachable ? "text-emerald-700 dark:text-emerald-400" : "text-amber-700 dark:text-amber-400"}>
+            {status ? (status.bot_admin.reachable ? "reachable" : "unreachable") : "checking"}
+          </div>
+          {runtime ? (
+            <div className="mt-1 text-muted-foreground">
+              {runtime.route_mode ?? "unknown"} · {runtime.static_spaces ?? 0} spaces · {runtime.static_routes ?? 0} routes
+              {runtime.cache_size !== undefined ? ` · cache ${runtime.cache_size}` : ""}
+            </div>
+          ) : null}
+          {status?.bot_admin.error && <div className="mt-1 text-muted-foreground line-clamp-2">{status.bot_admin.error}</div>}
+        </div>
+        <div className="rounded-md border bg-background/60 p-2">
+          <div className="font-medium">Platform configuration</div>
+          <div className="text-muted-foreground">
+            {status
+              ? platform?.reachable
+                ? `${platform.spaces_onboarded} spaces onboarded · ${platform.routes_configured} routes configured`
+                : "MongoDB summary unavailable"
+              : "checking"}
+          </div>
+          {platform?.spaces_onboarded || platform?.routes_configured ? (
+            <div className="text-muted-foreground">Configured in Admin → Integrations → Webex</div>
+          ) : (
+            <div className="text-muted-foreground">Onboard spaces in Admin → Integrations → Webex</div>
+          )}
+          {platform?.error && <div className="mt-1 text-amber-700 dark:text-amber-400 line-clamp-2">{platform.error}</div>}
+        </div>
+        <div className="rounded-md border bg-background/60 p-2">
+          <div className="font-medium">Space discovery cache</div>
+          <div className="text-muted-foreground">
+            {status
+              ? status.space_discovery.configured
+                ? `${status.space_discovery.status}: ${status.space_discovery.spaces_indexed} spaces indexed`
+                : "Optional · WEBEX_INTEGRATION_BOT_ACCESS_TOKEN unset"
+              : "checking"}
+          </div>
+          {status?.space_discovery.configured ? (
+            <div className="text-muted-foreground">
+              TTL {status.space_discovery.ttl_seconds ?? 0}s · updated {formatTime(status.space_discovery.updated_at)}
+            </div>
+          ) : (
+            <div className="text-muted-foreground">
+              Enables the Webex space picker; manual space IDs still work without it.
+            </div>
+          )}
+          {status?.space_discovery.last_error && (
+            <div className="mt-1 text-amber-700 dark:text-amber-400 line-clamp-2">{status.space_discovery.last_error}</div>
+          )}
         </div>
       </div>
     </div>

--- a/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
@@ -110,7 +110,7 @@ const WEBEX_ADAPTER: ConnectorAdminAdapter = {
   },
   itemKey: (item) => `${item.workspace_id}/${item.item_id}`,
   parseDiscoveryPage: (json) => {
-    const d = apiData<{ spaces: unknown[]; next_cursor?: string | null; has_more?: boolean }>(
+    const d = apiData<{ spaces: unknown[]; next_cursor?: string | null; has_more?: boolean; total_matches?: number }>(
       json as { spaces: unknown[] },
     );
     const spaces = (d.spaces ?? []) as Record<string, unknown>[];

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -87,6 +87,12 @@ const EDITOR_ROUTES_WITH_HEADER_DIALOG = [
   "/dynamic-agents",
 ];
 
+const PLATFORM_HEALTH_ADMIN_HREF = "/admin?cat=platform&tab=health";
+
+function openPlatformHealthDashboard(router: ReturnType<typeof useRouter>): void {
+  router.push(PLATFORM_HEALTH_ADMIN_HREF);
+}
+
 function isOnGuardedEditor(pathname: string | null | undefined): boolean {
   if (!pathname) return false;
   return EDITOR_ROUTES_WITH_OWN_DISCARD_DIALOG.some((p) =>
@@ -746,22 +752,46 @@ export function AppHeader() {
                       <div className="text-base font-bold text-white mb-1">System Status</div>
                       <div className="text-xs text-white/80">Dynamic agents, tools, identity, and knowledge services</div>
                     </div>
-                    <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-white/20 backdrop-blur-sm">
-                      <span className={cn(
-                        "inline-block w-2 h-2 rounded-full transition-colors duration-700",
-                        combinedStatus === "connected" ? "bg-green-400" :
-                        combinedStatus === "checking" ? "bg-amber-400" :
-                        combinedStatus === "degraded" ? "bg-amber-400" :
-                        combinedStatus === "rag-disconnected" ? "bg-amber-400" : "bg-red-400"
-                      )} />
-                      <span className="text-xs font-medium text-white">
-                        {combinedStatus === "connected" ? "All Systems Live" :
-                         combinedStatus === "checking" ? "Checking" :
-                         combinedStatus === "degraded" ? "Action Needed" :
-                         combinedStatus === "rag-disconnected" ? "RAG Offline" :
-                         "Issues Detected"}
-                      </span>
-                    </div>
+                    {isAdmin ? (
+                      <button
+                        type="button"
+                        onClick={() => openPlatformHealthDashboard(router)}
+                        title="Open full health dashboard"
+                        className="flex items-center gap-1.5 rounded-full bg-white/20 px-2.5 py-1 backdrop-blur-sm transition-colors hover:bg-white/30"
+                      >
+                        <span className={cn(
+                          "inline-block h-2 w-2 rounded-full transition-colors duration-700",
+                          combinedStatus === "connected" ? "bg-green-400" :
+                          combinedStatus === "checking" ? "bg-amber-400" :
+                          combinedStatus === "degraded" ? "bg-amber-400" :
+                          combinedStatus === "rag-disconnected" ? "bg-amber-400" : "bg-red-400"
+                        )} />
+                        <span className="text-xs font-medium text-white">
+                          {combinedStatus === "connected" ? "All Systems Live" :
+                           combinedStatus === "checking" ? "Checking" :
+                           combinedStatus === "degraded" ? "Action Needed" :
+                           combinedStatus === "rag-disconnected" ? "RAG Offline" :
+                           "Issues Detected"}
+                        </span>
+                      </button>
+                    ) : (
+                      <div className="flex items-center gap-1.5 rounded-full bg-white/20 px-2.5 py-1 backdrop-blur-sm">
+                        <span className={cn(
+                          "inline-block h-2 w-2 rounded-full transition-colors duration-700",
+                          combinedStatus === "connected" ? "bg-green-400" :
+                          combinedStatus === "checking" ? "bg-amber-400" :
+                          combinedStatus === "degraded" ? "bg-amber-400" :
+                          combinedStatus === "rag-disconnected" ? "bg-amber-400" : "bg-red-400"
+                        )} />
+                        <span className="text-xs font-medium text-white">
+                          {combinedStatus === "connected" ? "All Systems Live" :
+                           combinedStatus === "checking" ? "Checking" :
+                           combinedStatus === "degraded" ? "Action Needed" :
+                           combinedStatus === "rag-disconnected" ? "RAG Offline" :
+                           "Issues Detected"}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
 
@@ -771,19 +801,44 @@ export function AppHeader() {
                 >
                   <div className="rounded-xl border border-border/70 bg-background/40 p-3">
                     <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="text-sm font-semibold text-foreground">Platform Health</div>
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <div className="text-sm font-semibold text-foreground">Platform Health</div>
+                          {isAdmin ? (
+                            <button
+                              type="button"
+                              onClick={() => openPlatformHealthDashboard(router)}
+                              className="inline-flex items-center gap-0.5 text-[11px] font-medium text-primary hover:underline"
+                            >
+                              Full health report
+                              <ChevronRight className="h-3 w-3" />
+                            </button>
+                          ) : null}
+                        </div>
                         <div className="mt-0.5 text-xs text-muted-foreground">
                           {platformProbeSummary
                             ? `${platformProbeSummary.total} checks across dynamic agents, auth, storage, RAG, web ingestor, and migrations`
                             : "Checking dynamic agents, auth, storage, RAG, web ingestor, and migrations"}
                         </div>
                       </div>
-                      <span className={statusBadgeClassName(platformHealthTone)}>
-                        {platformProbeSummary
-                          ? `${platformProbeSummary.healthy}/${platformProbeSummary.total} ${platformHealthLabel}`
-                          : platformHealthLabel}
-                      </span>
+                      {isAdmin ? (
+                        <button
+                          type="button"
+                          onClick={() => openPlatformHealthDashboard(router)}
+                          title="Open full health dashboard"
+                          className={cn(statusBadgeClassName(platformHealthTone), "transition-opacity hover:opacity-90")}
+                        >
+                          {platformProbeSummary
+                            ? `${platformProbeSummary.healthy}/${platformProbeSummary.total} ${platformHealthLabel}`
+                            : platformHealthLabel}
+                        </button>
+                      ) : (
+                        <span className={statusBadgeClassName(platformHealthTone)}>
+                          {platformProbeSummary
+                            ? `${platformProbeSummary.healthy}/${platformProbeSummary.total} ${platformHealthLabel}`
+                            : platformHealthLabel}
+                        </span>
+                      )}
                     </div>
 
                     {platformProbes.length === 0 ? (
@@ -969,6 +1024,18 @@ export function AppHeader() {
 
                     <div className="mt-2 text-right text-[10px] font-mono text-muted-foreground">
                       Next probe: {platformProbeNextCheck}s
+                      {isAdmin ? (
+                        <>
+                          {" · "}
+                          <button
+                            type="button"
+                            onClick={() => openPlatformHealthDashboard(router)}
+                            className="font-sans font-medium text-primary hover:underline"
+                          >
+                            Open health dashboard
+                          </button>
+                        </>
+                      ) : null}
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -652,6 +652,35 @@ describe('AppHeader — connection status badge', () => {
       expect(screen.getByText('Platform Health')).toBeInTheDocument()
       expect(screen.getAllByText('Identity & Authz').length).toBeGreaterThan(0)
     })
+
+    it('links admins to the full platform health dashboard', () => {
+      mockIsAdmin = true
+      mockCaipeStatus = 'connected'
+      render(<AppHeader />)
+
+      fireEvent.click(screen.getByRole('button', { name: /full health report/i }))
+      expect(mockRouterPush).toHaveBeenCalledWith('/admin?cat=platform&tab=health')
+
+      mockRouterPush.mockClear()
+      fireEvent.click(screen.getByRole('button', { name: /all systems live/i }))
+      expect(mockRouterPush).toHaveBeenCalledWith('/admin?cat=platform&tab=health')
+
+      mockRouterPush.mockClear()
+      fireEvent.click(screen.getByRole('button', { name: /1\/1 ready/i }))
+      expect(mockRouterPush).toHaveBeenCalledWith('/admin?cat=platform&tab=health')
+    })
+
+    it('hides the health dashboard link for non-admins', () => {
+      mockIsAdmin = false
+      mockCaipeStatus = 'connected'
+      render(<AppHeader />)
+
+      expect(screen.queryByRole('button', { name: /full health report/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /open health dashboard/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /all systems live/i })).not.toBeInTheDocument()
+      expect(screen.getByText('All Systems Live')).toBeInTheDocument()
+      expect(screen.getByText('1/1 Ready')).toBeInTheDocument()
+    })
   })
 
   describe('amber — Checking', () => {

--- a/ui/src/lib/platform-health-remediation.ts
+++ b/ui/src/lib/platform-health-remediation.ts
@@ -1,0 +1,21 @@
+export interface PlatformHealthRemediationLink {
+  label: string;
+  href: string;
+  description: string;
+}
+
+/** Where operators land when AgentGateway probes fail in Platform Health. */
+export const AGENTGATEWAY_HEALTH_REMEDIATION: PlatformHealthRemediationLink = {
+  label: "MCP Servers",
+  href: "/dynamic-agents?tab=mcp-servers",
+  description:
+    "Open MCP Servers to sync AgentGateway routes, verify tool authorization, and run Repair AgentGateway if registrations are stale.",
+};
+
+export const PROMETHEUS_UNAVAILABLE_MESSAGE =
+  "Throughput and sub-agent charts are optional. Dependency checks above still report platform health without Prometheus.";
+
+export const PROMETHEUS_SETUP_GUIDANCE = {
+  title: "Optional: enable live agent metrics",
+  body: "Ask your platform admin to set PROMETHEUS_URL on the UI service (for example http://prometheus:9090), then restart caipe-ui. Until then, use the dependency checks above.",
+};

--- a/ui/src/lib/webex-bot-admin.ts
+++ b/ui/src/lib/webex-bot-admin.ts
@@ -40,11 +40,20 @@ async function getWebexBotAdminToken(): Promise<string> {
     return tokenCache.accessToken;
   }
 
-  const clientId = process.env.WEBEX_BOT_ADMIN_CLIENT_ID || "caipe-ui";
-  const clientSecret = process.env.WEBEX_BOT_ADMIN_CLIENT_SECRET;
+  const clientSecret =
+    process.env.WEBEX_BOT_ADMIN_CLIENT_SECRET?.trim() ||
+    process.env.OIDC_CLIENT_SECRET?.trim();
   if (!clientSecret) {
-    throw new ApiError("WEBEX_BOT_ADMIN_CLIENT_SECRET is not configured", 503);
+    throw new ApiError(
+      "WEBEX_BOT_ADMIN_CLIENT_SECRET (or OIDC_CLIENT_SECRET) is not configured",
+      503
+    );
   }
+
+  const clientId =
+    process.env.WEBEX_BOT_ADMIN_CLIENT_ID?.trim() ||
+    process.env.OIDC_CLIENT_ID?.trim() ||
+    "caipe-ui";
 
   const body = new URLSearchParams({
     grant_type: "client_credentials",


### PR DESCRIPTION
## Summary
- Expand the Platform Health admin tab with dependency probes, remediation links, Prometheus fallback guidance, and integration status sections.
- Route AgentGateway remediation to Dynamic Agents > MCP Servers.
- Add a Webex directory status API covering bot admin reachability, platform route counts, and space discovery cache state.
- Make the header health popover link admins to the full health dashboard.

## Why
Operators need a single health surface that works even when Prometheus is not configured and points them at the right repair page when AgentGateway or Webex routing is unhealthy.

## Validation
- `make caipe-ui-prod` completed successfully from the combined change set.
- `curl http://localhost:3000/api/health` returned `200` with `status: ok`.
- `curl http://localhost:3000/api/platform/health` returned `200` with `18/18` probes healthy.
- `npm test -- --runInBand src/app/api/platform/health/__tests__/route.test.ts src/app/api/admin/webex/directory/status/__tests__/route.test.ts src/components/layout/__tests__/AppHeader.test.tsx src/lib/rbac/__tests__/connector-diagnostic-messages.test.ts src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx` passed: 6 suites, 120 tests.
