### PR TITLE
fix(setup-caipe): update configBridge.bff to configBridge.ui secret path

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -5935,7 +5935,7 @@ deploy_caipe() {
   # key (patched in create_namespace_and_secrets), so both sides share the token.
   if $ENABLE_AGENTGATEWAY; then
     helm_args+=(
-      --set "global.agentgateway.static.configBridge.bff.existingSecret.name=caipe-ui-secret"
+      --set "global.agentgateway.static.configBridge.ui.existingSecret.name=caipe-ui-secret"
       --set "openfga-authz-bridge.agentContext.existingSecret.name=caipe-ui-secret"
       --set "dynamic-agents.agentContext.existingSecret.name=caipe-ui-secret"
     )


### PR DESCRIPTION
# Description

Commit 7194811aa renamed configBridge.bff to configBridge.ui in the agentgateway chart templates, but setup-caipe.sh was not updated. The stale .bff key was silently ignored by Helm, causing both the agentgateway config-bridge sidecar and caipe-ui to fall back to the non-existent default secret caipe-agentgateway-config-bridge-token, resulting in CreateContainerConfigError on both pods.


## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
