### PR TITLE
fix(docs): correct broken cross-link in architecture/gateway.md

### DIFF
--- a/docs/docs/architecture/gateway.md
+++ b/docs/docs/architecture/gateway.md
@@ -79,7 +79,7 @@ it raw). It then runs:
    - **`agent:agent_id can_call tool:server/name`** (wildcard fallback: `tool:server/*`)
 
 All checks must pass. The bridge fails **closed** — any error or timeout returns
-403 (never fail-open). See [Agent Context HMAC](./agent-context-hmac.md) for
+403 (never fail-open). See [Agent Context HMAC](../security/agent-context-hmac.md) for
 the full signed-header flow.
 
 ## Detailed Sequence


### PR DESCRIPTION
## Summary

- Fixes Docusaurus build failure on main introduced by #2070
- `architecture/gateway.md` linked to `./agent-context-hmac.md` (wrong — resolves to `architecture/agent-context-hmac.md`)
- Corrected to `../security/agent-context-hmac.md` where the file actually lives

## Test plan

- [ ] Docusaurus build passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)