### PR TITLE
feat(openfga-authz-bridge): add callerToolCheck.enabled to subchart

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
             - name: AUDIT_SUBJECT_SALT
               value: {{ .Values.audit.subjectSalt | quote }}
             {{- end }}
+            {{- if .Values.callerToolCheck.enabled }}
+            - name: CAIPE_CALLER_TOOL_CHECK_ENABLED
+              value: "true"
+            {{- end }}
           ports:
             - name: grpc
               containerPort: 9100

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
@@ -41,6 +41,11 @@ tokenValidation:
   algorithms:
     - RS256
 
+callerToolCheck:
+  # When enabled, the bridge additionally verifies that the calling user/team
+  # holds an explicit grant for the tool being invoked (dual-gate).
+  enabled: false
+
 audit:
   enabled: true
   # Release-name-derived default for the audit-service singleton. Rendered with


### PR DESCRIPTION
## Summary

- Adds `callerToolCheck.enabled` value (default: `false`) to the `openfga-authz-bridge` subchart
- Wires `CAIPE_CALLER_TOOL_CHECK_ENABLED` env var into the deployment template when enabled
- When `true`, the bridge performs a dual-gate authorization check: the calling agent must have access **and** the calling user/team must also hold an explicit grant for the tool

## Why

Without this flag, only the agent-side check runs at the gateway. The user/team side is not verified, so a team that has had an MCP unassigned can still call tools through an agent that does have access. Dual-gating ensures both sides must hold the grant for a call to succeed.

## Test plan

- [ ] Helm template renders `CAIPE_CALLER_TOOL_CHECK_ENABLED: "true"` when `callerToolCheck.enabled: true` is set
- [ ] Default (`enabled: false`) renders no env var — no behavior change for existing deployments
- [ ] After enabling in downstream values, unassigning an MCP from a team blocks that team's users from calling the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)