### PR TITLE
fix(rbac): repair Slack route diagnostics

### DIFF
--- a/ui/e2e/rbac/slack-run-as.spec.ts
+++ b/ui/e2e/rbac/slack-run-as.spec.ts
@@ -890,4 +890,157 @@ test.describe("mocked Slack Run as browser regression", () => {
     await expect.poll(() => routeWrites.length).toBe(1);
     await expect(page.getByText(/channel manage denied by policy/)).toBeVisible();
   });
+
+  test("fixes duplicate Slack route priorities from runtime diagnostics", async ({ page }) => {
+    const routeWrites: unknown[] = [];
+    let routes: unknown[] = [
+      {
+        agent_id: "incident-agent",
+        enabled: true,
+        priority: 100,
+        users: { enabled: true, listen: "mention" },
+      },
+      {
+        agent_id: "support-agent",
+        enabled: true,
+        priority: 100,
+        users: { enabled: true, listen: "mention" },
+      },
+    ];
+
+    const slackHandler: MockRouteHandler = async ({ route, path, method }) => {
+      if (path === "/api/admin/slack/channels" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            channels: [
+              {
+                workspace_id: "CAIPE",
+                channel_id: "C0DUPES",
+                channel_name: "routing-conflict",
+                team_slug: "platform-engineering",
+                primary_agent_id: "incident-agent",
+                active_grants: 2,
+                can_manage: true,
+              },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/dynamic-agents" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            items: [
+              { _id: "incident-agent", name: "Incident Agent" },
+              { _id: "support-agent", name: "Support Agent" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/teams" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            teams: [
+              { _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" },
+            ],
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/runtime/status" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            route_mode: "db_prefer",
+            static_config: { channels: 1, routes: 2 },
+            route_cache: { ttl_seconds: 60, cache_size: 1 },
+          },
+        });
+        return true;
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0DUPES/routes") {
+        if (method === "GET") {
+          await fulfillJson(route, { data: { routes } });
+          return true;
+        }
+
+        if (method === "PUT") {
+          const body = (await postJson(route)) as { routes?: unknown[] } | null;
+          routeWrites.push(body);
+          routes = Array.isArray(body?.routes) ? body.routes : [];
+          await fulfillJson(route, { data: { routes } });
+          return true;
+        }
+      }
+
+      if (path === "/api/admin/slack/channels/CAIPE/C0DUPES/diagnostics" && method === "GET") {
+        await fulfillJson(route, {
+          data: {
+            openfga: { reachable: true, tuple_count: 2 },
+            routes: [
+              {
+                agent_id: "incident-agent",
+                openfga_tuple: true,
+                route_metadata: true,
+                listen: "mention",
+                priority: 100,
+                runtime_matches: { mention: true, message: false },
+                warnings: ["duplicate priority"],
+              },
+              {
+                agent_id: "support-agent",
+                openfga_tuple: true,
+                route_metadata: true,
+                listen: "mention",
+                priority: 100,
+                runtime_matches: { mention: true, message: false },
+                warnings: ["duplicate priority"],
+              },
+            ],
+            warnings: [
+              "Multiple agents can answer mentions at priority 100. Fix routing issues to set a deterministic order.",
+            ],
+          },
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      gates: { slack: true },
+      handlers: [slackHandler],
+    });
+
+    await page.goto("/admin?cat=integrations&tab=slack", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: /#routing-conflict/ }).click();
+    await expect(page.getByText("Multiple agents can answer mentions at priority 100")).toBeVisible();
+    await page.getByRole("button", { name: "Fix routing issues" }).click();
+
+    await expect.poll(() => routeWrites.length).toBe(1);
+    expect(routeWrites[0]).toMatchObject({
+      routes: [
+        {
+          agent_id: "incident-agent",
+          priority: 100,
+          users: { enabled: true, listen: "mention" },
+        },
+        {
+          agent_id: "support-agent",
+          priority: 110,
+          users: { enabled: true, listen: "mention" },
+        },
+      ],
+    });
+  });
 });

--- a/ui/e2e/rbac/webex-workflow-agent-routes.spec.ts
+++ b/ui/e2e/rbac/webex-workflow-agent-routes.spec.ts
@@ -169,6 +169,7 @@ function webexHandler(state: {
               openfga_tuple: true,
               route_metadata: true,
               listen: "mention",
+              priority: 100,
               runtime_matches: { mention: true, message: false },
               warnings: ["Mention-only listen mode blocks plain messages"],
             },
@@ -249,7 +250,7 @@ test.describe("mocked Webex workflow agent routing regression", () => {
     await expect(page.getByText("Incident Bridge")).toBeVisible();
     await page.getByText("Incident Bridge").click();
     const fixButton = page.getByRole("button", {
-      name: new RegExp(`Fix agent:${workflowAgent.id} routing`),
+      name: new RegExp(`Fix routing for ${workflowAgent.id}`),
     });
     await expect(fixButton).toBeVisible();
     await fixButton.click();

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -689,7 +689,7 @@ describe("Slack channel ReBAC APIs", () => {
     });
     expect(body.data.warnings).toEqual(
       expect.arrayContaining([
-        expect.stringMatching(/stale-mongo-agent.*OpenFGA tuple is missing/i),
+        expect.stringMatching(/Stale Mongo Agent.*channel authorization entry is missing/i),
       ])
     );
     expect(body.data.warnings).not.toEqual(
@@ -724,7 +724,7 @@ describe("Slack channel ReBAC APIs", () => {
       error: "OpenFGA tuple read failed: 400",
     });
     expect(body.data.warnings).toEqual(
-      expect.arrayContaining([expect.stringMatching(/Slack bot cannot read OpenFGA tuples/i)])
+      expect.arrayContaining([expect.stringMatching(/Cannot verify channel permissions.*authorization service/i)])
     );
   });
 

--- a/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
+++ b/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
@@ -15,6 +15,7 @@ import { useToast } from "@/components/ui/toast";
 import { Tooltip,TooltipContent,TooltipTrigger } from "@/components/ui/tooltip";
 import { useSubtabParam } from "@/hooks/use-subtab-param";
 import { cn } from "@/lib/utils";
+import { routeStatusLabel } from "@/lib/rbac/connector-diagnostic-messages";
 import { ConnectorOnboardingWizard } from "./ConnectorOnboardingWizard";
 import type {
 ConnectorAdminAdapter,
@@ -257,6 +258,8 @@ function DiagnosticsPanel({
   missingRouteableAgent,
   autoFixAgentId,
   fixDiagnosticRoute,
+  fixAllDiagnosticIssues,
+  batchFixAvailable,
   fixMissingRouteableAgent,
   disabled,
   loading,
@@ -268,6 +271,8 @@ function DiagnosticsPanel({
   missingRouteableAgent: boolean;
   autoFixAgentId: string;
   fixDiagnosticRoute: (route: DiagnosticRoute) => Promise<void> | void;
+  fixAllDiagnosticIssues?: () => Promise<void> | void;
+  batchFixAvailable?: boolean;
   fixMissingRouteableAgent: () => Promise<void> | void;
   disabled: boolean;
   loading: boolean;
@@ -282,7 +287,7 @@ function DiagnosticsPanel({
     ? "Loading diagnostics..."
     : hasIssues
       ? `${diagnostics.warnings.length || diagnostics.routes.filter((route) => route.warnings.length > 0 || !route.openfga_tuple).length || 1} issue${diagnostics.warnings.length === 1 ? "" : "s"}`
-      : `${diagnostics.openfga.tuple_count} tuple${diagnostics.openfga.tuple_count === 1 ? "" : "s"} · ${diagnostics.routes.length} route${diagnostics.routes.length === 1 ? "" : "s"} · healthy`;
+      : `${diagnostics.openfga.tuple_count} authorized agent${diagnostics.openfga.tuple_count === 1 ? "" : "s"} · ${diagnostics.routes.length} route${diagnostics.routes.length === 1 ? "" : "s"} · healthy`;
 
   return (
     <div className="rounded-md border bg-background/60">
@@ -308,14 +313,14 @@ function DiagnosticsPanel({
             <>
               <div className="grid gap-2 text-sm md:grid-cols-3">
                 <div className="rounded-md border bg-background/60 p-3">
-                  <div className="text-xs text-muted-foreground">OpenFGA</div>
+                  <div className="text-xs text-muted-foreground">Authorization</div>
                   <div className="font-medium">{diagnostics.openfga.reachable ? "reachable" : "unreachable"}</div>
-                  <div className="text-xs text-muted-foreground">{diagnostics.openfga.tuple_count} {adapter.itemSingular}-agent tuples</div>
+                  <div className="text-xs text-muted-foreground">{diagnostics.openfga.tuple_count} authorized agent{diagnostics.openfga.tuple_count === 1 ? "" : "s"}</div>
                 </div>
                 <div className="rounded-md border bg-background/60 p-3">
                   <div className="text-xs text-muted-foreground">Runtime routes</div>
                   <div className="font-medium">{diagnostics.routes.length}</div>
-                  <div className="text-xs text-muted-foreground">OpenFGA-backed candidates</div>
+                  <div className="text-xs text-muted-foreground">Agents eligible to respond</div>
                 </div>
                 <div className="rounded-md border bg-background/60 p-3">
                   <div className="text-xs text-muted-foreground">Last error</div>
@@ -324,8 +329,21 @@ function DiagnosticsPanel({
                 </div>
               </div>
               {diagnostics.warnings.length > 0 && (
-                <div className="space-y-1 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
-                  <div className="text-xs font-medium uppercase tracking-wide">Issues found</div>
+                <div className="space-y-2 rounded-md border border-amber-300/60 bg-amber-50 p-3 text-sm text-amber-950 dark:bg-amber-950/30 dark:text-amber-200">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="text-xs font-medium uppercase tracking-wide">Issues found</div>
+                    {batchFixAvailable && fixAllDiagnosticIssues && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void fixAllDiagnosticIssues()}
+                        disabled={disabled || !selectedCanManage || loading}
+                      >
+                        Fix routing issues
+                      </Button>
+                    )}
+                  </div>
                   {diagnostics.warnings.map((warning) => <div key={warning}>{warning}</div>)}
                 </div>
               )}
@@ -354,30 +372,33 @@ function DiagnosticsPanel({
               )}
               {diagnostics.routes.length > 0 && (
                 <div className="space-y-2">
-                  {diagnostics.routes.map((route) => (
+                  {diagnostics.routes.map((route) => {
+                    const labels = routeStatusLabel(route);
+                    return (
                     <div key={route.agent_id} className="flex flex-wrap items-center gap-2 rounded-md border bg-background/60 p-3 text-sm">
-                      <span className="font-medium">agent:{route.agent_id}</span>
+                      <span className="font-medium">{route.agent_id}</span>
                       <Badge variant={route.openfga_tuple ? "default" : "outline"}>
-                        {route.openfga_tuple ? "OpenFGA tuple" : "missing tuple"}
+                        {labels.authBadge}
                       </Badge>
                       <Badge variant={route.route_metadata ? "secondary" : "outline"}>
-                        {route.route_metadata ? `listen:${route.listen}` : "default metadata"}
+                        {labels.routingBadge}
                       </Badge>
                       <span className="text-xs text-muted-foreground">
-                        mention {route.runtime_matches.mention ? "yes" : "no"} / message {route.runtime_matches.message ? "yes" : "no"}
+                        {labels.matchSummary}
                       </span>
                       {adapter.diagnosticRouteIsFixable(route) && (
                         <Button
                           type="button" variant="outline" size="sm" className="ml-auto"
                           onClick={() => void fixDiagnosticRoute(route)}
                           disabled={disabled || !selectedCanManage || loading}
-                          aria-label={`Fix agent:${route.agent_id} routing`}
+                          aria-label={`Fix routing for ${route.agent_id}`}
                         >
                           Fix it
                         </Button>
                       )}
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </>
@@ -402,6 +423,8 @@ interface ItemDetailProps {
   setLoading: (loading: boolean) => void;
   setMessage: (message: string | null) => void;
   fixDiagnosticRoute: (route: DiagnosticRoute) => Promise<void> | void;
+  fixAllDiagnosticIssues?: () => Promise<void> | void;
+  batchFixAvailable?: boolean;
   fixMissingRouteableAgent: () => Promise<void> | void;
   disabled: boolean; loading: boolean; selectedCanManage: boolean; message: string | null;
 }
@@ -409,7 +432,7 @@ interface ItemDetailProps {
 function ItemDetail({
   adapter, selected, diagnostics, routes,
   dynamicAgents, teams, onRefresh, onDeselect, setLoading, setMessage,
-  fixDiagnosticRoute, fixMissingRouteableAgent, disabled, loading, selectedCanManage,
+  fixDiagnosticRoute, fixAllDiagnosticIssues, batchFixAvailable, fixMissingRouteableAgent, disabled, loading, selectedCanManage,
 }: ItemDetailProps) {
   const diagnosticsMissingRouteableAgent =
     adapter.missingRouteableAgentAutoFix?.isApplicable(selected, diagnostics ?? {
@@ -426,6 +449,8 @@ function ItemDetail({
         missingRouteableAgent={diagnosticsMissingRouteableAgent}
         autoFixAgentId={autoFixAgentId}
         fixDiagnosticRoute={fixDiagnosticRoute}
+        fixAllDiagnosticIssues={fixAllDiagnosticIssues}
+        batchFixAvailable={batchFixAvailable}
         fixMissingRouteableAgent={fixMissingRouteableAgent}
         disabled={disabled}
         loading={loading}
@@ -806,6 +831,34 @@ export function ConnectorAdminPanel({
     if (!selected) return;
     toast(`Add an agent manually for this ${adapter.itemSingular}.`, "warning");
   };
+
+  const batchFixAvailable = Boolean(
+    selected &&
+      diagnostics &&
+      adapter.diagnosticIssuesBatchFixable?.({ diagnostics, routes }),
+  );
+
+  const fixAllDiagnosticIssues = adapter.fixAllDiagnosticIssues
+    ? async () => {
+        if (!selected || !diagnostics) return;
+        setLoading(true);
+        setMessage(null);
+        try {
+          const result = await adapter.fixAllDiagnosticIssues!({
+            item: selected,
+            diagnostics,
+            routes,
+          });
+          if (result.nextRoutes) setRoutes(result.nextRoutes);
+          await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
+          toast(result.toast, "success");
+        } catch (err) {
+          setMessage(err instanceof Error ? err.message : "Failed to fix routing issues");
+        } finally {
+          setLoading(false);
+        }
+      }
+    : undefined;
 
   // ── Discovery / onboarding ───────────────────────────────────────────────────
 
@@ -1304,7 +1357,10 @@ export function ConnectorAdminPanel({
                                   await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
                                 }}
                                 onDeselect={() => setSelectedKey("")}
-                                fixDiagnosticRoute={fixDiagnosticRoute} fixMissingRouteableAgent={fixMissingRouteableAgent}
+                                fixDiagnosticRoute={fixDiagnosticRoute}
+                                fixAllDiagnosticIssues={fixAllDiagnosticIssues}
+                                batchFixAvailable={batchFixAvailable}
+                                fixMissingRouteableAgent={fixMissingRouteableAgent}
                                 disabled={disabled} loading={loading} selectedCanManage={selectedCanManage} message={message}
                               />
                             </td>

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -12,6 +12,10 @@ RuntimeSyncSummary,
 import { ConnectorAdminPanel } from "./ConnectorAdminPanel";
 import { SlackConfiguredChannelDetail } from "./slack/SlackConfiguredChannelDetail";
 import { SlackVictoropsAgentSetting } from "./SlackVictoropsAgentSetting";
+import {
+  planSlackRouteFixes,
+  slackRouteFixesNeeded,
+} from "@/lib/rbac/slack-channel-route-fix";
 
 function apiData<T>(payload: { data?: T } & T): T {
   return (payload.data ?? payload) as T;
@@ -201,16 +205,67 @@ const SLACK_ADAPTER: ConnectorAdminAdapter = {
     />
   ),
 
-  diagnosticRouteIsFixable: (route: DiagnosticRoute) => route.route_metadata && !route.openfga_tuple,
-  fixDiagnosticRoute: async ({ item, route }) => {
+  diagnosticRouteIsFixable: (route: DiagnosticRoute) =>
+    (route.route_metadata && !route.openfga_tuple) ||
+    (route.openfga_tuple && !route.route_metadata),
+  fixDiagnosticRoute: async ({ item, route, routes }) => {
     const routeUrl = `/api/admin/slack/channels/${encodeURIComponent(item.workspace_id)}/${encodeURIComponent(item.item_id)}/routes`;
+    if (route.route_metadata && !route.openfga_tuple) {
+      const res = await fetch(routeUrl, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: route.agent_id }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return { toast: `Removed inactive routing rules for ${route.agent_id}.` };
+    }
+    const currentRoute = routes.find((entry) => entry.agent_id === route.agent_id);
+    const nextRoutes: typeof routes = [
+      ...routes.filter((entry) => entry.agent_id !== route.agent_id),
+      {
+        agent_id: route.agent_id,
+        enabled: true,
+        priority: currentRoute?.priority ?? 100,
+        users: { enabled: true, listen: currentRoute?.users?.listen ?? "mention" },
+        ...(currentRoute?.bots ? { bots: currentRoute.bots } : {}),
+        ...(currentRoute?.escalation ? { escalation: currentRoute.escalation } : {}),
+        ...(currentRoute?.execution_identity ? { execution_identity: currentRoute.execution_identity } : {}),
+      },
+    ];
     const res = await fetch(routeUrl, {
-      method: "DELETE",
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ agent_id: route.agent_id }),
+      body: JSON.stringify({ routes: nextRoutes }),
     });
     if (!res.ok) throw new Error(await res.text());
-    return { toast: `Removed stale route metadata for agent:${route.agent_id}.` };
+    const data = apiData<{ routes: typeof routes }>(await res.json());
+    return {
+      toast: `Saved default routing for ${route.agent_id} (@mentions only).`,
+      nextRoutes: data.routes ?? [],
+    };
+  },
+
+  diagnosticIssuesBatchFixable: ({ diagnostics, routes }) =>
+    slackRouteFixesNeeded(diagnostics.routes, routes),
+
+  fixAllDiagnosticIssues: async ({ item, diagnostics, routes }) => {
+    const routeUrl = `/api/admin/slack/channels/${encodeURIComponent(item.workspace_id)}/${encodeURIComponent(item.item_id)}/routes`;
+    const nextRoutes = planSlackRouteFixes(
+      diagnostics.routes,
+      routes,
+      item.primary_agent_id,
+    );
+    const res = await fetch(routeUrl, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ routes: nextRoutes }),
+    });
+    if (!res.ok) throw new Error(await res.text());
+    const data = apiData<{ routes: typeof routes }>(await res.json());
+    return {
+      toast: "Routing issues fixed: saved missing rules and set a clear primary agent priority.",
+      nextRoutes: data.routes ?? [],
+    };
   },
 
   applyOnboarding: async ({ rows, defaultTeamSlug, defaultAgentId, createDefaultRoutes, fetchFn }) => {

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -560,7 +560,7 @@ it("fixes stale Slack runtime diagnostics by deleting orphaned route metadata", 
   render(<SlackChannelRebacPanel />);
   await expandChannelRow("incidents");
 
-  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:foo-bar routing/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /Fix routing for foo-bar/i }));
 
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -136,8 +136,8 @@ function setupFetchMock() {
             "agent:foo-bar has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.",
           ],
           routes: [
-            { agent_id: "foo-bar", openfga_tuple: false, route_metadata: true, listen: "message", runtime_matches: { mention: false, message: true }, warnings: [] },
-            { agent_id: "incident-agent", openfga_tuple: true, route_metadata: true, listen: "mention", runtime_matches: { mention: true, message: false }, warnings: [] },
+            { agent_id: "foo-bar", openfga_tuple: false, route_metadata: true, listen: "message", priority: 90, runtime_matches: { mention: false, message: true }, warnings: [] },
+            { agent_id: "incident-agent", openfga_tuple: true, route_metadata: true, listen: "mention", priority: 100, runtime_matches: { mention: true, message: false }, warnings: [] },
           ],
           last_runtime_error: { ts: "2026-05-18T07:50:00.000Z", reason_code: "OPENFGA_READ_FAILED", message: "OpenFGA tuple read failed" },
         },
@@ -267,7 +267,7 @@ it("fixes stale diagnostic route metadata (orphan) by issuing DELETE", async () 
   render(<WebexSpaceRebacPanel />);
   await expandSpaceRow("Platform Alerts");
 
-  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:foo-bar routing/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /Fix routing for foo-bar/i }));
 
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
@@ -281,7 +281,7 @@ it("fixes mention-only diagnostic route by lifting listen mode to all", async ()
   render(<WebexSpaceRebacPanel />);
   await expandSpaceRow("Platform Alerts");
 
-  fireEvent.click(await screen.findByRole("button", { name: /Fix agent:incident-agent routing/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /Fix routing for incident-agent/i }));
 
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(

--- a/ui/src/components/admin/rebac/connector-admin-adapter.ts
+++ b/ui/src/components/admin/rebac/connector-admin-adapter.ts
@@ -303,6 +303,19 @@ export interface ConnectorAdminAdapter {
     routes: ItemAgentRoute[];
   }) => Promise<{ toast: string; nextRoutes?: ItemAgentRoute[] }>;
 
+  /** When true, show a batch Fix routing issues action for this channel/space. */
+  diagnosticIssuesBatchFixable?: (input: {
+    diagnostics: ItemDiagnostics;
+    routes: ItemAgentRoute[];
+  }) => boolean;
+
+  /** Apply safe automatic fixes for common routing diagnostics issues. */
+  fixAllDiagnosticIssues?: (input: {
+    item: ItemSummary;
+    diagnostics: ItemDiagnostics;
+    routes: ItemAgentRoute[];
+  }) => Promise<{ toast: string; nextRoutes?: ItemAgentRoute[] }>;
+
   // Webex only: auto-fix card when a space has no routeable agent.
   missingRouteableAgentAutoFix?: {
     title: string;

--- a/ui/src/components/admin/rebac/connector-admin-adapter.ts
+++ b/ui/src/components/admin/rebac/connector-admin-adapter.ts
@@ -78,7 +78,7 @@ export interface DiagnosticRoute {
   openfga_tuple: boolean;
   route_metadata: boolean;
   listen: "message" | "mention" | "all" | "unknown";
-  priority?: number;
+  priority: number;
   runtime_matches: { mention: boolean; message: boolean };
   warnings: string[];
 }

--- a/ui/src/lib/rbac/__tests__/connector-diagnostic-messages.test.ts
+++ b/ui/src/lib/rbac/__tests__/connector-diagnostic-messages.test.ts
@@ -1,0 +1,98 @@
+import {
+  ambiguousRoutesMessage,
+  formatAgentLabel,
+  missingRouteMetadataMessage,
+  staleRouteMetadataMessage,
+} from "@/lib/rbac/connector-diagnostic-messages";
+import {
+  planSlackRouteFixes,
+  slackRouteFixesNeeded,
+} from "@/lib/rbac/slack-channel-route-fix";
+import type { ConnectorRuntimeRouteDiagnostic } from "@/lib/rbac/connector-diagnostics";
+import type { ItemAgentRoute } from "@/components/admin/rebac/connector-admin-adapter";
+
+describe("connector-diagnostic-messages", () => {
+  it("formats agent slugs for admin copy", () => {
+    expect(formatAgentLabel("agent-meraki-file-upload")).toBe("Meraki File Upload");
+    expect(formatAgentLabel("agent-jira-gu")).toBe("Jira Gu");
+  });
+
+  it("uses plain language for missing route metadata", () => {
+    expect(missingRouteMetadataMessage("agent-meraki-file-upload")).toContain("Meraki File Upload");
+    expect(missingRouteMetadataMessage("agent-meraki-file-upload")).toContain("@mentions");
+  });
+
+  it("uses plain language for stale route metadata", () => {
+    expect(staleRouteMetadataMessage("agent-jira-gu")).toContain("Jira Gu");
+    expect(staleRouteMetadataMessage("agent-jira-gu")).toContain("inactive");
+  });
+
+  it("explains ambiguous routes without OpenFGA jargon", () => {
+    const message = ambiguousRoutesMessage(
+      ["agent-jira-gu", "agent-meraki-file-upload"],
+      "mention",
+      100,
+      "agent-jira-gu",
+    );
+    expect(message).toContain("Jira Gu");
+    expect(message).toContain("Meraki File Upload");
+    expect(message).toContain("Fix routing issues");
+    expect(message).not.toContain("OpenFGA");
+  });
+});
+
+describe("slack-channel-route-fix", () => {
+  const diagnosticsRoutes: ConnectorRuntimeRouteDiagnostic[] = [
+    {
+      agent_id: "agent-jira-gu",
+      openfga_tuple: true,
+      route_metadata: true,
+      listen: "all",
+      priority: 100,
+      runtime_matches: { mention: true, message: true },
+      warnings: [],
+    },
+    {
+      agent_id: "agent-meraki-file-upload",
+      openfga_tuple: true,
+      route_metadata: false,
+      listen: "mention",
+      priority: 100,
+      runtime_matches: { mention: true, message: false },
+      warnings: [],
+    },
+  ];
+
+  it("detects when automatic fixes are needed", () => {
+    const existingRoutes: ItemAgentRoute[] = [
+      {
+        agent_id: "agent-jira-gu",
+        enabled: true,
+        priority: 100,
+        users: { enabled: true, listen: "all" },
+      },
+    ];
+    expect(slackRouteFixesNeeded(diagnosticsRoutes, existingRoutes)).toBe(true);
+  });
+
+  it("saves missing metadata and separates mention priorities", () => {
+    const existingRoutes: ItemAgentRoute[] = [
+      {
+        agent_id: "agent-jira-gu",
+        enabled: true,
+        priority: 100,
+        users: { enabled: true, listen: "all" },
+      },
+    ];
+    const planned = planSlackRouteFixes(
+      diagnosticsRoutes,
+      existingRoutes,
+      "agent-jira-gu",
+    );
+    const meraki = planned.find((route) => route.agent_id === "agent-meraki-file-upload");
+    const jira = planned.find((route) => route.agent_id === "agent-jira-gu");
+    expect(meraki?.users?.listen).toBe("mention");
+    expect(jira?.priority).toBe(100);
+    expect(meraki?.priority).toBeGreaterThan(jira?.priority ?? 0);
+  });
+});

--- a/ui/src/lib/rbac/connector-diagnostic-messages.ts
+++ b/ui/src/lib/rbac/connector-diagnostic-messages.ts
@@ -1,0 +1,79 @@
+import type { ConnectorListenMode,ConnectorRuntimeRouteDiagnostic } from "@/lib/rbac/connector-diagnostics";
+
+/** Turn `agent-jira-gu` into a readable label for admin UI copy. */
+export function formatAgentLabel(agentId: string): string {
+  const slug = agentId.replace(/^agent-/, "").trim();
+  if (!slug) return agentId;
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function formatAgentList(agentIds: string[]): string {
+  return agentIds.map((id) => formatAgentLabel(id)).join(", ");
+}
+
+function listenLabel(listen: ConnectorListenMode): string {
+  switch (listen) {
+    case "all":
+      return "@mentions and plain messages";
+    case "message":
+      return "plain messages only";
+    case "mention":
+      return "@mentions only";
+    default:
+      return "unknown listen mode";
+  }
+}
+
+export function missingRouteMetadataMessage(agentId: string): string {
+  const label = formatAgentLabel(agentId);
+  return `${label} is authorized for this channel but has no saved routing rules. The bot only replies to @mentions until listen settings are saved. Select Fix it to save default routing.`;
+}
+
+export function staleRouteMetadataMessage(agentId: string): string {
+  const label = formatAgentLabel(agentId);
+  return `${label} has saved routing rules that are inactive because the channel authorization entry is missing. The bot ignores this configuration. Select Fix it to remove the stale entry.`;
+}
+
+export function openFgaReadFailureMessage(botLabel: string, error: string): string {
+  return `Cannot verify channel permissions (${botLabel} could not reach the authorization service). ${error}`;
+}
+
+export function noTuplesMessage(tupleNoun: string, runtimeLabel: string): string {
+  return `No agents are authorized for this channel. ${runtimeLabel} has nothing to dispatch until an agent is added below.`;
+}
+
+export function ambiguousRoutesMessage(
+  agentIds: string[],
+  mode: "mention" | "message",
+  priority: number,
+  preferredAgentId?: string,
+): string {
+  const labels = formatAgentList(agentIds);
+  const trigger = mode === "mention" ? "someone @mentions the bot" : "someone sends a plain channel message";
+  const preferred = preferredAgentId && agentIds.includes(preferredAgentId)
+    ? formatAgentLabel(preferredAgentId)
+    : formatAgentLabel([...agentIds].sort()[0] ?? agentIds[0] ?? "");
+  return `When ${trigger}, multiple agents can answer (${labels}) at the same priority (${priority}). Only ${preferred} responds first under current tie-break rules. Use Fix routing issues to set a clear primary agent, or adjust listen modes and priorities below.`;
+}
+
+export function routeStatusLabel(route: ConnectorRuntimeRouteDiagnostic): {
+  authBadge: string;
+  routingBadge: string;
+  matchSummary: string;
+} {
+  const authBadge = route.openfga_tuple ? "Authorized" : "Not authorized";
+  const routingBadge = route.route_metadata
+    ? `Listens: ${listenLabel(route.listen)}`
+    : "Default routing (@mentions only)";
+  const mention = route.runtime_matches.mention ? "responds to @mentions" : "ignores @mentions";
+  const message = route.runtime_matches.message ? "responds to plain messages" : "ignores plain messages";
+  return {
+    authBadge,
+    routingBadge,
+    matchSummary: `${mention}; ${message}`,
+  };
+}

--- a/ui/src/lib/rbac/connector-diagnostics.ts
+++ b/ui/src/lib/rbac/connector-diagnostics.ts
@@ -1,4 +1,11 @@
 import { getAuditReader } from "@/lib/audit/reader";
+import {
+  ambiguousRoutesMessage,
+  missingRouteMetadataMessage,
+  noTuplesMessage,
+  openFgaReadFailureMessage,
+  staleRouteMetadataMessage,
+} from "@/lib/rbac/connector-diagnostic-messages";
 
 export type ConnectorKind = "slack_channel" | "webex_space";
 
@@ -95,15 +102,11 @@ function buildBaseRouteWarnings(
   route: ConnectorRuntimeRouteDiagnostic,
 ): string[] {
   const warnings: string[] = [];
-  if (!route.openfga_tuple) {
-    warnings.push(
-      `agent:${route.agent_id} has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.`,
-    );
+  if (!route.openfga_tuple && route.route_metadata) {
+    warnings.push(staleRouteMetadataMessage(route.agent_id));
   }
-  if (!route.route_metadata) {
-    warnings.push(
-      `agent:${route.agent_id} has an OpenFGA tuple but no Mongo route metadata; runtime uses mention-only defaults.`,
-    );
+  if (route.openfga_tuple && !route.route_metadata) {
+    warnings.push(missingRouteMetadataMessage(route.agent_id));
   }
   return warnings;
 }
@@ -152,7 +155,7 @@ export async function computeConnectorDiagnostics(
     openfgaAgentIds = await adapter.listOpenFgaAgentIds(workspaceId, itemId);
   } catch (error) {
     openfgaError = error instanceof Error ? error.message : "OpenFGA tuple read failed";
-    warnings.push(`${adapter.botLabel} cannot read OpenFGA tuples: ${openfgaError}`);
+    warnings.push(openFgaReadFailureMessage(adapter.botLabel, openfgaError));
   }
 
   const allAgentIds = Array.from(
@@ -188,9 +191,7 @@ export async function computeConnectorDiagnostics(
   }
 
   if (!openfgaError && openfgaAgentIds.length === 0) {
-    warnings.push(
-      `No OpenFGA ${adapter.tupleNoun} tuples found. ${adapter.runtimeLabel} has no agent to dispatch.`,
-    );
+    warnings.push(noTuplesMessage(adapter.tupleNoun, adapter.runtimeLabel));
   }
 
   const lastError = await latestRuntimeError(adapter, workspaceId, itemId);

--- a/ui/src/lib/rbac/slack-channel-diagnostics.ts
+++ b/ui/src/lib/rbac/slack-channel-diagnostics.ts
@@ -1,11 +1,12 @@
+import { ambiguousRoutesMessage } from "@/lib/rbac/connector-diagnostic-messages";
 import {
-type ConnectorDiagnostics,
-type ConnectorDiagnosticsAdapter,
-type ConnectorHealthSummary,
-type ConnectorRouteMetadata,
-type ConnectorRuntimeRouteDiagnostic,
-computeConnectorDiagnostics,
-computeConnectorHealthSummary,
+  type ConnectorDiagnostics,
+  type ConnectorDiagnosticsAdapter,
+  type ConnectorHealthSummary,
+  type ConnectorRouteMetadata,
+  type ConnectorRuntimeRouteDiagnostic,
+  computeConnectorDiagnostics,
+  computeConnectorHealthSummary,
 } from "@/lib/rbac/connector-diagnostics";
 import { readOpenFgaTuples } from "@/lib/rbac/openfga";
 import { slackChannelSubjectId } from "@/lib/rbac/slack-channel-grant-store";
@@ -48,8 +49,8 @@ async function listOpenFgaSlackChannelAgentIds(workspaceId: string, channelId: s
 
 function buildAmbiguousRouteWarnings(routes: ConnectorRuntimeRouteDiagnostic[]): string[] {
   // Surface real misconfiguration: two enabled routes that match the
-  // same incoming message at the same priority. The Slack bot picks
-  // first-match-wins among ties, so the result is non-deterministic.
+  // same incoming message at the same priority. The Slack bot uses the
+  // lowest priority number first, then agent name as a tie-break.
   const eligible = routes.filter((route) => route.openfga_tuple);
   const warnings: string[] = [];
   for (const mode of ["mention", "message"] as const) {
@@ -63,9 +64,7 @@ function buildAmbiguousRouteWarnings(routes: ConnectorRuntimeRouteDiagnostic[]):
     }
     for (const [priority, agentIds] of byPriority) {
       if (agentIds.length < 2) continue;
-      warnings.push(
-        `Routes ${agentIds.map((id) => `agent:${id}`).join(", ")} all match ${mode === "mention" ? "@mentions" : "plain messages"} at priority ${priority}; the Slack bot will pick one non-deterministically. Adjust priority or listen mode so each message has a single winner.`,
-      );
+      warnings.push(ambiguousRoutesMessage(agentIds, mode, priority));
     }
   }
   return warnings;

--- a/ui/src/lib/rbac/slack-channel-route-fix.ts
+++ b/ui/src/lib/rbac/slack-channel-route-fix.ts
@@ -1,0 +1,98 @@
+import type { ConnectorRuntimeRouteDiagnostic } from "@/lib/rbac/connector-diagnostics";
+import type { ItemAgentRoute,RouteListenMode } from "@/components/admin/rebac/connector-admin-adapter";
+
+function listenMode(route: ItemAgentRoute): RouteListenMode {
+  return route.users?.listen ?? "mention";
+}
+
+function matchesMode(listen: RouteListenMode, mode: "mention" | "message"): boolean {
+  return listen === "all" || listen === mode;
+}
+
+function defaultRouteForAgent(agentId: string): ItemAgentRoute {
+  return {
+    agent_id: agentId,
+    enabled: true,
+    priority: 100,
+    users: { enabled: true, listen: "mention" },
+  };
+}
+
+/** Merge diagnostics with saved routes and apply safe automatic fixes. */
+export function planSlackRouteFixes(
+  diagnosticsRoutes: ConnectorRuntimeRouteDiagnostic[],
+  existingRoutes: ItemAgentRoute[],
+  primaryAgentId?: string,
+): ItemAgentRoute[] {
+  const byAgent = new Map<string, ItemAgentRoute>();
+  for (const route of existingRoutes) {
+    byAgent.set(route.agent_id, { ...route });
+  }
+
+  for (const diagnostic of diagnosticsRoutes) {
+    if (diagnostic.openfga_tuple && !diagnostic.route_metadata) {
+      byAgent.set(diagnostic.agent_id, defaultRouteForAgent(diagnostic.agent_id));
+    }
+  }
+
+  const activeRoutes = diagnosticsRoutes
+    .filter((route) => route.openfga_tuple)
+    .map((route) => {
+      const saved = byAgent.get(route.agent_id);
+      if (saved) return saved;
+      return defaultRouteForAgent(route.agent_id);
+    });
+
+  for (const mode of ["mention", "message"] as const) {
+    const groups = new Map<number, ItemAgentRoute[]>();
+    for (const route of activeRoutes) {
+      if (!matchesMode(listenMode(route), mode)) continue;
+      const priority = route.priority ?? 100;
+      const bucket = groups.get(priority) ?? [];
+      bucket.push(route);
+      groups.set(priority, bucket);
+    }
+
+    for (const [priority, group] of groups) {
+      if (group.length < 2) continue;
+      const sorted = [...group].sort((a, b) => a.agent_id.localeCompare(b.agent_id));
+      const winner =
+        (primaryAgentId && group.some((route) => route.agent_id === primaryAgentId)
+          ? group.find((route) => route.agent_id === primaryAgentId)
+          : sorted[0]) ?? sorted[0];
+      if (!winner) continue;
+
+      let bump = 10;
+      for (const route of group) {
+        if (route.agent_id === winner.agent_id) {
+          byAgent.set(route.agent_id, { ...route, priority });
+          continue;
+        }
+        byAgent.set(route.agent_id, { ...route, priority: priority + bump });
+        bump += 10;
+      }
+    }
+  }
+
+  return Array.from(byAgent.values()).sort(
+    (a, b) => (a.priority ?? 100) - (b.priority ?? 100) || a.agent_id.localeCompare(b.agent_id),
+  );
+}
+
+export function slackRouteFixesNeeded(
+  diagnosticsRoutes: ConnectorRuntimeRouteDiagnostic[],
+  existingRoutes: ItemAgentRoute[],
+): boolean {
+  const hasMissingMetadata = diagnosticsRoutes.some(
+    (route) => route.openfga_tuple && !route.route_metadata,
+  );
+  if (hasMissingMetadata) return true;
+
+  const planned = planSlackRouteFixes(diagnosticsRoutes, existingRoutes);
+  if (planned.length !== existingRoutes.length) return true;
+  return JSON.stringify(planned) !== JSON.stringify(
+    [...existingRoutes].sort(
+      (a, b) => (a.priority ?? 100) - (b.priority ?? 100) || a.agent_id.localeCompare(b.agent_id),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Replace OpenFGA-heavy Slack route diagnostics copy with operator-friendly messages.
- Add single-route and batch repair flows for stale route metadata, missing route metadata, and ambiguous Slack route priorities.
- Add shared diagnostic message helpers and Slack route planning coverage.

## Why
Slack channel route diagnostics could explain the data model but did not provide a clear repair path. The panel now explains which agents can respond and can apply safe route fixes directly.

## Validation
- `make caipe-ui-prod` completed successfully from the combined change set.
- `npm test -- --runInBand src/app/api/platform/health/__tests__/route.test.ts src/app/api/admin/webex/directory/status/__tests__/route.test.ts src/components/layout/__tests__/AppHeader.test.tsx src/lib/rbac/__tests__/connector-diagnostic-messages.test.ts src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx` passed: 6 suites, 120 tests.
