### PR TITLE
fix(health): restore AppHeader capability status

### DIFF
--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -11,12 +11,6 @@ Popover,
 PopoverContent,
 PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-Tooltip,
-TooltipContent,
-TooltipProvider,
-TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { UserMenu } from "@/components/user-menu";
 import { useAdminRole } from "@/hooks/use-admin-role";
 import { useAgentRuntimeHealth } from "@/hooks/use-agent-runtime-health";
@@ -40,7 +34,6 @@ ChevronRight,
 Database,
 FileText,
 Home,
-Info,
 KeyRound,
 Loader2,
 Shield,
@@ -84,12 +77,6 @@ const EDITOR_ROUTES_WITH_HEADER_DIALOG = [
   "/workflows",
   "/dynamic-agents",
 ];
-
-const PLATFORM_HEALTH_ADMIN_HREF = "/admin?cat=platform&tab=health";
-
-function openPlatformHealthDashboard(router: ReturnType<typeof useRouter>): void {
-  router.push(PLATFORM_HEALTH_ADMIN_HREF);
-}
 
 function isOnGuardedEditor(pathname: string | null | undefined): boolean {
   if (!pathname) return false;
@@ -218,8 +205,7 @@ export function AppHeader() {
   } = useRAGHealth();
   const {
     status: platformProbeStatus,
-    probes: platformProbes,
-    summary: platformProbeSummary,
+    capabilities: platformCapabilities,
     secondsUntilNextCheck: platformProbeNextCheck,
   } = usePlatformHealthProbes();
 
@@ -257,59 +243,32 @@ export function AppHeader() {
 
   const combinedStatus = getCombinedStatus();
   const combinedStatusLabel =
-    combinedStatus === "connected" ? "Connected" :
+    combinedStatus === "connected" ? "Healthy" :
     combinedStatus === "checking" ? "Checking" :
-    combinedStatus === "degraded" ? "Needs Attention" :
-    combinedStatus === "rag-disconnected" ? "RAG Disconnected" :
-    "Disconnected";
-  const platformProbeGroups = [
-    {
-      id: "core",
-      label: "Dynamic Agent Runtime",
-      description: "The path dynamic agents use to reach tools: AgentGateway plus the config bridge that publishes MCP targets.",
-    },
-    {
-      id: "identity",
-      label: "Identity & Authz",
-      description: "Keycloak sign-in, OpenFGA authorization, and the OpenFGA bridge used by runtime permission checks.",
-    },
-    {
-      id: "bootstrap",
-      label: "Bootstrap & Migrations",
-      description: "Outcome checks for one-time setup: Keycloak realm reconciliation, OpenFGA store/model seeding, and required RBAC migrations.",
-    },
-    {
-      id: "storage",
-      label: "Storage",
-      description: "Databases backing CAIPE, Keycloak, and OpenFGA.",
-    },
-    {
-      id: "rag",
-      label: "RAG & Web Ingestor",
-      description: "Knowledge services, vector-store dependencies, Redis queue readiness, and web ingestor readiness.",
-    },
-  ] as const;
-  const platformProbeIssues = platformProbes.filter((probe) => probe.status !== "healthy");
-  const platformProbeHealthyCount = platformProbes.filter((probe) => probe.status === "healthy").length;
-  const platformProbeIssueCount = platformProbeIssues.length;
+    "Degraded";
+  // assisted-by Codex Codex-sonnet-4-6
+  const activeCapabilities = platformCapabilities.filter(
+    (capability) => capability.status !== "disabled",
+  );
+  const [expandedHealthDetails, setExpandedHealthDetails] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleHealthDetail = React.useCallback((capabilityId: string) => {
+    setExpandedHealthDetails((current) => {
+      const next = new Set(current);
+      if (next.has(capabilityId)) {
+        next.delete(capabilityId);
+      } else {
+        next.add(capabilityId);
+      }
+      return next;
+    });
+  }, []);
   const platformHealthLabel =
     platformProbeStatus === "healthy" ? "Ready" :
-    platformProbeStatus === "degraded" ? "Attention" :
+    platformProbeStatus === "degraded" ? "Degraded" :
     platformProbeStatus === "down" ? "Down" :
     "Checking";
-  const platformHealthTone =
-    platformProbeStatus === "healthy" ? "green" :
-    platformProbeStatus === "down" ? "red" :
-    platformProbeStatus === "checking" ? "muted" :
-    "amber";
-  const statusBadgeClassName = (tone: "green" | "amber" | "red" | "muted") =>
-    cn(
-      "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold",
-      tone === "green" && "border-green-500/25 bg-green-500/10 text-green-500 dark:text-green-400",
-      tone === "amber" && "border-amber-500/25 bg-amber-500/10 text-amber-600 dark:text-amber-400",
-      tone === "red" && "border-red-500/25 bg-red-500/10 text-red-500 dark:text-red-400",
-      tone === "muted" && "border-border bg-muted/40 text-muted-foreground",
-    );
 
   const getActiveTab = () => {
     if (pathname === "/") return "home";
@@ -720,323 +679,126 @@ export function AppHeader() {
                 </AnimatePresence>
               </button>
             </PopoverTrigger>
-            <PopoverContent side="bottom" align="end" className="w-[600px] max-w-[calc(100vw-1rem)] max-h-[min(760px,calc(100vh-5rem))] p-0 overflow-hidden border-2">
-              <TooltipProvider delayDuration={150}>
-              <div className="flex max-h-[min(760px,calc(100vh-5rem))] flex-col bg-gradient-to-br from-card via-card to-card/95">
-                {/* Header with gradient */}
-                <div className="gradient-primary-br p-4">
+            <PopoverContent side="bottom" align="end" className="w-80 max-w-[calc(100vw-1rem)] p-0 overflow-hidden">
+              <div className="bg-card">
+                <div className="border-b border-border/60 p-4">
                   <div className="flex items-start justify-between gap-3">
-                    <div className="flex-1">
-                      <div className="text-base font-bold text-white mb-1">System Status</div>
-                      <div className="text-xs text-white/80">Dynamic agents, tools, identity, and knowledge services</div>
+                    <div className="min-w-0">
+                      {isAdmin ? (
+                        <GuardedLink
+                          href="/admin?cat=platform&tab=health"
+                          className="inline-flex max-w-full items-center gap-1 rounded-sm text-sm font-semibold text-foreground hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          aria-label="Open Admin health status"
+                        >
+                          <span className="truncate">System Status</span>
+                          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+                        </GuardedLink>
+                      ) : (
+                        <div className="text-sm font-semibold text-foreground">System Status</div>
+                      )}
                     </div>
-                    {isAdmin ? (
-                      <button
-                        type="button"
-                        onClick={() => openPlatformHealthDashboard(router)}
-                        title="Open full health dashboard"
-                        className="flex items-center gap-1.5 rounded-full bg-white/20 px-2.5 py-1 backdrop-blur-sm transition-colors hover:bg-white/30"
-                      >
-                        <span className={cn(
-                          "inline-block h-2 w-2 rounded-full transition-colors duration-700",
-                          combinedStatus === "connected" ? "bg-green-400" :
-                          combinedStatus === "checking" ? "bg-amber-400" :
-                          combinedStatus === "degraded" ? "bg-amber-400" :
-                          combinedStatus === "rag-disconnected" ? "bg-amber-400" : "bg-red-400"
-                        )} />
-                        <span className="text-xs font-medium text-white">
-                          {combinedStatus === "connected" ? "All Systems Live" :
-                           combinedStatus === "checking" ? "Checking" :
-                           combinedStatus === "degraded" ? "Action Needed" :
-                           combinedStatus === "rag-disconnected" ? "RAG Offline" :
-                           "Issues Detected"}
-                        </span>
-                      </button>
-                    ) : (
-                      <div className="flex items-center gap-1.5 rounded-full bg-white/20 px-2.5 py-1 backdrop-blur-sm">
-                        <span className={cn(
-                          "inline-block h-2 w-2 rounded-full transition-colors duration-700",
-                          combinedStatus === "connected" ? "bg-green-400" :
-                          combinedStatus === "checking" ? "bg-amber-400" :
-                          combinedStatus === "degraded" ? "bg-amber-400" :
-                          combinedStatus === "rag-disconnected" ? "bg-amber-400" : "bg-red-400"
-                        )} />
-                        <span className="text-xs font-medium text-white">
-                          {combinedStatus === "connected" ? "All Systems Live" :
-                           combinedStatus === "checking" ? "Checking" :
-                           combinedStatus === "degraded" ? "Action Needed" :
-                           combinedStatus === "rag-disconnected" ? "RAG Offline" :
-                           "Issues Detected"}
-                        </span>
-                      </div>
-                    )}
+                    <div className="flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs font-medium">
+                      <span className={cn(
+                        "h-2 w-2 rounded-full",
+                        combinedStatus === "connected" && "bg-green-400",
+                        combinedStatus === "checking" && "bg-amber-400",
+                        combinedStatus === "degraded" && "bg-amber-400",
+                        combinedStatus === "rag-disconnected" && "bg-amber-400",
+                        combinedStatus === "disconnected" && "bg-red-400",
+                      )} />
+                      {combinedStatusLabel}
+                    </div>
                   </div>
                 </div>
 
-                <div
-                  data-testid="platform-health-scroll"
-                  className="min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain p-4"
-                >
-                  <div className="rounded-xl border border-border/70 bg-background/40 p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                          <div className="text-sm font-semibold text-foreground">Platform Health</div>
-                          {isAdmin ? (
-                            <button
-                              type="button"
-                              onClick={() => openPlatformHealthDashboard(router)}
-                              className="inline-flex items-center gap-0.5 text-[11px] font-medium text-primary hover:underline"
-                            >
-                              Full health report
-                              <ChevronRight className="h-3 w-3" />
-                            </button>
-                          ) : null}
-                        </div>
-                        <div className="mt-0.5 text-xs text-muted-foreground">
-                          {platformProbeSummary
-                            ? `${platformProbeSummary.total} checks across dynamic agents, auth, storage, RAG, web ingestor, and migrations`
-                            : "Checking dynamic agents, auth, storage, RAG, web ingestor, and migrations"}
-                        </div>
+                <div className="space-y-3 p-4">
+                  <div className="rounded-lg border border-border/70 bg-muted/25 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Platform
                       </div>
-                      {isAdmin ? (
-                        <button
-                          type="button"
-                          onClick={() => openPlatformHealthDashboard(router)}
-                          title="Open full health dashboard"
-                          className={cn(statusBadgeClassName(platformHealthTone), "transition-opacity hover:opacity-90")}
-                        >
-                          {platformProbeSummary
-                            ? `${platformProbeSummary.healthy}/${platformProbeSummary.total} ${platformHealthLabel}`
-                            : platformHealthLabel}
-                        </button>
-                      ) : (
-                        <span className={statusBadgeClassName(platformHealthTone)}>
-                          {platformProbeSummary
-                            ? `${platformProbeSummary.healthy}/${platformProbeSummary.total} ${platformHealthLabel}`
-                            : platformHealthLabel}
-                        </span>
-                      )}
+                      <div className="text-xs text-muted-foreground">{platformHealthLabel}</div>
                     </div>
-
-                    {platformProbes.length === 0 ? (
-                      <div className="mt-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-                        Checking Keycloak, OpenFGA, AgentGateway, RAG, storage, web ingestor readiness, and migrations...
+                    {platformProbeStatus === "checking" && activeCapabilities.length === 0 ? (
+                      <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Checking capabilities
                       </div>
-                    ) : (
-                      <div className="mt-3 flex flex-wrap gap-1.5">
-                        {platformProbeGroups.map((group) => {
-                          const groupProbes = platformProbes.filter((probe) => probe.group === group.id);
-                          if (groupProbes.length === 0) return null;
-                          const downCount = groupProbes.filter((probe) => probe.status === "down").length;
-                          const warningCount = groupProbes.filter((probe) => probe.status === "warning").length;
-                          const groupStatus = downCount > 0 ? "down" : warningCount > 0 ? "warning" : "healthy";
+                    ) : activeCapabilities.length > 0 ? (
+                      <div className="mt-3 space-y-2">
+                        {activeCapabilities.map((capability) => {
+                          const showDetail = capability.status === "degraded" || capability.status === "down";
+                          const expanded = expandedHealthDetails.has(capability.id);
+                          const dot = (
+                            <span className={cn(
+                              "mt-1 h-2 w-2 shrink-0 rounded-full",
+                              capability.status === "healthy" && "bg-green-400",
+                              capability.status === "degraded" && "bg-amber-400",
+                              capability.status === "down" && "bg-red-400",
+                            )} />
+                          );
+
+                          if (!showDetail) {
+                            return (
+                              <div key={capability.id} className="flex items-center justify-between gap-3">
+                                <div className="min-w-0 truncate text-xs font-medium text-foreground">
+                                  {capability.label}
+                                </div>
+                                <span className={cn(
+                                  "h-2 w-2 shrink-0 rounded-full",
+                                  capability.status === "healthy" && "bg-green-400",
+                                )} />
+                              </div>
+                            );
+                          }
+
                           return (
-                            <Tooltip key={group.id}>
-                              <TooltipTrigger asChild>
+                            <div key={capability.id} className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 flex-1">
+                                <div className="truncate text-xs font-medium text-foreground">
+                                  {capability.label}
+                                </div>
                                 <button
                                   type="button"
                                   className={cn(
-                                    "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium",
-                                    groupStatus === "healthy" && "border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400",
-                                    groupStatus === "warning" && "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400",
-                                    groupStatus === "down" && "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400",
+                                    "mt-0.5 block max-w-full rounded-sm text-left text-[11px] leading-snug text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                                    expanded ? "whitespace-normal break-words" : "overflow-hidden text-ellipsis whitespace-nowrap",
                                   )}
+                                  aria-expanded={expanded}
+                                  aria-label={`${expanded ? "Collapse" : "Expand"} ${capability.label} details`}
+                                  onClick={() => toggleHealthDetail(capability.id)}
                                 >
-                                  <span className={cn(
-                                    "h-1.5 w-1.5 rounded-full",
-                                    groupStatus === "healthy" && "bg-green-400",
-                                    groupStatus === "warning" && "bg-amber-400",
-                                    groupStatus === "down" && "bg-red-400",
-                                  )} />
-                                  {group.label}
-                                  <Info className="h-3 w-3 opacity-70" />
+                                  <span
+                                    className={cn(
+                                      "block max-w-full",
+                                      expanded ? "whitespace-normal break-words" : "overflow-hidden text-ellipsis whitespace-nowrap",
+                                    )}
+                                  >
+                                    {capability.detail}
+                                  </span>
                                 </button>
-                              </TooltipTrigger>
-                              <TooltipContent side="top" className="max-h-80 max-w-[28rem] overflow-y-auto whitespace-normal text-left">
-                                <div className="font-semibold">{group.label}</div>
-                                <div className="mt-1 text-muted-foreground">{group.description}</div>
-                                <div className="mt-1 text-[10px] text-muted-foreground">
-                                  {groupStatus === "healthy"
-                                    ? `${groupProbes.length} checks OK`
-                                    : `${downCount + warningCount} of ${groupProbes.length} need attention`}
-                                </div>
-                                <div className="mt-2 space-y-1.5 border-t border-border/60 pt-2">
-                                  <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                                    Probes
-                                  </div>
-                                  {groupProbes.map((probe) => (
-                                    <div key={probe.id} className="rounded bg-muted/35 px-2 py-1.5">
-                                      <div className="flex items-center justify-between gap-2 text-[11px] font-medium">
-                                        <span>{probe.label}</span>
-                                        <span className={cn(
-                                          "shrink-0",
-                                          probe.status === "healthy" && "text-green-500 dark:text-green-400",
-                                          probe.status === "warning" && "text-amber-600 dark:text-amber-400",
-                                          probe.status === "down" && "text-red-500 dark:text-red-400",
-                                        )}>
-                                          {probe.status === "healthy" ? "OK" : probe.status === "warning" ? "Check" : "Down"}
-                                        </span>
-                                      </div>
-                                      <div className="mt-0.5 text-[10px] text-muted-foreground">
-                                        {probe.detail}
-                                        {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
-                                      </div>
-                                      <div className="mt-1 break-all font-mono text-[10px] text-muted-foreground">
-                                        {probe.target}
-                                      </div>
-                                    </div>
-                                  ))}
-                                </div>
-                              </TooltipContent>
-                            </Tooltip>
+                              </div>
+                              {dot}
+                            </div>
                           );
                         })}
                       </div>
-                    )}
-
-                    {platformProbeIssues.length > 0 ? (
-                      <div className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/10 p-2.5">
-                        <div className="mb-2 flex items-center justify-between gap-2">
-                          <div className="text-xs font-semibold text-amber-700 dark:text-amber-300">
-                            Action needed
-                          </div>
-                          <div className="text-[10px] text-amber-700/80 dark:text-amber-300/80">
-                            {platformProbeHealthyCount} healthy · {platformProbeIssueCount} attention
-                          </div>
-                        </div>
-                        <div className="space-y-1.5">
-                          {platformProbeIssues.slice(0, 3).map((probe) => (
-                            <div
-                              key={probe.id}
-                              title={`${probe.target} — ${probe.detail}`}
-                              className="flex items-center justify-between gap-2 rounded-md bg-background/70 px-2.5 py-2"
-                            >
-                              <div className="min-w-0">
-                                <div className="truncate text-xs font-medium text-foreground">
-                                  {probe.label}
-                                </div>
-                                <div className="truncate text-[10px] text-muted-foreground">
-                                  {probe.detail}
-                                </div>
-                              </div>
-                              {probe.remediation ? (
-                                <button
-                                  type="button"
-                                  onClick={() => router.push(probe.remediation!.href)}
-                                  className="shrink-0 rounded-md bg-primary px-2.5 py-1 text-[10px] font-semibold text-primary-foreground hover:bg-primary/90"
-                                  title={probe.remediation.description}
-                                >
-                                  {probe.remediation.label}
-                                </button>
-                              ) : (
-                                <span className={statusBadgeClassName(probe.status === "warning" ? "amber" : "red")}>
-                                  {probe.status === "warning" ? "Check" : "Down"}
-                                </span>
-                              )}
-                            </div>
-                          ))}
-                          {platformProbeIssues.length > 3 && (
-                            <div className="px-1 text-[10px] text-muted-foreground">
-                              {platformProbeIssues.length - 3} more checks need attention.
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    ) : platformProbes.length > 0 ? (
-                      <div className="mt-3 rounded-lg border border-green-500/20 bg-green-500/10 px-3 py-2 text-xs text-muted-foreground">
-                        All critical checks are ready.
-                      </div>
-                    ) : null}
-
-                    {platformProbes.length > 0 && (
-                      <div className="mt-3 overflow-hidden rounded-lg border border-border/60">
-                        <div className="grid grid-cols-[minmax(0,1fr)_auto] bg-muted/30 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                          <span>Probe</span>
-                          <span>Status</span>
-                        </div>
-                        <div
-                          data-testid="platform-health-probe-list"
-                          className="max-h-48 divide-y divide-border/60 overflow-y-auto overscroll-contain"
-                        >
-                          {platformProbes.map((probe) => (
-                            <Tooltip key={probe.id}>
-                              <TooltipTrigger asChild>
-                                <div className="grid cursor-help grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 hover:bg-muted/30">
-                                  <div className="min-w-0">
-                                    <div className="truncate text-xs font-medium text-foreground">
-                                      {probe.label}
-                                    </div>
-                                    <div className="truncate text-[10px] text-muted-foreground">
-                                      {probe.detail}
-                                      {probe.latency_ms !== null ? ` · ${probe.latency_ms}ms` : ""}
-                                    </div>
-                                  </div>
-                                  <span className={statusBadgeClassName(
-                                    probe.status === "healthy" ? "green" : probe.status === "warning" ? "amber" : "red",
-                                  )}>
-                                    {probe.status === "healthy" ? "OK" : probe.status === "warning" ? "Check" : "Down"}
-                                  </span>
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent side="left" className="max-w-96 whitespace-normal text-left">
-                                <div className="font-semibold">{probe.label}</div>
-                                <div className="mt-1 text-muted-foreground">Validation: {probe.detail}</div>
-                                <div className="mt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                                  Probe target
-                                </div>
-                                <div className="mt-2 break-all rounded bg-muted/40 px-2 py-1 font-mono text-[10px] text-muted-foreground">
-                                  {probe.target}
-                                </div>
-                                {probe.remediation && (
-                                  <div className="mt-2 text-[10px] text-muted-foreground">
-                                    Action: {probe.remediation.description}
-                                  </div>
-                                )}
-                              </TooltipContent>
-                            </Tooltip>
-                          ))}
-                        </div>
+                    ) : (
+                      <div className="mt-3 text-xs text-muted-foreground">
+                        No active platform capabilities reported.
                       </div>
                     )}
-
-                    <div className="mt-2 text-right text-[10px] font-mono text-muted-foreground">
-                      Next probe: {platformProbeNextCheck}s
-                      {isAdmin ? (
-                        <>
-                          {" · "}
-                          <button
-                            type="button"
-                            onClick={() => openPlatformHealthDashboard(router)}
-                            className="font-sans font-medium text-primary hover:underline"
-                          >
-                            Open health dashboard
-                          </button>
-                        </>
-                      ) : null}
-                    </div>
                   </div>
                 </div>
 
-                {/* Footer */}
-                <div className="px-4 py-2.5 bg-muted/20 border-t border-border/50 space-y-1.5">
-                  <div className="flex items-center justify-between text-xs">
-                    <div className="flex items-center gap-2 text-muted-foreground">
-                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-                      <span>Health checks active (30s interval)</span>
-                    </div>
-                    <div className="text-muted-foreground">
-                      {combinedStatus === "connected" ? "All systems operational" :
-                       combinedStatus === "checking" ? "Checking status..." :
-                       combinedStatus === "degraded" ? "Action available" :
-                       combinedStatus === "rag-disconnected" ? "RAG server unavailable" :
-                       "Check logs for details"}
-                    </div>
+                <div className="space-y-1.5 border-t border-border/50 bg-muted/20 px-4 py-2.5">
+                  <div className="text-right text-xs text-muted-foreground">
+                    Next: {platformProbeNextCheck}s
                   </div>
                   {versionInfo && (
-                    <div className="flex items-center justify-between text-[10px] text-muted-foreground font-mono">
-                      <div className="flex items-center gap-2">
-                        <span className="font-semibold text-primary">UI Version:</span>
+                    <div className="flex items-center justify-between gap-3 text-[10px] text-muted-foreground font-mono">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="font-semibold text-primary">UI:</span>
                         <span>{versionInfo.version}</span>
                         {versionInfo.gitCommit !== "unknown" && (
                           <span className="text-muted-foreground/60">
@@ -1052,15 +814,14 @@ export function AppHeader() {
                         </button>
                       </div>
                       {versionInfo.buildDate && (
-                        <span className="text-muted-foreground/60">
+                        <span className="shrink-0 text-muted-foreground/60">
                           Built: {new Date(versionInfo.buildDate).toLocaleDateString()}
                         </span>
                       )}
                     </div>
                   )}
                 </div>
-                </div>
-              </TooltipProvider>
+              </div>
             </PopoverContent>
           </Popover>
           {noAuthConfigured && (

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -110,37 +110,35 @@ let mockPlatformProbeStatus: 'healthy' | 'degraded' | 'down' | 'checking' = 'hea
 type MockPlatformProbe = {
   id: string
   label: string
-  group: 'core' | 'identity' | 'storage' | 'rag' | 'bootstrap'
-  status: 'healthy' | 'warning' | 'down'
+  group: 'runtime' | 'knowledge' | 'identity' | 'observability' | 'messaging'
+  status: 'healthy' | 'degraded' | 'down' | 'disabled'
+  required: boolean
+  description: string
   detail: string
-  target: string
-  latency_ms: number
-  remediation?: {
-    label: string
-    href: string
-    description: string
-  }
+  latency_ms: number | null
 }
 let mockPlatformProbes: MockPlatformProbe[] = [
   {
-    id: 'keycloak',
-    label: 'Keycloak',
-    group: 'identity',
+    id: 'chat-runtime',
+    label: 'Chat Runtime',
+    group: 'runtime',
     status: 'healthy',
-    detail: 'HTTP 200',
-    target: 'http://keycloak:7080',
+    required: true,
+    description: 'Checks the runtime health endpoint used by the chat experience.',
+    detail: 'Runtime reachable',
     latency_ms: 12,
   },
 ]
 jest.mock('@/hooks/use-platform-health-probes', () => ({
   usePlatformHealthProbes: () => ({
     status: mockPlatformProbeStatus,
-    probes: mockPlatformProbes,
+    capabilities: mockPlatformProbes,
     summary: {
       total: mockPlatformProbes.length,
       healthy: mockPlatformProbes.filter((p) => p.status === 'healthy').length,
-      warning: mockPlatformProbes.filter((p) => p.status === 'warning').length,
+      degraded: mockPlatformProbes.filter((p) => p.status === 'degraded').length,
       down: mockPlatformProbes.filter((p) => p.status === 'down').length,
+      disabled: mockPlatformProbes.filter((p) => p.status === 'disabled').length,
     },
     secondsUntilNextCheck: 30,
     checkNow: jest.fn(),
@@ -439,7 +437,7 @@ describe('AppHeader — nav tabs', () => {
     it('always shows Skills and Chat tabs', () => {
       render(<AppHeader />)
       expect(screen.getByText('Skills')).toBeInTheDocument()
-      expect(screen.getByText(/Chat/)).toBeInTheDocument()
+      expect(screen.getByTestId('link-/chat')).toHaveTextContent('Chat')
     })
 
     it('collapses nav items into More dropdown and keeps right cluster intact on narrow widths', () => {
@@ -454,12 +452,12 @@ describe('AppHeader — nav tabs', () => {
       expect(screen.getByRole('button', { name: /more navigation/i })).toHaveTextContent('More')
       // All items still accessible (inside the always-open popover mock)
       expect(screen.getByText('Home')).toBeInTheDocument()
-      expect(screen.getByText(/Chat/)).toBeInTheDocument()
+      expect(screen.getByTestId('link-/chat')).toHaveTextContent('Chat')
       expect(screen.getByText('Skills')).toBeInTheDocument()
       expect(screen.getByTestId('link-/dynamic-agents')).toBeInTheDocument()
       expect(screen.getByTestId('link-/admin')).toBeInTheDocument()
       // Right cluster: status stays icon-only circle, Report a Problem keeps its label
-      expect(screen.getByRole('button', { name: /system status: connected/i })).toHaveClass('w-8')
+      expect(screen.getByRole('button', { name: /system status: healthy/i })).toHaveClass('w-8')
       expect(screen.getByText('Report a Problem')).toBeInTheDocument()
       expect(screen.getByTestId('settings-panel')).toBeInTheDocument()
       expect(screen.getByTestId('user-menu')).toBeInTheDocument()
@@ -601,12 +599,13 @@ describe('AppHeader — connection status badge', () => {
     mockPlatformProbeStatus = 'healthy'
     mockPlatformProbes = [
       {
-        id: 'keycloak',
-        label: 'Keycloak',
-        group: 'identity',
+        id: 'chat-runtime',
+        label: 'Chat Runtime',
+        group: 'runtime',
         status: 'healthy',
-        detail: 'HTTP 200',
-        target: 'http://keycloak:7080',
+        required: true,
+        description: 'Checks the runtime health endpoint used by the chat experience.',
+        detail: 'Runtime reachable',
         latency_ms: 12,
       },
     ]
@@ -624,46 +623,78 @@ describe('AppHeader — connection status badge', () => {
       mockRagStatus = 'connected'
       render(<AppHeader />)
 
-      const btn = screen.getByRole('button', { name: /system status: connected/i })
-      // Icon-only: no visible "Connected" label text (AnimatePresence hides it)
+      const btn = screen.getByRole('button', { name: /system status: healthy/i })
+      // Header button remains icon-only when healthy.
       expect(btn).toBeInTheDocument()
       expect(btn.className).toContain('green')
       expect(btn.className).toContain('w-8') // fixed-size circle, not pill
-      expect(screen.queryByText('Connected')).not.toBeInTheDocument()
-      // Popover content reflects healthy state
-      expect(screen.getByText('All Systems Live')).toBeInTheDocument()
-      expect(screen.getByText('All systems operational')).toBeInTheDocument()
-      expect(screen.getByText('Platform Health')).toBeInTheDocument()
-      expect(screen.getAllByText('Identity & Authz').length).toBeGreaterThan(0)
+      expect(screen.getByText('System Status')).toBeInTheDocument()
+      expect(screen.getByText('Platform')).toBeInTheDocument()
+      expect(screen.getAllByText('Chat Runtime').length).toBeGreaterThan(0)
     })
 
-    it('links admins to the full platform health dashboard', () => {
+    it('shows enabled messaging integrations in the health popover', () => {
+      mockPlatformProbes = [
+        ...mockPlatformProbes,
+        {
+          id: 'slack-integration',
+          label: 'Slack',
+          group: 'messaging',
+          status: 'healthy',
+          required: false,
+          description: 'Checks Slack integration availability.',
+          detail: 'Slack ready',
+          latency_ms: 18,
+        },
+        {
+          id: 'webex-integration',
+          label: 'Webex',
+          group: 'messaging',
+          status: 'degraded',
+          required: false,
+          description: 'Checks Webex bot admin access and space discovery prerequisites.',
+          detail: 'Webex integration token is not configured on the UI service; fetch failed',
+          latency_ms: 15,
+        },
+      ]
+      mockPlatformProbeStatus = 'degraded'
+
+      render(<AppHeader />)
+
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
+      expect(screen.getAllByText('Slack').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Webex').length).toBeGreaterThan(0)
+      expect(screen.queryByText('Slack ready')).not.toBeInTheDocument()
+      expect(screen.getByText('Webex integration token is not configured on the UI service; fetch failed')).toBeInTheDocument()
+      const webexDetail = screen.getByRole('button', { name: /expand webex details/i })
+      expect(webexDetail).toHaveAttribute('aria-expanded', 'false')
+      expect(webexDetail).toHaveClass('overflow-hidden', 'text-ellipsis', 'whitespace-nowrap')
+      fireEvent.click(webexDetail)
+      expect(webexDetail).toHaveAttribute('aria-expanded', 'true')
+      expect(webexDetail).toHaveClass('whitespace-normal', 'break-words')
+      expect(webexDetail).not.toHaveClass('overflow-hidden')
+    })
+
+    it('links admins from the health popover to the Admin health tab', () => {
       mockIsAdmin = true
       mockRuntimeStatus = 'connected'
       render(<AppHeader />)
 
-      fireEvent.click(screen.getByRole('button', { name: /full health report/i }))
-      expect(mockRouterPush).toHaveBeenCalledWith('/admin?cat=platform&tab=health')
-
-      mockRouterPush.mockClear()
-      fireEvent.click(screen.getByRole('button', { name: /all systems live/i }))
-      expect(mockRouterPush).toHaveBeenCalledWith('/admin?cat=platform&tab=health')
-
-      mockRouterPush.mockClear()
-      fireEvent.click(screen.getByRole('button', { name: /1\/1 ready/i }))
-      expect(mockRouterPush).toHaveBeenCalledWith('/admin?cat=platform&tab=health')
+      const link = screen.getByRole('link', { name: /open admin health status/i })
+      expect(link).toHaveAttribute('href', '/admin?cat=platform&tab=health')
+      expect(mockRouterPush).not.toHaveBeenCalled()
     })
 
-    it('hides the health dashboard link for non-admins', () => {
+    it('keeps the same simplified health popover for non-admins', () => {
       mockIsAdmin = false
       mockRuntimeStatus = 'connected'
       render(<AppHeader />)
 
       expect(screen.queryByRole('button', { name: /full health report/i })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /open health dashboard/i })).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: /all systems live/i })).not.toBeInTheDocument()
-      expect(screen.getByText('All Systems Live')).toBeInTheDocument()
-      expect(screen.getByText('1/1 Ready')).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /open admin health status/i })).not.toBeInTheDocument()
+      expect(screen.getByText('System Status')).toBeInTheDocument()
+      expect(screen.getAllByText('Chat Runtime').length).toBeGreaterThan(0)
     })
   })
 
@@ -727,21 +758,21 @@ describe('AppHeader — connection status badge', () => {
     })
   })
 
-  describe('amber — RAG Disconnected (platform up, RAG down)', () => {
-    it('shows "RAG Disconnected" when the platform is online but RAG is offline', () => {
+  describe('amber — Degraded (platform up, RAG down)', () => {
+    it('shows "Degraded" when the platform is online but RAG is offline', () => {
       mockRuntimeStatus = 'connected'
       mockRagEnabled = true
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('RAG Disconnected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
     })
 
-    it('RAG Disconnected badge has amber styling, not red', () => {
+    it('Degraded badge has amber styling, not red', () => {
       mockRuntimeStatus = 'connected'
       mockRagEnabled = true
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      const badge = screen.getByText('RAG Disconnected').closest('button')
+      const badge = screen.getByRole('button', { name: /system status: degraded/i })
       expect(badge?.className).toContain('amber')
       expect(badge?.className).not.toContain('red')
     })
@@ -759,99 +790,78 @@ describe('AppHeader — connection status badge', () => {
       mockRagEnabled = false
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      // RAG is not enabled, so its status is ignored → Connected (icon-only, no label text)
+      // RAG is not enabled, so its status is ignored → Healthy (icon-only, no label text)
       expect(screen.queryByText('RAG Disconnected')).not.toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: healthy/i })).toBeInTheDocument()
     })
 
-    it('popover header shows "RAG Offline" when the platform is up but RAG is down', () => {
+    it('popover badge shows "Degraded" when runtime is up but RAG is down', () => {
       mockRuntimeStatus = 'connected'
       mockRagEnabled = true
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('RAG Offline')).toBeInTheDocument()
-    })
-
-    it('popover footer shows "RAG server unavailable" when the platform is up but RAG is down', () => {
-      mockRuntimeStatus = 'connected'
-      mockRagEnabled = true
-      mockRagStatus = 'disconnected'
-      render(<AppHeader />)
-      expect(screen.getByText('RAG server unavailable')).toBeInTheDocument()
-    })
-
-    it('does NOT show "Issues Detected" when only RAG is offline', () => {
-      mockRuntimeStatus = 'connected'
-      mockRagEnabled = true
-      mockRagStatus = 'disconnected'
-      render(<AppHeader />)
-      expect(screen.queryByText('Issues Detected')).not.toBeInTheDocument()
+      expect(screen.getAllByText('Degraded').length).toBeGreaterThan(0)
     })
   })
 
-  describe('red — Disconnected (platform down)', () => {
-    it('shows "Disconnected" when the platform is offline', () => {
+  describe('red — Degraded (platform down)', () => {
+    it('shows "Degraded" when the platform is offline', () => {
       mockRuntimeStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('Disconnected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
     })
 
-    it('shows "Disconnected" when a platform dependency probe is down', () => {
+    it('shows "Degraded" when required platform capability is down', () => {
       mockRuntimeStatus = 'connected'
       mockPlatformProbeStatus = 'down'
       mockPlatformProbes = [
         {
-          id: 'openfga',
-          label: 'OpenFGA',
-          group: 'identity',
+          id: 'chat-runtime',
+          label: 'Chat Runtime',
+          group: 'runtime',
           status: 'down',
+          required: true,
+          description: 'Checks the runtime health endpoint used by the chat experience.',
           detail: 'HTTP 503',
-          target: 'http://openfga:8080/healthz',
           latency_ms: 20,
         },
       ]
       render(<AppHeader />)
-      expect(screen.getByText('Disconnected')).toBeInTheDocument()
-      expect(screen.getAllByText('OpenFGA').length).toBeGreaterThan(0)
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
+      expect(screen.getAllByText('Chat Runtime').length).toBeGreaterThan(0)
       expect(screen.getAllByText('Down').length).toBeGreaterThan(0)
     })
 
-    it('Disconnected badge has red styling', () => {
+    it('Degraded badge has red styling for platform outages', () => {
       mockRuntimeStatus = 'disconnected'
       render(<AppHeader />)
-      const badge = screen.getByText('Disconnected').closest('button')
+      const badge = screen.getByRole('button', { name: /system status: degraded/i })
       expect(badge?.className).toContain('red')
       expect(badge?.className).not.toContain('amber')
     })
 
-    it('shows "Disconnected" (red) when the platform is offline even if RAG is online', () => {
+    it('shows "Degraded" (red) when the platform is offline even if RAG is online', () => {
       mockRuntimeStatus = 'disconnected'
       mockRagEnabled = true
       mockRagStatus = 'connected'
       render(<AppHeader />)
-      expect(screen.getByText('Disconnected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
       expect(screen.queryByText('RAG Disconnected')).not.toBeInTheDocument()
     })
 
-    it('shows "Disconnected" (red) when both the platform and RAG are offline', () => {
+    it('shows "Degraded" (red) when both the platform and RAG are offline', () => {
       mockRuntimeStatus = 'disconnected'
       mockRagEnabled = true
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('Disconnected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
       expect(screen.queryByText('RAG Disconnected')).not.toBeInTheDocument()
     })
 
-    it('popover header shows "Issues Detected" when the platform is offline', () => {
+    it('popover badge shows "Degraded" when the platform is offline', () => {
       mockRuntimeStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('Issues Detected')).toBeInTheDocument()
-    })
-
-    it('popover footer shows "Check logs for details" when the platform is offline', () => {
-      mockRuntimeStatus = 'disconnected'
-      render(<AppHeader />)
-      expect(screen.getByText('Check logs for details')).toBeInTheDocument()
+      expect(screen.getAllByText('Degraded').length).toBeGreaterThan(0)
     })
   })
 
@@ -870,7 +880,7 @@ describe('AppHeader — connection status badge', () => {
       mockRagEnabled = true
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('Disconnected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
       expect(screen.queryByText('RAG Disconnected')).not.toBeInTheDocument()
     })
 
@@ -879,8 +889,8 @@ describe('AppHeader — connection status badge', () => {
       mockRagEnabled = true
       mockRagStatus = 'disconnected'
       render(<AppHeader />)
-      expect(screen.getByText('RAG Disconnected')).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: /system status: connected/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /system status: degraded/i })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /system status: healthy/i })).not.toBeInTheDocument()
     })
   })
 })
@@ -1072,7 +1082,7 @@ describe('AppHeader — Chat tab notification dots', () => {
 
     render(<AppHeader />)
 
-    expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /system status: healthy/i })).toBeInTheDocument()
     expect(screen.queryByTestId(triggerSelector)).not.toBeInTheDocument()
   })
 
@@ -1091,7 +1101,7 @@ describe('AppHeader — Chat tab notification dots', () => {
 
     render(<AppHeader />)
 
-    expect(screen.getByRole('button', { name: /system status: connected/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /system status: healthy/i })).toBeInTheDocument()
     const trigger = screen.getByTestId(triggerSelector)
     expect(trigger.tagName).toBe('BUTTON')
     expect(trigger.textContent ?? '').toContain('Alerts:')


### PR DESCRIPTION
# Description

Restores the AppHeader platform health status behavior that was lost while resolving conflicts in PR #2005.

Changes:
- Uses `capabilities` from `usePlatformHealthProbes()` instead of the legacy diagnostic `probes` list.
- Restores `Healthy` / `Degraded` header copy instead of `Connected` / `Needs Attention`.
- Restores the compact capability popover with expandable degraded/down capability details.
- Restores the admin `System Status` link to `/admin?cat=platform&tab=health`.
- Updates AppHeader unit tests to use capability-shaped mocked health data.

Root cause: the AppHeader portion of Kevin's original #2005 health refactor was dropped in commit `e91826e` while resolving main merge conflicts, leaving the header on the old probe-oriented UI even though the platform health API/hook had moved to capabilities.

Validation:
- `npm test -- src/components/layout/__tests__/AppHeader.test.tsx --runInBand`
- `npm exec eslint -- src/components/layout/AppHeader.tsx src/components/layout/__tests__/AppHeader.test.tsx`
- `git diff --check`

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable. No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
