### PR TITLE
feat(conversations): open Slack conversations to all thread participants

### DIFF
--- a/ui/src/app/api/v1/chat/__tests__/routes.test.ts
+++ b/ui/src/app/api/v1/chat/__tests__/routes.test.ts
@@ -156,6 +156,67 @@ describe("Dynamic Agent chat Web UI backend routes", () => {
     );
   });
 
+  it("bypasses the conversation#write check for Slack conversations so any thread participant can invoke", async () => {
+    // Slack threads are multi-participant. A non-owner (bob) must be able to
+    // invoke the agent within the thread. agent#can_use is still enforced first;
+    // the conversation#write ReBAC check is skipped for client_type === 'slack'.
+    mockAuthenticateRequest.mockResolvedValue({
+      subject: "bob-sub",
+      email: "bob@example.com",
+      tenantId: "default",
+      bearerToken: "token",
+    });
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn(async () => ({
+        _id: "conv-1",
+        owner_id: "alice@example.com",
+        owner_subject: "alice-sub",
+        client_type: "slack",
+      })),
+    });
+
+    const response = await startPost(
+      jsonRequest("/api/v1/chat/stream/start", {
+        message: "hi",
+        conversation_id: "conv-1",
+        agent_id: "agent-1",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRequireAgentUsePermission).toHaveBeenCalledTimes(1);
+    // The write check is short-circuited for Slack conversations.
+    expect(mockRequireConversationResourcePermission).not.toHaveBeenCalled();
+    expect(mockProxySSEStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("still enforces the conversation#write check for non-Slack conversations", async () => {
+    // Regression guard: the Slack bypass must not leak to webui conversations.
+    mockRequireConversationResourcePermission.mockRejectedValue(
+      Object.assign(new Error("denied"), { statusCode: 403, code: "conversation#write" }),
+    );
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn(async () => ({
+        _id: "conv-1",
+        owner_id: "alice@example.com",
+        owner_subject: "alice-sub",
+        client_type: "webui",
+      })),
+    });
+
+    const response = await startPost(
+      jsonRequest("/api/v1/chat/stream/start", {
+        message: "hi",
+        conversation_id: "conv-1",
+        agent_id: "agent-1",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockRequireConversationResourcePermission).toHaveBeenCalledTimes(1);
+    expect(mockProxySSEStream).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["start", startPost, "/api/v1/chat/stream/start", { message: "hi", conversation_id: "conv-1", agent_id: "agent-1" }],
     ["invoke", invokePost, "/api/v1/chat/invoke", { message: "hi", conversation_id: "conv-1", agent_id: "agent-1" }],

--- a/ui/src/app/api/v1/chat/_conversation-authz.ts
+++ b/ui/src/app/api/v1/chat/_conversation-authz.ts
@@ -23,6 +23,26 @@ export async function requireConversationWriteAccess(
     );
   }
 
+  // Slack threads are inherently multi-participant — anyone in the channel
+  // should be able to invoke the agent within a thread, not just the user who
+  // originally @mentioned the bot. Rather than granting wildcard writer tuples
+  // (which would also leak read access via the model's `can_read: ... or
+  // can_write` rule), we bypass the conversation#write check for Slack
+  // conversations here.
+  //
+  // Safe because:
+  //   - agent#can_use is enforced first and independently on every invoke/stream
+  //     route, so this grants no tool/data/agent access.
+  //   - `client_type` is read from the stored document, never the request body,
+  //     so a caller cannot spoof it; no update path lets it be flipped to 'slack'.
+  //   - Read endpoints (GET messages/turns/detail) still require `can_read`,
+  //     which this does not touch — thread history stays ReBAC-protected.
+  //   - Metadata mutation is separately gated (owner-only), so routing keys
+  //     cannot be injected via this path.
+  if (conversation.client_type === "slack") {
+    return null;
+  }
+
   try {
     await requireConversationResourcePermission(
       // Carry isServiceAccount so subjectFromSession graphs SA callers as


### PR DESCRIPTION
# Description

_[GAI]_

Slack threads are inherently multi-participant — anyone in the channel should be able to invoke the agent within a thread, not just the user who originally @mentioned the bot. Previously, a second participant in the same thread hit a `403 conversation#write` because they weren't the conversation owner.

**This is the successor to #2100**, using a simpler and safer approach. #2100 is being closed in favor of this branch (which also builds a prebuild image for direct dev testing).

## Change

Bypass the `conversation#write` check for `client_type === 'slack'` inside `requireConversationWriteAccess` — the single chokepoint for all v1 chat write paths (invoke, stream start/cancel/resume). One file, one guard clause.

## Why this over the `user:*` / `service_account:*` wildcard tuples (#2100)

| | Wildcard tuples (#2100) | This bypass |
|---|---|---|
| Leaks Slack thread history to any authed user | **Yes** — `can_read: … or can_write` makes `user:*` writer transitively grant read | **No** — only the write path is touched |
| OpenFGA model change | Yes (`user:*`, `service_account:*` on `writer`) | None |
| Tuple write on create + idempotency heal loop | Yes | None |
| Covers unlinked-user (SA fallback) callers | Needed a second wildcard | Covered automatically |

## Why it's safe

- **`agent#can_use` is enforced first and independently** on every invoke/stream route, so this grants no tool/data/agent access.
- **`client_type` can't be spoofed** — it's read from the stored Mongo document, never the request body, and no update path lets an existing conversation be flipped to `'slack'`.
- **Reads stay ReBAC-protected** — `GET` messages/turns/detail still require `can_read`.
- **Metadata mutation remains owner-only** (separately gated).

Residual risk is limited to appending a turn to a thread whose random UUID you already know *and* for which you hold `agent#can_use` — no confidentiality or privilege escalation.

## Type of Change

- [x] New Feature

## Checklist

- [x] All code style checks pass (`eslint` clean)
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass (`routes.test` 20/20, conversation-authz + metadata-auth suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)