### PR TITLE
fix(webex): simplify space onboarding and direct routing

### DIFF
--- a/ai_platform_engineering/integrations/webex_bot/app.py
+++ b/ai_platform_engineering/integrations/webex_bot/app.py
@@ -134,6 +134,7 @@ class RouteResolverProtocol(Protocol):
         space_id: str,
         person_id: str,
         text: str,
+        is_direct: bool = False,
     ) -> WebexRouteResolution:
         """Resolve the agent route to dispatch this message to."""
         raise NotImplementedError
@@ -357,6 +358,7 @@ class _WebexAgentRouteResolver:
         space_id: str,
         person_id: str,
         text: str,
+        is_direct: bool = False,
     ) -> WebexRouteResolution:
         from .utils.webex_agent_routes import resolve_webex_agent_route
 
@@ -365,6 +367,7 @@ class _WebexAgentRouteResolver:
             space_id=space_id,
             person_id=person_id,
             text=text,
+            is_direct=is_direct,
         )
         return WebexRouteResolution(agent_id=agent_id, deny_message=deny_message)
 
@@ -603,6 +606,7 @@ async def handle_webex_message(
         space_id=parsed.space_id,
         person_id=parsed.person_id,
         text=parsed.text,
+        is_direct=parsed.is_direct,
     )
     agent_id = route.agent_id
     if not agent_id:

--- a/ai_platform_engineering/integrations/webex_bot/tests/test_runtime_gate.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_runtime_gate.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from ai_platform_engineering.integrations.webex_bot.app import (
@@ -109,8 +109,10 @@ class FakeRebacChecker:
 @dataclass
 class FakeRouteResolver:
     agent_id: Optional[str] = "agent-1"
+    calls: list[dict[str, Any]] = field(default_factory=list)
 
     async def resolve_route(self, **kwargs: Any) -> WebexRouteResolution:
+        self.calls.append(kwargs)
         if not self.agent_id:
             return WebexRouteResolution(
                 agent_id=None,
@@ -414,3 +416,24 @@ def test_parsed_webex_event_carries_is_direct_flag() -> None:
     )
     assert unspecified is not None
     assert unspecified.is_direct is False
+
+
+def test_direct_webex_event_passes_direct_flag_to_route_resolver() -> None:
+    route_resolver = FakeRouteResolver(agent_id="incident-agent")
+    dispatcher = FakeDispatcher()
+    result = asyncio.run(
+        handle_webex_message(
+            _event(text="howdy") | {"roomType": "direct"},
+            identity_linker=FakeIdentityLinker(),
+            team_resolver=FakeTeamResolver(),
+            obo_exchanger=FakeOboExchanger(),
+            rebac_checker=FakeRebacChecker(),
+            route_resolver=route_resolver,
+            dispatcher=dispatcher,
+        )
+    )
+
+    assert result.allowed is True
+    assert result.dispatched is True
+    assert route_resolver.calls[0]["is_direct"] is True
+    assert dispatcher.calls[0]["agent_id"] == "incident-agent"

--- a/ai_platform_engineering/integrations/webex_bot/tests/test_webex_agent_routes.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_webex_agent_routes.py
@@ -130,6 +130,79 @@ def test_resolver_matches_enabled_routes_by_listen_and_priority() -> None:
     assert [match.agent_id for match in matches] == ["high-priority-agent", "low-priority-agent"]
 
 
+def test_resolve_direct_webex_message_uses_existing_mention_route(monkeypatch) -> None:
+    monkeypatch.setenv("WEBEX_AGENT_ROUTES_MODE", "db_only")
+    collection = _Collection(
+        [
+            {
+                "workspace_id": "CAIPE-WEBEX",
+                "space_id": "direct-space12345",
+                "agent_id": "personal-agent",
+                "enabled": True,
+                "priority": 10,
+                "status": "active",
+                "users": {"enabled": True, "listen": "mention"},
+            },
+        ]
+    )
+    resolver = WebexAgentRouteResolver(
+        collection_factory=lambda: collection,
+        openfga_agent_ids_factory=lambda _workspace_id, _space_id: ["personal-agent"],
+    )
+
+    async def _run() -> tuple[str | None, str | None]:
+        return await resolve_webex_agent_route(
+            workspace_id="CAIPE-WEBEX",
+            space_id="direct-space12345",
+            person_id="person1234",
+            text="howdy",
+            is_direct=True,
+            resolver=resolver,
+        )
+
+    agent_id, deny = asyncio.run(_run())
+
+    assert agent_id == "personal-agent"
+    assert deny is None
+
+
+def test_plain_group_message_route_mismatch_uses_plain_language() -> None:
+    collection = _Collection(
+        [
+            {
+                "workspace_id": "CAIPE-WEBEX",
+                "space_id": "space12345",
+                "agent_id": "mention-only-agent",
+                "enabled": True,
+                "priority": 10,
+                "status": "active",
+                "users": {"enabled": True, "listen": "mention"},
+            },
+        ]
+    )
+    resolver = WebexAgentRouteResolver(
+        collection_factory=lambda: collection,
+        openfga_agent_ids_factory=lambda _workspace_id, _space_id: ["mention-only-agent"],
+    )
+
+    explanation = resolver.explain_no_route_match(
+        workspace_id="CAIPE-WEBEX",
+        space_id="space12345",
+        is_bot=False,
+        user_id="person1234",
+        listen="message",
+        route_required=True,
+    )
+
+    assert explanation == (
+        "I can help in this Webex space when you mention CAIPE. Try mentioning "
+        "CAIPE with your question, or ask an admin to enable always-on replies "
+        "for this space."
+    )
+    for internal_term in ("OpenFGA", "Listen mode", "plain space messages", "Admin >"):
+        assert internal_term not in explanation
+
+
 def test_resolver_ignores_mongo_routes_without_openfga_tuple() -> None:
     collection = _Collection(
         [
@@ -348,6 +421,27 @@ def test_resolve_webex_agent_route_denies_on_openfga_outage_db_prefer(monkeypatc
 
 def test_resolve_webex_agent_route_denies_on_openfga_outage_db_only(monkeypatch) -> None:
     _resolve_denies_when_last_error("db_only", monkeypatch)
+
+
+def test_route_required_without_space_agent_association_uses_setup_message() -> None:
+    resolver = WebexAgentRouteResolver(
+        collection_factory=lambda: _Collection([]),
+        openfga_agent_ids_factory=lambda _workspace_id, _space_id: [],
+    )
+
+    explanation = resolver.explain_no_route_match(
+        workspace_id="CAIPE-WEBEX",
+        space_id="space12345",
+        is_bot=False,
+        user_id="person1234",
+        listen="message",
+        route_required=True,
+    )
+
+    assert explanation == (
+        "This Webex space is not set up for CAIPE yet. Ask an admin to set up "
+        "the Webex integration for this space in CAIPE."
+    )
 
 
 def test_resolve_webex_agent_route_db_prefer_falls_back_to_default_agent(monkeypatch) -> None:

--- a/ai_platform_engineering/integrations/webex_bot/tests/test_webex_responder.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_webex_responder.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -94,6 +95,10 @@ class FailingThreadContextWebexApi(FakeWebexApi):
         raise RuntimeError("webex unavailable")
 
 
+def _webex_timestamp(age: timedelta = timedelta()) -> str:
+    return (datetime.now(timezone.utc) - age).isoformat().replace("+00:00", "Z")
+
+
 def test_unlinked_user_gets_private_card_and_generic_thread_notice(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("APP_NAME", "Grid")
     api = FakeWebexApi()
@@ -122,6 +127,7 @@ def test_unlinked_user_gets_private_card_and_generic_thread_notice(monkeypatch: 
     assert direct_message["markdown"] == "Link your Grid account to Webex to continue."
     card = direct_message["attachments"][0]["content"]
     assert card["type"] == "AdaptiveCard"
+    assert card["body"][1]["text"] == "Verify your identity to interface with Grid agents."
     assert card["actions"][0] == {
         "type": "Action.OpenUrl",
         "title": "Link with SSO",
@@ -173,6 +179,112 @@ def test_unlinked_user_does_not_get_duplicate_linking_cards_within_cooldown(
     assert len(direct_messages) == 1
     assert len(thread_messages) == 2
     assert "card I sent earlier" in thread_messages[1]["markdown"]
+
+
+def test_unlinked_user_does_not_get_duplicate_card_when_room_already_has_link_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ai_platform_engineering.integrations.webex_bot import webex_responder as responder_module
+
+    monkeypatch.setenv("APP_NAME", "Grid")
+    responder_module._recent_linking_cards_sent.clear()
+    api = FakeWebexApi(
+        thread_messages=[
+            {
+                "markdown": "Link your Grid account to Webex to continue.",
+                "created": _webex_timestamp(),
+                "attachments": [
+                    {
+                        "content": {
+                            "type": "AdaptiveCard",
+                            "body": [{"text": "Link Grid to Webex"}],
+                            "actions": [{"title": "Link with SSO"}],
+                        }
+                    }
+                ],
+            }
+        ]
+    )
+    responder = WebexResponder(webex_api=api)
+    event = {
+        "data": {
+            "id": "message-public-id",
+            "webexRoomId": "room-public-id",
+            "personId": "person-public-id",
+        }
+    }
+    result = WebexMessageResult(
+        allowed=False,
+        dispatched=False,
+        ignored=False,
+        reason_code="WEBEX_USER_NOT_LINKED",
+        deny_message="Your Webex account is not linked.",
+        linking_url="http://localhost:3000/api/auth/webex-link?x=2",
+    )
+
+    asyncio.run(responder.reply_to_result(event, result))
+
+    direct_messages = [msg for msg in api.created if msg.get("person_id")]
+    assert direct_messages == []
+    assert api.created == [
+        {
+            "room_id": "room-public-id",
+            "parent_id": "message-public-id",
+            "markdown": (
+                "Your Webex account still needs to be linked to Grid. "
+                "Open your **1:1 chat with me** and tap **Link with SSO** on the card I sent earlier "
+                "(links expire after 10 minutes). After linking, retry here — no need to wait for a new card."
+            ),
+        }
+    ]
+
+
+def test_unlinked_user_gets_new_card_when_existing_card_is_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ai_platform_engineering.integrations.webex_bot import webex_responder as responder_module
+
+    monkeypatch.setenv("APP_NAME", "Grid")
+    responder_module._recent_linking_cards_sent.clear()
+    api = FakeWebexApi(
+        thread_messages=[
+            {
+                "markdown": "Link your Grid account to Webex to continue.",
+                "created": _webex_timestamp(timedelta(minutes=11)),
+                "attachments": [
+                    {
+                        "content": {
+                            "type": "AdaptiveCard",
+                            "body": [{"text": "Link Grid to Webex"}],
+                            "actions": [{"title": "Link with SSO"}],
+                        }
+                    }
+                ],
+            }
+        ]
+    )
+    responder = WebexResponder(webex_api=api)
+    event = {
+        "data": {
+            "id": "message-public-id",
+            "webexRoomId": "room-public-id",
+            "personId": "person-public-id",
+        }
+    }
+    result = WebexMessageResult(
+        allowed=False,
+        dispatched=False,
+        ignored=False,
+        reason_code="WEBEX_USER_NOT_LINKED",
+        deny_message="Your Webex account is not linked.",
+        linking_url="http://localhost:3000/api/auth/webex-link?x=3",
+    )
+
+    asyncio.run(responder.reply_to_result(event, result))
+
+    direct_messages = [msg for msg in api.created if msg.get("person_id")]
+    assert len(direct_messages) == 1
+    assert direct_messages[0]["attachments"][0]["content"]["actions"][0]["url"].endswith("x=3")
 
 
 def test_unlinked_user_dm_failure_does_not_post_signed_link_publicly(

--- a/ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py
@@ -18,6 +18,7 @@ from ai_platform_engineering.integrations.webex_bot.webex_wdm import (
     websocket_connect_header_kwargs,
     websocket_handshake_status,
 )
+from ai_platform_engineering.integrations.webex_bot.app import parse_webex_event
 from ai_platform_engineering.integrations.webex_bot.utils.webex_ids import (
     canonicalize_webex_space_id,
     public_webex_room_id_from_uuid,
@@ -50,6 +51,7 @@ def test_wdm_activity_uses_fetched_message_detail_for_gate_payload() -> None:
         "roomId": PUBLIC_ROOM_ID,
         "personId": "person-public-id",
         "personEmail": "user@example.com",
+        "roomType": "direct",
         "text": "neo-coder hello",
         "mentionedPeople": ["bot-person-id"],
     }
@@ -69,11 +71,15 @@ def test_wdm_activity_uses_fetched_message_detail_for_gate_payload() -> None:
             "webexRoomId": PUBLIC_ROOM_ID,
             "personId": "person-public-id",
             "personEmail": "user@example.com",
+            "roomType": "direct",
             "text": "neo-coder hello",
             "mentionedPeople": ["bot-person-id"],
             "isSelf": False,
         },
     }
+    parsed = parse_webex_event(event)
+    assert parsed is not None
+    assert parsed.is_direct is True
 
 
 # ── WDM device reuse + message dedup ───────────────────────────────────────

--- a/ai_platform_engineering/integrations/webex_bot/utils/user_messages.py
+++ b/ai_platform_engineering/integrations/webex_bot/utils/user_messages.py
@@ -17,6 +17,23 @@ GENERIC_REQUEST_DENIED_MESSAGE = (
     "Please try again, or ask an admin to check the space setup in CAIPE."
 )
 
+
+WEBEX_SPACE_MENTION_REQUIRED_MESSAGE = (
+    "I can help in this Webex space when you mention {app_name}. "
+    "Try mentioning {app_name} with your question, or ask an admin to enable "
+    "always-on replies for this space."
+)
+
+WEBEX_SPACE_SETUP_REQUIRED_MESSAGE = (
+    "This Webex space is not set up for {app_name} yet. Ask an admin to set up "
+    "the Webex integration for this space in {app_name}."
+)
+
+WEBEX_DIRECT_AGENT_REQUIRED_MESSAGE = (
+    "I couldn't find an agent for this 1:1 Webex chat. Open {app_name} and "
+    "choose a default agent, or ask an admin to check your Webex setup."
+)
+
 FRIENDLY_REASON_MESSAGES = {
     "WEBEX_OBO_FAILED": TEAM_SESSION_UNAVAILABLE_MESSAGE,
     "WEBEX_WORKSPACE_UNCONFIGURED": (

--- a/ai_platform_engineering/integrations/webex_bot/utils/webex_agent_routes.py
+++ b/ai_platform_engineering/integrations/webex_bot/utils/webex_agent_routes.py
@@ -21,6 +21,11 @@ from ai_platform_engineering.integrations.slack_bot.utils.config_models import (
     EscalationConfig,
     UsersConfig,
 )
+from ai_platform_engineering.integrations.webex_bot.utils.user_messages import (
+    WEBEX_DIRECT_AGENT_REQUIRED_MESSAGE,
+    WEBEX_SPACE_MENTION_REQUIRED_MESSAGE,
+    WEBEX_SPACE_SETUP_REQUIRED_MESSAGE,
+)
 
 logger = logging.getLogger("caipe.webex_bot.webex_agent_routes")
 DEFAULT_OPENFGA_HTTP = "http://openfga:8080"
@@ -322,6 +327,7 @@ class WebexAgentRouteResolver:
         listen: Optional[str] = None,
         app_name: str = "CAIPE",
         route_required: bool = False,
+        is_direct: bool = False,
     ) -> str | None:
         """Return a user-facing explanation when a routed Webex message has no match."""
 
@@ -346,23 +352,18 @@ class WebexAgentRouteResolver:
                 "so I cannot safely dispatch this message. Please try again shortly "
                 "or ask an admin to check Webex Runtime Diagnostics."
             )
+        if is_direct:
+            return WEBEX_DIRECT_AGENT_REQUIRED_MESSAGE.format(app_name=app_name)
         if candidates and listen == "message":
-            return (
-                f"This Webex space has {app_name} agent routes, but none are configured "
-                f"to listen to plain space messages. Mention {app_name}, or set the route "
-                "Listen mode to `message` or `all` in Admin > OpenFGA ReBAC > Webex Spaces."
-            )
+            return WEBEX_SPACE_MENTION_REQUIRED_MESSAGE.format(app_name=app_name)
         if candidates and listen == "mention":
             return (
-                f"This Webex space has {app_name} agent routes, but none are configured "
-                "to listen to mentions. Set the route Listen mode to `mention` or `all` "
-                "in Admin > OpenFGA ReBAC > Webex Spaces."
+                f"I found Webex routes for this space, but none can respond to "
+                f"{app_name} mentions yet. Ask an admin to check this space's "
+                f"Webex setup in {app_name}."
             )
         if route_required:
-            return (
-                "No OpenFGA space-agent association is configured for this Webex space. "
-                "Ask an admin to add one in Admin > OpenFGA ReBAC > Webex Spaces."
-            )
+            return WEBEX_SPACE_SETUP_REQUIRED_MESSAGE.format(app_name=app_name)
         return None
 
     def invalidate(self, workspace_id: str, space_id: str) -> None:
@@ -391,12 +392,16 @@ async def resolve_webex_agent_route(
     space_id: str,
     person_id: str,
     text: str,
+    is_direct: bool = False,
     resolver: WebexAgentRouteResolver | None = None,
 ) -> tuple[Optional[str], Optional[str]]:
     """Resolve the agent for a Webex message (agent_id, deny_message)."""
 
     mode = webex_agent_route_mode()
-    listen = infer_listen_mode(text)
+    # assisted-by Codex Codex-sonnet-4-6
+    # 1:1 Webex rooms have no mention gesture, so direct messages should
+    # use any active user route for that room instead of requiring message mode.
+    listen = None if is_direct else infer_listen_mode(text)
     active = resolver or get_webex_agent_route_resolver()
 
     if mode == "config":
@@ -419,6 +424,7 @@ async def resolve_webex_agent_route(
             is_bot=False,
             user_id=person_id,
             listen=listen,
+            is_direct=is_direct,
             route_required=True,
         )
     if matches:
@@ -430,6 +436,7 @@ async def resolve_webex_agent_route(
             is_bot=False,
             user_id=person_id,
             listen=listen,
+            is_direct=is_direct,
             route_required=True,
         )
         return None, deny or "No agent route is configured for this Webex space."
@@ -443,6 +450,7 @@ async def resolve_webex_agent_route(
         is_bot=False,
         user_id=person_id,
         listen=listen,
+        is_direct=is_direct,
         route_required=not bool(agent_id),
     )
     return None, deny or "No agent route is configured for this Webex space."

--- a/ai_platform_engineering/integrations/webex_bot/webex_responder.py
+++ b/ai_platform_engineering/integrations/webex_bot/webex_responder.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import os
 import time
+from datetime import datetime
 from typing import Any, Protocol
 
 import httpx
@@ -27,7 +28,10 @@ logger = logging.getLogger("caipe.webex_bot.webex_responder")
 
 WEBEX_API_BASE_URL = "https://webexapis.com/v1"
 # Avoid spamming duplicate 1:1 linking cards when the user retries before completing SSO.
-_LINKING_CARD_COOLDOWN_SECONDS = 15 * 60
+# Webex link HMACs expire after 10 minutes in the UI BFF. Keep the resend
+# guard shorter so we never point users at an expired card.
+# assisted-by Codex Codex-sonnet-4-6
+_LINKING_CARD_COOLDOWN_SECONDS = 9 * 60
 _recent_linking_cards_sent: dict[str, float] = {}
 
 
@@ -218,7 +222,9 @@ class WebexResponder:
 
         now = time.time()
         last_sent = _recent_linking_cards_sent.get(person_id)
-        if last_sent is not None and now - last_sent < _LINKING_CARD_COOLDOWN_SECONDS:
+        if (
+            last_sent is not None and now - last_sent < _LINKING_CARD_COOLDOWN_SECONDS
+        ) or await self._recent_linking_card_exists(room_id=room_id, app_name=app_name, now=now):
             await self._reply_to_thread(
                 room_id=room_id,
                 parent_id=parent_id,
@@ -258,6 +264,29 @@ class WebexResponder:
                 "Complete linking there, then retry your request."
             ),
         )
+
+    async def _recent_linking_card_exists(self, *, room_id: str, app_name: str, now: float) -> bool:
+        # assisted-by Codex Codex-sonnet-4-6
+        # Webex WDM can replay messages across reconnects or across duplicate
+        # bot instances. The in-memory person cache is still fast, but checking
+        # the 1:1 room history prevents another card after a local restart.
+        try:
+            messages = await asyncio.to_thread(
+                self._webex_api.list_messages,
+                room_id=room_id,
+                max_messages=20,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not inspect Webex room for recent linking cards (type=%s)", type(exc).__name__)
+            return False
+
+        for message in messages:
+            if not _looks_like_linking_message(message, app_name=app_name):
+                continue
+            created_at = _message_created_at(message)
+            if created_at is not None and now - created_at <= _LINKING_CARD_COOLDOWN_SECONDS:
+                return True
+        return False
 
     async def _reply_to_thread(self, *, room_id: str, parent_id: str, markdown: str) -> None:
         await asyncio.to_thread(
@@ -456,10 +485,7 @@ def _linking_card(app_name: str, linking_url: str | None) -> dict[str, Any]:
                 },
                 {
                     "type": "TextBlock",
-                    "text": (
-                        "Verify with enterprise SSO so this Webex identity can use "
-                        f"{app_name} agents on your behalf."
-                    ),
+                    "text": f"Verify your identity to interface with {app_name} agents.",
                     "wrap": True,
                 },
                 {
@@ -478,6 +504,48 @@ def _linking_card(app_name: str, linking_url: str | None) -> dict[str, Any]:
             ],
         },
     }
+
+
+def _message_created_at(message: dict[str, Any]) -> float | None:
+    raw = message.get("created") or message.get("createdAt") or message.get("created_at")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        return datetime.fromisoformat(raw.strip().replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _looks_like_linking_message(message: dict[str, Any], *, app_name: str) -> bool:
+    expected_title = f"Link {app_name} to Webex"
+    markdown = str(message.get("markdown") or message.get("text") or "")
+    if expected_title in markdown or f"Link your {app_name} account to Webex" in markdown:
+        return True
+
+    attachments = message.get("attachments")
+    if not isinstance(attachments, list):
+        return False
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        content = attachment.get("content")
+        if not isinstance(content, dict):
+            continue
+        if _card_contains_text(content.get("body"), expected_title):
+            return True
+        if _card_contains_text(content.get("actions"), "Link with SSO"):
+            return True
+    return False
+
+
+def _card_contains_text(value: object, expected: str) -> bool:
+    if isinstance(value, str):
+        return expected in value
+    if isinstance(value, dict):
+        return any(_card_contains_text(child, expected) for child in value.values())
+    if isinstance(value, list):
+        return any(_card_contains_text(child, expected) for child in value)
+    return False
 
 
 def _app_name() -> str:

--- a/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
@@ -103,6 +103,8 @@ def webex_event_from_wdm_activity(
             "webexRoomId": public_room_id,
             "personId": person_id,
             "personEmail": message_detail.get("personEmail"),
+            # assisted-by Codex Codex-sonnet-4-6: keep 1:1 WDM events on the direct-message path.
+            "roomType": message_detail.get("roomType"),
             "text": message_detail.get("text") or message_detail.get("markdown") or "",
             "mentionedPeople": message_detail.get("mentionedPeople") or [],
             "isSelf": bool(bot_person_id and person_id == bot_person_id),

--- a/ui/e2e/rbac/webex-configure-spaces.spec.ts
+++ b/ui/e2e/rbac/webex-configure-spaces.spec.ts
@@ -1,0 +1,531 @@
+// assisted-by Codex Codex-sonnet-4-6
+/**
+ * Mocked Playwright coverage for Admin > Integrations > Webex > Configure spaces.
+ *
+ * The Configure spaces surface is intentionally a single workflow now. These
+ * tests drive every admin option in that workflow: discovery cache settings,
+ * Webex refresh, discovery search, pagination, select/clear, personal DM rows,
+ * bulk team/agent apply, per-row overrides, and setup payload grouping.
+ */
+
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import {
+  fulfillJson,
+  installMockedRbacApp,
+  mockedRbacEnabled,
+  postJson,
+  type MockRouteHandler,
+} from "./_mocked-rbac";
+
+const adminSession = {
+  email: "admin@caipe.local",
+  name: "Platform Admin",
+  role: "admin" as const,
+  canViewAdmin: true,
+};
+
+const teams = [
+  { _id: "team-platform", slug: "platform", name: "Platform Team" },
+  { _id: "team-ops", slug: "ops", name: "Operations Team" },
+];
+
+const agents = [
+  { _id: "agent-sre", name: "SRE Agent" },
+  { _id: "agent-kb", name: "KB Agent" },
+];
+
+type WebexSpace = {
+  id: string;
+  name: string;
+  type?: "group" | "direct";
+  is_locked?: boolean;
+};
+
+type WebexConfigureState = {
+  ttl: number;
+  platformConfigPatches: unknown[];
+  discoveryRequests: URL[];
+  defaultsRequests: unknown[];
+  configuredSpaces: Array<{
+    workspace_id: string;
+    space_id: string;
+    space_name: string;
+    team_slug?: string;
+    primary_agent_id?: string;
+    active_grants?: number;
+    can_manage?: boolean;
+  }>;
+};
+
+function pageOneSpaces(): WebexSpace[] {
+  return [
+    {
+      id: "space-incidents",
+      name: "Incident Bridge",
+      type: "group",
+      is_locked: false,
+    },
+    {
+      id: "space-alerts",
+      name: "Workflow Alerts",
+      type: "group",
+      is_locked: false,
+    },
+    {
+      id: "direct-sri",
+      name: "Sri Aradhyula",
+      type: "direct",
+      is_locked: false,
+    },
+  ];
+}
+
+function pageTwoSpaces(): WebexSpace[] {
+  return [
+    {
+      id: "space-night-ops",
+      name: "Night Ops",
+      type: "group",
+      is_locked: false,
+    },
+  ];
+}
+
+function defaultState(): WebexConfigureState {
+  return {
+    ttl: 45,
+    platformConfigPatches: [],
+    discoveryRequests: [],
+    defaultsRequests: [],
+    configuredSpaces: [
+      {
+        workspace_id: "WEBEX-WORKSPACE",
+        space_id: "space-incidents",
+        space_name: "Incident Bridge",
+        team_slug: "platform",
+        primary_agent_id: "agent-sre",
+        active_grants: 1,
+        can_manage: true,
+      },
+    ],
+  };
+}
+
+function visibleSpacesForSearch(query: string): WebexSpace[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return pageOneSpaces();
+  return [...pageOneSpaces(), ...pageTwoSpaces()].filter((space) =>
+    `${space.name} ${space.id}`.toLowerCase().includes(normalized),
+  );
+}
+
+function webexConfigureHandler(state: WebexConfigureState): MockRouteHandler {
+  return async ({ route, path, method, url }) => {
+    if (path === "/api/admin/webex/spaces" && method === "GET") {
+      await fulfillJson(route, {
+        success: true,
+        data: { spaces: state.configuredSpaces },
+      });
+      return true;
+    }
+
+    if (path === "/api/admin/platform-config" && method === "GET") {
+      await fulfillJson(route, {
+        success: true,
+        data: {
+          discovery_cache_ttl_minutes: state.ttl,
+          release_notes: { enabled: false },
+        },
+      });
+      return true;
+    }
+
+    if (path === "/api/admin/platform-config" && method === "PATCH") {
+      const body = await postJson(route);
+      state.platformConfigPatches.push(body);
+      const nextTtl = Number(
+        (body as { discovery_cache_ttl_minutes?: unknown } | null)
+          ?.discovery_cache_ttl_minutes,
+      );
+      if (Number.isFinite(nextTtl)) state.ttl = nextTtl;
+      await fulfillJson(route, {
+        success: true,
+        data: { discovery_cache_ttl_minutes: state.ttl },
+      });
+      return true;
+    }
+
+    if (path === "/api/admin/webex/available-spaces" && method === "GET") {
+      state.discoveryRequests.push(url);
+      if (url.searchParams.get("refresh") === "1") {
+        await fulfillJson(route, {
+          success: true,
+          data: {
+            spaces: pageOneSpaces().slice(0, 1),
+            has_more: false,
+            next_cursor: null,
+            total_matches: 1,
+          },
+        });
+        return true;
+      }
+
+      const query = url.searchParams.get("q") ?? "";
+      const cursor = url.searchParams.get("cursor");
+      if (query.trim()) {
+        const spaces = visibleSpacesForSearch(query);
+        await fulfillJson(route, {
+          success: true,
+          data: {
+            spaces,
+            has_more: false,
+            next_cursor: null,
+            total_matches: spaces.length,
+          },
+        });
+        return true;
+      }
+
+      if (cursor === "page-2") {
+        await fulfillJson(route, {
+          success: true,
+          data: {
+            spaces: pageTwoSpaces(),
+            has_more: false,
+            next_cursor: null,
+            total_matches: 4,
+          },
+        });
+        return true;
+      }
+
+      await fulfillJson(route, {
+        success: true,
+        data: {
+          spaces: pageOneSpaces(),
+          has_more: true,
+          next_cursor: "page-2",
+          total_matches: 4,
+        },
+      });
+      return true;
+    }
+
+    if (path === "/api/dynamic-agents" && method === "GET") {
+      await fulfillJson(route, { success: true, data: { items: agents } });
+      return true;
+    }
+
+    if (path === "/api/admin/teams" && method === "GET") {
+      await fulfillJson(route, { success: true, data: { teams } });
+      return true;
+    }
+
+    if (path === "/api/admin/webex/spaces/defaults" && method === "GET") {
+      await fulfillJson(route, {
+        success: true,
+        data: { defaults: { team_slug: "", agent_id: "" } },
+      });
+      return true;
+    }
+
+    if (path === "/api/admin/webex/spaces/defaults" && method === "POST") {
+      const body = await postJson(route);
+      state.defaultsRequests.push(body);
+      const request = body as {
+        team_slug?: string;
+        agent_id?: string;
+        manual_spaces?: Array<{ id: string; name?: string }>;
+      } | null;
+      for (const space of request?.manual_spaces ?? []) {
+        state.configuredSpaces.push({
+          workspace_id: "WEBEX-WORKSPACE",
+          space_id: space.id,
+          space_name: space.name ?? space.id,
+          team_slug: request?.team_slug,
+          primary_agent_id: request?.agent_id,
+          active_grants: 1,
+          can_manage: true,
+        });
+      }
+      await fulfillJson(route, {
+        success: true,
+        data: {
+          summary: {
+            spaces_onboarded: request?.manual_spaces?.length ?? 0,
+            spaces_assigned_team: request?.manual_spaces?.length ?? 0,
+            space_grants_ensured: request?.manual_spaces?.length ?? 0,
+            routes_ensured: request?.manual_spaces?.length ?? 0,
+            routes_preserved: 0,
+          },
+        },
+      });
+      return true;
+    }
+
+    return false;
+  };
+}
+
+async function installWebexConfigureApp(
+  page: Page,
+  state = defaultState(),
+): Promise<WebexConfigureState> {
+  await installMockedRbacApp(page, {
+    isAdmin: true,
+    session: adminSession,
+    gates: { webex: true },
+    handlers: [webexConfigureHandler(state)],
+  });
+  return state;
+}
+
+async function gotoConfigureSpaces(page: Page) {
+  await page.goto("/admin?cat=integrations&tab=webex", {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(
+    page.getByRole("region", { name: "Configure spaces" }),
+  ).toBeVisible();
+  await expect(page.getByText("Configure spaces")).toBeVisible();
+}
+
+async function pickTeam(page: Page, buttonName: RegExp, optionName: RegExp) {
+  await page.getByRole("button", { name: buttonName }).click();
+  await page.getByRole("option", { name: optionName }).click();
+}
+
+async function pickAgent(page: Page, buttonName: RegExp, optionName: RegExp) {
+  await page.getByRole("button", { name: buttonName }).click();
+  await page.getByRole("option", { name: optionName }).click();
+}
+
+function spaceRow(page: Page, spaceName: string): Locator {
+  return page.locator(".grid", { hasText: spaceName }).last();
+}
+
+test.describe("mocked Webex Configure spaces UI", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run mocked Webex Configure spaces coverage.",
+    );
+  });
+
+  test("saves discovery cache TTL and force-refreshes Webex discovery", async ({
+    page,
+  }) => {
+    const state = await installWebexConfigureApp(page);
+    await gotoConfigureSpaces(page);
+
+    await page.getByTestId("discovery-cache-controls-trigger-webex").click();
+    const ttlInput = page.getByTestId("discovery-cache-ttl-input-webex");
+    await expect(ttlInput).toHaveValue("45");
+
+    await ttlInput.fill("30");
+    await page.getByTestId("discovery-cache-ttl-save-webex").click();
+    await expect(page.getByText("Saved")).toBeVisible();
+    expect(state.platformConfigPatches).toContainEqual({
+      discovery_cache_ttl_minutes: 30,
+    });
+
+    await page.getByTestId("discovery-cache-refresh-webex").click();
+    await expect(page.getByText("Refreshed")).toBeVisible();
+    await expect
+      .poll(() =>
+        state.discoveryRequests.some(
+          (request) => request.searchParams.get("refresh") === "1",
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        state.discoveryRequests.some(
+          (request) => request.searchParams.get("limit") === "200",
+        ),
+      )
+      .toBe(true);
+  });
+
+  test("uses every Configure spaces option to discover, filter, select, bulk-apply, override, and set up spaces", async ({
+    page,
+  }) => {
+    const state = await installWebexConfigureApp(page);
+    await gotoConfigureSpaces(page);
+
+    await expect(
+      page.getByRole("tablist", { name: "Webex admin views" }),
+    ).toHaveCount(0);
+    await expect(page.getByText("Incident Bridge")).toBeVisible();
+    await expect(
+      page.getByRole("status", { name: /Discovered: 1 .* Configured: 1/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/^Discovered: 1$/)).toHaveCount(0);
+    await expect(page.getByText(/^Configured: 1$/)).toHaveCount(0);
+
+    const search = page.getByRole("searchbox", { name: "Search spaces" });
+    await search.fill("Incident");
+    await expect(page.getByText("Incident Bridge")).toBeVisible();
+    await expect(page.getByText("No spaces match")).toHaveCount(0);
+    await page.getByRole("button", { name: "Clear spaces search" }).click();
+
+    await page.getByRole("button", { name: "Find spaces" }).click();
+    await expect(page.getByText("Workflow Alerts")).toBeVisible();
+    await expect(page.getByText("Sri Aradhyula")).toBeVisible();
+    await expect(
+      page.getByRole("status", {
+        name: /Discovered: 3 .* Configured: 1 .* New: 2/i,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText(/^Discovered: 3$/)).toHaveCount(0);
+    await expect(page.getByText(/^Configured: 1$/)).toHaveCount(0);
+    await expect(page.getByText("New: 2", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Load more spaces" }),
+    ).toBeVisible();
+
+    const directCheckbox = page.getByRole("checkbox", {
+      name: "Import Sri Aradhyula",
+    });
+    await expect(directCheckbox).toBeDisabled();
+    await expect(
+      spaceRow(page, "Sri Aradhyula").getByText("Personal DM").first(),
+    ).toBeVisible();
+
+    await search.fill("Alerts");
+    await expect
+      .poll(() =>
+        state.discoveryRequests.some(
+          (request) => request.searchParams.get("q") === "Alerts",
+        ),
+      )
+      .toBe(true);
+    await expect(page.getByText("Workflow Alerts")).toBeVisible();
+    await expect(page.getByText("Incident Bridge")).toHaveCount(0);
+    await expect(page.getByText("1 shown · 1 match")).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear spaces search" }).click();
+    await expect(page.getByText("Incident Bridge")).toBeVisible();
+    await page.getByRole("button", { name: "Load more spaces" }).click();
+    await expect(page.getByText("Night Ops")).toBeVisible();
+    await expect
+      .poll(() =>
+        state.discoveryRequests.some(
+          (request) => request.searchParams.get("cursor") === "page-2",
+        ),
+      )
+      .toBe(true);
+
+    await page.getByRole("button", { name: "Clear selection" }).click();
+    await expect(
+      page.getByRole("checkbox", { name: "Import Workflow Alerts" }),
+    ).not.toBeChecked();
+    await expect(
+      page.getByRole("button", { name: /^Set up 0 spaces$/ }),
+    ).toBeDisabled();
+
+    await pickAgent(
+      page,
+      /Dynamic Agent for Workflow Alerts/i,
+      /SRE Agent.*agent:agent-sre/,
+    );
+    await expect(
+      page.getByRole("checkbox", { name: "Import Workflow Alerts" }),
+    ).toBeChecked();
+    await expect(
+      page.getByRole("button", { name: /^Set up 0 spaces$/ }),
+    ).toBeDisabled();
+    await pickTeam(
+      page,
+      /Team for Workflow Alerts/i,
+      /Platform Team.*team:platform/,
+    );
+    await expect(
+      page.getByRole("checkbox", { name: "Import Workflow Alerts" }),
+    ).toBeChecked();
+    await expect(
+      page.getByRole("button", { name: /^Set up 1 space$/ }),
+    ).toBeEnabled();
+
+    await page.getByRole("button", { name: "Clear selection" }).click();
+    await expect(
+      page.getByRole("checkbox", { name: "Import Workflow Alerts" }),
+    ).not.toBeChecked();
+
+    await page.getByRole("button", { name: "Select all" }).click();
+    await expect(
+      page.getByRole("checkbox", { name: "Import Workflow Alerts" }),
+    ).toBeChecked();
+    await expect(
+      page.getByRole("checkbox", { name: "Import Night Ops" }),
+    ).toBeChecked();
+    await expect(directCheckbox).not.toBeChecked();
+
+    await page.getByRole("button", { name: "Clear selection" }).click();
+    await page
+      .getByRole("checkbox", { name: "Import Workflow Alerts" })
+      .check();
+    await page.getByRole("checkbox", { name: "Import Night Ops" }).check();
+
+    await pickTeam(
+      page,
+      /Bulk team for selected rows/,
+      /Platform Team.*team:platform/,
+    );
+    await pickAgent(
+      page,
+      /Bulk Dynamic Agent for selected rows/,
+      /SRE Agent.*agent:agent-sre/,
+    );
+    await page
+      .getByRole("button", { name: "Apply to 2 selected rows" })
+      .click();
+
+    await expect(
+      page.getByRole("button", { name: /Team for Workflow Alerts/i }),
+    ).toContainText("Platform Team");
+    await expect(
+      page.getByRole("button", { name: /Dynamic Agent for Workflow Alerts/i }),
+    ).toContainText("SRE Agent");
+    await expect(
+      page.getByRole("button", { name: /Team for Night Ops/i }),
+    ).toContainText("Platform Team");
+    await expect(
+      page.getByRole("button", { name: /Dynamic Agent for Night Ops/i }),
+    ).toContainText("SRE Agent");
+
+    await pickTeam(page, /Team for Night Ops/i, /Operations Team.*team:ops/);
+    await pickAgent(
+      page,
+      /Dynamic Agent for Night Ops/i,
+      /KB Agent.*agent:agent-kb/,
+    );
+    await expect(
+      page.getByRole("button", { name: /Team for Night Ops/i }),
+    ).toContainText("Operations Team");
+    await expect(
+      page.getByRole("button", { name: /Dynamic Agent for Night Ops/i }),
+    ).toContainText("KB Agent");
+
+    await page.getByRole("button", { name: /^Set up 2 spaces$/ }).click();
+    await expect.poll(() => state.defaultsRequests.length).toBe(2);
+    expect(state.defaultsRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          team_slug: "platform",
+          agent_id: "agent-sre",
+          create_routes: true,
+          manual_spaces: [{ id: "space-alerts", name: "Workflow Alerts" }],
+        }),
+        expect.objectContaining({
+          team_slug: "ops",
+          agent_id: "agent-kb",
+          create_routes: true,
+          manual_spaces: [{ id: "space-night-ops", name: "Night Ops" }],
+        }),
+      ]),
+    );
+    expect(JSON.stringify(state.defaultsRequests)).not.toContain("direct-sri");
+  });
+});

--- a/ui/e2e/rbac/webex-workflow-agent-routes.spec.ts
+++ b/ui/e2e/rbac/webex-workflow-agent-routes.spec.ts
@@ -31,7 +31,10 @@ function webexHandler(state: {
   routes: unknown[];
 }): MockRouteHandler {
   return async ({ route, path, method }) => {
-    if (path === "/api/admin/webex/spaces" || path === "/api/admin/webex/spaces?health=1") {
+    if (
+      path === "/api/admin/webex/spaces" ||
+      path === "/api/admin/webex/spaces?health=1"
+    ) {
       await fulfillJson(route, {
         data: {
           spaces: [
@@ -49,7 +52,10 @@ function webexHandler(state: {
       return true;
     }
 
-    if (path.startsWith("/api/admin/webex/available-spaces") && method === "GET") {
+    if (
+      path.startsWith("/api/admin/webex/available-spaces") &&
+      method === "GET"
+    ) {
       await fulfillJson(route, {
         data: {
           spaces: [
@@ -73,7 +79,10 @@ function webexHandler(state: {
       return true;
     }
 
-    if (path === "/api/dynamic-agents?enabled_only=true" || path === "/api/dynamic-agents") {
+    if (
+      path === "/api/dynamic-agents?enabled_only=true" ||
+      path === "/api/dynamic-agents"
+    ) {
       await fulfillJson(route, {
         data: {
           items: [
@@ -88,7 +97,9 @@ function webexHandler(state: {
     if (path === "/api/admin/teams" && method === "GET") {
       await fulfillJson(route, {
         data: {
-          teams: [{ _id: "team-platform", slug: "platform", name: "Platform Team" }],
+          teams: [
+            { _id: "team-platform", slug: "platform", name: "Platform Team" },
+          ],
         },
       });
       return true;
@@ -135,7 +146,8 @@ function webexHandler(state: {
     }
 
     if (
-      path === "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-incidents/routes" &&
+      path ===
+        "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-incidents/routes" &&
       method === "GET"
     ) {
       await fulfillJson(route, { data: { routes: state.routes } });
@@ -143,12 +155,15 @@ function webexHandler(state: {
     }
 
     if (
-      path === "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-incidents/routes" &&
+      path ===
+        "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-incidents/routes" &&
       method === "PUT"
     ) {
       const body = await postJson(route);
       state.routeWrites.push(body);
-      state.routes = Array.isArray((body as { routes?: unknown[] } | null)?.routes)
+      state.routes = Array.isArray(
+        (body as { routes?: unknown[] } | null)?.routes,
+      )
         ? ((body as { routes: unknown[] }).routes ?? [])
         : [];
       await fulfillJson(route, { data: { routes: state.routes } });
@@ -156,7 +171,8 @@ function webexHandler(state: {
     }
 
     if (
-      path === "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-incidents/diagnostics" &&
+      path ===
+        "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-incidents/diagnostics" &&
       method === "GET"
     ) {
       await fulfillJson(route, {
@@ -204,25 +220,51 @@ test.describe("mocked Webex workflow agent routing regression", () => {
       handlers: [webexHandler({ routeWrites, defaultsRequests, routes })],
     });
 
-    await page.goto("/admin?cat=integrations&tab=webex", { waitUntil: "domcontentloaded" });
-    await page.getByRole("tab", { name: "Onboard spaces" }).click();
+    await page.goto("/admin?cat=integrations&tab=webex", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.getByRole("region", { name: "Configure spaces" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Find spaces" }).click();
+
+    await expect(
+      page.getByRole("status", { name: /Discovered: 2/i }),
+    ).toBeVisible();
     await page
-      .getByRole("button", { name: /^(Find spaces|Find Webex Spaces with Bot Integration)$/i })
+      .getByRole("checkbox", { name: /Import Incident Bridge/i })
+      .check();
+    await page
+      .getByRole("button", { name: "Bulk team for selected rows" })
+      .click();
+    await page
+      .getByRole("option", { name: /Platform Team.*team:platform/i })
+      .click();
+    await page
+      .getByRole("button", { name: "Bulk Dynamic Agent for selected rows" })
+      .click();
+    await page
+      .getByRole("option", { name: new RegExp(workflowAgent.name, "i") })
+      .click();
+    await page
+      .getByRole("button", { name: /^Apply to 2 selected rows$/i })
       .click();
 
-    await expect(page.getByText(/bot-visible spaces discovered/i)).toBeVisible();
-    await page.getByRole("checkbox", { name: /Import Incident Bridge/i }).check();
-    await page.getByRole("button", { name: "Bulk team for selected rows" }).click();
-    await page.getByRole("option", { name: /Platform Team.*team:platform/i }).click();
-    await page.getByRole("button", { name: "Bulk Dynamic Agent for selected rows" }).click();
-    await page.getByRole("option", { name: new RegExp(workflowAgent.name, "i") }).click();
-    await page.getByRole("button", { name: /^Apply to 2 selected rows$/i }).click();
-
-    await expect(page.getByRole("button", { name: /Team for Incident Bridge/i })).toContainText("Platform Team");
-    await expect(page.getByRole("button", { name: /Dynamic Agent for Incident Bridge/i })).toContainText(workflowAgent.name);
-    await expect(page.getByRole("checkbox", { name: /Import Workflow Alerts/i })).toBeChecked();
-    await expect(page.getByRole("button", { name: /Team for Workflow Alerts/i })).toContainText("Platform Team");
-    await expect(page.getByRole("button", { name: /Dynamic Agent for Workflow Alerts/i })).toContainText(workflowAgent.name);
+    await expect(
+      page.getByRole("button", { name: /Team for Incident Bridge/i }),
+    ).toContainText("Platform Team");
+    await expect(
+      page.getByRole("button", { name: /Dynamic Agent for Incident Bridge/i }),
+    ).toContainText(workflowAgent.name);
+    await expect(
+      page.getByRole("checkbox", { name: /Import Workflow Alerts/i }),
+    ).toBeChecked();
+    await expect(
+      page.getByRole("button", { name: /Team for Workflow Alerts/i }),
+    ).toContainText("Platform Team");
+    await expect(
+      page.getByRole("button", { name: /Dynamic Agent for Workflow Alerts/i }),
+    ).toContainText(workflowAgent.name);
     await page.getByRole("button", { name: /^Set up 2 spaces$/ }).click();
 
     await expect.poll(() => defaultsRequests.length).toBe(1);
@@ -251,13 +293,23 @@ test.describe("mocked Webex workflow agent routing regression", () => {
     ];
 
     await installMockedRbacApp(page, {
-      isAdmin: true,
-      session: adminSession,
-      gates: { webex: true },
+      isAdmin: false,
+      session: teamMemberSession,
+      gates: {
+        webex: true,
+        settings: false,
+        teams: false,
+        users: false,
+        metrics: false,
+        health: false,
+      },
       handlers: [webexHandler({ routeWrites, defaultsRequests: [], routes })],
     });
 
-    await page.goto("/admin?cat=integrations&tab=webex", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin?cat=integrations&tab=webex", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByText("My Webex Space Settings")).toBeVisible();
     await expect(page.getByText("Incident Bridge")).toBeVisible();
     await page.getByText("Incident Bridge").click();
     const fixButton = page.getByRole("button", {
@@ -297,7 +349,9 @@ test.describe("mocked Webex workflow agent routing regression", () => {
       handlers: [webexHandler({ routeWrites, defaultsRequests: [], routes })],
     });
 
-    await page.goto("/admin?cat=integrations&tab=webex", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin?cat=integrations&tab=webex", {
+      waitUntil: "domcontentloaded",
+    });
     await expect(page.getByText("My Webex Space Settings")).toBeVisible();
     await expect(
       page.getByText(
@@ -306,7 +360,9 @@ test.describe("mocked Webex workflow agent routing regression", () => {
     ).toBeVisible();
     await page.getByText("Incident Bridge").click();
     await expect(page.getByText(workflowAgent.id)).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Onboard spaces" })).toHaveCount(0);
+    await expect(page.getByRole("tab", { name: "Onboard spaces" })).toHaveCount(
+      0,
+    );
     await expect(page.getByRole("tab", { name: "Advanced" })).toHaveCount(0);
   });
 });

--- a/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
+++ b/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight,FileUp,HelpCircle,Loader2,RefreshCw,RotateCw,Settings2 } from "lucide-react";
+import { ChevronRight,FileUp,HelpCircle,RefreshCw,RotateCw,Settings2 } from "lucide-react";
 import React,{ useCallback,useEffect,useLayoutEffect,useMemo,useRef,useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -494,20 +494,30 @@ function enrichDiscoveredRows(
   return rows.map((row) => {
     const existing = sources.configuredItemsById.get(row.id);
     const legacyAgent = sources.legacyChannelAgents[row.id];
+    // assisted-by Codex Codex-sonnet-4-6: 1:1 Webex rooms are personal bot DMs, not team-assigned spaces.
+    const teamRequired = row.teamRequired !== false;
+    const selectable = row.selectable !== false && teamRequired;
     const teamSlug =
-      row.team_slug ||
-      existing?.team_slug ||
-      sources.globalDefaults.team_slug ||
-      "";
+      teamRequired
+        ? row.team_slug ||
+          existing?.team_slug ||
+          sources.globalDefaults.team_slug ||
+          ""
+        : "";
     const agentId =
-      row.agent_id ||
-      existing?.primary_agent_id ||
-      legacyAgent ||
-      sources.globalDefaults.agent_id ||
-      "";
-    const isSetupComplete = Boolean(existing?.team_slug && (existing?.active_grants ?? 0) > 0);
+      selectable
+        ? row.agent_id ||
+          existing?.primary_agent_id ||
+          legacyAgent ||
+          sources.globalDefaults.agent_id ||
+          ""
+        : "";
+    const isSetupComplete = teamRequired && Boolean(existing?.team_slug && (existing?.active_grants ?? 0) > 0);
     return {
       ...row,
+      teamRequired,
+      selectable,
+      selected: selectable ? row.selected : false,
       team_slug: teamSlug,
       agent_id: agentId,
       is_existing: row.is_existing || isSetupComplete,
@@ -527,6 +537,11 @@ function mergeDiscoveredById(base: DiscoveredItem[], incoming: DiscoveredItem[])
   const byId = new Map(base.map((item) => [item.id, item]));
   for (const item of incoming) byId.set(item.id, item);
   return [...byId.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function discoveredItemMatchesSearch(item: DiscoveredItem, query: string): boolean {
+  if (!query) return true;
+  return `${item.name} ${item.id} ${item.secondary}`.toLowerCase().includes(query);
 }
 
 const MIN_LOADING_VISIBLE_MS = process.env.NODE_ENV === "test" ? 0 : 400;
@@ -602,7 +617,10 @@ export function ConnectorAdminPanel({
   // self-service mode there is no tab bar — the configured table always shows —
   // so `view` stays local there and the URL is left untouched.
   const [view, setView] = useSubtabParam(PANEL_VIEWS, "channels");
-  const panelView: PanelView = selfService ? "channels" : view;
+  const singlePanelView = selfService ? undefined : adapter.singlePanelView;
+  const panelView: PanelView = selfService ? "channels" : singlePanelView ?? view;
+  const showTabBar = !selfService && !singlePanelView;
+  const hasAdvancedView = !selfService && (!singlePanelView || singlePanelView === "advanced");
   const [configuredSearch, setConfiguredSearch] = useState("");
   const [discoverySearch, setDiscoverySearch] = useState("");
 
@@ -636,7 +654,13 @@ export function ConnectorAdminPanel({
     [configuredItemIds, discoveredItems],
   );
   const selectedDiscoveredRows = useMemo(
-    () => discoveredRows.filter((row) => row.selected && row.team_slug && row.agent_id),
+    () =>
+      discoveredRows.filter((row) =>
+        row.selectable !== false &&
+        row.selected &&
+        (row.teamRequired === false || row.team_slug) &&
+        row.agent_id,
+      ),
     [discoveredRows],
   );
 
@@ -796,10 +820,10 @@ export function ConnectorAdminPanel({
     void loadTeams().catch((e) => setMessage(e instanceof Error ? e.message : "Failed to load teams"));
   }, [loadTeams, selfService]);
   useEffect(() => {
-    if (selfService) return;
+    if (!hasAdvancedView) return;
     void loadRuntimeStatus().catch((e) =>
       setMessage(e instanceof Error ? e.message : `Failed to load ${adapter.connectorName} bot runtime status`));
-  }, [loadRuntimeStatus, selfService, adapter.connectorName]);
+  }, [loadRuntimeStatus, hasAdvancedView, adapter.connectorName]);
   const connectorName = adapter.connectorName;
   const itemSingular = adapter.itemSingular;
   useEffect(() => {
@@ -865,30 +889,36 @@ export function ConnectorAdminPanel({
   const buildDiscoveredRows = useCallback(
     (discovered: DiscoveredItem[], previousRows: DiscoveredRow[]): DiscoveredRow[] => {
       const prevById = new Map(previousRows.map((row) => [row.id, row]));
-      const hasNewItems = discovered.some((item) => !configuredItemIds.has(item.id));
       const built = discovered.map((item) => {
         const prev = prevById.get(item.id);
         const existing = configuredItemsById.get(item.id);
         const isExisting = configuredItemIds.has(item.id);
-        const isSetupComplete = Boolean(existing?.team_slug && (existing.active_grants ?? 0) > 0);
+        const teamRequired = item.teamRequired !== false;
+        const selectable = item.selectable !== false && teamRequired;
+        const isSetupComplete = teamRequired && Boolean(existing?.team_slug && (existing.active_grants ?? 0) > 0);
         const autoSelect = adapter.discoveryAutoSelectNewItems
-          ? (hasNewItems ? !isExisting : true)
+          ? selectable && !isExisting
           : false;
         if (prev) {
           return {
             ...prev,
             name: item.name,
             secondary: item.secondary,
-            team_slug: prev.team_slug || existing?.team_slug || "",
-            agent_id: prev.agent_id || existing?.primary_agent_id || "",
+            teamRequired,
+            selectable,
+            selected: selectable ? prev.selected : false,
+            team_slug: teamRequired ? prev.team_slug || existing?.team_slug || "" : "",
+            agent_id: selectable ? prev.agent_id || existing?.primary_agent_id || "" : "",
             is_existing: isSetupComplete || prev.is_existing,
           };
         }
         return {
           ...item,
           selected: autoSelect,
-          team_slug: existing?.team_slug ?? "",
-          agent_id: existing?.primary_agent_id ?? "",
+          teamRequired,
+          selectable,
+          team_slug: teamRequired ? existing?.team_slug ?? "" : "",
+          agent_id: selectable ? existing?.primary_agent_id ?? "" : "",
           is_existing: isSetupComplete,
         };
       });
@@ -938,12 +968,21 @@ export function ConnectorAdminPanel({
         setDiscoveryHasMore(pageData.hasMore);
         setDiscoveryTotalMatches(pageData.totalMatches ?? null);
 
-        const configuredSeed = itemsToDiscovered(items);
+        const query = opts.q?.trim().toLowerCase() ?? "";
+        const configuredSeed = itemsToDiscovered(items).filter((item) =>
+          discoveredItemMatchesSearch(item, query),
+        );
         if (opts.append) {
           setDiscoveredItems((prev) => mergeDiscoveredById(prev, pageData.items));
           setDiscoveredRows((prev) => {
             const merged = mergeDiscoveredById(
-              prev.map((row) => ({ id: row.id, name: row.name, secondary: row.secondary })),
+              prev.map((row) => ({
+                id: row.id,
+                name: row.name,
+                secondary: row.secondary,
+                teamRequired: row.teamRequired,
+                selectable: row.selectable,
+              })),
               pageData.items,
             );
             return buildDiscoveredRows(merged, prev);
@@ -977,7 +1016,7 @@ export function ConnectorAdminPanel({
         }
       }
     },
-    [adapter, buildDiscoveredRows, items, paginatedDiscovery, toast, loadLegacyChannelHints],
+    [adapter, buildDiscoveredRows, items, toast, loadLegacyChannelHints],
   );
 
   useEffect(() => {
@@ -1048,21 +1087,31 @@ export function ConnectorAdminPanel({
     setDiscoveredRows((rows) => rows.map((row) => row.id === itemId ? { ...row, ...updates } : row));
   };
   const setAllRowsSelected = (sel: boolean) => {
-    setDiscoveredRows((rows) => rows.map((row) => ({ ...row, selected: sel })));
+    setDiscoveredRows((rows) => rows.map((row) => ({ ...row, selected: row.selectable === false ? false : sel })));
   };
 
   const applyOnboarding = async () => {
     setLoading(true); setMessage(null);
     try {
       const result = await adapter.applyOnboarding({
-        rows: discoveredRows.map((r) => ({ id: r.id, name: r.name, teamSlug: r.team_slug, agentId: r.agent_id, selected: r.selected })),
+        rows: discoveredRows.map((r) => ({
+          id: r.id,
+          name: r.name,
+          teamSlug: r.team_slug,
+          agentId: r.agent_id,
+          selected: r.selected,
+          teamRequired: r.teamRequired,
+          selectable: r.selectable,
+        })),
         defaultTeamSlug: onboardingDefaults.team_slug,
         defaultAgentId: onboardingDefaults.agent_id,
         createDefaultRoutes: true,
         fetchFn: fetch,
       });
       await Promise.all([loadItems(), loadRoutes(), loadDiagnostics()]);
-      const appliedIds = new Set(discoveredRows.filter((r) => r.selected).map((r) => r.id));
+      const appliedIds = new Set(
+        discoveredRows.filter((r) => r.selected && r.selectable !== false).map((r) => r.id),
+      );
       setDiscoveredRows((rows) => rows.map((row) => appliedIds.has(row.id) ? { ...row, is_existing: true, selected: false } : row));
       toast(result.toastMessage, "success");
     } catch (err) {
@@ -1095,17 +1144,44 @@ export function ConnectorAdminPanel({
 
   // ── Render ────────────────────────────────────────────────────────────────────
 
+  const showCompactOnboardingHeader = !selfService && panelView === "onboard";
+
+  const onboardingHeader = showCompactOnboardingHeader ? (
+    <div className="flex min-w-0 items-center gap-2">
+      <h3 className="truncate text-base font-semibold tracking-tight">
+        {viewTitle.onboard}
+      </h3>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${adapter.connectorName} ${adapter.itemPlural} setup details`}
+            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <HelpCircle className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-xl space-y-2 whitespace-normal text-xs">
+          <p>{viewDescription.onboard}</p>
+          <div className="space-y-2">{adapter.authzDisclaimer}</div>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  ) : null;
+
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{selfService ? adapter.copy.selfServiceTitle : viewTitle[view]}</CardTitle>
-        <CardDescription>
-          {selfService ? adapter.copy.selfServiceDescription : viewDescription[view]}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+      {!showCompactOnboardingHeader && (
+        <CardHeader>
+          <CardTitle>{selfService ? adapter.copy.selfServiceTitle : viewTitle[panelView]}</CardTitle>
+          <CardDescription>
+            {selfService ? adapter.copy.selfServiceDescription : viewDescription[panelView]}
+          </CardDescription>
+        </CardHeader>
+      )}
+      <CardContent className={cn("flex flex-col gap-4", showCompactOnboardingHeader && "pt-6")}>
         {/* Tab bar */}
-        {!selfService && (
+        {showTabBar && (
           <div role="tablist" aria-label={adapter.ariaLabels.tablist}
             className="flex flex-wrap gap-1 rounded-md border bg-muted/30 p-1">
             {(Object.keys(viewTitle) as PanelView[]).map((key) => (
@@ -1119,7 +1195,7 @@ export function ConnectorAdminPanel({
         )}
 
         {/* Auth disclaimer */}
-        {(selfService || panelView === "onboard") && (
+        {(selfService || (panelView === "onboard" && !showCompactOnboardingHeader)) && (
           <div className="space-y-2 rounded-md border p-3 text-sm text-muted-foreground">
             {adapter.authzDisclaimer}
           </div>
@@ -1385,6 +1461,7 @@ export function ConnectorAdminPanel({
             isAdmin={!selfService}
             itemSingular={adapter.itemSingular}
             itemPlural={adapter.itemPlural}
+            header={onboardingHeader}
             discoveredLabel={adapter.copy.discoveryDiscoveredLabel}
             findLabel={adapter.copy.discoveryFindLabel}
             refreshLabel={adapter.copy.discoveryRefreshLabel}
@@ -1393,6 +1470,7 @@ export function ConnectorAdminPanel({
             description={adapter.copy.discoveryDescription}
             discoveryStatusText={discoveryStatusText}
             discoveredCount={discoveredItems.length}
+            configuredCount={items.length}
             newCount={discoveredNewCount}
             selectedCount={selectedDiscoveredRows.length}
             rows={discoveredRows.map((row) => ({
@@ -1403,6 +1481,8 @@ export function ConnectorAdminPanel({
               teamSlug: row.team_slug,
               agentId: row.agent_id,
               isExisting: row.is_existing,
+              teamRequired: row.teamRequired,
+              selectable: row.selectable,
               importLabel: `Import ${row.name}`,
               teamLabel: `Team for ${row.name}`,
               agentLabel: `Dynamic Agent for ${row.name}`,
@@ -1420,7 +1500,7 @@ export function ConnectorAdminPanel({
             discoveryLoadingMore={discoveryLoadingMore}
             onLoadMore={paginatedDiscovery ? loadMoreDiscovery : undefined}
             discoveryTotalMatches={paginatedDiscovery ? discoveryTotalMatches : null}
-            serverSideSearch={adapter.discoveryServerSearch === true}
+            serverSideSearch={adapter.discoveryServerSearch === true && discoveryLiveFetched}
             searchDisabled={discoverLoading || discoveryLoadingMore}
             searchValue={discoverySearch}
             onSearchChange={setDiscoverySearch}

--- a/ui/src/components/admin/rebac/ConnectorOnboardingWizard.tsx
+++ b/ui/src/components/admin/rebac/ConnectorOnboardingWizard.tsx
@@ -1,18 +1,30 @@
 "use client";
 
-import { AlertCircle,CheckCircle2,CircleDashed,Loader2,Search } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  CircleDashed,
+  Loader2,
+  Search,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
+import type { ReactNode } from "react";
 import { useState } from "react";
 
 import {
-DiscoveryCacheControls,
-type DiscoveryCacheProvider,
+  DiscoveryCacheControls,
+  type DiscoveryCacheProvider,
 } from "@/components/admin/rebac/DiscoveryCacheControls";
-import { AgentPicker,type AgentPickerOption } from "@/components/ui/agent-picker";
+import {
+  AgentPicker,
+  type AgentPickerOption,
+} from "@/components/ui/agent-picker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CAIPESpinner } from "@/components/ui/caipe-spinner";
 import { Input } from "@/components/ui/input";
-import { TeamPicker,type TeamPickerOption } from "@/components/ui/team-picker";
+import { TeamPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 import { cn } from "@/lib/utils";
 
 export interface ConnectorOnboardingOption {
@@ -28,6 +40,8 @@ export interface ConnectorOnboardingRow {
   teamSlug: string;
   agentId: string;
   isExisting: boolean;
+  teamRequired?: boolean;
+  selectable?: boolean;
   importLabel: string;
   teamLabel: string;
   agentLabel: string;
@@ -52,6 +66,7 @@ interface ConnectorOnboardingWizardProps {
   isAdmin?: boolean;
   itemSingular: string;
   itemPlural: string;
+  header?: ReactNode;
   discoveredLabel: string;
   findLabel: string;
   refreshLabel: string;
@@ -60,6 +75,7 @@ interface ConnectorOnboardingWizardProps {
   description: string;
   discoveryStatusText: string;
   discoveredCount: number;
+  configuredCount: number;
   newCount: number;
   selectedCount: number;
   rows: ConnectorOnboardingRow[];
@@ -79,7 +95,9 @@ interface ConnectorOnboardingWizardProps {
   onClearSelection: () => void;
   onRowChange: (
     id: string,
-    updates: Partial<Pick<ConnectorOnboardingRow, "selected" | "teamSlug" | "agentId">>,
+    updates: Partial<
+      Pick<ConnectorOnboardingRow, "selected" | "teamSlug" | "agentId">
+    >,
   ) => void;
   onApply: () => void;
   /** When provided, render a search box that filters the visible rows by
@@ -103,24 +121,39 @@ interface ConnectorOnboardingWizardProps {
 
 type ReadinessState = "ready" | "needs_setup" | "blocked" | "skipped";
 
-function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+function pluralize(
+  count: number,
+  singular: string,
+  plural = `${singular}s`,
+): string {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function rowIsSelectable(row: ConnectorOnboardingRow): boolean {
+  return row.selectable !== false;
+}
+
+function rowNeedsTeam(row: ConnectorOnboardingRow): boolean {
+  return row.teamRequired !== false;
 }
 
 function readinessFor(row: ConnectorOnboardingRow): {
   state: ReadinessState;
   label: string;
 } {
+  if (!rowIsSelectable(row)) {
+    return { state: "skipped", label: "Personal DM" };
+  }
   if (row.isExisting) {
     return { state: "ready", label: "Configured" };
   }
   if (!row.selected) {
     return { state: "skipped", label: "Not selected" };
   }
-  if (!row.teamSlug && !row.agentId) {
+  if (rowNeedsTeam(row) && !row.teamSlug && !row.agentId) {
     return { state: "blocked", label: "Pick team and agent" };
   }
-  if (!row.teamSlug) {
+  if (rowNeedsTeam(row) && !row.teamSlug) {
     return { state: "blocked", label: "Pick a team" };
   }
   if (!row.agentId) {
@@ -135,15 +168,19 @@ function readinessClass(state: ReadinessState): string {
   // (already done) is a softer slate so the eye lands on rows that
   // actually need the admin's attention.
   if (state === "ready") return "border-slate-300 bg-slate-50 text-slate-700";
-  if (state === "needs_setup") return "border-emerald-300 bg-emerald-50 text-emerald-700";
+  if (state === "needs_setup")
+    return "border-emerald-300 bg-emerald-50 text-emerald-700";
   if (state === "blocked") return "border-amber-300 bg-amber-50 text-amber-700";
   return "border-slate-300 bg-slate-50 text-slate-600";
 }
 
 function ReadinessIcon({ state }: { state: ReadinessState }) {
-  if (state === "ready") return <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />;
-  if (state === "needs_setup") return <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />;
-  if (state === "blocked") return <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />;
+  if (state === "ready")
+    return <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />;
+  if (state === "needs_setup")
+    return <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />;
+  if (state === "blocked")
+    return <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />;
   return <CircleDashed className="h-3.5 w-3.5" aria-hidden="true" />;
 }
 
@@ -152,7 +189,7 @@ export function ConnectorOnboardingWizard({
   isAdmin = false,
   itemSingular,
   itemPlural,
-  discoveredLabel,
+  header,
   findLabel,
   refreshLabel,
   loadingLabel,
@@ -189,19 +226,29 @@ export function ConnectorOnboardingWizard({
 }: ConnectorOnboardingWizardProps) {
   const search = searchValue ?? "";
   const normalizedSearch = search.trim().toLowerCase();
-  const visibleRows = serverSideSearch || !normalizedSearch
-    ? rows
-    : rows.filter((row) =>
-        `${row.name} ${row.secondary}`.toLowerCase().includes(normalizedSearch),
-      );
-  const selectedRows = rows.filter((row) => row.selected);
-  const blockedRows = selectedRows.filter((row) => readinessFor(row).state === "blocked");
+  const visibleRows =
+    serverSideSearch || !normalizedSearch
+      ? rows
+      : rows.filter((row) =>
+          `${row.name} ${row.secondary}`
+            .toLowerCase()
+            .includes(normalizedSearch),
+        );
+  const selectedRows = rows.filter(
+    (row) => row.selected && rowIsSelectable(row),
+  );
+  const blockedRows = selectedRows.filter(
+    (row) => readinessFor(row).state === "blocked",
+  );
   // Rows that will actually be set up when the admin clicks Apply: selected
   // and not blocked (they have both a team and an agent). Blocked rows are
   // skipped rather than blocking the whole batch, so one unconfigured row
   // can't strand the rows that are already ready to go.
-  const readyRows = selectedRows.filter((row) => readinessFor(row).state !== "blocked");
-  const applyDisabled = disabled || loading || Boolean(error) || readyRows.length === 0;
+  const readyRows = selectedRows.filter(
+    (row) => readinessFor(row).state !== "blocked",
+  );
+  const applyDisabled =
+    disabled || loading || Boolean(error) || readyRows.length === 0;
   const disabledReason =
     selectedRows.length === 0
       ? `Select at least one ${itemSingular} to set up.`
@@ -221,7 +268,9 @@ export function ConnectorOnboardingWizard({
   const [bulkAgentId, setBulkAgentId] = useState("");
   const applyBulkToSelected = () => {
     selectedRows.forEach((row) => {
-      const updates: Partial<Pick<ConnectorOnboardingRow, "teamSlug" | "agentId">> = {};
+      const updates: Partial<
+        Pick<ConnectorOnboardingRow, "teamSlug" | "agentId">
+      > = {};
       if (bulkTeamSlug) updates.teamSlug = bulkTeamSlug;
       if (bulkAgentId) updates.agentId = bulkAgentId;
       if (Object.keys(updates).length > 0) onRowChange(row.id, updates);
@@ -232,103 +281,152 @@ export function ConnectorOnboardingWizard({
   const discoveryBusy = discovering || initialLoading;
   const discoveryBusyLabel = discovering ? loadingLabel : initialLoadingLabel;
   const showFullDiscoveryLoading = discoveryBusy && rows.length === 0;
-  const showDiscoveryResults = (error || discoveredCount > 0 || rows.length > 0) && !showFullDiscoveryLoading;
+  const showDiscoveryResults =
+    (error || discoveredCount > 0 || rows.length > 0) &&
+    !showFullDiscoveryLoading;
+  const showProgressBadges = newCount > 0 || selectedCount > 0;
 
   return (
     <div
       role="region"
-      aria-label={`Discover ${itemPlural}`}
+      aria-label={`Configure ${itemPlural}`}
       data-section-tone="sky"
-      className="space-y-4 rounded-md border bg-background/60 p-4 text-sm"
+      className="space-y-3 rounded-md border bg-background/60 p-3 text-sm"
     >
-        <div className="space-y-1">
-          <h3 className="text-base font-semibold tracking-tight">
-            Discover {itemPlural}
-          </h3>
-          <p className="text-xs text-muted-foreground">{description}</p>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onDiscover}
-          disabled={disabled || discovering}
-        >
-          {discovering ? (
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-          ) : (
-            <Search className="h-4 w-4" aria-hidden="true" />
-          )}
-          {discovering ? loadingLabel : discoveryLiveFetched ? refreshLabel : findLabel}
-        </Button>
-        {provider && (
-          <DiscoveryCacheControls
-            provider={provider}
-            isAdmin={isAdmin}
-            // After a force-refresh, kick off another discovery query so
-            // the wizard reflects the fresh server-side snapshot without
-            // the admin having to click "Find ..." again.
-            onAfterRefresh={onDiscover}
-          />
-        )}
-        <span
-          role="status"
-          aria-label={discoveryStatusText}
-          className="text-xs text-muted-foreground"
-        >
-          {discoveryStatusText}
-        </span>
-        </div>
-
-        {showFullDiscoveryLoading && (
-          <div
-            role="status"
-            aria-live="polite"
-            aria-label={discoveryBusyLabel}
-            data-testid="discovery-loading"
-            className="flex min-h-[10rem] items-center justify-center rounded-md border border-dashed bg-muted/10 px-4 py-8"
-          >
-            <CAIPESpinner size="md" message={discoveryBusyLabel} />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {header ? (
+          <div className="min-w-0">{header}</div>
+        ) : (
+          <div className="min-w-0" title={description}>
+            <h3 className="text-base font-semibold tracking-tight">
+              Configure {itemPlural}
+            </h3>
           </div>
         )}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onDiscover}
+            disabled={disabled || discoveryBusy}
+          >
+            {discovering ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Search className="h-4 w-4" aria-hidden="true" />
+            )}
+            {discovering
+              ? loadingLabel
+              : discoveryLiveFetched
+                ? refreshLabel
+                : findLabel}
+          </Button>
+          {provider && (
+            <DiscoveryCacheControls
+              provider={provider}
+              isAdmin={isAdmin}
+              // After a force-refresh, kick off another discovery query so
+              // the wizard reflects the fresh server-side snapshot without
+              // the admin having to click "Find ..." again.
+              onAfterRefresh={onDiscover}
+            />
+          )}
+          <span
+            role="status"
+            aria-label={discoveryStatusText}
+            className="hidden text-xs text-muted-foreground lg:inline"
+          >
+            {discoveryStatusText}
+          </span>
+        </div>
+      </div>
 
-        {showDiscoveryResults && (
-          <>
+      {showFullDiscoveryLoading && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={discoveryBusyLabel}
+          data-testid="discovery-loading"
+          className="flex min-h-[10rem] items-center justify-center rounded-md border border-dashed bg-muted/10 px-4 py-8"
+        >
+          <CAIPESpinner size="md" message={discoveryBusyLabel} />
+        </div>
+      )}
+
+      {showDiscoveryResults && (
+        <>
           {error ? (
             <div className="text-destructive">{error}</div>
           ) : (
             <>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="secondary">{pluralize(discoveredCount, discoveredLabel)} discovered</Badge>
-                <Badge variant="outline">{pluralize(newCount, `new ${itemSingular}`)} new</Badge>
-                <Badge variant="outline">{pluralize(selectedCount, itemSingular)} selected</Badge>
+              <div
+                className={cn(
+                  "flex flex-wrap items-center gap-2",
+                  !showProgressBadges && "lg:hidden",
+                )}
+              >
+                {newCount > 0 && (
+                  <Badge variant="outline">New: {newCount}</Badge>
+                )}
+                {selectedCount > 0 && (
+                  <Badge variant="outline">Selected: {selectedCount}</Badge>
+                )}
+                <span className="text-xs text-muted-foreground lg:hidden">
+                  {discoveryStatusText}
+                </span>
               </div>
-              {onSearchChange && (
-                <div className="flex items-center gap-2">
-                  <Input
-                    type="search"
-                    aria-label={`Search ${itemPlural}`}
-                    placeholder={`Search ${itemPlural} by name…`}
-                    value={search}
-                    onChange={(event) => onSearchChange(event.target.value)}
-                    disabled={searchDisabled}
-                    className="max-w-sm"
-                  />
-                  {normalizedSearch && (
-                    <span className="text-xs text-muted-foreground">
-                      {serverSideSearch && discoveryTotalMatches !== null
-                        ? `${visibleRows.length} shown · ${discoveryTotalMatches} match${discoveryTotalMatches === 1 ? "" : "es"} in cache`
-                        : `${visibleRows.length} of ${rows.length} ${itemPlural}`}
-                    </span>
-                  )}
-                </div>
-              )}
-              <div className="flex flex-wrap gap-2">
-                <Button type="button" variant="outline" size="sm" onClick={onSelectAll} disabled={loading || rows.length === 0}>
+              <div className="flex flex-wrap items-center gap-2">
+                {onSearchChange && (
+                  <label className="flex min-w-[18rem] max-w-xl flex-1 items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-within:ring-1 focus-within:ring-ring">
+                    <Search
+                      className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                    <Input
+                      type="search"
+                      aria-label={`Search ${itemPlural}`}
+                      placeholder={`Search ${itemPlural} by name or ID...`}
+                      value={search}
+                      onChange={(event) => onSearchChange(event.target.value)}
+                      disabled={searchDisabled}
+                      className="h-auto min-w-0 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+                    />
+                    {normalizedSearch && !searchDisabled && (
+                      <button
+                        type="button"
+                        aria-label={`Clear ${itemPlural} search`}
+                        onClick={() => onSearchChange("")}
+                        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                      >
+                        <X className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                    )}
+                  </label>
+                )}
+                {normalizedSearch && (
+                  <span className="text-xs text-muted-foreground">
+                    {serverSideSearch && discoveryTotalMatches !== null
+                      ? `${visibleRows.length} shown · ${discoveryTotalMatches} match${discoveryTotalMatches === 1 ? "" : "es"}`
+                      : `${visibleRows.length} of ${rows.length} ${itemPlural}`}
+                  </span>
+                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onSelectAll}
+                  disabled={loading || rows.length === 0}
+                >
                   Select all
                 </Button>
-                <Button type="button" variant="outline" size="sm" onClick={onClearSelection} disabled={loading || rows.length === 0}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onClearSelection}
+                  disabled={loading || rows.length === 0}
+                >
                   Clear selection
                 </Button>
               </div>
@@ -339,9 +437,12 @@ export function ConnectorOnboardingWizard({
                   className="flex flex-wrap items-end gap-2 rounded-md border bg-background/80 p-3"
                 >
                   <div className="flex flex-col gap-1">
-                    <span className="text-xs font-medium text-muted-foreground">Bulk apply to selected</span>
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Bulk apply to selected
+                    </span>
                     <span className="text-[11px] text-muted-foreground">
-                      Pick a team and/or agent, then click Apply. Per-row picks below override these.
+                      Pick a team and/or agent, then click Apply. Per-row picks
+                      below override these.
                     </span>
                   </div>
                   <div className="min-w-[200px]">
@@ -381,6 +482,7 @@ export function ConnectorOnboardingWizard({
                     onClick={applyBulkToSelected}
                     disabled={bulkApplyDisabled}
                   >
+                    <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
                     Apply to {pluralize(selectedRows.length, "selected row")}
                   </Button>
                 </div>
@@ -397,108 +499,150 @@ export function ConnectorOnboardingWizard({
                     <CAIPESpinner size="md" message={loadingLabel} />
                   </div>
                 )}
-              <div className="max-h-[460px] overflow-auto rounded-md border bg-background/80">
-                <div className="grid min-w-[860px] grid-cols-[minmax(240px,1fr)_190px_220px_190px] gap-3 border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground">
-                  <div>{itemSingular[0].toUpperCase() + itemSingular.slice(1)}</div>
-                  <div>Team</div>
-                  <div>Dynamic Agent</div>
-                  <div>Status</div>
-                </div>
-                {visibleRows.length === 0 ? (
-                  <div className="px-3 py-4 text-sm text-muted-foreground">
-                    {rows.length === 0
-                      ? emptyLabel
-                      : `No ${itemPlural} match "${search}".`}
+                <div className="max-h-[460px] overflow-auto rounded-md border bg-background/80">
+                  <div className="grid min-w-[860px] grid-cols-[minmax(240px,1fr)_190px_220px_190px] gap-3 border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground">
+                    <div>
+                      {itemSingular[0].toUpperCase() + itemSingular.slice(1)}
+                    </div>
+                    <div>Team</div>
+                    <div>Dynamic Agent</div>
+                    <div>Status</div>
                   </div>
-                ) : (
-                  visibleRows.map((row) => {
-                    const readiness = readinessFor(row);
-                    return (
-                      <div
-                        key={row.id}
-                        className={cn(
-                          "grid min-w-[860px] grid-cols-[minmax(240px,1fr)_190px_220px_190px] gap-3 border-b px-3 py-3 last:border-b-0",
-                          readiness.state === "blocked" && "bg-amber-500/5",
-                          readiness.state === "needs_setup" && "bg-emerald-500/5",
-                        )}
-                      >
-                        <label className="flex items-start gap-2 text-sm">
-                          <input
-                            type="checkbox"
-                            aria-label={row.importLabel}
-                            checked={row.selected}
-                            onChange={(event) => onRowChange(row.id, { selected: event.target.checked })}
-                            disabled={loading}
-                          />
-                          <span>
-                            <span className="font-medium">{row.name}</span>
-                            <span className="block text-xs text-muted-foreground">{row.secondary}</span>
-                          </span>
-                        </label>
-                        {/* Switched from native <select> to TeamPicker on
-                            2026-05-27 — environments with hundreds of
-                            AWS-* / SSO-* teams made the per-row
-                            dropdown unusable and made the wizard
-                            impossible to scan. The picker is portaled
-                            so it can sit comfortably inside the
-                            wizard's tight grid row. */}
-                        <TeamPicker
-                          ariaLabel={row.teamLabel}
-                          triggerClassName="h-9 text-sm"
-                          value={row.teamSlug}
-                          onChange={(value) => onRowChange(row.id, { teamSlug: value })}
-                          disabled={loading || !row.selected}
-                          placeholder="Select team"
-                          searchPlaceholder="Search teams..."
-                          options={teams.map<TeamPickerOption>((team) => ({
-                            slug: team.value,
-                            name: team.label,
-                          }))}
-                        />
-                        <AgentPicker
-                          ariaLabel={row.agentLabel}
-                          triggerClassName="h-9 text-sm"
-                          value={row.agentId}
-                          onChange={(value) => onRowChange(row.id, { agentId: value })}
-                          disabled={loading || !row.selected}
-                          placeholder="Select agent"
-                          searchPlaceholder="Search agents..."
-                          options={agents.map<AgentPickerOption>((agent) => ({
-                            value: agent.value,
-                            label: agent.label,
-                          }))}
-                        />
-                        <div className="space-y-1">
-                          <Badge variant="outline" className={cn("w-fit gap-1.5", readinessClass(readiness.state))}>
-                            <ReadinessIcon state={readiness.state} />
-                            {readiness.label}
-                          </Badge>
+                  {visibleRows.length === 0 ? (
+                    <div className="px-3 py-4 text-sm text-muted-foreground">
+                      {rows.length === 0
+                        ? emptyLabel
+                        : `No ${itemPlural} match "${search}".`}
+                    </div>
+                  ) : (
+                    visibleRows.map((row) => {
+                      const readiness = readinessFor(row);
+                      return (
+                        <div
+                          key={row.id}
+                          className={cn(
+                            "grid min-w-[860px] grid-cols-[minmax(240px,1fr)_190px_220px_190px] gap-3 border-b px-3 py-3 last:border-b-0",
+                            readiness.state === "blocked" && "bg-amber-500/5",
+                            readiness.state === "needs_setup" &&
+                              "bg-emerald-500/5",
+                          )}
+                        >
+                          <label className="flex items-start gap-2 text-sm">
+                            <input
+                              type="checkbox"
+                              aria-label={row.importLabel}
+                              checked={
+                                rowIsSelectable(row) ? row.selected : false
+                              }
+                              onChange={(event) =>
+                                onRowChange(row.id, {
+                                  selected: event.target.checked,
+                                })
+                              }
+                              disabled={loading || !rowIsSelectable(row)}
+                            />
+                            <span>
+                              <span className="font-medium">{row.name}</span>
+                              <span className="block text-xs text-muted-foreground">
+                                {row.secondary}
+                              </span>
+                            </span>
+                          </label>
+                          {/* assisted-by Codex Codex-sonnet-4-6 */}
+                          {/* Editing a selectable row implies intent to set it up, so the checkbox follows. */}
+                          {rowNeedsTeam(row) ? (
+                            <TeamPicker
+                              ariaLabel={row.teamLabel}
+                              triggerClassName="h-9 text-sm"
+                              value={row.teamSlug}
+                              onChange={(value) =>
+                                onRowChange(row.id, {
+                                  teamSlug: value,
+                                  selected: true,
+                                })
+                              }
+                              disabled={loading || !rowIsSelectable(row)}
+                              placeholder="Select team"
+                              searchPlaceholder="Search teams..."
+                              options={teams.map<TeamPickerOption>((team) => ({
+                                slug: team.value,
+                                name: team.label,
+                              }))}
+                            />
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className="w-fit border-slate-300 bg-slate-50 text-slate-700"
+                            >
+                              Personal DM
+                            </Badge>
+                          )}
+                          {rowIsSelectable(row) ? (
+                            <AgentPicker
+                              ariaLabel={row.agentLabel}
+                              triggerClassName="h-9 text-sm"
+                              value={row.agentId}
+                              onChange={(value) =>
+                                onRowChange(row.id, {
+                                  agentId: value,
+                                  selected: true,
+                                })
+                              }
+                              disabled={loading || !rowIsSelectable(row)}
+                              placeholder="Select agent"
+                              searchPlaceholder="Search agents..."
+                              options={agents.map<AgentPickerOption>(
+                                (agent) => ({
+                                  value: agent.value,
+                                  label: agent.label,
+                                }),
+                              )}
+                            />
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              Direct user routing
+                            </span>
+                          )}
+                          <div className="space-y-1">
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                "w-fit gap-1.5",
+                                readinessClass(readiness.state),
+                              )}
+                            >
+                              <ReadinessIcon state={readiness.state} />
+                              {readiness.label}
+                            </Badge>
+                          </div>
                         </div>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-              {onLoadMore && discoveryHasMore && (
-                <div className="flex justify-center border-t bg-muted/20 px-3 py-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={onLoadMore}
-                    disabled={searchDisabled || discoveryLoadingMore}
-                  >
-                    {discoveryLoadingMore ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-                        Loading more…
-                      </>
-                    ) : (
-                      `Load more ${itemPlural}`
-                    )}
-                  </Button>
+                      );
+                    })
+                  )}
                 </div>
-              )}
+                {onLoadMore && discoveryHasMore && (
+                  <div className="flex justify-center border-t bg-muted/20 px-3 py-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={onLoadMore}
+                      disabled={searchDisabled || discoveryLoadingMore}
+                    >
+                      {discoveryLoadingMore ? (
+                        <>
+                          <Loader2
+                            className="mr-2 h-4 w-4 animate-spin"
+                            aria-hidden="true"
+                          />
+                          Loading more…
+                        </>
+                      ) : (
+                        `Load more ${itemPlural}`
+                      )}
+                    </Button>
+                  </div>
+                )}
               </div>
             </>
           )}
@@ -506,11 +650,20 @@ export function ConnectorOnboardingWizard({
             <div />
             <div className="flex flex-col items-end gap-1">
               <div className="flex flex-wrap justify-end gap-2">
-                <Button type="button" variant="outline" onClick={onDiscover} disabled={disabled || discovering}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onDiscover}
+                  disabled={disabled || discoveryBusy}
+                >
                   <Search className="h-4 w-4" aria-hidden="true" />
                   Refresh
                 </Button>
-                <Button type="button" onClick={onApply} disabled={applyDisabled}>
+                <Button
+                  type="button"
+                  onClick={onApply}
+                  disabled={applyDisabled}
+                >
                   <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
                   {loading
                     ? "Setting up..."
@@ -518,15 +671,19 @@ export function ConnectorOnboardingWizard({
                 </Button>
               </div>
               {applyDisabled && disabledReason && (
-                <div className="max-w-xs text-right text-xs text-muted-foreground">{disabledReason}</div>
+                <div className="max-w-xs text-right text-xs text-muted-foreground">
+                  {disabledReason}
+                </div>
               )}
               {skipNote && (
-                <div className="max-w-xs text-right text-xs text-amber-600">{skipNote}</div>
+                <div className="max-w-xs text-right text-xs text-amber-600">
+                  {skipNote}
+                </div>
               )}
             </div>
           </div>
-          </>
-        )}
+        </>
+      )}
     </div>
   );
 }

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -179,10 +179,12 @@ const SLACK_ADAPTER: ConnectorAdminAdapter = {
     advancedRegion: "Advanced Setup - Import/Sync with Slackbot",
   },
 
-  discoveryStatusText: ({ discoveredCount, newCount, configuredCount, unassignedCount }) =>
-    discoveredCount > 0
-      ? `${discoveredCount} bot-member found · ${newCount} new · ${configuredCount} in CAIPE · ${unassignedCount} missing team`
-      : `${configuredCount} in CAIPE · ${unassignedCount} missing team`,
+  discoveryStatusText: ({ discoveredCount, newCount, configuredCount, unassignedCount }) => [
+    `Discovered: ${discoveredCount}`,
+    `Configured: ${configuredCount}`,
+    ...(newCount > 0 ? [`New: ${newCount}`] : []),
+    ...(unassignedCount > 0 ? [`Missing team: ${unassignedCount}`] : []),
+  ].join(" · "),
 
   staticConfigLabel: ({ items, routes }) => `${items} channels / ${routes} routes`,
   routeCacheLabel: (count) => `${count} cached channel${count === 1 ? "" : "s"}`,

--- a/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexSpaceRebacPanel.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { HelpCircle } from "lucide-react";
-
-import { Tooltip,TooltipContent,TooltipTrigger } from "@/components/ui/tooltip";
 import { ConnectorAdminPanel } from "./ConnectorAdminPanel";
 import type {
 ConnectorAdminAdapter,
@@ -11,41 +8,6 @@ ItemAgentRoute,
 ItemDiagnostics,
 ItemSummary,
 } from "./connector-admin-adapter";
-
-function WebexAccessNote() {
-  return (
-    <div className="flex max-w-4xl items-start gap-2 rounded-md border border-border/60 bg-background/50 px-3 py-2 text-sm text-muted-foreground">
-      <span>
-        Members of the assigned team can manage this Webex space&apos;s bot routing. The space and the
-        assigned team must both be allowed to use an agent before the bot will call it.
-      </span>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label="Webex access details"
-            className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <HelpCircle className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-md whitespace-normal break-words text-xs">
-          <div className="space-y-2">
-            <p>
-              Team assignment controls who can manage this space&apos;s integration. Before dispatch,
-              the Webex bot checks that the space has <code className="mx-0.5">can_use agent:&lt;id&gt;</code>{" "}
-              and the user&apos;s active team has the same permission.
-            </p>
-            <p>
-              Adding an agent to a team-assigned space grants every member of that team permission to
-              invoke the agent in the space, even if they were never granted the agent directly.
-            </p>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </div>
-  );
-}
 
 function apiData<T>(payload: { data?: T } & T): T {
   return (payload.data ?? payload) as T;
@@ -72,6 +34,7 @@ const WEBEX_ADAPTER: ConnectorAdminAdapter = {
   connectorName: "Webex",
   itemSingular: "space",
   itemPlural: "spaces",
+  singlePanelView: "onboard",
 
   api: {
     list: "/api/admin/webex/spaces",
@@ -115,11 +78,17 @@ const WEBEX_ADAPTER: ConnectorAdminAdapter = {
     );
     const spaces = (d.spaces ?? []) as Record<string, unknown>[];
     return {
-      items: spaces.map((sp) => ({
-        id: String(sp.id ?? ""),
-        name: String(sp.name ?? sp.id),
-        secondary: [String(sp.id ?? ""), sp.type, sp.is_locked ? "locked" : ""].filter(Boolean).join(" · "),
-      })),
+      items: spaces.map((sp) => {
+        const type = String(sp.type ?? "group").trim().toLowerCase() || "group";
+        const isDirect = type === "direct";
+        return {
+          id: String(sp.id ?? ""),
+          name: String(sp.name ?? sp.id),
+          secondary: [String(sp.id ?? ""), type, sp.is_locked ? "locked" : ""].filter(Boolean).join(" · "),
+          teamRequired: !isDirect,
+          selectable: !isDirect,
+        };
+      }),
       nextCursor: d.next_cursor ?? null,
       hasMore: Boolean(d.has_more),
       totalMatches: typeof d.total_matches === "number" ? d.total_matches : undefined,
@@ -152,7 +121,7 @@ const WEBEX_ADAPTER: ConnectorAdminAdapter = {
   copy: {
     configuredTabTitle: "Configured spaces",
     configuredTabDescription: "Spaces CAIPE already knows about. Click a space to manage its agents and diagnostics.",
-    onboardTabTitle: "Onboard spaces",
+    onboardTabTitle: "Configure spaces",
     onboardTabDescription: "Find Webex spaces where the bot is installed and set them up.",
     advancedTabTitle: "Advanced",
     advancedTabDescription: "One-time YAML import and Webex bot runtime status. Most admins won't need this.",
@@ -174,10 +143,12 @@ const WEBEX_ADAPTER: ConnectorAdminAdapter = {
     advancedRegion: "Advanced Setup - Import/Sync with Webex Bot",
   },
 
-  discoveryStatusText: ({ discoveredCount, newCount, configuredCount, unassignedCount }) =>
-    discoveredCount > 0
-      ? `${discoveredCount} bot-visible found · ${newCount} new · ${configuredCount} in CAIPE · ${unassignedCount} missing team`
-      : `${configuredCount} in CAIPE · ${unassignedCount} missing team`,
+  discoveryStatusText: ({ discoveredCount, newCount, configuredCount, unassignedCount }) => [
+    `Discovered: ${discoveredCount}`,
+    `Configured: ${configuredCount}`,
+    ...(newCount > 0 ? [`New: ${newCount}`] : []),
+    ...(unassignedCount > 0 ? [`Missing team: ${unassignedCount}`] : []),
+  ].join(" · "),
 
   staticConfigLabel: ({ items, routes }) => `${items} spaces / ${routes} routes`,
   routeCacheLabel: (count) => `${count} cached space${count === 1 ? "" : "s"}`,
@@ -243,7 +214,13 @@ const WEBEX_ADAPTER: ConnectorAdminAdapter = {
   },
 
   applyOnboarding: async ({ rows, defaultTeamSlug, defaultAgentId, createDefaultRoutes, fetchFn }) => {
-    const selectedImports = rows.filter((r) => r.selected && r.teamSlug && r.agentId);
+    const selectedImports = rows.filter((r) =>
+      r.selectable !== false &&
+      r.teamRequired !== false &&
+      r.selected &&
+      r.teamSlug &&
+      r.agentId
+    );
     if (selectedImports.length === 0) return { toastMessage: "No spaces selected." };
     const grouped = new Map<string, Array<{ id: string; name?: string }>>();
     for (const sp of selectedImports) {

--- a/ui/src/components/admin/rebac/__tests__/ConnectorOnboardingWizard.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/ConnectorOnboardingWizard.test.tsx
@@ -15,6 +15,8 @@ function makeRow(overrides: Partial<ConnectorOnboardingRow>): ConnectorOnboardin
     teamSlug: overrides.teamSlug ?? "",
     agentId: overrides.agentId ?? "",
     isExisting: overrides.isExisting ?? false,
+    teamRequired: overrides.teamRequired,
+    selectable: overrides.selectable,
     importLabel: `Import ${name}`,
     teamLabel: `Team for ${name}`,
     agentLabel: `Dynamic Agent for ${name}`,
@@ -34,6 +36,7 @@ function renderWizard(rows: ConnectorOnboardingRow[], onApply = jest.fn()) {
       description="desc"
       discoveryStatusText="status"
       discoveredCount={rows.length}
+      configuredCount={rows.filter((r) => r.isExisting).length}
       newCount={rows.length}
       selectedCount={rows.filter((r) => r.selected && r.teamSlug && r.agentId).length}
       rows={rows}
@@ -92,4 +95,28 @@ it("disables Set up when nothing is selected", () => {
 
   expect(screen.getByRole("button", { name: "Set up 0 spaces" })).toBeDisabled();
   expect(screen.getByText("Select at least one space to set up.")).toBeInTheDocument();
+});
+
+it("shows non-team direct rooms as personal DMs instead of team-assigned rows", () => {
+  renderWizard([
+    makeRow({
+      id: "direct",
+      name: "Sri Aradhyula",
+      secondary: "direct-room · direct",
+      selected: true,
+      teamSlug: "team-a",
+      agentId: "agent-a",
+      teamRequired: false,
+      selectable: false,
+    }),
+  ]);
+
+  const checkbox = screen.getByRole("checkbox", { name: "Import Sri Aradhyula" });
+  expect(checkbox).toBeDisabled();
+  expect(checkbox).not.toBeChecked();
+  expect(screen.queryByLabelText("Team for Sri Aradhyula")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Dynamic Agent for Sri Aradhyula")).not.toBeInTheDocument();
+  expect(screen.getAllByText("Personal DM")).toHaveLength(2);
+  expect(screen.getByText("Direct user routing")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Set up 0 spaces" })).toBeDisabled();
 });

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 
 const mockToast = jest.fn();
 jest.mock("@/components/ui/toast", () => ({
@@ -26,7 +32,10 @@ beforeEach(() => {
   fetchMock.mockReset();
   global.fetch = fetchMock as unknown as typeof fetch;
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url === "/api/admin/slack/channels" || url === "/api/admin/slack/channels?health=1") {
+    if (
+      url === "/api/admin/slack/channels" ||
+      url === "/api/admin/slack/channels?health=1"
+    ) {
       return response({
         data: {
           channels: [
@@ -56,13 +65,20 @@ beforeEach(() => {
       return response({
         data: {
           teams: [
-            { _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" },
+            {
+              _id: "team-1",
+              slug: "platform-engineering",
+              name: "Platform Engineering",
+            },
             { _id: "team-2", slug: "security", name: "Security" },
           ],
         },
       });
     }
-    if (url === "/api/admin/slack/channels/defaults" && init?.method === "POST") {
+    if (
+      url === "/api/admin/slack/channels/defaults" &&
+      init?.method === "POST"
+    ) {
       return response({
         data: {
           summary: {
@@ -89,7 +105,11 @@ beforeEach(() => {
         data: {
           route_mode: "db_prefer",
           static_config: { channels: 1, routes: 1 },
-          route_cache: { ttl_seconds: 60, cache_size: 1, cached_channels: ["CAIPE/C123456789"] },
+          route_cache: {
+            ttl_seconds: 60,
+            cache_size: 1,
+            cached_channels: ["CAIPE/C123456789"],
+          },
           last_sync: null,
         },
       });
@@ -164,7 +184,17 @@ beforeEach(() => {
       });
     }
     if (url.endsWith("/resources") && init?.method === "PUT") {
-      return response({ data: { grants: [{ resource: { type: "agent", id: "test-april-2025" }, actions: ["use"], status: "active" }] } });
+      return response({
+        data: {
+          grants: [
+            {
+              resource: { type: "agent", id: "test-april-2025" },
+              actions: ["use"],
+              status: "active",
+            },
+          ],
+        },
+      });
     }
     if (url.endsWith("/resources")) {
       return response({ data: { grants: [] } });
@@ -252,7 +282,10 @@ it("shows a loading spinner while self-service channels load", async () => {
     resolveChannels = resolve;
   });
   fetchMock.mockImplementation(async (url: string) => {
-    if (url === "/api/admin/slack/channels" || url === "/api/admin/slack/channels?health=1") {
+    if (
+      url === "/api/admin/slack/channels" ||
+      url === "/api/admin/slack/channels?health=1"
+    ) {
       return channelsPromise;
     }
     if (url === "/api/dynamic-agents?enabled_only=true") {
@@ -264,15 +297,21 @@ it("shows a loading spinner while self-service channels load", async () => {
   render(<SlackChannelRebacPanel selfService />);
   expect(screen.getByTestId("connector-items-loading")).toBeInTheDocument();
   expect(screen.getByText("Loading Slack channels…")).toBeInTheDocument();
-  expect(screen.queryByText("No channels shared with your team yet.")).not.toBeInTheDocument();
+  expect(
+    screen.queryByText("No channels shared with your team yet."),
+  ).not.toBeInTheDocument();
 
   resolveChannels?.(
     response({
       data: { channels: [] },
     }),
   );
-  expect(await screen.findByText("No channels shared with your team yet.")).toBeInTheDocument();
-  expect(screen.queryByTestId("connector-items-loading")).not.toBeInTheDocument();
+  expect(
+    await screen.findByText("No channels shared with your team yet."),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByTestId("connector-items-loading"),
+  ).not.toBeInTheDocument();
 });
 
 it("shows discovery loading while Find channels scans Slack", async () => {
@@ -280,18 +319,33 @@ it("shows discovery loading while Find channels scans Slack", async () => {
   const discoveryPromise = new Promise<Response>((resolve) => {
     resolveDiscovery = resolve;
   });
-  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url === "/api/admin/slack/channels" || url === "/api/admin/slack/channels?health=1") {
+  fetchMock.mockImplementation(async (url: string) => {
+    if (
+      url === "/api/admin/slack/channels" ||
+      url === "/api/admin/slack/channels?health=1"
+    ) {
       return response({ data: { channels: [] } });
     }
     if (url.startsWith("/api/admin/slack/available-channels")) {
       return discoveryPromise;
     }
     if (url === "/api/dynamic-agents?enabled_only=true") {
-      return response({ data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] } });
+      return response({
+        data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] },
+      });
     }
     if (url === "/api/admin/teams") {
-      return response({ data: { teams: [{ _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" }] } });
+      return response({
+        data: {
+          teams: [
+            {
+              _id: "team-1",
+              slug: "platform-engineering",
+              name: "Platform Engineering",
+            },
+          ],
+        },
+      });
     }
     if (url === "/api/admin/slack/channels/defaults") {
       return response({ data: { defaults: { team_slug: "", agent_id: "" } } });
@@ -304,13 +358,21 @@ it("shows discovery loading while Find channels scans Slack", async () => {
   fireEvent.click(screen.getByRole("button", { name: "Find channels" }));
 
   expect(await screen.findByTestId("discovery-loading")).toBeInTheDocument();
-  expect(screen.getByTestId("discovery-loading")).toHaveTextContent("Finding channels…");
+  expect(screen.getByTestId("discovery-loading")).toHaveTextContent(
+    "Finding channels…",
+  );
 
   resolveDiscovery?.(
     response({
       data: {
         channels: [
-          { id: "CNEWMISSING", name: "new-alerts", is_private: false, is_member: true, num_members: 7 },
+          {
+            id: "CNEWMISSING",
+            name: "new-alerts",
+            is_private: false,
+            is_member: true,
+            num_members: 7,
+          },
         ],
         total_matches: 1,
         total_visible: 1,
@@ -322,11 +384,17 @@ it("shows discovery loading while Find channels scans Slack", async () => {
       },
     }),
   );
-  await waitFor(() => expect(screen.queryByTestId("discovery-loading")).not.toBeInTheDocument());
-  expect(await screen.findByText(/1 bot-member found/i)).toBeInTheDocument();
+  await waitFor(() =>
+    expect(screen.queryByTestId("discovery-loading")).not.toBeInTheDocument(),
+  );
+  expect(
+    await screen.findByRole("status", { name: /Discovered: 1/i }),
+  ).toBeInTheDocument();
 });
 
-async function switchToTab(name: "Configured channels" | "Onboard channels" | "Advanced") {
+async function switchToTab(
+  name: "Configured channels" | "Onboard channels" | "Advanced",
+) {
   const tab = await screen.findByRole("tab", { name });
   fireEvent.click(tab);
 }
@@ -339,7 +407,8 @@ async function switchToTab(name: "Configured channels" | "Onboard channels" | "A
  */
 async function expandChannelRow(channelName: string): Promise<void> {
   const row = (await screen.findByText(`#${channelName}`)).closest("tr");
-  if (!row) throw new Error(`expandChannelRow: row for #${channelName} not found`);
+  if (!row)
+    throw new Error(`expandChannelRow: row for #${channelName} not found`);
   fireEvent.click(row);
 }
 
@@ -349,7 +418,9 @@ it("uses enabled Dynamic Agents dropdown for Slack channel-agent associations", 
   // Configured channels appears twice on screen — as the CardTitle and as
   // the active tab button. Targeting the tab unambiguously also doubles
   // as a smoke test that the tab structure rendered.
-  expect(await screen.findByRole("tab", { name: "Configured channels" })).toBeInTheDocument();
+  expect(
+    await screen.findByRole("tab", { name: "Configured channels" }),
+  ).toBeInTheDocument();
   expect(screen.queryByLabelText("Resource Type")).not.toBeInTheDocument();
   expect(screen.queryByLabelText("Action")).not.toBeInTheDocument();
 
@@ -367,8 +438,8 @@ it("uses enabled Dynamic Agents dropdown for Slack channel-agent associations", 
       expect.objectContaining({
         method: "PUT",
         body: expect.stringContaining('"agent_id":"test-april-2025"'),
-      })
-    )
+      }),
+    ),
   );
 });
 
@@ -377,26 +448,60 @@ it("preserves imported escalation/overthink/bots when editing a route (no data l
   // old editor only sent users.listen + priority, so saving silently
   // stripped the rest. This pins the full round-trip.
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url === "/api/admin/slack/channels" || url === "/api/admin/slack/channels?health=1") {
+    if (
+      url === "/api/admin/slack/channels" ||
+      url === "/api/admin/slack/channels?health=1"
+    ) {
       return response({
         data: {
           channels: [
-            { workspace_id: "T123456789", channel_id: "C123456789", channel_name: "incidents", active_grants: 1 },
+            {
+              workspace_id: "T123456789",
+              channel_id: "C123456789",
+              channel_name: "incidents",
+              active_grants: 1,
+            },
           ],
         },
       });
     }
     if (url === "/api/dynamic-agents?enabled_only=true") {
-      return response({ data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] } });
+      return response({
+        data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] },
+      });
     }
     if (url === "/api/admin/teams") {
-      return response({ data: { teams: [{ _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" }] } });
+      return response({
+        data: {
+          teams: [
+            {
+              _id: "team-1",
+              slug: "platform-engineering",
+              name: "Platform Engineering",
+            },
+          ],
+        },
+      });
     }
     if (url === "/api/admin/slack/channels/defaults") {
-      return response({ data: { defaults: { team_slug: "platform-engineering", agent_id: "incident-agent" } } });
+      return response({
+        data: {
+          defaults: {
+            team_slug: "platform-engineering",
+            agent_id: "incident-agent",
+          },
+        },
+      });
     }
     if (url === "/api/admin/slack/runtime/status") {
-      return response({ data: { route_mode: "db_prefer", static_config: { channels: 1, routes: 1 }, route_cache: { ttl_seconds: 60, cache_size: 1, cached_channels: [] }, last_sync: null } });
+      return response({
+        data: {
+          route_mode: "db_prefer",
+          static_config: { channels: 1, routes: 1 },
+          route_cache: { ttl_seconds: 60, cache_size: 1, cached_channels: [] },
+          last_sync: null,
+        },
+      });
     }
     if (url.endsWith("/routes") && init?.method === "PUT") {
       const body = JSON.parse(String(init.body ?? "{}"));
@@ -410,16 +515,36 @@ it("preserves imported escalation/overthink/bots when editing a route (no data l
               agent_id: "incident-agent",
               enabled: true,
               priority: 100,
-              users: { enabled: true, listen: "all", user_list: ["U1"], overthink: { enabled: true, skip_markers: ["DEFER"] } },
-              bots: { enabled: true, listen: "message", bot_list: ["AlertBot"] },
-              escalation: { victorops: { enabled: true, team: "dao" }, emoji: { enabled: true, name: "rotating_light" }, users: ["U027"] },
+              users: {
+                enabled: true,
+                listen: "all",
+                user_list: ["U1"],
+                overthink: { enabled: true, skip_markers: ["DEFER"] },
+              },
+              bots: {
+                enabled: true,
+                listen: "message",
+                bot_list: ["AlertBot"],
+              },
+              escalation: {
+                victorops: { enabled: true, team: "dao" },
+                emoji: { enabled: true, name: "rotating_light" },
+                users: ["U027"],
+              },
             },
           ],
         },
       });
     }
     if (url.endsWith("/diagnostics")) {
-      return response({ data: { openfga: { reachable: true, tuple_count: 1 }, warnings: [], routes: [], last_runtime_error: null } });
+      return response({
+        data: {
+          openfga: { reachable: true, tuple_count: 1 },
+          warnings: [],
+          routes: [],
+          last_runtime_error: null,
+        },
+      });
     }
     if (url.endsWith("/resources")) {
       return response({ data: { grants: [] } });
@@ -434,19 +559,29 @@ it("preserves imported escalation/overthink/bots when editing a route (no data l
   expect(await screen.findByText("bots:message")).toBeInTheDocument();
   expect(screen.getByText("escalation")).toBeInTheDocument();
 
-  fireEvent.click(await screen.findByRole("button", { name: /edit agent:incident-agent/i }));
+  fireEvent.click(
+    await screen.findByRole("button", { name: /edit agent:incident-agent/i }),
+  );
   // Tweak only the priority; everything else must survive untouched.
-  const editor = screen.getByRole("dialog", { name: /edit agent:incident-agent/i });
-  fireEvent.change(within(editor).getByLabelText("Priority"), { target: { value: "50" } });
+  const editor = screen.getByRole("dialog", {
+    name: /edit agent:incident-agent/i,
+  });
+  fireEvent.change(within(editor).getByLabelText("Priority"), {
+    target: { value: "50" },
+  });
   fireEvent.click(screen.getByRole("button", { name: "Update Agent" }));
 
   await waitFor(() => {
     const putCall = fetchMock.mock.calls.find(
-      ([u, i]) => String(u).endsWith("/routes") && (i as RequestInit | undefined)?.method === "PUT",
+      ([u, i]) =>
+        String(u).endsWith("/routes") &&
+        (i as RequestInit | undefined)?.method === "PUT",
     );
     expect(putCall).toBeTruthy();
     const body = JSON.parse(String((putCall![1] as RequestInit).body));
-    const saved = body.routes.find((r: { agent_id: string }) => r.agent_id === "incident-agent");
+    const saved = body.routes.find(
+      (r: { agent_id: string }) => r.agent_id === "incident-agent",
+    );
     expect(saved.priority).toBe(50);
     expect(saved.users.listen).toBe("all");
     expect(saved.users.user_list).toEqual(["U1"]);
@@ -455,14 +590,20 @@ it("preserves imported escalation/overthink/bots when editing a route (no data l
     expect(saved.bots.listen).toBe("message");
     expect(saved.bots.bot_list).toEqual(["AlertBot"]);
     expect(saved.escalation.victorops).toEqual({ enabled: true, team: "dao" });
-    expect(saved.escalation.emoji).toEqual({ enabled: true, name: "rotating_light" });
+    expect(saved.escalation.emoji).toEqual({
+      enabled: true,
+      name: "rotating_light",
+    });
     expect(saved.escalation.users).toEqual(["U027"]);
   });
 });
 
 it("renders the full per-channel/agent breakdown in the sync preview modal", async () => {
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url === "/api/admin/slack/channels" || url === "/api/admin/slack/channels?health=1") {
+    if (
+      url === "/api/admin/slack/channels" ||
+      url === "/api/admin/slack/channels?health=1"
+    ) {
       return response({ data: { channels: [] } });
     }
     if (url === "/api/dynamic-agents?enabled_only=true") {
@@ -475,7 +616,14 @@ it("renders the full per-channel/agent breakdown in the sync preview modal", asy
       return response({ data: { defaults: {} } });
     }
     if (url === "/api/admin/slack/runtime/status") {
-      return response({ data: { route_mode: "db_prefer", static_config: { channels: 2, routes: 2 }, route_cache: { ttl_seconds: 60, cache_size: 0, cached_channels: [] }, last_sync: null } });
+      return response({
+        data: {
+          route_mode: "db_prefer",
+          static_config: { channels: 2, routes: 2 },
+          route_cache: { ttl_seconds: 60, cache_size: 0, cached_channels: [] },
+          last_sync: null,
+        },
+      });
     }
     if (url === "/api/admin/slack/runtime/sync-from-config") {
       const body = JSON.parse(String(init?.body ?? "{}"));
@@ -498,7 +646,10 @@ it("renders the full per-channel/agent breakdown in the sync preview modal", asy
                   agent_id: "default",
                   priority: 100,
                   users: { enabled: true, listen: "mention" },
-                  escalation: { victorops: { enabled: true, team: "dao" }, emoji: { enabled: true, name: "ai-for-brains" } },
+                  escalation: {
+                    victorops: { enabled: true, team: "dao" },
+                    emoji: { enabled: true, name: "ai-for-brains" },
+                  },
                 },
               ],
             },
@@ -509,7 +660,15 @@ it("renders the full per-channel/agent breakdown in the sync preview modal", asy
               team_slug: null,
               has_team: false,
               agents: [
-                { agent_id: "agent-huyn-test-agent", priority: 100, users: { enabled: true, listen: "mention", overthink: { enabled: true } } },
+                {
+                  agent_id: "agent-huyn-test-agent",
+                  priority: 100,
+                  users: {
+                    enabled: true,
+                    listen: "mention",
+                    overthink: { enabled: true },
+                  },
+                },
               ],
             },
           ],
@@ -522,9 +681,13 @@ it("renders the full per-channel/agent breakdown in the sync preview modal", asy
   render(<SlackChannelRebacPanel />);
   await switchToTab("Advanced");
 
-  fireEvent.click(await screen.findByRole("button", { name: "Import from YAML" }));
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Import from YAML" }),
+  );
 
-  expect(await screen.findByText("Slack Bot Config Sync Preview")).toBeInTheDocument();
+  expect(
+    await screen.findByText("Slack Bot Config Sync Preview"),
+  ).toBeInTheDocument();
   // Channel + team rendering.
   expect(await screen.findByText("#forge-beta")).toBeInTheDocument();
   expect(screen.getByText("team:platform-engineering")).toBeInTheDocument();
@@ -560,7 +723,9 @@ it("fixes stale Slack runtime diagnostics by deleting orphaned route metadata", 
   render(<SlackChannelRebacPanel />);
   await expandChannelRow("incidents");
 
-  fireEvent.click(await screen.findByRole("button", { name: /Fix routing for foo-bar/i }));
+  fireEvent.click(
+    await screen.findByRole("button", { name: /Fix routing for foo-bar/i }),
+  );
 
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
@@ -568,8 +733,8 @@ it("fixes stale Slack runtime diagnostics by deleting orphaned route metadata", 
       expect.objectContaining({
         method: "DELETE",
         body: JSON.stringify({ agent_id: "foo-bar" }),
-      })
-    )
+      }),
+    ),
   );
 });
 
@@ -577,7 +742,9 @@ it("surfaces Slack runtime diagnostics warnings", async () => {
   render(<SlackChannelRebacPanel />);
   await expandChannelRow("incidents");
 
-  expect(await screen.findByText(/Plain channel messages will be ignored/i)).toBeInTheDocument();
+  expect(
+    await screen.findByText(/Plain channel messages will be ignored/i),
+  ).toBeInTheDocument();
   expect(screen.getByText(/OpenFGA tuple read failed/i)).toBeInTheDocument();
 });
 
@@ -586,12 +753,21 @@ it("edits and deletes Slack channel-agent associations with metadata warning", a
   render(<SlackChannelRebacPanel />);
   await expandChannelRow("incidents");
 
-  expect(await screen.findByRole("button", { name: /edit agent:incident-agent/i })).toBeInTheDocument();
-  fireEvent.click(screen.getByRole("button", { name: /edit agent:incident-agent/i }));
-  const editor = screen.getByRole("dialog", { name: /edit agent:incident-agent/i });
-  fireEvent.change(within(editor).getAllByRole("combobox", { name: "Listen" })[0], {
-    target: { value: "message" },
+  expect(
+    await screen.findByRole("button", { name: /edit agent:incident-agent/i }),
+  ).toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole("button", { name: /edit agent:incident-agent/i }),
+  );
+  const editor = screen.getByRole("dialog", {
+    name: /edit agent:incident-agent/i,
   });
+  fireEvent.change(
+    within(editor).getAllByRole("combobox", { name: "Listen" })[0],
+    {
+      target: { value: "message" },
+    },
+  );
   fireEvent.change(within(editor).getByLabelText("Priority"), {
     target: { value: "25" },
   });
@@ -603,27 +779,35 @@ it("edits and deletes Slack channel-agent associations with metadata warning", a
       expect.objectContaining({
         method: "PUT",
         body: expect.stringContaining('"priority":25'),
-      })
-    )
+      }),
+    ),
   );
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/admin/slack/channels/T123456789/C123456789/routes",
     expect.objectContaining({
       method: "PUT",
       body: expect.stringContaining('"listen":"message"'),
-    })
+    }),
   );
 
   // saveRoute leaves loading=true until its loadChannels/loadDiagnostics
   // chain settles; clicking Delete while disabled is a silent no-op,
   // which is what stalled this test before. Wait for the button to
   // reactivate first.
-  const deleteButton = await screen.findByRole("button", { name: /delete agent:incident-agent/i });
+  const deleteButton = await screen.findByRole("button", {
+    name: /delete agent:incident-agent/i,
+  });
   await waitFor(() => expect(deleteButton).not.toBeDisabled());
   fireEvent.click(deleteButton);
   expect(confirmSpy).not.toHaveBeenCalled();
-  expect(await screen.findByRole("dialog", { name: "Remove agent from channel?" })).toBeInTheDocument();
-  expect(screen.getByText(/removes agent:incident-agent from the selected Slack channel/i)).toBeInTheDocument();
+  expect(
+    await screen.findByRole("dialog", { name: "Remove agent from channel?" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      /removes agent:incident-agent from the selected Slack channel/i,
+    ),
+  ).toBeInTheDocument();
   fireEvent.click(screen.getByRole("button", { name: "Remove agent" }));
 
   await waitFor(() =>
@@ -632,8 +816,8 @@ it("edits and deletes Slack channel-agent associations with metadata warning", a
       expect.objectContaining({
         method: "DELETE",
         body: JSON.stringify({ agent_id: "incident-agent" }),
-      })
-    )
+      }),
+    ),
   );
 });
 
@@ -641,12 +825,24 @@ it("keeps Slack onboarding intentional without saved defaults or bulk apply cont
   render(<SlackChannelRebacPanel />);
   await switchToTab("Onboard channels");
 
-  expect(screen.queryByText("Default team and agent for new channels")).not.toBeInTheDocument();
+  expect(
+    screen.queryByText("Default team and agent for new channels"),
+  ).not.toBeInTheDocument();
   expect(screen.queryByLabelText("Preselected Team")).not.toBeInTheDocument();
-  expect(screen.queryByLabelText("Preselected Dynamic Agent")).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Apply Selection to Managed Channels" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Refresh lists" })).not.toBeInTheDocument();
-  expect(screen.queryByText(/Create matching Slack routes when onboarding/i)).not.toBeInTheDocument();
+  expect(
+    screen.queryByLabelText("Preselected Dynamic Agent"),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", {
+      name: "Apply Selection to Managed Channels",
+    }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Refresh lists" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/Create matching Slack routes when onboarding/i),
+  ).not.toBeInTheDocument();
 });
 
 it("discovers bot-member channels and applies defaults after admin consent", async () => {
@@ -655,20 +851,27 @@ it("discovers bot-member channels and applies defaults after admin consent", asy
 
   fireEvent.click(screen.getByRole("button", { name: "Find channels" }));
 
-  expect(await screen.findByText(/2 bot-member channels discovered/i)).toBeInTheDocument();
-  // Discovery no longer auto-selects rows.
-  expect(screen.getByRole("checkbox", { name: /Import #incidents/i })).not.toBeChecked();
-  expect(screen.getByRole("checkbox", { name: /Import #new-alerts/i })).not.toBeChecked();
   expect(
-    screen.getByRole("status", {
-      name: /2 bot-member found .* 1 new .* 1 in CAIPE .* 0 missing team/i,
-    })
+    await screen.findByRole("status", {
+      name: /Discovered: 2 .* Configured: 1 .* New: 1/i,
+    }),
   ).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Refresh channels" })).toBeInTheDocument();
+  // Discovery no longer auto-selects rows.
+  expect(
+    screen.getByRole("checkbox", { name: /Import #incidents/i }),
+  ).not.toBeChecked();
+  expect(
+    screen.getByRole("checkbox", { name: /Import #new-alerts/i }),
+  ).not.toBeChecked();
+  expect(
+    screen.getByRole("button", { name: "Refresh channels" }),
+  ).toBeInTheDocument();
 
   // Admin opts in to both rows, then fills out the second row's picks.
   fireEvent.click(screen.getByRole("checkbox", { name: /Import #incidents/i }));
-  fireEvent.click(screen.getByRole("checkbox", { name: /Import #new-alerts/i }));
+  fireEvent.click(
+    screen.getByRole("checkbox", { name: /Import #new-alerts/i }),
+  );
   await pickTeam("Team for #incidents", "platform-engineering");
   await pickAgent("Dynamic Agent for #incidents", "incident-agent");
   // #incidents is already in CAIPE with team + agent; onboard row shows Configured.
@@ -677,16 +880,20 @@ it("discovers bot-member channels and applies defaults after admin consent", asy
   await pickTeam("Team for #new-alerts", "security");
   await pickAgent("Dynamic Agent for #new-alerts", "test-april-2025");
   await waitFor(() => {
-    expect(screen.getByRole("button", { name: /^Set up 2 channels?$/ })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: /^Set up 2 channels?$/ }),
+    ).toBeEnabled();
   });
 
-  fireEvent.click(screen.getByRole("button", { name: /^Set up \d+ channels?$/ }));
+  fireEvent.click(
+    screen.getByRole("button", { name: /^Set up \d+ channels?$/ }),
+  );
 
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/api/admin/slack/available-channels?"),
-      expect.anything()
-    )
+      expect.anything(),
+    ),
   );
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
@@ -694,50 +901,53 @@ it("discovers bot-member channels and applies defaults after admin consent", asy
       expect.objectContaining({
         method: "POST",
         body: expect.stringContaining('"channel_defaults"'),
-      })
-    )
+      }),
+    ),
   );
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/admin/slack/channels/defaults",
     expect.objectContaining({
       body: expect.stringContaining('"id":"CNEWMISSING"'),
-    })
+    }),
   );
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/admin/slack/channels/defaults",
     expect.objectContaining({
       body: expect.stringContaining('"id":"C123456789"'),
-    })
+    }),
   );
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/admin/slack/channels/defaults",
     expect.objectContaining({
       body: expect.stringContaining('"team_slug":"platform-engineering"'),
-    })
+    }),
   );
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/admin/slack/channels/defaults",
     expect.objectContaining({
       body: expect.stringContaining('"team_slug":"security"'),
-    })
+    }),
   );
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/admin/slack/channels/defaults",
     expect.objectContaining({
       body: expect.stringContaining('"agent_id":"test-april-2025"'),
-    })
+    }),
   );
   await waitFor(() =>
     expect(mockToast).toHaveBeenCalledWith(
       expect.stringContaining("Discovered defaults applied"),
-      "success"
-    )
+      "success",
+    ),
   );
 });
 
 it("discovers Slack channels even when no onboarding default team is configured", async () => {
   fetchMock.mockImplementation(async (url: string) => {
-    if (url === "/api/admin/slack/channels" || url === "/api/admin/slack/channels?health=1") {
+    if (
+      url === "/api/admin/slack/channels" ||
+      url === "/api/admin/slack/channels?health=1"
+    ) {
       return response({ data: { channels: [] } });
     }
     if (url === "/api/dynamic-agents?enabled_only=true") {
@@ -750,7 +960,13 @@ it("discovers Slack channels even when no onboarding default team is configured"
     if (url === "/api/admin/teams") {
       return response({
         data: {
-          teams: [{ _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" }],
+          teams: [
+            {
+              _id: "team-1",
+              slug: "platform-engineering",
+              name: "Platform Engineering",
+            },
+          ],
         },
       });
     }
@@ -768,13 +984,26 @@ it("discovers Slack channels even when no onboarding default team is configured"
       });
     }
     if (url === "/api/admin/slack/runtime/config-defaults") {
-      return response({ data: { workspace_id: "T123456789", channels_seen: 0, routes_seen: 0, channels: {} } });
+      return response({
+        data: {
+          workspace_id: "T123456789",
+          channels_seen: 0,
+          routes_seen: 0,
+          channels: {},
+        },
+      });
     }
     if (url.startsWith("/api/admin/slack/available-channels")) {
       return response({
         data: {
           channels: [
-            { id: "CNEWMISSING", name: "new-alerts", is_private: false, is_member: true, num_members: 7 },
+            {
+              id: "CNEWMISSING",
+              name: "new-alerts",
+              is_private: false,
+              is_member: true,
+              num_members: 7,
+            },
           ],
           next_cursor: null,
           has_more: false,
@@ -803,15 +1032,21 @@ it("discovers Slack channels even when no onboarding default team is configured"
   render(<SlackChannelRebacPanel />);
   await switchToTab("Onboard channels");
 
-  const discoverButton = await screen.findByRole("button", { name: "Find channels" });
+  const discoverButton = await screen.findByRole("button", {
+    name: "Find channels",
+  });
   await waitFor(() => expect(discoverButton).not.toBeDisabled());
   fireEvent.click(discoverButton);
 
-  expect(await screen.findByText(/1 bot-member channel discovered/i)).toBeInTheDocument();
+  expect(
+    await screen.findByRole("status", { name: /Discovered: 1/i }),
+  ).toBeInTheDocument();
   // TeamPicker is a <button>, not a form control — assert the
   // empty-state placeholder is rendered on the trigger instead of
   // `.toHaveValue("")`.
-  expect(screen.getByLabelText("Team for #new-alerts")).toHaveTextContent(/Select team/);
+  expect(screen.getByLabelText("Team for #new-alerts")).toHaveTextContent(
+    /Select team/,
+  );
 });
 
 it("shows discovered channel setup feedback as a toast without shifting the action row", async () => {
@@ -820,30 +1055,40 @@ it("shows discovered channel setup feedback as a toast without shifting the acti
 
   fireEvent.click(screen.getByRole("button", { name: "Find channels" }));
 
-  expect(await screen.findByText(/2 bot-member channels discovered/i)).toBeInTheDocument();
+  expect(
+    await screen.findByRole("status", { name: /Discovered: 2/i }),
+  ).toBeInTheDocument();
   // Discovery no longer auto-selects rows — opt in explicitly before
   // setting team and agent.
   fireEvent.click(screen.getByRole("checkbox", { name: /Import #incidents/i }));
-  fireEvent.click(screen.getByRole("checkbox", { name: /Import #new-alerts/i }));
+  fireEvent.click(
+    screen.getByRole("checkbox", { name: /Import #new-alerts/i }),
+  );
   await pickTeam("Team for #incidents", "platform-engineering");
   await pickAgent("Dynamic Agent for #incidents", "incident-agent");
   await pickTeam("Team for #new-alerts", "security");
   await pickAgent("Dynamic Agent for #new-alerts", "test-april-2025");
 
-  const applyButton = screen.getByRole("button", { name: /^Set up \d+ channels?$/ });
+  const applyButton = screen.getByRole("button", {
+    name: /^Set up \d+ channels?$/,
+  });
   fireEvent.click(applyButton);
 
   await waitFor(() =>
     expect(mockToast).toHaveBeenCalledWith(
       expect.stringContaining("Discovered defaults applied"),
-      "success"
-    )
+      "success",
+    ),
   );
-  expect(screen.queryByRole("dialog", { name: "Slack setup complete" })).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("dialog", { name: "Slack setup complete" }),
+  ).not.toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
   expect(screen.queryByText("Ready to set up")).not.toBeInTheDocument();
   expect(screen.getAllByText("Configured").length).toBeGreaterThanOrEqual(2);
-  expect(applyButton.parentElement).not.toHaveTextContent(/Channel setup applied/i);
+  expect(applyButton.parentElement).not.toHaveTextContent(
+    /Channel setup applied/i,
+  );
 });
 
 it("uses a streamlined setup flow with icons and toast action confirmations", async () => {
@@ -852,18 +1097,24 @@ it("uses a streamlined setup flow with icons and toast action confirmations", as
   // Channels view (default) shows the configured-channels table; the
   // diagnostics + agents detail panel collapses inline when a row is
   // expanded.
-  expect(await screen.findByRole("tab", { name: "Configured channels" })).toBeInTheDocument();
+  expect(
+    await screen.findByRole("tab", { name: "Configured channels" }),
+  ).toBeInTheDocument();
   expect(await screen.findByText("#incidents")).toBeInTheDocument();
   await expandChannelRow("incidents");
   // The detail panel adds Diagnostics + Agents section labels alongside
   // the existing "Agents" table header — assert the buttons that only
   // appear inside the detail panel to disambiguate.
   expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
-  expect(await screen.findByRole("button", { name: "Add Agent" })).toBeInTheDocument();
+  expect(
+    await screen.findByRole("button", { name: "Add Agent" }),
+  ).toBeInTheDocument();
 
   // Onboard view shows only the discovery wizard.
   await switchToTab("Onboard channels");
-  expect(screen.getByRole("button", { name: "Find channels" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Find channels" }),
+  ).toBeInTheDocument();
 
   // Advanced view exposes runtime status + YAML import controls.
   await switchToTab("Advanced");
@@ -874,48 +1125,64 @@ it("uses a streamlined setup flow with icons and toast action confirmations", as
   await waitFor(() => expect(reloadButton).not.toBeDisabled());
   fireEvent.click(reloadButton);
   await waitFor(() =>
-    expect(mockToast).toHaveBeenCalledWith("Slack bot route cache reloaded.", "success")
+    expect(mockToast).toHaveBeenCalledWith(
+      "Slack bot route cache reloaded.",
+      "success",
+    ),
   );
 
   fireEvent.click(screen.getByRole("button", { name: "Import from YAML" }));
-  const importButton = await screen.findByRole("button", { name: "Apply Import" });
+  const importButton = await screen.findByRole("button", {
+    name: "Apply Import",
+  });
   fireEvent.click(importButton);
   await waitFor(() =>
     expect(mockToast).toHaveBeenCalledWith(
       expect.stringContaining("Config sync applied"),
-      "success"
-    )
+      "success",
+    ),
   );
 });
 
 it("organizes Slack admin into Configured / Onboard / Advanced tabs", async () => {
   render(<SlackChannelRebacPanel />);
 
-  expect(await screen.findByRole("tab", { name: "Configured channels" })).toBeInTheDocument();
+  expect(
+    await screen.findByRole("tab", { name: "Configured channels" }),
+  ).toBeInTheDocument();
 
   // Configured tab is selected by default.
-  expect(screen.getByRole("tab", { name: "Configured channels" })).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
+  expect(
+    screen.getByRole("tab", { name: "Configured channels" }),
+  ).toHaveAttribute("aria-selected", "true");
   expect(
     screen.getByRole("region", { name: "Configured Slack channels" }),
   ).toBeInTheDocument();
   expect(
-    screen.queryByRole("region", { name: "Default team and agent for new channels" }),
+    screen.queryByRole("region", {
+      name: "Default team and agent for new channels",
+    }),
   ).not.toBeInTheDocument();
   expect(
-    screen.queryByRole("region", { name: "Advanced Setup - Import/Sync with Slackbot" }),
+    screen.queryByRole("region", {
+      name: "Advanced Setup - Import/Sync with Slackbot",
+    }),
   ).not.toBeInTheDocument();
 
   // Onboard tab swaps in discovery wizard, hides the configured table.
   await switchToTab("Onboard channels");
-  expect(screen.getByRole("button", { name: "Find channels" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Find channels" }),
+  ).toBeInTheDocument();
   // assisted-by Codex Codex-sonnet-4-6
   expect(
-    screen.getByText(/Members of the assigned team can update this Slack channel's bot routing/i),
+    screen.getByRole("button", { name: "Slack channels setup details" }),
   ).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Slack access details" })).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      /Members of the assigned team can update this Slack channel's bot routing/i,
+    ),
+  ).not.toBeInTheDocument();
   expect(screen.queryByText(/user:\* can_use agent/i)).not.toBeInTheDocument();
   expect(screen.queryByText(/Sharing model:/i)).not.toBeInTheDocument();
   expect(
@@ -925,9 +1192,15 @@ it("organizes Slack admin into Configured / Onboard / Advanced tabs", async () =
   // Advanced tab shows runtime status + YAML import controls only.
   await switchToTab("Advanced");
   expect(
-    await screen.findByRole("region", { name: "Advanced Setup - Import/Sync with Slackbot" }),
+    await screen.findByRole("region", {
+      name: "Advanced Setup - Import/Sync with Slackbot",
+    }),
   ).toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Default team and agent for new channels" })).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("region", {
+      name: "Default team and agent for new channels",
+    }),
+  ).not.toBeInTheDocument();
 });
 
 it("writes the active sub-tab to the subtab URL param", async () => {
@@ -935,22 +1208,33 @@ it("writes the active sub-tab to the subtab URL param", async () => {
   await screen.findByRole("tab", { name: "Configured channels" });
 
   await switchToTab("Advanced");
-  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=advanced", { scroll: false });
+  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=advanced", {
+    scroll: false,
+  });
 
   await switchToTab("Onboard channels");
-  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=onboard", { scroll: false });
+  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=onboard", {
+    scroll: false,
+  });
 
   await switchToTab("Configured channels");
-  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=channels", { scroll: false });
+  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=channels", {
+    scroll: false,
+  });
 });
 
 it("opens the sub-tab named by the subtab URL param on load", async () => {
   currentSearchParams = new URLSearchParams("subtab=advanced");
   render(<SlackChannelRebacPanel />);
 
-  expect(await screen.findByRole("tab", { name: "Advanced" })).toHaveAttribute("aria-selected", "true");
+  expect(await screen.findByRole("tab", { name: "Advanced" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
   expect(
-    await screen.findByRole("region", { name: "Advanced Setup - Import/Sync with Slackbot" }),
+    await screen.findByRole("region", {
+      name: "Advanced Setup - Import/Sync with Slackbot",
+    }),
   ).toBeInTheDocument();
 });
 
@@ -958,25 +1242,37 @@ it("shows Slack bot runtime sync status and triggers reload/config sync", async 
   render(<SlackChannelRebacPanel />);
   await switchToTab("Advanced");
 
-  expect(await screen.findByRole("heading", { name: "Import from Slackbot YAML" })).toBeInTheDocument();
+  expect(
+    await screen.findByRole("heading", { name: "Import from Slackbot YAML" }),
+  ).toBeInTheDocument();
   expect(screen.getByText("db_prefer")).toBeInTheDocument();
   expect(screen.getByText(/1 cached channel/i)).toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Slackbot sync legend" })).not.toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Help: Route mode" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Help: Static config" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Help: Route cache" })).toBeInTheDocument();
+  expect(
+    screen.queryByRole("region", { name: "Slackbot sync legend" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Help: Route mode" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Help: Static config" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Help: Route cache" }),
+  ).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("button", { name: "Reload Bot Cache" }));
   await waitFor(() =>
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/admin/slack/runtime/reload",
-      expect.objectContaining({ method: "POST" })
-    )
+      expect.objectContaining({ method: "POST" }),
+    ),
   );
 
   // Reload sets loading=true which disables Import from YAML; wait
   // for the click to take effect before firing the next one.
-  const previewButton = screen.getByRole("button", { name: "Import from YAML" });
+  const previewButton = screen.getByRole("button", {
+    name: "Import from YAML",
+  });
   await waitFor(() => expect(previewButton).not.toBeDisabled());
   fireEvent.click(previewButton);
   await waitFor(() =>
@@ -985,8 +1281,8 @@ it("shows Slack bot runtime sync status and triggers reload/config sync", async 
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ dry_run: true }),
-      })
-    )
+      }),
+    ),
   );
   expect(await screen.findByText("Preview complete")).toBeInTheDocument();
 
@@ -999,8 +1295,8 @@ it("shows Slack bot runtime sync status and triggers reload/config sync", async 
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ dry_run: false }),
-      })
-    )
+      }),
+    ),
   );
   expect(await screen.findByText("Apply complete")).toBeInTheDocument();
 });
@@ -1009,7 +1305,9 @@ it("opens a runtime sync modal with preview progress and apply results", async (
   render(<SlackChannelRebacPanel />);
   await switchToTab("Advanced");
 
-  fireEvent.click(await screen.findByRole("button", { name: "Import from YAML" }));
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Import from YAML" }),
+  );
 
   expect(await screen.findByRole("dialog")).toBeInTheDocument();
   expect(screen.getByText("Slack Bot Config Sync Preview")).toBeInTheDocument();
@@ -1026,8 +1324,8 @@ it("opens a runtime sync modal with preview progress and apply results", async (
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ dry_run: false }),
-      })
-    )
+      }),
+    ),
   );
   expect(await screen.findByText("Apply complete")).toBeInTheDocument();
   expect(screen.getByText("1 route upserted")).toBeInTheDocument();

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -21,7 +21,10 @@ const fetchMock = jest.fn();
 
 function setupFetchMock() {
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-    if (url === "/api/admin/webex/spaces" || url === "/api/admin/webex/spaces?health=1") {
+    if (
+      url === "/api/admin/webex/spaces" ||
+      url === "/api/admin/webex/spaces?health=1"
+    ) {
       return response({
         data: {
           spaces: [
@@ -41,8 +44,18 @@ function setupFetchMock() {
       return response({
         data: {
           spaces: [
-            { id: "space-abc", name: "Platform Alerts", type: "group", is_locked: false },
-            { id: "space-new-123", name: "Incident War Room", type: "group", is_locked: false },
+            {
+              id: "space-abc",
+              name: "Platform Alerts",
+              type: "group",
+              is_locked: false,
+            },
+            {
+              id: "space-new-123",
+              name: "Incident War Room",
+              type: "group",
+              is_locked: false,
+            },
           ],
           has_more: false,
           next_cursor: null,
@@ -61,7 +74,15 @@ function setupFetchMock() {
     }
     if (url === "/api/admin/teams") {
       return response({
-        data: { teams: [{ _id: "team-1", slug: "platform-engineering", name: "Platform Engineering" }] },
+        data: {
+          teams: [
+            {
+              _id: "team-1",
+              slug: "platform-engineering",
+              name: "Platform Engineering",
+            },
+          ],
+        },
       });
     }
     if (url === "/api/admin/webex/spaces/defaults" && init?.method === "POST") {
@@ -84,13 +105,23 @@ function setupFetchMock() {
       const body = JSON.parse(String(init.body ?? "{}"));
       return response({
         data: {
-          defaults: { ...body, source: "db", updated_at: "2026-05-27T08:00:00.000Z", updated_by: "admin@example.com" },
+          defaults: {
+            ...body,
+            source: "db",
+            updated_at: "2026-05-27T08:00:00.000Z",
+            updated_by: "admin@example.com",
+          },
         },
       });
     }
     if (url === "/api/admin/webex/spaces/defaults") {
       return response({
-        data: { defaults: { team_slug: "platform-engineering", agent_id: "incident-agent" } },
+        data: {
+          defaults: {
+            team_slug: "platform-engineering",
+            agent_id: "incident-agent",
+          },
+        },
       });
     }
     if (url === "/api/admin/webex/runtime/status") {
@@ -126,7 +157,18 @@ function setupFetchMock() {
       return response({ data: { deleted: { agent_id: "foo-bar" } } });
     }
     if (url.endsWith("/routes")) {
-      return response({ data: { routes: [{ agent_id: "incident-agent", enabled: true, priority: 100, users: { enabled: true, listen: "mention" } }] } });
+      return response({
+        data: {
+          routes: [
+            {
+              agent_id: "incident-agent",
+              enabled: true,
+              priority: 100,
+              users: { enabled: true, listen: "mention" },
+            },
+          ],
+        },
+      });
     }
     if (url.endsWith("/diagnostics")) {
       return response({
@@ -136,10 +178,28 @@ function setupFetchMock() {
             "agent:foo-bar has Mongo route metadata, but the OpenFGA tuple is missing; runtime ignores it.",
           ],
           routes: [
-            { agent_id: "foo-bar", openfga_tuple: false, route_metadata: true, listen: "message", runtime_matches: { mention: false, message: true }, warnings: [] },
-            { agent_id: "incident-agent", openfga_tuple: true, route_metadata: true, listen: "mention", runtime_matches: { mention: true, message: false }, warnings: [] },
+            {
+              agent_id: "foo-bar",
+              openfga_tuple: false,
+              route_metadata: true,
+              listen: "message",
+              runtime_matches: { mention: false, message: true },
+              warnings: [],
+            },
+            {
+              agent_id: "incident-agent",
+              openfga_tuple: true,
+              route_metadata: true,
+              listen: "mention",
+              runtime_matches: { mention: true, message: false },
+              warnings: [],
+            },
           ],
-          last_runtime_error: { ts: "2026-05-18T07:50:00.000Z", reason_code: "OPENFGA_READ_FAILED", message: "OpenFGA tuple read failed" },
+          last_runtime_error: {
+            ts: "2026-05-18T07:50:00.000Z",
+            reason_code: "OPENFGA_READ_FAILED",
+            message: "OpenFGA tuple read failed",
+          },
         },
       });
     }
@@ -156,19 +216,37 @@ beforeEach(() => {
   setupFetchMock();
 });
 
-afterEach(() => { jest.useRealTimers(); });
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 function response(payload: unknown): Response {
-  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) } as Response;
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
 }
 
-it("shows a loading spinner on the configured spaces tab while spaces load", async () => {
+async function clickFindSpaces() {
+  const discoverButton = await screen.findByRole("button", {
+    name: "Find spaces",
+  });
+  await waitFor(() => expect(discoverButton).toBeEnabled());
+  fireEvent.click(discoverButton);
+}
+
+it("shows the onboarding loading state while configured spaces seed the table", async () => {
   let resolveSpaces: ((value: Response) => void) | undefined;
   const spacesPromise = new Promise<Response>((resolve) => {
     resolveSpaces = resolve;
   });
   fetchMock.mockImplementation(async (url: string) => {
-    if (url === "/api/admin/webex/spaces" || url === "/api/admin/webex/spaces?health=1") {
+    if (
+      url === "/api/admin/webex/spaces" ||
+      url === "/api/admin/webex/spaces?health=1"
+    ) {
       return spacesPromise;
     }
     if (url === "/api/dynamic-agents?enabled_only=true") {
@@ -178,140 +256,144 @@ it("shows a loading spinner on the configured spaces tab while spaces load", asy
   });
 
   render(<WebexSpaceRebacPanel />);
-  expect(screen.getByTestId("connector-items-loading")).toBeInTheDocument();
-  expect(screen.getByText("Loading Webex spaces…")).toBeInTheDocument();
-  expect(screen.queryByText("No spaces configured yet.")).not.toBeInTheDocument();
+  expect(screen.getByTestId("discovery-loading")).toBeInTheDocument();
+  expect(screen.getByText("Loading configured spaces…")).toBeInTheDocument();
+  expect(
+    screen.queryByText("No spaces configured yet."),
+  ).not.toBeInTheDocument();
 
   resolveSpaces?.(response({ data: { spaces: [] } }));
-  expect(await screen.findByText("No spaces configured yet.")).toBeInTheDocument();
-  expect(screen.queryByTestId("connector-items-loading")).not.toBeInTheDocument();
+  await waitFor(() =>
+    expect(screen.queryByTestId("discovery-loading")).not.toBeInTheDocument(),
+  );
 });
 
-async function switchToTab(name: "Configured spaces" | "Onboard spaces" | "Advanced") {
-  fireEvent.click(await screen.findByRole("tab", { name }));
-}
+// ── Single onboarding layout ────────────────────────────────────────────────
 
-async function expandSpaceRow(spaceName: string) {
-  const row = (await screen.findByText(spaceName)).closest("tr");
-  if (!row) throw new Error(`Row for "${spaceName}" not found`);
-  fireEvent.click(row);
-}
-
-// ── Tab layout ──────────────────────────────────────────────────────────────
-
-it("organises Webex admin into Configured / Onboard / Advanced tabs, mirrors Slack layout", async () => {
+it("renders Webex as a single onboarding view without Configured or Advanced tabs", async () => {
   render(<WebexSpaceRebacPanel />);
 
-  // Configured tab is default and shows the space table once data loads
-  expect(await screen.findByRole("tab", { name: "Configured spaces" })).toHaveAttribute("aria-selected", "true");
-  expect(await screen.findByRole("region", { name: "Configured Webex spaces" })).toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Onboarding Default Selection" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Advanced Setup - Import/Sync with Webex Bot" })).not.toBeInTheDocument();
-
-  // Onboard tab shows discovery wizard only.
-  await switchToTab("Onboard spaces");
-  expect(screen.queryByRole("region", { name: "Onboarding Default Selection" })).not.toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Find spaces" })).toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Configured Webex spaces" })).not.toBeInTheDocument();
-
-  // Advanced tab shows runtime status controls only
-  await switchToTab("Advanced");
-  expect(await screen.findByRole("region", { name: "Advanced Setup - Import/Sync with Webex Bot" })).toBeInTheDocument();
-  expect(screen.queryByRole("region", { name: "Onboarding Default Selection" })).not.toBeInTheDocument();
+  expect(await screen.findByText("Configure spaces")).toBeInTheDocument();
+  expect(
+    screen.queryByRole("tablist", { name: "Webex admin views" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("tab", { name: "Configured spaces" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("tab", { name: "Advanced" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Find spaces" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("region", { name: "Configured Webex spaces" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("region", {
+      name: "Advanced Setup - Import/Sync with Webex Bot",
+    }),
+  ).not.toBeInTheDocument();
 });
 
-it("writes the active sub-tab to the subtab URL param", async () => {
-  render(<WebexSpaceRebacPanel />);
-  await screen.findByRole("tab", { name: "Configured spaces" });
-
-  await switchToTab("Advanced");
-  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=advanced", { scroll: false });
-
-  await switchToTab("Onboard spaces");
-  expect(replaceMock).toHaveBeenLastCalledWith("/admin?subtab=onboard", { scroll: false });
-});
-
-it("opens the sub-tab named by the subtab URL param on load", async () => {
+it("ignores stale Webex subtab URL params and stays on onboarding", async () => {
   currentSearchParams = new URLSearchParams("subtab=advanced");
   render(<WebexSpaceRebacPanel />);
 
-  expect(await screen.findByRole("tab", { name: "Advanced" })).toHaveAttribute("aria-selected", "true");
-  expect(await screen.findByRole("region", { name: "Advanced Setup - Import/Sync with Webex Bot" })).toBeInTheDocument();
-});
-
-// ── Configured spaces table + diagnostics ──────────────────────────────────
-
-it("shows spaces in a table and expands a row to show diagnostics without manual route controls", async () => {
-  render(<WebexSpaceRebacPanel />);
-
-  // Space appears in the table; no "X grants" column
-  expect(await screen.findByText("Platform Alerts")).toBeInTheDocument();
-  expect(screen.queryByText(/0 grants/i)).not.toBeInTheDocument();
-  expect(screen.getByText("team:platform-engineering")).toBeInTheDocument();
-  expect(screen.getByText("Incident Agent")).toBeInTheDocument();
-  expect(screen.getByText("incident-agent")).toBeInTheDocument();
-
-  // Expand the row
-  await expandSpaceRow("Platform Alerts");
-  expect(await screen.findByText("Diagnostics")).toBeInTheDocument();
-  expect(await screen.findByText(/OpenFGA tuple read failed/i)).toBeInTheDocument();
-
-  // No manual route form — Webex routes are managed via onboarding + auto-fix
-  expect(screen.queryByLabelText("Dynamic Agent")).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "Create Association" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: /edit agent:incident-agent/i })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: /delete agent:incident-agent/i })).not.toBeInTheDocument();
-});
-
-it("fixes stale diagnostic route metadata (orphan) by issuing DELETE", async () => {
-  render(<WebexSpaceRebacPanel />);
-  await expandSpaceRow("Platform Alerts");
-
-  fireEvent.click(await screen.findByRole("button", { name: /Fix routing for foo-bar/i }));
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
-      expect.objectContaining({ method: "DELETE", body: JSON.stringify({ agent_id: "foo-bar" }) })
-    )
-  );
-});
-
-it("fixes mention-only diagnostic route by lifting listen mode to all", async () => {
-  render(<WebexSpaceRebacPanel />);
-  await expandSpaceRow("Platform Alerts");
-
-  fireEvent.click(await screen.findByRole("button", { name: /Fix routing for incident-agent/i }));
-
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/spaces/WEBEX-WORKSPACE/space-abc/routes",
-      expect.objectContaining({ method: "PUT", body: expect.stringContaining('"listen":"all"') })
-    )
-  );
+  expect(await screen.findByText("Configure spaces")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Find spaces" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("region", {
+      name: "Advanced Setup - Import/Sync with Webex Bot",
+    }),
+  ).not.toBeInTheDocument();
+  expect(replaceMock).not.toHaveBeenCalled();
 });
 
 // ── Discovery + onboarding ─────────────────────────────────────────────────
 
 it("seeds configured Webex spaces on the onboard tab before discovery", async () => {
   render(<WebexSpaceRebacPanel />);
-  await switchToTab("Onboard spaces");
 
   expect(await screen.findByText("Platform Alerts")).toBeInTheDocument();
   expect(screen.getByText("Configured")).toBeInTheDocument();
-  expect(fetchMock.mock.calls.some(([url]) => String(url).startsWith("/api/admin/webex/available-spaces"))).toBe(false);
+  expect(
+    fetchMock.mock.calls.some(([url]) =>
+      String(url).startsWith("/api/admin/webex/available-spaces"),
+    ),
+  ).toBe(false);
+});
+
+it("filters configured Webex spaces locally before live discovery runs", async () => {
+  const baseFetch = fetchMock.getMockImplementation();
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (
+      url === "/api/admin/webex/spaces" ||
+      url === "/api/admin/webex/spaces?health=1"
+    ) {
+      return response({
+        data: {
+          spaces: [
+            {
+              workspace_id: "WEBEX-WORKSPACE",
+              space_id: "space-abc",
+              space_name: "Platform Alerts",
+              team_slug: "platform-engineering",
+              primary_agent_id: "incident-agent",
+              active_grants: 1,
+            },
+            {
+              workspace_id: "WEBEX-WORKSPACE",
+              space_id: "space-caipe",
+              space_name: "CAIPE Demo",
+              team_slug: "platform-engineering",
+              primary_agent_id: "incident-agent",
+              active_grants: 1,
+            },
+          ],
+        },
+      });
+    }
+    return baseFetch?.(url, init) ?? response({});
+  });
+
+  render(<WebexSpaceRebacPanel />);
+
+  expect(await screen.findByText("Platform Alerts")).toBeInTheDocument();
+  expect(screen.getByText("CAIPE Demo")).toBeInTheDocument();
+
+  fireEvent.change(screen.getByRole("searchbox", { name: "Search spaces" }), {
+    target: { value: "CAIPE" },
+  });
+
+  expect(screen.getByText("CAIPE Demo")).toBeInTheDocument();
+  expect(screen.queryByText("Platform Alerts")).not.toBeInTheDocument();
+  expect(
+    fetchMock.mock.calls.some(([url]) =>
+      String(url).startsWith("/api/admin/webex/available-spaces"),
+    ),
+  ).toBe(false);
 });
 
 it("discovers Webex bot spaces, auto-selects new ones, and POSTs per-space defaults on apply", async () => {
   render(<WebexSpaceRebacPanel />);
-  await switchToTab("Onboard spaces");
 
-  fireEvent.click(screen.getByRole("button", { name: "Find spaces" }));
+  await clickFindSpaces();
 
   // Only the new space (Incident War Room) is auto-selected; existing one (Platform Alerts) is not
-  expect(await screen.findByText(/2 bot-visible spaces discovered/i)).toBeInTheDocument();
-  expect(screen.getByRole("checkbox", { name: /Import Incident War Room/i })).toBeChecked();
-  expect(screen.getByRole("checkbox", { name: /Import Platform Alerts/i })).not.toBeChecked();
+  expect(
+    await screen.findByRole("status", {
+      name: /Discovered: 2 .* Configured: 1/i,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("checkbox", { name: /Import Incident War Room/i }),
+  ).toBeChecked();
+  expect(
+    screen.getByRole("checkbox", { name: /Import Platform Alerts/i }),
+  ).not.toBeChecked();
   await pickTeam("Team for Incident War Room", "platform-engineering");
   await pickAgent("Dynamic Agent for Incident War Room", "incident-agent");
 
@@ -328,14 +410,82 @@ it("discovers Webex bot spaces, auto-selects new ones, and POSTs per-space defau
           create_routes: true,
           manual_spaces: [{ id: "space-new-123", name: "Incident War Room" }],
         }),
-      })
-    )
+      }),
+    ),
   );
   await waitFor(() =>
-    expect(mockToast).toHaveBeenCalledWith(expect.stringContaining("Discovered Webex spaces applied"), "success")
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.stringContaining("Discovered Webex spaces applied"),
+      "success",
+    ),
   );
   expect(screen.queryByText("Ready to set up")).not.toBeInTheDocument();
   expect(screen.getAllByText("Configured").length).toBeGreaterThan(0);
+});
+
+it("shows direct Webex rooms as personal DMs and excludes them from team setup", async () => {
+  const baseFetch = fetchMock.getMockImplementation();
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (String(url).startsWith("/api/admin/webex/available-spaces")) {
+      return response({
+        data: {
+          spaces: [
+            {
+              id: "direct-room-123456",
+              name: "Sri Aradhyula",
+              type: "direct",
+              is_locked: false,
+            },
+            {
+              id: "space-new-123",
+              name: "Incident War Room",
+              type: "group",
+              is_locked: false,
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      });
+    }
+    return baseFetch?.(url, init) ?? response({});
+  });
+
+  render(<WebexSpaceRebacPanel />);
+
+  await clickFindSpaces();
+
+  expect(
+    await screen.findByRole("status", {
+      name: /Discovered: 3 .* Configured: 1/i,
+    }),
+  ).toBeInTheDocument();
+  const directCheckbox = screen.getByRole("checkbox", {
+    name: /Import Sri Aradhyula/i,
+  });
+  expect(directCheckbox).toBeDisabled();
+  expect(directCheckbox).not.toBeChecked();
+  expect(
+    screen.queryByLabelText("Team for Sri Aradhyula"),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByLabelText("Dynamic Agent for Sri Aradhyula"),
+  ).not.toBeInTheDocument();
+  expect(screen.getAllByText("Personal DM").length).toBeGreaterThan(0);
+  expect(screen.getByRole("button", { name: "Set up 1 space" })).toBeEnabled();
+
+  fireEvent.click(screen.getByRole("button", { name: "Set up 1 space" }));
+
+  await waitFor(() => {
+    const postCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        url === "/api/admin/webex/spaces/defaults" && init?.method === "POST",
+    );
+    expect(postCall).toBeTruthy();
+    expect(
+      JSON.parse(String(postCall?.[1]?.body ?? "{}")).manual_spaces,
+    ).toEqual([{ id: "space-new-123", name: "Incident War Room" }]);
+  });
 });
 
 it("allows discovery before global defaults are configured", async () => {
@@ -348,79 +498,24 @@ it("allows discovery before global defaults are configured", async () => {
   });
 
   render(<WebexSpaceRebacPanel />);
-  await switchToTab("Onboard spaces");
 
-  const discoverButton = await screen.findByRole("button", { name: "Find spaces" });
-  await waitFor(() => expect(discoverButton).toBeEnabled());
-  fireEvent.click(discoverButton);
+  await clickFindSpaces();
 
   await waitFor(() =>
-    expect(fetchMock.mock.calls.some(([url]) =>
-      String(url).startsWith("/api/admin/webex/available-spaces") && String(url).includes("limit=200")
-    )).toBe(true)
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          String(url).startsWith("/api/admin/webex/available-spaces") &&
+          String(url).includes("limit=200"),
+      ),
+    ).toBe(true),
   );
-  expect(await screen.findByText(/2 bot-visible spaces discovered/i)).toBeInTheDocument();
-  expect(screen.getByRole("checkbox", { name: /Import Incident War Room/i })).toBeChecked();
-});
-
-// ── Advanced tab ───────────────────────────────────────────────────────────
-
-it("shows Webex-specific runtime status including Thread context tile and triggers YAML sync", async () => {
-  render(<WebexSpaceRebacPanel />);
-  await switchToTab("Advanced");
-
-  expect(await screen.findByText("db_prefer")).toBeInTheDocument();
-  expect(await screen.findByText(/1 cached space/i)).toBeInTheDocument();
-  expect(screen.getByText("Thread context")).toBeInTheDocument();
-  expect(screen.getByText("Enabled, 10 messages / 4000 chars")).toBeInTheDocument();
-
-  expect(screen.getByRole("button", { name: "Help: Route mode" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Help: Thread context" })).toBeInTheDocument();
-
-  fireEvent.click(screen.getByRole("button", { name: "Import from YAML" }));
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({ method: "POST", body: JSON.stringify({ dry_run: true }) })
-    )
-  );
-  expect(await screen.findByText("Preview complete")).toBeInTheDocument();
-
-  const importButton = await screen.findByRole("button", { name: "Apply Import" });
-  await waitFor(() => expect(importButton).not.toBeDisabled());
-  fireEvent.click(importButton);
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({ method: "POST", body: JSON.stringify({ dry_run: false }) })
-    )
-  );
-  expect(await screen.findByText("Apply complete")).toBeInTheDocument();
-});
-
-it("opens sync modal with accurate preview and apply counts", async () => {
-  render(<WebexSpaceRebacPanel />);
-  await switchToTab("Advanced");
-
-  const previewButton = await screen.findByRole("button", { name: "Import from YAML" });
-  await waitFor(() => expect(previewButton).toBeEnabled());
-  fireEvent.click(previewButton);
-
-  expect(await screen.findByRole("dialog")).toBeInTheDocument();
-  expect(screen.getByText("Webex Bot Config Sync Preview")).toBeInTheDocument();
-  expect(await screen.findByText("Preview complete")).toBeInTheDocument();
-  expect(screen.getByText("1 route planned")).toBeInTheDocument();
-  expect(screen.getByText("1 space scanned")).toBeInTheDocument();
-  expect(screen.getByText("0 routes upserted")).toBeInTheDocument();
-
-  fireEvent.click(screen.getByRole("button", { name: "Apply Import" }));
-  await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/admin/webex/runtime/sync-from-config",
-      expect.objectContaining({ body: JSON.stringify({ dry_run: false }) })
-    )
-  );
-  expect(await screen.findByText("Apply complete")).toBeInTheDocument();
-  expect(screen.getByText("1 route upserted")).toBeInTheDocument();
-  expect(screen.getByText("1 OpenFGA tuple written")).toBeInTheDocument();
+  expect(
+    await screen.findByRole("status", {
+      name: /Discovered: 2 .* Configured: 1/i,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("checkbox", { name: /Import Incident War Room/i }),
+  ).toBeChecked();
 });

--- a/ui/src/components/admin/rebac/connector-admin-adapter.ts
+++ b/ui/src/components/admin/rebac/connector-admin-adapter.ts
@@ -151,6 +151,8 @@ export interface DiscoveredItem {
   id: string;
   name: string;
   secondary: string;
+  teamRequired?: boolean;
+  selectable?: boolean;
 }
 
 export interface DiscoveryPage {
@@ -166,6 +168,7 @@ export interface ConnectorAdminAdapter {
   connectorName: string;    // "Slack" | "Webex"
   itemSingular: string;     // "channel" | "space"
   itemPlural: string;       // "channels" | "spaces"
+  singlePanelView?: "channels" | "onboard" | "advanced";
 
   // ── API paths ─────────────────────────────────────────────────────────
   api: {
@@ -255,7 +258,15 @@ export interface ConnectorAdminAdapter {
   // Different connectors send different POST payloads and fire different
   // success messages. The adapter owns the request(s) and the toast text.
   applyOnboarding: (input: {
-    rows: Array<{ id: string; name?: string; teamSlug: string; agentId: string; selected: boolean }>;
+    rows: Array<{
+      id: string;
+      name?: string;
+      teamSlug: string;
+      agentId: string;
+      selected: boolean;
+      teamRequired?: boolean;
+      selectable?: boolean;
+    }>;
     defaultTeamSlug: string;
     defaultAgentId: string;
     createDefaultRoutes: boolean;


### PR DESCRIPTION
## Summary
- Simplify the Webex integration UI into the Configure spaces flow and tighten the discover/filter/select/setup controls.
- Make team/agent route edits auto-select rows, avoid team assignment for personal direct spaces, and clean up confusing user-facing Webex messages.
- Keep product naming driven by app configuration instead of hard-coded Grid copy.

## Validation
- `uv run pytest ai_platform_engineering/integrations/webex_bot/tests/test_webex_agent_routes.py ai_platform_engineering/integrations/webex_bot/tests/test_runtime_gate.py ai_platform_engineering/integrations/webex_bot/tests/test_user_messages.py ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py`
- `uv run ruff check ai_platform_engineering/integrations/webex_bot/app.py ai_platform_engineering/integrations/webex_bot/utils/user_messages.py ai_platform_engineering/integrations/webex_bot/utils/webex_agent_routes.py ai_platform_engineering/integrations/webex_bot/webex_responder.py ai_platform_engineering/integrations/webex_bot/webex_wdm.py ai_platform_engineering/integrations/webex_bot/tests/test_webex_agent_routes.py ai_platform_engineering/integrations/webex_bot/tests/test_runtime_gate.py ai_platform_engineering/integrations/webex_bot/tests/test_user_messages.py ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py`
- `npm test -- src/components/admin/rebac/__tests__/ConnectorOnboardingWizard.test.tsx src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx --runInBand`
- `npm exec eslint -- e2e/rbac/webex-configure-spaces.spec.ts e2e/rbac/webex-workflow-agent-routes.spec.ts src/components/admin/rebac/ConnectorAdminPanel.tsx src/components/admin/rebac/ConnectorOnboardingWizard.tsx src/components/admin/rebac/WebexSpaceRebacPanel.tsx`
- `RUN_RBAC_REGRESSION=1 npx playwright test --config=playwright.rbac.config.ts e2e/rbac/webex-configure-spaces.spec.ts e2e/rbac/webex-workflow-agent-routes.spec.ts`
- `git diff --check`