### PR TITLE
fix(ui): cache session auth for repeated api calls

### DIFF
--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -52,6 +52,8 @@ jest.mock('@/lib/audit', () => ({
 
 const mockGetServerSession = jest.requireMock('next-auth').getServerSession;
 const mockGetCollection = jest.requireMock('@/lib/mongodb').getCollection;
+const mockValidateBearerJWT = jest.requireMock('@/lib/jwt-validation').validateBearerJWT;
+const mockValidateLocalSkillsJWT = jest.requireMock('@/lib/jwt-validation').validateLocalSkillsJWT;
 const mockCheckOpenFgaTuple = jest.requireMock('@/lib/rbac/openfga').checkOpenFgaTuple;
 const mockCheckPermission = jest.requireMock('@/lib/rbac/keycloak-authz').checkPermission;
 
@@ -59,6 +61,7 @@ beforeEach(() => {
   mockGetConfig.mockImplementation((key: string) => key === 'ssoEnabled');
   mockAuditWrite.mockClear();
   delete process.env.CAIPE_UNSAFE_RBAC_BYPASS;
+  delete process.env.CAIPE_SESSION_AUTH_CACHE_TTL_MS;
 });
 
 jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -79,9 +82,15 @@ import {
   requireOwnership,
   requireAdmin,
   requireRbacPermission,
+  clearSessionAuthCacheForTests,
+  getAuthFromBearerOrSession,
   getAuthenticatedUser,
   withAuth,
 } from '../api-middleware';
+
+beforeEach(() => {
+  clearSessionAuthCacheForTests();
+});
 
 describe('ApiError', () => {
   it('creates with message and default status 500', () => {
@@ -897,6 +906,119 @@ describe('getAuthenticatedUser', () => {
     const result = await getAuthenticatedUser(req);
 
     expect(result.user.role).toBe('user');
+  });
+
+  it('caches valid cookie sessions for repeated API calls', async () => {
+    process.env.CAIPE_SESSION_AUTH_CACHE_TTL_MS = '10000';
+    const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'alice@test.com', name: 'Alice' },
+      role: 'user',
+      sub: 'alice-sub',
+    });
+    mockGetCollection.mockResolvedValue({ updateOne });
+
+    const makeRequest = () =>
+      new Request('http://test.com/api/admin/slack/channels', {
+        headers: { cookie: 'next-auth.session-token=alice-session' },
+      }) as unknown as NextRequest;
+
+    const first = await getAuthenticatedUser(makeRequest());
+    const second = await getAuthenticatedUser(makeRequest());
+
+    expect(first.user).toEqual(second.user);
+    expect(mockGetServerSession).toHaveBeenCalledTimes(1);
+    expect(updateOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache session auth when no cookie header is present', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'nocookie@test.com', name: 'No Cookie' },
+      role: 'user',
+    });
+
+    const makeRequest = () =>
+      new Request('http://test.com/api/admin/slack/channels') as unknown as NextRequest;
+
+    await getAuthenticatedUser(makeRequest());
+    await getAuthenticatedUser(makeRequest());
+
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes session auth after the cache ttl expires', async () => {
+    process.env.CAIPE_SESSION_AUTH_CACHE_TTL_MS = '50';
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'ttl@test.com', name: 'TTL User' },
+      role: 'user',
+    });
+
+    const makeRequest = () =>
+      new Request('http://test.com/api/admin/slack/channels', {
+        headers: { cookie: 'next-auth.session-token=ttl-session' },
+      }) as unknown as NextRequest;
+
+    await getAuthenticatedUser(makeRequest());
+    nowSpy.mockReturnValue(1049);
+    await getAuthenticatedUser(makeRequest());
+    nowSpy.mockReturnValue(1051);
+    await getAuthenticatedUser(makeRequest());
+
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+
+  it('does not cache sessions denied by the Web UI admission gate', async () => {
+    mockGetServerSession
+      .mockResolvedValueOnce({
+        user: { email: 'blocked@test.com', name: 'Blocked User' },
+        role: 'user',
+        isAuthorized: false,
+      })
+      .mockResolvedValueOnce({
+        user: { email: 'blocked@test.com', name: 'Blocked User' },
+        role: 'user',
+        isAuthorized: true,
+      });
+
+    const makeRequest = () =>
+      new Request('http://test.com/api/admin/slack/channels', {
+        headers: { cookie: 'next-auth.session-token=blocked-session' },
+      }) as unknown as NextRequest;
+
+    await expect(getAuthenticatedUser(makeRequest())).rejects.toMatchObject({
+      code: 'WEB_UI_ACCESS_DENIED',
+    });
+
+    const result = await getAuthenticatedUser(makeRequest());
+
+    expect(result.user.email).toBe('blocked@test.com');
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps bearer authentication outside the cookie session cache', async () => {
+    mockValidateLocalSkillsJWT.mockResolvedValue(null);
+    mockValidateBearerJWT.mockResolvedValue({
+      email: 'service@test.com',
+      name: 'Service Account',
+      sub: 'service-sub',
+      org: 'caipe',
+    });
+
+    const makeRequest = () =>
+      new Request('http://test.com/api/admin/slack/channels', {
+        headers: {
+          authorization: 'Bearer service-token',
+          cookie: 'next-auth.session-token=browser-session',
+        },
+      }) as unknown as NextRequest;
+
+    await getAuthFromBearerOrSession(makeRequest());
+    await getAuthFromBearerOrSession(makeRequest());
+
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+    expect(mockValidateBearerJWT).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -1,6 +1,7 @@
 // API middleware for Next.js API routes
 // Provides authentication, error handling, and validation
 
+import { createHash } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions, isBootstrapAdmin } from '@/lib/auth-config';
@@ -140,6 +141,112 @@ export interface GetAuthenticatedUserOptions {
   allowAnonymous?: boolean;
 }
 
+type SessionAuthSession = Record<string, unknown> & {
+  user?: Record<string, unknown> | null;
+};
+
+type SessionAuthPayload = {
+  user: {
+    email: string;
+    name: string;
+    role: string;
+  };
+  session: SessionAuthSession;
+};
+
+type SessionAuthCacheEntry = SessionAuthPayload & {
+  expiresAt: number;
+};
+
+const DEFAULT_SESSION_AUTH_CACHE_TTL_MS = 10_000;
+const MAX_SESSION_AUTH_CACHE_ENTRIES = 500;
+const sessionAuthCache = new Map<string, SessionAuthCacheEntry>();
+
+function getSessionAuthCacheTtlMs(): number {
+  const raw = process.env.CAIPE_SESSION_AUTH_CACHE_TTL_MS;
+  if (!raw) {
+    return DEFAULT_SESSION_AUTH_CACHE_TTL_MS;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SESSION_AUTH_CACHE_TTL_MS;
+  }
+
+  return Math.min(parsed, 60_000);
+}
+
+function getSessionAuthCacheKey(request: NextRequest): string | null {
+  const cookie = request.headers.get('cookie')?.trim();
+  if (!cookie) {
+    return null;
+  }
+
+  return createHash('sha256').update(cookie).digest('hex');
+}
+
+function cloneSessionAuthPayload(value: SessionAuthPayload): SessionAuthPayload {
+  const sessionUser = value.session.user;
+  return {
+    user: { ...value.user },
+    session: {
+      ...value.session,
+      user: sessionUser ? { ...sessionUser } : sessionUser,
+    },
+  };
+}
+
+// assisted-by Codex Codex-sonnet-4-6
+function readCachedSessionAuth(request: NextRequest): SessionAuthPayload | null {
+  const key = getSessionAuthCacheKey(request);
+  if (!key) {
+    return null;
+  }
+
+  const entry = sessionAuthCache.get(key);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    sessionAuthCache.delete(key);
+    return null;
+  }
+
+  sessionAuthCache.delete(key);
+  sessionAuthCache.set(key, entry);
+  return cloneSessionAuthPayload(entry);
+}
+
+function writeCachedSessionAuth(request: NextRequest, value: SessionAuthPayload): void {
+  const ttlMs = getSessionAuthCacheTtlMs();
+  if (ttlMs === 0) {
+    return;
+  }
+
+  const key = getSessionAuthCacheKey(request);
+  if (!key) {
+    return;
+  }
+
+  while (sessionAuthCache.size >= MAX_SESSION_AUTH_CACHE_ENTRIES) {
+    const oldestKey = sessionAuthCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    sessionAuthCache.delete(oldestKey);
+  }
+
+  sessionAuthCache.set(key, {
+    ...cloneSessionAuthPayload(value),
+    expiresAt: Date.now() + ttlMs,
+  });
+}
+
+export function clearSessionAuthCacheForTests(): void {
+  sessionAuthCache.clear();
+}
+
 function resolveKeycloakSubFromSession(session: { sub?: unknown; accessToken?: unknown }): string | null {
   if (typeof session.sub === 'string' && session.sub.trim()) {
     return session.sub.trim();
@@ -207,6 +314,11 @@ export async function getAuthenticatedUser(
   request: NextRequest,
   options: GetAuthenticatedUserOptions = {}
 ) {
+  const cached = readCachedSessionAuth(request);
+  if (cached) {
+    return cached;
+  }
+
   const session = await getServerSession(authOptions);
 
   if (!session || !session.user?.email) {
@@ -249,7 +361,9 @@ export async function getAuthenticatedUser(
 
   await persistKeycloakSubMapping(session, user);
 
-  return { user, session: { ...session, role } };
+  const authenticated = { user, session: { ...session, role } };
+  writeCachedSessionAuth(request, authenticated);
+  return cloneSessionAuthPayload(authenticated);
 }
 
 /**


### PR DESCRIPTION
## Summary
- adds a small cookie-scoped cache for successful NextAuth browser sessions
- avoids repeated `getServerSession(authOptions)` calls during bursts of admin API requests
- keeps bearer JWT, catalog-key, anonymous-dev, denied, and missing-session paths outside the cache
- adds regression tests for cache hits, no-cookie misses, TTL expiry, admission-denied sessions, and bearer auth bypass

## Why
Slack Configured channels and other admin pages can issue several browser-authenticated API calls at once. Each call currently asks NextAuth/Keycloak to resolve the same session. During Keycloak warmup, those repeated calls stack into slow page loads. A short success-only cache reduces that pressure while keeping auth changes bounded by a 10s default TTL.

Refs #2036

## Validation
- `NODE_PATH=/Users/sraradhy/outshift/ai-platform-engineering/ui/node_modules /Users/sraradhy/outshift/ai-platform-engineering/ui/node_modules/.bin/jest src/lib/__tests__/api-middleware.test.ts --runInBand --rootDir /tmp/caipe-session-auth-cache/ui`
- `./node_modules/.bin/eslint src/lib/api-middleware.ts src/lib/__tests__/api-middleware.test.ts` (0 errors; pre-existing warnings only)
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`