### PR TITLE
fix(idp-sync): link Okta-synced users to IdP broker on provision

### DIFF
--- a/ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts
@@ -122,7 +122,7 @@ describe("Okta directory connector (SDK-based)", () => {
         display_name: "Engineering Platform Users",
         member_count: 1,
         members: [
-          { subject: undefined, email: "bob@example.test", display_name: "Bob Example", active: true },
+          { subject: undefined, email: "bob@example.test", display_name: "Bob Example", active: true, idp_user_id: "00u-bob" },
         ],
       }),
     ]);
@@ -170,8 +170,8 @@ describe("Okta directory connector (SDK-based)", () => {
     const [group] = await fetchOktaExternalGroups({ providerId: "okta-main" });
 
     expect(group.members).toEqual([
-      { subject: undefined, email: "gone@example.test", display_name: "gone@example.test", active: false },
-      { subject: undefined, email: "ok@example.test", display_name: "ok@example.test", active: true },
+      { subject: undefined, email: "gone@example.test", display_name: "gone@example.test", active: false, idp_user_id: "u1" },
+      { subject: undefined, email: "ok@example.test", display_name: "ok@example.test", active: true, idp_user_id: "u2" },
     ]);
   });
 

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -20,7 +20,7 @@ import {
   reapStaleIdpSyncRuns,
   updateIdpSyncRun,
 } from "@/lib/rbac/idp-sync-store";
-import { provisionShellUser } from "@/lib/rbac/keycloak-admin";
+import { addUserFederatedIdentity, provisionShellUser } from "@/lib/rbac/keycloak-admin";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
 import type { IdpSyncRun } from "./mongo-collections";
@@ -161,7 +161,7 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // skips everyone as `missing_subject`. Cached per run so a user appearing in
     // many groups is resolved once.
     const subCache = new Map<string, string | null>();
-    for (const group of groups as Array<{ members?: Array<{ email?: string; active?: boolean; subject?: string }> }>) {
+    for (const group of groups as Array<{ members?: Array<{ email?: string; active?: boolean; subject?: string; idp_user_id?: string }> }>) {
       for (const member of group.members ?? []) {
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
@@ -185,7 +185,23 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
           }
         }
         const sub = subCache.get(email);
-        if (sub) member.subject = sub;
+        if (sub) {
+          member.subject = sub;
+          // Link the user to the IdP broker so user_is_federated() returns true
+          // and the Slack bot routes them via OBO rather than as "unlinked".
+          // Runs on every sync (not just first provision) so existing users are
+          // backfilled when the sync runs after this change. Idempotent: 409 = already linked.
+          if (member.idp_user_id && provider.startsWith("okta")) {
+            try {
+              await addUserFederatedIdentity(sub, "okta", member.idp_user_id, email);
+            } catch (linkErr) {
+              console.warn(
+                `[IdpSync] run ${runId}: failed to link federated identity for ${email}: ` +
+                  (linkErr instanceof Error ? linkErr.message : String(linkErr))
+              );
+            }
+          }
+        }
       }
     }
 

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -581,6 +581,27 @@ export async function getUserFederatedIdentities(
   }));
 }
 
+/**
+ * Create a federated identity link between a Keycloak user and an external IdP.
+ * Idempotent: a 409 (link already exists) is treated as success.
+ */
+export async function addUserFederatedIdentity(
+  userId: string,
+  provider: string,
+  idpUserId: string,
+  userName: string,
+): Promise<void> {
+  const enc = encodeURIComponent(userId);
+  const providerEnc = encodeURIComponent(provider);
+  const body: KeycloakFederatedIdentity = { identityProvider: provider, userId: idpUserId, userName };
+  const response = await adminFetch(`/users/${enc}/federated-identity/${providerEnc}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (response.status === 409) return; // already linked — idempotent
+  await assertOk(response, "addUserFederatedIdentity");
+}
+
 export async function assignRealmRolesToUser(
   userId: string,
   roles: KeycloakRole[]

--- a/ui/src/lib/rbac/okta-directory-connector.ts
+++ b/ui/src/lib/rbac/okta-directory-connector.ts
@@ -8,6 +8,8 @@ export type OktaExternalGroup = ExternalGroup & {
     email: string;
     display_name?: string;
     active: boolean;
+    /** Okta user ID — used to create the Keycloak federated identity link at sync time. */
+    idp_user_id?: string;
   }>;
 };
 
@@ -155,6 +157,7 @@ async function collectGroupMembers(client: Client, groupId: string): Promise<Okt
       email,
       display_name: oktaUserDisplayName(user),
       active: user.status !== "DEPROVISIONED" && user.status !== "SUSPENDED",
+      idp_user_id: user.id ?? undefined,
     });
   });
   return members;


### PR DESCRIPTION
## Summary

- `okta-directory-connector.ts`: capture `user.id` (Okta user ID) as `idp_user_id` on each member object
- `keycloak-admin.ts`: add `addUserFederatedIdentity()` helper calling `POST /users/{id}/federated-identity/{provider}`; 409 treated as idempotent success
- `idp-sync-runner.ts`: after resolving each member's Keycloak sub, call `addUserFederatedIdentity` when `idp_user_id` is present and provider is `okta` — runs every sync pass so existing users are backfilled automatically

## Problem

`oktaSync` provisions shell users in Keycloak but never creates a federated identity link. The Slack bot calls `user_is_federated()` which checks for non-empty `federatedIdentities` on the Keycloak user. When the realm has an active IdP broker (standard production config), an empty `federatedIdentities` causes the bot to route the user as "unlinked" and fall back to the platform service account. That SA creates the conversation under its own identity, so the next request from the user hits a `403 conversation#write` check in OpenFGA.

## Fix

On each sync pass, after provisioning or resolving the user's Keycloak sub, create a federated identity link via the Keycloak admin API. The call is idempotent (409 = already linked, treated as success), so re-running the sync after this change will backfill all previously-synced users.

## Test plan

- [ ] Run an Okta sync against a realm with an active IdP broker — confirm synced users now have `federatedIdentities` populated in Keycloak
- [ ] Confirm that a user synced before this change (empty `federatedIdentities`) gets the link backfilled on the next sync run
- [ ] Confirm Slack bot routes previously-unlinked synced users via OBO (no `403 conversation#write`)
- [ ] Confirm a user who has already logged in (link already exists) doesn't error — 409 silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)