### PR TITLE
fix(ui): actually use the seedConfig source for mcp

### DIFF
--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -313,8 +313,22 @@ async function seedMCPServers(
     // Preserve created_at if document already exists
     const existing = await collection.findOne({ _id: serverId });
     const createdAt = existing?.created_at ?? now;
+    const source: MCPServerConfig["source"] | undefined =
+      serverData.source === "manual" ||
+      serverData.source === "config" ||
+      serverData.source === "agentgateway"
+        ? serverData.source
+        : undefined;
+    const agentgatewayEndpoint =
+      typeof serverData.agentgateway_endpoint === "string"
+        ? serverData.agentgateway_endpoint
+        : undefined;
+    const agentgatewayTargetEndpoint =
+      typeof serverData.agentgateway_target_endpoint === "string"
+        ? serverData.agentgateway_target_endpoint
+        : undefined;
 
-    const doc = {
+    const doc: MCPServerConfig = {
       _id: serverId,
       name: (serverData.name as string) ?? serverId,
       description: (serverData.description as string) ?? "",
@@ -323,8 +337,18 @@ async function seedMCPServers(
       command: (serverData.command as string) ?? undefined,
       args: (serverData.args as string[]) ?? undefined,
       env: (serverData.env as Record<string, string>) ?? undefined,
+      credential_sources: Array.isArray(serverData.credential_sources)
+        ? (serverData.credential_sources as MCPServerConfig["credential_sources"])
+        : undefined,
       enabled: (serverData.enabled as boolean) ?? true,
       config_driven: true,
+      source,
+      agentgateway_discovered:
+        typeof serverData.agentgateway_discovered === "boolean"
+          ? serverData.agentgateway_discovered
+          : undefined,
+      agentgateway_endpoint: agentgatewayEndpoint,
+      agentgateway_target_endpoint: agentgatewayTargetEndpoint,
       created_at: createdAt,
       updated_at: now,
     };


### PR DESCRIPTION
# Description

MCP seed config missing bunch of fields from the seed config and thus adding fields e.g. `credential_sources: []` currently does nothing.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
