### PR TITLE
fix(health): probe self API routes via internal base URL, not request origin

### DIFF
--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -102,8 +102,21 @@ function hasComposeProfile(...profileNames: string[]): boolean {
   return profileNames.some((profile) => profiles.has(profile));
 }
 
-function requestOrigin(request: NextRequest): string {
-  return request.nextUrl?.origin ?? new URL(request.url).origin;
+/**
+ * Returns the internal base URL the server should use to probe its own API
+ * routes (e.g. /api/rag/healthz, /api/dynamic-agents/health).
+ *
+ * These capability checks run server-side inside the UI pod, so they must NOT
+ * use the request origin: when the page is loaded through an external ingress,
+ * the origin is the public hostname, and a pod-originated fetch to that
+ * hostname does not route back to the pod (split-horizon DNS / ingress), so
+ * the self-probe fails even though the route is healthy. Loop back to the
+ * local server on its own listen port (PORT, the var Next.js itself reads,
+ * defaulting to 3000) instead.
+ */
+function selfBaseUrl(): string {
+  const port = envValue("PORT") || "3000";
+  return `http://localhost:${port}`;
 }
 
 function slackDirectoryToken(): string | null {
@@ -1028,7 +1041,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 async function getPlatformHealth(request: NextRequest): Promise<NextResponse> {
   const config = getServerConfig();
   const serverOnly = getServerOnlyConfig();
-  const origin = requestOrigin(request);
+  const selfBase = selfBaseUrl();
   const includeDiagnostics = new URL(request.url).searchParams.get("diagnostics") === "1";
   const capabilityResults = await Promise.all([
     probeHttpCapability({
@@ -1047,7 +1060,7 @@ async function getPlatformHealth(request: NextRequest): Promise<NextResponse> {
           id: "dynamic-agents",
           label: "Dynamic Agents",
           group: "runtime",
-          target: `${origin}/api/dynamic-agents/health`,
+          target: `${selfBase}/api/dynamic-agents/health`,
           required: true,
           description: "Checks Dynamic Agents when custom agent runtime is enabled.",
           healthyDetail: "Runtime reachable",
@@ -1069,7 +1082,7 @@ async function getPlatformHealth(request: NextRequest): Promise<NextResponse> {
           id: "knowledge-bases",
           label: "Knowledge Bases",
           group: "knowledge",
-          target: `${origin}/api/rag/healthz`,
+          target: `${selfBase}/api/rag/healthz`,
           required: false,
           description: "Checks the RAG API used by Knowledge Bases.",
           healthyDetail: "RAG API reachable",


### PR DESCRIPTION
## Problem

The `knowledge-bases` and `dynamic-agents` capability checks in the platform health route build their probe targets from the **request origin** (`request.nextUrl.origin`):

```ts
target: `${origin}/api/rag/healthz`
target: `${origin}/api/dynamic-agents/health`
```

These checks run **server-side inside the UI pod**. When the health page is loaded through an external ingress, `origin` resolves to the public hostname. A pod-originated `fetch()` to that public hostname does not route back to the pod (split-horizon DNS / ingress only routes from outside the cluster), so the self-probe fails with **HTTP 404** even though the route is perfectly healthy.

The symptom: "Knowledge Bases" shows *unreachable* and "Dynamic Agents" shows *down* in the admin health UI when accessed through an ingress, while every other diagnostic — which uses explicit internal service targets — is green. Hitting the same endpoint via `localhost` inside the pod returns healthy, confirming the origin is the only difference.

## Fix

Introduce `selfBaseUrl()` and use it for the two self-referential capability probes instead of the request origin. It loops back to the local server on its own listen port — `http://localhost:$PORT` (the `PORT` var Next.js already reads, defaulting to 3000) — so the probe always reaches the pod itself regardless of how the request arrived.

Diagnostic probes that already use explicit internal targets are unchanged.

## Testing

- Verified that, inside the pod, `https://<public-ingress>/api/rag/healthz` returns 404 while `http://localhost:3000/api/rag/healthz` returns 200 — confirming the root cause.
- With the fix, both capabilities resolve against the loopback base and report healthy when accessed through an ingress.