### PR TITLE
fix(ci): use github token for UI GHCR push

### DIFF
--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -141,16 +141,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
       - name: Free disk space
         run: |
           echo "Disk usage before cleanup:"
@@ -183,7 +173,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.app-token.outputs.token }}
+          password: ${{ github.token }}
 
       - name: Extract metadata for Docker
         id: meta


### PR DESCRIPTION
# Description

Fixes the CAIPE UI publish failure seen in https://github.com/cnoe-io/ai-platform-engineering/actions/runs/28185848780.

PR #2010 changed the main `build-and-push` GHCR login in `.github/workflows/ci-caipe-ui.yml` from the workflow `github.token` to the `CI_BUILD_APP` installation token. The Docker build now succeeds, but GHCR rejects the custom app token while pushing `ghcr.io/cnoe-io/caipe-ui`:

```text
installation not allowed to Write organization package
```

This restores the supported, pre-#2010 behavior for the main UI image push: use the repository-scoped GitHub Actions token (`github.token`) for GHCR publishing. The job already grants `packages: write`, and this avoids using a human PAT while matching GitHub Packages' documented Actions auth path.

The now-unused `Generate GitHub App token` step is removed from `build-and-push`. Other CI app-token usage in `retag-unchanged` and `notify-release` is left unchanged.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

Validation:

- `git diff --check`
- `actionlint -ignore 'unexpected key "description"' -ignore 'shellcheck reported issue' .github/workflows/ci-caipe-ui.yml`

Note: unfiltered `actionlint` still reports pre-existing workflow issues unrelated to this patch.