### PR TITLE
fix(health): use localhost for self-referential capability probes

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -108,6 +108,8 @@ spec:
             - name: WEBEX_WORKSPACE_ALIAS
               value: {{ . | quote }}
             {{- end }}
+            - name: A2A_BASE_URL
+              value: {{ index .Values.config "A2A_BASE_URL" | default (printf "http://%s-supervisor-agent:8000" .Release.Name) | quote }}
             - name: DYNAMIC_AGENTS_URL
               value: {{ index .Values.config "DYNAMIC_AGENTS_URL" | default (printf "http://%s-dynamic-agents:8001" .Release.Name) | quote }}
             - name: SKILL_SCANNER_URL

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             - name: A2A_BASE_URL
-              value: {{ index .Values.config "A2A_BASE_URL" | default (printf "http://%s-supervisor-agent:8000" .Release.Name) | quote }}
+              value: {{ index .Values.config "A2A_BASE_URL" | default (printf "http://%s-dynamic-agents:8001" .Release.Name) | quote }}
             - name: DYNAMIC_AGENTS_URL
               value: {{ index .Values.config "DYNAMIC_AGENTS_URL" | default (printf "http://%s-dynamic-agents:8001" .Release.Name) | quote }}
             - name: SKILL_SCANNER_URL

--- a/ui/src/app/api/platform/health/__tests__/route.test.ts
+++ b/ui/src/app/api/platform/health/__tests__/route.test.ts
@@ -106,11 +106,11 @@ describe("/api/platform/health", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://localhost/api/dynamic-agents/health",
+      "http://localhost:3000/api/dynamic-agents/health",
       expect.objectContaining({ method: "GET" }),
     );
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://localhost/api/rag/healthz",
+      "http://localhost:3000/api/rag/healthz",
       expect.objectContaining({ method: "GET" }),
     );
   });

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -66,6 +66,7 @@ const HTTP_TIMEOUT_MS = 3000;
 const TCP_TIMEOUT_MS = 2000;
 const healthCache = createJsonResponseCacheStore();
 const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+const DISABLED_VALUES = new Set(["0", "false", "no", "off"]);
 
 function envValue(name: string): string | null {
   const value = process.env[name]?.trim();
@@ -78,6 +79,11 @@ function envValue(name: string): string | null {
 function envEnabled(name: string): boolean {
   const value = envValue(name)?.toLowerCase();
   return value ? ENABLED_VALUES.has(value) : false;
+}
+
+function envExplicitlyDisabled(name: string): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  return value ? DISABLED_VALUES.has(value) : false;
 }
 
 function envPort(name: string, defaultPort: number): number {
@@ -949,6 +955,15 @@ async function probeAuditServiceCapability(auditBackend: string): Promise<Capabi
 }
 
 async function probeSlackIntegration(): Promise<CapabilityResult | null> {
+  if (envExplicitlyDisabled("SLACK_INTEGRATION_ENABLED")) {
+    return disabledCapability({
+      id: "slack-integration",
+      label: "Slack",
+      group: "messaging",
+      description: "Slack messaging integration is not enabled for this deployment.",
+      detail: "Not Configured",
+    });
+  }
   if (!slackIntegrationEnabled()) {
     return disabledCapability({
       id: "slack-integration",
@@ -988,6 +1003,15 @@ async function probeSlackIntegration(): Promise<CapabilityResult | null> {
 }
 
 async function probeWebexIntegration(): Promise<CapabilityResult | null> {
+  if (envExplicitlyDisabled("WEBEX_INTEGRATION_ENABLED")) {
+    return disabledCapability({
+      id: "webex-integration",
+      label: "Webex",
+      group: "messaging",
+      description: "Webex messaging integration is not enabled for this deployment.",
+      detail: "Not Configured",
+    });
+  }
   if (!webexIntegrationEnabled()) {
     return disabledCapability({
       id: "webex-integration",

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -106,6 +106,16 @@ function requestOrigin(request: NextRequest): string {
   return request.nextUrl?.origin ?? new URL(request.url).origin;
 }
 
+// assisted-by claude code claude-sonnet-4-6
+// Use localhost for server-side self-calls to avoid stale keep-alive connections
+// through the external ingress. requestOrigin() returns the external domain (correct
+// for client-facing URLs), but server→server health probes must stay on loopback to
+// prevent ECONNRESET failures when the ingress connection pool goes stale.
+function selfBaseUrl(): string {
+  const port = process.env.PORT ?? "3000";
+  return `http://localhost:${port}`;
+}
+
 function slackDirectoryToken(): string | null {
   return envValue("SLACK_BOT_TOKEN") ?? envValue("SLACK_INTEGRATION_BOT_TOKEN");
 }
@@ -1047,7 +1057,7 @@ async function getPlatformHealth(request: NextRequest): Promise<NextResponse> {
           id: "dynamic-agents",
           label: "Dynamic Agents",
           group: "runtime",
-          target: `${origin}/api/dynamic-agents/health`,
+          target: `${selfBaseUrl()}/api/dynamic-agents/health`,
           required: true,
           description: "Checks Dynamic Agents when custom agent runtime is enabled.",
           healthyDetail: "Runtime reachable",
@@ -1069,7 +1079,7 @@ async function getPlatformHealth(request: NextRequest): Promise<NextResponse> {
           id: "knowledge-bases",
           label: "Knowledge Bases",
           group: "knowledge",
-          target: `${origin}/api/rag/healthz`,
+          target: `${selfBaseUrl()}/api/rag/healthz`,
           required: false,
           description: "Checks the RAG API used by Knowledge Bases.",
           healthyDetail: "RAG API reachable",


### PR DESCRIPTION
## Problem

The **Dynamic Agents** and **Knowledge Bases** capability probes in `/api/platform/health` call themselves via `${requestOrigin(request)}/api/...`. When triggered by a browser request, `requestOrigin()` returns the external ingress URL.

The Next.js server process maintains a persistent HTTP connection pool to that domain. When the ingress closes those connections (keep-alive timeout), the next self-call gets an immediate `ECONNRESET` — before any bytes reach nginx. This surfaces as **"Dynamic Agents health check is unreachable - 4ms"** even when the actual dynamic-agents service is healthy.

Evidence:
- nginx access logs show **zero requests** during these health probe calls
- Standalone `node -e` fetches to the same URL succeed (~95ms) because they use fresh connections outside the server process pool
- The `chat-runtime` probe (which uses `getInternalA2AUrl()` — a cluster-internal URL) is **not affected**

## Fix

Add `selfBaseUrl()` that returns `http://localhost:${PORT}` and use it for the two self-referential probes. Loopback connections bypass the external ingress connection pool entirely.

\`\`\`ts
function selfBaseUrl(): string {
  const port = process.env.PORT ?? "3000";
  return \`http://localhost:\${port}\`;
}
\`\`\`

No new env var needed — `PORT` is already set by the Next.js standalone server.

## Changes

- `ui/src/app/api/platform/health/route.ts`: add `selfBaseUrl()`, replace `${origin}` with `${selfBaseUrl()}` for dynamic-agents and rag health probe targets
- `charts/.../caipe-ui/templates/deployment.yaml`: wire `A2A_BASE_URL` with default pointing to `dynamic-agents:8001`
- `ui/src/app/api/platform/health/route.ts`: add `envExplicitlyDisabled()` to short-circuit Slack/Webex probes when explicitly disabled

## Test plan

- [ ] Port-forward to caipe-ui pod (`kubectl port-forward ... 3000:3000`) and call `GET /api/platform/health` — Dynamic Agents and Knowledge Bases should show healthy
- [ ] Confirm via browser that the same endpoint returns healthy (no stale-connection ECONNRESET)
- [ ] Confirm `chat-runtime` probe unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)