### PR TITLE
feat(credentials): add hash tabs for secrets

### DIFF
--- a/ui/e2e/rbac/_credentials-browser-fixtures.ts
+++ b/ui/e2e/rbac/_credentials-browser-fixtures.ts
@@ -1,4 +1,3 @@
-// assisted-by Codex Codex-sonnet-4-6
 
 import { type Page } from "@playwright/test";
 

--- a/ui/e2e/rbac/_credentials-browser-fixtures.ts
+++ b/ui/e2e/rbac/_credentials-browser-fixtures.ts
@@ -1,3 +1,5 @@
+// assisted-by Codex Codex-sonnet-4-6
+
 import { type Page } from "@playwright/test";
 
 import {
@@ -504,9 +506,9 @@ export async function gotoAdminCredentialsTab(page: Page): Promise<void> {
 }
 
 export async function gotoPersonalCredentialsSecrets(page: Page): Promise<void> {
-  await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+  await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
 }
 
 export async function gotoPersonalCredentialsConnections(page: Page): Promise<void> {
-  await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+  await page.goto("/credentials#connections", { waitUntil: "domcontentloaded" });
 }

--- a/ui/e2e/rbac/credential-secrets-management.spec.ts
+++ b/ui/e2e/rbac/credential-secrets-management.spec.ts
@@ -253,7 +253,7 @@ test.describe("RBAC e2e — credential secrets management", () => {
     const env = rbacEnvOrSkip();
     await signIn(page, env);
 
-    await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+    await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
 
     await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible({
@@ -285,7 +285,7 @@ test.describe("RBAC e2e — credential secrets management", () => {
     const env = rbacEnvOrSkip();
     await signIn(page, env);
 
-    await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+    await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
 
     await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible({
@@ -342,7 +342,7 @@ test.describe("RBAC e2e — credential secrets management", () => {
     const env = rbacEnvOrSkip();
     await signIn(page, env);
 
-    await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+    await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
     await expect(page.getByText("GitHub token")).toBeVisible({ timeout: 30_000 });
 
@@ -367,7 +367,7 @@ test.describe("RBAC e2e — credential secrets management", () => {
     const env = rbacEnvOrSkip();
     await signIn(page, env);
 
-    await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+    await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
     await expect(page.getByText("GitHub token")).toBeVisible({ timeout: 30_000 });
 
@@ -492,7 +492,7 @@ test.describe("RBAC e2e — credential secrets management", () => {
     });
 
     await signIn(page, env);
-    await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+    await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
     await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible({
       timeout: 30_000,
@@ -507,8 +507,8 @@ test.describe("RBAC e2e — credential secrets management", () => {
     await relayPage.close().catch(() => undefined);
 
     await expect
-      .poll(() => new URL(page.url()).searchParams.get("tab"), { timeout: 15_000 })
-      .toBe("connections");
+      .poll(() => new URL(page.url()).hash, { timeout: 15_000 })
+      .toBe("#connections");
     await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
     await expect(page.getByText("Atlassian Cloud")).toBeVisible();
     await expect(page.getByText("healthy")).toBeVisible();

--- a/ui/e2e/rbac/credential-team-sharing.spec.ts
+++ b/ui/e2e/rbac/credential-team-sharing.spec.ts
@@ -74,7 +74,7 @@ test.describe("RBAC e2e — credential team sharing", () => {
     });
 
     await signIn(page, env);
-    await page.goto("/credentials", { waitUntil: "domcontentloaded" });
+    await page.goto("/credentials#secrets", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
 
     await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible({

--- a/ui/e2e/rbac/credentials-hash-tabs.spec.ts
+++ b/ui/e2e/rbac/credentials-hash-tabs.spec.ts
@@ -1,10 +1,10 @@
 // assisted-by claude code claude-sonnet-4-6
+// assisted-by Codex Codex-sonnet-4-6
 import { expect, test } from "@playwright/test";
 
 import {
   DEFAULT_OAUTH_CONNECTOR,
   CREDENTIALS_ADMIN_SESSION,
-  gotoPersonalCredentialsSecrets,
   installCredentialsBrowserMocks,
 } from "./_credentials-browser-fixtures";
 import { dismissReleaseUpgradeDialog, installTestSession } from "./_helpers";
@@ -21,8 +21,9 @@ function minimalSessionEnv() {
 
 async function assertCredentialsPageAvailable(
   page: import("@playwright/test").Page,
+  target = "/credentials#connections",
 ): Promise<void> {
-  await gotoPersonalCredentialsSecrets(page);
+  await page.goto(target, { waitUntil: "domcontentloaded" });
   await dismissReleaseUpgradeDialog(page);
   try {
     await expect(page.getByRole("heading", { name: "Credentials" })).toBeVisible({
@@ -36,7 +37,7 @@ async function assertCredentialsPageAvailable(
   }
 }
 
-test.describe("credentials single-pane layout", () => {
+test.describe("credentials hash-tab layout", () => {
   test.beforeEach(() => {
     test.skip(
       !mockedRbacEnabled(),
@@ -54,24 +55,33 @@ test.describe("credentials single-pane layout", () => {
     });
   });
 
-  test("renders both sections on a single page without tabs", async ({ page }) => {
-    await assertCredentialsPageAvailable(page);
+  test("defaults to Connections and normalizes /credentials to #connections", async ({ page }) => {
+    await assertCredentialsPageAvailable(page, "/credentials");
 
-    await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
-    expect(await page.getByRole("tab").count()).toBe(0);
+    await expect(page.getByRole("heading", { name: "Saved Secrets" })).toHaveCount(0);
+    await expect(page.getByRole("tab", { name: "Connections" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page).toHaveURL(/\/credentials#connections$/);
   });
 
-  test("shows consistent empty states for both sections", async ({ page }) => {
+  test("shows each empty state on its hash-backed tab", async ({ page }) => {
     await assertCredentialsPageAvailable(page);
 
-    // Both empty states must be visible simultaneously — no tab click required
-    await expect(page.getByText("No secrets yet.")).toBeVisible();
     await expect(page.getByText("No apps connected yet.")).toBeVisible();
+    await expect(page.getByText("No secrets yet.")).toHaveCount(0);
+
+    await page.getByRole("tab", { name: "Secrets" }).click();
+
+    await expect(page).toHaveURL(/\/credentials#secrets$/);
+    await expect(page.getByText("No secrets yet.")).toBeVisible();
+    await expect(page.getByText("No apps connected yet.")).toHaveCount(0);
   });
 
   test("stays on the same page URL after adding a secret", async ({ page }) => {
-    await assertCredentialsPageAvailable(page);
+    await assertCredentialsPageAvailable(page, "/credentials#secrets");
     const urlBefore = page.url();
 
     await page.getByRole("button", { name: /add secret/i }).click();
@@ -83,10 +93,11 @@ test.describe("credentials single-pane layout", () => {
     await expect(dialog).toHaveCount(0);
 
     expect(page.url()).toBe(urlBefore);
-    await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Connected Apps" })).toHaveCount(0);
   });
 
-  test("returns OAuth relinks to the connected apps section without tab navigation", async ({
+  test("returns OAuth relinks to the connected apps tab", async ({
     context,
     page,
   }) => {
@@ -103,7 +114,7 @@ test.describe("credentials single-pane layout", () => {
         },
       ],
     });
-    await assertCredentialsPageAvailable(page);
+    await assertCredentialsPageAvailable(page, "/credentials#secrets");
 
     await context.route("**/oauth-callback-relay", async (route) => {
       await route.fulfill({
@@ -130,11 +141,9 @@ test.describe("credentials single-pane layout", () => {
     await relayPage.waitForLoadState("domcontentloaded");
     await relayPage.close().catch(() => undefined);
 
-    // URL must not get a ?tab= suffix — single-pane layout uses no tab routing
-    await expect(page).toHaveURL(/\/credentials$/);
-    // Both sections still visible
-    await expect(page.getByRole("heading", { name: "Saved Secrets" })).toBeVisible();
+    await expect(page).toHaveURL(/\/credentials#connections$/);
     await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Saved Secrets" })).toHaveCount(0);
     await expect(page.getByText("Atlassian Cloud")).toBeVisible();
   });
 });

--- a/ui/e2e/rbac/credentials-hash-tabs.spec.ts
+++ b/ui/e2e/rbac/credentials-hash-tabs.spec.ts
@@ -1,5 +1,4 @@
 // assisted-by claude code claude-sonnet-4-6
-// assisted-by Codex Codex-sonnet-4-6
 import { expect, test } from "@playwright/test";
 
 import {

--- a/ui/e2e/rbac/credentials-workspace-regression.spec.ts
+++ b/ui/e2e/rbac/credentials-workspace-regression.spec.ts
@@ -1,4 +1,3 @@
-// assisted-by Codex Codex-sonnet-4-6
 
 import { expect, test, type Page } from "@playwright/test";
 

--- a/ui/e2e/rbac/credentials-workspace-regression.spec.ts
+++ b/ui/e2e/rbac/credentials-workspace-regression.spec.ts
@@ -1,3 +1,5 @@
+// assisted-by Codex Codex-sonnet-4-6
+
 import { expect, test, type Page } from "@playwright/test";
 
 import {
@@ -321,7 +323,7 @@ test.describe("mocked credentials workspace browser regression", () => {
       await relayPage.waitForLoadState("domcontentloaded");
       await relayPage.close().catch(() => undefined);
 
-      await expect(page).toHaveURL(/\/credentials$/);
+      await expect(page).toHaveURL(/\/credentials#connections$/);
       await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
       await expect(page.getByText("Atlassian Cloud")).toBeVisible();
       await expect(page.getByText("healthy")).toBeVisible();

--- a/ui/e2e/rbac/mcp-caller-scoped-credentials.spec.ts
+++ b/ui/e2e/rbac/mcp-caller-scoped-credentials.spec.ts
@@ -21,7 +21,7 @@ const CHAT_CONVERSATION_ID = "rbac-caller-cred-conv";
 
 const CALLER_CREDENTIAL_WARNING =
   "Jira needs your Atlassian account connected. " +
-  "[Connect Atlassian](/credentials?tab=connections) — then start a new chat.";
+  "[Connect Atlassian](/credentials#connections) — then start a new chat.";
 
 function minimalSessionEnv() {
   return {
@@ -225,14 +225,14 @@ test.describe("RBAC e2e — caller-scoped MCP credentials", () => {
 
       const connectLink = page.getByRole("link", { name: "Connect Atlassian" });
       await expect(connectLink).toBeVisible();
-      await expect(connectLink).toHaveAttribute("href", "/credentials?tab=connections");
+      await expect(connectLink).toHaveAttribute("href", "/credentials#connections");
 
       await expect(page.getByText(/cannot access Jira without your Atlassian connection/i)).toBeVisible();
 
       await installCredentialsBrowserMocks(page);
       await connectLink.click({ force: true });
 
-      await expect(page).toHaveURL(/\/credentials\?tab=connections$/);
+      await expect(page).toHaveURL(/\/credentials#connections$/);
       await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
     });
   });

--- a/ui/src/components/credentials/CredentialsWorkspace.tsx
+++ b/ui/src/components/credentials/CredentialsWorkspace.tsx
@@ -1,18 +1,23 @@
 "use client";
 
 // assisted-by claude code claude-sonnet-4-6
-// assisted-by Codex Codex-sonnet-4-6
 
 import React from "react";
 
+import { Columns2, Rows2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { ProviderConnections } from "./ProviderConnections";
 import { SecretsManager } from "./SecretsManager";
 
 type CredentialsTab = "connections" | "secrets";
+type CredentialsLayout = "tabs" | "single";
 
 const DEFAULT_TAB: CredentialsTab = "connections";
+const LAYOUT_STORAGE_KEY = "caipe.credentials.layout";
 
 function coerceCredentialsTab(value: string): CredentialsTab {
   return value === "secrets" ? "secrets" : DEFAULT_TAB;
@@ -23,9 +28,16 @@ function tabFromHash(hash: string): CredentialsTab {
 }
 
 export function CredentialsWorkspace() {
+  const [layout, setLayout] = React.useState<CredentialsLayout>("tabs");
   const [activeTab, setActiveTab] = React.useState<CredentialsTab>(DEFAULT_TAB);
   const [appsCollapsed, setAppsCollapsed] = React.useState(false);
   const [secretsCollapsed, setSecretsCollapsed] = React.useState(false);
+
+  // Hydrate layout from localStorage after mount to avoid SSR mismatch
+  React.useEffect(() => {
+    const stored = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    setLayout(stored === "single" ? "single" : "tabs");
+  }, []);
 
   const setTabHash = React.useCallback((tab: CredentialsTab, mode: "push" | "replace") => {
     if (typeof window === "undefined") return;
@@ -42,74 +54,129 @@ export function CredentialsWorkspace() {
     [setTabHash],
   );
 
+  const toggleLayout = React.useCallback(() => {
+    setLayout((prev) => {
+      const next: CredentialsLayout = prev === "tabs" ? "single" : "tabs";
+      localStorage.setItem(LAYOUT_STORAGE_KEY, next);
+      if (next === "single" && typeof window !== "undefined") {
+        // Remove hash when switching to single-page view
+        const url = new URL(window.location.href);
+        url.hash = "";
+        window.history.replaceState(null, "", url.pathname + url.search);
+      } else if (next === "tabs" && typeof window !== "undefined") {
+        // Restore hash for current tab when switching back to tabs
+        setTabHash(activeTab, "replace");
+      }
+      return next;
+    });
+  }, [activeTab, setTabHash]);
+
+  // Sync tab state with URL hash (tabs mode only)
   React.useEffect(() => {
+    if (layout !== "tabs") return;
+
     const syncTabWithHash = () => setActiveTab(tabFromHash(window.location.hash));
 
     syncTabWithHash();
     if (tabFromHash(window.location.hash) === DEFAULT_TAB && window.location.hash !== "#connections") {
-      // assisted-by Codex Codex-sonnet-4-6
       setTabHash(DEFAULT_TAB, "replace");
     }
 
     window.addEventListener("hashchange", syncTabWithHash);
     return () => window.removeEventListener("hashchange", syncTabWithHash);
-  }, [setTabHash]);
+  }, [layout, setTabHash]);
 
+  // postMessage OAuth relay → switch to connections tab
   React.useEffect(() => {
-    const showConnectionsAfterOAuth = () => showTab("connections", "replace");
-
     const handleOAuthMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
       if (event.data?.type !== "caipe.oauth.connection") return;
-      showConnectionsAfterOAuth();
+      if (layout === "tabs") showTab("connections", "replace");
     };
 
     window.addEventListener("message", handleOAuthMessage);
     return () => window.removeEventListener("message", handleOAuthMessage);
-  }, [showTab]);
+  }, [layout, showTab]);
 
+  // BroadcastChannel OAuth relay → switch to connections tab
   React.useEffect(() => {
     if (typeof BroadcastChannel === "undefined") return;
     const channel = new BroadcastChannel("caipe.oauth.connection");
     channel.addEventListener("message", (event) => {
-      if (event.data?.type === "caipe.oauth.connection") {
+      if (event.data?.type === "caipe.oauth.connection" && layout === "tabs") {
         showTab("connections", "replace");
       }
     });
     return () => channel.close();
-  }, [showTab]);
+  }, [layout, showTab]);
 
   return (
     <section className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Credentials</h1>
-        <p className="text-sm text-muted-foreground">
-          Keep saved secrets and connected apps in one place. Secret values stay protected after
-          you save them.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Credentials</h1>
+          <p className="text-sm text-muted-foreground">
+            Keep saved secrets and connected apps in one place. Secret values stay protected after
+            you save them.
+          </p>
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={toggleLayout}
+              aria-label={layout === "tabs" ? "Switch to single-page view" : "Switch to tabbed view"}
+            >
+              {layout === "tabs" ? (
+                <Rows2 className="h-4 w-4" />
+              ) : (
+                <Columns2 className="h-4 w-4" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {layout === "tabs" ? "Single-page view" : "Tabbed view"}
+          </TooltipContent>
+        </Tooltip>
       </div>
-      <Tabs
-        value={activeTab}
-        onValueChange={(value) => showTab(coerceCredentialsTab(value))}
-        className="space-y-6"
-      >
-        <TabsList aria-label="Credentials sections" className="grid w-full max-w-sm grid-cols-2">
-          <TabsTrigger value="connections">Connections</TabsTrigger>
-          <TabsTrigger value="secrets">Secrets</TabsTrigger>
-        </TabsList>
-        <TabsContent value="connections" className="mt-0">
+
+      {layout === "single" ? (
+        <>
           <ProviderConnections
             collapsed={appsCollapsed}
             onToggle={() => setAppsCollapsed((c) => !c)}
           />
-        </TabsContent>
-        <TabsContent value="secrets" className="mt-0">
+          <hr className="border-border" />
           <SecretsManager
             collapsed={secretsCollapsed}
             onToggle={() => setSecretsCollapsed((c) => !c)}
           />
-        </TabsContent>
-      </Tabs>
+        </>
+      ) : (
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => showTab(coerceCredentialsTab(value))}
+          className="space-y-6"
+        >
+          <TabsList aria-label="Credentials sections" className="grid w-full max-w-sm grid-cols-2">
+            <TabsTrigger value="connections">Connections</TabsTrigger>
+            <TabsTrigger value="secrets">Secrets</TabsTrigger>
+          </TabsList>
+          <TabsContent value="connections" className="mt-0">
+            <ProviderConnections
+              collapsed={appsCollapsed}
+              onToggle={() => setAppsCollapsed((c) => !c)}
+            />
+          </TabsContent>
+          <TabsContent value="secrets" className="mt-0">
+            <SecretsManager
+              collapsed={secretsCollapsed}
+              onToggle={() => setSecretsCollapsed((c) => !c)}
+            />
+          </TabsContent>
+        </Tabs>
+      )}
     </section>
   );
 }

--- a/ui/src/components/credentials/CredentialsWorkspace.tsx
+++ b/ui/src/components/credentials/CredentialsWorkspace.tsx
@@ -1,15 +1,83 @@
 "use client";
 
 // assisted-by claude code claude-sonnet-4-6
+// assisted-by Codex Codex-sonnet-4-6
 
 import React from "react";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { ProviderConnections } from "./ProviderConnections";
 import { SecretsManager } from "./SecretsManager";
 
+type CredentialsTab = "connections" | "secrets";
+
+const DEFAULT_TAB: CredentialsTab = "connections";
+
+function coerceCredentialsTab(value: string): CredentialsTab {
+  return value === "secrets" ? "secrets" : DEFAULT_TAB;
+}
+
+function tabFromHash(hash: string): CredentialsTab {
+  return coerceCredentialsTab(hash.replace(/^#/, "").toLowerCase());
+}
+
 export function CredentialsWorkspace() {
+  const [activeTab, setActiveTab] = React.useState<CredentialsTab>(DEFAULT_TAB);
   const [appsCollapsed, setAppsCollapsed] = React.useState(false);
   const [secretsCollapsed, setSecretsCollapsed] = React.useState(false);
+
+  const setTabHash = React.useCallback((tab: CredentialsTab, mode: "push" | "replace") => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    url.hash = tab;
+    window.history[mode === "push" ? "pushState" : "replaceState"](null, "", url);
+  }, []);
+
+  const showTab = React.useCallback(
+    (tab: CredentialsTab, mode: "push" | "replace" = "push") => {
+      setActiveTab(tab);
+      setTabHash(tab, mode);
+    },
+    [setTabHash],
+  );
+
+  React.useEffect(() => {
+    const syncTabWithHash = () => setActiveTab(tabFromHash(window.location.hash));
+
+    syncTabWithHash();
+    if (tabFromHash(window.location.hash) === DEFAULT_TAB && window.location.hash !== "#connections") {
+      // assisted-by Codex Codex-sonnet-4-6
+      setTabHash(DEFAULT_TAB, "replace");
+    }
+
+    window.addEventListener("hashchange", syncTabWithHash);
+    return () => window.removeEventListener("hashchange", syncTabWithHash);
+  }, [setTabHash]);
+
+  React.useEffect(() => {
+    const showConnectionsAfterOAuth = () => showTab("connections", "replace");
+
+    const handleOAuthMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type !== "caipe.oauth.connection") return;
+      showConnectionsAfterOAuth();
+    };
+
+    window.addEventListener("message", handleOAuthMessage);
+    return () => window.removeEventListener("message", handleOAuthMessage);
+  }, [showTab]);
+
+  React.useEffect(() => {
+    if (typeof BroadcastChannel === "undefined") return;
+    const channel = new BroadcastChannel("caipe.oauth.connection");
+    channel.addEventListener("message", (event) => {
+      if (event.data?.type === "caipe.oauth.connection") {
+        showTab("connections", "replace");
+      }
+    });
+    return () => channel.close();
+  }, [showTab]);
 
   return (
     <section className="space-y-6">
@@ -20,15 +88,28 @@ export function CredentialsWorkspace() {
           you save them.
         </p>
       </div>
-      <ProviderConnections
-        collapsed={appsCollapsed}
-        onToggle={() => setAppsCollapsed((c) => !c)}
-      />
-      <hr className="border-border" />
-      <SecretsManager
-        collapsed={secretsCollapsed}
-        onToggle={() => setSecretsCollapsed((c) => !c)}
-      />
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => showTab(coerceCredentialsTab(value))}
+        className="space-y-6"
+      >
+        <TabsList aria-label="Credentials sections" className="grid w-full max-w-sm grid-cols-2">
+          <TabsTrigger value="connections">Connections</TabsTrigger>
+          <TabsTrigger value="secrets">Secrets</TabsTrigger>
+        </TabsList>
+        <TabsContent value="connections" className="mt-0">
+          <ProviderConnections
+            collapsed={appsCollapsed}
+            onToggle={() => setAppsCollapsed((c) => !c)}
+          />
+        </TabsContent>
+        <TabsContent value="secrets" className="mt-0">
+          <SecretsManager
+            collapsed={secretsCollapsed}
+            onToggle={() => setSecretsCollapsed((c) => !c)}
+          />
+        </TabsContent>
+      </Tabs>
     </section>
   );
 }

--- a/ui/src/components/credentials/__tests__/CredentialsWorkspace.test.tsx
+++ b/ui/src/components/credentials/__tests__/CredentialsWorkspace.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 // assisted-by claude code claude-sonnet-4-6
+// assisted-by Codex Codex-sonnet-4-6
 
 import { CredentialsWorkspace } from "../CredentialsWorkspace";
 
@@ -13,12 +15,53 @@ jest.mock("../ProviderConnections", () => ({
 }));
 
 describe("CredentialsWorkspace", () => {
-  it("renders secrets and connections in a single pane", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/credentials");
+  });
+
+  it("defaults to the Connections tab and normalizes the hash", async () => {
     render(<CredentialsWorkspace />);
 
-    expect(screen.getByText("Saved Secrets content")).toBeInTheDocument();
     expect(screen.getByText("Connected Apps content")).toBeInTheDocument();
-    expect(screen.queryByRole("tab")).toBeNull();
+    expect(screen.queryByText("Saved Secrets content")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(window.location.hash).toBe("#connections"));
+    expect(screen.getByRole("tab", { name: "Connections" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("opens the Secrets tab from the URL hash", async () => {
+    window.history.replaceState(null, "", "/credentials#secrets");
+
+    render(<CredentialsWorkspace />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Secrets" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+    expect(screen.getByText("Saved Secrets content")).toBeInTheDocument();
+    expect(screen.queryByText("Connected Apps content")).not.toBeInTheDocument();
+  });
+
+  it("updates the URL hash when users switch tabs", async () => {
+    const user = userEvent.setup();
+    render(<CredentialsWorkspace />);
+
+    await waitFor(() => expect(window.location.hash).toBe("#connections"));
+
+    await user.click(screen.getByRole("tab", { name: "Secrets" }));
+
+    await waitFor(() => expect(window.location.hash).toBe("#secrets"));
+    expect(screen.getByText("Saved Secrets content")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Connections" }));
+
+    await waitFor(() => expect(window.location.hash).toBe("#connections"));
+    expect(screen.getByText("Connected Apps content")).toBeInTheDocument();
   });
 
   it("renders the Credentials heading", () => {

--- a/ui/src/components/credentials/__tests__/CredentialsWorkspace.test.tsx
+++ b/ui/src/components/credentials/__tests__/CredentialsWorkspace.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // assisted-by claude code claude-sonnet-4-6
-// assisted-by Codex Codex-sonnet-4-6
 
 import { CredentialsWorkspace } from "../CredentialsWorkspace";
 

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -391,7 +391,7 @@ export function AppHeader() {
     },
     storageMode === "mongodb" && config.userConnectionsEnabled && {
       key: "credentials",
-      href: "/credentials",
+      href: "/credentials#connections",
       label: "Credentials",
       Icon: KeyRound,
       activeClassName: "bg-primary text-primary-foreground shadow-sm",


### PR DESCRIPTION
# Description

Adds hash-backed tabs to the user Credentials workspace so connected apps stay first at `/credentials#connections` and saved secrets are available at `/credentials#secrets`. The page now normalizes `/credentials` to `#connections`, keeps the AppHeader Credentials link pointed at Connections, and returns OAuth relink callbacks to the Connections tab.

This keeps secrets from being pushed below connected apps while preserving direct links to both views.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in tests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

## Validation

- `npm test -- src/components/credentials/__tests__/CredentialsWorkspace.test.tsx --runInBand`
- `npm exec eslint -- src/components/credentials/CredentialsWorkspace.tsx src/components/credentials/__tests__/CredentialsWorkspace.test.tsx src/components/layout/AppHeader.tsx e2e/rbac/_credentials-browser-fixtures.ts e2e/rbac/credentials-hash-tabs.spec.ts e2e/rbac/credentials-workspace-regression.spec.ts e2e/rbac/credential-secrets-management.spec.ts e2e/rbac/credential-team-sharing.spec.ts e2e/rbac/mcp-caller-scoped-credentials.spec.ts`
- `git diff --check`

Focused checks passed. The RBAC Playwright specs were updated but not run locally because `/credentials` depends on the SSR session/OpenFGA dev stack.