### PR TITLE
test(slack): cover configured channel health bounds

### DIFF
--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -266,6 +266,76 @@ describe("Slack channel ReBAC APIs", () => {
         active_grants: 1,
       }),
     ]);
+    expect(body.data.channels[0].health).toBeUndefined();
+    expect(mockAuditQuery).not.toHaveBeenCalled();
+  });
+
+  it("adds bounded health summaries for the configured Slack channel list when requested", async () => {
+    // assisted-by Codex Codex-sonnet-4-6
+    mockCollections.channel_team_mappings = createMockCollection([
+      {
+        slack_workspace_id: workspaceId,
+        slack_channel_id: channelId,
+        channel_name: "incidents",
+        team_slug: "platform-engineering",
+        active: true,
+      },
+      {
+        slack_workspace_id: workspaceId,
+        slack_channel_id: "CSUPPORT",
+        channel_name: "support",
+        team_slug: "platform-engineering",
+        active: true,
+      },
+    ]);
+    mockAuditQuery.mockImplementation(async (query: { resourceRef?: string }) => {
+      if (query.resourceRef === `slack_channel:${workspaceAlias}--CSUPPORT`) {
+        return [
+          {
+            ts: "2026-06-25T12:00:00.000Z",
+            reason_code: "OPENFGA_READ_FAILED",
+            message: "OpenFGA tuple read failed",
+          },
+        ];
+      }
+      return [];
+    });
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/slack/channels?health=1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.channels).toHaveLength(2);
+    expect(body.data.channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          channel_id: channelId,
+          health: expect.objectContaining({
+            openfga_reachable: true,
+            last_runtime_error_ts: null,
+          }),
+        }),
+        expect.objectContaining({
+          channel_id: "CSUPPORT",
+          health: expect.objectContaining({
+            openfga_reachable: true,
+            last_runtime_error_ts: "2026-06-25T12:00:00.000Z",
+          }),
+        }),
+      ])
+    );
+    expect(mockAuditQuery).toHaveBeenCalledTimes(2);
+    for (const [query] of mockAuditQuery.mock.calls) {
+      const until = query.until as Date;
+      const since = query.since as Date;
+      expect(query).toMatchObject({
+        component: "slack_bot",
+        outcome: "error",
+        limit: 1,
+      });
+      expect(until.getTime() - since.getTime()).toBe(24 * 60 * 60 * 1000);
+    }
   });
 
   it("filters the Slack channel list to concrete channels the caller can read or manage", async () => {


### PR DESCRIPTION
## Summary
- adds regression coverage for `GET /api/admin/slack/channels?health=1`
- verifies the default configured-channel list does not run health/audit lookups
- verifies health mode attaches summaries and keeps audit lookup bounded to one 24-hour, limit-1 query per returned channel

## Why
Configured channels previously felt blocked by slow dependency checks. This test keeps the health path explicit and bounded so future changes do not accidentally expand the audit-service lookback or run diagnostics when the UI did not request them.

Refs #2037

## Validation
- `NODE_PATH=/Users/sraradhy/outshift/ai-platform-engineering/ui/node_modules /Users/sraradhy/outshift/ai-platform-engineering/ui/node_modules/.bin/jest src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts --runInBand --rootDir /tmp/caipe-slack-load-regression/ui`
- `./node_modules/.bin/eslint src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts` (0 errors; pre-existing warnings only)
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`