### PR TITLE
test(rbac): add rich local regression coverage

### DIFF
--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -67,6 +67,36 @@ const platformTeam = {
   tool_wildcard: false,
 };
 
+const visibilityTeam = {
+  _id: "team-visibility",
+  name: "Visibility Team",
+  slug: "visibility-team",
+  owner_id: adminSession.email,
+  description: "OpenFGA-backed team visibility fixture",
+  member_count: 4,
+  agent_count: 2,
+  skill_count: 1,
+  workflow_count: 1,
+  kb_count: 3,
+  tool_count: 2,
+  tool_wildcard: false,
+};
+
+const wildcardTeam = {
+  _id: "team-wildcard",
+  name: "Wildcard Team",
+  slug: "wildcard-team",
+  owner_id: adminSession.email,
+  description: "OpenFGA wildcard fixture",
+  member_count: 1,
+  agent_count: 1,
+  skill_count: 0,
+  workflow_count: 0,
+  kb_count: 0,
+  tool_count: 0,
+  tool_wildcard: true,
+};
+
 type TeamResourcePutBody = {
   agents?: string[];
   agent_admins?: string[];
@@ -78,8 +108,60 @@ type InstalledTeamMocks = {
   resourcePutBodies: TeamResourcePutBody[];
 };
 
-async function installTeamResourceMocks(page: Page): Promise<InstalledTeamMocks> {
+type TeamResourceMockOptions = {
+  getResourcesStatus?: number;
+  getResourcesError?: string;
+  putResourcesStatus?: number;
+  putResourcesError?: string;
+  putResourcesData?: {
+    members_updated?: string[];
+    members_skipped?: string[];
+  };
+};
+
+type TeamResourceFixture = {
+  team: typeof platformTeam;
+  resources: {
+    agents: string[];
+    agent_admins: string[];
+    tools: string[];
+    tool_wildcard: boolean;
+    skills?: Array<{ id: string; name: string; description?: string }>;
+    workflows?: Array<{ id: string; name: string; description?: string }>;
+  };
+  available: {
+    agents: Array<{ id: string; name: string; description?: string }>;
+    tools: Array<{ id: string; name: string; description?: string }>;
+  };
+};
+
+async function installTeamResourceMocks(
+  page: Page,
+  fixtures: TeamResourceFixture[] = [
+    {
+      team: platformTeam,
+      resources: {
+        agents: ["agent-keep"],
+        agent_admins: [],
+        tools: ["mcp-confluence-mcp_*"],
+        tool_wildcard: false,
+      },
+      available: {
+        agents: [{ id: "agent-keep", name: "Keep Agent", description: "" }],
+        tools: [
+          {
+            id: "mcp-confluence-mcp_*",
+            name: "mcp-confluence-mcp_*",
+            description: "Confluence MCP",
+          },
+        ],
+      },
+    },
+  ],
+  options: TeamResourceMockOptions = {},
+): Promise<InstalledTeamMocks> {
   const resourcePutBodies: TeamResourcePutBody[] = [];
+  const fixturesById = new Map(fixtures.map((fixture) => [fixture.team._id, fixture]));
 
   await installMockedRbacApp(page, {
     isAdmin: true,
@@ -87,30 +169,27 @@ async function installTeamResourceMocks(page: Page): Promise<InstalledTeamMocks>
     handlers: [
       async ({ route, path, method }) => {
         if (path.startsWith("/api/admin/teams") && method === "GET" && !path.includes("/resources")) {
-          await fulfillJson(route, { success: true, data: { teams: [platformTeam] } });
+          await fulfillJson(route, { success: true, data: { teams: fixtures.map((fixture) => fixture.team) } });
           return true;
         }
 
         if (method === "GET" && /\/api\/admin\/teams\/[^/]+\/resources$/.test(path)) {
+          if (options.getResourcesStatus && options.getResourcesStatus >= 400) {
+            await fulfillJson(
+              route,
+              { success: false, error: options.getResourcesError ?? "OpenFGA list-objects failed" },
+              options.getResourcesStatus,
+            );
+            return true;
+          }
+          const teamId = path.match(/\/api\/admin\/teams\/([^/]+)\/resources$/)?.[1] ?? "";
+          const fixture = fixturesById.get(teamId) ?? fixtures[0];
           await fulfillJson(route, {
             success: true,
             data: {
-              resources: {
-                agents: ["agent-keep"],
-                agent_admins: [],
-                tools: ["mcp-confluence-mcp_*"],
-                tool_wildcard: false,
-              },
-              available: {
-                agents: [{ id: "agent-keep", name: "Keep Agent", description: "" }],
-                tools: [
-                  {
-                    id: "mcp-confluence-mcp_*",
-                    name: "mcp-confluence-mcp_*",
-                    description: "Confluence MCP",
-                  },
-                ],
-              },
+              team_id: fixture.team._id,
+              resources: fixture.resources,
+              available: fixture.available,
             },
           });
           return true;
@@ -118,9 +197,17 @@ async function installTeamResourceMocks(page: Page): Promise<InstalledTeamMocks>
 
         if (method === "PUT" && /\/api\/admin\/teams\/[^/]+\/resources$/.test(path)) {
           resourcePutBodies.push((await postJson(route)) as TeamResourcePutBody);
+          if (options.putResourcesStatus && options.putResourcesStatus >= 400) {
+            await fulfillJson(
+              route,
+              { success: false, error: options.putResourcesError ?? "OpenFGA reconcile failed" },
+              options.putResourcesStatus,
+            );
+            return true;
+          }
           await fulfillJson(route, {
             success: true,
-            data: {
+            data: options.putResourcesData ?? {
               members_updated: ["alice@example.com"],
               members_skipped: [],
             },
@@ -134,6 +221,26 @@ async function installTeamResourceMocks(page: Page): Promise<InstalledTeamMocks>
   });
 
   return { resourcePutBodies };
+}
+
+function teamCard(page: Page, teamName: string) {
+  return page
+    .locator("div", { hasText: teamName })
+    .filter({ has: page.getByRole("button", { name: /Manage team/i }) })
+    .first();
+}
+
+function resourceRow(page: Page, text: string) {
+  return page.getByRole("dialog").locator("li", { hasText: text }).first();
+}
+
+async function openTeamDialogFromChip(page: Page, teamName: string, chipLabel: string | RegExp) {
+  const card = teamCard(page, teamName);
+  await expect(card).toBeVisible();
+  await card.getByRole("button", { name: chipLabel }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByRole("dialog").getByText(teamName)).toBeVisible();
+  return card;
 }
 
 type InstalledMcpMocks = {
@@ -535,6 +642,495 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
       !mockedRbacEnabled(),
       "Set RUN_RBAC_REGRESSION=1 to run the mocked MCP OpenFGA browser regression.",
     );
+  });
+
+  test("team cards and details use OpenFGA-derived resource counts instead of legacy team.resources", async ({
+    page,
+  }) => {
+    await installTeamResourceMocks(page, [
+      {
+        team: {
+          ...visibilityTeam,
+          // Deliberately provide no `resources` field. The old UI path would
+          // render zeros here; the branch must trust the server-decorated
+          // OpenFGA counts instead.
+        },
+        resources: {
+          agents: ["agent-sre", "agent-kb"],
+          agent_admins: ["agent-sre"],
+          tools: ["mcp-jira/*", "mcp-confluence/*"],
+          tool_wildcard: false,
+          skills: [
+            {
+              id: "skill-incident-summary",
+              name: "Incident Summary",
+              description: "Summarize active incidents",
+            },
+          ],
+          workflows: [
+            {
+              id: "workflow-release-check",
+              name: "Release Check",
+              description: "Validate release readiness",
+            },
+          ],
+        },
+        available: {
+          agents: [
+            { id: "agent-sre", name: "SRE Agent", description: "Ops automation" },
+            { id: "agent-kb", name: "KB Agent", description: "Knowledge search" },
+          ],
+          tools: [
+            { id: "mcp-jira/*", name: "mcp-jira/*", description: "Jira" },
+            { id: "mcp-confluence/*", name: "mcp-confluence/*", description: "Confluence" },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+
+    const card = teamCard(page, visibilityTeam.name);
+    await expect(card).toBeVisible();
+    await expect(card.getByRole("button", { name: /4\s+Members/i })).toBeVisible();
+    await expect(card.getByRole("button", { name: /2\s+Agents/i })).toBeVisible();
+    await expect(card.getByRole("button", { name: /2\s+MCPs/i })).toBeVisible();
+    await expect(card.getByRole("button", { name: /3\s+KBs/i })).toBeVisible();
+
+    await card.getByRole("button", { name: /2\s+Agents/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByText("Dynamic agents (2 / 2)")).toBeVisible();
+    await expect(page.getByText("SRE Agent")).toBeVisible();
+    await expect(page.getByText("KB Agent")).toBeVisible();
+
+    await page.getByRole("button", { name: "MCPs", exact: true }).click();
+    await expect(page.getByText("MCP servers (2 / 2)")).toBeVisible();
+    await expect(page.getByText("mcp-jira/*")).toBeVisible();
+    await expect(page.getByText("mcp-confluence/*")).toBeVisible();
+  });
+
+  test("team stat chips deep-link into resource tabs without refetching away unsaved OpenFGA state", async ({
+    page,
+  }) => {
+    await installTeamResourceMocks(page, [
+      {
+        team: visibilityTeam,
+        resources: {
+          agents: ["agent-sre"],
+          agent_admins: [],
+          tools: ["mcp-jira/*"],
+          tool_wildcard: false,
+          skills: [],
+          workflows: [],
+        },
+        available: {
+          agents: [
+            { id: "agent-sre", name: "SRE Agent", description: "Ops automation" },
+            { id: "agent-kb", name: "KB Agent", description: "Knowledge search" },
+          ],
+          tools: [
+            { id: "mcp-jira/*", name: "mcp-jira/*", description: "Jira" },
+            { id: "mcp-confluence/*", name: "mcp-confluence/*", description: "Confluence" },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    const resourcesResponses: string[] = [];
+    page.on("response", (response) => {
+      const url = new URL(response.url());
+      if (/\/api\/admin\/teams\/[^/]+\/resources$/.test(url.pathname)) {
+        resourcesResponses.push(url.pathname);
+      }
+    });
+
+    const card = teamCard(page, visibilityTeam.name);
+    await card.getByRole("button", { name: /2\s+Agents/i }).click();
+    await expect(page.getByText("Dynamic agents (1 / 2)")).toBeVisible();
+    await expect(resourceRow(page, "SRE Agent").locator("input").first()).toBeChecked();
+    await expect(resourceRow(page, "KB Agent").locator("input").first()).not.toBeChecked();
+
+    await page.getByRole("button", { name: "MCPs", exact: true }).click();
+    await expect(page.getByText("MCP servers (1 / 2)")).toBeVisible();
+    await expect(resourceRow(page, "mcp-jira/*").locator("input").first()).toBeChecked();
+    await expect(resourceRow(page, "mcp-confluence/*").locator("input").first()).not.toBeChecked();
+
+    await expect.poll(() => resourcesResponses.length).toBe(1);
+  });
+
+  test("agent manage implies use and one save preserves edited agents plus MCP choices across tabs", async ({
+    page,
+  }) => {
+    const mocks = await installTeamResourceMocks(page, [
+      {
+        team: visibilityTeam,
+        resources: {
+          agents: ["agent-sre"],
+          agent_admins: [],
+          tools: ["mcp-jira/*"],
+          tool_wildcard: false,
+          skills: [],
+          workflows: [],
+        },
+        available: {
+          agents: [
+            { id: "agent-sre", name: "SRE Agent", description: "Ops automation" },
+            { id: "agent-kb", name: "KB Agent", description: "Knowledge search" },
+          ],
+          tools: [
+            { id: "mcp-jira/*", name: "mcp-jira/*", description: "Jira" },
+            { id: "mcp-confluence/*", name: "mcp-confluence/*", description: "Confluence" },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await openTeamDialogFromChip(page, visibilityTeam.name, /2\s+Agents/i);
+
+    const kbAgentInputs = resourceRow(page, "KB Agent").locator("input");
+    await kbAgentInputs.nth(1).check();
+    await expect(kbAgentInputs.nth(0)).toBeChecked();
+    await expect(kbAgentInputs.nth(0)).toBeDisabled();
+    await expect(kbAgentInputs.nth(1)).toBeChecked();
+
+    await page.getByRole("button", { name: "MCPs", exact: true }).click();
+    await resourceRow(page, "mcp-confluence/*").locator("input").first().check();
+
+    const putResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        /\/api\/admin\/teams\/[^/]+\/resources$/.test(new URL(response.url()).pathname),
+    );
+    await page.getByRole("button", { name: "Save MCP access" }).click();
+    await putResponse;
+
+    await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
+    expect(mocks.resourcePutBodies[0]).toEqual({
+      agents: ["agent-sre", "agent-kb"],
+      agent_admins: ["agent-kb"],
+      tools: ["mcp-jira/*", "mcp-confluence/*"],
+      tool_wildcard: false,
+    });
+  });
+
+  test("team skills and workflows are visible from OpenFGA but read-only in the team dialog", async ({
+    page,
+  }) => {
+    await installTeamResourceMocks(page, [
+      {
+        team: visibilityTeam,
+        resources: {
+          agents: [],
+          agent_admins: [],
+          tools: [],
+          tool_wildcard: false,
+          skills: [
+            {
+              id: "skill-incident-summary",
+              name: "Incident Summary",
+              description: "Summarize active incidents",
+            },
+          ],
+          workflows: [
+            {
+              id: "workflow-release-check",
+              name: "Release Check",
+              description: "Validate release readiness",
+            },
+          ],
+        },
+        available: {
+          agents: [],
+          tools: [],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await openTeamDialogFromChip(page, visibilityTeam.name, /2\s+Agents/i);
+
+    await page.getByRole("button", { name: "Skills", exact: true }).click();
+    await expect(page.getByText("Skills shared with this team (owned + shared).")).toBeVisible();
+    await expect(page.getByText("Incident Summary")).toBeVisible();
+    await expect(page.getByText("Summarize active incidents")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Save skill/i })).toHaveCount(0);
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Workflows", exact: true }).click();
+    await expect(page.getByText("Workflows shared with this team (owned + shared).")).toBeVisible();
+    await expect(page.getByText("Release Check")).toBeVisible();
+    await expect(page.getByText("Validate release readiness")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Save workflow/i })).toHaveCount(0);
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
+  });
+
+  test("read-only skill and workflow tabs show explicit empty states when OpenFGA returns no grants", async ({
+    page,
+  }) => {
+    await installTeamResourceMocks(page, [
+      {
+        team: {
+          ...visibilityTeam,
+          skill_count: 0,
+          workflow_count: 0,
+        },
+        resources: {
+          agents: [],
+          agent_admins: [],
+          tools: [],
+          tool_wildcard: false,
+          skills: [],
+          workflows: [],
+        },
+        available: {
+          agents: [],
+          tools: [],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await teamCard(page, visibilityTeam.name).getByRole("button", { name: /Manage team/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    await page.getByRole("button", { name: "Skills", exact: true }).click();
+    await expect(page.getByText("No skills are shared with this team yet.")).toBeVisible();
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Workflows", exact: true }).click();
+    await expect(page.getByText("No workflows are shared with this team yet.")).toBeVisible();
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
+  });
+
+  test("wildcard MCP grants show as star counts and save the wildcard intent with selected agents", async ({
+    page,
+  }) => {
+    const mocks = await installTeamResourceMocks(page, [
+      {
+        team: wildcardTeam,
+        resources: {
+          agents: ["agent-sre"],
+          agent_admins: [],
+          tools: [],
+          tool_wildcard: true,
+          skills: [],
+          workflows: [],
+        },
+        available: {
+          agents: [{ id: "agent-sre", name: "SRE Agent", description: "" }],
+          tools: [
+            { id: "mcp-jira/*", name: "mcp-jira/*", description: "Jira" },
+            { id: "mcp-confluence/*", name: "mcp-confluence/*", description: "Confluence" },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    const card = teamCard(page, wildcardTeam.name);
+    await expect(card.getByRole("button", { name: /\*\s+MCPs/i })).toBeVisible();
+
+    await card.getByRole("button", { name: /\*\s+MCPs/i }).click();
+    await expect(page.getByText("MCP servers (0 / 2)")).toBeVisible();
+    await expect(page.getByText("wildcard", { exact: true })).toBeVisible();
+    await expect(page.getByLabel(/All MCP servers \(wildcard\)/i)).toBeChecked();
+
+    await page.getByLabel(/mcp-jira\/\*/i).check();
+    const putResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        /\/api\/admin\/teams\/[^/]+\/resources$/.test(new URL(response.url()).pathname),
+    );
+    await page.getByRole("button", { name: "Save MCP access" }).click();
+    await putResponse;
+
+    await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
+    expect(mocks.resourcePutBodies[0]).toEqual({
+      agents: ["agent-sre"],
+      agent_admins: [],
+      tools: ["mcp-jira/*"],
+      tool_wildcard: true,
+    });
+  });
+
+  test("turning off wildcard keeps explicit server grants and sends tool_wildcard false", async ({
+    page,
+  }) => {
+    const mocks = await installTeamResourceMocks(page, [
+      {
+        team: wildcardTeam,
+        resources: {
+          agents: ["agent-sre"],
+          agent_admins: [],
+          tools: ["mcp-jira/*", "mcp-confluence/*"],
+          tool_wildcard: true,
+          skills: [],
+          workflows: [],
+        },
+        available: {
+          agents: [{ id: "agent-sre", name: "SRE Agent", description: "" }],
+          tools: [
+            { id: "mcp-jira/*", name: "mcp-jira/*", description: "Jira" },
+            { id: "mcp-confluence/*", name: "mcp-confluence/*", description: "Confluence" },
+          ],
+        },
+      },
+    ]);
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await openTeamDialogFromChip(page, wildcardTeam.name, /\*\s+MCPs/i);
+
+    await expect(page.getByLabel(/All MCP servers \(wildcard\)/i)).toBeChecked();
+    await expect(resourceRow(page, "mcp-jira/*").locator("input").first()).toBeChecked();
+    await expect(resourceRow(page, "mcp-confluence/*").locator("input").first()).toBeChecked();
+    await page.getByLabel(/All MCP servers \(wildcard\)/i).uncheck();
+
+    const putResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        /\/api\/admin\/teams\/[^/]+\/resources$/.test(new URL(response.url()).pathname),
+    );
+    await page.getByRole("button", { name: "Save MCP access" }).click();
+    await putResponse;
+
+    await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
+    expect(mocks.resourcePutBodies[0]).toEqual({
+      agents: ["agent-sre"],
+      agent_admins: [],
+      tools: ["mcp-jira/*", "mcp-confluence/*"],
+      tool_wildcard: false,
+    });
+  });
+
+  test("resource load failures surface the OpenFGA error and do not show stale empty pickers", async ({
+    page,
+  }) => {
+    await installTeamResourceMocks(
+      page,
+      [
+        {
+          team: visibilityTeam,
+          resources: {
+            agents: [],
+            agent_admins: [],
+            tools: [],
+            tool_wildcard: false,
+          },
+          available: { agents: [], tools: [] },
+        },
+      ],
+      {
+        getResourcesStatus: 503,
+        getResourcesError: "OpenFGA list-objects failed",
+      },
+    );
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await openTeamDialogFromChip(page, visibilityTeam.name, /2\s+Agents/i);
+
+    await expect(page.getByText("OpenFGA list-objects failed")).toBeVisible();
+    await expect(page.getByText("No agents available")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Save agent access" })).toBeDisabled();
+  });
+
+  test("resource save failures keep the dialog open, surface the error, and retain the attempted selection", async ({
+    page,
+  }) => {
+    const mocks = await installTeamResourceMocks(
+      page,
+      [
+        {
+          team: visibilityTeam,
+          resources: {
+            agents: [],
+            agent_admins: [],
+            tools: [],
+            tool_wildcard: false,
+          },
+          available: {
+            agents: [{ id: "agent-sre", name: "SRE Agent", description: "" }],
+            tools: [],
+          },
+        },
+      ],
+      {
+        putResourcesStatus: 500,
+        putResourcesError: "OpenFGA reconcile failed",
+      },
+    );
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await teamCard(page, visibilityTeam.name).getByRole("button", { name: /Manage team/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: "Agents", exact: true }).click();
+    await resourceRow(page, "SRE Agent").locator("input").first().check();
+
+    const putResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        /\/api\/admin\/teams\/[^/]+\/resources$/.test(new URL(response.url()).pathname),
+    );
+    await page.getByRole("button", { name: "Save agent access" }).click();
+    await putResponse;
+
+    await expect(page.getByText("OpenFGA reconcile failed")).toBeVisible();
+    await expect(resourceRow(page, "SRE Agent").locator("input").first()).toBeChecked();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
+  });
+
+  test("save success explains skipped team members without dropping the selected grants", async ({
+    page,
+  }) => {
+    const mocks = await installTeamResourceMocks(
+      page,
+      [
+        {
+          team: visibilityTeam,
+          resources: {
+            agents: [],
+            agent_admins: [],
+            tools: [],
+            tool_wildcard: false,
+          },
+          available: {
+            agents: [{ id: "agent-sre", name: "SRE Agent", description: "" }],
+            tools: [],
+          },
+        },
+      ],
+      {
+        putResourcesData: {
+          members_updated: ["alice@example.com", "bob@example.com"],
+          members_skipped: ["future-user@example.com"],
+        },
+      },
+    );
+
+    await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
+    await teamCard(page, visibilityTeam.name).getByRole("button", { name: /Manage team/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: "Agents", exact: true }).click();
+    await resourceRow(page, "SRE Agent").locator("input").first().check();
+
+    const putResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        /\/api\/admin\/teams\/[^/]+\/resources$/.test(new URL(response.url()).pathname),
+    );
+    await page.getByRole("button", { name: "Save agent access" }).click();
+    await putResponse;
+
+    await expect(page.getByText(/Saved\. 2 member\(s\) updated; 1 skipped/)).toBeVisible();
+    await expect(page.getByText("future-user@example.com")).toBeVisible();
+    await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
+    expect(mocks.resourcePutBodies[0]).toMatchObject({
+      agents: ["agent-sre"],
+      tools: [],
+      tool_wildcard: false,
+    });
   });
 
   test("team resources save sends the full selected MCP tool list for drift repair", async ({ page }) => {

--- a/ui/e2e/rbac/rbac-rich-local-regression-live.spec.ts
+++ b/ui/e2e/rbac/rbac-rich-local-regression-live.spec.ts
@@ -1,0 +1,895 @@
+// assisted-by Codex Codex-sonnet-4-6
+/**
+ * Real local RBAC regression matrix.
+ *
+ * This spec intentionally creates a broad local fixture through product/admin
+ * APIs only. It must not write MongoDB rows directly or write OpenFGA tuples
+ * directly; the point is to prove that the public lifecycle paths create
+ * source-owned relationships that Self Check can explain and clean up.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { rbacEnvOrSkip, type RbacEnv } from "./_env";
+import { installTestSession } from "./_helpers";
+
+type ApiResult<T = unknown> = {
+  status: number;
+  body: T;
+};
+
+type DecisionExpectation = "ALLOW" | "DENY";
+type ActorType = "user" | "service_account";
+type BulkAgentKind = "ops-team" | "data-shared" | "global" | "service-account-scoped";
+
+type SelfCheckAssertion = {
+  id: string;
+  title: string;
+  actor: { type: ActorType; id: string; label: string };
+  resource: { type: string; id: string; label: string };
+  action: string;
+  expect: DecisionExpectation;
+};
+
+type CreatedUser = { email: string; id: string; sub: string; label: string };
+type CreatedTeam = { id: string; slug: string; label: string };
+type CreatedAgent = { id: string; label: string; kind: BulkAgentKind };
+type CreatedChannel = { workspaceId: string; channelId: string; objectId: string };
+type CreatedWebexSpace = { workspaceId: string; spaceId: string; objectId: string };
+
+type RichFixture = {
+  runId: string;
+  teams: CreatedTeam[];
+  users: CreatedUser[];
+  agents: CreatedAgent[];
+  mcpServers: string[];
+  llmModels: string[];
+  credentials: string[];
+  serviceAccounts: string[];
+  slackChannels: CreatedChannel[];
+  webexSpaces: CreatedWebexSpace[];
+  assertions: SelfCheckAssertion[];
+};
+
+type RbacSelfCheckFinding = {
+  id?: string;
+  severity?: string;
+  title?: string;
+  detail?: string;
+  fix?: string;
+  tuple?: { user: string; relation: string; object: string };
+};
+
+let env: RbacEnv;
+
+const CORE_AGENT_COUNT = 4;
+const SOURCE = "rbac-rich-local-regression";
+const DEFAULT_AGENT_COUNT = 12;
+
+test.beforeAll(() => {
+  env = rbacEnvOrSkip({ requireUserSub: true });
+});
+
+function runSuffix(): string {
+  return randomUUID().replaceAll("-", "").slice(0, 12);
+}
+
+function configuredAgentCount(): number {
+  const raw = process.env.RBAC_RICH_AGENT_COUNT?.trim();
+  if (!raw) return DEFAULT_AGENT_COUNT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < CORE_AGENT_COUNT) return DEFAULT_AGENT_COUNT;
+  return Math.floor(parsed);
+}
+
+function shouldKeepFixture(): boolean {
+  const raw = process.env.RBAC_RICH_KEEP_FIXTURE?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function cleanupRunId(): string | null {
+  return process.env.RBAC_RICH_CLEANUP_RUN_ID?.trim() || null;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function compactId(value: string): string {
+  return value.replace(/[^A-Za-z0-9]/g, "").slice(0, 24) || runSuffix();
+}
+
+function bodyRecord(result: ApiResult): Record<string, unknown> {
+  return typeof result.body === "object" && result.body !== null
+    ? (result.body as Record<string, unknown>)
+    : {};
+}
+
+function dataRecord(result: ApiResult): Record<string, unknown> {
+  const body = bodyRecord(result);
+  return typeof body.data === "object" && body.data !== null
+    ? (body.data as Record<string, unknown>)
+    : body;
+}
+
+function itemsFromResult(result: ApiResult): unknown[] {
+  const body = bodyRecord(result);
+  const data = dataRecord(result);
+  const keys = [
+    "items",
+    "users",
+    "teams",
+    "channels",
+    "spaces",
+    "members",
+    "agents",
+    "servers",
+    "models",
+    "service_accounts",
+  ];
+  for (const key of keys) {
+    const value = data[key] ?? body[key];
+    if (Array.isArray(value)) return value;
+  }
+  if (Array.isArray(body.data)) return body.data;
+  if (Array.isArray(result.body)) return result.body;
+  return [];
+}
+
+function idFrom(result: ApiResult, keys: string[]): string {
+  const data = dataRecord(result);
+  const body = bodyRecord(result);
+  for (const key of keys) {
+    const value = data[key] ?? body[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value === "number") return String(value);
+    if (value && typeof value === "object" && "toString" in value) {
+      const rendered = String(value);
+      if (rendered && rendered !== "[object Object]") return rendered;
+    }
+  }
+  throw new Error(`Could not extract id from response: ${JSON.stringify(result.body)}`);
+}
+
+function nestedRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function apiError(result: ApiResult): string {
+  return `${result.status} ${JSON.stringify(result.body)}`;
+}
+
+function expectStatus(result: ApiResult, statuses: number[]): void {
+  expect(statuses, apiError(result)).toContain(result.status);
+}
+
+async function fetchJson<T = unknown>(
+  page: Page,
+  path: string,
+  init?: RequestInit,
+): Promise<ApiResult<T>> {
+  return page.evaluate(
+    async ({ path: requestPath, init: requestInit }) => {
+      const response = await fetch(requestPath, requestInit);
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        body = await response.text();
+      }
+      return { status: response.status, body };
+    },
+    { path, init },
+  ) as Promise<ApiResult<T>>;
+}
+
+function jsonInit(method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+async function postJson<T = unknown>(page: Page, path: string, body: unknown): Promise<ApiResult<T>> {
+  return fetchJson<T>(page, path, jsonInit("POST", body));
+}
+
+async function putJson<T = unknown>(page: Page, path: string, body: unknown): Promise<ApiResult<T>> {
+  return fetchJson<T>(page, path, jsonInit("PUT", body));
+}
+
+async function patchJson<T = unknown>(page: Page, path: string, body: unknown): Promise<ApiResult<T>> {
+  return fetchJson<T>(page, path, jsonInit("PATCH", body));
+}
+
+async function deleteJson<T = unknown>(page: Page, path: string): Promise<ApiResult<T>> {
+  return fetchJson<T>(page, path, { method: "DELETE" });
+}
+
+async function installSession(
+  page: Page,
+  input: { email: string; subject: string; role: "admin" | "user" },
+): Promise<void> {
+  await page.context().clearCookies();
+  await installTestSession(page, env, input);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+}
+
+function assertion(
+  id: string,
+  title: string,
+  actor: { type?: ActorType; id: string; label: string },
+  resource: { type: string; id: string; label: string },
+  action: string,
+  expectDecision: DecisionExpectation,
+): SelfCheckAssertion {
+  return {
+    id,
+    title,
+    actor: { type: actor.type ?? "user", id: actor.id, label: actor.label },
+    resource,
+    action,
+    expect: expectDecision,
+  };
+}
+
+async function provisionUser(page: Page, runId: string, key: string, label: string): Promise<CreatedUser> {
+  const email = `${runId}-${key}@example.test`;
+  const result = await postJson(page, "/api/admin/users/provision-shell", {
+    email,
+    source: SOURCE,
+    attributes: {
+      rbac_e2e_run_id: [runId],
+      rbac_e2e_label: [label],
+    },
+  });
+  expectStatus(result, [200]);
+  const sub = idFrom(result, ["sub"]);
+  return { email, id: sub, sub, label };
+}
+
+async function createTeam(page: Page, runId: string, key: string, label: string): Promise<CreatedTeam> {
+  const slug = `${runId}-${key}`.slice(0, 63);
+  const result = await postJson(page, "/api/admin/teams", {
+    name: `${label} ${runId}`,
+    slug,
+    description: `${SOURCE} ${runId}`,
+    members: [],
+  });
+  expectStatus(result, [201]);
+  return { id: idFrom(result, ["team_id", "id", "_id"]), slug, label };
+}
+
+async function addTeamMember(
+  page: Page,
+  team: CreatedTeam,
+  user: CreatedUser,
+  role: "member" | "admin",
+): Promise<void> {
+  const result = await postJson(page, `/api/admin/teams/${encodeURIComponent(team.id)}/members`, {
+    user_id: user.email,
+    role,
+  });
+  expectStatus(result, [201]);
+}
+
+async function createMcpServer(page: Page, runId: string, key: string, team: CreatedTeam): Promise<string> {
+  const id = `mcp-${runId}-${key}`.slice(0, 96);
+  const result = await postJson(page, "/api/mcp-servers", {
+    id,
+    name: `RBAC rich ${key} MCP ${runId}`,
+    description: `${SOURCE} ${runId}`,
+    transport: "sse",
+    endpoint: `https://example.test/${runId}/${key}/sse`,
+    owner_team_slug: team.slug,
+    enabled: true,
+  });
+  expectStatus(result, [201]);
+  return idFrom(result, ["_id", "id"]);
+}
+
+async function createAgent(
+  page: Page,
+  input: {
+    runId: string;
+    key: string;
+    label: string;
+    kind: BulkAgentKind;
+    ownerTeam: CreatedTeam;
+    sharedTeams?: CreatedTeam[];
+    visibility?: "team" | "global";
+    allowedTools?: Record<string, string[]>;
+  },
+): Promise<CreatedAgent> {
+  const result = await postJson(page, "/api/dynamic-agents", {
+    name: `${input.label} ${input.runId}`,
+    description: `${SOURCE} ${input.runId} ${input.kind}`,
+    system_prompt: `Local RBAC regression fixture ${input.runId}.`,
+    model: { id: "gpt-4o-mini", provider: "openai" },
+    visibility: input.visibility ?? "team",
+    owner_team_slug: input.visibility === "global" ? undefined : input.ownerTeam.slug,
+    shared_with_teams: input.sharedTeams?.map((team) => team.slug) ?? [],
+    allowed_tools: input.allowedTools ?? {},
+    enabled: true,
+  });
+  expectStatus(result, [201]);
+  return {
+    id: idFrom(result, ["_id", "id"]),
+    label: input.label,
+    kind: input.kind,
+  };
+}
+
+async function createLlmModel(page: Page, runId: string): Promise<string> {
+  const modelId = `${runId}-llm`;
+  const result = await postJson(page, "/api/llm-models", {
+    model_id: modelId,
+    name: `RBAC rich LLM ${runId}`,
+    provider: "local-regression",
+    description: `${SOURCE} ${runId}`,
+  });
+  expectStatus(result, [201]);
+  return modelId;
+}
+
+async function createCredential(page: Page, runId: string, key: string): Promise<string> {
+  const result = await postJson(page, "/api/credentials/secrets", {
+    name: `RBAC rich ${key} credential ${runId}`,
+    type: "api_key",
+    description: `${SOURCE} ${runId}`,
+    value: `secret-${runId}-${key}`,
+  });
+  expectStatus(result, [201]);
+  return idFrom(result, ["id", "_id", "secret_id"]);
+}
+
+async function shareCredentialWithTeam(page: Page, secretId: string, team: CreatedTeam): Promise<void> {
+  const result = await patchJson(page, `/api/credentials/secrets/${encodeURIComponent(secretId)}`, {
+    action: "share",
+    teamId: team.slug,
+  });
+  expectStatus(result, [200]);
+}
+
+async function createServiceAccount(
+  page: Page,
+  runId: string,
+  ownerTeam: CreatedTeam,
+  agentScopes: string[],
+): Promise<string> {
+  const result = await postJson(page, "/api/admin/service-accounts", {
+    name: `RBAC rich ${runId} SA`.slice(0, 64),
+    description: `${SOURCE} ${runId}`,
+    owning_team_id: ownerTeam.slug,
+    scopes: agentScopes.map((agentId) => ({ type: "agent", ref: agentId })),
+  });
+  expectStatus(result, [201]);
+  return idFrom(result, ["id", "sa_sub"]);
+}
+
+async function maybeUnlinkedServiceAccount(page: Page): Promise<string | null> {
+  const result = await fetchJson(page, "/api/admin/service-accounts/unlinked");
+  if (result.status !== 200) return null;
+  const data = dataRecord(result);
+  const value = data.id ?? data.sa_sub ?? data.subject_id;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function createSlackChannel(
+  page: Page,
+  runId: string,
+  team: CreatedTeam,
+  agentId: string,
+): Promise<CreatedChannel> {
+  const workspaceId = "CAIPE";
+  const channelId = `C${compactId(runId).toUpperCase()}`;
+  const teamResult = await putJson(page, `/api/admin/slack/channels/${workspaceId}/${channelId}/team`, {
+    team_slug: team.slug,
+    channel_name: `rbac-rich-${runId}`,
+  });
+  expectStatus(teamResult, [200]);
+
+  const grantsResult = await putJson(page, `/api/admin/slack/channels/${workspaceId}/${channelId}/resources`, {
+    grants: [
+      {
+        resource: { type: "agent", id: agentId },
+        actions: ["use"],
+      },
+    ],
+  });
+  expectStatus(grantsResult, [200]);
+  const resolvedWorkspace = String(dataRecord(teamResult).workspace_id ?? workspaceId);
+  return {
+    workspaceId: resolvedWorkspace,
+    channelId,
+    objectId: `${resolvedWorkspace}--${channelId}`,
+  };
+}
+
+async function createWebexSpace(
+  page: Page,
+  runId: string,
+  team: CreatedTeam,
+  agentId: string,
+): Promise<CreatedWebexSpace> {
+  const workspaceId = "Cisco";
+  const spaceId = `space-${slugify(runId)}`.slice(0, 80);
+  const result = await postJson(page, "/api/admin/webex/spaces/onboard", {
+    workspace_id: workspaceId,
+    space_id: spaceId,
+    space_name: `rbac-rich-${runId}`,
+    team_slug: team.slug,
+    agent_id: agentId,
+    listen: "mention",
+    reload_runtime: false,
+  });
+  expectStatus(result, [200]);
+  const data = dataRecord(result);
+  const resolvedWorkspace = String(data.workspace_id ?? workspaceId);
+  return {
+    workspaceId: resolvedWorkspace,
+    spaceId,
+    objectId: `${resolvedWorkspace}--${spaceId}`,
+  };
+}
+
+async function createFixture(page: Page, runId: string): Promise<RichFixture> {
+  const users = [
+    await provisionUser(page, runId, "ops-member", "Ops member"),
+    await provisionUser(page, runId, "ops-admin", "Ops team admin"),
+    await provisionUser(page, runId, "data-member", "Data member"),
+    await provisionUser(page, runId, "outsider", "Outsider"),
+  ];
+  const [opsMember, opsAdmin, dataMember, outsider] = users;
+
+  const opsTeam = await createTeam(page, runId, "ops", "RBAC rich ops team");
+  const dataTeam = await createTeam(page, runId, "data", "RBAC rich data team");
+  await addTeamMember(page, opsTeam, opsMember, "member");
+  await addTeamMember(page, opsTeam, opsAdmin, "admin");
+  await addTeamMember(page, dataTeam, dataMember, "member");
+
+  const mcpOps = await createMcpServer(page, runId, "ops", opsTeam);
+  const mcpData = await createMcpServer(page, runId, "data", dataTeam);
+  const llmModel = await createLlmModel(page, runId);
+
+  const agents: CreatedAgent[] = [];
+  const serviceScopedAgents: string[] = [];
+  const privateAgent = await createAgent(page, {
+    runId,
+    key: "private",
+    label: "RBAC rich private agent",
+    kind: "ops-team",
+    ownerTeam: opsTeam,
+    allowedTools: { [mcpOps]: ["*"] },
+  });
+  agents.push(privateAgent);
+  const sharedAgent = await createAgent(page, {
+    runId,
+    key: "shared",
+    label: "RBAC rich shared agent",
+    kind: "data-shared",
+    ownerTeam: opsTeam,
+    sharedTeams: [dataTeam],
+    allowedTools: { [mcpData]: ["*"] },
+  });
+  agents.push(sharedAgent);
+  const globalAgent = await createAgent(page, {
+    runId,
+    key: "global",
+    label: "RBAC rich global agent",
+    kind: "global",
+    ownerTeam: opsTeam,
+    visibility: "global",
+  });
+  agents.push(globalAgent);
+  const serviceAgent = await createAgent(page, {
+    runId,
+    key: "service",
+    label: "RBAC rich service scoped agent",
+    kind: "service-account-scoped",
+    ownerTeam: opsTeam,
+    allowedTools: { [mcpOps]: ["*"] },
+  });
+  agents.push(serviceAgent);
+  serviceScopedAgents.push(serviceAgent.id);
+
+  const bulkKinds: BulkAgentKind[] = ["ops-team", "data-shared", "global", "service-account-scoped"];
+  const targetAgentCount = configuredAgentCount();
+  for (let index = agents.length; index < targetAgentCount; index += 1) {
+    const kind = bulkKinds[index % bulkKinds.length];
+    const label = `RBAC rich generated agent ${String(index + 1).padStart(3, "0")}`;
+    const agent = await createAgent(page, {
+      runId,
+      key: String(index + 1).padStart(3, "0"),
+      label,
+      kind,
+      ownerTeam: opsTeam,
+      sharedTeams: kind === "data-shared" ? [dataTeam] : [],
+      visibility: kind === "global" ? "global" : "team",
+      allowedTools: kind === "data-shared" ? { [mcpData]: ["*"] } : { [mcpOps]: ["*"] },
+    });
+    agents.push(agent);
+    if (kind === "service-account-scoped") serviceScopedAgents.push(agent.id);
+  }
+
+  const privateCredential = await createCredential(page, runId, "private");
+  const sharedCredential = await createCredential(page, runId, "shared");
+  await shareCredentialWithTeam(page, sharedCredential, opsTeam);
+
+  const serviceAccount = await createServiceAccount(page, runId, opsTeam, serviceScopedAgents);
+  const unlinkedServiceAccount = await maybeUnlinkedServiceAccount(page);
+  const slackChannel = await createSlackChannel(page, runId, opsTeam, privateAgent.id);
+  const webexSpace = await createWebexSpace(page, runId, opsTeam, sharedAgent.id);
+
+  const admin = { id: env.user.sub!, label: "Current org admin" };
+  const linkedSa = { type: "service_account" as const, id: serviceAccount, label: "Linked service account" };
+  const unlinkedSa = unlinkedServiceAccount
+    ? { type: "service_account" as const, id: unlinkedServiceAccount, label: "Unlinked service account" }
+    : null;
+  const r = (type: string, id: string, label: string) => ({ type, id, label });
+
+  const assertions: SelfCheckAssertion[] = [
+    assertion("ops-member-can-use-private-agent", "Ops member can use team agent", opsMember, r("agent", privateAgent.id, privateAgent.label), "use", "ALLOW"),
+    assertion("data-member-cannot-use-private-agent", "Data member cannot use ops-only agent", dataMember, r("agent", privateAgent.id, privateAgent.label), "use", "DENY"),
+    assertion("data-member-can-use-shared-agent", "Data member can use shared agent", dataMember, r("agent", sharedAgent.id, sharedAgent.label), "use", "ALLOW"),
+    assertion("outsider-can-use-global-agent", "Outsider can use global agent", outsider, r("agent", globalAgent.id, globalAgent.label), "use", "ALLOW"),
+    assertion("linked-sa-can-use-scoped-agent", "Linked service account can use scoped agent", linkedSa, r("agent", serviceAgent.id, serviceAgent.label), "use", "ALLOW"),
+    ...(unlinkedSa
+      ? [
+          assertion("unlinked-sa-cannot-use-scoped-agent", "Unlinked service account cannot use scoped agent", unlinkedSa, r("agent", serviceAgent.id, serviceAgent.label), "use", "DENY"),
+        ]
+      : []),
+
+    assertion("ops-member-can-read-mcp", "Ops member can read MCP server", opsMember, r("mcp_server", mcpOps, "Ops MCP"), "read", "ALLOW"),
+    assertion("ops-member-can-use-mcp", "Ops member can use MCP server", opsMember, r("mcp_server", mcpOps, "Ops MCP"), "use", "ALLOW"),
+    assertion("data-member-cannot-use-ops-mcp", "Data member cannot use ops MCP server", dataMember, r("mcp_server", mcpOps, "Ops MCP"), "use", "DENY"),
+    assertion("data-member-can-use-data-mcp", "Data member can use data MCP server", dataMember, r("mcp_server", mcpData, "Data MCP"), "use", "ALLOW"),
+
+    assertion("admin-can-read-private-credential", "Credential owner can read private credential metadata", admin, r("secret_ref", privateCredential, "Private credential"), "read-metadata", "ALLOW"),
+    assertion("ops-member-cannot-use-private-credential", "Ops member cannot use private credential", opsMember, r("secret_ref", privateCredential, "Private credential"), "use", "DENY"),
+    assertion("ops-member-can-use-shared-credential", "Ops member can use shared credential", opsMember, r("secret_ref", sharedCredential, "Shared credential"), "use", "ALLOW"),
+    assertion("outsider-cannot-use-shared-credential", "Outsider cannot use shared credential", outsider, r("secret_ref", sharedCredential, "Shared credential"), "use", "DENY"),
+
+    assertion("admin-can-manage-llm", "Org admin can manage created LLM model", admin, r("llm_model", llmModel, "Regression LLM"), "manage", "ALLOW"),
+    assertion("outsider-cannot-read-llm", "Outsider cannot read created LLM model", outsider, r("llm_model", llmModel, "Regression LLM"), "read", "DENY"),
+
+    assertion("ops-member-can-use-slack-channel", "Ops member can use Slack channel", opsMember, r("slack_channel", slackChannel.objectId, "Regression Slack channel"), "use", "ALLOW"),
+    assertion("outsider-cannot-use-slack-channel", "Outsider cannot use Slack channel", outsider, r("slack_channel", slackChannel.objectId, "Regression Slack channel"), "use", "DENY"),
+    assertion("ops-member-can-use-webex-space", "Ops member can use Webex space", opsMember, r("webex_space", webexSpace.objectId, "Regression Webex space"), "use", "ALLOW"),
+    assertion("outsider-cannot-use-webex-space", "Outsider cannot use Webex space", outsider, r("webex_space", webexSpace.objectId, "Regression Webex space"), "use", "DENY"),
+    assertion("linked-sa-can-list-gateway", "Linked service account can list MCP gateway", linkedSa, r("mcp_gateway", "list", "MCP gateway list"), "call", "ALLOW"),
+  ];
+
+  for (const agent of agents) {
+    const resource = r("agent", agent.id, agent.label);
+    if (agent.kind === "ops-team") {
+      assertions.push(
+        assertion(`${agent.id}:ops-member-allow`, `Ops member can use ${agent.label}`, opsMember, resource, "use", "ALLOW"),
+        assertion(`${agent.id}:outsider-deny`, `Outsider cannot use ${agent.label}`, outsider, resource, "use", "DENY"),
+      );
+    } else if (agent.kind === "data-shared") {
+      assertions.push(
+        assertion(`${agent.id}:data-member-allow`, `Data member can use ${agent.label}`, dataMember, resource, "use", "ALLOW"),
+        assertion(`${agent.id}:outsider-deny`, `Outsider cannot use ${agent.label}`, outsider, resource, "use", "DENY"),
+      );
+    } else if (agent.kind === "global") {
+      assertions.push(
+        assertion(`${agent.id}:outsider-allow`, `Outsider can use global ${agent.label}`, outsider, resource, "use", "ALLOW"),
+      );
+    } else {
+      assertions.push(
+        assertion(`${agent.id}:linked-sa-allow`, `Linked service account can use ${agent.label}`, linkedSa, resource, "use", "ALLOW"),
+        ...(unlinkedSa
+          ? [assertion(`${agent.id}:unlinked-sa-deny`, `Unlinked service account cannot use ${agent.label}`, unlinkedSa, resource, "use", "DENY")]
+          : []),
+      );
+    }
+  }
+
+  return {
+    runId,
+    teams: [opsTeam, dataTeam],
+    users,
+    agents,
+    mcpServers: [mcpOps, mcpData],
+    llmModels: [llmModel],
+    credentials: [privateCredential, sharedCredential],
+    serviceAccounts: [serviceAccount],
+    slackChannels: [slackChannel],
+    webexSpaces: [webexSpace],
+    assertions,
+  };
+}
+
+async function expectSelfCheckAssertions(page: Page, assertions: SelfCheckAssertion[]): Promise<void> {
+  const result = await postJson(page, "/api/admin/rebac/self-check/tests", {
+    suites: ["custom_assertions"],
+    assertions,
+  });
+  expectStatus(result, [200]);
+  const data = dataRecord(result);
+  const summary = nestedRecord(data.summary);
+  expect(summary.failed, JSON.stringify(result.body)).toBe(0);
+  expect(summary.blocked, JSON.stringify(result.body)).toBe(0);
+  const suites = Array.isArray(data.suites) ? (data.suites as Array<Record<string, unknown>>) : [];
+  const customSuite = suites.find((suite) => suite.id === "custom_assertions");
+  expect(customSuite?.status, JSON.stringify(result.body)).toBe("pass");
+}
+
+function findingMatchesRun(finding: unknown, runId: string): boolean {
+  return JSON.stringify(finding).includes(runId);
+}
+
+async function runSelfCheck(page: Page): Promise<Record<string, unknown>> {
+  const result = await fetchJson(page, "/api/admin/rebac/self-check");
+  expectStatus(result, [200]);
+  return dataRecord(result);
+}
+
+async function expectNoRunIdSelfCheckFindings(page: Page, runId: string, label: string): Promise<void> {
+  const report = await runSelfCheck(page);
+  const findings = Array.isArray(report.findings) ? report.findings : [];
+  const runFindings = findings.filter((finding) => findingMatchesRun(finding, runId)) as RbacSelfCheckFinding[];
+  expect(
+    runFindings,
+    `${label}: Self Check still reports findings for ${runId}: ${JSON.stringify(runFindings.slice(0, 10), null, 2)}`,
+  ).toHaveLength(0);
+}
+
+async function bestEffortDelete(page: Page, path: string): Promise<void> {
+  const result = await deleteJson(page, path);
+  if (![200, 204, 404].includes(result.status)) {
+    throw new Error(`DELETE ${path} failed: ${apiError(result)}`);
+  }
+}
+
+async function removeTeamMemberIfPresent(page: Page, team: CreatedTeam, user: CreatedUser): Promise<void> {
+  const path = `/api/admin/teams/${encodeURIComponent(team.id)}/members?user_id=${encodeURIComponent(user.email)}`;
+  const result = await deleteJson(page, path);
+  if (![200, 204, 400, 404].includes(result.status)) {
+    throw new Error(`DELETE ${path} failed: ${apiError(result)}`);
+  }
+}
+
+async function cleanupFixture(page: Page, fixture: RichFixture): Promise<void> {
+  await installSession(page, { email: env.user.email, subject: env.user.sub!, role: "admin" });
+
+  for (const channel of fixture.slackChannels) {
+    await bestEffortDelete(
+      page,
+      `/api/admin/slack/channels/${encodeURIComponent(channel.workspaceId)}/${encodeURIComponent(channel.channelId)}`,
+    );
+  }
+  for (const space of fixture.webexSpaces) {
+    await bestEffortDelete(
+      page,
+      `/api/admin/webex/spaces/${encodeURIComponent(space.workspaceId)}/${encodeURIComponent(space.spaceId)}`,
+    );
+  }
+  for (const id of fixture.serviceAccounts) {
+    await bestEffortDelete(page, `/api/admin/service-accounts/${encodeURIComponent(id)}`);
+  }
+  for (const id of fixture.credentials) {
+    await bestEffortDelete(page, `/api/credentials/secrets/${encodeURIComponent(id)}`);
+  }
+  for (const agent of fixture.agents) {
+    await bestEffortDelete(page, `/api/dynamic-agents?id=${encodeURIComponent(agent.id)}`);
+  }
+  for (const id of fixture.mcpServers) {
+    await bestEffortDelete(page, `/api/mcp-servers?id=${encodeURIComponent(id)}`);
+  }
+  for (const id of fixture.llmModels) {
+    await bestEffortDelete(page, `/api/llm-models?id=${encodeURIComponent(id)}`);
+  }
+
+  for (const team of fixture.teams) {
+    for (const user of fixture.users) {
+      await removeTeamMemberIfPresent(page, team, user);
+    }
+  }
+  for (const team of fixture.teams) {
+    await bestEffortDelete(page, `/api/admin/teams/${encodeURIComponent(team.id)}`);
+  }
+  for (const user of fixture.users) {
+    await bestEffortDelete(page, `/api/admin/users/${encodeURIComponent(user.sub)}`);
+  }
+}
+
+async function listAll(page: Page, path: string): Promise<unknown[]> {
+  const result = await fetchJson(page, path);
+  if (result.status !== 200) return [];
+  return itemsFromResult(result);
+}
+
+function itemContainsRunId(item: unknown, runId: string): boolean {
+  return JSON.stringify(item).includes(runId);
+}
+
+function rowString(row: unknown, keys: string[]): string | null {
+  const record = nestedRecord(row);
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function expectedFixtureAgentIds(runId: string): string[] {
+  const ids = new Set<string>([
+    `agent-rbac-rich-private-agent-${runId}`,
+    `agent-rbac-rich-shared-agent-${runId}`,
+    `agent-rbac-rich-global-agent-${runId}`,
+    `agent-rbac-rich-service-scoped-agent-${runId}`,
+  ]);
+  for (let index = CORE_AGENT_COUNT; index < 250; index += 1) {
+    ids.add(`agent-rbac-rich-generated-agent-${String(index + 1).padStart(3, "0")}-${runId}`);
+  }
+  return [...ids];
+}
+
+async function cleanupByRunId(page: Page, runId: string): Promise<Record<string, number>> {
+  await installSession(page, { email: env.user.email, subject: env.user.sub!, role: "admin" });
+  const deleted: Record<string, number> = {};
+
+  const bump = (key: string) => {
+    deleted[key] = (deleted[key] ?? 0) + 1;
+  };
+
+  for (const row of (await listAll(page, "/api/admin/slack/channels?health=0")).filter((item) => itemContainsRunId(item, runId))) {
+    const workspaceId = rowString(row, ["workspace_id", "slack_workspace_id"]) ?? "CAIPE";
+    const channelId = rowString(row, ["channel_id", "slack_channel_id"]);
+    if (channelId) {
+      await bestEffortDelete(page, `/api/admin/slack/channels/${encodeURIComponent(workspaceId)}/${encodeURIComponent(channelId)}`);
+      bump("slack_channels");
+    }
+  }
+
+  for (const row of (await listAll(page, "/api/admin/webex/spaces?health=0")).filter((item) => itemContainsRunId(item, runId))) {
+    const workspaceId = rowString(row, ["workspace_id", "webex_workspace_id"]) ?? "Cisco";
+    const spaceId = rowString(row, ["space_id", "webex_space_id"]);
+    if (spaceId) {
+      await bestEffortDelete(page, `/api/admin/webex/spaces/${encodeURIComponent(workspaceId)}/${encodeURIComponent(spaceId)}`);
+      bump("webex_spaces");
+    }
+  }
+
+  for (const row of (await listAll(page, "/api/admin/service-accounts?include_revoked=true")).filter((item) => itemContainsRunId(item, runId))) {
+    const id = rowString(row, ["id", "sa_sub"]);
+    if (id) {
+      await bestEffortDelete(page, `/api/admin/service-accounts/${encodeURIComponent(id)}`);
+      bump("service_accounts");
+    }
+  }
+
+  for (const row of (await listAll(page, "/api/credentials/secrets")).filter((item) => itemContainsRunId(item, runId))) {
+    const id = rowString(row, ["id", "_id", "secret_id"]);
+    if (id) {
+      await bestEffortDelete(page, `/api/credentials/secrets/${encodeURIComponent(id)}`);
+      bump("credentials");
+    }
+  }
+
+  for (const row of (await listAll(page, "/api/dynamic-agents?page=1&page_size=500&pageSize=500")).filter((item) => itemContainsRunId(item, runId))) {
+    const id = rowString(row, ["_id", "id"]);
+    if (id) {
+      await bestEffortDelete(page, `/api/dynamic-agents?id=${encodeURIComponent(id)}`);
+      bump("agents");
+    }
+  }
+  for (const id of expectedFixtureAgentIds(runId)) {
+    await bestEffortDelete(page, `/api/dynamic-agents?id=${encodeURIComponent(id)}`);
+  }
+
+  for (const row of (await listAll(page, "/api/mcp-servers?page=1&page_size=500&pageSize=500")).filter((item) => itemContainsRunId(item, runId))) {
+    const id = rowString(row, ["_id", "id"]);
+    if (id) {
+      await bestEffortDelete(page, `/api/mcp-servers?id=${encodeURIComponent(id)}`);
+      bump("mcp_servers");
+    }
+  }
+  for (const id of [`mcp-${runId}-ops`, `mcp-${runId}-data`]) {
+    await bestEffortDelete(page, `/api/mcp-servers?id=${encodeURIComponent(id)}`);
+  }
+
+  for (const row of (await listAll(page, "/api/llm-models?page=1&page_size=500&pageSize=500")).filter((item) => itemContainsRunId(item, runId))) {
+    const id = rowString(row, ["_id", "id", "model_id"]);
+    if (id) {
+      await bestEffortDelete(page, `/api/llm-models?id=${encodeURIComponent(id)}`);
+      bump("llm_models");
+    }
+  }
+
+  const teamRows = (await listAll(page, `/api/admin/teams?page=1&page_size=100&search=${encodeURIComponent(runId)}`))
+    .filter((item) => itemContainsRunId(item, runId));
+  const userRows = (await listAll(page, `/api/admin/users?page=1&pageSize=100&search=${encodeURIComponent(runId)}`))
+    .filter((item) => itemContainsRunId(item, runId));
+  const users = userRows
+    .map((row) => ({
+      id: rowString(row, ["id", "_id"]),
+      email: rowString(row, ["email", "username"]),
+    }))
+    .filter((row): row is { id: string; email: string } => Boolean(row.id && row.email));
+
+  for (const teamRow of teamRows) {
+    const teamId = rowString(teamRow, ["_id", "id"]);
+    if (!teamId) continue;
+    for (const user of users) {
+      const result = await deleteJson(
+        page,
+        `/api/admin/teams/${encodeURIComponent(teamId)}/members?user_id=${encodeURIComponent(user.email)}`,
+      );
+      if (![200, 204, 400, 404].includes(result.status)) {
+        throw new Error(`Team member cleanup failed: ${apiError(result)}`);
+      }
+    }
+  }
+  for (const teamRow of teamRows) {
+    const teamId = rowString(teamRow, ["_id", "id"]);
+    if (teamId) {
+      await bestEffortDelete(page, `/api/admin/teams/${encodeURIComponent(teamId)}`);
+      bump("teams");
+    }
+  }
+  for (const user of users) {
+    await bestEffortDelete(page, `/api/admin/users/${encodeURIComponent(user.id)}`);
+    bump("users");
+  }
+
+  return deleted;
+}
+
+test.describe.serial("RBAC rich local regression fixture", () => {
+  test("creates source-owned resources through APIs and leaves no unexplained tuples", async ({ page }, testInfo) => {
+    const cleanupTarget = cleanupRunId();
+    if (cleanupTarget) {
+      const deleted = await cleanupByRunId(page, cleanupTarget);
+      await expectNoRunIdSelfCheckFindings(page, cleanupTarget, "after cleanup-by-run-id");
+      console.log(`Cleaned ${cleanupTarget}: ${JSON.stringify(deleted)}`);
+      return;
+    }
+
+    const runId = `rbac-rich-api-${runSuffix()}`;
+    console.log(`RBAC rich regression run id: ${runId}`);
+    testInfo.annotations.push({ type: "run_id", description: runId });
+    let fixture: RichFixture | null = null;
+    let primaryError: unknown = null;
+    const keep = shouldKeepFixture();
+
+    try {
+      await installSession(page, { email: env.user.email, subject: env.user.sub!, role: "admin" });
+      fixture = await createFixture(page, runId);
+      await expectSelfCheckAssertions(page, fixture.assertions);
+      await expectNoRunIdSelfCheckFindings(page, runId, "fixture in place");
+
+      if (keep) {
+        console.log(
+          `Retained RBAC rich fixture ${runId}. Cleanup with RBAC_RICH_CLEANUP_RUN_ID=${runId} RUN_RBAC_E2E=1 npx playwright test ui/e2e/rbac/rbac-rich-local-regression-live.spec.ts`,
+        );
+      }
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      if (fixture && !keep) {
+        try {
+          await cleanupFixture(page, fixture);
+          if (!primaryError) {
+            await expectNoRunIdSelfCheckFindings(page, runId, "after fixture cleanup");
+          }
+        } catch (cleanupError) {
+          if (!primaryError) throw cleanupError;
+          console.warn(`Cleanup for ${runId} failed after primary error:`, cleanupError);
+        }
+      }
+    }
+  });
+});

--- a/ui/e2e/rbac/resource-lifecycle-live.spec.ts
+++ b/ui/e2e/rbac/resource-lifecycle-live.spec.ts
@@ -66,6 +66,14 @@ type GrantIntent = {
 
 type Cleanup = () => Promise<void>;
 
+type SelfCheckAssertion = {
+  id: string;
+  actor: { type: "user" | "service_account"; id: string; label?: string };
+  resource: { type: ResourceType; id: string; label?: string };
+  action: Action;
+  expect: "ALLOW" | "DENY";
+};
+
 async function fetchJson<T = unknown>(
   page: Page,
   path: string,
@@ -221,6 +229,20 @@ async function expectDecisionEventually(
       { timeout: 20_000, intervals: [250, 500, 1_000, 2_000, 5_000] },
     )
     .toBe(expected);
+}
+
+async function expectSelfCheckAssertions(page: Page, assertions: SelfCheckAssertion[]): Promise<void> {
+  const result = await postJson(page, "/api/admin/rebac/self-check/tests", {
+    suites: ["custom_assertions"],
+    assertions,
+  });
+  expect(result.status, JSON.stringify(result.body)).toBe(200);
+  const data = dataRecord(result);
+  const summary = data.summary as { failed?: number; blocked?: number };
+  expect(summary.failed, JSON.stringify(result.body)).toBe(0);
+  expect(summary.blocked, JSON.stringify(result.body)).toBe(0);
+  const suites = Array.isArray(data.suites) ? data.suites as Array<{ id?: string; status?: string }> : [];
+  expect(suites.find((suite) => suite.id === "custom_assertions")?.status, JSON.stringify(result.body)).toBe("pass");
 }
 
 async function grant(page: Page, intent: GrantIntent): Promise<void> {
@@ -525,6 +547,22 @@ test.describe("RBAC live e2e — resource lifecycle matrix", () => {
         resourceId: agentId,
         action: "write",
       }, "DENY");
+      await expectSelfCheckAssertions(page, [
+        {
+          id: "team-member-can-use-agent",
+          actor: { type: "user", id: teamMemberSubject, label: "team member" },
+          resource: { type: "agent", id: agentId },
+          action: "use",
+          expect: "ALLOW",
+        },
+        {
+          id: "outsider-cannot-use-agent",
+          actor: { type: "user", id: outsiderSubject, label: "outsider" },
+          resource: { type: "agent", id: agentId },
+          action: "use",
+          expect: "DENY",
+        },
+      ]);
 
       await installSession(page, env, {
         email: teamMemberEmail,
@@ -563,6 +601,22 @@ test.describe("RBAC live e2e — resource lifecycle matrix", () => {
         resourceId: mcpServerId,
         action: "read",
       }, "DENY");
+      await expectSelfCheckAssertions(page, [
+        {
+          id: "team-member-can-read-mcp",
+          actor: { type: "user", id: teamMemberSubject },
+          resource: { type: "mcp_server", id: mcpServerId },
+          action: "read",
+          expect: "ALLOW",
+        },
+        {
+          id: "outsider-cannot-read-mcp",
+          actor: { type: "user", id: outsiderSubject },
+          resource: { type: "mcp_server", id: mcpServerId },
+          action: "read",
+          expect: "DENY",
+        },
+      ]);
 
       await installSession(page, env, {
         email: delegatedManagerEmail,
@@ -601,6 +655,22 @@ test.describe("RBAC live e2e — resource lifecycle matrix", () => {
         resourceId: modelId,
         action: "read",
       }, "DENY");
+      await expectSelfCheckAssertions(page, [
+        {
+          id: "team-member-can-read-model",
+          actor: { type: "user", id: teamMemberSubject },
+          resource: { type: "llm_model", id: modelId },
+          action: "read",
+          expect: "ALLOW",
+        },
+        {
+          id: "outsider-cannot-read-model",
+          actor: { type: "user", id: outsiderSubject },
+          resource: { type: "llm_model", id: modelId },
+          action: "read",
+          expect: "DENY",
+        },
+      ]);
 
       await installSession(page, env, {
         email: delegatedManagerEmail,
@@ -636,6 +706,29 @@ test.describe("RBAC live e2e — resource lifecycle matrix", () => {
         resourceId: datasourceId,
         action: "read",
       }, "DENY");
+      await expectSelfCheckAssertions(page, [
+        {
+          id: "team-member-can-ingest-kb",
+          actor: { type: "user", id: teamMemberSubject },
+          resource: { type: "knowledge_base", id: datasourceId },
+          action: "ingest",
+          expect: "ALLOW",
+        },
+        {
+          id: "team-member-can-read-data-source",
+          actor: { type: "user", id: teamMemberSubject },
+          resource: { type: "data_source", id: datasourceId },
+          action: "read",
+          expect: "ALLOW",
+        },
+        {
+          id: "outsider-cannot-read-kb",
+          actor: { type: "user", id: outsiderSubject },
+          resource: { type: "knowledge_base", id: datasourceId },
+          action: "read",
+          expect: "DENY",
+        },
+      ]);
 
       const ragCreate = await postJson(page, "/api/rag/v1/datasource", {
         datasource_id: datasourceId,

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,10 @@
     "test:e2e:rbac-live-openfga": "RUN_RBAC_E2E=1 playwright test e2e/rbac/openfga-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-slack-bff": "RUN_RBAC_E2E=1 playwright test e2e/rbac/slack-bff-user-directory-live.spec.ts --config=playwright.rbac.config.ts",
     "test:e2e:rbac-live-resources": "RUN_RBAC_E2E=1 playwright test e2e/rbac/resource-lifecycle-live.spec.ts --config=playwright.rbac.config.ts",
-    "test:e2e:rbac-live-full": "RUN_RBAC_E2E=1 playwright test e2e/rbac/openfga-live.spec.ts e2e/rbac/mcp-server-create-live.spec.ts e2e/rbac/resource-lifecycle-live.spec.ts e2e/rbac/credential-team-sharing.spec.ts --config=playwright.rbac.config.ts"
+    "test:e2e:rbac-live-rich": "RUN_RBAC_E2E=1 playwright test e2e/rbac/rbac-rich-local-regression-live.spec.ts --config=playwright.rbac.config.ts",
+    "test:e2e:rbac-live-rich-keep": "RUN_RBAC_E2E=1 RBAC_RICH_KEEP_FIXTURE=1 playwright test e2e/rbac/rbac-rich-local-regression-live.spec.ts --config=playwright.rbac.config.ts",
+    "test:e2e:rbac-live-rich-cleanup": "RUN_RBAC_E2E=1 playwright test e2e/rbac/rbac-rich-local-regression-live.spec.ts --config=playwright.rbac.config.ts",
+    "test:e2e:rbac-live-full": "RUN_RBAC_E2E=1 playwright test e2e/rbac/openfga-live.spec.ts e2e/rbac/mcp-server-create-live.spec.ts e2e/rbac/resource-lifecycle-live.spec.ts e2e/rbac/credential-team-sharing.spec.ts e2e/rbac/rbac-rich-local-regression-live.spec.ts --config=playwright.rbac.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "3.1051.0",


### PR DESCRIPTION
## Summary

Stacked on #2060.

Adds a richer RBAC regression layer that exercises API-created resources, source-owned tuples, Self Check assertions, and team-resource UI behavior without directly writing MongoDB rows or OpenFGA tuples.

## What changed

- Adds `rbac-rich-local-regression-live.spec.ts` for public-API fixture creation and cleanup.
- Supports configurable fixture size with `RBAC_RICH_AGENT_COUNT`.
- Supports manual inspection with `RBAC_RICH_KEEP_FIXTURE=1`.
- Supports later cleanup with `RBAC_RICH_CLEANUP_RUN_ID=<run id>`.
- Extends MCP/OpenFGA browser regression coverage for OpenFGA-derived team resources.
- Adds Self Check custom assertions into the live resource lifecycle matrix.
- Adds npm scripts for rich live runs and rich fixture cleanup.

## Validation

- `npx tsc --noEmit --pretty false`
- `RUN_RBAC_REGRESSION=1 CAIPE_UI_BASE_URL=http://localhost:3000 npx playwright test --config=playwright.rbac.config.ts e2e/rbac/mcp-openfga-tuples.spec.ts e2e/rbac/rbac-self-check.spec.ts`: 21 passed
- Earlier live local rich regression runs passed with `RBAC_RICH_AGENT_COUNT=4` and `RBAC_RICH_AGENT_COUNT=100`

## Notes

This PR should merge after #2060.