### PR TITLE
fix(mcp): stabilize tool schema and health scans

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import copy
 import hashlib
 import hmac
 import json
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 CALLER_PROVIDER_NOT_CONNECTED = "caller_provider_not_connected"
 PINNED_PROVIDER_UNAVAILABLE = "pinned_provider_unavailable"
+TOP_LEVEL_UNION_SCHEMA_KEYS = ("oneOf", "anyOf", "allOf")
 
 _PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "atlassian": "Atlassian",
@@ -1157,6 +1159,130 @@ def _format_tool_error(tool_name: str, exc: Exception) -> str:
     )
 
 
+def _json_schema_dict(schema: Any) -> dict[str, Any] | None:
+    """Return a JSON-schema dict for Pydantic model classes or schema dicts."""
+    if isinstance(schema, dict):
+        return copy.deepcopy(schema)
+
+    if isinstance(schema, type):
+        model_json_schema = getattr(schema, "model_json_schema", None)
+        if callable(model_json_schema):
+            return copy.deepcopy(model_json_schema())
+        schema_method = getattr(schema, "schema", None)
+        if callable(schema_method):
+            return copy.deepcopy(schema_method())
+
+    return None
+
+
+def _resolve_local_schema_ref(ref: str, root: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve local JSON-schema refs like ``#/$defs/Foo``."""
+    if not ref.startswith("#/"):
+        return None
+
+    node: Any = root
+    for raw_part in ref[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+
+    return copy.deepcopy(node) if isinstance(node, dict) else None
+
+
+def _dereference_schema(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _resolve_local_schema_ref(ref, root)
+        if resolved is not None:
+            return resolved
+    return schema
+
+
+def _object_shape_from_schema(schema: dict[str, Any], root: dict[str, Any]) -> tuple[dict[str, Any], set[str]]:
+    """Extract object properties and required fields from a schema branch."""
+    schema = _dereference_schema(schema, root)
+    properties: dict[str, Any] = {}
+    required: set[str] = set()
+
+    for key in TOP_LEVEL_UNION_SCHEMA_KEYS:
+        branches = schema.get(key)
+        if not isinstance(branches, list):
+            continue
+
+        branch_required_sets: list[set[str]] = []
+        for branch in branches:
+            if not isinstance(branch, dict):
+                continue
+            branch_properties, branch_required = _object_shape_from_schema(branch, root)
+            properties.update(branch_properties)
+            branch_required_sets.append(branch_required)
+
+        if key == "allOf":
+            for branch_required in branch_required_sets:
+                required.update(branch_required)
+        elif branch_required_sets:
+            required.update(set.intersection(*branch_required_sets))
+
+    branch_properties = schema.get("properties")
+    if isinstance(branch_properties, dict):
+        properties.update(copy.deepcopy(branch_properties))
+
+    branch_required = schema.get("required")
+    if isinstance(branch_required, list):
+        required.update(item for item in branch_required if isinstance(item, str))
+
+    return properties, required
+
+
+def _collapse_top_level_union_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Collapse a top-level union/intersection schema into a provider-safe object."""
+    properties, required = _object_shape_from_schema(schema, schema)
+    collapsed: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": True,
+    }
+
+    for metadata_key in ("title", "description"):
+        value = schema.get(metadata_key)
+        if isinstance(value, str) and value:
+            collapsed[metadata_key] = value
+
+    if required:
+        collapsed["required"] = sorted(required)
+
+    return collapsed
+
+
+def _model_safe_args_schema(tool: BaseTool, agent_name: str) -> Any:
+    """Return an args schema that model providers can accept for tool binding."""
+    try:
+        schema = _json_schema_dict(getattr(tool, "tool_call_schema", None))
+    except Exception as exc:  # noqa: BLE001 - schema inspection should not drop a tool
+        logger.debug("[%s] Could not inspect tool schema for '%s': %s", agent_name, tool.name, exc)
+        return tool.args_schema
+
+    if not schema:
+        return tool.args_schema
+
+    top_level_keys = [key for key in TOP_LEVEL_UNION_SCHEMA_KEYS if key in schema]
+    if not top_level_keys:
+        return tool.args_schema
+
+    # assisted-by Codex Codex-sonnet-4-6
+    # Bedrock Converse rejects top-level oneOf/anyOf/allOf in tool input
+    # schemas. Collapse just the root into an object while preserving known
+    # properties so one bad MCP schema cannot prevent quick chat from starting.
+    logger.warning(
+        "[%s] Sanitizing Bedrock-incompatible top-level schema for tool '%s' (keys=%s)",
+        agent_name,
+        tool.name,
+        ",".join(top_level_keys),
+    )
+    return _collapse_top_level_union_schema(schema)
+
+
 def wrap_tools_with_error_handling(
     tools: list[BaseTool],
     agent_name: str = "agent",
@@ -1210,7 +1336,7 @@ def wrap_tools_with_error_handling(
         new_tool = StructuredTool(
             name=tool.name,
             description=tool.description or "",
-            args_schema=tool.args_schema,
+            args_schema=_model_safe_args_schema(tool, agent_name),
             coroutine=_safe_coro,
             response_format=resp_fmt,
             metadata=tool.metadata,

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_tool_schema_sanitizer.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_tool_schema_sanitizer.py
@@ -1,0 +1,81 @@
+"""Tool schema normalization for provider compatibility."""
+
+from __future__ import annotations
+
+from langchain_core.tools import StructuredTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+
+from dynamic_agents.services.mcp_client import wrap_tools_with_error_handling
+
+
+async def _echo_tool(**kwargs: object) -> dict[str, object]:
+    return dict(kwargs)
+
+
+def test_wrap_tools_collapses_top_level_anyof_schema():
+    # assisted-by Codex Codex-sonnet-4-6
+    schema = {
+        "title": "JiraLookupArgs",
+        "description": "Lookup by issue key or JQL.",
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"issue_key": {"type": "string"}},
+                "required": ["issue_key"],
+            },
+            {
+                "type": "object",
+                "properties": {"jql": {"type": "string"}},
+                "required": ["jql"],
+            },
+        ],
+    }
+    tool = StructuredTool(
+        name="jira_lookup",
+        description="Lookup Jira issues",
+        args_schema=schema,
+        coroutine=_echo_tool,
+    )
+
+    wrapped = wrap_tools_with_error_handling([tool], agent_name="test-agent")[0]
+    tool_schema = wrapped.tool_call_schema
+    converted = convert_to_openai_tool(wrapped)
+    converted_schema = converted["function"]["parameters"]
+
+    assert "anyOf" not in tool_schema
+    assert "anyOf" not in converted_schema
+    assert tool_schema["type"] == "object"
+    assert set(tool_schema["properties"]) == {"issue_key", "jql"}
+    assert "required" not in tool_schema
+
+
+def test_wrap_tools_resolves_defs_when_collapsing_top_level_anyof_schema():
+    schema = {
+        "title": "SearchArgs",
+        "$defs": {
+            "ByName": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            "ByNamespace": {
+                "type": "object",
+                "properties": {"namespace": {"type": "string"}},
+                "required": ["namespace"],
+            },
+        },
+        "anyOf": [{"$ref": "#/$defs/ByName"}, {"$ref": "#/$defs/ByNamespace"}],
+    }
+    tool = StructuredTool(
+        name="kubernetes_search",
+        description="Search Kubernetes resources",
+        args_schema=schema,
+        coroutine=_echo_tool,
+    )
+
+    wrapped = wrap_tools_with_error_handling([tool], agent_name="test-agent")[0]
+    tool_schema = wrapped.tool_call_schema
+
+    assert "anyOf" not in tool_schema
+    assert set(tool_schema["properties"]) == {"name", "namespace"}
+    assert "required" not in tool_schema

--- a/build/agents/Dockerfile.mcp
+++ b/build/agents/Dockerfile.mcp
@@ -30,6 +30,10 @@ COPY --chown=root:root ./ai_platform_engineering/mcp/common \
 
 WORKDIR /app/ai_platform_engineering/mcp/${AGENT_NAME}
 
+# Keep the dependency environment outside the source tree. Dev compose bind
+# mounts each MCP source directory and would otherwise hide the image-built venv.
+ENV UV_PROJECT_ENVIRONMENT=/opt/caipe-mcp-venvs/${AGENT_NAME}
+
 # Install dependencies into venv (no dev deps)
 # Increase timeout for large packages (e.g., pyarrow 39MB) and to absorb
 # stalled TCP streams when docker compose builds 20+ images in parallel.
@@ -103,11 +107,11 @@ RUN mkdir -p /usr/local/bin \
 # Create appuser in final image
 RUN groupadd -r appuser && useradd -r -g appuser -u 1001 -m appuser
 
-# Mirror the layout used in the builder stage so the editable
-# `mcp-agent-auth` install (whose .pth file points to ../common/mcp-auth)
-# still resolves at runtime. Pin WORKDIR + venv to the per-agent mcp dir.
-ENV UV_PROJECT_ENVIRONMENT=/app/ai_platform_engineering/mcp/${AGENT_NAME}/.venv \
-    PATH="/app/ai_platform_engineering/mcp/${AGENT_NAME}/.venv/bin:${PATH}" \
+# Mirror the source layout used in the builder stage so relative source
+# dependencies such as `../common/mcp-auth` still resolve at runtime. Keep the
+# venv outside /app so dev source mounts cannot hide installed dependencies.
+ENV UV_PROJECT_ENVIRONMENT=/opt/caipe-mcp-venvs/${AGENT_NAME} \
+    PATH="/opt/caipe-mcp-venvs/${AGENT_NAME}/bin:${PATH}" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     AGENT_NAME=${AGENT_NAME}
@@ -116,6 +120,7 @@ WORKDIR /app/ai_platform_engineering/mcp/${AGENT_NAME}
 
 # Copy venv & code from builder (whole /app to preserve the mcp/common/
 # sibling directory referenced by the editable mcp-agent-auth package).
+COPY --from=builder --chown=appuser:appuser /opt/caipe-mcp-venvs /opt/caipe-mcp-venvs
 COPY --from=builder --chown=appuser:appuser /app /app
 
 USER appuser

--- a/tests/test_mcp_dockerfile_venv_layout.py
+++ b/tests/test_mcp_dockerfile_venv_layout.py
@@ -1,0 +1,45 @@
+# assisted-by Codex Codex-sonnet-4-6
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MCP_DOCKERFILE = ROOT / "build" / "agents" / "Dockerfile.mcp"
+DEV_COMPOSE = ROOT / "docker-compose.dev.yaml"
+EXPECTED_SHARED_DOCKERFILE_MCPS = {
+  "mcp-argocd": "argocd",
+  "mcp-backstage": "backstage",
+  "mcp-jira": "jira",
+  "mcp-komodor": "komodor",
+  "mcp-netutils": "netutils",
+  "mcp-pagerduty": "pagerduty",
+  "mcp-splunk": "splunk",
+  "mcp-victorops": "victorops",
+  "mcp-webex": "webex",
+}
+
+
+def test_mcp_dockerfile_keeps_venv_outside_dev_source_mounts() -> None:
+  dockerfile = MCP_DOCKERFILE.read_text()
+
+  assert "UV_PROJECT_ENVIRONMENT=/opt/caipe-mcp-venvs/${AGENT_NAME}" in dockerfile
+  assert 'PATH="/opt/caipe-mcp-venvs/${AGENT_NAME}/bin:${PATH}"' in dockerfile
+  assert "/app/ai_platform_engineering/mcp/${AGENT_NAME}/.venv" not in dockerfile
+
+
+def test_all_dev_built_mcps_use_shared_dockerfile_layout() -> None:
+  compose = DEV_COMPOSE.read_text()
+  services: dict[str, str] = {}
+
+  for match in re.finditer(r"(?ms)^  ([a-zA-Z0-9_-]+):\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)", compose):
+    body = match.group("body")
+    if "dockerfile: build/agents/Dockerfile.mcp" not in body:
+      continue
+
+    agent_name = re.search(r"- AGENT_NAME=([^\n]+)", body)
+    assert agent_name is not None, f"{match.group(1)} must set AGENT_NAME"
+    services[match.group(1)] = agent_name.group(1).strip()
+
+  assert services == EXPECTED_SHARED_DOCKERFILE_MCPS

--- a/ui/e2e/rbac/chat-stream-regression.spec.ts
+++ b/ui/e2e/rbac/chat-stream-regression.spec.ts
@@ -1,0 +1,273 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import {
+  dismissReleaseUpgradeDialog,
+  expectChatComposerReady,
+  installChatBootMocks,
+  installTestSession,
+} from "./_helpers";
+import { mockedRbacEnabled } from "./_mocked-rbac";
+
+const CHAT_AGENT_ID = "agent-sre-schema-e2e";
+const CHAT_CONVERSATION_ID = "chat-schema-e2e-conv";
+const USER_EMAIL = "schema-e2e@caipe.local";
+const OLD_BEDROCK_SCHEMA_ERROR =
+  "Model call failed after 6 attempts with ValidationException: " +
+  "tools.454.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level";
+
+type StreamStartPayload = {
+  message?: string;
+  conversation_id?: string;
+  agent_id?: string;
+  protocol?: string;
+  client_context?: { source?: string };
+};
+
+type StreamMode = "success" | "bedrock-schema-error";
+
+function minimalSessionEnv() {
+  return {
+    baseUrl: process.env.CAIPE_UI_BASE_URL ?? "http://localhost:3000",
+    keycloakUrl: process.env.KEYCLOAK_URL ?? "http://localhost:7080",
+    keycloakRealm: process.env.KEYCLOAK_REALM ?? "caipe",
+    user: { email: USER_EMAIL, password: "" },
+  };
+}
+
+function aguiSse(frames: string[]): string {
+  return frames.join("");
+}
+
+async function fulfillStream(route: Route, mode: StreamMode): Promise<void> {
+  if (mode === "bedrock-schema-error") {
+    await route.fulfill({
+      status: 500,
+      contentType: "text/plain",
+      body: OLD_BEDROCK_SCHEMA_ERROR,
+    });
+    return;
+  }
+
+  await route.fulfill({
+    status: 200,
+    contentType: "text/event-stream",
+    headers: { "Cache-Control": "no-cache" },
+    body: aguiSse([
+      'event: RUN_STARTED\ndata: {"runId":"quick-chat-e2e-run"}\n\n',
+      'event: TEXT_MESSAGE_START\ndata: {"messageId":"assistant-1"}\n\n',
+      'event: TEXT_MESSAGE_CONTENT\ndata: {"delta":"Quick chat is healthy "}\n\n',
+      'event: TEXT_MESSAGE_CONTENT\ndata: {"delta":"after MCP schemas were sanitized."}\n\n',
+      'event: TEXT_MESSAGE_END\ndata: {"messageId":"assistant-1"}\n\n',
+      'event: RUN_FINISHED\ndata: {"outcome":"success"}\n\n',
+    ]),
+  });
+}
+
+async function installQuickChatMocks(
+  page: Page,
+  options: {
+    mode: StreamMode;
+    streamStartRequests?: StreamStartPayload[];
+  },
+): Promise<void> {
+  const env = minimalSessionEnv();
+
+  await installChatBootMocks(page, env, {
+    conversationId: CHAT_CONVERSATION_ID,
+    ownerEmail: USER_EMAIL,
+    agentId: CHAT_AGENT_ID,
+    title: "Quick Chat Schema Regression",
+  });
+
+  await page.route("**/api/platform/health", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "healthy",
+        checked_at: new Date().toISOString(),
+        summary: { total: 1, healthy: 1, degraded: 0, down: 0, disabled: 0 },
+        capabilities: [
+          {
+            id: "chat-runtime",
+            label: "Chat Runtime",
+            group: "runtime",
+            status: "healthy",
+            required: true,
+            description: "Checks the runtime health endpoint used by the chat experience.",
+            detail: "Chat runtime reachable",
+            latency_ms: 12,
+          },
+        ],
+        probe_summary: { total: 0, healthy: 0, warning: 0, down: 0 },
+        probes: [],
+      }),
+    });
+  });
+
+  await page.route("**/api/dynamic-agents**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    const method = request.method();
+    const agent = {
+      _id: CHAT_AGENT_ID,
+      name: "SRE Agent",
+      description: "Mocked SRE agent with many MCP tools",
+      enabled: true,
+      allowed_tools: {
+        argocd: true,
+        gitlab: true,
+        jira: true,
+      },
+      ui: {},
+    };
+
+    if (path === "/api/dynamic-agents/available" && method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: [agent] }),
+      });
+      return;
+    }
+
+    if (path === "/api/dynamic-agents" && method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: { items: [agent], total: 1, page: 1, page_size: 20 } }),
+      });
+      return;
+    }
+
+    if (path === `/api/dynamic-agents/agents/${CHAT_AGENT_ID}` && method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: agent }),
+      });
+      return;
+    }
+
+    if (
+      path === `/api/dynamic-agents/conversations/${CHAT_CONVERSATION_ID}/interrupt-state` &&
+      method === "GET"
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: { interrupted: false } }),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.route(`**/api/chat/conversations/${CHAT_CONVERSATION_ID}/messages`, async (route) => {
+    const request = route.request();
+    const method = request.method();
+
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { items: [], total: 0, page: 1, page_size: 100, has_more: false },
+        }),
+      });
+      return;
+    }
+
+    if (method === "POST") {
+      const body = JSON.parse(request.postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: `msg-${Date.now()}`,
+            role: body.role ?? "assistant",
+            content: body.content ?? "",
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.route("**/api/v1/chat/stream/start", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    options.streamStartRequests?.push(JSON.parse(route.request().postData() ?? "{}"));
+    await fulfillStream(route, options.mode);
+  });
+
+  await installTestSession(page, env, {
+    email: USER_EMAIL,
+    subject: "playwright-chat-schema-sub",
+    role: "user",
+  });
+}
+
+async function submitPrompt(page: Page, prompt: string): Promise<void> {
+  await page.goto(`/chat/${CHAT_CONVERSATION_ID}`, { waitUntil: "domcontentloaded" });
+  await dismissReleaseUpgradeDialog(page);
+  await expectChatComposerReady(page);
+
+  const composer = page.locator("textarea").first();
+  await composer.fill(prompt);
+  await composer.press("Enter");
+}
+
+test.describe("mocked RBAC e2e — chat stream regression", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run the mocked chat stream regression.",
+    );
+    test.skip(!process.env.NEXTAUTH_SECRET, "NEXTAUTH_SECRET required for chat stream SSR.");
+  });
+
+  test("streams a quick chat response through AG-UI after MCP tool schema sanitization", async ({ page }) => {
+    const streamStartRequests: StreamStartPayload[] = [];
+    await installQuickChatMocks(page, { mode: "success", streamStartRequests });
+
+    await submitPrompt(page, "hi");
+
+    await expect.poll(() => streamStartRequests.length).toBe(1);
+    expect(streamStartRequests[0]).toMatchObject({
+      message: "hi",
+      conversation_id: CHAT_CONVERSATION_ID,
+      agent_id: CHAT_AGENT_ID,
+      protocol: "agui",
+      client_context: { source: "webui" },
+    });
+
+    await expect(page.getByText(/Quick chat is healthy after MCP schemas were sanitized/i)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(/input_schema does not support/i)).toHaveCount(0);
+    await expect(page.getByText(/Response was interrupted/i)).toHaveCount(0);
+  });
+
+  test("surfaces the old Bedrock schema failure when the backend still returns it", async ({ page }) => {
+    const streamStartRequests: StreamStartPayload[] = [];
+    await installQuickChatMocks(page, { mode: "bedrock-schema-error", streamStartRequests });
+
+    await submitPrompt(page, "hi");
+
+    await expect.poll(() => streamStartRequests.length).toBe(1);
+    await expect(page.getByText(/ValidationException/i)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/input_schema does not support oneOf, allOf, or anyOf/i)).toBeVisible();
+    await expect(page.getByText(/Quick chat is healthy after MCP schemas were sanitized/i)).toHaveCount(0);
+  });
+});

--- a/ui/e2e/rbac/mcp-server-permission-gating.spec.ts
+++ b/ui/e2e/rbac/mcp-server-permission-gating.spec.ts
@@ -61,6 +61,7 @@ async function installMcpPermissionMocks(
     servers: McpServerFixture[];
     capabilities?: { repair_agentgateway: boolean };
     isAdmin?: boolean;
+    probeErrors?: Record<string, string>;
   },
 ): Promise<void> {
   const capabilities = options.capabilities ?? { repair_agentgateway: false };
@@ -82,6 +83,19 @@ async function installMcpPermissionMocks(
 
         if (path === "/api/mcp-servers/probe" && method === "POST") {
           const serverId = new URL(route.request().url()).searchParams.get("id") ?? "";
+          const probeError = options.probeErrors?.[serverId];
+          if (probeError) {
+            await fulfillJson(route, {
+              success: true,
+              data: {
+                server_id: serverId,
+                success: false,
+                error: probeError,
+                tools: [],
+              },
+            });
+            return true;
+          }
           await fulfillJson(route, {
             success: true,
             data: {
@@ -116,7 +130,7 @@ async function installMcpPermissionMocks(
 }
 
 test.describe("RBAC e2e — MCP server permission gating", () => {
-  test.beforeEach(({ page: _page }, testInfo) => {
+  test.beforeEach(({}, testInfo) => {
     test.skip(
       !mockedRbacEnabled(),
       "Set RUN_RBAC_REGRESSION=1 to run the mocked MCP permission gating regression.",
@@ -178,6 +192,46 @@ test.describe("RBAC e2e — MCP server permission gating", () => {
     await expect(page.getByText("Discover Only MCP")).toBeVisible();
     await expect(page.getByRole("button", { name: /Probe tools for Discover Only MCP/i })).toBeVisible();
     await expect(page.getByRole("button", { name: /Test MCP tools for Discover Only MCP/i })).toHaveCount(0);
+  });
+
+  test("shows green and amber tool health indicators after probing MCP rows", async ({ page }) => {
+    await installMcpPermissionMocks(page, {
+      servers: [
+        {
+          _id: "mcp-healthy",
+          name: "Healthy MCP",
+          transport: "http",
+          endpoint: "http://mcp-healthy:8000/mcp",
+          enabled: true,
+          permissions: { can_manage: false, can_invoke: false, can_discover: true },
+        },
+        {
+          _id: "mcp-degraded",
+          name: "Degraded MCP",
+          transport: "http",
+          endpoint: "http://mcp-degraded:8000/mcp",
+          enabled: true,
+          permissions: { can_manage: false, can_invoke: false, can_discover: true },
+        },
+      ],
+      probeErrors: {
+        "mcp-degraded": "MCP initialize failed with HTTP 500",
+      },
+    });
+
+    await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
+    const mcpServersPanel = page.getByLabel("MCP Servers");
+    await expect(page.getByText("Healthy MCP")).toBeVisible();
+    await expect(page.getByText("Degraded MCP")).toBeVisible();
+
+    await page.getByRole("button", { name: /Probe tools for Healthy MCP/i }).click();
+    await expect(mcpServersPanel.getByText("Healthy", { exact: true })).toBeVisible();
+    await expect(page.getByText("1 tool(s) available")).toBeVisible();
+
+    await page.getByRole("button", { name: /Probe tools for Degraded MCP/i }).click();
+    await expect(mcpServersPanel.getByText("Degraded", { exact: true })).toBeVisible();
+    await expect(page.getByText("Tool Scan Degraded")).toBeVisible();
+    await expect(page.getByText("MCP initialize failed with HTTP 500")).toBeVisible();
   });
 
   test("shows test action only when can_invoke is granted", async ({ page }) => {

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -56,6 +56,8 @@ interface ProbeResult {
   error?: string;
 }
 
+type ToolHealthStatus = "healthy" | "degraded" | "checking" | "unknown" | "disabled";
+
 interface AgentGatewayMigrationWarning {
   id: string;
   endpoint: string;
@@ -106,6 +108,86 @@ function serverCanProbe(server: MCPServerConfigWithPermissions | null | undefine
 
 function serverCanTest(server: MCPServerConfigWithPermissions | null | undefined): boolean {
   return serverCanInvoke(server) || serverCanManage(server);
+}
+
+function toolHealthStatus(
+  server: MCPServerConfigWithPermissions,
+  probe: ProbeResult | undefined,
+): { status: ToolHealthStatus; label: string; title: string } {
+  if (!server.enabled) {
+    return {
+      status: "disabled",
+      label: "Disabled",
+      title: "Disabled servers are not scanned for tools",
+    };
+  }
+  if (probe?.loading) {
+    return {
+      status: "checking",
+      label: "Checking",
+      title: "Listing MCP tools",
+    };
+  }
+  if (probe?.error || (probe?.tools && probe.tools.length === 0)) {
+    return {
+      status: "degraded",
+      label: "Degraded",
+      title: probe.error || "tools/list returned no tools",
+    };
+  }
+  if (probe?.tools && probe.tools.length > 0) {
+    return {
+      status: "healthy",
+      label: "Healthy",
+      title: `${probe.tools.length} tool${probe.tools.length === 1 ? "" : "s"} available`,
+    };
+  }
+  if (!serverCanProbe(server)) {
+    return {
+      status: "unknown",
+      label: "Not scanned",
+      title: "You do not have permission to scan this MCP server",
+    };
+  }
+  if (server.transport !== "http") {
+    return {
+      status: "unknown",
+      label: "Not scanned",
+      title: "Tool health scans currently support HTTP MCP servers",
+    };
+  }
+  return {
+    status: "unknown",
+    label: "Not scanned",
+    title: "Run the tool probe to check tools/list health",
+  };
+}
+
+function toolHealthClass(status: ToolHealthStatus): string {
+  switch (status) {
+    case "healthy":
+      return "text-green-600 dark:text-green-400";
+    case "degraded":
+      return "text-amber-600 dark:text-amber-400";
+    case "checking":
+    case "unknown":
+    case "disabled":
+      return "text-muted-foreground";
+  }
+}
+
+function toolHealthDotClass(status: ToolHealthStatus): string {
+  switch (status) {
+    case "healthy":
+      return "bg-green-500";
+    case "degraded":
+      return "bg-amber-500";
+    case "checking":
+      return "bg-blue-500";
+    case "unknown":
+    case "disabled":
+      return "bg-muted-foreground/60";
+  }
 }
 
 export function MCPServersTab() {
@@ -550,6 +632,7 @@ export function MCPServersTab() {
             {servers.map((server) => {
               const probe = probeResults[server._id];
               const rowActionError = rowActionErrors[server._id];
+              const toolHealth = toolHealthStatus(server, probe);
               return (
                 <div key={server._id} className="space-y-2">
                   <div
@@ -606,7 +689,7 @@ export function MCPServersTab() {
                       )}
                     </div>
 
-                    <div className="col-span-2">
+                    <div className="col-span-2 space-y-1">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -641,6 +724,17 @@ export function MCPServersTab() {
                           </>
                         )}
                       </button>
+                      <div
+                        className={`flex items-center gap-1.5 text-xs ${toolHealthClass(toolHealth.status)}`}
+                        title={toolHealth.title}
+                      >
+                        {toolHealth.status === "checking" ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <span className={`h-2 w-2 rounded-full ${toolHealthDotClass(toolHealth.status)}`} />
+                        )}
+                        <span>{toolHealth.label}</span>
+                      </div>
                     </div>
 
                     <div className="col-span-2 flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
@@ -772,11 +866,11 @@ export function MCPServersTab() {
                   {probe && !probe.loading && (
                     <div className="ml-12 pl-4 border-l-2 border-muted">
                       {probe.error ? (
-                        <div className="flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/30 p-3">
-                          <AlertCircle className="h-4 w-4 text-destructive mt-0.5 flex-shrink-0" />
+                        <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/30 p-3">
+                          <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
                           <div className="space-y-1">
-                            <p className="text-sm font-medium text-destructive">Probe Failed</p>
-                            <p className="text-sm text-destructive/80">{probe.error}</p>
+                            <p className="text-sm font-medium text-amber-800 dark:text-amber-300">Tool Scan Degraded</p>
+                            <p className="text-sm text-amber-700 dark:text-amber-400">{probe.error}</p>
                           </div>
                         </div>
                       ) : probe.tools && probe.tools.length > 0 ? (
@@ -801,9 +895,9 @@ export function MCPServersTab() {
                           </div>
                         </div>
                       ) : (
-                        <div className="flex items-center gap-2 text-muted-foreground">
+                        <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 border border-amber-500/30 p-3 text-amber-700 dark:text-amber-400">
                           <AlertCircle className="h-4 w-4" />
-                          <p className="text-sm">No tools found on this server</p>
+                          <p className="text-sm">Tool scan returned no tools</p>
                         </div>
                       )}
                     </div>

--- a/ui/src/lib/__tests__/mcp-credential-headers.test.ts
+++ b/ui/src/lib/__tests__/mcp-credential-headers.test.ts
@@ -7,6 +7,7 @@
 import { NextRequest } from "next/server";
 
 import {
+  _resetMcpCredentialHeaderTokenCacheForTests,
   readMcpToolApplicationSuccess,
   resolveMcpHeaderCredentials,
 } from "@/lib/mcp-credential-headers";
@@ -36,8 +37,14 @@ jest.mock("@/lib/rbac/resource-authz", () => ({
 }));
 
 describe("mcp-credential-headers", () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    global.fetch = originalFetch;
+    delete process.env.MCP_SERVICE_OIDC_TOKEN_URL;
+    delete process.env.MCP_SERVICE_OIDC_CLIENT_ID;
+    delete process.env.MCP_SERVICE_OIDC_CLIENT_SECRET;
     mockGetCredentialRetrievalService.mockResolvedValue({ retrieve: mockRetrieve });
     mockGetProviderConnectionService.mockResolvedValue({
       listConnections: mockListConnections,
@@ -46,6 +53,7 @@ describe("mcp-credential-headers", () => {
     });
     mockIsCredentialFeatureEnabled.mockReturnValue(true);
     mockRetrieve.mockResolvedValue({ credential: "secret-token" });
+    _resetMcpCredentialHeaderTokenCacheForTests();
     mockListConnections.mockResolvedValue([
       {
         id: "atlassian-conn-1",
@@ -55,6 +63,13 @@ describe("mcp-credential-headers", () => {
       },
     ]);
     mockRefreshConnection.mockResolvedValue({ accessToken: "atlassian-oauth-token", expiresIn: 3600 });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.MCP_SERVICE_OIDC_TOKEN_URL;
+    delete process.env.MCP_SERVICE_OIDC_CLIENT_ID;
+    delete process.env.MCP_SERVICE_OIDC_CLIENT_SECRET;
   });
 
   it("exchanges provider_connection credentials onto X-CAIPE-Provider-Token for AgentGateway", async () => {
@@ -121,6 +136,87 @@ describe("mcp-credential-headers", () => {
 
     expect(result.sources).toEqual([
       expect.objectContaining({ kind: "provider_connection", origin: "none", provider: "atlassian" }),
+    ]);
+  });
+
+  it("forwards caller_token credentials as the provider token for AgentGateway-routed RAG", async () => {
+    const request = new NextRequest("http://localhost:3000/api/mcp-servers/probe", { method: "POST" });
+    const resolution = await resolveMcpHeaderCredentials({
+      request,
+      session: { sub: "user-sub", accessToken: "user-jwt" },
+      viaAgentGateway: true,
+      server: {
+        _id: "knowledge-base",
+        id: "knowledge-base",
+        name: "Knowledge Base",
+        transport: "http",
+        enabled: true,
+        credential_sources: [
+          {
+            kind: "caller_token",
+            target: "header",
+            name: "X-CAIPE-Provider-Token",
+            fallback_client_credentials: true,
+          },
+        ],
+      },
+    });
+
+    expect(resolution.headers.Authorization).toBe("Bearer user-jwt");
+    expect(resolution.headers["X-CAIPE-Provider-Token"]).toBe("user-jwt");
+    expect(resolution.sources).toEqual([
+      expect.objectContaining({
+        kind: "caller_token",
+        origin: "user_jwt",
+      }),
+    ]);
+  });
+
+  it("uses caller_token client-credentials fallback when no user JWT is available", async () => {
+    process.env.MCP_SERVICE_OIDC_TOKEN_URL = "http://keycloak/token";
+    process.env.MCP_SERVICE_OIDC_CLIENT_ID = "caipe-platform";
+    process.env.MCP_SERVICE_OIDC_CLIENT_SECRET = "secret";
+    const fetchMock = jest.fn().mockResolvedValue(
+      Response.json({ access_token: "service-jwt", expires_in: 300 }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const request = new NextRequest("http://localhost:3000/api/mcp-servers/probe", { method: "POST" });
+    const resolution = await resolveMcpHeaderCredentials({
+      request,
+      session: { sub: "system-probe" },
+      viaAgentGateway: true,
+      server: {
+        _id: "knowledge-base",
+        id: "knowledge-base",
+        name: "Knowledge Base",
+        transport: "http",
+        enabled: true,
+        credential_sources: [
+          {
+            kind: "caller_token",
+            target: "header",
+            name: "X-CAIPE-Provider-Token",
+            fallback_client_credentials: true,
+          },
+        ],
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://keycloak/token",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(URLSearchParams),
+      }),
+    );
+    expect(resolution.headers.Authorization).toBe("Bearer service-jwt");
+    expect(resolution.headers["X-CAIPE-Provider-Token"]).toBe("service-jwt");
+    expect(resolution.sources).toEqual([
+      expect.objectContaining({
+        kind: "caller_token",
+        origin: "client_credentials",
+      }),
     ]);
   });
 

--- a/ui/src/lib/mcp-credential-headers.ts
+++ b/ui/src/lib/mcp-credential-headers.ts
@@ -15,7 +15,13 @@ import type { MCPCredentialSource, MCPServerConfig } from "@/types/dynamic-agent
 import type { NextRequest } from "next/server";
 import type { ResourceAuthzSession } from "@/lib/rbac/resource-authz";
 
-export type McpCredentialOrigin = "secret_ref" | "provider_connection" | "fallback_env" | "none";
+export type McpCredentialOrigin =
+  | "secret_ref"
+  | "provider_connection"
+  | "fallback_env"
+  | "user_jwt"
+  | "client_credentials"
+  | "none";
 
 export interface McpCredentialSourceDebug {
   name: string;
@@ -30,6 +36,13 @@ export interface McpCredentialResolution {
   headers: Record<string, string>;
   sources: McpCredentialSourceDebug[];
 }
+
+interface ServiceTokenCacheEntry {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+const serviceTokenCache = new Map<string, ServiceTokenCacheEntry>();
 
 export {
   MCP_CREDENTIAL_UNAVAILABLE,
@@ -73,12 +86,95 @@ function credentialServiceHeaders(caller: string): Headers {
   });
 }
 
+function tokenEndpointFromIssuer(value: string | undefined): string | null {
+  const issuer = value?.trim().replace(/\/+$/, "");
+  if (!issuer) return null;
+  if (issuer.endsWith("/protocol/openid-connect/token")) return issuer;
+  const withoutDiscovery = issuer.replace(/\/\.well-known\/openid-configuration$/, "");
+  return `${withoutDiscovery}/protocol/openid-connect/token`;
+}
+
+function serviceTokenConfig(): { tokenUrl: string; clientId: string; clientSecret: string } | null {
+  const tokenUrl =
+    process.env.MCP_SERVICE_OIDC_TOKEN_URL?.trim() ||
+    process.env.OAUTH2_TOKEN_URL?.trim() ||
+    tokenEndpointFromIssuer(process.env.INGESTOR_OIDC_ISSUER) ||
+    tokenEndpointFromIssuer(process.env.OIDC_DISCOVERY_URL) ||
+    tokenEndpointFromIssuer(process.env.OIDC_ISSUER) ||
+    tokenEndpointFromIssuer(
+      process.env.KEYCLOAK_URL
+        ? `${process.env.KEYCLOAK_URL.replace(/\/+$/, "")}/realms/${process.env.KEYCLOAK_REALM || "caipe"}`
+        : undefined,
+    );
+  const clientId =
+    process.env.MCP_SERVICE_OIDC_CLIENT_ID?.trim() ||
+    process.env.INGESTOR_OIDC_CLIENT_ID?.trim() ||
+    process.env.OAUTH2_CLIENT_ID?.trim() ||
+    process.env.OIDC_CLIENT_ID?.trim() ||
+    process.env.KEYCLOAK_RESOURCE_SERVER_ID?.trim() ||
+    "caipe-platform";
+  const clientSecret =
+    process.env.MCP_SERVICE_OIDC_CLIENT_SECRET?.trim() ||
+    process.env.INGESTOR_OIDC_CLIENT_SECRET?.trim() ||
+    process.env.OAUTH2_CLIENT_SECRET?.trim() ||
+    process.env.OIDC_CLIENT_SECRET?.trim() ||
+    process.env.KEYCLOAK_CLIENT_SECRET?.trim();
+
+  if (!tokenUrl || !clientId || !clientSecret) return null;
+  return { tokenUrl, clientId, clientSecret };
+}
+
+async function mintServiceClientCredentialsToken(): Promise<string | null> {
+  const config = serviceTokenConfig();
+  if (!config) return null;
+
+  const cacheKey = `${config.tokenUrl}|${config.clientId}`;
+  const now = Date.now();
+  const cached = serviceTokenCache.get(cacheKey);
+  if (cached && cached.expiresAtMs - 30_000 > now) return cached.accessToken;
+
+  try {
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+    });
+    const response = await fetch(config.tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (!response.ok) {
+      console.warn(`[mcp-credential-headers] service token request failed: ${response.status}`);
+      return null;
+    }
+    const payload = (await response.json()) as { access_token?: unknown; expires_in?: unknown };
+    if (typeof payload.access_token !== "string" || !payload.access_token.trim()) return null;
+    const expiresInSeconds = typeof payload.expires_in === "number" ? payload.expires_in : 300;
+    serviceTokenCache.set(cacheKey, {
+      accessToken: payload.access_token,
+      expiresAtMs: now + expiresInSeconds * 1000,
+    });
+    return payload.access_token;
+  } catch (error) {
+    console.warn(
+      `[mcp-credential-headers] service token request failed: ${error instanceof Error ? error.name : "unknown"}`,
+    );
+    return null;
+  }
+}
+
+function asBearerToken(value: string): string {
+  return value.toLowerCase().startsWith("bearer ") ? value : `Bearer ${value}`;
+}
+
 async function resolveSourceCredential(
   session: ResourceAuthzSession,
   source: MCPCredentialSource,
   server: MCPServerConfig,
   viaAgentGateway: boolean,
   retrievalCaller: string,
+  callerAuthorization: string | null,
 ): Promise<{ credential: string; origin: McpCredentialOrigin; debug: McpCredentialSourceDebug } | null> {
   if (source.target !== "header") return null;
 
@@ -164,6 +260,33 @@ async function resolveSourceCredential(
     };
   }
 
+  if (source.kind === "caller_token") {
+    if (callerAuthorization) {
+      return {
+        credential: callerAuthorization,
+        origin: "user_jwt",
+        debug: { ...baseDebug, origin: "user_jwt" },
+      };
+    }
+
+    if (source.fallback_client_credentials) {
+      const minted = await mintServiceClientCredentialsToken();
+      if (minted) {
+        return {
+          credential: minted,
+          origin: "client_credentials",
+          debug: { ...baseDebug, origin: "client_credentials" },
+        };
+      }
+    }
+
+    return {
+      credential: "",
+      origin: "none",
+      debug: { ...baseDebug, origin: "none" },
+    };
+  }
+
   return null;
 }
 
@@ -190,6 +313,8 @@ export async function resolveMcpHeaderCredentials(input: {
   const headers: Record<string, string> = {};
   const sources: McpCredentialSourceDebug[] = [];
   const retrievalCaller = input.retrievalCaller ?? "mcp-http-server-client";
+  const callerAuthorization = userAuthorizationHeader(input.request, input.session);
+  let agentGatewayServiceAuthorization: string | null = null;
 
   for (const source of input.server.credential_sources ?? []) {
     const resolved = await resolveSourceCredential(
@@ -198,6 +323,7 @@ export async function resolveMcpHeaderCredentials(input: {
       input.server,
       input.viaAgentGateway,
       retrievalCaller,
+      callerAuthorization,
     );
     if (!resolved) continue;
 
@@ -216,10 +342,13 @@ export async function resolveMcpHeaderCredentials(input: {
       headerName,
       input.viaAgentGateway,
     );
+    if (source.kind === "caller_token" && resolved.origin === "client_credentials") {
+      agentGatewayServiceAuthorization = asBearerToken(resolved.credential);
+    }
   }
 
   if (input.viaAgentGateway) {
-    const authorization = userAuthorizationHeader(input.request, input.session);
+    const authorization = callerAuthorization ?? agentGatewayServiceAuthorization;
     if (!authorization) {
       throw new Error("MCP_AUTH_REQUIRED");
     }
@@ -227,6 +356,10 @@ export async function resolveMcpHeaderCredentials(input: {
   }
 
   return { headers, sources };
+}
+
+export function _resetMcpCredentialHeaderTokenCacheForTests(): void {
+  serviceTokenCache.clear();
 }
 
 export function readMcpToolApplicationSuccess(toolResult: unknown): boolean | undefined {

--- a/ui/src/lib/mcp-http-server-client.ts
+++ b/ui/src/lib/mcp-http-server-client.ts
@@ -306,3 +306,69 @@ export async function listHttpMcpTools(input: {
     await revokeDiagnosticAgentAccess(diagnosticTuples, "mcp-http-server-client");
   }
 }
+
+export async function listDirectHttpMcpTools(input: {
+  endpoint: string;
+  timeoutMs?: number;
+}): Promise<{ tools: MCPToolInfo[]; sessionId?: string }> {
+  // assisted-by Codex Codex-sonnet-4-6
+  // Health diagnostics are read-only: list tools directly without temporary
+  // AgentGateway authorization tuples or tool invocation smoke tests.
+  const headers: Record<string, string> = {};
+  const first = await mcpJsonRpc({
+    endpoint: input.endpoint,
+    headers,
+    payload: {
+      jsonrpc: "2.0",
+      id: `tools-list-${Date.now()}`,
+      method: "tools/list",
+      params: {},
+    },
+    timeoutMs: input.timeoutMs,
+  });
+  if (first.ok) {
+    const tools = extractTools(first.payload);
+    if (tools) return { tools, sessionId: first.sessionId };
+  }
+
+  const initialized = await mcpJsonRpc({
+    endpoint: input.endpoint,
+    headers,
+    payload: {
+      jsonrpc: "2.0",
+      id: `initialize-${Date.now()}`,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "caipe-ui-health", version: "0.5.16" },
+      },
+    },
+    timeoutMs: input.timeoutMs,
+  });
+  if (!initialized.ok || !initialized.sessionId) {
+    throw new ApiError(`MCP initialize failed with HTTP ${initialized.status}`, 502, "MCP_INIT_FAILED");
+  }
+
+  const listed = await mcpJsonRpc({
+    endpoint: input.endpoint,
+    headers,
+    sessionId: initialized.sessionId,
+    payload: {
+      jsonrpc: "2.0",
+      id: `tools-list-${Date.now()}`,
+      method: "tools/list",
+      params: {},
+    },
+    timeoutMs: input.timeoutMs,
+  });
+  if (!listed.ok) {
+    throw new ApiError(`MCP tools/list failed with HTTP ${listed.status}`, 502, "MCP_LIST_FAILED");
+  }
+
+  const tools = extractTools(listed.payload);
+  if (!tools) {
+    throw new ApiError("MCP tools/list returned an unexpected payload", 502, "MCP_LIST_INVALID");
+  }
+  return { tools, sessionId: initialized.sessionId };
+}


### PR DESCRIPTION
## Summary
- Sanitize MCP tool input schemas so Bedrock Converse does not receive top-level `oneOf`, `allOf`, or `anyOf` schemas.
- Fix the MCP Docker image venv layout so bind-mounted source trees do not hide runtime dependencies like `python-dotenv`.
- Add MCP server tool-scan health indicators and credential header resolution coverage.

## Validation
- `PYTHONPATH=ai_platform_engineering/dynamic_agents/src uv run pytest ai_platform_engineering/dynamic_agents/tests/test_mcp_tool_schema_sanitizer.py tests/test_mcp_dockerfile_venv_layout.py`
- `PYTHONPATH=ai_platform_engineering/dynamic_agents/src uv run ruff check ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py ai_platform_engineering/dynamic_agents/tests/test_mcp_tool_schema_sanitizer.py tests/test_mcp_dockerfile_venv_layout.py`
- `npm test -- src/lib/__tests__/mcp-credential-headers.test.ts --runInBand`
- `npm exec eslint -- e2e/rbac/mcp-server-permission-gating.spec.ts e2e/rbac/chat-stream-regression.spec.ts src/components/dynamic-agents/MCPServersTab.tsx src/lib/mcp-credential-headers.ts src/lib/mcp-http-server-client.ts`
- `RUN_RBAC_REGRESSION=1 npx playwright test --config=playwright.rbac.config.ts e2e/rbac/mcp-server-permission-gating.spec.ts e2e/rbac/chat-stream-regression.spec.ts`
- `RUN_RBAC_REGRESSION=1 npx playwright test --config=playwright.rbac.config.ts e2e/rbac/mcp-test-modal-and-agentgateway.spec.ts`
- `git diff --check`