### PR TITLE
fix(audit): run store.query in thread and narrow health-check lookback to 24h

### DIFF
--- a/ai_platform_engineering/audit_service/main.py
+++ b/ai_platform_engineering/audit_service/main.py
@@ -226,28 +226,27 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         query_limit = min(limit or current_settings.read_default_limit, current_settings.read_max_limit)
         query_time_resolution = _normalize_time_resolution(time_resolution)
-        result = store.query(
-            AuditQuery(
-                since=query_since,
-                until=query_until,
-                limit=query_limit,
-                time_resolution=query_time_resolution,
-                type=type,
-                outcome=outcome,
-                component=component,
-                correlation_id=correlation_id,
-                tenant_id=tenant_id,
-                source=source,
-                action=action,
-                capability=capability,
-                resource_ref=resource_ref,
-                subject_hash=subject_hash,
-                reason_code=reason_code,
-                agent_name=agent_name,
-                tool_name=tool_name,
-                user_email=user_email,
-            )
+        audit_query = AuditQuery(
+            since=query_since,
+            until=query_until,
+            limit=query_limit,
+            time_resolution=query_time_resolution,
+            type=type,
+            outcome=outcome,
+            component=component,
+            correlation_id=correlation_id,
+            tenant_id=tenant_id,
+            source=source,
+            action=action,
+            capability=capability,
+            resource_ref=resource_ref,
+            subject_hash=subject_hash,
+            reason_code=reason_code,
+            agent_name=agent_name,
+            tool_name=tool_name,
+            user_email=user_email,
         )
+        result = await asyncio.to_thread(store.query, audit_query)
         return QueryResponse(records=result.records, total=result.total, limit=query_limit, truncated=result.truncated)
 
     return app

--- a/ui/src/lib/rbac/connector-diagnostics.ts
+++ b/ui/src/lib/rbac/connector-diagnostics.ts
@@ -119,7 +119,7 @@ async function latestRuntimeError(
   const resourceRef = adapter.auditResourceRef(workspaceId, itemId);
   try {
     const until = new Date();
-    const since = new Date(until.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const since = new Date(until.getTime() - 24 * 60 * 60 * 1000);
     const rows = await getAuditReader().query({
       since,
       until,


### PR DESCRIPTION
# Description

The admin **Integrations → Slack** configured-channels page (`GET /api/admin/slack/channels?health=1`) was hanging for ~60s when audit-service was under load.

**Root cause 1 — audit-service event loop deadlock:** `store.query()` in `main.py` is a synchronous blocking call (disk scan for local backend, S3 list+read for S3 backend) invoked directly inside an `async` FastAPI handler. Under concurrent requests — e.g. 3 Slack channels each triggering a `latestRuntimeError` health query in parallel — the event loop blocks completely, `/healthz` stops responding, and kubelet kills the pod via liveness probe (exit code 137). This manifested as 9 pod restarts in ~2.5 hours on the dev cluster.

**Fix:** Wrap `store.query()` in `asyncio.to_thread()` so disk/network I/O runs off the event loop. Health probes remain responsive under any query load.

**Root cause 2 — 7-day scan window:** `latestRuntimeError` in `connector-diagnostics.ts` queried audit-service with a 7-day lookback. For a "recently errored?" health badge, 24 hours is sufficient and reduces the scan cost significantly.

**Fix:** Narrow the lookback from 7 days to 24 hours.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass