### PR TITLE
fix(okta-sync): handle DPoP nonce requirement automatically

### DIFF
--- a/ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts
@@ -10,6 +10,11 @@ const clientCtor = jest.fn();
 let mockGroups: unknown[] = [];
 let mockUsersByGroup: Record<string, unknown[]> = {};
 let listGroupsError: Error | null = null;
+// When set, the mock oauth.getAccessToken throws this on the first call (no nonce).
+let mockDpopNonceError: (Error & { status?: number; headers?: { get: (k: string) => string | null } }) | null = null;
+
+// Captures the last Client instance so tests can inspect oauth state after a call.
+let lastClientInstance: { oauth?: { isDPoP: boolean; accessToken: unknown } } | null = null;
 
 function makeCollection<T>(items: T[]) {
   return {
@@ -31,10 +36,31 @@ jest.mock(
         listGroups: (args?: unknown) => Promise<unknown>;
         listGroupUsers: (args: { groupId: string }) => Promise<unknown>;
       };
+      oauth: { isDPoP: boolean; accessToken: unknown; getAccessToken: (nonce?: string | null) => Promise<unknown> };
       constructor(config: unknown) {
         clientCtor(config);
+        // Simulate the SDK's OAuth object. patchOAuthDpopNonce wraps getAccessToken,
+        // so we set up the real-looking shape here. mockDpopNonceError lets tests
+        // inject a use_dpop_nonce failure on the first (no-nonce) call.
+        this.oauth = {
+          isDPoP: false,
+          accessToken: null,
+          getAccessToken: async function (nonce?: string | null) {
+            if (this.accessToken) return this.accessToken;
+            if (mockDpopNonceError && !nonce) throw mockDpopNonceError;
+            const tokenType = mockDpopNonceError ? "DPoP" : "Bearer";
+            this.accessToken = { access_token: "mock-token", token_type: tokenType };
+            return this.accessToken;
+          },
+        };
+        lastClientInstance = this as typeof lastClientInstance;
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
         this.groupApi = {
+          // Simulate the SDK calling oauth.getAccessToken before each request,
+          // so tests can exercise the DPoP patch without the real HTTP layer.
           listGroups: async (args?: unknown) => {
+            await self.oauth.getAccessToken();
             listGroupsCalls.push((args ?? {}) as Record<string, unknown>);
             if (listGroupsError) throw listGroupsError;
             return makeCollection(mockGroups);
@@ -57,7 +83,9 @@ describe("Okta directory connector (SDK-based)", () => {
     mockGroups = [];
     mockUsersByGroup = {};
     listGroupsError = null;
+    mockDpopNonceError = null;
     listGroupsCalls.length = 0;
+    lastClientInstance = null;
     process.env = {
       ...originalEnv,
       IDENTITY_SYNC_OKTA_ORG_URL: "https://example.okta.com",
@@ -200,6 +228,44 @@ describe("Okta directory connector (SDK-based)", () => {
     await expect(fetchOktaExternalGroups({ providerId: "okta-main" })).rejects.toThrow(
       "Okta directory connector is not configured"
     );
+  });
+
+  describe("DPoP nonce retry (patchOAuthDpopNonce)", () => {
+    const oauthEnv = {
+      IDENTITY_SYNC_OKTA_ORG_URL: "https://example.okta.com",
+      IDENTITY_SYNC_OKTA_OAUTH_CLIENT_ID: "0oaclient",
+      IDENTITY_SYNC_OKTA_OAUTH_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+    };
+
+    it("retries with the nonce and sets isDPoP=true when Okta returns use_dpop_nonce (400 + dpop-nonce header)", async () => {
+      process.env = { ...originalEnv, ...oauthEnv };
+      mockGroups = [];
+      // Inject a use_dpop_nonce error that carries the nonce in its headers.
+      // patchOAuthDpopNonce catches this, reads the nonce, retries, and sets isDPoP.
+      mockDpopNonceError = Object.assign(new Error("use_dpop_nonce"), {
+        status: 400,
+        headers: { get: (k: string) => (k === "dpop-nonce" ? "server-nonce-xyz" : null) },
+      });
+
+      const { fetchOktaExternalGroups } = await import("../../okta-directory-connector");
+      // Should not throw: the patch retries with the nonce successfully.
+      await expect(fetchOktaExternalGroups({ providerId: "okta-main" })).resolves.toEqual([]);
+      // isDPoP must be set so subsequent API calls use DPoP-bound auth.
+      expect(lastClientInstance?.oauth?.isDPoP).toBe(true);
+    });
+
+    it("does not retry and re-throws when the 400 has no dpop-nonce header", async () => {
+      process.env = { ...originalEnv, ...oauthEnv };
+      mockGroups = [];
+      // 400 error but no nonce header — should not retry, should propagate.
+      mockDpopNonceError = Object.assign(new Error("Bad Request"), {
+        status: 400,
+        headers: { get: () => null },
+      });
+
+      const { fetchOktaExternalGroups } = await import("../../okta-directory-connector");
+      await expect(fetchOktaExternalGroups({ providerId: "okta-main" })).rejects.toThrow("Bad Request");
+    });
   });
 
   describe("checkOktaConnectorHealth", () => {

--- a/ui/src/lib/rbac/okta-directory-connector.ts
+++ b/ui/src/lib/rbac/okta-directory-connector.ts
@@ -80,6 +80,36 @@ function oktaConfig(): OktaConnectorConfig {
 }
 
 /**
+ * The SDK's OAuth.getAccessToken always sends a DPoP header on the token
+ * request, but its use_dpop_nonce retry is unreachable: Http.errorFilter
+ * throws on 400 before the nonce check runs. This patch catches the thrown
+ * error, reads the dpop-nonce header Okta returns, and retries once with it.
+ * The guard `!dpop_nonce` prevents infinite retry if the second attempt also
+ * fails (it re-throws so the caller sees the real error).
+ */
+function patchOAuthDpopNonce(client: Client): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const oauth = (client as any).oauth;
+  if (!oauth) return;
+  const original = oauth.getAccessToken.bind(oauth) as (nonce?: string | null) => Promise<unknown>;
+  oauth.getAccessToken = async function (dpop_nonce: string | null = null): Promise<unknown> {
+    if (this.accessToken) return this.accessToken;
+    try {
+      return await original(dpop_nonce);
+    } catch (err: unknown) {
+      // OktaApiError surfaces status + headers from the raw fetch response.
+      const e = err as { status?: number; headers?: { get?: (k: string) => string | null } };
+      const nonce = e?.status === 400 ? (e?.headers?.get?.("dpop-nonce") ?? null) : null;
+      if (nonce && !dpop_nonce) {
+        this.isDPoP = true;
+        return await original(nonce);
+      }
+      throw err;
+    }
+  };
+}
+
+/**
  * Build an Okta SDK client for the configured auth mode. The SDK owns
  * pagination AND rate-limit handling (it honors Okta's X-Rate-Limit-* headers
  * and retries/queues internally), which is why we no longer hand-roll backoff
@@ -92,7 +122,7 @@ function buildOktaClient(config: OktaConnectorConfig): Client {
     const privateKey: string | Record<string, unknown> = trimmed.startsWith("{")
       ? (JSON.parse(trimmed) as Record<string, unknown>)
       : trimmed;
-    return new Client({
+    const client = new Client({
       orgUrl: config.orgUrl,
       authorizationMode: "PrivateKey",
       clientId: config.oauth.clientId,
@@ -100,6 +130,8 @@ function buildOktaClient(config: OktaConnectorConfig): Client {
       privateKey,
       ...(config.oauth.keyId ? { keyId: config.oauth.keyId } : {}),
     });
+    patchOAuthDpopNonce(client);
+    return client;
   }
   return new Client({ orgUrl: config.orgUrl, token: config.apiToken });
 }


### PR DESCRIPTION
# Description

The Okta SDK v8 (`@okta/okta-sdk-nodejs`) includes DPoP proof-of-possession support but has an unreachable retry path: `Http.errorFilter` throws on the `400 use_dpop_nonce` response before the nonce-check code can run. On Okta orgs that enforce DPoP on their API Services app, every token request fails silently, surfacing as a `Premature close` error on the first Management API call (`/api/v1/groups`).

This fix patches `oauth.getAccessToken` in `buildOktaClient` to catch the thrown `400` error, read the `dpop-nonce` header Okta returns, and retry the token request with it. After a successful nonce handshake, `isDPoP` is set to `true`, causing `http.js` to switch to `Authorization: DPoP …` + a DPoP proof header on all subsequent API calls — which is exactly what the SDK was already built to do, but never reached.

**No config change required** — DPoP is auto-detected. Orgs that don't enforce DPoP continue to work as before (first token call succeeds, `isDPoP` stays `false`).

Changed files:
- `ui/src/lib/rbac/okta-directory-connector.ts` — `patchOAuthDpopNonce()` helper + call from `buildOktaClient`
- `ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts` — 2 new tests covering nonce retry success and passthrough on errors without a nonce header

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass