### PR TITLE
perf(teams): stop rewriting membership tuples on resource save

### DIFF
--- a/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
+++ b/ui/e2e/rbac/mcp-openfga-tuples.spec.ts
@@ -1081,7 +1081,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
   });
 
-  test("save success explains skipped team members without dropping the selected grants", async ({
+  test("save success shows Saved notice without dropping the selected grants", async ({
     page,
   }) => {
     const mocks = await installTeamResourceMocks(
@@ -1101,12 +1101,6 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
           },
         },
       ],
-      {
-        putResourcesData: {
-          members_updated: ["alice@example.com", "bob@example.com"],
-          members_skipped: ["future-user@example.com"],
-        },
-      },
     );
 
     await page.goto("/admin?cat=people&tab=teams", { waitUntil: "domcontentloaded" });
@@ -1123,8 +1117,7 @@ test.describe("mocked MCP OpenFGA tuple browser regression", () => {
     await page.getByRole("button", { name: "Save agent access" }).click();
     await putResponse;
 
-    await expect(page.getByText(/Saved\. 2 member\(s\) updated; 1 skipped/)).toBeVisible();
-    await expect(page.getByText("future-user@example.com")).toBeVisible();
+    await expect(page.getByText(/Saved\./)).toBeVisible();
     await expect.poll(() => mocks.resourcePutBodies.length).toBe(1);
     expect(mocks.resourcePutBodies[0]).toMatchObject({
       agents: ["agent-sre"],

--- a/ui/src/app/api/__tests__/admin-team-resources.test.ts
+++ b/ui/src/app/api/__tests__/admin-team-resources.test.ts
@@ -6,13 +6,13 @@
  *
  * What we're guarding against:
  *   1. Non-admins cannot reassign team resources (auth gates fire before
- *      any KC mutation).
+ *      any tuple mutation).
  *   2. Add/remove diffs are reconciled to OpenFGA tuples, not Keycloak roles.
  *      Previous state is read from OpenFGA (via TeamResourceListingCache), not
  *      the dropped `team.resources` array — so revocations diff real grants.
- *   3. Members who don't yet have a Keycloak account are reported in
- *      `members_skipped` and the rest of the operation still succeeds —
- *      otherwise inviting "future" emails would brick the whole panel.
+ *   3. Resource grants are keyed on the `team:<slug>` userset, so this path
+ *      never resolves member emails or writes per-member membership tuples —
+ *      member access is transitive via membership owned by the members route.
  *   4. The Mongo `updated_at` touch + legacy `resources` $unset happens AFTER
  *      OpenFGA reconciliation so it never gets ahead of the PDP state.
  */
@@ -49,11 +49,6 @@ const mockGetCollection = jest.fn((name: string) => {
 jest.mock("@/lib/mongodb", () => ({
   getCollection: (...args: unknown[]) => mockGetCollection(...args),
   isMongoDBConfigured: true,
-}));
-
-const mockFindUserIdByEmail = jest.fn();
-jest.mock("@/lib/rbac/keycloak-admin", () => ({
-  findUserIdByEmail: (...a: unknown[]) => mockFindUserIdByEmail(...a),
 }));
 
 const mockBuildTeamResourceTupleDiff = jest.fn();
@@ -239,8 +234,6 @@ beforeEach(() => {
   Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
   setDefaultPermissionMock(false);
   mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
-  // Default: every email resolves to a fake KC id; tests override per-case.
-  mockFindUserIdByEmail.mockImplementation(async (email: string) => `kc-${email}`);
   mockBuildTeamResourceTupleDiff.mockReturnValue({ writes: [], deletes: [] });
   mockReconcileTupleDiff.mockResolvedValue({ enabled: false, writes: 0, deletes: 0 });
   // Default: team holds no OpenFGA grants. Tests that exercise revocation seed
@@ -258,10 +251,6 @@ beforeEach(() => {
 
 async function loadRoute() {
   jest.resetModules();
-  // Re-bind keycloak admin mocks after resetModules.
-  jest.doMock("@/lib/rbac/keycloak-admin", () => ({
-    findUserIdByEmail: (...a: unknown[]) => mockFindUserIdByEmail(...a),
-  }));
   jest.doMock("@/lib/authz", () => ({
     reconcileTupleDiff: (...a: unknown[]) => mockReconcileTupleDiff(...a),
   }));
@@ -305,7 +294,6 @@ describe("PUT /api/admin/teams/[id]/resources — auth gating", () => {
     );
 
     expect(res.status).toBe(401);
-    expect(mockFindUserIdByEmail).not.toHaveBeenCalled();
     expect(mockReconcileTupleDiff).not.toHaveBeenCalled();
   });
 
@@ -313,8 +301,8 @@ describe("PUT /api/admin/teams/[id]/resources — auth gating", () => {
     // Issue #1509: the auth gate now runs AFTER the team document is loaded
     // so requireTeamMembershipManagementPermission can evaluate scoped team
     // admin membership. Seed a team where user@example.com is NOT an
-    // owner/admin to assert the deny path. The test still proves Keycloak
-    // mutations never fire before authz fails.
+    // owner/admin to assert the deny path. The test still proves resource
+    // tuple mutations never fire before authz fails.
     setDefaultPermissionMock(false);
     mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
     mockGetServerSession.mockResolvedValue(userSession());
@@ -337,7 +325,6 @@ describe("PUT /api/admin/teams/[id]/resources — auth gating", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(mockFindUserIdByEmail).not.toHaveBeenCalled();
     expect(mockReconcileTupleDiff).not.toHaveBeenCalled();
   });
 });
@@ -374,11 +361,6 @@ describe("PUT /api/admin/teams/[id]/resources — reconciliation", () => {
 
     expect(res.status).toBe(200);
 
-    // Resource changes resolve member subjects for OpenFGA tuples, but never
-    // create or assign per-resource Keycloak realm roles.
-    expect(mockFindUserIdByEmail).toHaveBeenCalledWith("alice@example.com");
-    expect(mockFindUserIdByEmail).toHaveBeenCalledWith("bob@example.com");
-
     // No `resources` array is written anymore; the route only touches
     // updated_at and unsets any legacy field.
     expect(teamsCol.updateOne).toHaveBeenCalledTimes(1);
@@ -394,22 +376,19 @@ describe("PUT /api/admin/teams/[id]/resources — reconciliation", () => {
       tools_added: ["github/*"],
       tools_removed: [],
     });
-    expect(body.data.members_resolved).toEqual(["alice@example.com", "bob@example.com"]);
-    expect(body.data.members_skipped).toEqual([]);
+    // Grants are keyed on the team userset, so saving resources reports only
+    // the resource diff — no per-member resolution fields anymore.
+    expect(body.data.members_resolved).toBeUndefined();
+    expect(body.data.members_skipped).toBeUndefined();
   });
 
-  it("reports missing Keycloak accounts while still saving OpenFGA resource grants", async () => {
+  it("does not resolve member emails or build membership tuples (team-userset grants)", async () => {
     mockGetServerSession.mockResolvedValue(adminSession());
     setDefaultPermissionMock(true);
 
     const teamsCol = createMockCollection();
     teamsCol.findOne.mockResolvedValue(teamWith({ agents: [], tools: [] }));
     mockCollections["teams"] = teamsCol;
-
-    // bob has not logged in yet → no KC account.
-    mockFindUserIdByEmail.mockImplementation(async (email: string) =>
-      email === "bob@example.com" ? null : `kc-${email}`
-    );
 
     const { PUT } = await loadRoute();
 
@@ -422,13 +401,18 @@ describe("PUT /api/admin/teams/[id]/resources — reconciliation", () => {
     );
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.data.members_resolved).toEqual(["alice@example.com"]);
-    expect(body.data.members_skipped).toEqual(["bob@example.com"]);
 
-    // Mongo persistence must still happen even when some members are skipped —
-    // otherwise re-saving on the next page load would re-trigger reconciliation
-    // with stale state.
+    // The tuple builder is invoked WITHOUT any memberUserIds — member access is
+    // resolved transitively from membership tuples owned by the members route,
+    // so this path must never re-resolve the roster against Keycloak.
+    const builderArg = mockBuildTeamResourceTupleDiff.mock.calls[0][0];
+    expect(builderArg).not.toHaveProperty("memberUserIds");
+
+    const body = await res.json();
+    expect(body.data.members_resolved).toBeUndefined();
+    expect(body.data.members_skipped).toBeUndefined();
+
+    // Mongo persistence still happens.
     expect(teamsCol.updateOne).toHaveBeenCalledTimes(1);
   });
 
@@ -470,7 +454,6 @@ describe("PUT /api/admin/teams/[id]/resources — reconciliation", () => {
     expect(res.status).toBe(200);
     expect(mockBuildTeamResourceTupleDiff).toHaveBeenCalledWith({
       teamSlug: "platform-engineering",
-      memberUserIds: ["kc-alice@example.com", "kc-bob@example.com"],
       agents: { added: ["agent-new"], removed: ["agent-old"] },
       agentAdmins: { added: [], removed: [] },
       tools: { added: ["jira/*"], removed: [] },
@@ -528,7 +511,6 @@ describe("PUT /api/admin/teams/[id]/resources — reconciliation", () => {
     expect(res.status).toBe(200);
     expect(mockBuildTeamResourceTupleDiff).toHaveBeenCalledWith({
       teamSlug: "platform-engineering",
-      memberUserIds: ["kc-alice@example.com", "kc-bob@example.com"],
       agents: { added: ["agent-keep"], removed: [] },
       agentAdmins: { added: ["agent-admin"], removed: [] },
       tools: { added: ["mcp-confluence-mcp/*"], removed: [] },
@@ -625,7 +607,7 @@ describe("PUT /api/admin/teams/[id]/resources — reconciliation", () => {
     );
 
     expect(res.status).toBe(400);
-    expect(mockFindUserIdByEmail).not.toHaveBeenCalled();
+    expect(mockBuildTeamResourceTupleDiff).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/app/api/admin/teams/[id]/resources/route.ts
+++ b/ui/src/app/api/admin/teams/[id]/resources/route.ts
@@ -35,16 +35,12 @@ withErrorHandler,
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import { reconcileTupleDiff } from "@/lib/authz";
 import {
-findUserIdByEmail,
-} from "@/lib/rbac/keycloak-admin";
-import {
 buildTeamResourceTupleDiff,
 teamToolWildcardSentinelTuple,
 TEAM_TOOL_WILDCARD_SENTINEL_OBJECT,
 } from "@/lib/rbac/openfga";
 import { TeamResourceListingCache } from "@/lib/rbac/team-resource-listing";
 import { requireTeamMembershipManagementPermission } from "@/lib/rbac/team-admin-guards";
-import { loadActiveTeamMembers } from "@/lib/rbac/team-membership-store";
 import type { Team } from "@/types/teams";
 import { ObjectId } from "mongodb";
 import { NextRequest,NextResponse } from "next/server";
@@ -404,36 +400,16 @@ export const PUT = withErrorHandler(
       const agentAdminDiff = diff(prevAgentAdmins, nextAgentAdmins);
       const toolDiff = diff(prevTools, nextTools);
 
-      // ── 2. Resolve current member subjects for OpenFGA team membership.
-      //
-      //    Member list comes from the canonical team_membership_sources
-      //    store (post 2026-05-26 canonical-membership refactor); deduped
-      //    by identity, status:"active" only. A team can have a member
-      //    email that doesn't have a Keycloak account yet (e.g. invited
-      //    but never logged in). We log + skip those rather than failing
-      //    the whole PUT — the UI flags them in the response. Subject-
-      //    only rows (no email) are also skipped because Keycloak lookup
-      //    is by email.
-      const canonicalMembers = await loadActiveTeamMembers(slug);
-      const memberEmails: string[] = canonicalMembers
-        .map((m) => m.user_email)
-        .filter((email): email is string => typeof email === "string" && email.length > 0);
-      const skippedMembers: string[] = [];
-      const resolvedMembers: string[] = [];
-      const resolvedMemberUserIds: string[] = [];
-
-      for (const memberEmail of memberEmails) {
-        const userId = await findUserIdByEmail(memberEmail);
-        if (!userId) {
-          skippedMembers.push(memberEmail);
-          continue;
-        }
-        resolvedMemberUserIds.push(userId);
-        resolvedMembers.push(memberEmail);
-      }
-
-      // ── 3. Reconcile OpenFGA ReBAC tuples. OpenFGA owns relationship facts;
+      // ── 2. Reconcile OpenFGA ReBAC tuples. OpenFGA owns relationship facts;
       //    there is no Mongo authz array to persist anymore.
+      //
+      //    Grants are keyed on the `team:<slug>#member` / `#admin` userset, so a
+      //    member's access resolves transitively at check time via their
+      //    `user:<id> member team:<slug>` membership tuple. Those membership
+      //    tuples are owned by the team-membership writers (members route +
+      //    sync/audit reconcilers), so this path deliberately does NOT touch
+      //    them — it used to re-resolve every member email→id against Keycloak
+      //    (an O(members) serial lookup) on every save for no authorization gain.
       //
       //    Treat Save as authoritative: selected resources are desired writes
       //    (the writer filters tuples that already exist), and removals come
@@ -442,7 +418,6 @@ export const PUT = withErrorHandler(
       //    explicit per-server prefixes above.
       const tupleDiffInput = {
         teamSlug: slug,
-        memberUserIds: resolvedMemberUserIds,
         agents: { added: nextAgents, removed: agentDiff.removed },
         agentAdmins: { added: nextAgentAdmins, removed: agentAdminDiff.removed },
         tools: { added: nextTools, removed: toolDiff.removed },
@@ -468,7 +443,7 @@ export const PUT = withErrorHandler(
         tenantId: session.org,
       });
 
-      // ── 4. Touch updated_at and drop any legacy `resources` array (FGA is the
+      // ── 3. Touch updated_at and drop any legacy `resources` array (FGA is the
       //    single source of truth; the migration backfills + unsets in bulk,
       //    this keeps re-saved teams clean immediately).
       const now = new Date();
@@ -481,7 +456,7 @@ export const PUT = withErrorHandler(
       );
 
       console.log(
-        `[Admin TeamResources] PUT team=${id} agents+=${agentDiff.added.length}/-${agentDiff.removed.length} agent_admins+=${agentAdminDiff.added.length}/-${agentAdminDiff.removed.length} tools+=${toolDiff.added.length}/-${toolDiff.removed.length} wildcard=${wildcard ? "on" : "off"} members_resolved=${resolvedMembers.length} members_skipped=${skippedMembers.length} by=${user.email}`
+        `[Admin TeamResources] PUT team=${id} agents+=${agentDiff.added.length}/-${agentDiff.removed.length} agent_admins+=${agentAdminDiff.added.length}/-${agentAdminDiff.removed.length} tools+=${toolDiff.added.length}/-${toolDiff.removed.length} wildcard=${wildcard ? "on" : "off"} by=${user.email}`
       );
 
       return successResponse({
@@ -494,9 +469,6 @@ export const PUT = withErrorHandler(
           tools_added: toolDiff.added,
           tools_removed: toolDiff.removed,
         },
-        members_resolved: resolvedMembers,
-        members_updated: resolvedMembers,
-        members_skipped: skippedMembers,
         openfga,
       });
   }

--- a/ui/src/components/admin/teams/TeamDetailsDialog.tsx
+++ b/ui/src/components/admin/teams/TeamDetailsDialog.tsx
@@ -621,13 +621,11 @@ export function TeamDetailsDialog({
       if (!data.success) {
         throw new Error(data.error || "Failed to save agents and MCP access");
       }
-      const skipped: string[] = data.data?.members_skipped ?? [];
-      const updated: string[] = data.data?.members_updated ?? [];
-      setResourcesNotice(
-        skipped.length > 0
-          ? `Saved. ${updated.length} member(s) updated; ${skipped.length} skipped (no Keycloak account yet): ${skipped.join(", ")}`
-          : `Saved. ${updated.length} member(s) updated.`
-      );
+      // Resource grants are keyed on the team userset, so saving touches only
+      // the team's resource tuples — member access resolves transitively from
+      // their existing team membership (owned by the members tab), nothing to
+      // report per-member here.
+      setResourcesNotice("Saved.");
       onTeamUpdated();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save agents and MCP access");

--- a/ui/src/lib/rbac/__tests__/mcp-openfga-tuples.test.ts
+++ b/ui/src/lib/rbac/__tests__/mcp-openfga-tuples.test.ts
@@ -39,7 +39,6 @@ describe("MCP OpenFGA tuple contract", () => {
       const selection = mcpServerSelection(serverId);
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: [], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: [selection], removed: [] },
@@ -75,7 +74,6 @@ describe("MCP OpenFGA tuple contract", () => {
       const selection = mcpServerSelection(serverId);
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: ["agent-platform-helper"], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: [selection], removed: [] },
@@ -98,7 +96,6 @@ describe("MCP OpenFGA tuple contract", () => {
       const selection = mcpServerSelection(serverId);
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: ["agent-keep"], removed: ["agent-drop"] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: [], removed: [selection] },
@@ -116,7 +113,6 @@ describe("MCP OpenFGA tuple contract", () => {
     it("expands tool wildcard to per-server agent tuples AgentGateway can check", () => {
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: ["agent-a"], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: [], removed: [] },
@@ -143,7 +139,6 @@ describe("MCP OpenFGA tuple contract", () => {
     it("accepts slash-form MCP server selections from the team resources picker", () => {
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: ["agent-platform-helper"], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: ["mcp-confluence-mcp/*"], removed: [] },
@@ -184,7 +179,6 @@ describe("MCP OpenFGA tuple contract", () => {
     it("revokes per-server wildcard agent tuples when an agent is removed but wildcard stays on", () => {
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: ["agent-keep"], removed: ["agent-drop"] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: [], removed: [] },
@@ -208,7 +202,6 @@ describe("MCP OpenFGA tuple contract", () => {
     it("revokes direct tool grants for removed agents", () => {
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: ["agent-keep"], removed: ["agent-drop"] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: ["jira/search"], removed: [] },
@@ -227,7 +220,6 @@ describe("MCP OpenFGA tuple contract", () => {
       const selection = mcpServerSelection(serverId);
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: [], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: [], removed: [selection] },
@@ -253,7 +245,6 @@ describe("MCP OpenFGA tuple contract", () => {
     it("keeps non-wildcard tool ids on the legacy tool: object type", () => {
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: [],
         agents: { added: [], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: ["jira/search"], removed: [] },
@@ -268,10 +259,9 @@ describe("MCP OpenFGA tuple contract", () => {
       );
     });
 
-    it("matches the drift-repair PUT body used by admin Team Resources for MCP servers", () => {
+    it("matches the PUT body used by admin Team Resources for MCP servers", () => {
       const diff = buildTeamResourceTupleDiff({
         teamSlug: TEAM,
-        memberUserIds: ["kc-alice", "kc-bob"],
         agents: { added: ["agent-keep"], removed: [] },
         agentAdmins: { added: [], removed: [] },
         tools: { added: ["mcp-confluence-mcp_*"], removed: [] },
@@ -280,8 +270,6 @@ describe("MCP OpenFGA tuple contract", () => {
 
       expect(diff.writes).toEqual(
         expect.arrayContaining([
-          { user: "user:kc-alice", relation: "member", object: `team:${TEAM}` },
-          { user: "user:kc-bob", relation: "member", object: `team:${TEAM}` },
           { user: `team:${TEAM}#member`, relation: "caller", object: "tool:mcp-confluence-mcp/*" },
           { user: `team:${TEAM}#admin`, relation: "manager", object: "mcp_server:mcp-confluence-mcp" },
           {
@@ -289,6 +277,25 @@ describe("MCP OpenFGA tuple contract", () => {
             relation: "caller",
             object: "tool:mcp-confluence-mcp/*",
           },
+        ]),
+      );
+    });
+
+    it("never writes per-member team-membership tuples (those are owned by the members route)", () => {
+      const diff = buildTeamResourceTupleDiff({
+        teamSlug: TEAM,
+        agents: { added: ["agent-keep"], removed: [] },
+        agentAdmins: { added: [], removed: [] },
+        tools: { added: ["mcp-confluence-mcp_*"], removed: [] },
+        toolWildcard: { added: false, removed: false },
+      });
+
+      // Resource grants are keyed on the team userset; a member's access
+      // resolves transitively from their existing membership tuple. This path
+      // must not emit `user:<id> member team:<slug>` tuples.
+      expect(diff.writes).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ relation: "member", object: `team:${TEAM}` }),
         ]),
       );
     });

--- a/ui/src/lib/rbac/__tests__/openfga.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga.test.ts
@@ -108,7 +108,6 @@ describe("OpenFGA team resource tuple reconciliation", () => {
   it("maps team members and resource diffs to OpenFGA tuples", () => {
     const diff = buildTeamResourceTupleDiff({
       teamSlug: "platform-engineering",
-      memberUserIds: ["sub-alice", "sub-bob"],
       agents: { added: ["agent-1"], removed: ["agent-old"] },
       agentAdmins: { added: ["agent-admin"], removed: [] },
       tools: { added: ["jira_*"], removed: ["github_*"] },
@@ -118,8 +117,6 @@ describe("OpenFGA team resource tuple reconciliation", () => {
 
     expect(diff.writes).toEqual(
       expect.arrayContaining([
-        { user: "user:sub-alice", relation: "member", object: "team:platform-engineering" },
-        { user: "user:sub-bob", relation: "member", object: "team:platform-engineering" },
         { user: "team:platform-engineering#member", relation: "user", object: "agent:agent-1" },
         {
           user: "team:platform-engineering#admin",
@@ -174,7 +171,6 @@ describe("OpenFGA team resource tuple reconciliation", () => {
     // assisted-by Codex Codex-sonnet-4-6
     const diff = buildTeamResourceTupleDiff({
       teamSlug: "platform-engineering",
-      memberUserIds: [],
       agents: { added: [], removed: [] },
       agentAdmins: { added: [], removed: [] },
       tools: { added: ["mcp-confluence-mcp_*"], removed: ["mcp-litellm_*"] },
@@ -224,7 +220,6 @@ describe("OpenFGA team resource tuple reconciliation", () => {
   it("writes manager grants with admin usersets that match the OpenFGA model", () => {
     const diff = buildTeamResourceTupleDiff({
       teamSlug: "platform-engineering",
-      memberUserIds: [],
       agents: { added: [], removed: [] },
       agentAdmins: { added: ["agent-admin"], removed: ["agent-admin-old"] },
       tools: { added: [], removed: [] },

--- a/ui/src/lib/rbac/openfga.ts
+++ b/ui/src/lib/rbac/openfga.ts
@@ -29,7 +29,6 @@ export interface ResourceBooleanDiff {
 
 export interface TeamResourceTupleDiffInput {
   teamSlug: string;
-  memberUserIds: string[];
   agents: ResourceStringDiff;
   agentAdmins: ResourceStringDiff;
   tools: ResourceStringDiff;
@@ -314,20 +313,18 @@ function mcpServerLegacyToolGrantDeletes(teamSlug: string, toolIds: string[]): O
 }
 
 export function buildTeamResourceTupleDiff(input: TeamResourceTupleDiffInput): TeamResourceTupleDiff {
-  const teamObject = `team:${input.teamSlug}`;
-  const memberTuples = input.memberUserIds.map((userId) => ({
-    user: `user:${userId}`,
-    relation: "member",
-    object: teamObject,
-  }));
-
+  // Resource grants are keyed on the `team:<slug>#member` / `#admin` userset, so
+  // a member's access is resolved transitively at check time via their
+  // `user:<id> member team:<slug>` membership tuple. Those membership tuples are
+  // owned exclusively by the team-membership writers (members route + sync/audit
+  // reconcilers), NOT this resource-save path — re-writing them here forced an
+  // O(members) Keycloak email→id lookup on every save for no authorization gain.
   const addedTools = splitTeamToolSelections(input.tools.added);
   const removedTools = splitTeamToolSelections(input.tools.removed);
   const wildcardServerSelections = mcpServerSelectionsFromIds(input.allMcpServerIds ?? []);
   const combinedToolIds = combinedTeamToolIds(input.tools.added, input.tools.removed);
 
   const writes = uniqueTuples([
-    ...memberTuples,
     ...resourceTuples(input.teamSlug, "user", "agent", input.agents.added),
     ...resourceTuples(input.teamSlug, "manager", "agent", input.agentAdmins.added, "admin"),
     ...resourceTuples(input.teamSlug, "caller", "tool", addedTools.directToolIds),


### PR DESCRIPTION
## Summary

- Removes the O(members) serial Keycloak email→ID lookups from the team resource save path
- Resource grants are keyed on the `team:<slug>#member` userset — no per-user membership tuples need to be written on every save
- Membership tuples are owned exclusively by the `/api/admin/teams/[id]/members` route; the resources route was redundantly rewriting them
- Simplifies save response to `"Saved."` (removes `members_updated`/`members_skipped` counts)

## Why

Saving MCP/agent assignments to a team was making one Keycloak HTTP lookup per team member on every save, serially. For a team with many members this caused noticeable latency. The lookups were unnecessary: OpenFGA resolves `team:<slug>#member` transitively at check time, so no per-user resource tuple is needed.

## Test plan

- [ ] Save agent/tool assignments to a team — completes immediately regardless of team size
- [ ] Members retain access to assigned resources after save
- [ ] Removing a resource assignment blocks member access

🤖 Generated with [Claude Code](https://claude.com/claude-code)