### PR TITLE
fix(ui): make custom popover dropdowns work inside dialogs

### DIFF
--- a/ui/src/components/rag/MCPToolsView.tsx
+++ b/ui/src/components/rag/MCPToolsView.tsx
@@ -638,28 +638,9 @@ function ToolFormDialog({ open, onClose, onSave, initial, isEdit }: ToolFormDial
   const toolIdValid = isEdit || (toolId.length > 0 && TOOL_ID_REGEX.test(toolId));
   const canSave = toolIdValid && parallelSearches.length > 0 && parallelSearches.every((ps) => ps.label.trim().length > 0);
 
-  // The team owner/share pickers render their dropdown in a portal to
-  // `document.body` (so it can escape this dialog's `overflow-y-auto`
-  // clipping). A Radix *modal* Dialog would then trap focus away from the
-  // portaled search box (no typing) and treat row clicks as "interact
-  // outside" (no selecting). Running the dialog non-modal disables the focus
-  // trap, and the guard below keeps the dialog open while the user is
-  // interacting with that portaled popover.
-  const keepOpenForPopover = (event: { detail?: { originalEvent?: Event } } & Event) => {
-    const original = event.detail?.originalEvent;
-    const target = (original?.target ?? event.target) as HTMLElement | null;
-    if (target?.closest?.("[data-popover-content]")) {
-      event.preventDefault();
-    }
-  };
-
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()} modal={false}>
-      <DialogContent
-        className="max-w-xl max-h-[90vh] overflow-y-auto"
-        onInteractOutside={keepOpenForPopover}
-        onFocusOutside={keepOpenForPopover}
-      >
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit MCP Tool" : "Create MCP Tool"}</DialogTitle>
         </DialogHeader>

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react"
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { PortalContainerContext } from "@/components/ui/popover"
 
 const Dialog = DialogPrimitive.Root
 
@@ -32,25 +33,40 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+>(({ className, children, ...props }, ref) => {
+  const [contentEl, setContentEl] = React.useState<HTMLDivElement | null>(null);
+
+  const setRefs = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      setContentEl(node);
+      if (typeof ref === "function") ref(node);
+      else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [ref],
+  );
+
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={setRefs}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-lg",
+          className
+        )}
+        {...props}
+      >
+        <PortalContainerContext.Provider value={contentEl}>
+          {children}
+        </PortalContainerContext.Provider>
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -4,6 +4,16 @@ import { cn } from "@/lib/utils";
 import * as React from "react";
 import { createPortal } from "react-dom";
 
+/**
+ * Consumed by PopoverContent to portal into the nearest dialog element instead
+ * of document.body.  Radix Dialog's DismissableLayer prevents pointer events
+ * on nodes outside its DOM subtree — portalling to body makes the popover
+ * invisible to Radix, so scroll and focus are swallowed.  DialogContent
+ * provides itself as the container so the popover stays inside the Radix
+ * FocusScope while position:fixed lets it escape overflow-y:auto clipping.
+ */
+export const PortalContainerContext = React.createContext<HTMLElement | null>(null);
+
 interface PopoverProps {
   children: React.ReactNode;
   open?: boolean;
@@ -120,19 +130,27 @@ interface PopoverContentProps {
 }
 
 /**
- * Popover content rendered via React portal to `document.body`.
+ * Popover content rendered via React portal — to `document.body` by default,
+ * or into a `PortalContainerContext` element (e.g. a Radix Dialog) when one is
+ * present.
  *
  * The previous implementation used `position: absolute` inside the trigger's
  * relative parent, which meant any ancestor with `overflow: hidden` (e.g. a
  * narrow resizable panel like the Skill workspace Files tree) clipped the
- * popover. Portalling to body + computing fixed-position coordinates from
- * the trigger's `getBoundingClientRect()` lets the popover escape those
- * clipping contexts and stay anchored under any layout. We also clamp the
- * final coordinates to the viewport so a narrow panel can never push the
- * popover off-screen — the bug that motivated this change.
+ * popover. Portalling + computing fixed-position coordinates from the
+ * trigger's `getBoundingClientRect()` lets the popover escape those clipping
+ * contexts and stay anchored under any layout. We also clamp the final
+ * coordinates to the viewport so a narrow panel can never push the popover
+ * off-screen — the bug that motivated this change.
+ *
+ * When portalled into a container that has a CSS transform (Radix Dialog uses
+ * `translate-*-[-50%]` to center itself), that container — not the viewport —
+ * becomes the containing block for our `position: fixed` node, so we translate
+ * the viewport coordinates into the container's frame (see computeCoords).
  *
  * Recomputed on open, on resize, and on scroll so it tracks the trigger
- * even when the user resizes the workspace pane while the popover is open.
+ * even when the user resizes the workspace pane or scrolls a dialog body
+ * while the popover is open.
  */
 const VIEWPORT_PADDING = 8;
 
@@ -146,6 +164,7 @@ export function PopoverContent({
   portalled = true,
 }: PopoverContentProps) {
   const { open, setOpen, triggerRef } = React.useContext(PopoverStateContext);
+  const portalContainer = React.useContext(PortalContainerContext);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const [coords, setCoords] = React.useState<{ top: number; left: number } | null>(null);
   const [mounted, setMounted] = React.useState(false);
@@ -216,8 +235,25 @@ export function PopoverContent({
       content.style.overflowY = "";
     }
 
+    // `top`/`left` above are viewport coordinates, correct for a
+    // `position: fixed` element whose containing block IS the viewport.  But
+    // when we portal into a `portalContainer` (a Dialog), that container has a
+    // CSS transform (`translate-*-[-50%]`), which makes it — not the viewport —
+    // the containing block for our fixed element.  A fixed element trapped by a
+    // transformed ancestor behaves like `absolute`: it resolves against the
+    // container's padding box AND lives in the container's *scrolled* content
+    // space.  So we (1) subtract the container's padding-box origin and
+    // (2) add back its scroll offset.  Adding scrollTop makes the result
+    // scroll-independent, so the popover rides the dialog's native scroll in
+    // lockstep with the trigger instead of drifting by the scroll delta.
+    if (portalContainer) {
+      const pRect = portalContainer.getBoundingClientRect();
+      top -= pRect.top + portalContainer.clientTop - portalContainer.scrollTop;
+      left -= pRect.left + portalContainer.clientLeft - portalContainer.scrollLeft;
+    }
+
     setCoords({ top, left });
-  }, [align, alignOffset, side, sideOffset, triggerRef]);
+  }, [align, alignOffset, side, sideOffset, triggerRef, portalContainer]);
 
   React.useLayoutEffect(() => {
     if (!open) {
@@ -297,5 +333,5 @@ export function PopoverContent({
     </div>
   );
 
-  return createPortal(node, document.body);
+  return createPortal(node, portalContainer ?? document.body);
 }


### PR DESCRIPTION
# Description

Dropdowns built on the custom `Popover` component (e.g. the agent picker in
the Slack channel routing modal, the team/owner pickers in the Knowledge Base
ownership & sharing modal, and the MCP Tools modal) could not be scrolled or
searched when rendered inside a Radix `Dialog`. Fixing that surfaced a second
bug: the popover was mispositioned and drifted out of sync ("parallaxed") when
the dialog body was scrolled.

## Root causes

1. **Focus/scroll trap** — Radix `Dialog`'s `FocusScope`/`DismissableLayer`
   blocks pointer and focus events on nodes portalled *outside* the dialog's
   DOM subtree. The custom `PopoverContent` portalled to `document.body`, so
   the dialog swallowed all scroll and search interactions inside the dropdown.

2. **Positioning/parallax** — Radix `DialogContent` centers itself with a CSS
   transform (`translate-x/y-[-50%]`). A transformed ancestor becomes the
   containing block for `position: fixed` descendants, so once the popover was
   portalled into the dialog its fixed coordinates resolved against the
   dialog's padding box and it scrolled with the dialog body — causing both a
   constant offset and drift on scroll.

## Changes

- Add a `PortalContainerContext` (in `popover.tsx`). `DialogContent` now
  provides its own DOM node through it, so `PopoverContent` portals **into**
  the dialog and stays within the Radix focus scope — fixing scroll & search.
- In `PopoverContent`'s coordinate computation, when portalled into a
  container, translate the viewport coordinates into the container's frame and
  add its scroll offset, so the popover stays anchored to its trigger and
  tracks dialog scroll in lockstep — fixing the misalignment and parallax.
- Remove the now-redundant `modal={false}` + `keepOpenForPopover` workaround in
  the MCP Tools modal. That workaround existed only to dodge the focus trap;
  the generic fix handles it properly, and dropping it restores proper modal
  accessibility (inert background).

The fix lives in the shared `popover.tsx`/`dialog.tsx`, so every
custom-popover-based dropdown rendered inside a `Dialog` benefits automatically.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Manually verified the dropdowns in three modals — the Slack channel routing
modal (agent picker), the Knowledge Base ownership & sharing modal (team/owner
pickers), and the MCP Tools modal (team/owner pickers). Confirmed in each that
the dropdown scrolls, searches, is aligned to its trigger, tracks dialog scroll
without drift, and selects rows without closing the dialog. Confirmed the MCP
Tools dialog is now modal again (inert background) and still closes normally.
`npm run build` and `npm run lint` pass.

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
