### PR TITLE
chore(ci): rename Sub-Agents MCP workflows to MCP Servers

### DIFF
--- a/.github/workflows/ci-mcp-servers.yml
+++ b/.github/workflows/ci-mcp-servers.yml
@@ -1,5 +1,5 @@
-name: "[CI][MCP] Sub-Agents MCP Docker Build and Push"
-description: "Build and push MCP Docker images for sub-agents"
+name: "[CI][MCP] MCP Servers Docker Build and Push"
+description: "Build and push MCP server Docker images"
 
 on:
   push:

--- a/.github/workflows/prebuild-mcp-servers.yml
+++ b/.github/workflows/prebuild-mcp-servers.yml
@@ -1,5 +1,5 @@
-name: "[Prebuild][MCP] Sub-Agents MCP Docker Build and Push"
-description: "Build and push MCP Docker images for sub-agents"
+name: "[Prebuild][MCP] MCP Servers Docker Build and Push"
+description: "Build and push MCP server Docker images"
 
 on:
   pull_request:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -86,7 +86,7 @@ jobs:
           # tag, so an unbuilt image would otherwise produce ImagePullBackOff
           # on every fresh install with global.skillScanner.enabled=true.
           REQUIRED_WORKFLOWS=(
-            "[CI][MCP] Sub-Agents MCP Docker Build and Push"
+            "[CI][MCP] MCP Servers Docker Build and Push"
             "[CI] CAIPE RAG Build and Push"
             "[CI] Dynamic Agents Build and Push"
             "[CI] CAIPE UI Build and Push"

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -211,7 +211,7 @@ jobs:
           echo "### CI (triggered by tag push) ⏳" >> $GITHUB_STEP_SUMMARY
           echo "CI workflows run from the pushed \`$NEW_VERSION\` tag and publish matching artifacts when complete:" >> $GITHUB_STEP_SUMMARY
           echo "- Dynamic agents" >> $GITHUB_STEP_SUMMARY
-          echo "- MCP sub-agents" >> $GITHUB_STEP_SUMMARY
+          echo "- MCP servers" >> $GITHUB_STEP_SUMMARY
           echo "- RAG components" >> $GITHUB_STEP_SUMMARY
           echo "- CAIPE UI" >> $GITHUB_STEP_SUMMARY
           echo "- Slack bot" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Renames `ci-mcp-sub-agent.yml` → `ci-mcp-servers.yml` and `prebuild-mcp-agent.yml` → `prebuild-mcp-servers.yml`
- Drops "Sub-Agents" from both workflow display names now that the sub-agent concept has been removed
- Updates `release-finalize.yml` `REQUIRED_WORKFLOWS` array and `release-manual.yml` step summary to match the new name

## Test plan
- [ ] CI workflow appears as `[CI][MCP] MCP Servers Docker Build and Push` on next PR touching MCP paths
- [ ] `release-finalize.yml` correctly waits on the renamed workflow

🤖 Generated with [Claude Code](https://claude.ai/claude-code)