### PR TITLE
fix(workflows): avoid raw step response rendering

### DIFF
--- a/ui/src/components/workflows/WorkflowStepTimeline.tsx
+++ b/ui/src/components/workflows/WorkflowStepTimeline.tsx
@@ -11,6 +11,7 @@ import { AgentTimeline } from "@/components/chat/DynamicAgentTimeline";
 import { MetadataInputForm,type InputField } from "@/components/chat/MetadataInputForm";
 import { ToolApprovalCard } from "@/components/chat/ToolApprovalCard";
 import { AgentAvatar } from "@/components/dynamic-agents/AgentAvatar";
+import { MarkdownRenderer } from "@/components/shared/timeline";
 import {
 Tooltip,
 TooltipContent,
@@ -99,6 +100,7 @@ export function WorkflowStepTimeline({
 
   const isStreaming = step.status === "running" && isActive;
   const { data } = useAgentTimeline(events, isStreaming, turnStatus);
+  const showResponseFallback = events.length === 0 && Boolean(step.response?.trim());
 
   // Duration calculation — capture mount time via lazy useState initializer
   // so the React compiler does not flag Date.now() as an impure call.
@@ -192,12 +194,12 @@ export function WorkflowStepTimeline({
             </div>
           )}
 
-          {step.response?.trim() && (
+          {showResponseFallback && step.response?.trim() && (
             <div
               className="px-3 py-2 mb-2 text-sm text-foreground bg-muted/40 rounded-lg border border-border whitespace-pre-wrap"
               data-testid="workflow-step-response"
             >
-              {step.response.trim()}
+              <MarkdownRenderer content={step.response.trim()} />
             </div>
           )}
 

--- a/ui/src/components/workflows/__tests__/WorkflowStepTimeline.test.tsx
+++ b/ui/src/components/workflows/__tests__/WorkflowStepTimeline.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import type { StreamEvent } from "@/lib/streaming/types";
+import type { WfStepRun } from "@/store/workflow-exec-store";
+import { WorkflowStepTimeline } from "../WorkflowStepTimeline";
+
+jest.mock("@/components/chat/DynamicAgentTimeline", () => ({
+  AgentTimeline: ({ data }: { data: { finalAnswer: string | null } }) => (
+    <div data-testid="agent-timeline">{data.finalAnswer}</div>
+  ),
+}));
+
+jest.mock("@/components/chat/MetadataInputForm", () => ({
+  MetadataInputForm: () => null,
+}));
+
+jest.mock("@/components/chat/ToolApprovalCard", () => ({
+  ToolApprovalCard: () => null,
+}));
+
+jest.mock("@/components/dynamic-agents/AgentAvatar", () => ({
+  AgentAvatar: () => <span data-testid="agent-avatar" />,
+}));
+
+jest.mock("@/components/shared/timeline", () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => (
+    <div data-testid="markdown-renderer">{content}</div>
+  ),
+}));
+
+jest.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const baseStep: WfStepRun = {
+  type: "step",
+  index: 0,
+  display_text: "Do the work",
+  agent_id: "agent-1",
+  status: "completed",
+  prompt_sent: "prompt",
+  response: "RAW TOOL RESULT",
+  started_at: "2026-06-29T10:00:00.000Z",
+  completed_at: "2026-06-29T10:00:02.000Z",
+  attempts: 1,
+  error: null,
+  interrupt: null,
+};
+
+const contentEvent: StreamEvent = {
+  id: "event-1",
+  timestamp: new Date("2026-06-29T10:00:01.000Z"),
+  type: "content",
+  raw: {},
+  namespace: [],
+  content: "Clean streamed answer",
+};
+
+describe("WorkflowStepTimeline", () => {
+  it("does not render stored step.response before the timeline when stream events exist", async () => {
+    render(
+      <WorkflowStepTimeline
+        step={baseStep}
+        events={[contentEvent]}
+        isActive={false}
+        agentInfo={{ name: "Agent One" }}
+      />,
+    );
+
+    expect(screen.queryByTestId("workflow-step-response")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-timeline")).toHaveTextContent("Clean streamed answer");
+    });
+  });
+
+  it("renders stored step.response as a markdown fallback when no stream events exist", () => {
+    render(
+      <WorkflowStepTimeline
+        step={{ ...baseStep, response: "Fallback **answer**" }}
+        events={[]}
+        isActive={false}
+        agentInfo={{ name: "Agent One" }}
+      />,
+    );
+
+    expect(screen.getByTestId("workflow-step-response")).toBeInTheDocument();
+    expect(screen.getByTestId("markdown-renderer")).toHaveTextContent("Fallback **answer**");
+    expect(screen.queryByTestId("agent-timeline")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
@@ -11,7 +11,15 @@ jest.mock("@/lib/streaming/clients/server-agui-consumer", () => ({ consumeAgentS
 jest.mock("@/lib/server/event-store", () => ({ readEvents: jest.fn() }));
 jest.mock("@/lib/authz", () => ({ authorize: jest.fn() }));
 
-import { runOwnerSubject } from "../workflow-engine";
+import { readEvents } from "@/lib/server/event-store";
+import type { StreamEvent } from "@/lib/streaming/types";
+import { resolveStepResponseText, runOwnerSubject } from "../workflow-engine";
+
+const mockReadEvents = readEvents as jest.MockedFunction<typeof readEvents>;
+
+beforeEach(() => {
+  mockReadEvents.mockReset();
+});
 
 /** Build a JWT (`header.payload.signature`) with a base64url-encoded payload. */
 function jwt(payload: Record<string, unknown>): string {
@@ -61,3 +69,50 @@ describe("runOwnerSubject", () => {
     expect(runOwnerSubject({ Authorization: `Bearer ${jwt({ sub: 12345 })}` })).toBeNull();
   });
 });
+
+describe("resolveStepResponseText", () => {
+  it("prefers assistant text over longer raw tool results", async () => {
+    mockReadEvents.mockResolvedValue([
+      contentEvent("Short assistant answer."),
+      toolEndEvent("tool-1", JSON.stringify({ raw: "x".repeat(200) })),
+    ]);
+
+    await expect(resolveStepResponseText("source-1", "Short assistant answer.")).resolves.toBe(
+      "Short assistant answer.",
+    );
+  });
+
+  it("falls back to tool results when the step produced no assistant text", async () => {
+    mockReadEvents.mockResolvedValue([
+      toolEndEvent("tool-1", "Only tool output"),
+      toolEndEvent("tool-2", "Longer tool output"),
+    ]);
+
+    await expect(resolveStepResponseText("source-1", "")).resolves.toBe("Longer tool output");
+  });
+});
+
+function contentEvent(content: string): StreamEvent {
+  return {
+    id: `content-${content.length}`,
+    timestamp: new Date("2026-06-29T10:00:00.000Z"),
+    type: "content",
+    raw: {},
+    namespace: [],
+    content,
+  };
+}
+
+function toolEndEvent(toolCallId: string, result: string): StreamEvent {
+  return {
+    id: `tool-${toolCallId}`,
+    timestamp: new Date("2026-06-29T10:00:01.000Z"),
+    type: "tool_end",
+    raw: {},
+    namespace: [],
+    toolData: {
+      tool_call_id: toolCallId,
+      result,
+    },
+  };
+}

--- a/ui/src/lib/server/workflow-engine.ts
+++ b/ui/src/lib/server/workflow-engine.ts
@@ -731,19 +731,25 @@ async function extractStepArtifacts(sourceId: string): Promise<{
   return { toolCalls, filesWritten, fullOutput, toolResults };
 }
 
-/** Pick the richest step output from stream text, content events, and tool results. */
-async function resolveStepResponseText(
+/** Pick assistant text for step output, falling back to tool results only when no text exists. */
+export async function resolveStepResponseText(
   sourceId: string,
   streamText: string | undefined | null,
 ): Promise<string | null> {
   const { fullOutput, toolResults } = await extractStepArtifacts(sourceId);
-  const candidates = [
+  const textCandidates = [
     streamText?.trim(),
     fullOutput.trim(),
-    ...toolResults.map((result) => result.trim()),
   ].filter((value): value is string => Boolean(value));
-  if (candidates.length === 0) return null;
-  return candidates.reduce((longest, current) =>
+  if (textCandidates.length > 0) {
+    return textCandidates.reduce((longest, current) =>
+      current.length > longest.length ? current : longest,
+    );
+  }
+
+  const toolResultCandidates = toolResults.map((result) => result.trim()).filter(Boolean);
+  if (toolResultCandidates.length === 0) return null;
+  return toolResultCandidates.reduce((longest, current) =>
     current.length > longest.length ? current : longest,
   );
 }


### PR DESCRIPTION
# Description

Fixes a workflow run rendering bug where a completed step could show a raw stored `step.response` block before the collapsible execution/tool timeline.

Root cause:
- `WorkflowStepTimeline` rendered persisted `step.response` independently of the streamed timeline, so completed runs with stream events could duplicate or expose raw text before the collapsible details.
- `resolveStepResponseText` picked the longest value from assistant text and tool results, which allowed large raw tool JSON/results to become the persisted step response.

What changed:
- Prefer assistant/content text when resolving workflow step responses, with tool results only used when no assistant text exists.
- Render persisted `step.response` on workflow step detail only as a fallback when no stream events are present.
- Render that fallback through the shared markdown renderer.
- Add regression coverage for both the UI rendering path and the server resolver.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

Validation:
- `npm test -- WorkflowStepTimeline.test.tsx workflow-engine-owner-subject.test.ts --runInBand`
- `npx eslint src/components/workflows/WorkflowStepTimeline.tsx src/components/workflows/__tests__/WorkflowStepTimeline.test.tsx src/lib/server/workflow-engine.ts src/lib/server/__tests__/workflow-engine-owner-subject.test.ts`