### PR TITLE
fix(rbac): team tool/agent visibility, channel repair gate, Slack search races, N+1 channel queries

### DIFF
--- a/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
+++ b/ui/src/app/api/admin/service-accounts/__tests__/grantable.test.ts
@@ -81,7 +81,8 @@ describe("GET /api/admin/service-accounts/grantable", () => {
   it("keys on the CALLER's own holdings (FR-007/009) and shapes {ref,name}", async () => {
     mockListOpenFgaObjects
       .mockResolvedValueOnce({ objects: ["agent:incident-resolver"] }) // can_use agent
-      .mockResolvedValueOnce({ objects: ["tool:jira/search", "tool:jira/*"] }); // can_call tool
+      .mockResolvedValueOnce({ objects: ["tool:jira/search", "tool:jira/*"] }) // can_call tool
+      .mockResolvedValueOnce({ objects: [] }); // member team (no teams → no traversal)
     mockListRebacCatalog.mockResolvedValue({
       resources: [{ type: "agent", id: "incident-resolver", display_name: "Incident Resolver" }],
     });
@@ -91,11 +92,12 @@ describe("GET /api/admin/service-accounts/grantable", () => {
     const body = await res.json();
     expect(body.success).toBe(true);
 
-    // The two list-objects calls are keyed on the caller subject + correct relations.
+    // The first three list-objects calls are keyed on the caller subject + correct relations.
     const calls = mockListOpenFgaObjects.mock.calls.map((c) => c[0]);
-    expect(calls).toEqual([
+    expect(calls.slice(0, 3)).toEqual([
       { user: "user:caller-sub", relation: "can_use", type: "agent" },
       { user: "user:caller-sub", relation: "can_call", type: "tool" },
+      { user: "user:caller-sub", relation: "member", type: "team" },
     ]);
 
     expect(body.data.agents).toEqual([{ ref: "incident-resolver", name: "Incident Resolver" }]);
@@ -109,7 +111,8 @@ describe("GET /api/admin/service-accounts/grantable", () => {
   it("falls back to the raw ref when the catalog has no display name", async () => {
     mockListOpenFgaObjects
       .mockResolvedValueOnce({ objects: ["agent:mystery-agent"] })
-      .mockResolvedValueOnce({ objects: [] });
+      .mockResolvedValueOnce({ objects: [] })
+      .mockResolvedValueOnce({ objects: [] }); // member team
 
     const res = await GET();
     const body = await res.json();
@@ -120,7 +123,8 @@ describe("GET /api/admin/service-accounts/grantable", () => {
   it("still returns agents/tools when the name catalog throws (names are decorative)", async () => {
     mockListOpenFgaObjects
       .mockResolvedValueOnce({ objects: ["agent:a1"] })
-      .mockResolvedValueOnce({ objects: ["tool:srv/do"] });
+      .mockResolvedValueOnce({ objects: ["tool:srv/do"] })
+      .mockResolvedValueOnce({ objects: [] }); // member team
     mockListRebacCatalog.mockRejectedValue(new Error("catalog down"));
 
     const res = await GET();

--- a/ui/src/app/api/admin/service-accounts/grantable/route.ts
+++ b/ui/src/app/api/admin/service-accounts/grantable/route.ts
@@ -249,10 +249,47 @@ export async function GET(request?: NextRequest | Request) {
         );
     }
 
-    const [agentObjects, toolObjects] = await Promise.all([
+    // Fetch direct grants and team memberships in parallel.
+    const [agentObjects, toolObjects, teamObjects] = await Promise.all([
       listOpenFgaObjects({ user: caller, relation: "can_use", type: "agent" }),
       listOpenFgaObjects({ user: caller, relation: "can_call", type: "tool" }),
+      listOpenFgaObjects({ user: caller, relation: "member", type: "team" }),
     ]);
+
+    // For each team the caller belongs to, fetch tool AND agent grants held by
+    // that team's members. This surfaces team-inherited grants (e.g.
+    // `tool:gitlab/*`, `agent:foo`) that are not written as direct user tuples.
+    const teamGrantResults = await Promise.all(
+      teamObjects.objects.map(async (teamObject) => {
+        const teamSlug = stripType(teamObject, "team");
+        const teamMember = `team:${teamSlug}#member`;
+        const [teamTools, teamAgents] = await Promise.all([
+          listOpenFgaObjects({ user: teamMember, relation: "can_call", type: "tool" })
+            .catch((err) => {
+              console.warn("[service-accounts/grantable] team tool lookup failed", { teamSlug, err });
+              return { objects: [] as string[] };
+            }),
+          listOpenFgaObjects({ user: teamMember, relation: "can_use", type: "agent" })
+            .catch((err) => {
+              console.warn("[service-accounts/grantable] team agent lookup failed", { teamSlug, err });
+              return { objects: [] as string[] };
+            }),
+        ]);
+        return { teamTools, teamAgents };
+      })
+    );
+
+    // Union direct grants with team-inherited grants (dedup by ref).
+    const allToolRefs = new Set<string>(
+      toolObjects.objects.map((o) => stripType(o, "tool"))
+    );
+    const allAgentRefs = new Set<string>(
+      agentObjects.objects.map((o) => stripType(o, "agent"))
+    );
+    for (const { teamTools, teamAgents } of teamGrantResults) {
+      for (const o of teamTools.objects) allToolRefs.add(stripType(o, "tool"));
+      for (const o of teamAgents.objects) allAgentRefs.add(stripType(o, "agent"));
+    }
 
     // Resolve friendly names best-effort from the ReBAC resource catalog;
     // fall back to the ref itself so the picker is always usable even if the
@@ -267,15 +304,15 @@ export async function GET(request?: NextRequest | Request) {
       // Names are decorative; ignore catalog failures.
     }
 
-    const agents: GrantableItem[] = agentObjects.objects.map((object) => {
-      const ref = stripType(object, "agent");
-      return { ref, name: nameByAgentId.get(ref) ?? ref };
-    });
+    const agents: GrantableItem[] = Array.from(allAgentRefs).map((ref) => ({
+      ref,
+      name: nameByAgentId.get(ref) ?? ref,
+    }));
 
-    const tools: GrantableItem[] = toolObjects.objects.map((object) => {
-      const ref = stripType(object, "tool");
-      return { ref, name: humanizeToolRef(ref) };
-    });
+    const tools: GrantableItem[] = Array.from(allToolRefs).map((ref) => ({
+      ref,
+      name: humanizeToolRef(ref),
+    }));
 
     // Stable ordering for a predictable picker.
     agents.sort((a, b) => a.name.localeCompare(b.name));

--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -187,7 +187,7 @@ const agentGrant = {
   actions: ["use"],
 };
 
-beforeEach(() => {
+beforeEach(async () => {
   jest.clearAllMocks();
   process.env.OPENFGA_HTTP = "http://openfga:8080";
   process.env.SLACK_WORKSPACE_ALIAS = workspaceAlias;
@@ -214,6 +214,10 @@ beforeEach(() => {
     },
   ]);
   mockCollections.slack_channel_grants = createMockCollection([]);
+  // Reset the module-scope repairedObjects Set so repair tests don't bleed
+  // into each other (the set persists across Jest's module cache lifetime).
+  const channelsRoute = await import("../route");
+  channelsRoute.__resetRepairedObjectsForTests();
 });
 
 afterEach(() => {

--- a/ui/src/app/api/admin/slack/channels/route.ts
+++ b/ui/src/app/api/admin/slack/channels/route.ts
@@ -33,6 +33,14 @@ interface ChannelListRow {
   source: "team_mapping" | "route_metadata";
 }
 
+// Process-lifetime set of objects already repaired this run. Prevents
+// re-attempting the writeOpenFgaTuples + filterTupleDiff read-back on every
+// page load once the tuples are confirmed to be in place.
+const repairedObjects = new Set<string>();
+
+/** Test-only: reset the repair dedup set between Jest test runs. */
+export const __resetRepairedObjectsForTests = (): void => repairedObjects.clear();
+
 function pickPrimaryAgentId(routes: SlackChannelAgentRouteDocument[]): string | undefined {
   const enabledRoute = routes
     .filter((route) => route.enabled !== false)
@@ -58,11 +66,17 @@ async function slackChannelAccess(
   ]);
   let [read, manage] = await checkAccess();
   let repairedManageGrant = false;
-  if (read.allowed && !manage.allowed && teamSlug) {
+  // Only attempt repair when: (a) the channel is team-mapped (teamSlug set),
+  // (b) some permission is missing, and (c) we haven't already repaired this
+  // object in the current process lifetime — avoids re-running the expensive
+  // writeOpenFgaTuples + filterTupleDiff read-back on every page load for
+  // channels that are already correctly configured.
+  if (teamSlug && (!read.allowed || !manage.allowed) && !repairedObjects.has(object)) {
     // assisted-by Codex Codex-sonnet-4-6
-    // Older channel assignments may only have the team-member use tuple.
-    // Re-materialize the central assignment policy so upgraded installs get
-    // the new team-member manage tuple without a manual migration first.
+    // Older channel assignments may only have the team-member use tuple, or
+    // may be missing tuples entirely (e.g. a write failure during assignment).
+    // Re-materialize the central assignment policy so upgraded installs and
+    // members with zero access get correct grants without a manual migration.
     const repair = await writeOpenFgaTuples(
       buildUniversalRebacTupleDiff({
         writes: slackChannelTeamVisibilityRelationships(workspaceId, channelId, teamSlug),
@@ -77,6 +91,9 @@ async function slackChannelAccess(
       });
       return null;
     });
+    // Mark repaired regardless of write count — if tuples were already present
+    // (writes: 0 from filterTupleDiff), we skip re-attempting next time too.
+    if (repair?.enabled) repairedObjects.add(object);
     repairedManageGrant = Boolean(repair?.enabled && repair.writes > 0);
     [read, manage] = await checkAccess();
   }


### PR DESCRIPTION
## Summary

- **SA grantable picker**: Team members saw no tools or agents because \`listOpenFgaObjects\` only returns direct personal grants. Added team-membership traversal to union team-inherited grants (tools and agents) with personal grants.
- **Slack channel visibility**: The auto-repair in \`slackChannelAccess\` only triggered when \`read=true && manage=false\`, leaving zero-access members unrepaired. Widened to trigger whenever any permission is missing. Added a process-lifetime \`repairedObjects\` set to prevent re-running the expensive repair+check on every page load.

## Test plan

- [ ] As a team member (not platform admin), open the SA grantable picker — team-granted tools (e.g. \`gitlab: all tools\`) and agents should now appear
- [ ] As a platform admin, verify the SA picker still shows the full catalog as before
- [ ] Set up a Slack channel owned by a team. Log in as a team member with no prior channel access — channel should now be visible after first load (repair fires once)
- [ ] Confirm repair only fires once per channel per process lifetime (no repeat writes on subsequent page loads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)