### PR TITLE
fix(ui-admin): remove Knowledge Bases settings tab

### DIFF
--- a/ui/e2e/rbac/admin-settings-regression.spec.ts
+++ b/ui/e2e/rbac/admin-settings-regression.spec.ts
@@ -37,6 +37,26 @@ test.describe("mocked admin settings browser regression", () => {
     await expect(page.getByRole("button", { name: "Manage Unlinked Access" })).toBeVisible();
   });
 
+  test("does not expose the removed Knowledge Bases settings tab", async ({ page }) => {
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+    });
+
+    await page.goto("/admin?cat=settings&tab=rag-access", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page).toHaveURL(/\/admin\?cat=settings&tab=settings$/);
+    await expect(page.getByRole("button", { name: "Settings", exact: true })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("tab", { name: "General" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByRole("tab", { name: "Knowledge Bases" })).toHaveCount(0);
+    await expect(page.getByText("RAG Team Access")).toHaveCount(0);
+  });
+
   test("explains Unlinked Access on the settings card and modal", async ({ page }) => {
     await installMockedRbacApp(page, {
       isAdmin: true,

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -10,6 +10,8 @@
  * - Data rendering (stats cards, user list, team list)
  */
 
+// assisted-by Codex Codex-sonnet-4-6
+
 import React from 'react';
 import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 
@@ -123,11 +125,6 @@ jest.mock('@/components/admin/rebac/WebexSpaceRebacPanel', () => ({
     </div>
   ),
 }));
-
-jest.mock('@/components/admin/rebac/RagTeamAccessPanel', () => ({
-  RagTeamAccessPanel: () => <div data-testid="rag-team-access-panel">RagTeamAccessPanel</div>,
-}));
-
 
 jest.mock('@/components/admin/security/MigrationTab', () => ({
   MigrationTab: () => <div data-testid="migration-tab">MigrationTab</div>,
@@ -749,7 +746,6 @@ describe('Admin Dashboard Page', () => {
         'General',
         'AI Review',
         'Credentials',
-        'Knowledge Bases',
         'Skills',
         'Service Accounts',
       ]);
@@ -758,7 +754,7 @@ describe('Admin Dashboard Page', () => {
       expect(screen.queryByRole('tab', { name: /release notes/i })).not.toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /skills/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /ai review/i })).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: /knowledge bases/i })).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: /knowledge bases/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /rag team access/i })).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole('button', { name: 'Insights' }));
@@ -854,7 +850,6 @@ describe('Admin Dashboard Page', () => {
     it.each([
       ['settings', 'settings', /^General$/i],
       ['settings', 'ai-review', /^AI Review$/i],
-      ['settings', 'rag-access', /^Knowledge Bases$/i],
       ['settings', 'skills', /^Skills$/i],
       ['people', 'users', /^Users$/i],
       ['people', 'teams', /^Teams$/i],
@@ -908,49 +903,56 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getByTestId('webex-integration-panel')).toBeInTheDocument();
     });
 
-    it('moves Knowledge Bases under Settings', async () => {
+    it('falls back from removed Settings Knowledge Bases links to General', async () => {
       currentSearchParams = new URLSearchParams('cat=settings&tab=rag-access');
 
       render(<AdminPage />);
 
       expect(await screen.findByText('Settings')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
-      expect(screen.getByRole('tab', { name: /^Knowledge Bases$/i })).toHaveAttribute(
+      expect(screen.getByRole('tab', { name: /^General$/i })).toHaveAttribute(
         'aria-selected',
         'true'
       );
-      expect(screen.getByTestId('rag-team-access-panel')).toBeInTheDocument();
-    });
-
-    it('canonicalizes legacy OpenFGA RAG deep links to Settings Knowledge Bases', async () => {
-      currentSearchParams = new URLSearchParams('cat=security&tab=openfga&subtab=rag&openfgaTab=rag');
-
-      render(<AdminPage />);
-
-      expect(await screen.findByText('Settings')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
-      expect(screen.getByRole('tab', { name: /^Knowledge Bases$/i })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
-      expect(screen.getByTestId('rag-team-access-panel')).toBeInTheDocument();
-      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=settings&tab=rag-access', {
+      expect(screen.queryByRole('tab', { name: /^Knowledge Bases$/i })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('rag-team-access-panel')).not.toBeInTheDocument();
+      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=settings&tab=settings', {
         scroll: false,
       });
     });
 
-    it('canonicalizes legacy Resources Knowledge Base links to Settings', async () => {
+    it('keeps legacy OpenFGA RAG deep links on the Policy Graph category', async () => {
+      currentSearchParams = new URLSearchParams('cat=security&tab=openfga&subtab=rag&openfgaTab=rag');
+
+      render(<AdminPage />);
+
+      expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('tab', { name: /^Policy Graph$/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.queryByRole('tab', { name: /^Knowledge Bases$/i })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('rag-team-access-panel')).not.toBeInTheDocument();
+      expect(replaceMock).not.toHaveBeenCalledWith('/admin?cat=settings&tab=rag-access', {
+        scroll: false,
+      });
+    });
+
+    it('canonicalizes legacy Resources Knowledge Base links to Settings General', async () => {
       currentSearchParams = new URLSearchParams('cat=resources&tab=rag-access');
 
       render(<AdminPage />);
 
       expect(await screen.findByText('Settings')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
-      expect(screen.getByRole('tab', { name: /^Knowledge Bases$/i })).toHaveAttribute(
+      expect(screen.getByRole('tab', { name: /^General$/i })).toHaveAttribute(
         'aria-selected',
         'true'
       );
-      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=settings&tab=rag-access', {
+      expect(screen.queryByRole('tab', { name: /^Knowledge Bases$/i })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('rag-team-access-panel')).not.toBeInTheDocument();
+      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=settings&tab=settings', {
         scroll: false,
       });
     });

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -16,7 +16,6 @@ import { MetricsTab } from "@/components/admin/platform/MetricsTab";
 import { SkillHubsSection } from "@/components/admin/platform/SkillHubsSection";
 import { SlackStatsSection } from "@/components/admin/platform/SlackStatsSection";
 import { CasInsightsTab } from "@/components/admin/CasInsightsTab";
-import { RagTeamAccessPanel } from "@/components/admin/rebac/RagTeamAccessPanel";
 import { SlackChannelRebacPanel } from "@/components/admin/rebac/SlackChannelRebacPanel";
 import { WebexSpaceRebacPanel } from "@/components/admin/rebac/WebexSpaceRebacPanel";
 import { AuditLogsTab } from "@/components/admin/security/AuditLogsTab";
@@ -223,7 +222,7 @@ interface SimulationTeamOption {
   description?: string;
 }
 
-const VALID_TABS = ['users', 'teams', 'identity-sync', 'stats', 'skills', 'feedback', 'metrics', 'health', 'cas-insights', 'credentials', 'audit-logs', 'action-audit', 'openfga', 'keycloak', 'migrations', 'ai-review', 'settings', 'release-notes', 'slack', 'webex', 'rag-access', 'service-accounts'] as const;
+const VALID_TABS = ['users', 'teams', 'identity-sync', 'stats', 'skills', 'feedback', 'metrics', 'health', 'cas-insights', 'credentials', 'audit-logs', 'action-audit', 'openfga', 'keycloak', 'migrations', 'ai-review', 'settings', 'release-notes', 'slack', 'webex', 'service-accounts'] as const;
 const VALID_OPENFGA_SUBTABS = ['builder', 'explorer', 'graph', 'tuples', 'access', 'baseline', 'diagnostics'] as const;
 const MOVED_ADMIN_TAB_MAP = {
   insights: 'stats',
@@ -231,7 +230,6 @@ const MOVED_ADMIN_TAB_MAP = {
 const MOVED_OPENFGA_DEEPLINK_TAB_MAP = {
   slack: 'slack',
   webex: 'webex',
-  rag: 'rag-access',
 } as const;
 
 type CategoryKey = 'settings' | 'people' | 'integrations' | 'insights' | 'platform' | 'security';
@@ -260,7 +258,6 @@ const CATEGORIES: Category[] = [
       { value: 'settings', label: 'General', icon: Settings, gateKey: 'settings' },
       { value: 'ai-review', label: 'AI Review', icon: ShieldCheck, gateKey: 'ai_review' },
       { value: 'credentials', label: 'Credentials', icon: Shield, gateKey: 'credentials' },
-      { value: 'rag-access', label: 'Knowledge Bases', icon: Database, gateKey: 'openfga' },
       { value: 'skills', label: 'Skills', icon: Layers, gateKey: 'skills' },
       { value: 'service-accounts', label: 'Service Accounts', icon: Bot, gateKey: 'service_accounts' },
     ],
@@ -1479,12 +1476,6 @@ function AdminPage() {
               {tabGateValues.credentials && (
                 <TabsContent value="credentials" className="space-y-4">
                   <AdminCredentialManagementPanel />
-                </TabsContent>
-              )}
-
-              {tabGateValues.openfga && (
-                <TabsContent value="rag-access" className="space-y-4">
-                  <RagTeamAccessPanel isAdmin={isAdmin} />
                 </TabsContent>
               )}
 


### PR DESCRIPTION
# Description

Removes the Admin Dashboard Settings `Knowledge Bases` tab and stops rendering the old `RAG Team Access` admin surface from `/admin`.

Fixes #1923.

## What changed

- Removed `rag-access` from the Admin Settings tab model and valid admin tab list.
- Removed the `RagTeamAccessPanel` render path from the Admin page.
- Updated unit coverage for Settings navigation and old `rag-access` deep links.
- Added mocked Playwright regression coverage that direct `rag-access` links fall back to Settings → General.

## Screenshot

Screenshot evidence will be attached in the PR conversation only; no screenshot files are committed in this branch.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- [x] `npm test -- --runTestsByPath 'src/app/(app)/admin/__tests__/admin-page.test.tsx'`
- [x] `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://127.0.0.1:3217 npx playwright test e2e/rbac/admin-settings-regression.spec.ts --config=playwright.rbac.config.ts`
- [x] `npm run lint`
- [x] `npm run build`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in tests and PR context
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing targeted tests pass
