### PR TITLE
fix(slack): batch configured channel health audit lookup

### DIFF
--- a/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
+++ b/ui/src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts
@@ -288,18 +288,20 @@ describe("Slack channel ReBAC APIs", () => {
         active: true,
       },
     ]);
-    mockAuditQuery.mockImplementation(async (query: { resourceRef?: string }) => {
-      if (query.resourceRef === `slack_channel:${workspaceAlias}--CSUPPORT`) {
-        return [
-          {
-            ts: "2026-06-25T12:00:00.000Z",
-            reason_code: "OPENFGA_READ_FAILED",
-            message: "OpenFGA tuple read failed",
-          },
-        ];
-      }
-      return [];
-    });
+    mockAuditQuery.mockResolvedValue([
+      {
+        ts: "2026-06-25T12:00:00.000Z",
+        resource_ref: `slack_channel:${workspaceAlias}--CSUPPORT`,
+        reason_code: "OPENFGA_READ_FAILED",
+        message: "OpenFGA tuple read failed",
+      },
+      {
+        ts: "2026-06-25T11:00:00.000Z",
+        resource_ref: `slack_channel:${workspaceAlias}--CIGNORED`,
+        reason_code: "OPENFGA_READ_FAILED",
+        message: "Ignored channel",
+      },
+    ]);
     const { GET } = await import("../route");
 
     const response = await GET(request("/api/admin/slack/channels?health=1"));
@@ -325,17 +327,17 @@ describe("Slack channel ReBAC APIs", () => {
         }),
       ])
     );
-    expect(mockAuditQuery).toHaveBeenCalledTimes(2);
-    for (const [query] of mockAuditQuery.mock.calls) {
-      const until = query.until as Date;
-      const since = query.since as Date;
-      expect(query).toMatchObject({
-        component: "slack_bot",
-        outcome: "error",
-        limit: 1,
-      });
-      expect(until.getTime() - since.getTime()).toBe(24 * 60 * 60 * 1000);
-    }
+    expect(mockAuditQuery).toHaveBeenCalledTimes(1);
+    const [query] = mockAuditQuery.mock.calls[0];
+    const until = query.until as Date;
+    const since = query.since as Date;
+    expect(query).toMatchObject({
+      component: "slack_bot",
+      outcome: "error",
+      limit: 1000,
+    });
+    expect(query.resourceRef).toBeUndefined();
+    expect(until.getTime() - since.getTime()).toBe(24 * 60 * 60 * 1000);
   });
 
   it("filters the Slack channel list to concrete channels the caller can read or manage", async () => {

--- a/ui/src/app/api/admin/slack/channels/route.ts
+++ b/ui/src/app/api/admin/slack/channels/route.ts
@@ -1,15 +1,13 @@
 import { NextRequest } from "next/server";
 
 import { getAuthFromBearerOrSession,successResponse,withErrorHandler } from "@/lib/api-middleware";
+import { getAuditReader } from "@/lib/audit/reader";
 import { getCollection } from "@/lib/mongodb";
 import { checkOpenFgaTuple,writeOpenFgaTuples } from "@/lib/rbac/openfga";
 import { requireAdminSurfaceManage } from "@/lib/rbac/require-openfga";
 import { subjectFromSession } from "@/lib/rbac/resource-authz";
 import { slackChannelTeamVisibilityRelationships } from "@/lib/rbac/slack-channel-rebac";
-import {
-computeSlackChannelHealthSummary,
-type SlackChannelHealthSummary,
-} from "@/lib/rbac/slack-channel-diagnostics";
+import type { SlackChannelHealthSummary } from "@/lib/rbac/slack-channel-diagnostics";
 import { listSlackChannelGrants,slackWorkspaceRef } from "@/lib/rbac/slack-channel-grant-store";
 import { buildUniversalRebacTupleDiff } from "@/lib/rbac/tuple-builders";
 import type { SlackChannelAgentRouteDocument } from "@/lib/rbac/slack-channel-route-store";
@@ -43,6 +41,75 @@ function pickPrimaryAgentId(routes: SlackChannelAgentRouteDocument[]): string | 
     )[0];
   const agentId = enabledRoute?.agent_id;
   return typeof agentId === "string" && agentId.trim() ? agentId.trim() : undefined;
+}
+
+const SLACK_LIST_HEALTH_AUDIT_LIMIT = 1000;
+
+function slackChannelAuditResourceRef(workspaceId: string, channelId: string): string {
+  return `slack_channel:${slackWorkspaceRef(workspaceId)}--${channelId}`;
+}
+
+function auditEventTimestamp(event: Record<string, unknown>): string | null {
+  const raw = event.ts;
+  if (raw instanceof Date) return raw.toISOString();
+  return typeof raw === "string" && raw.trim() ? raw : null;
+}
+
+function auditEventResourceRef(event: Record<string, unknown>): string | null {
+  const raw = event.resource_ref ?? event.resourceRef;
+  return typeof raw === "string" && raw.trim() ? raw : null;
+}
+
+// assisted-by Codex Codex-sonnet-4-6
+async function loadSlackListHealth(rows: ChannelListRow[]): Promise<Map<string, SlackChannelHealthSummary>> {
+  const healthByKey = new Map<string, SlackChannelHealthSummary>();
+  if (rows.length === 0) return healthByKey;
+
+  for (const row of rows) {
+    const workspaceId = slackWorkspaceRef(row.slack_workspace_id);
+    healthByKey.set(`${workspaceId}/${row.slack_channel_id}`, {
+      warnings_count: 0,
+      openfga_reachable: true,
+      last_runtime_error_ts: null,
+    });
+  }
+
+  const until = new Date();
+  const since = new Date(until.getTime() - 24 * 60 * 60 * 1000);
+  const resourceKeys = new Map(
+    rows.map((row) => {
+      const workspaceId = slackWorkspaceRef(row.slack_workspace_id);
+      return [
+        slackChannelAuditResourceRef(workspaceId, row.slack_channel_id),
+        `${workspaceId}/${row.slack_channel_id}`,
+      ] as const;
+    })
+  );
+
+  const events = await getAuditReader().query({
+    since,
+    until,
+    component: "slack_bot",
+    outcome: "error",
+    limit: SLACK_LIST_HEALTH_AUDIT_LIMIT,
+  });
+
+  for (const event of events) {
+    const resourceRef = auditEventResourceRef(event);
+    if (!resourceRef) continue;
+    const key = resourceKeys.get(resourceRef);
+    if (!key) continue;
+    const ts = auditEventTimestamp(event);
+    if (!ts) continue;
+    const existing = healthByKey.get(key);
+    if (!existing) continue;
+    const current = existing.last_runtime_error_ts;
+    if (!current || Date.parse(ts) > Date.parse(current)) {
+      existing.last_runtime_error_ts = ts;
+    }
+  }
+
+  return healthByKey;
 }
 
 async function slackChannelAccess(
@@ -134,6 +201,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       .sort((left, right) => (left.channel_name ?? left.slack_channel_id).localeCompare(right.channel_name ?? right.slack_channel_id))
       .slice(0, 500);
 
+    const healthByKey = includeHealth ? await loadSlackListHealth(rows) : new Map<string, SlackChannelHealthSummary>();
+
     const channels = await Promise.all(
       rows.map(async (row) => {
         const workspaceId = slackWorkspaceRef(row.slack_workspace_id);
@@ -152,15 +221,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
           routeCollection
             .find({ workspace_id: workspaceId, channel_id: row.slack_channel_id, status: "active" } as never)
             .toArray(),
-          includeHealth
-            ? computeSlackChannelHealthSummary(workspaceId, row.slack_channel_id).catch(
-                (): SlackChannelHealthSummary => ({
-                  warnings_count: 0,
-                  openfga_reachable: false,
-                  last_runtime_error_ts: null,
-                }),
-              )
-            : Promise.resolve(undefined),
+          Promise.resolve(includeHealth ? healthByKey.get(`${workspaceId}/${row.slack_channel_id}`) : undefined),
         ]);
         return {
           workspace_id: workspaceId,


### PR DESCRIPTION
# Description

The 8k-channel scale test showed that `GET /api/admin/slack/channels?health=1` still timed out even after the Keycloak/session fixes, because the configured-channel list computed full diagnostics per displayed row. With 500 returned rows that meant hundreds of audit-service lookups and OpenFGA tuple scans in one request.

This changes the list endpoint to keep detailed diagnostics in the per-channel drill-in route, but use one bounded 24h audit query for the configured-channel list health summary. The list still reports recent runtime-error timestamps when present, without issuing one audit query per channel.

Live local validation with 8,000 synthetic Slack channels + 1,001 synthetic teams:

- Before this patch: `/api/admin/slack/channels?health=1` aborted after 180s
- After this patch: first health request returned 500 rows in 1,014 ms
- Repeat health request returned 500 rows in 497 ms
- Audit-service logs showed 1 aggregate audit query per health request instead of hundreds of per-channel queries

Related context: #2038, #2039, #2040 are already merged.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

N/A

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `NODE_PATH=/Users/sraradhy/outshift/ai-platform-engineering/ui/node_modules /Users/sraradhy/outshift/ai-platform-engineering/ui/node_modules/.bin/jest src/lib/__tests__/api-middleware.test.ts src/app/api/admin/slack/channels/__tests__/channel-resources-route.test.ts --runInBand --rootDir /tmp/caipe-slack-list-health-pr/ui`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- Rebuilt and recreated `caipe-ui-prod` from `/tmp/caipe-slack-load-test`
- Seeded local Mongo with 8,000 synthetic Slack channel mappings and 1,001 synthetic teams
- Live-tested `GET /api/admin/slack/channels` and `GET /api/admin/slack/channels?health=1` against `localhost:3000`
