### PR TITLE
fix(rbac): filter OpenFGA tuples server-side in slack channel diagnostics

### DIFF
--- a/ui/src/lib/rbac/slack-channel-diagnostics.ts
+++ b/ui/src/lib/rbac/slack-channel-diagnostics.ts
@@ -34,11 +34,11 @@ async function listOpenFgaSlackChannelAgentIds(workspaceId: string, channelId: s
   let continuationToken: string | undefined;
   do {
     const result = await readOpenFgaTuples({
+      tuple: { user: subject, relation: "user", object: "agent:" },
       pageSize: 100,
       ...(continuationToken ? { continuationToken } : {}),
     });
     for (const tuple of result.tuples) {
-      if (tuple.key.user !== subject || tuple.key.relation !== "user") continue;
       const agentId = agentIdFromObject(tuple.key.object);
       if (agentId) seen.add(agentId);
     }


### PR DESCRIPTION
# Description

The admin **Integrations → Slack** channel list (`GET /api/admin/slack/channels?health=1`) was taking ~1.5 minutes even with only 2 channels.

**Root cause:** `listOpenFgaSlackChannelAgentIds()` in `ui/src/lib/rbac/slack-channel-diagnostics.ts` called `readOpenFgaTuples()` with **no `tuple` filter**, so it paged through OpenFGA's *entire* tuple store (100 at a time, sequentially) and filtered in JS. This runs once per channel, and the health summary fans it out across every row — turning into hundreds of sequential OpenFGA round-trips regardless of how few channels match.

**Fix:** Pass a server-side filter `{ user: subject, relation: "user", object: "agent:" }` so OpenFGA returns only this channel's agent tuples (typically one short page). This mirrors `listOpenFgaWebexSpaceAgentIds` in `webex-space-openfga.ts`, which already filtered correctly — the Slack path was just missing it. Removed the now-redundant JS-side `user`/`relation` check since the server enforces it.

**Impact:** From O(total_tuples / 100) round-trips *per channel* down to ~1 round-trip per channel. The call should drop from minutes to well under a second.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass