### PR TITLE
feat(mcp): add mcpSecrets alias and deprecate agentSecrets; fix ExternalSecret empty-data rejection

### DIFF
--- a/charts/ai-platform-engineering/charts/mcp-server/templates/NOTES.txt
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/NOTES.txt
@@ -1,3 +1,13 @@
+{{- if and .Values.agentSecrets (or .Values.agentSecrets.create .Values.agentSecrets.externalSecrets.enabled) }}
+DEPRECATION WARNING: agentSecrets is deprecated and will be removed in a future release.
+  Rename it to mcpSecrets in your values — the structure is identical:
+
+    mcpSecrets:
+      {{ toYaml .Values.agentSecrets | nindent 6 | trim }}
+
+  agentSecrets continues to work and is merged with mcpSecrets (mcpSecrets wins on conflict).
+{{- end }}
+
 {{- if .Values.vpa.enabled }}
 NOTE: VPA is enabled. Ensure VerticalPodAutoscaler is installed in your cluster before deploying.
       Install VPA: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/installation.md

--- a/charts/ai-platform-engineering/charts/mcp-server/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/_helpers.tpl
@@ -165,7 +165,7 @@ mcpSecrets (new) is deep-merged on top of agentSecrets (deprecated) so either ke
 Keys set in mcpSecrets take precedence; unset keys fall back to agentSecrets values.
 */}}
 {{- define "agent.effectiveSecrets" -}}
-    {{- mergeOverwrite (deepCopy .Values.agentSecrets) .Values.mcpSecrets | toYaml -}}
+    {{- mergeOverwrite (deepCopy .Values.agentSecrets) (.Values.mcpSecrets | default dict) | toYaml -}}
 {{- end -}}
 
 {{/*

--- a/charts/ai-platform-engineering/charts/mcp-server/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/_helpers.tpl
@@ -160,14 +160,24 @@ Get llmSecrets.externalSecrets.secretStoreRef with global fallback
 {{- end -}}
 
 {{/*
+Resolve the effective MCP secrets config.
+mcpSecrets (new) is deep-merged on top of agentSecrets (deprecated) so either key works.
+Keys set in mcpSecrets take precedence; unset keys fall back to agentSecrets values.
+*/}}
+{{- define "agent.effectiveSecrets" -}}
+    {{- mergeOverwrite (deepCopy .Values.agentSecrets) .Values.mcpSecrets | toYaml -}}
+{{- end -}}
+
+{{/*
 Get agentSecrets.create with global fallback
 Always false when requiresSecret is false
 */}}
 {{- define "agent.agentSecrets.create" -}}
-    {{- if not .Values.agentSecrets.requiresSecret -}}
+    {{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
+    {{- if not $s.requiresSecret -}}
         {{- false -}}
     {{- else -}}
-        {{- $create := .Values.agentSecrets.create -}}
+        {{- $create := $s.create -}}
         {{- with .Values.global -}}
             {{- with .agentSecrets -}}
                 {{- if hasKey . "create" -}}
@@ -183,10 +193,11 @@ Always false when requiresSecret is false
 Determine if external secrets are enabled for agentSecrets - prioritize global
 */}}
 {{- define "agent.agentSecrets.externalSecrets.enabled" -}}
-    {{- if not .Values.agentSecrets.requiresSecret -}}
+    {{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
+    {{- if not $s.requiresSecret -}}
         {{- false -}}
     {{- else -}}
-        {{- $enabled := (default false .Values.agentSecrets.externalSecrets.enabled) -}}
+        {{- $enabled := (default false $s.externalSecrets.enabled) -}}
         {{- with .Values.global -}}
             {{- with .externalSecrets -}}
                 {{- if and (hasKey . "enabled") .enabled -}}
@@ -209,7 +220,8 @@ Determine if external secrets are enabled for agentSecrets - prioritize global
 Get agentSecrets.externalSecrets.secretStoreRef with global fallback
 */}}
 {{- define "agent.agentSecrets.externalSecrets.secretStoreRef" -}}
-    {{- $ref := .Values.agentSecrets.externalSecrets.secretStoreRef -}}
+    {{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
+    {{- $ref := $s.externalSecrets.secretStoreRef -}}
     {{- with .Values.global -}}
         {{- with .externalSecrets -}}
             {{- if hasKey . "secretStoreRef" -}}
@@ -224,9 +236,10 @@ Get agentSecrets.externalSecrets.secretStoreRef with global fallback
 Get agentSecrets.secretName - if empty assume no secret, if not append agent.name as prefix
 */}}
 {{- define "agent.agentSecrets.secretName" -}}
-    {{- if .Values.agentSecrets.requiresSecret -}}
-        {{- if .Values.agentSecrets.secretName -}}
-            {{- .Values.agentSecrets.secretName -}}
+    {{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
+    {{- if $s.requiresSecret -}}
+        {{- if $s.secretName -}}
+            {{- $s.secretName -}}
         {{- else -}}
             {{- printf "%s-secret" (include "agent.name" .) -}}
         {{- end -}}
@@ -239,9 +252,10 @@ Get agentSecrets.secretName - if empty assume no secret, if not append agent.nam
 Get agentSecrets.externalSecrets.name - if empty assume no secret, if not append agent.name as prefix
 */}}
 {{- define "agent.agentSecrets.externalSecrets.name" -}}
-    {{- if .Values.agentSecrets.requiresSecret -}}
-        {{- if .Values.agentSecrets.externalSecrets.name -}}
-            {{- .Values.agentSecrets.externalSecrets.name -}}
+    {{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
+    {{- if $s.requiresSecret -}}
+        {{- if $s.externalSecrets.name -}}
+            {{- $s.externalSecrets.name -}}
         {{- else -}}
             {{- printf "%s-secret" (include "agent.name" .) -}}
         {{- end -}}

--- a/charts/ai-platform-engineering/charts/mcp-server/templates/agent-externalsecrets.yaml
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/agent-externalsecrets.yaml
@@ -38,7 +38,13 @@ spec:
     {{- end }}
 
   # Data defines the connection between the Kubernetes Secret keys and the Provider data
+  {{- if .Values.agentSecrets.externalSecrets.data }}
   data:
     {{- toYaml .Values.agentSecrets.externalSecrets.data | nindent 4 }}
+  {{- end }}
+  {{- if .Values.agentSecrets.externalSecrets.dataFrom }}
+  dataFrom:
+    {{- toYaml .Values.agentSecrets.externalSecrets.dataFrom | nindent 4 }}
+  {{- end }}
 ---
 {{- end }}

--- a/charts/ai-platform-engineering/charts/mcp-server/templates/agent-externalsecrets.yaml
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/agent-externalsecrets.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "agent.agentSecrets.externalSecrets.enabled" .) "true" }}
+{{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -22,29 +23,29 @@ spec:
     # Defaults to .metadata.name of the ExternalSecret
     # It is immutable
     name: {{ include "agent.agentSecrets.secretName" . }}
-    {{- if .Values.agentSecrets.externalSecrets.target.template }}
+    {{- if $s.externalSecrets.target.template }}
     template:
-      {{- if .Values.agentSecrets.externalSecrets.target.template.engineVersion }}
-      engineVersion: {{ .Values.agentSecrets.externalSecrets.target.template.engineVersion }}
+      {{- if $s.externalSecrets.target.template.engineVersion }}
+      engineVersion: {{ $s.externalSecrets.target.template.engineVersion }}
       {{- end }}
-      {{- if .Values.agentSecrets.externalSecrets.target.template.data }}
+      {{- if $s.externalSecrets.target.template.data }}
       data:
-        {{- toYaml .Values.agentSecrets.externalSecrets.target.template.data | nindent 8 }}
+        {{- toYaml $s.externalSecrets.target.template.data | nindent 8 }}
       {{- end }}
-      {{- if .Values.agentSecrets.externalSecrets.target.template.metadata }}
+      {{- if $s.externalSecrets.target.template.metadata }}
       metadata:
-        {{- toYaml .Values.agentSecrets.externalSecrets.target.template.metadata | nindent 8 }}
+        {{- toYaml $s.externalSecrets.target.template.metadata | nindent 8 }}
       {{- end }}
     {{- end }}
 
   # Data defines the connection between the Kubernetes Secret keys and the Provider data
-  {{- if .Values.agentSecrets.externalSecrets.data }}
+  {{- if $s.externalSecrets.data }}
   data:
-    {{- toYaml .Values.agentSecrets.externalSecrets.data | nindent 4 }}
+    {{- toYaml $s.externalSecrets.data | nindent 4 }}
   {{- end }}
-  {{- if .Values.agentSecrets.externalSecrets.dataFrom }}
+  {{- if $s.externalSecrets.dataFrom }}
   dataFrom:
-    {{- toYaml .Values.agentSecrets.externalSecrets.dataFrom | nindent 4 }}
+    {{- toYaml $s.externalSecrets.dataFrom | nindent 4 }}
   {{- end }}
 ---
 {{- end }}

--- a/charts/ai-platform-engineering/charts/mcp-server/templates/agent-secret.yaml
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/agent-secret.yaml
@@ -8,7 +8,8 @@ metadata:
     {{- include "agent.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $value := .Values.agentSecrets.data }}
+  {{- $s := fromYaml (include "agent.effectiveSecrets" .) -}}
+  {{- range $key, $value := $s.data }}
   {{- if $value }}
   {{ $key }}: {{ $value | toString | b64enc | quote }}
   {{- end }}

--- a/charts/ai-platform-engineering/charts/mcp-server/values.yaml
+++ b/charts/ai-platform-engineering/charts/mcp-server/values.yaml
@@ -101,7 +101,15 @@ llmSecrets:
       kind: ClusterSecretStore # Use your secret store kind
     data: []
 
-# Secrets configuration for agent-specific secrets (API keys, etc.).
+# Secrets configuration for MCP server-specific secrets (API keys, etc.).
+# mcpSecrets keys take precedence over agentSecrets when both are set.
+mcpSecrets:
+  # Override any subset of agentSecrets fields here. Unset keys fall back to agentSecrets.
+  # Example: set externalSecrets.enabled: true here to enable ExternalSecret without
+  # duplicating the full agentSecrets block.
+
+# -- DEPRECATED: use mcpSecrets instead. Retained for backwards compatibility.
+# agentSecrets and mcpSecrets are deep-merged; mcpSecrets wins on conflict.
 agentSecrets:
   requiresSecret: true # if false, no agent secret is required e.g. api keys
   create: false # if false, it'll assume that the secret already exists
@@ -115,6 +123,7 @@ agentSecrets:
       kind: ClusterSecretStore # Use your secret store kind
     target: {}
     data: []
+    dataFrom: []
     dataFrom: []
 
 # MCP (Model Context Protocol) server configuration.

--- a/charts/ai-platform-engineering/charts/mcp-server/values.yaml
+++ b/charts/ai-platform-engineering/charts/mcp-server/values.yaml
@@ -103,10 +103,9 @@ llmSecrets:
 
 # Secrets configuration for MCP server-specific secrets (API keys, etc.).
 # mcpSecrets keys take precedence over agentSecrets when both are set.
-mcpSecrets:
-  # Override any subset of agentSecrets fields here. Unset keys fall back to agentSecrets.
-  # Example: set externalSecrets.enabled: true here to enable ExternalSecret without
-  # duplicating the full agentSecrets block.
+# mcpSecrets overrides agentSecrets when set. Unset keys fall back to agentSecrets values.
+# Example: set mcpSecrets.externalSecrets.enabled: true without duplicating the full block.
+mcpSecrets: {}
 
 # -- DEPRECATED: use mcpSecrets instead. Retained for backwards compatibility.
 # agentSecrets and mcpSecrets are deep-merged; mcpSecrets wins on conflict.

--- a/charts/ai-platform-engineering/charts/mcp-server/values.yaml
+++ b/charts/ai-platform-engineering/charts/mcp-server/values.yaml
@@ -115,6 +115,7 @@ agentSecrets:
       kind: ClusterSecretStore # Use your secret store kind
     target: {}
     data: []
+    dataFrom: []
 
 # MCP (Model Context Protocol) server configuration.
 # An in-cluster MCP HTTP Deployment + Service is created when mode is "http" and


### PR DESCRIPTION
## Summary

- Introduces `mcpSecrets` as the canonical key for MCP server secret config, deprecating `agentSecrets` (which predates the MCP server naming). Both keys work via a deep merge — `mcpSecrets` wins on conflict, `agentSecrets` is the fallback. No breaking change.
- Fixes ExternalSecret admission webhook rejection: when `externalSecrets.enabled: true` but `data: []`, the template rendered `data: []` which was rejected with `either data or dataFrom should be specified`. Guards both fields so they only render when non-empty.
- Adds `dataFrom` support to `agent-externalsecrets.yaml` (was missing entirely from both template and values), enabling Vault bulk-extract as an alternative to listing keys individually.

## Changes

| File | What changed |
|---|---|
| `_helpers.tpl` | New `agent.effectiveSecrets` helper (mergeOverwrite agentSecrets ← mcpSecrets); all existing `agentSecrets` helpers updated to use it |
| `agent-externalsecrets.yaml` | Uses `agent.effectiveSecrets`; guards `data:`/`dataFrom:`; adds `dataFrom` block |
| `agent-secret.yaml` | Uses `agent.effectiveSecrets` |
| `values.yaml` | Adds `mcpSecrets: {}` with migration comment; marks `agentSecrets` deprecated; adds `dataFrom: []` default |
| `NOTES.txt` | Prints deprecation warning when `agentSecrets` is actively used (create or externalSecrets.enabled) |

## Migration (no urgency — agentSecrets still works)

```yaml
# Before
agentSecrets:
  externalSecrets:
    enabled: true
    data: [...]

# After
mcpSecrets:
  externalSecrets:
    enabled: true
    data: [...]
```

## Test plan

- [ ] `helm template` with `agentSecrets` config renders identically to before
- [ ] `helm template` with `mcpSecrets` config produces same output as equivalent `agentSecrets` config
- [ ] `helm template` with `externalSecrets.enabled=true` and empty `data` no longer renders a `data:` field
- [ ] `helm template` with populated `dataFrom` renders the new `dataFrom:` block
- [ ] `helm install` with old `agentSecrets` values shows deprecation warning in NOTES output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)