### PR TITLE
fix(rbac): atomically acquire migration lock to prevent multi-replica race

### DIFF
--- a/ui/e2e/rbac/platform-health-probes.spec.ts
+++ b/ui/e2e/rbac/platform-health-probes.spec.ts
@@ -95,8 +95,8 @@ const healthyProbes: Probe[] = [
     label: "Keycloak Bootstrap",
     group: "bootstrap",
     status: "healthy",
-    detail: "Realm and clients ready",
-    target: "caipe realm",
+    detail: "completed by caipe-ui-0 · 07:31 UTC",
+    target: "caipe",
     latency_ms: 13,
   },
   {
@@ -535,6 +535,64 @@ test.describe("platform health probes", () => {
     await expect
       .poll(async () => probeList.evaluate((node) => node.scrollTop > 0))
       .toBe(true);
+  });
+
+  test("keycloak-bootstrap detail shows completed pod and time when migration succeeded", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "keycloak-bootstrap"
+        ? { ...probe, detail: "completed by caipe-ui-0 · 07:31 UTC" }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+    await openSystemStatus(page);
+
+    await expect(page.getByText("Keycloak Bootstrap", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("completed by caipe-ui-0 · 07:31 UTC").first()).toBeVisible();
+  });
+
+  test("keycloak-bootstrap detail shows running state when migration is in progress on another pod", async ({ page }) => {
+    const env = rbacEnvOrSkip({ requireUserSub: true });
+    await installStableHeaderHealthMocks(page);
+    const probes = healthyProbes.map((probe) =>
+      probe.id === "keycloak-bootstrap"
+        ? {
+            ...probe,
+            status: "warning" as const,
+            detail: "running on caipe-ui-1 since 07:28 UTC",
+            latency_ms: 0,
+            remediation: {
+              label: "Keycloak Health",
+              href: "/admin?cat=security&tab=keycloak",
+              description: "Open Keycloak health to inspect reconciliation and admin credential setup.",
+            },
+          }
+        : probe,
+    );
+    await page.route("**/api/platform/health", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(platformHealthPayload(probes)),
+      });
+    });
+
+    await installSessionAndOpenHome(page, env);
+
+    await expect(page.getByRole("button", { name: /system status: needs attention/i })).toBeVisible();
+    await openSystemStatus(page);
+
+    await expect(page.getByText("Keycloak Bootstrap", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("running on caipe-ui-1 since 07:28 UTC").first()).toBeVisible();
   });
 
   test("pending probe results show an explicit checking state", async ({ page }) => {

--- a/ui/e2e/rbac/platform-health.spec.ts
+++ b/ui/e2e/rbac/platform-health.spec.ts
@@ -58,7 +58,7 @@ const ALL_HEALTHY_PROBES = [
   makeProbe("milvus-minio", "rag", "healthy", "Milvus MinIO"),
   makeProbe("etcd", "rag", "healthy", "etcd"),
   makeProbe("openfga-bootstrap", "bootstrap", "healthy", "OpenFGA Bootstrap"),
-  makeProbe("keycloak-bootstrap", "bootstrap", "healthy", "Keycloak Bootstrap"),
+  { ...makeProbe("keycloak-bootstrap", "bootstrap", "healthy", "Keycloak Bootstrap"), detail: "completed by caipe-ui-0 · 07:31 UTC" },
   makeProbe("rebac-migrations", "bootstrap", "healthy", "ReBAC Migrations"),
   makeProbe("web-ingestor", "rag", "healthy", "Web Ingestor"),
 ];

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -249,6 +249,12 @@ async function probeOpenFgaBootstrap(openfgaUrl: string): Promise<ProbeResult> {
   }
 }
 
+function formatUtcHHMM(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return `${String(d.getUTCHours()).padStart(2, "0")}:${String(d.getUTCMinutes()).padStart(2, "0")} UTC`;
+}
+
 async function probeKeycloakBootstrap(): Promise<ProbeResult> {
   const remediation = {
     label: "Keycloak Health",
@@ -258,6 +264,8 @@ async function probeKeycloakBootstrap(): Promise<ProbeResult> {
   try {
     const health = await getKeycloakMigrationHealth({ actor: "platform-health" });
     const failingInvariants = health.keycloak_invariants?.summary.failing ?? 0;
+    const lastRun = health.migration.last_run;
+
     if (!health.keycloak.reachable || health.keycloak.status !== "reachable") {
       return {
         id: "keycloak-bootstrap",
@@ -270,6 +278,23 @@ async function probeKeycloakBootstrap(): Promise<ProbeResult> {
         remediation,
       };
     }
+
+    // Surface mid-migration state so multi-replica races are visible in the UI.
+    if (lastRun?.status === "running") {
+      const since = lastRun.locked_at ? ` since ${formatUtcHHMM(lastRun.locked_at)}` : "";
+      const pod = lastRun.actor ?? "unknown pod";
+      return {
+        id: "keycloak-bootstrap",
+        label: "Keycloak Bootstrap",
+        group: "bootstrap",
+        status: "warning",
+        detail: `running on ${pod}${since}`,
+        target: health.keycloak.realm,
+        latency_ms: null,
+        remediation,
+      };
+    }
+
     if (health.schema_area.status !== "current" || failingInvariants > 0) {
       return {
         id: "keycloak-bootstrap",
@@ -285,12 +310,18 @@ async function probeKeycloakBootstrap(): Promise<ProbeResult> {
         remediation,
       };
     }
+
+    const completedDetail =
+      lastRun?.status === "completed" && lastRun.actor && lastRun.completed_at
+        ? `completed by ${lastRun.actor} · ${formatUtcHHMM(lastRun.completed_at)}`
+        : "Realm and reconciliation ready";
+
     return {
       id: "keycloak-bootstrap",
       label: "Keycloak Bootstrap",
       group: "bootstrap",
       status: "healthy",
-      detail: "Realm and reconciliation ready",
+      detail: completedDetail,
       target: health.keycloak.realm,
       latency_ms: null,
     };

--- a/ui/src/components/admin/security/KeycloakMigrationHealthPanel.tsx
+++ b/ui/src/components/admin/security/KeycloakMigrationHealthPanel.tsx
@@ -377,6 +377,7 @@ export function KeycloakMigrationHealthPanel({ compact = false }: KeycloakMigrat
       setHealth(nextHealth);
     } catch (err) {
       if (hasLoadedHealthRef.current && isTransientFetchFailure(err)) {
+        setError("Failed to refresh — connection error. Try again.");
         return;
       }
       setError(err instanceof Error ? err.message : "Failed to load Keycloak migration health");

--- a/ui/src/components/admin/security/__tests__/KeycloakMigrationHealthPanel.test.tsx
+++ b/ui/src/components/admin/security/__tests__/KeycloakMigrationHealthPanel.test.tsx
@@ -693,4 +693,39 @@ describe("KeycloakMigrationHealthPanel", () => {
     expect(row1Text).toMatch(/KEYCLOAK_USER_PROFILE_UNMANAGED_ATTRIBUTE_POLICY/);
   });
 
+  it("shows a friendly error when a refresh fetch fails with a transient network error", async () => {
+    // First load succeeds (hasLoadedHealthRef becomes true), then a Refresh
+    // throws TypeError: fetch failed — should show the friendly message
+    // rather than silently doing nothing.
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(completedHealth))
+      .mockRejectedValueOnce(Object.assign(new TypeError("fetch failed"), {}));
+
+    render(<KeycloakMigrationHealthPanel />);
+
+    // Wait for first load to finish — button is disabled while loading.
+    const refreshBtn = screen.getByRole("button", { name: /Refresh/i });
+    await waitFor(() => expect(refreshBtn).not.toBeDisabled());
+
+    expect(screen.queryByText(/Failed to refresh/i)).not.toBeInTheDocument();
+
+    fireEvent.click(refreshBtn);
+
+    expect(await screen.findByText(/Failed to refresh.*connection error/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the raw error on first load when the network is unreachable", async () => {
+    // On the very first load hasLoadedHealthRef is false, so a transient
+    // network failure must not be suppressed — the user needs to know the
+    // panel never loaded.
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new TypeError("fetch failed"), {}));
+
+    render(<KeycloakMigrationHealthPanel />);
+
+    expect(await screen.findByText(/fetch failed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to refresh/i)).not.toBeInTheDocument();
+  });
 });

--- a/ui/src/lib/rbac/keycloak-migration-health.ts
+++ b/ui/src/lib/rbac/keycloak-migration-health.ts
@@ -43,6 +43,7 @@ interface SchemaMigrationRunDoc {
   completed_at?: string;
   updated_at?: string;
   updated_by?: string;
+  locked_at?: string;
 }
 
 export interface KeycloakMigrationHealth {
@@ -61,6 +62,7 @@ export interface KeycloakMigrationHealth {
       status: MigrationStatus | "skipped";
       actor?: string;
       completed_at?: string;
+      locked_at?: string;
       updated_at?: string;
       applied_counts: Record<string, number>;
       planned_counts: Record<string, number>;
@@ -218,6 +220,7 @@ export async function getKeycloakMigrationHealth(input: {
             status: run.status ?? "not_started",
             actor: run.updated_by,
             completed_at: run.completed_at,
+            locked_at: run.locked_at,
             updated_at: run.updated_at,
             applied_counts: run.applied_counts ?? {},
             planned_counts: run.planned_counts ?? {},

--- a/ui/src/lib/rbac/keycloak-rbac-reconciliation.ts
+++ b/ui/src/lib/rbac/keycloak-rbac-reconciliation.ts
@@ -124,25 +124,44 @@ async function loadTeamSlugs(now: string, warnings: string[]): Promise<string[]>
   return [...slugs].sort();
 }
 
-async function recordRunning(actor: string, now: string): Promise<void> {
+// Pods that lose the race or find a completed migration return immediately.
+// A lock older than LOCK_TTL_MS is treated as stale (crashed pod) and overwritten.
+const LOCK_TTL_MS = 5 * 60 * 1000;
+
+async function acquireMigrationLock(actor: string, now: string): Promise<boolean> {
+  const staleThreshold = new Date(Date.now() - LOCK_TTL_MS).toISOString();
   const migrations = await getCollection<StringIdRow>("schema_migrations");
-  await migrations.updateOne(
-    { _id: KEYCLOAK_RBAC_RECONCILIATION_MIGRATION_ID },
-    {
-      $set: {
-        release: KEYCLOAK_RBAC_MIGRATION_DEFINITION.release,
-        schema_area: KEYCLOAK_RBAC_SCHEMA_AREA,
-        from_version: 0,
-        to_version: KEYCLOAK_RBAC_SCHEMA_VERSION,
-        kind: "implicit",
-        status: "running",
-        updated_at: now,
-        updated_by: actor,
+  try {
+    const result = await migrations.findOneAndUpdate(
+      {
+        _id: KEYCLOAK_RBAC_RECONCILIATION_MIGRATION_ID,
+        $or: [
+          { status: { $nin: ["running", "completed"] } },
+          { status: "running", locked_at: { $lt: staleThreshold } },
+        ],
       },
-      $setOnInsert: { created_at: now, created_by: actor },
-    },
-    { upsert: true }
-  );
+      {
+        $set: {
+          release: KEYCLOAK_RBAC_MIGRATION_DEFINITION.release,
+          schema_area: KEYCLOAK_RBAC_SCHEMA_AREA,
+          from_version: 0,
+          to_version: KEYCLOAK_RBAC_SCHEMA_VERSION,
+          kind: "implicit",
+          status: "running",
+          locked_at: now,
+          updated_at: now,
+          updated_by: actor,
+        },
+        $setOnInsert: { created_at: now, created_by: actor },
+      },
+      { upsert: true, returnDocument: "after" }
+    );
+    return result !== null;
+  } catch (e: unknown) {
+    // E11000: document exists with status running/completed — another pod won the race.
+    if ((e as { code?: number }).code === 11000) return false;
+    throw e;
+  }
 }
 
 async function recordCompleted(input: {
@@ -290,9 +309,18 @@ export async function runKeycloakRbacStartupMigration(input: {
     };
   }
 
+  const acquired = await acquireMigrationLock(actor, now);
+  if (!acquired) {
+    return {
+      migration_id: KEYCLOAK_RBAC_RECONCILIATION_MIGRATION_ID,
+      status: "skipped",
+      counts,
+      warnings: ["Migration already running or completed on another pod; skipped."],
+    };
+  }
+
   try {
     await seedManifest(now);
-    await recordRunning(actor, now);
     const teamSlugs = await loadTeamSlugs(now, warnings);
     counts.mongo_teams_seen = teamSlugs.length;
 

--- a/ui/src/lib/rbac/keycloak-rbac-reconciliation.ts
+++ b/ui/src/lib/rbac/keycloak-rbac-reconciliation.ts
@@ -279,7 +279,7 @@ export async function runKeycloakRbacStartupMigration(input: {
   actor?: string;
   now?: string;
 } = {}): Promise<KeycloakRbacStartupMigrationResult> {
-  const actor = input.actor ?? "webui-startup";
+  const actor = input.actor ?? process.env.HOSTNAME ?? "webui-startup";
   const now = input.now ?? nowIso();
   const warnings: string[] = [];
   // Phase 3 (spec 2026-05-24-derive-team-from-channel) removed the per-team


### PR DESCRIPTION
## Problem

When `replicaCount > 1`, all pods start simultaneously. Each calls `recordRunning` — a plain `updateOne` with `upsert: true` that has no guard. All pods see status ≠ `running/completed`, all proceed through the same Keycloak API calls, and the one that hits a conflict surfaces `warnings=1`, which shows as **keycloak-bootstrap: fetch failed** in the Platform Health widget.

## Fix

Replace `recordRunning` with `acquireMigrationLock`: an atomic `findOneAndUpdate` that sets `status=running` only when the document is absent or not already `running`/`completed`.

```
filter:
  status NOT IN [running, completed]
  OR (status = running AND locked_at < now - 5min)
```

- **Only one pod proceeds** — the others get `null` or an E11000 duplicate-key error (document exists but filter rejected it) and return `{ status: "skipped" }` immediately.
- **5-minute stale-lock TTL** — if a pod crashes mid-migration, the `locked_at` field lets the next deploy reclaim the lock after 5 minutes rather than being permanently blocked.

## Workaround (until merged)

Set `caipe-ui.replicaCount: 1` before upgrading, scale back to 3 after the first pod is healthy.

## Test plan

- [ ] Deploy with `replicaCount: 3` and confirm only one pod logs `completed`, others log `skipped`
- [ ] Confirm Platform Health widget shows keycloak-bootstrap as healthy after upgrade
- [ ] Confirm a single-replica deploy is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)