### PR TITLE
fix(security): address audit and pnpm alerts

### DIFF
--- a/ai_platform_engineering/audit_service/main.py
+++ b/ai_platform_engineering/audit_service/main.py
@@ -56,11 +56,12 @@ def _storage_health(store: LocalAuditStore | S3AuditStore, settings: Settings) -
                 critical_percent=settings.local_disk_critical_percent,
             )
         return store.storage_health()
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
+        _logger.exception("audit storage health check failed")
         health: dict[str, Any] = {
             "backend": settings.backend,
             "status": "down",
-            "detail": f"storage health check failed: {exc}",
+            "detail": "storage health check failed; see audit-service logs",
         }
         if settings.backend == "local":
             health["local_path"] = settings.local_path
@@ -184,8 +185,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         service: AuditQueueService = request.app.state.audit_queue
         try:
             service.store.readiness_check()
-        except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=503, detail=f"storage unavailable: {exc}") from exc
+        except Exception:  # noqa: BLE001
+            _logger.exception("audit storage readiness check failed")
+            raise HTTPException(status_code=503, detail="storage unavailable")
         status = service.status()
         if not status["running"]:
             raise HTTPException(status_code=503, detail="audit worker is not running")

--- a/ai_platform_engineering/audit_service/queue_service.py
+++ b/ai_platform_engineering/audit_service/queue_service.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from abc import abstractmethod
 from datetime import datetime, timezone
 from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# assisted-by Codex Codex-sonnet-4-6
+PUBLIC_FLUSH_ERROR = "audit flush failed; see audit-service logs"
 
 
 class AuditStore(Protocol):
@@ -160,9 +166,10 @@ class AuditQueueService:
             self.flushed_events += len(batch)
             self.last_flush_at = _utc_now_iso()
             self.last_error = None
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             self.failed_flushes += 1
-            self.last_error = str(exc)
+            self.last_error = PUBLIC_FLUSH_ERROR
+            logger.exception("failed to flush audit batch")
         finally:
             for _ in batch:
                 self.queue.task_done()

--- a/ai_platform_engineering/audit_service/test_audit_service.py
+++ b/ai_platform_engineering/audit_service/test_audit_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -10,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from ai_platform_engineering.audit_service.config import Settings
 from ai_platform_engineering.audit_service.main import create_app
+from ai_platform_engineering.audit_service.queue_service import PUBLIC_FLUSH_ERROR, AuditQueueService
 from ai_platform_engineering.audit_service.storage import AuditQuery, LocalAuditStore, S3AuditStore
 
 
@@ -177,6 +179,51 @@ def test_status_reports_local_disk_critical(tmp_path: Path, monkeypatch) -> None
 
     assert status.status_code == 200
     assert status.json()["storage"]["status"] == "down"
+
+
+def test_status_sanitizes_storage_health_errors(tmp_path: Path, monkeypatch) -> None:
+    def fail_storage_health(self: LocalAuditStore, **_: object) -> dict[str, object]:
+        raise RuntimeError("secret backend path /tmp/audit-token")
+
+    monkeypatch.setattr(LocalAuditStore, "storage_health", fail_storage_health)
+    app = create_app(_settings(tmp_path))
+
+    with TestClient(app) as client:
+        status = client.get("/v1/audit/status")
+
+    assert status.status_code == 200
+    storage = status.json()["storage"]
+    assert storage["status"] == "down"
+    assert storage["detail"] == "storage health check failed; see audit-service logs"
+    assert "secret" not in storage["detail"]
+
+
+def test_queue_status_sanitizes_flush_errors() -> None:
+    class FailingStore:
+        @property
+        def backend_name(self) -> str:
+            return "local"
+
+        def readiness_check(self) -> None:
+            return None
+
+        def write_batch(self, records: list[dict[str, object]]) -> str | None:
+            raise RuntimeError("secret stack trace payload")
+
+    service = AuditQueueService(
+        FailingStore(),
+        queue_max_size=10,
+        flush_batch_size=1,
+        flush_interval_seconds=0.01,
+    )
+
+    assert service.enqueue_many([{"type": "auth"}])
+    asyncio.run(service._flush_remaining())
+
+    status = service.status()
+    assert status["failed_flushes"] == 1
+    assert status["last_error"] == PUBLIC_FLUSH_ERROR
+    assert "secret" not in status["last_error"]
 
 
 def test_local_store_purges_expired_audit_files(tmp_path: Path) -> None:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "mongodb": "7.2.0",
-        "pnpm": "10.28.2"
+        "pnpm": "11.9.0"
       },
       "devDependencies": {
         "@types/node": "25.7.0",
@@ -249,16 +249,18 @@
       }
     },
     "node_modules/pnpm": {
-      "version": "10.28.2",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-10.28.2.tgz",
-      "integrity": "sha512-QYcvA3rSL3NI47Heu69+hnz9RI8nJtnPdMCPGVB8MdLI56EVJbmD/rwt9kC1Q43uYCPrsfhO1DzC1lTSvDJiZA==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.9.0.tgz",
+      "integrity": "sha512-vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw==",
       "license": "MIT",
       "bin": {
-        "pnpm": "bin/pnpm.cjs",
-        "pnpx": "bin/pnpx.cjs"
+        "pn": "bin/pnpm.mjs",
+        "pnpm": "bin/pnpm.mjs",
+        "pnpx": "bin/pnpx.mjs",
+        "pnx": "bin/pnpx.mjs"
       },
       "engines": {
-        "node": ">=18.12"
+        "node": ">=22.13"
       },
       "funding": {
         "url": "https://opencollective.com/pnpm"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "mongodb": "7.2.0",
-    "pnpm": "10.28.2"
+    "pnpm": "11.9.0"
   },
   "devDependencies": {
     "@types/node": "25.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,10 +132,10 @@ mongodb@7.2.0:
     bson "^7.2.0"
     mongodb-connection-string-url "^7.0.0"
 
-pnpm@10.28.2:
-  version "10.28.2"
-  resolved "https://registry.npmjs.org/pnpm/-/pnpm-10.28.2.tgz"
-  integrity sha512-QYcvA3rSL3NI47Heu69+hnz9RI8nJtnPdMCPGVB8MdLI56EVJbmD/rwt9kC1Q43uYCPrsfhO1DzC1lTSvDJiZA==
+pnpm@11.9.0:
+  version "11.9.0"
+  resolved "https://registry.npmjs.org/pnpm/-/pnpm-11.9.0.tgz"
+  integrity sha512-vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw==
 
 punycode@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
## Summary
- Dismissed 23 stale Dependabot `joserfc` alerts for removed `ai_platform_engineering/agents/**/uv.lock` manifests.
- Bumped the root `pnpm` dependency from `10.28.2` to `11.9.0` in `package.json`, `package-lock.json`, and `yarn.lock`.
- Sanitized audit-service readiness/status error responses so raw backend exception text is logged server-side but not returned to callers.
- Added audit-service regression coverage for sanitized storage health and queue flush errors.

## Security Alerts
- Addresses Dependabot `pnpm` alerts on `package-lock.json` and `yarn.lock`.
- Addresses CodeQL `py/stack-trace-exposure` alert #18942 for `ai_platform_engineering/audit_service/main.py`.
- The remaining Grype code-scanning alerts are image/package findings against built images and should be handled with image rebuild/hardening work, not this source-level patch.

## Validation
- `uv run pytest ai_platform_engineering/audit_service/test_audit_service.py`
- `uv run ruff check ai_platform_engineering/audit_service/main.py ai_platform_engineering/audit_service/queue_service.py ai_platform_engineering/audit_service/test_audit_service.py`
- `npm audit --audit-level=moderate`
- `yarn audit --level moderate`
- `git diff --check`