### PR TITLE
fix(agents): grant owner team members full manage access and fix read-only message

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga/authorization-model.json
+++ b/charts/ai-platform-engineering/charts/openfga/authorization-model.json
@@ -1490,6 +1490,10 @@
               },
               {
                 "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
                 "relation": "admin"
               },
               {

--- a/deploy/openfga/model.fga
+++ b/deploy/openfga/model.fga
@@ -161,7 +161,7 @@ type agent
     define reader: [user, service_account, team#member, team#admin, external_group#member, slack_channel, webex_space]
     define user: [user, user:*, service_account, team#member, team#admin, external_group#member, slack_channel, webex_space]
     define writer: [user, service_account, team#member, team#admin]
-    define manager: [user, service_account, team#admin, organization#admin]
+    define manager: [user, service_account, team#member, team#admin, organization#admin]
     define auditor: [user, service_account, team#admin]
     define can_discover: can_read
     define can_read: reader or can_use or can_manage or owner

--- a/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
@@ -53,7 +53,8 @@ const CodeMirrorEditor = React.lazy(() => import("@uiw/react-codemirror"));
 interface DynamicAgentEditorProps {
   agent: DynamicAgentConfig | null; // null = creating new
   cloneFrom?: DynamicAgentConfig | null; // Agent to clone from (for pre-filling)
-  readOnly?: boolean; // true for config-driven agents (view only)
+  readOnly?: boolean; // true for view-only mode
+  readOnlyReason?: "config" | "permissions"; // why readOnly is true
   onSave: () => void;
   onCancel: () => void;
 }
@@ -335,7 +336,7 @@ function AdvancedStep({
   );
 }
 
-export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCancel }: DynamicAgentEditorProps) {
+export function DynamicAgentEditor({ agent, cloneFrom, readOnly, readOnlyReason, onSave, onCancel }: DynamicAgentEditorProps) {
   const isEditing = !!agent;
   const isCloning = !!cloneFrom;
   const { toast } = useToast();
@@ -1160,7 +1161,9 @@ export function DynamicAgentEditor({ agent, cloneFrom, readOnly, onSave, onCance
             </CardTitle>
             <CardDescription>
               {readOnly
-                ? "This agent is managed by configuration and cannot be edited"
+                ? readOnlyReason === "permissions"
+                  ? "You do not have permission to edit this agent"
+                  : "This agent is managed by configuration and cannot be edited"
                 : isEditing
                 ? "Update the agent configuration"
                 : isCloning

--- a/ui/src/components/dynamic-agents/DynamicAgentsTab.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentsTab.tsx
@@ -219,6 +219,7 @@ export function DynamicAgentsTab() {
         agent={editingAgent}
         cloneFrom={cloningAgent}
         readOnly={Boolean(editingAgent?.config_driven || (editingAgent && !agentCanEdit(editingAgent)))}
+        readOnlyReason={editingAgent?.config_driven ? "config" : "permissions"}
         onSave={() => {
           setEditingAgent(null);
           setIsCreating(false);

--- a/ui/src/lib/rbac/__tests__/openfga-agent-tools-shared-teams.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-agent-tools-shared-teams.test.ts
@@ -189,5 +189,61 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
         expect.objectContaining({ relation: "writer" }),
       ]),
     );
+    // shared-only teams must NOT receive the member manager grant
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([
+        { user: "team:sre#member", relation: "manager", object: "agent:agent-test" },
+      ]),
+    );
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([
+        { user: "team:ops#member", relation: "manager", object: "agent:agent-test" },
+      ]),
+    );
+  });
+
+  it("emits no member manager write when ownerTeamSlug is absent", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      agentId: "agent-test",
+      previousAllowedTools: {},
+      nextAllowedTools: {},
+      ownerSubject: "alice-sub",
+      organizationId: "caipe",
+      // no ownerTeamSlug
+    });
+
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ relation: "manager", user: expect.stringContaining("#member") }),
+      ]),
+    );
+    expect(diff.deletes).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ relation: "manager", user: expect.stringContaining("#member") }),
+      ]),
+    );
+  });
+
+  it("deletes member manager grant when owner team is removed (transfer to no team)", () => {
+    const diff = buildAgentRelationshipTupleDiff({
+      agentId: "agent-test",
+      previousAllowedTools: {},
+      nextAllowedTools: {},
+      ownerSubject: "alice-sub",
+      organizationId: "caipe",
+      ownerTeamSlug: undefined,
+      previousOwnerTeamSlug: "platform",
+    });
+
+    expect(diff.deletes).toEqual(
+      expect.arrayContaining([
+        { user: "team:platform#member", relation: "manager", object: "agent:agent-test" },
+      ]),
+    );
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ relation: "manager", user: expect.stringContaining("#member") }),
+      ]),
+    );
   });
 });

--- a/ui/src/lib/rbac/__tests__/openfga-agent-tools-shared-teams.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-agent-tools-shared-teams.test.ts
@@ -19,7 +19,7 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
     ownerTeamSlug: "platform",
   } as const;
 
-  it("writes member+admin tuples for every additional shared team (no member writer)", () => {
+  it("writes member+admin tuples for every additional shared team (no member writer); owner team members also get manager", () => {
     const diff = buildAgentRelationshipTupleDiff({
       ...baseInput,
       nextSharedTeamSlugs: ["sre", "ops"],
@@ -28,8 +28,11 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
 
     expect(diff.writes).toEqual(
       expect.arrayContaining([
+        // owner team members get both user and manager
         { user: "team:platform#member", relation: "user", object: "agent:agent-test" },
+        { user: "team:platform#member", relation: "manager", object: "agent:agent-test" },
         { user: "team:platform#admin", relation: "manager", object: "agent:agent-test" },
+        // shared team members only get user
         { user: "team:sre#member", relation: "user", object: "agent:agent-test" },
         { user: "team:sre#admin", relation: "manager", object: "agent:agent-test" },
         { user: "team:ops#member", relation: "user", object: "agent:agent-test" },
@@ -61,10 +64,12 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
     const platformMemberWrites = diff.writes.filter(
       (t) => t.user === "team:platform#member" && t.object === "agent:agent-test",
     );
-    expect(platformMemberWrites.map((t) => t.relation).sort()).toEqual(["user"]);
+    // owner team members get user + manager (no duplicates)
+    expect(platformMemberWrites.map((t) => t.relation).sort()).toEqual(["manager", "user"]);
     const sreMemberWrites = diff.writes.filter(
       (t) => t.user === "team:sre#member" && t.object === "agent:agent-test",
     );
+    // shared-only team members get just user
     expect(sreMemberWrites.map((t) => t.relation).sort()).toEqual(["user"]);
   });
 
@@ -103,10 +108,12 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
       previousSharedTeamSlugs: ["sre"],
     });
 
+    // old owner team loses its user grant (from teamGrants diff) and its member manager grant
     expect(diff.deletes).toEqual(
       expect.arrayContaining([
         { user: "team:platform#member", relation: "user", object: "agent:agent-test" },
         { user: "team:platform#member", relation: "writer", object: "agent:agent-test" },
+        { user: "team:platform#member", relation: "manager", object: "agent:agent-test" },
         { user: "team:platform#admin", relation: "manager", object: "agent:agent-test" },
       ]),
     );
@@ -115,9 +122,11 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
         expect.objectContaining({ user: "team:sre#member", relation: "user" }),
       ]),
     );
+    // new owner team gets user + manager for members
     expect(diff.writes).toEqual(
       expect.arrayContaining([
         { user: "team:sre#member", relation: "user", object: "agent:agent-test" },
+        { user: "team:sre#member", relation: "manager", object: "agent:agent-test" },
         { user: "team:sre#admin", relation: "manager", object: "agent:agent-test" },
       ]),
     );
@@ -140,7 +149,8 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
       .filter((u) => u.startsWith("team:"));
     expect(teamSubjects).toEqual(
       expect.arrayContaining([
-        "team:platform#member",
+        "team:platform#member", // user
+        "team:platform#member", // manager (owner team)
         "team:platform#admin",
         "team:sre#member",
         "team:sre#admin",
@@ -168,6 +178,8 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
     );
     expect(diff.writes).toEqual(
       expect.arrayContaining([
+        // owner team members get manager
+        { user: "team:platform#member", relation: "manager", object: "agent:agent-test" },
         { user: "team:sre#member", relation: "user", object: "agent:agent-test" },
         { user: "team:ops#member", relation: "user", object: "agent:agent-test" },
       ]),

--- a/ui/src/lib/rbac/__tests__/openfga.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga.test.ts
@@ -312,7 +312,7 @@ describe("OpenFGA team resource tuple reconciliation", () => {
         type: "team",
         relation: "admin",
       });
-      expect(directlyRelatedUserTypes(modelPath, "agent", "manager")).not.toContainEqual({
+      expect(directlyRelatedUserTypes(modelPath, "agent", "manager")).toContainEqual({
         type: "team",
         relation: "member",
       });

--- a/ui/src/lib/rbac/__tests__/openfga.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga.test.ts
@@ -774,6 +774,8 @@ describe("OpenFGA team resource tuple reconciliation", () => {
       { user: "organization:default#admin", relation: "manager", object: "agent:agent-platform-helper" },
       { user: "team:platform#member", relation: "user", object: "agent:agent-platform-helper" },
       { user: "team:platform#admin", relation: "manager", object: "agent:agent-platform-helper" },
+      // owner team members get full management access
+      { user: "team:platform#member", relation: "manager", object: "agent:agent-platform-helper" },
       { user: "agent:agent-platform-helper", relation: "caller", object: "tool:jira/search" },
     ]);
     expect(diff.deletes).toEqual([

--- a/ui/src/lib/rbac/openfga-agent-tools.ts
+++ b/ui/src/lib/rbac/openfga-agent-tools.ts
@@ -159,11 +159,10 @@ export function buildAgentRelationshipTupleDiff(input: AgentToolTupleDiffInput):
     });
   }
   // Owner-team + shared-team grants are delegated to the shared
-  // `buildTeamGrantTuples` primitive (spec 2026-06-03, US1 / FR-003). Team
-  // members receive `user` (can_use / discover in the admin list). Config
-  // edits require owner, team admin (`manager`), or org admin — not member
-  // `writer`. The primitive handles the owner ∪ shared union, owner-team
-  // transition deletes, and shared-team revoke diffs.
+  // `buildTeamGrantTuples` primitive (spec 2026-06-03, US1 / FR-003). All
+  // team members receive `user` (can_use / discover). Owner team members
+  // additionally receive `manager` (full can_manage access per CAIPE policy);
+  // shared team members require team admin (`manager`) or org admin to edit.
   const agentObject = `agent:${input.agentId}`;
   const teamGrants = buildTeamGrantTuples({
     object: agentObject,
@@ -175,6 +174,20 @@ export function buildAgentRelationshipTupleDiff(input: AgentToolTupleDiffInput):
   });
   writes.push(...teamGrants.writes);
   deletes.push(...teamGrants.deletes);
+
+  // Owner team members get full management access (can_manage). Write for
+  // the current owner team; delete for the previous owner when it changes
+  // so ownership transfers don't leave a stale manager grant on the old team.
+  if (input.ownerTeamSlug && isValidOpenFgaId(input.ownerTeamSlug)) {
+    writes.push({ user: `team:${input.ownerTeamSlug}#member`, relation: "manager", object: agentObject });
+  }
+  if (
+    input.previousOwnerTeamSlug &&
+    isValidOpenFgaId(input.previousOwnerTeamSlug) &&
+    input.previousOwnerTeamSlug !== input.ownerTeamSlug
+  ) {
+    deletes.push({ user: `team:${input.previousOwnerTeamSlug}#member`, relation: "manager", object: agentObject });
+  }
 
   // Drop legacy member `writer` grants from older reconciles so team members
   // cannot mutate agent config (color, prompt, tools) without manage rights.


### PR DESCRIPTION
_[GAI]_

## Context

Two related fixes to dynamic agent permissions and the editor UI:

**1. Owner team members now get full `can_manage` access on agents**

Previously, members of an agent's owning team only received the `user` relation (`can_use`), with `manager` (and thus `can_write`/`can_manage`) restricted to team admins only. Per CAIPE policy, all members of the owning team should have full management access to agents their team owns.

- Adds `team:<ownerSlug>#member → manager → agent:<id>` tuple alongside the existing `user` grant for the owner team
- On owner team change, revokes the old owner team's `#member manager` grant to prevent stale access
- Shared teams (non-owner) are unchanged: members keep `user` only

> **Note for existing agents**: the new tuple is written on next save. Agents that haven't been re-saved since this deploy will not automatically get the grant.

**2. Correct read-only message when user lacks edit permission**

The agent editor always showed "This agent is managed by configuration and cannot be edited" whenever `readOnly` was true — even when the real reason was insufficient permissions. This was misleading.

- Adds `readOnlyReason?: 'config' | 'permissions'` prop to `DynamicAgentEditor`
- Shows "You do not have permission to edit this agent" when reason is `permissions`
- Preserves the config-managed message for config-driven agents

## Validation

- Unit tests updated and passing (`openfga-agent-tools-shared-teams.test.ts`, `openfga.test.ts`)
- `prebuild/` branch prefix triggers Docker image build for dev testing