### PR TITLE
fix(slack): don't show 'agent not assigned' on transient PDP failures

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -84,7 +84,7 @@ if RBAC_ENABLED:
     )
     from utils.slack_channel_auto_assign import get_slack_channel_auto_assigner
     from utils.obo_exchange import impersonate_user, impersonate_service_account, OboExchangeError
-    from utils.slack_rebac import get_slack_channel_rebac_evaluator
+    from utils.slack_rebac import get_slack_channel_rebac_evaluator, is_missing_channel_grant
     from utils.user_messages import TEAM_SESSION_UNAVAILABLE_MESSAGE
     from utils.service_account_resolver import get_unlinked_service_account_sub
     from utils.keycloak_admin import user_is_federated, realm_has_enabled_idp_broker
@@ -280,6 +280,30 @@ def _slack_agent_channel_grant_check(context, channel_id: str | None, agent_id: 
         obo_token=obo_token if isinstance(obo_token, str) else None,
     )
     if decision.channel_allowed:
+        return None
+
+    # `channel_allowed=False` covers two very different situations that must NOT
+    # look the same to the user:
+    #   - missing_channel_grant → the agent genuinely isn't assigned here.
+    #   - pdp_unavailable        → we couldn't reach/parse the PDP (timeout, 5xx
+    #                              from the BFF, OpenFGA blip, or no OBO token).
+    # Only the first is an admin-actionable misconfiguration. Surfacing the
+    # "not assigned — ask an admin" message on a transient PDP failure sends
+    # users to chase a config problem that doesn't exist (observed twice in
+    # dev when the grant was in fact present).
+    #
+    # On a transient failure we FAIL OPEN for this channel-grant pre-check: the
+    # request proceeds and the API's independent gates still apply downstream
+    # (`agent#can_use` when the conversation is created, plus `conversation#write`),
+    # so no authorization is actually bypassed — we just avoid a misleading deny.
+    if not is_missing_channel_grant(decision):
+        logger.warning(
+            "Slack channel grant check unavailable channel={} agent={} reason={} — "
+            "failing open (downstream API gates still apply)",
+            channel_id,
+            agent_id,
+            decision.reason,
+        )
         return None
 
     logger.info(

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ai_platform_engineering.integrations.slack_bot.utils.slack_rebac import (
     SlackChannelRebacDecision,
     SlackChannelRebacEvaluator,
+    is_missing_channel_grant,
 )
 
 
@@ -82,3 +83,68 @@ def test_channel_grant_check_allows_when_channel_grant_exists() -> None:
 
     assert decision.channel_allowed is True
     assert decision.reason == "allowed"
+
+
+def test_channel_grant_check_without_obo_token_returns_pdp_unavailable() -> None:
+    """No OBO token must yield a clean pdp_unavailable decision, not a crash.
+
+    Regression: the no-token branch constructed SlackChannelRebacDecision with a
+    ``user_allowed`` kwarg the dataclass does not define, raising TypeError and
+    taking down the whole mention handler when the OBO exchange had failed.
+    """
+    evaluator = SlackChannelRebacEvaluator(base_url="http://caipe-ui")
+
+    decision = evaluator.check_channel_grant(
+        workspace_id="T123456789",
+        channel_id="C123456789",
+        agent_id="incident-agent",
+        obo_token=None,
+    )
+
+    assert decision.allowed is False
+    assert decision.channel_allowed is False
+    # Transient/unknown — NOT missing_channel_grant, so callers won't render the
+    # misleading "not assigned — ask an admin" message.
+    assert decision.reason == "pdp_unavailable"
+
+
+def test_channel_grant_check_without_base_url_returns_pdp_unavailable() -> None:
+    """No configured base URL must yield pdp_unavailable, not a crash.
+
+    Regression for the same removed ``user_allowed`` kwarg on the no-base-url path.
+    """
+    evaluator = SlackChannelRebacEvaluator(base_url="")
+
+    decision = evaluator.check_channel_grant(
+        workspace_id="T123456789",
+        channel_id="C123456789",
+        agent_id="incident-agent",
+        obo_token="obo-token",
+    )
+
+    assert decision.allowed is False
+    assert decision.channel_allowed is False
+    assert decision.reason == "pdp_unavailable"
+
+
+def test_is_missing_channel_grant_only_true_for_genuine_grant_miss() -> None:
+    """Only a channel_allowed=False + missing_channel_grant decision is admin-actionable.
+
+    This is the guard that stops transient PDP failures from being rendered as
+    the "agent not assigned to this channel — ask an admin" message.
+    """
+    genuine_miss = SlackChannelRebacDecision(
+        allowed=False, channel_allowed=False, reason="missing_channel_grant"
+    )
+    assert is_missing_channel_grant(genuine_miss) is True
+
+    # Transient / non-actionable denials must NOT be treated as a grant miss.
+    for reason in ("pdp_unavailable", "unsupported_action"):
+        transient = SlackChannelRebacDecision(
+            allowed=False, channel_allowed=False, reason=reason  # type: ignore[arg-type]
+        )
+        assert is_missing_channel_grant(transient) is False, reason
+
+    # An allowed decision is never a grant miss.
+    allowed = SlackChannelRebacDecision(allowed=True, channel_allowed=True, reason="allowed")
+    assert is_missing_channel_grant(allowed) is False

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_rebac.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_rebac.py
@@ -44,6 +44,25 @@ class SlackChannelRebacDecision:
 PostCheck = Callable[[str, dict[str, object], str], SlackChannelRebacDecision]
 
 
+def is_missing_channel_grant(decision: SlackChannelRebacDecision) -> bool:
+    """Return True only when the channel genuinely lacks the agent grant.
+
+    A denied decision (``channel_allowed=False``) can mean either:
+      - ``missing_channel_grant`` — an admin-actionable misconfiguration; the
+        agent really isn't assigned to this channel.
+      - anything else (``pdp_unavailable``, ``unsupported_action``) — a transient
+        or non-actionable condition where we could not obtain a real grant answer.
+
+    Callers use this to decide whether to surface the "not assigned — ask an
+    admin" message. On a non-actionable denial they should fail open for this
+    pre-check: the API's independent gates (``agent#can_use`` at conversation
+    creation and ``conversation#write``) still apply downstream, so nothing is
+    actually bypassed — we just avoid telling users to chase a config problem
+    that may not exist.
+    """
+    return not decision.channel_allowed and decision.reason == "missing_channel_grant"
+
+
 def _default_base_url() -> str:
     return (
         os.environ.get("SLACK_REBAC_API_URL")
@@ -103,7 +122,6 @@ class SlackChannelRebacEvaluator:
             return SlackChannelRebacDecision(
                 allowed=False,
                 channel_allowed=False,
-                user_allowed=False,
                 reason="pdp_unavailable",
             )
         return _http_post_check(self.base_url, path, payload, token)
@@ -130,7 +148,6 @@ class SlackChannelRebacEvaluator:
             return SlackChannelRebacDecision(
                 allowed=False,
                 channel_allowed=False,
-                user_allowed=False,
                 reason="pdp_unavailable",
             )
 


### PR DESCRIPTION
# Description

The Slack channel-grant pre-check surfaced the message **"Agent *X* is not assigned to this channel — ask an admin to add it in the Admin panel"** whenever the ReBAC decision came back not-allowed, discarding the decision's `reason`. A denied decision actually covers two very different cases:

| `reason` | Meaning | Correct UX |
|---|---|---|
| `missing_channel_grant` | Agent genuinely isn't assigned | "Not assigned — ask an admin" ✅ |
| `pdp_unavailable` | **Transient**: BFF timeout/5xx, OpenFGA blip, or a missing OBO token | Should NOT blame config ❌ |

Collapsing both into the "not assigned" message sent users to chase a misconfiguration that didn't exist — observed intermittently in a live channel where the agent grant was in fact present.

### Changes

- **Distinguish transient failures from genuine grant misses.** Add an `is_missing_channel_grant()` helper so the caller only shows the admin-actionable message for a real grant miss. On any other denial the channel-grant pre-check **fails open** — the API's independent gates (`agent#can_use` at conversation creation, plus `conversation#write`) still apply downstream, so no authorization is bypassed; we just avoid a misleading deny.
- **Fix a latent crash.** Two `SlackChannelRebacDecision` constructors (the no-OBO-token and no-base-url paths) passed an invalid `user_allowed=` kwarg the dataclass doesn't define. Those paths raised `TypeError` and took down the mention handler instead of returning a clean `pdp_unavailable` decision. The no-OBO-token path is reachable in production when the token exchange fails.
- **Tests.** Added regression coverage for the no-OBO-token / no-base-url paths and for `is_missing_channel_grant` reason handling.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass