### PR TITLE
fix(slack-bot): skip bot identity resolution in middleware and fix allowlist matching

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -474,7 +474,7 @@ def _agent_listens_to(agent_listen, requested):
   return agent_listen == "all" or agent_listen == requested
 
 
-def _match_agents(channel_config, is_bot, bot_username=None, user_id=None, listen=None):
+def _match_agents(channel_config, is_bot, bot_username=None, bot_user_id=None, user_id=None, listen=None):
   """Return all agents configured for this sender type and listen mode."""
   matched = []
   for agent in channel_config.agents:
@@ -483,8 +483,10 @@ def _match_agents(channel_config, is_bot, bot_username=None, user_id=None, liste
         continue
       if listen and not _agent_listens_to(agent.bots.listen, listen):
         continue
-      if agent.bots.bot_list is not None and bot_username not in agent.bots.bot_list:
-        continue
+      if agent.bots.bot_list is not None:
+        # Allow matching by name (e.g. "GitLab") OR by U-prefixed user ID.
+        if bot_username not in agent.bots.bot_list and bot_user_id not in agent.bots.bot_list:
+          continue
       matched.append(agent)
     elif not is_bot and agent.users:
       if not agent.users.enabled:
@@ -516,6 +518,7 @@ def _match_channel_agents(
   channel_config,
   is_bot,
   bot_username=None,
+  bot_user_id=None,
   user_id=None,
   listen=None,
   workspace_id=None,
@@ -529,6 +532,7 @@ def _match_channel_agents(
     channel_config,
     is_bot=is_bot,
     bot_username=bot_username,
+    bot_user_id=bot_user_id,
     user_id=user_id,
     listen=listen,
   )
@@ -1991,8 +1995,9 @@ def handle_message_events(body, say, client, context=None):
     return
 
   bot_username = None
+  sender_bot_user_id = None
   if is_bot:
-    bot_username = utils.get_username_by_bot_id(bot_id)
+    bot_username, sender_bot_user_id = utils.get_bot_info_by_id(bot_id)
 
   sender_user_id = event.get("user") if not is_bot else None
   matches = _match_channel_agents(
@@ -2000,6 +2005,7 @@ def handle_message_events(body, say, client, context=None):
     channel_config,
     is_bot=is_bot,
     bot_username=bot_username,
+    bot_user_id=sender_bot_user_id,
     user_id=sender_user_id,
     listen="message",
     workspace_id=_event_workspace_id(event),

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -1072,13 +1072,13 @@ def rbac_global_middleware(body, context, next, logger):
             bot_loop = asyncio.new_event_loop()
             unlinked_token = bot_loop.run_until_complete(_mint_unlinked_obo_token())
         except Exception as exc:
-            logger.warning("[{}] rbac_global_middleware: unlinked SA mint failed for bot={}: {}", event.get("ts", "?"), bot_slack_user_id, exc)
+            logger.warning("[{}] rbac_global_middleware: unlinked SA mint failed for bot={}: {}", event.get("ts"), bot_slack_user_id, exc)
             unlinked_token = None
         finally:
             if bot_loop is not None:
                 bot_loop.close()
         if unlinked_token is None:
-            logger.warning("[{}] rbac_global_middleware: no unlinked SA available, dropping bot message from {}", event.get("ts", "?"), bot_slack_user_id)
+            logger.warning("[{}] rbac_global_middleware: no unlinked SA available, dropping bot message from {}", event.get("ts"), bot_slack_user_id)
             return _HANDLED_200
         context["obo_token"] = unlinked_token
         context["unlinked_fallback"] = True

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -1033,6 +1033,54 @@ def rbac_global_middleware(body, context, next, logger):
         next()
         return
 
+    # Bot messages: skip Keycloak resolution and nudge; mint unlinked SA token
+    # directly as a baseline. Bots have no Keycloak account so resolution always
+    # fails, and the nudge path tries to DM the bot which also fails noisily.
+    #
+    # We still need a baseline obo_token in context so that obo_user routes
+    # have something to carry (service_account routes will overwrite it in
+    # _route_to_agent anyway). The bot's Slack user ID and bot_id are recorded
+    # so downstream logging and the allowlist check in _match_agents work as
+    # normal.
+    if event.get("bot_id"):
+        # Resolve the bot's U-prefixed user ID via bots.info (mirrors the
+        # pattern in _route_to_agent lines 1518-1519), falling back to the
+        # raw bot_id only if the lookup fails.
+        _, _bot_user_id = utils.get_bot_info_by_id(event.get("bot_id"))
+        bot_slack_user_id = _bot_user_id or event.get("user") or event.get("bot_id")
+        slack_team_id = (
+            body.get("team_id")
+            or event.get("team")
+            or os.environ.get("SLACK_WORKSPACE_ID")
+        )
+        channel = (
+            event.get("channel")
+            or body.get("channel", {}).get("id")
+            or body.get("channel_id")
+        )
+        context["rbac_enabled"] = True
+        context["slack_user_id"] = bot_slack_user_id
+        context["is_bot"] = True
+        context["slack_workspace_id"] = slack_workspace_ref(str(slack_team_id) if slack_team_id else None)
+        context["surface_kind"] = "dm" if is_dm_channel(channel) else "channel"
+        bot_loop = None
+        try:
+            bot_loop = asyncio.new_event_loop()
+            unlinked_token = bot_loop.run_until_complete(_mint_unlinked_obo_token())
+        except Exception as exc:
+            logger.warning("[{}] rbac_global_middleware: unlinked SA mint failed for bot={}: {}", event.get("ts", "?"), bot_slack_user_id, exc)
+            unlinked_token = None
+        finally:
+            if bot_loop is not None:
+                bot_loop.close()
+        if unlinked_token is None:
+            logger.warning("[{}] rbac_global_middleware: no unlinked SA available, dropping bot message from {}", event.get("ts", "?"), bot_slack_user_id)
+            return _HANDLED_200
+        context["obo_token"] = unlinked_token
+        context["unlinked_fallback"] = True
+        next()
+        return
+
     slack_user_id = (
         event.get("user")
         or body.get("user", {}).get("id")

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -1286,6 +1286,7 @@ def handle_mention(event, say, client, context=None):
         should_proceed = apply_execution_identity(
           run_as_mode=exec_id.mode,
           sa_sub=exec_id.service_account_sub,
+          sa_name=exec_id.service_account_name,
           agent_id=agent_id,
           context=context,
           event=event,
@@ -1508,6 +1509,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
             should_proceed = apply_execution_identity(
                 run_as_mode=exec_id.mode,
                 sa_sub=exec_id.service_account_sub,
+                sa_name=exec_id.service_account_name,
                 agent_id=agent_match.agent_id,
                 context=context,
                 event=event,

--- a/ai_platform_engineering/integrations/slack_bot/utils/dispatch_identity.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/dispatch_identity.py
@@ -23,12 +23,11 @@ Callers must ``return`` immediately on False.
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any, Awaitable, Callable, Optional
 
-from .user_messages import send_error_notice as _send_error_notice_impl
+from loguru import logger
 
-logger = logging.getLogger("caipe.slack_bot.dispatch_identity")
+from .user_messages import send_error_notice as _send_error_notice_impl
 
 # Type alias for the coroutine function that mints a token for a given SA sub.
 ImpersonateFn = Callable[[str], Awaitable[Any]]
@@ -86,15 +85,24 @@ def apply_execution_identity(
     """
     # Resolve the effective mode: prefer run_as_mode, fall back to exec_mode alias.
     effective_mode = run_as_mode or exec_mode
+    thread_ts = event.get("ts", "?") if event else "?"
     if effective_mode != "service_account":
         # obo_user path — context["obo_token"] was set by the middleware; nothing to do.
+        unlinked = context.get("unlinked_fallback", False) if context else False
+        logger.info(
+            "[{}] dispatch_identity: run_as=obo_user agent={} unlinked_fallback={} — using middleware token",
+            thread_ts,
+            agent_id,
+            unlinked,
+        )
         return True
 
     if not sa_sub or not sa_sub.strip():
         # Misconfigured route: run_as=service_account with no sub.
         logger.warning(
-            "dispatch_identity: run_as=service_account agent=%s has no "
+            "[{}] dispatch_identity: run_as=service_account agent={} has no "
             "service_account_sub — aborting dispatch (misconfigured route)",
+            thread_ts,
             agent_id,
         )
         _send_error_notice(
@@ -117,7 +125,8 @@ def apply_execution_identity(
         sa_obo = sa_loop.run_until_complete(impersonate_fn(sa_sub))
         context["obo_token"] = sa_obo.access_token
         logger.info(
-            "dispatch_identity: run_as=service_account agent=%s sa_sub=%s — minted SA token",
+            "[{}] dispatch_identity: run_as=service_account agent={} sa_sub={} — minted SA token",
+            thread_ts,
             agent_id,
             sa_sub,
         )
@@ -125,9 +134,10 @@ def apply_execution_identity(
     except asyncio.CancelledError as exc:
         # PY-B2 / PY-S3: abort — never dispatch under the wrong identity.
         logger.warning(
-            "dispatch_identity: run_as=service_account token mint cancelled "
-            "agent=%s sa_sub=%s: %s — aborting dispatch to avoid running "
+            "[{}] dispatch_identity: run_as=service_account token mint cancelled "
+            "agent={} sa_sub={}: {} — aborting dispatch to avoid running "
             "under wrong identity",
+            thread_ts,
             agent_id,
             sa_sub,
             exc,
@@ -147,9 +157,10 @@ def apply_execution_identity(
     except Exception as exc:
         # PY-B2 / PY-S3: abort — never dispatch under the wrong identity.
         logger.warning(
-            "dispatch_identity: run_as=service_account token mint failed "
-            "agent=%s sa_sub=%s: %s — aborting dispatch to avoid running "
+            "[{}] dispatch_identity: run_as=service_account token mint failed "
+            "agent={} sa_sub={}: {} — aborting dispatch to avoid running "
             "under wrong identity",
+            thread_ts,
             agent_id,
             sa_sub,
             exc,

--- a/ai_platform_engineering/integrations/slack_bot/utils/dispatch_identity.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/dispatch_identity.py
@@ -37,6 +37,7 @@ def apply_execution_identity(
     *,
     run_as_mode: str = "",
     sa_sub: Optional[str],
+    sa_name: Optional[str] = None,
     agent_id: str,
     context: dict[str, Any],
     event: dict[str, Any],
@@ -125,9 +126,10 @@ def apply_execution_identity(
         sa_obo = sa_loop.run_until_complete(impersonate_fn(sa_sub))
         context["obo_token"] = sa_obo.access_token
         logger.info(
-            "[{}] dispatch_identity: run_as=service_account agent={} sa_sub={} — minted SA token",
+            "[{}] dispatch_identity: run_as=service_account agent={} sa={} ({}) — minted SA token",
             thread_ts,
             agent_id,
+            sa_name or sa_sub,
             sa_sub,
         )
         return True
@@ -135,10 +137,11 @@ def apply_execution_identity(
         # PY-B2 / PY-S3: abort — never dispatch under the wrong identity.
         logger.warning(
             "[{}] dispatch_identity: run_as=service_account token mint cancelled "
-            "agent={} sa_sub={}: {} — aborting dispatch to avoid running "
+            "agent={} sa={} ({}): {} — aborting dispatch to avoid running "
             "under wrong identity",
             thread_ts,
             agent_id,
+            sa_name or sa_sub,
             sa_sub,
             exc,
         )
@@ -158,10 +161,11 @@ def apply_execution_identity(
         # PY-B2 / PY-S3: abort — never dispatch under the wrong identity.
         logger.warning(
             "[{}] dispatch_identity: run_as=service_account token mint failed "
-            "agent={} sa_sub={}: {} — aborting dispatch to avoid running "
+            "agent={} sa={} ({}): {} — aborting dispatch to avoid running "
             "under wrong identity",
             thread_ts,
             agent_id,
+            sa_name or sa_sub,
             sa_sub,
             exc,
         )

--- a/ai_platform_engineering/integrations/slack_bot/utils/dispatch_identity.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/dispatch_identity.py
@@ -85,7 +85,7 @@ def apply_execution_identity(
     """
     # Resolve the effective mode: prefer run_as_mode, fall back to exec_mode alias.
     effective_mode = run_as_mode or exec_mode
-    thread_ts = event.get("ts", "?") if event else "?"
+    thread_ts = event.get("ts") if event else None
     if effective_mode != "service_account":
         # obo_user path — context["obo_token"] was set by the middleware; nothing to do.
         unlinked = context.get("unlinked_fallback", False) if context else False


### PR DESCRIPTION
## Summary

- Bot messages in \`rbac_global_middleware\` were attempting Keycloak identity resolution using the bot's Slack user ID, which has no Keycloak account — falling through to the unlinked fallback path, trying to send a nudge DM to the bot, and logging a \`Could not send unlinked-access nudge\` warning on every bot message
- Bot allowlist comparison in \`_match_agents\` compared the bot's **name** string (e.g. \`"GitLab"\`) against the configured list, but operators typically configure the allowlist with the **user ID** (e.g. \`"U05LC2AV99N"\`) — these never matched, causing every bot message to be a route miss regardless of route type

## Fix

**Middleware (app.py — \`rbac_global_middleware\`)**: For bot messages (\`event.get("bot_id")\` is set), short-circuit to:
1. Skip Keycloak resolution and the nudge entirely
2. Resolve the bot's \`U\`-prefixed user ID via \`bots.info\` (mirrors the pattern in \`_route_to_agent\`), falling back to \`event["user"]\` then raw \`bot_id\`
3. Set \`slack_workspace_id\` and \`surface_kind\` in context (same as the human path)
4. Mint the unlinked SA token directly as a baseline \`obo_token\`
5. Set \`context["is_bot"] = True\` for downstream logging and allowlist checks

**Allowlist matching (app.py — \`_match_agents\`)**: Resolve both bot name and \`U\`-prefixed user ID via \`get_bot_info_by_id\` at the call site; accept a match on either. Operators can configure the allowlist with either format. This was the root cause of bot messages being silently dropped.

**Logging (dispatch_identity.py)**: Switch from stdlib \`logging\` to loguru (so log lines actually appear in bot output), add \`obo_user\` path log line, fix \`%s\` → \`{}\` format strings, use \`None\` ts fallback consistent with rest of codebase, log SA name alongside UUID.

Preserves correct behavior for both execution modes:
- **\`obo_user\`** routes: bot gets the unlinked SA token (same as an unlinked human), no nudge
- **\`service_account\`** routes: bot gets the unlinked SA token as baseline, which \`apply_execution_identity\` in \`_route_to_agent\` overwrites with the named SA token as normal

## Test plan

- [x] Human user message, \`run_as=obo_user\` → \`unlinked_fallback=False\`, user OBO token
- [x] Bot message, \`run_as=obo_user\` → \`unlinked_fallback=True\`, unlinked SA token, no nudge warning
- [x] Human user message, \`run_as=service_account\` → SA token minted
- [x] Bot message, \`run_as=service_account\` → SA token minted via new bot middleware code path, \`Routing bot message\` log confirmed
- [x] No \`Could not send unlinked-access nudge\` warning for bot messages
- [x] Bot allowlist matching works with both name string (e.g. \`GitLab\`) and U-prefixed user ID (e.g. \`U05LC2AV99N\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)