### PR TITLE
feat(mcp): default servers to streamable HTTP

### DIFF
--- a/ui/e2e/rbac/credentials-workspace-regression.spec.ts
+++ b/ui/e2e/rbac/credentials-workspace-regression.spec.ts
@@ -410,7 +410,7 @@ test.describe("mocked credentials workspace browser regression", () => {
         {
           kind: "provider_connection",
           target: "header",
-          name: "Authorization",
+          name: "X-CAIPE-Provider-Token",
           connection_scope: "pinned",
           provider_connection_id: "conn-atlassian",
         },

--- a/ui/e2e/rbac/mcp-empty-credential-sources.spec.ts
+++ b/ui/e2e/rbac/mcp-empty-credential-sources.spec.ts
@@ -197,7 +197,7 @@ test.describe("RBAC e2e — MCP upstream-only credentials (mocked)", () => {
     await page.getByRole("button", { name: /Edit generated name/i }).click();
     await page.getByLabel(/Generated name/i).fill("upstream-only");
     await page.getByLabel(/Endpoint URL/i).fill("http://mcp-jira:8000/mcp");
-    await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+    await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
     await page.getByRole("button", { name: "Create Server" }).click();
 
     await expect.poll(() => mocks.createRequests.length).toBe(1);

--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -565,7 +565,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     });
   });
 
-  test("created MCP servers remain visible after the list refresh", async ({ page }) => {
+  test("new MCP servers default to Streamable HTTP and remain visible after refresh", async ({ page }) => {
     const mocks = await installMcpServerMocks(page);
 
     await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
@@ -573,6 +573,12 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
 
     await page.getByRole("button", { name: "Add Server" }).first().click();
     await expect(page.getByText("Add MCP Server")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /SSE/i })).toHaveCount(0);
+    await expect(page.getByLabel(/Endpoint URL/i)).toHaveAttribute(
+      "placeholder",
+      "e.g., http://localhost:3000/mcp",
+    );
 
     await fillNewMcpServerBasics(page, {
       displayName: "Ops Tools",
@@ -585,7 +591,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     expect(mocks.createRequests[0]).toMatchObject({
       id: "ops-tools",
       name: "Ops Tools",
-      transport: "sse",
+      transport: "http",
       endpoint: "https://mcp.example.test/mcp",
     });
 
@@ -635,7 +641,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
 
     await page.getByRole("button", { name: "Add Credential" }).click();
     await expect(page.getByLabel(/^Secret$/).first()).toContainText("Jira token");
-    await expect(page.getByLabel(/Credential header/i).first()).toHaveValue("Authorization");
+    await expect(page.getByLabel(/Credential header/i).first()).toHaveValue("X-CAIPE-Provider-Token");
     await page.getByLabel(/^Secret$/).first().selectOption(secretIds.jira);
 
     await page.getByRole("button", { name: "Add Credential" }).click();
@@ -656,7 +662,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
       {
         kind: "secret_ref",
         target: "header",
-        name: "Authorization",
+        name: "X-CAIPE-Provider-Token",
         secret_ref: "secret-jira-token",
       },
       {
@@ -694,7 +700,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
       displayName: "Test Netutils",
       serverId: "test-netutils",
     });
-    await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+    await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
     await page.getByLabel(/Endpoint URL/i).fill("http://mcp-netutils:8000");
     await page.getByRole("button", { name: /check url/i }).click();
     await expect(page.getByText(/http:\/\/mcp-netutils:8000\/mcp/i)).toBeVisible();
@@ -776,7 +782,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
       {
         kind: "provider_connection",
         target: "header",
-        name: "Authorization",
+        name: "X-CAIPE-Provider-Token",
         connection_scope: "pinned",
         provider_connection_id: "conn-atlassian",
       },

--- a/ui/e2e/rbac/mcp-pinned-credentials.spec.ts
+++ b/ui/e2e/rbac/mcp-pinned-credentials.spec.ts
@@ -55,7 +55,7 @@ test.describe("RBAC e2e — MCP pinned provider credentials", () => {
       serverId: "pinned-jira",
     });
     await selectAgentGatewayTarget(page, /Jira/i);
-    await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+    await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
 
     await page.getByRole("button", { name: "Add Credential" }).click();
     await page.getByLabel(/Credential kind/i).selectOption("provider_connection");
@@ -89,7 +89,7 @@ test.describe("RBAC e2e — MCP pinned provider credentials", () => {
       serverId: "caller-jira",
     });
     await selectAgentGatewayTarget(page, /Jira/i);
-    await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+    await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
 
     await page.getByRole("button", { name: "Add Credential" }).click();
     await page.getByLabel(/Credential kind/i).selectOption("provider_connection");
@@ -102,7 +102,7 @@ test.describe("RBAC e2e — MCP pinned provider credentials", () => {
       {
         kind: "provider_connection",
         target: "header",
-        name: "Authorization",
+        name: "X-CAIPE-Provider-Token",
         connection_scope: "caller",
         provider: "atlassian",
       },
@@ -143,7 +143,7 @@ test.describe("RBAC e2e — MCP pinned provider credentials", () => {
       {
         kind: "provider_connection",
         target: "header",
-        name: "Authorization",
+        name: "X-CAIPE-Provider-Token",
         connection_scope: "pinned",
         provider_connection_id: ADMIN_ATLASSIAN_CONNECTION.id,
       },

--- a/ui/e2e/rbac/mcp-test-modal-and-agentgateway.spec.ts
+++ b/ui/e2e/rbac/mcp-test-modal-and-agentgateway.spec.ts
@@ -93,7 +93,7 @@ test.describe("RBAC e2e — MCP AgentGateway picker and test modal", () => {
         serverId: "jira-via-ag",
       });
       await selectAgentGatewayTarget(page, /Jira/i);
-      await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+      await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
       await page.getByRole("button", { name: "Create Server" }).click();
 
       await expect.poll(() => mocks.createRequests.length).toBe(1);
@@ -115,7 +115,7 @@ test.describe("RBAC e2e — MCP AgentGateway picker and test modal", () => {
 
       await gotoMcpServersTab(page);
       await openAddMcpServerEditor(page);
-      await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+      await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
 
       await expect(
         page.getByText(/always go through AgentGateway so tool access can be authorized/i),
@@ -159,7 +159,7 @@ test.describe("RBAC e2e — MCP AgentGateway picker and test modal", () => {
       await gotoMcpServersTab(page);
       await openAddMcpServerEditor(page);
 
-      await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+      await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
       await page.getByLabel(/Endpoint URL/i).fill("http://custom-mcp:8000");
       await page.getByRole("button", { name: /check url/i }).click();
 
@@ -507,7 +507,7 @@ test.describe("RBAC e2e — MCP AgentGateway picker and test modal", () => {
         serverId: "jira-e2e",
       });
       await selectAgentGatewayTarget(page, /Jira/i);
-      await page.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }).click();
+      await expect(page.getByRole("button", { name: /Streamable HTTP.*recommended/i })).toBeVisible();
 
       await page.getByRole("button", { name: "Add Credential" }).click();
       await page.getByLabel(/Credential kind/i).selectOption("provider_connection");

--- a/ui/src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts
@@ -110,7 +110,7 @@ describe("remaining conversation routes use OpenFGA instead of legacy owner/team
     mockRequireConversationResourcePermission.mockResolvedValue(undefined);
   });
 
-  it("shared conversations fetch candidates without Mongo team-membership prefiltering", async () => {
+  it("shared conversations prefilter sharing candidates before OpenFGA authorization", async () => {
     const candidate = conversation();
     const conversations = collectionWithItems([candidate]);
     mockGetCollection.mockResolvedValue(conversations);
@@ -125,7 +125,12 @@ describe("remaining conversation routes use OpenFGA instead of legacy owner/team
         owner_id: { $ne: "alice@example.com" },
       }),
     );
-    expect(conversations.find.mock.calls[0][0]).not.toHaveProperty("$or");
+    expect(conversations.find.mock.calls[0][0].$or).toEqual([
+      { "sharing.is_public": true },
+      { "sharing.shared_with": "alice@example.com" },
+      { "sharing.share_link_enabled": true },
+      { "sharing.shared_with_teams.0": { $exists: true } },
+    ]);
     expect(mockFilterConversationsByImplicitOrExplicitPermission).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
       "alice@example.com",

--- a/ui/src/app/api/__tests__/chat-sharing-public.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-public.test.ts
@@ -605,9 +605,7 @@ describe('GET /api/chat/shared — public conversations', () => {
     GET = mod.GET;
   });
 
-  // Spec 098-enterprise-rbac: `/api/chat/shared` now relies on the ReBAC
-  // post-filter and the Mongo query is just `{ owner_id: { $ne: caller } }`.
-  it('queries only owner_id !== caller and delegates is_public visibility to the ReBAC filter', async () => {
+  it('prefilters sharing candidates and delegates final visibility to the ReBAC filter', async () => {
     mockGetServerSession.mockResolvedValue(userSession(VIEWER_EMAIL));
 
     const teamsCol = createMockCollection();
@@ -627,7 +625,12 @@ describe('GET /api/chat/shared — public conversations', () => {
 
     const findCall = convsCol.find.mock.calls[0][0];
     expect(findCall.owner_id).toEqual({ $ne: VIEWER_EMAIL });
-    expect(JSON.stringify(findCall)).not.toContain('sharing.');
+    expect(findCall.$or).toEqual([
+      { 'sharing.is_public': true },
+      { 'sharing.shared_with': VIEWER_EMAIL },
+      { 'sharing.share_link_enabled': true },
+      { 'sharing.shared_with_teams.0': { $exists: true } },
+    ]);
   });
 
   it('excludes own public conversations from shared listing', async () => {

--- a/ui/src/app/api/platform/health/__tests__/route.test.ts
+++ b/ui/src/app/api/platform/health/__tests__/route.test.ts
@@ -99,11 +99,12 @@ describe("/api/platform/health", () => {
 
     expect(response.status).toBe(200);
     expect(body.status).toBe("healthy");
-    expect(body.summary).toEqual({ total: 18, healthy: 18, warning: 0, down: 0 });
+    expect(body.summary).toEqual({ total: 19, healthy: 19, warning: 0, down: 0 });
     expect(body.probes.map((probe: { id: string }) => probe.id)).toEqual([
       "keycloak",
       "openfga",
       "openfga-authz-bridge",
+      "dynamic-agents",
       "agentgateway-config-bridge",
       "agentgateway",
       "caipe-mongodb",

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -44,8 +44,11 @@ interface MCPServerEditorProps {
 
 const TRANSPORT_OPTIONS: { value: TransportType; label: string; description: string }[] = [
   { value: "stdio", label: "STDIO", description: "Local process via stdin/stdout" },
-  { value: "sse", label: "SSE", description: "Server-Sent Events endpoint" },
-  { value: "http", label: "HTTP", description: "HTTP/REST endpoint" },
+  {
+    value: "http",
+    label: "Streamable HTTP",
+    description: "MCP Streamable HTTP endpoint (recommended)",
+  },
 ];
 
 const MCP_PROVIDER_CREDENTIAL_HEADER = "X-CAIPE-Provider-Token";
@@ -210,7 +213,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
   const [showGeneratedNameEditor, setShowGeneratedNameEditor] = React.useState(false);
   const [name, setName] = React.useState(server?.name || "");
   const [description, setDescription] = React.useState(server?.description || "");
-  const [transport, setTransport] = React.useState<TransportType>(server?.transport || "sse");
+  const [transport, setTransport] = React.useState<TransportType>(server?.transport || "http");
   const [endpoint, setEndpoint] = React.useState(
     server?.agentgateway_target_endpoint || server?.endpoint || "",
   );
@@ -739,6 +742,11 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   </button>
                 ))}
               </div>
+              {isEditing && transport === "sse" ? (
+                <p className="text-xs text-muted-foreground">
+                  This server uses the legacy SSE transport. New servers should use Streamable HTTP.
+                </p>
+              ) : null}
             </div>
 
             {/* Transport-specific fields */}
@@ -855,7 +863,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   <div className="space-y-2">
                     <Label htmlFor="agentgateway-target">AgentGateway target</Label>
                     <p className="text-xs text-muted-foreground">
-                      Pick a routed MCP target from AgentGateway. Saved HTTP and SSE MCP servers
+                      Pick a routed MCP target from AgentGateway. Saved Streamable HTTP MCP servers
                       always go through AgentGateway so tool access can be authorized.
                     </p>
                     <TeamPicker
@@ -890,7 +898,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                   <Input
                     id="endpoint"
                     name="mcp-endpoint"
-                    placeholder={`e.g., http://localhost:3000/${transport === "sse" ? "sse" : "mcp"}`}
+                    placeholder="e.g., http://localhost:3000/mcp"
                     value={endpoint}
                     onChange={(e) => {
                       const nextEndpoint = e.target.value;
@@ -992,7 +1000,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel }: MCPServe
                 </p>
                 {usesAgentGatewayRouting(transport) ? (
                   <p className="mt-2 text-xs text-muted-foreground">
-                    HTTP and SSE MCP servers route through AgentGateway. The{" "}
+                    Streamable HTTP MCP servers route through AgentGateway. The{" "}
                     <code className="font-mono">Authorization</code> header is reserved for the
                     caller JWT — use{" "}
                     <code className="font-mono">{MCP_PROVIDER_CREDENTIAL_HEADER}</code> for provider

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -430,7 +430,7 @@ export function MCPServersTab() {
           <div>
             <CardTitle>MCP Servers</CardTitle>
             <CardDescription>
-              Configure MCP server connections. HTTP and SSE servers are routed through AgentGateway so each tool call can be authorized before it reaches the server.
+              Configure MCP server connections. Streamable HTTP servers are routed through AgentGateway so each tool call can be authorized before it reaches the server.
             </CardDescription>
           </div>
           <div className="flex items-center gap-2">

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -192,7 +192,6 @@ describe("MCPServerEditor credential sources", () => {
     const user = userEvent.setup();
     render(<MCPServerEditor server={null} onSave={jest.fn()} onCancel={jest.fn()} />);
 
-    await user.click(screen.getByRole("button", { name: /http http\/rest endpoint/i }));
     await user.type(screen.getByLabelText(/upstream url|endpoint url/i), "http://mcp-argocd:8000");
     await user.click(screen.getByRole("button", { name: /check url/i }));
 
@@ -317,7 +316,6 @@ describe("MCPServerEditor credential sources", () => {
     await user.type(screen.getByLabelText(/generated name/i), "jira-gu");
     await user.click(await screen.findByRole("button", { name: /agentgateway target/i }));
     await user.click(screen.getByRole("option", { name: /^Jira$/i }));
-    await user.click(screen.getByRole("button", { name: /HTTP HTTP\/REST endpoint/i }));
     await user.click(screen.getByRole("button", { name: /create server/i }));
 
     await waitFor(() =>


### PR DESCRIPTION
## Summary
- Default new MCP server connections to Streamable HTTP.
- Remove SSE from the new-server transport choices while preserving a legacy SSE note when editing existing SSE servers.
- Update MCP Server copy and credential tests for the new default.

## Why
New MCP servers should follow the current Streamable HTTP path through AgentGateway. Existing SSE configurations remain visible when edited, but new setup steers users toward the supported default.

## Validation
- `make caipe-ui-prod` completed successfully from the combined change set.
- `npm test -- --runInBand src/app/api/platform/health/__tests__/route.test.ts src/app/api/admin/webex/directory/status/__tests__/route.test.ts src/components/layout/__tests__/AppHeader.test.tsx src/lib/rbac/__tests__/connector-diagnostic-messages.test.ts src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx` passed: 6 suites, 120 tests.
