### PR TITLE
fix(ui): restore scroll in team dialog lists

### DIFF
--- a/ui/src/components/admin/teams/TeamDetailsDialog.tsx
+++ b/ui/src/components/admin/teams/TeamDetailsDialog.tsx
@@ -1225,7 +1225,7 @@ export function TeamDetailsDialog({
             </div>
 
             {/* Members List */}
-            <ScrollArea className="flex-1 -mx-1 px-1" style={{ maxHeight: "320px" }}>
+            <ScrollArea className="max-h-[320px] -mx-1 px-1">
               <div className="space-y-1">
                 {membersLoading && memberPage.length === 0 ? (
                   <div className="flex justify-center py-8">
@@ -1679,7 +1679,7 @@ function ReadOnlyResourceList({
       ) : items.length === 0 ? (
         <p className="text-sm text-muted-foreground text-center py-6">{emptyLabel}</p>
       ) : (
-        <ScrollArea className="flex-1 rounded-md border p-2" style={{ maxHeight: "320px" }}>
+        <ScrollArea className="max-h-[320px] rounded-md border p-2">
           <ul className="space-y-1">
             {items.map((item) => (
               <li
@@ -1738,7 +1738,7 @@ function AgentList({
           <span>Manage</span>
         </div>
       </div>
-      <ScrollArea className="flex-1 p-2" style={{ maxHeight: "260px" }}>
+      <ScrollArea className="max-h-[260px] p-2">
         {options.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No agents available
@@ -1848,7 +1848,7 @@ function ToolList({
           </span>
         </label>
       </div>
-      <ScrollArea className="flex-1 p-2" style={{ maxHeight: "200px" }}>
+      <ScrollArea className="max-h-[200px] p-2">
         {options.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No MCP servers available
@@ -1910,7 +1910,7 @@ function SlackChannelsPanel({
           Assigned channels ({assigned.length})
         </p>
       </div>
-      <ScrollArea className="flex-1 p-2" style={{ maxHeight: "320px" }}>
+      <ScrollArea className="max-h-[320px] p-2">
         {assigned.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No channels assigned. Assign channels under Integrations &rarr; Slack.
@@ -1970,7 +1970,7 @@ function WebexSpacesPanel({
           Assigned spaces ({assigned.length})
         </p>
       </div>
-      <ScrollArea className="flex-1 p-2" style={{ maxHeight: "320px" }}>
+      <ScrollArea className="max-h-[320px] p-2">
         {assigned.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No spaces assigned. Assign spaces under Integrations &rarr; Webex.

--- a/ui/src/components/admin/teams/TeamDetailsDialog.tsx
+++ b/ui/src/components/admin/teams/TeamDetailsDialog.tsx
@@ -1225,7 +1225,7 @@ export function TeamDetailsDialog({
             </div>
 
             {/* Members List */}
-            <ScrollArea className="max-h-[320px] -mx-1 px-1">
+            <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[320px] -mx-1 px-1">
               <div className="space-y-1">
                 {membersLoading && memberPage.length === 0 ? (
                   <div className="flex justify-center py-8">
@@ -1679,7 +1679,7 @@ function ReadOnlyResourceList({
       ) : items.length === 0 ? (
         <p className="text-sm text-muted-foreground text-center py-6">{emptyLabel}</p>
       ) : (
-        <ScrollArea className="max-h-[320px] rounded-md border p-2">
+        <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[320px] rounded-md border p-2">
           <ul className="space-y-1">
             {items.map((item) => (
               <li
@@ -1738,7 +1738,7 @@ function AgentList({
           <span>Manage</span>
         </div>
       </div>
-      <ScrollArea className="max-h-[260px] p-2">
+      <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[260px] p-2">
         {options.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No agents available
@@ -1848,7 +1848,7 @@ function ToolList({
           </span>
         </label>
       </div>
-      <ScrollArea className="max-h-[200px] p-2">
+      <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[200px] p-2">
         {options.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No MCP servers available
@@ -1910,7 +1910,7 @@ function SlackChannelsPanel({
           Assigned channels ({assigned.length})
         </p>
       </div>
-      <ScrollArea className="max-h-[320px] p-2">
+      <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[320px] p-2">
         {assigned.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No channels assigned. Assign channels under Integrations &rarr; Slack.
@@ -1970,7 +1970,7 @@ function WebexSpacesPanel({
           Assigned spaces ({assigned.length})
         </p>
       </div>
-      <ScrollArea className="max-h-[320px] p-2">
+      <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:max-h-[320px] p-2">
         {assigned.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No spaces assigned. Assign spaces under Integrations &rarr; Webex.


### PR DESCRIPTION
# Description

The lists inside the team management dialog could not be scrolled — content was clipped at the max height with no scrollbar and no way to reach items below the fold. This affected every list in the dialog: **Members, Agents, MCP servers, Skills, Workflows, Slack channels, and Webex spaces**.

## Root cause

Each list used a Radix `ScrollArea` whose height was capped on the **Root** element (originally `flex-1 ... style={{ maxHeight: "Npx" }}`).

Radix gives the `ScrollArea` Viewport `overflow-y: scroll` but no height of its own, and our wrapper forces the Viewport to `h-full` (`height: 100%`). With no ancestor resolving to a **definite** height, `height: 100%` computes to `auto` — so the Viewport simply grows with its content and the Root clips it. Capping the Root (whether via `flex-1` + inline `max-height` or a `max-h-[Npx]` class) never constrains the actual scrollable element, so the list still can't scroll.

## Fix

Cap the **Viewport itself** via the `[&>[data-radix-scroll-area-viewport]]:max-h-[Npx]` arbitrary variant. Since the Viewport already scrolls its overflow, a max-height applied directly to it makes tall lists scroll while short lists stay compact.

Applied to all six lists in `TeamDetailsDialog.tsx`. No logic, data, or API changes — purely the `ScrollArea` class declarations.

## Type of Change

- [x] Bugfix

## Checklist

- [x] All code style checks pass (eslint: 0 errors)
- [x] I have verified this change is not present in other open pull requests