### PR TITLE
fix(ci): use github token for UI tag detection

### DIFF
--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -22,6 +22,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -43,23 +44,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: read
-          permission-actions: read
-
       - name: Determine Tag
         id: version
         uses: ./.github/actions/determine-release-tag
         with:
           manual_tag: ${{ inputs.tag_version }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
 
       - name: Detect changed paths
         id: filter


### PR DESCRIPTION
# Description

Fixes the CAIPE UI build workflow failure seen in https://github.com/cnoe-io/ai-platform-engineering/actions/runs/28181631151.

The `determine-changes` job was creating a GitHub App installation token even on tag and PR runs where the token is not needed. The explicit `permission-actions: read` request fails when the CI app installation does not grant Actions read access, so the workflow stops before tag detection or image build decisions run.

This PR changes `determine-changes` to use the built-in `GITHUB_TOKEN` for `.github/actions/determine-release-tag`, with workflow-level `actions: read` permission. The later package publishing and release notification app-token steps are left unchanged.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

Validation:

- `git diff --check`
- `actionlint -ignore 'unexpected key "description"' -ignore 'shellcheck reported issue' .github/workflows/ci-caipe-ui.yml`

Note: unfiltered `actionlint .github/workflows/ci-caipe-ui.yml` still reports pre-existing workflow issues: top-level `description` and shellcheck warnings in existing run blocks.