### PR TITLE
fix(keycloak-init): Retry admin token acquisition

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -50,10 +50,18 @@ get_admin_token() {
   json_field "${TOKEN_RESP}" "access_token"
 }
 
-echo "${TAG} Obtaining admin access token ..."
-ACCESS_TOKEN=$(get_admin_token) || exit 1
+echo "${TAG} Waiting for Keycloak admin API and obtaining access token ..."
+ACCESS_TOKEN=""
+_i=0
+while [ "${_i}" -lt 72 ]; do
+  ACCESS_TOKEN=$(get_admin_token || true)
+  [ -n "${ACCESS_TOKEN}" ] && break
+  _i=$((_i + 1))
+  echo "${TAG}   Keycloak not ready (${_i}/72) — retrying in 5s ..." >&2
+  sleep 5
+done
 if [ -z "${ACCESS_TOKEN}" ]; then
-  echo "${TAG} ERROR: empty access_token" >&2
+  echo "${TAG} ERROR: could not obtain admin access_token after ~6 min — is Keycloak up?" >&2
   exit 1
 fi
 AUTH="Authorization: Bearer ${ACCESS_TOKEN}"


### PR DESCRIPTION
# Description

Prevents script failures if Keycloak is not immediately available during startup, improving robustness.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
