### PR TITLE
feat(ui): bulk UI/UX fixes and improvements

### DIFF
--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1607,8 +1607,8 @@ function AdminPage() {
                         <CardHeader>
                           <div className="flex items-center justify-between">
                             <div>
-                              <div className="flex items-center gap-2">
-                                <CardTitle className="text-lg">{team.name}</CardTitle>
+                              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                <CardTitle className="text-lg min-w-0 break-words">{team.name}</CardTitle>
                                 {(team.idp_source_types?.length ?? 0) > 0 && (
                                   <IdpSyncedBadge sourceTypes={team.idp_source_types!} />
                                 )}

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -355,7 +355,7 @@ function IdpSyncedBadge({ sourceTypes }: { sourceTypes: string[] }) {
         return (
           <span
             key={t}
-            className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 border border-border"
+            className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 border border-border whitespace-nowrap"
             title={title}
             aria-label={title}
           >

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -58,7 +58,7 @@ import { getConfig } from "@/lib/config";
 import { cn } from "@/lib/utils";
 import type { SkillMetricsAdmin } from "@/types/agent-skill";
 import type { Team as TeamType } from "@/types/teams";
-import { Activity,Bot,CheckCircle2,ChevronLeft,ChevronRight,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,HelpCircle,Layers,ListChecks,Loader2,MessageSquare,RefreshCw,Search,Settings,Share2,Shield,ShieldCheck,ThumbsDown,ThumbsUp,Trash2,TrendingUp,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
+import { Activity,Archive,Bot,CheckCircle2,ChevronLeft,ChevronRight,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,HelpCircle,Layers,ListChecks,Loader2,MessageSquare,RefreshCw,Search,Settings,Share2,Shield,ShieldCheck,ThumbsDown,ThumbsUp,Trash2,TrendingUp,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { usePathname,useRouter,useSearchParams } from "next/navigation";
 import React,{ useCallback,useEffect,useMemo,useRef,useState } from "react";
@@ -163,6 +163,10 @@ interface Team {
   description?: string;
   owner_id: string;
   created_at: Date;
+  // Lifecycle status. "archived" teams (Okta group vanished, or admin-retired)
+  // are hidden by default and rendered with a dimmed card + ArchivedBadge; they
+  // grant no access (their resource-grant tuples are stripped on archive).
+  status?: string;
   // Commit 5/8 of the canonical-team-membership refactor (spec
   // 2026-05-26-canonical-team-membership): `member_count` is now the
   // authoritative source for the Members badge, aggregated server-side
@@ -373,6 +377,27 @@ function IdpSyncedBadge({ sourceTypes }: { sourceTypes: string[] }) {
   );
 }
 
+// Shown on a team card when the team is archived — an identity-sync team whose
+// Okta group vanished, or a team an admin retired. Archived teams grant no
+// access (their resource tuples are stripped on archive), so the pill flags
+// that the card is inert. Styled to match IdpSyncedBadge but in a muted-warning
+// tone so it reads as a state, not an IdP source.
+function ArchivedBadge() {
+  const title = "Archived — grants no access";
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 border border-amber-500/30 whitespace-nowrap"
+      title={title}
+      aria-label={title}
+    >
+      <Archive className="h-3 w-3 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+      <span className="text-[10px] font-medium text-amber-700 dark:text-amber-300">
+        Archived
+      </span>
+    </span>
+  );
+}
+
 function isValidTab(tab: string | null): tab is typeof VALID_TABS[number] {
   return Boolean(tab && (VALID_TABS as readonly string[]).includes(tab));
 }
@@ -498,6 +523,9 @@ function AdminPage() {
   const [gridPage, setGridPage] = useState(1);
   const [gridLoading, setGridLoading] = useState(false);
   const [gridLoaded, setGridLoaded] = useState(false);
+  // Archived teams are hidden by default; this toggles the `include_archived`
+  // query param so admins can reveal retired / orphaned-from-Okta teams.
+  const [showArchivedTeams, setShowArchivedTeams] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedUserEmail, setSelectedUserEmail] = useState<string | null>(null);
@@ -868,6 +896,7 @@ function AdminPage() {
         fresh: String(Date.now()),
       });
       if (search.trim()) params.set('search', search.trim());
+      if (showArchivedTeams) params.set('include_archived', 'true');
       const response = await fetch(`/api/admin/teams?${params.toString()}`, {
         cache: 'no-store',
       });
@@ -884,7 +913,7 @@ function AdminPage() {
     } finally {
       setGridLoading(false);
     }
-  }, []);
+  }, [showArchivedTeams]);
 
   // Debounced server-side search for the Teams grid. Typing resets to page 1
   // and re-queries the server (~250ms after the last keystroke), matching the
@@ -1545,7 +1574,19 @@ function AdminPage() {
                       </button>
                     )}
                   </div>
-                  <div className="flex justify-end gap-2">
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    <label
+                      className="flex cursor-pointer select-none items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+                      title="Archived teams (retired, or whose Okta group was removed) grant no access"
+                    >
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-input accent-primary"
+                        checked={showArchivedTeams}
+                        onChange={(event) => setShowArchivedTeams(event.target.checked)}
+                      />
+                      Show archived
+                    </label>
                     <Button
                       type="button"
                       variant="outline"
@@ -1603,12 +1644,13 @@ function AdminPage() {
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                     {gridTeams.map((team) => {
                       return (
-                      <Card key={team._id}>
+                      <Card key={team._id} className={cn(team.status === 'archived' && "opacity-60")}>
                         <CardHeader>
                           <div className="flex items-center justify-between">
                             <div>
                               <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                                 <CardTitle className="text-lg min-w-0 break-words">{team.name}</CardTitle>
+                                {team.status === 'archived' && <ArchivedBadge />}
                                 {(team.idp_source_types?.length ?? 0) > 0 && (
                                   <IdpSyncedBadge sourceTypes={team.idp_source_types!} />
                                 )}

--- a/ui/src/app/api/admin/service-accounts/route.ts
+++ b/ui/src/app/api/admin/service-accounts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-config";
+import { getAuthFromBearerOrSession } from "@/lib/api-middleware";
 import {
   checkOpenFgaTuple,
   deleteExactOpenFgaTuples,
@@ -148,26 +149,37 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  // Read the caller's role so admins can see SAs for teams they don't belong to.
+  const { user: callerUser } = await getAuthFromBearerOrSession(request);
+  const isAdmin = callerUser.role === "admin";
+
   const searchParams = new URL(request.url).searchParams;
   const includeRevoked = searchParams.get("include_revoked") === "true";
   // Optional: narrow to a single owning team (e.g. the team that owns a Slack
-  // channel). Still bounded by the caller's memberships below, so this only
-  // ever filters within what the caller may already see.
+  // channel). Still bounded by the caller's memberships below (unless admin),
+  // so this only ever filters within what the caller may already see.
   const teamFilter = searchParams.get("team")?.trim() || null;
 
   try {
-    // Visibility boundary: the caller's own team memberships (FR-021).
-    const teamObjects = await listOpenFgaObjects({
-      user: `user:${session.sub}`,
-      relation: "member",
-      type: "team",
-    });
-    let owningTeamIds = teamObjects.objects.map(teamIdFromObject);
+    let owningTeamIds: string[];
 
-    if (teamFilter) {
-      // Intersect the requested team with the caller's memberships. If the
-      // caller isn't in that team, the result is empty (no cross-team leak).
-      owningTeamIds = owningTeamIds.filter((id) => id === teamFilter);
+    if (teamFilter && isAdmin) {
+      // Admins can see SAs for any team — no membership intersection needed.
+      owningTeamIds = [teamFilter];
+    } else {
+      // Visibility boundary: the caller's own team memberships (FR-021).
+      const teamObjects = await listOpenFgaObjects({
+        user: `user:${session.sub}`,
+        relation: "member",
+        type: "team",
+      });
+      owningTeamIds = teamObjects.objects.map(teamIdFromObject);
+
+      if (teamFilter) {
+        // Intersect the requested team with the caller's memberships. If the
+        // caller isn't in that team, the result is empty (no cross-team leak).
+        owningTeamIds = owningTeamIds.filter((id) => id === teamFilter);
+      }
     }
 
     if (owningTeamIds.length === 0) {

--- a/ui/src/app/api/admin/teams/route.ts
+++ b/ui/src/app/api/admin/teams/route.ts
@@ -114,10 +114,18 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const pageSizeRaw = parseInt(url.searchParams.get('page_size') || '24', 10) || 24;
   const pageSize = Math.min(100, Math.max(1, pageSizeRaw));
   const search = (url.searchParams.get('search') || '').trim();
+  // Archived teams (identity-sync teams whose Okta group vanished, or teams an
+  // admin retired) are hidden by default so the grid only shows live teams.
+  // The admin UI opts back in via `?include_archived=true` behind a checkbox.
+  const includeArchived = url.searchParams.get('include_archived') === 'true';
 
   // Build the Mongo query honoring per-row access control + search so the
   // skip/limit and the aggregations only ever touch matching rows.
   const andClauses: Record<string, unknown>[] = [];
+  if (!includeArchived) {
+    // Treat a missing `status` as active — legacy team docs predate the field.
+    andClauses.push({ status: { $ne: 'archived' } });
+  }
   if (!hasAdminView) {
     const allowedSlugs = Array.from(memberSlugs);
     if (allowedSlugs.length === 0) {

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -358,6 +358,7 @@ async function validateSubagentVisibility(
  *
  * Query params:
  * - enabled_only=true: Only return enabled agents (useful for subagent selection)
+ * - search=<string>: Filter agents by name or description (case-insensitive)
  */
 export const GET = withErrorHandler(async (request: NextRequest) => {
   const { session } = await getAuthFromBearerOrSession(request);
@@ -367,10 +368,24 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const { page, pageSize, skip } = getPaginationParams(request);
     const { searchParams } = new URL(request.url);
     const enabledOnly = searchParams.get("enabled_only") === "true";
+    const search = searchParams.get("search")?.trim() || "";
 
     const query: Record<string, unknown> = enabledOnly
       ? { $or: [{ enabled: true }, { enabled: { $exists: false } }] }
       : {};
+
+    if (search) {
+      const regex = { $regex: search, $options: "i" };
+      const orClauses: Record<string, unknown>[] = [{ name: regex }, { description: regex }];
+      if (ObjectId.isValid(search)) orClauses.push({ _id: new ObjectId(search) });
+      const searchClause = { $or: orClauses };
+      if (query.$or) {
+        query.$and = [{ $or: query.$or }, searchClause];
+        delete query.$or;
+      } else {
+        Object.assign(query, searchClause);
+      }
+    }
 
     const allItems = await collection.find(query).sort({ created_at: -1 }).toArray();
 

--- a/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
+++ b/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
@@ -250,11 +250,11 @@ export function UnlinkedServiceAccountModal({
                         return (
                           <li
                             key={`${scope.type}:${scope.ref}`}
-                            className="flex items-center justify-between gap-2 rounded-md border border-input px-2.5 py-1.5"
+                            className="flex min-w-0 items-center justify-between gap-2 rounded-md border border-input px-2.5 py-1.5"
                           >
-                            <span className="inline-flex items-center gap-1.5 text-sm">
-                              <Bot className="h-3.5 w-3.5 text-muted-foreground" />
-                              <code className="text-xs" data-testid={`scope-${scope.type}-${scope.ref}`}>
+                            <span className="inline-flex min-w-0 items-center gap-1.5 text-sm">
+                              <Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                              <code className="truncate text-xs" data-testid={`scope-${scope.type}-${scope.ref}`}>
                                 {scope.type}/{scope.ref}
                               </code>
                             </span>

--- a/ui/src/components/admin/platform/PrometheusCharts.tsx
+++ b/ui/src/components/admin/platform/PrometheusCharts.tsx
@@ -8,7 +8,7 @@ usePrometheusQuery
 } from "@/hooks/use-prometheus";
 import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
-import React,{ useMemo } from "react";
+import React,{ useCallback, useMemo } from "react";
 import {
 Area,
 AreaChart,
@@ -168,8 +168,8 @@ export function TimeseriesChart({
     refreshInterval,
   });
 
-  const { chartData, series } = useMemo(() => {
-    if (!data || data.length === 0) return { chartData: [], series: [] as string[] };
+  const { chartData, series, legendSeries, hiddenCount } = useMemo(() => {
+    if (!data || data.length === 0) return { chartData: [], series: [] as string[], legendSeries: [] as string[], hiddenCount: 0 };
 
     const seriesNames = new Set<string>();
     const timeMap = new Map<number, Record<string, number>>();
@@ -199,10 +199,90 @@ export function TimeseriesChart({
         ...vals,
       }));
 
-    return { chartData: sorted, series: Array.from(seriesNames) };
+    const allSeries = Array.from(seriesNames);
+
+    // Rank series by max value so we show the most active ones in the legend
+    const maxBySeries = allSeries.map((name) => ({
+      name,
+      max: Math.max(...sorted.map((row) => (row as Record<string, number>)[name] ?? 0)),
+    }));
+    maxBySeries.sort((a, b) => b.max - a.max);
+
+    const TOP_N = 5;
+    const legendSeries = maxBySeries.slice(0, TOP_N).map((s) => s.name);
+    const hiddenCount = Math.max(0, allSeries.length - TOP_N);
+
+    return { chartData: sorted, series: allSeries, legendSeries, hiddenCount };
   }, [data, labelKey, formatTime]);
 
   const ChartComponent = type === "area" ? AreaChart : LineChart;
+
+  // Map each series name to its stable color index (by position in full series array)
+  const seriesColorIndex = useMemo(
+    () => Object.fromEntries(series.map((name, i) => [name, i])),
+    [series],
+  );
+
+  const renderLegend = useCallback(() => (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 px-1 text-xs text-muted-foreground">
+      {legendSeries.map((name) => (
+        <span key={name} className="flex items-center gap-1.5 min-w-0">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: CHART_COLORS[seriesColorIndex[name] % CHART_COLORS.length] }}
+          />
+          <span className="truncate max-w-[160px]" title={name}>{name}</span>
+        </span>
+      ))}
+      {hiddenCount > 0 && (
+        <span className="italic opacity-60">+{hiddenCount} more (hover to explore)</span>
+      )}
+    </div>
+  ), [legendSeries, hiddenCount, seriesColorIndex]);
+
+  const renderTooltip = useCallback(
+    ({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string }>; label?: string }) => {
+      if (!active || !payload || payload.length === 0) return null;
+      const sorted = [...payload].sort((a, b) => b.value - a.value);
+      const TOP_TOOLTIP = 3;
+      const visible = sorted.slice(0, TOP_TOOLTIP);
+      const tooltipHidden = Math.max(0, sorted.length - TOP_TOOLTIP);
+      return (
+        <div
+          style={{
+            backgroundColor: "hsl(var(--card))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: "8px",
+            fontSize: "12px",
+            padding: "8px 12px",
+            minWidth: "160px",
+          }}
+        >
+          <p className="font-medium mb-1.5 text-foreground">{label}</p>
+          {visible.map((entry) => (
+            <div key={entry.name} className="flex items-center justify-between gap-4 py-0.5">
+              <span className="flex items-center gap-1.5 min-w-0">
+                <span
+                  className="inline-block w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="truncate max-w-[140px] text-muted-foreground" title={entry.name}>
+                  {entry.name}
+                </span>
+              </span>
+              <span className="font-medium tabular-nums text-foreground shrink-0">
+                {formatValue(entry.value)}
+              </span>
+            </div>
+          ))}
+          {tooltipHidden > 0 && (
+            <p className="mt-1 text-muted-foreground opacity-60 italic">+{tooltipHidden} more</p>
+          )}
+        </div>
+      );
+    },
+    [formatValue],
+  );
 
   return (
     <Card>
@@ -228,54 +308,48 @@ export function TimeseriesChart({
             No data available
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height={height}>
-            <ChartComponent data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
-              <XAxis
-                dataKey="timeLabel"
-                tick={{ fontSize: 11 }}
-                className="text-muted-foreground"
-                interval="preserveStartEnd"
-              />
-              <YAxis
-                tick={{ fontSize: 11 }}
-                className="text-muted-foreground"
-                tickFormatter={formatValue}
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "hsl(var(--card))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: "8px",
-                  fontSize: "12px",
-                }}
-                formatter={(val) => [formatValue(Number(val)), ""]}
-              />
-              <Legend />
-              {series.map((name, i) =>
-                type === "area" ? (
-                  <Area
-                    key={name}
-                    type="monotone"
-                    dataKey={name}
-                    stroke={CHART_COLORS[i % CHART_COLORS.length]}
-                    fill={CHART_COLORS[i % CHART_COLORS.length]}
-                    fillOpacity={0.15}
-                    strokeWidth={2}
-                  />
-                ) : (
-                  <Line
-                    key={name}
-                    type="monotone"
-                    dataKey={name}
-                    stroke={CHART_COLORS[i % CHART_COLORS.length]}
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                ),
-              )}
-            </ChartComponent>
-          </ResponsiveContainer>
+          <>
+            <ResponsiveContainer width="100%" height={height}>
+              <ChartComponent data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+                <XAxis
+                  dataKey="timeLabel"
+                  tick={{ fontSize: 11 }}
+                  className="text-muted-foreground"
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tick={{ fontSize: 11 }}
+                  className="text-muted-foreground"
+                  tickFormatter={formatValue}
+                />
+                <Tooltip content={renderTooltip as React.ComponentType} />
+                {series.map((name, i) =>
+                  type === "area" ? (
+                    <Area
+                      key={name}
+                      type="monotone"
+                      dataKey={name}
+                      stroke={CHART_COLORS[i % CHART_COLORS.length]}
+                      fill={CHART_COLORS[i % CHART_COLORS.length]}
+                      fillOpacity={0.15}
+                      strokeWidth={2}
+                    />
+                  ) : (
+                    <Line
+                      key={name}
+                      type="monotone"
+                      dataKey={name}
+                      stroke={CHART_COLORS[i % CHART_COLORS.length]}
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  ),
+                )}
+              </ChartComponent>
+            </ResponsiveContainer>
+            {renderLegend()}
+          </>
         )}
       </CardContent>
     </Card>

--- a/ui/src/components/admin/platform/PrometheusCharts.tsx
+++ b/ui/src/components/admin/platform/PrometheusCharts.tsx
@@ -323,7 +323,8 @@ export function TimeseriesChart({
                   className="text-muted-foreground"
                   tickFormatter={formatValue}
                 />
-                <Tooltip content={renderTooltip as React.ComponentType} />
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                <Tooltip content={renderTooltip as any} />
                 {series.map((name, i) =>
                   type === "area" ? (
                     <Area

--- a/ui/src/components/admin/platform/PrometheusCharts.tsx
+++ b/ui/src/components/admin/platform/PrometheusCharts.tsx
@@ -204,7 +204,7 @@ export function TimeseriesChart({
     // Rank series by max value so we show the most active ones in the legend
     const maxBySeries = allSeries.map((name) => ({
       name,
-      max: Math.max(...sorted.map((row) => (row as Record<string, number>)[name] ?? 0)),
+      max: Math.max(...sorted.map((row) => (row as Record<string, unknown>)[name] as number ?? 0)),
     }));
     maxBySeries.sort((a, b) => b.max - a.max);
 

--- a/ui/src/components/admin/rebac/ConnectorOnboardingWizard.tsx
+++ b/ui/src/components/admin/rebac/ConnectorOnboardingWizard.tsx
@@ -230,7 +230,7 @@ export function ConnectorOnboardingWizard({
     serverSideSearch || !normalizedSearch
       ? rows
       : rows.filter((row) =>
-          `${row.name} ${row.secondary}`
+          `${row.name} ${row.id ?? ""} ${row.secondary}`
             .toLowerCase()
             .includes(normalizedSearch),
         );

--- a/ui/src/components/admin/rebac/slack/ServiceAccountSelect.tsx
+++ b/ui/src/components/admin/rebac/slack/ServiceAccountSelect.tsx
@@ -36,6 +36,7 @@ export function ServiceAccountSelect({
   value,
   onChange,
   teamSlug,
+  displayName,
   disabled,
   error,
   id = "route-exec-sa",
@@ -47,6 +48,8 @@ export function ServiceAccountSelect({
   onChange: (sub: string, name: string) => void;
   /** Owning team to scope the list to. When absent, no SAs are shown. */
   teamSlug?: string;
+  /** Fallback display name when the SA list is empty but a value is already set (e.g. caller lacks team membership). */
+  displayName?: string;
   disabled?: boolean;
   error?: string;
   id?: string;
@@ -117,6 +120,10 @@ export function ServiceAccountSelect({
     () => serviceAccounts.find((sa) => sa.sa_sub === value),
     [serviceAccounts, value],
   );
+  // When the caller lacks team membership the SA list is empty but a value may
+  // already be saved on the route. Fall back to displayName so the picker shows
+  // the current SA name rather than the "no SAs found" empty state.
+  const resolvedDisplayName = selected?.name ?? (value ? displayName : undefined);
 
   const filtered = React.useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -140,7 +147,7 @@ export function ServiceAccountSelect({
             Retry
           </button>
         </div>
-      ) : serviceAccounts.length === 0 ? (
+      ) : serviceAccounts.length === 0 && !value ? (
         <p className="text-xs text-muted-foreground">
           {!teamSlug
             ? "No team assigned to this channel — assign a team first."
@@ -162,8 +169,8 @@ export function ServiceAccountSelect({
               )}
             >
               <span className="min-w-0 flex-1 truncate">
-                {selected ? (
-                  selected.name
+                {resolvedDisplayName ? (
+                  resolvedDisplayName
                 ) : (
                   <span className="text-muted-foreground">Select service account...</span>
                 )}

--- a/ui/src/components/admin/rebac/slack/ServiceAccountSelect.tsx
+++ b/ui/src/components/admin/rebac/slack/ServiceAccountSelect.tsx
@@ -123,7 +123,7 @@ export function ServiceAccountSelect({
   // When the caller lacks team membership the SA list is empty but a value may
   // already be saved on the route. Fall back to displayName so the picker shows
   // the current SA name rather than the "no SAs found" empty state.
-  const resolvedDisplayName = selected?.name ?? (value ? displayName : undefined);
+  const resolvedDisplayName = selected?.name ?? ((value || displayName) ? displayName : undefined);
 
   const filtered = React.useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -147,7 +147,7 @@ export function ServiceAccountSelect({
             Retry
           </button>
         </div>
-      ) : serviceAccounts.length === 0 && !value ? (
+      ) : serviceAccounts.length === 0 && !value && !displayName ? (
         <p className="text-xs text-muted-foreground">
           {!teamSlug
             ? "No team assigned to this channel — assign a team first."

--- a/ui/src/components/admin/rebac/slack/SlackConfiguredChannelDetail.tsx
+++ b/ui/src/components/admin/rebac/slack/SlackConfiguredChannelDetail.tsx
@@ -256,6 +256,7 @@ function EscalationEditor({ enabled, onToggleEnabled, escalation, onChange, disa
 function ExecutionIdentitySelector({
   mode,
   serviceAccountSub,
+  serviceAccountName,
   onModeChange,
   onServiceAccountChange,
   teamSlug,
@@ -264,6 +265,7 @@ function ExecutionIdentitySelector({
 }: {
   mode: SlackRouteExecutionMode;
   serviceAccountSub: string;
+  serviceAccountName: string;
   onModeChange: (mode: SlackRouteExecutionMode) => void;
   onServiceAccountChange: (sub: string, name: string) => void;
   teamSlug?: string;
@@ -317,6 +319,7 @@ function ExecutionIdentitySelector({
               value={serviceAccountSub}
               onChange={onServiceAccountChange}
               teamSlug={teamSlug}
+              displayName={serviceAccountName}
               disabled={disabled}
               error={error}
             />
@@ -442,6 +445,7 @@ function SlackRouteEditorDialog({
               <ExecutionIdentitySelector
                 mode={routeDraft.executionMode}
                 serviceAccountSub={routeDraft.executionServiceAccountSub}
+                serviceAccountName={routeDraft.executionServiceAccountName}
                 onModeChange={(mode) =>
                   setRouteDraft((prev) => ({
                     ...prev,

--- a/ui/src/components/credentials/ProviderConnections.tsx
+++ b/ui/src/components/credentials/ProviderConnections.tsx
@@ -902,6 +902,7 @@ function summarizeProfile(profile: Record<string, unknown> | undefined): string 
 
 function needsAutoRefresh(connection: ProviderConnection): boolean {
   if (connection.status !== "connected" || !connection.expiresAt) return false;
+  if (connection.renewable === false) return false;
   const expiresAt = new Date(connection.expiresAt).getTime();
   if (Number.isNaN(expiresAt)) return false;
   return expiresAt <= Date.now() + 15 * 60 * 1000;

--- a/ui/src/components/dynamic-agents/DynamicAgentsTab.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentsTab.tsx
@@ -11,6 +11,8 @@ import type { DynamicAgentConfigWithPermissions } from "@/types/dynamic-agent";
 import {
 Bot,
 AlertCircle,
+ChevronLeft,
+ChevronRight,
 CopyPlus,
 Download,
 Globe,
@@ -18,12 +20,14 @@ Loader2,
 Lock,
 Plus,
 RefreshCw,
+Search,
 ToggleLeft,
 ToggleRight,
 Trash2,
 Users,
 } from "lucide-react";
 import React from "react";
+import { Input } from "@/components/ui/input";
 import { AgentAvatar } from "./AgentAvatar";
 import { DynamicAgentEditor } from "./DynamicAgentEditor";
 
@@ -56,12 +60,24 @@ export function DynamicAgentsTab() {
   const [pendingDeleteAgentId, setPendingDeleteAgentId] = React.useState<string | null>(null);
   const [deletingAgentId, setDeletingAgentId] = React.useState<string | null>(null);
   const [rowActionErrors, setRowActionErrors] = React.useState<Record<string, string>>({});
+  const [search, setSearch] = React.useState("");
+  const [searchInput, setSearchInput] = React.useState("");
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(20);
+  const [total, setTotal] = React.useState(0);
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   const fetchAgents = React.useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/dynamic-agents?page_size=100");
+      const params = new URLSearchParams({
+        page: page.toString(),
+        page_size: pageSize.toString(),
+      });
+      if (search.trim()) params.set("search", search.trim());
+      const response = await fetch(`/api/dynamic-agents?${params}`);
       const data = await response.json();
       if (data.success) {
         setAgents(
@@ -70,6 +86,7 @@ export function DynamicAgentsTab() {
             permissions: agent.permissions ?? DEFAULT_ROW_PERMISSIONS,
           })),
         );
+        setTotal(data.data.total ?? 0);
       } else {
         setError(data.error || "Failed to fetch agents");
       }
@@ -78,11 +95,22 @@ export function DynamicAgentsTab() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [page, pageSize, search]);
 
   React.useEffect(() => {
     fetchAgents();
   }, [fetchAgents]);
+
+  // Debounce search input
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchInput !== search) {
+        setSearch(searchInput);
+        setPage(1);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput, search]);
 
   const clearRowActionError = React.useCallback((agentId: string) => {
     setRowActionErrors((prev) => {
@@ -246,6 +274,15 @@ export function DynamicAgentsTab() {
             </CardDescription>
           </div>
           <div className="flex items-center gap-2">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search by name or ID..."
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                className="pl-9 h-9 w-48"
+              />
+            </div>
             <Button variant="outline" size="sm" onClick={fetchAgents} disabled={loading}>
               <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
               Refresh
@@ -272,14 +309,26 @@ export function DynamicAgentsTab() {
         ) : agents.length === 0 ? (
           <div className="text-center py-12">
             <Bot className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No agents yet</h3>
-            <p className="text-muted-foreground mb-4">
-              Create an agent when you are ready to give your team a tailored assistant.
-            </p>
-            <Button onClick={() => setIsCreating(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Create Agent
-            </Button>
+            {search ? (
+              <>
+                <h3 className="text-lg font-semibold mb-2">No agents match &quot;{search}&quot;</h3>
+                <p className="text-muted-foreground mb-4">Try a different search term.</p>
+                <Button variant="outline" onClick={() => { setSearchInput(""); setSearch(""); }}>
+                  Clear search
+                </Button>
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-semibold mb-2">No agents yet</h3>
+                <p className="text-muted-foreground mb-4">
+                  Create an agent when you are ready to give your team a tailored assistant.
+                </p>
+                <Button onClick={() => setIsCreating(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Create Agent
+                </Button>
+              </>
+            )}
           </div>
         ) : (
           <div className="space-y-3">
@@ -292,6 +341,15 @@ export function DynamicAgentsTab() {
               <div className="col-span-2">Status</div>
               <div className="col-span-2 text-right">Actions</div>
             </div>
+
+            {/* Result count */}
+            {total > 0 && (
+              <div className="text-xs text-muted-foreground px-2 pb-1">
+                {search
+                  ? `${total} result${total !== 1 ? "s" : ""} for "${search}"`
+                  : `${total} agent${total !== 1 ? "s" : ""}`}
+              </div>
+            )}
 
             {/* Agent rows */}
             {agents.map((agent) => {
@@ -475,6 +533,69 @@ export function DynamicAgentsTab() {
               </div>
             );
             })}
+
+            {/* Pagination */}
+            {total > pageSize && (
+              <div className="flex items-center justify-between pt-4 gap-4 border-t">
+                <span className="text-sm text-muted-foreground whitespace-nowrap">
+                  Showing {Math.min((page - 1) * pageSize + 1, total)}–{Math.min(page * pageSize, total)} of {total}
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  {Array.from({ length: totalPages }, (_, i) => i + 1)
+                    .filter((p) => p === 1 || p === totalPages || Math.abs(p - page) <= 1)
+                    .reduce<(number | "ellipsis")[]>((acc, p, idx, arr) => {
+                      if (idx > 0 && p - (arr[idx - 1] as number) > 1) acc.push("ellipsis");
+                      acc.push(p);
+                      return acc;
+                    }, [])
+                    .map((item, idx) =>
+                      item === "ellipsis" ? (
+                        <span key={`ellipsis-${idx}`} className="px-1 text-muted-foreground text-sm">...</span>
+                      ) : (
+                        <Button
+                          key={item}
+                          variant={page === item ? "default" : "outline"}
+                          size="sm"
+                          className="h-8 w-8 p-0"
+                          onClick={() => setPage(item)}
+                        >
+                          {item}
+                        </Button>
+                      )
+                    )}
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page === totalPages}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label className="text-sm text-muted-foreground whitespace-nowrap">Rows</label>
+                  <select
+                    value={pageSize}
+                    onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}
+                    className="h-8 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {[10, 20, 50, 100].map((size) => (
+                      <option key={size} value={size}>{size}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </CardContent>

--- a/ui/src/lib/credentials/oauth-service.ts
+++ b/ui/src/lib/credentials/oauth-service.ts
@@ -875,7 +875,11 @@ export class ProviderConnectionService {
       {
         $set: {
           status: "connected",
-          renewable: Boolean(token.refresh_token),
+          // Only update `renewable` when the provider returned a new refresh
+          // token. Providers that don't rotate their refresh token omit it from
+          // the response; overwriting with `false` here would incorrectly mark a
+          // still-renewable connection as non-auto-renew.
+          ...(token.refresh_token ? { renewable: true } : {}),
           expiresAt: token.expires_in ? new Date(this.now().getTime() + token.expires_in * 1000) : undefined,
           updatedAt: this.now(),
         },

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/sync-reconciler.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/sync-reconciler.test.ts
@@ -5,6 +5,7 @@ const teamsFind = jest.fn();
 const teamsInsertOne = jest.fn();
 const teamsDeleteOne = jest.fn();
 const teamsUpdateOne = jest.fn();
+const teamsUpdateMany = jest.fn();
 
 jest.mock("../../team-membership-source-store", () => ({
   upsertTeamMembershipSource: (...args: unknown[]) => upsertTeamMembershipSource(...args),
@@ -33,6 +34,7 @@ jest.mock("@/lib/mongodb", () => ({
         insertOne: (...args: unknown[]) => teamsInsertOne(...args),
         deleteOne: (...args: unknown[]) => teamsDeleteOne(...args),
         updateOne: (...args: unknown[]) => teamsUpdateOne(...args),
+        updateMany: (...args: unknown[]) => teamsUpdateMany(...args),
       };
     }
     return {};
@@ -53,6 +55,7 @@ describe("identity group sync apply reconciler", () => {
     teamsInsertOne.mockReset().mockResolvedValue({ insertedId: "created-team-id" });
     teamsDeleteOne.mockReset().mockResolvedValue({ deletedCount: 1 });
     teamsUpdateOne.mockReset().mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+    teamsUpdateMany.mockReset().mockResolvedValue({ matchedCount: 0, modifiedCount: 0 });
   });
 
   it("persists membership source changes and writes OpenFGA tuple diff", async () => {
@@ -92,6 +95,7 @@ describe("identity group sync apply reconciler", () => {
       tupleWrites: 1,
       tupleDeletes: 0,
       openFgaEnabled: true,
+      teamsArchived: 0,
     });
 
     expect(upsertTeamMembershipSource).toHaveBeenCalledTimes(1);
@@ -448,6 +452,77 @@ describe("identity group sync apply reconciler", () => {
         last_applied_at: "2026-05-12T01:00:00.000Z",
       }),
     );
+  });
+
+  it("archives identity_group_sync teams that become orphaned after membership removal", async () => {
+    teamsUpdateMany.mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 1 });
+    const { applyIdentityGroupSyncPlan } = await import("../../identity-group-sync-reconciler");
+
+    const result = await applyIdentityGroupSyncPlan({
+      plan: {
+        matched_groups: [],
+        ignored_groups: [],
+        teams_to_create: [],
+        membership_sources_to_add: [],
+        membership_sources_to_remove: [
+          {
+            team_id: "team-1",
+            team_slug: "old-okta-team",
+            user_subject: "alice-sub",
+            relationship: "member",
+            source_type: "okta",
+            managed: true,
+            status: "active",
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        tuple_writes: [],
+        tuple_deletes: [{ user: "user:alice-sub", relation: "member", object: "team:old-okta-team" }],
+        skipped_users: [],
+        conflicts: [],
+        safety_warnings: [
+          {
+            code: "orphaned_team_membership",
+            severity: "warning",
+            message: "Team old-okta-team would have no active managed identity-sync memberships.",
+            requires_acknowledgement: true,
+            team_slug: "old-okta-team",
+          },
+        ],
+      },
+      actor: "admin@example.test",
+      now: "2026-07-02T00:00:00.000Z",
+    });
+
+    expect(result.teamsArchived).toBe(1);
+    expect(teamsUpdateMany).toHaveBeenCalledWith(
+      { slug: { $in: ["old-okta-team"] }, source: "identity_group_sync", status: { $ne: "archived" } },
+      expect.objectContaining({ $set: expect.objectContaining({ status: "archived", updated_by: "admin@example.test" }) }),
+    );
+  });
+
+  it("does not archive teams when no orphaned_team_membership warnings present", async () => {
+    const { applyIdentityGroupSyncPlan } = await import("../../identity-group-sync-reconciler");
+
+    const result = await applyIdentityGroupSyncPlan({
+      plan: {
+        matched_groups: [],
+        ignored_groups: [],
+        teams_to_create: [],
+        membership_sources_to_add: [],
+        membership_sources_to_remove: [],
+        tuple_writes: [],
+        tuple_deletes: [],
+        skipped_users: [],
+        conflicts: [],
+        safety_warnings: [],
+      },
+      actor: "admin@example.test",
+      now: "2026-07-02T00:00:00.000Z",
+    });
+
+    expect(result.teamsArchived).toBe(0);
+    expect(teamsUpdateMany).not.toHaveBeenCalled();
   });
 
   it("logs and surfaces the original error when rollback itself fails", async () => {

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/sync-reconciler.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/sync-reconciler.test.ts
@@ -92,6 +92,7 @@ describe("identity group sync apply reconciler", () => {
       teamsCreated: 0,
       membershipSourcesAdded: 1,
       membershipSourcesRemoved: 0,
+      membershipSourcesRefreshed: 0,
       tupleWrites: 1,
       tupleDeletes: 0,
       openFgaEnabled: true,

--- a/ui/src/lib/rbac/__tests__/self-check.test.ts
+++ b/ui/src/lib/rbac/__tests__/self-check.test.ts
@@ -417,6 +417,7 @@ describe("deriveRbacSelfCheckReport", () => {
         { user: "organization:caipe#admin", relation: "manager", object: "agent:agent-private-project-agent" },
         { user: "team:current-team#member", relation: "user", object: "agent:agent-private-project-agent" },
         { user: "team:current-team#admin", relation: "manager", object: "agent:agent-private-project-agent" },
+        { user: "team:current-team#member", relation: "manager", object: "agent:agent-private-project-agent" },
         { user: "team:old-team#member", relation: "user", object: "agent:agent-private-project-agent" },
       ],
     }));
@@ -434,6 +435,37 @@ describe("deriveRbacSelfCheckReport", () => {
         }),
       ]),
     );
+  });
+
+  it("does not flag owner-team #member manager as unowned after an ownership transfer", () => {
+    // After transferring an agent from team A to team B, the reconciler writes
+    // team:team-b#member manager agent:<id> for the new owner. Before this fix
+    // the self-check did not expect that tuple and reported it as "Unowned tuple".
+    const report = deriveRbacSelfCheckReport(baseInput({
+      teams: [
+        { slug: "old-team", name: "Old Team" },
+        { slug: "new-owner-team", name: "New Owner Team" },
+      ],
+      dynamicAgents: [
+        {
+          _id: "agent-transferred",
+          name: "Transferred Agent",
+          visibility: "team",
+          owner_team_slug: "new-owner-team",
+        },
+      ],
+      actualTuples: [
+        { user: "organization:caipe#admin", relation: "manager", object: "agent:agent-transferred" },
+        { user: "team:new-owner-team#member", relation: "user", object: "agent:agent-transferred" },
+        { user: "team:new-owner-team#admin", relation: "manager", object: "agent:agent-transferred" },
+        // This is the owner-team #member manager tuple written by the agent reconciler.
+        { user: "team:new-owner-team#member", relation: "manager", object: "agent:agent-transferred" },
+      ],
+    }));
+
+    expect(report.summary.missing_tuples).toBe(0);
+    expect(report.summary.orphan_candidates).toBe(0);
+    expect(report.findings.filter((f) => f.severity === "orphan_candidate")).toHaveLength(0);
   });
 
   it("labels membership tuples for deleted teams as stale deleted-team memberships", () => {

--- a/ui/src/lib/rbac/__tests__/self-check.test.ts
+++ b/ui/src/lib/rbac/__tests__/self-check.test.ts
@@ -572,6 +572,64 @@ describe("deriveRbacSelfCheckReport", () => {
     expect(report.status).toBe("pass");
   });
 
+  it("flags lingering resource grants from an archived team as revocable and does not expect them", () => {
+    // An archived team must grant nothing. Its resource-grant tuples should be
+    // stripped at archive time; if one survives it must surface as a revocable
+    // orphan candidate — NOT be re-added by repair.
+    const report = deriveRbacSelfCheckReport(baseInput({
+      teams: [{ slug: "retired-team", name: "Retired Team", status: "archived" }],
+      dynamicAgents: [
+        {
+          _id: "agent-shared",
+          name: "Shared Agent",
+          visibility: "team",
+          owner_team_slug: "retired-team",
+        },
+      ],
+      actualTuples: [
+        { user: "organization:caipe#admin", relation: "manager", object: "agent:agent-shared" },
+        // Lingering grant from the archived team — must be flagged, not expected.
+        { user: "team:retired-team#member", relation: "user", object: "agent:agent-shared" },
+        { user: "team:retired-team#admin", relation: "manager", object: "agent:agent-shared" },
+      ],
+    }));
+
+    // Archival stripped these grants from the expected set, so they are not
+    // "missing" (repair must not rewrite them).
+    expect(report.summary.missing_tuples).toBe(0);
+    expect(repairableMissingTuples(report)).toEqual([]);
+    // The survivors are revocable orphan candidates.
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "orphan_candidate",
+          title: "Archived-team resource grant",
+          detail: expect.stringContaining("Team retired-team is archived"),
+          review_action: expect.objectContaining({ type: "revoke_tuple" }),
+          tuple: { user: "team:retired-team#member", relation: "user", object: "agent:agent-shared" },
+        }),
+      ]),
+    );
+  });
+
+  it("keeps an archived team's membership roster expected so un-archive can restore grants", () => {
+    // The team-as-OBJECT roster is intentionally kept on archive; it must not be
+    // reported as a stale deleted-team membership or repaired away.
+    const report = deriveRbacSelfCheckReport(baseInput({
+      teams: [{ slug: "retired-team", name: "Retired Team", status: "archived" }],
+      teamMembershipSources: [
+        { team_slug: "retired-team", user_subject: "user-1", relationship: "member" },
+      ],
+      actualTuples: [
+        { user: "user:user-1", relation: "member", object: "team:retired-team" },
+      ],
+    }));
+
+    expect(report.summary.missing_tuples).toBe(0);
+    expect(report.summary.orphan_candidates).toBe(0);
+    expect(report.status).toBe("pass");
+  });
+
   it("passes when every expected tuple is present", () => {
     const report = deriveRbacSelfCheckReport(baseInput({
       teamMembershipSources: [

--- a/ui/src/lib/rbac/archived-team-grants.ts
+++ b/ui/src/lib/rbac/archived-team-grants.ts
@@ -1,0 +1,121 @@
+// Archiving a team must also revoke every resource grant that flows through
+// the team's `#member` / `#admin` userset — otherwise `team:<slug>#member
+// can_use agent:X` still resolves true for anyone still on the roster, so an
+// "archived" team would keep granting access. `team.status` is NOT consulted
+// anywhere in the OpenFGA authorization path (OpenFGA is the source of truth),
+// so archival is only real if the tuples go with it.
+//
+// What we strip: tuples where the archived team's userset is the SUBJECT —
+//   team:<slug>#member  <relation>  <resource:id>
+//   team:<slug>#admin   manager     <resource:id>
+// across every shareable resource type (agent, skill, task, tool,
+// knowledge_base, mcp_server, secret_ref, slack_channel, webex_space,
+// conversation, service_account, ...).
+//
+// What we KEEP: the membership roster itself — `user:<sub> member team:<slug>`
+// (the team is the OBJECT there, never the subject). Keeping the roster means
+// un-archiving a team can restore its grants by replaying resource
+// reconciliation, and the admin UI still shows who was on the team.
+//
+// Deletes go through `deleteExactOpenFgaTuples` with keys read straight from
+// the store. Userset tuples (`team:<slug>#member ...`) MUST be deleted this
+// way: `writeOpenFgaTuples` runs a per-tuple `/check` that cannot resolve a
+// userset as the `user`, so it would treat every such delete as "already gone"
+// and silently drop it (see the note on `deleteExactOpenFgaTuples`).
+
+import {
+  deleteExactOpenFgaTuples,
+  isOpenFgaReconciliationEnabled,
+  readOpenFgaTuples,
+  type OpenFgaTupleKey,
+} from "./openfga";
+
+/** Userset relations a team can hold as the SUBJECT of a resource grant. */
+const TEAM_GRANT_USERSET_RELATIONS = new Set(["member", "admin", "owner"]);
+
+/**
+ * Parse `team:<slug>#<userset>` from a tuple `user` field. Returns the team
+ * slug when the user is a team userset we treat as a grant subject, else null.
+ * Plain memberships (`user:<sub>`) and non-team usersets return null.
+ */
+function archivedTeamSlugFromGrantSubject(user: string, archivedSlugs: Set<string>): string | null {
+  const match = /^team:([^#]+)#(member|admin|owner)$/.exec(user);
+  if (!match) return null;
+  const [, slug, userset] = match;
+  if (!TEAM_GRANT_USERSET_RELATIONS.has(userset)) return null;
+  return archivedSlugs.has(slug) ? slug : null;
+}
+
+/**
+ * Return every stored tuple that grants a resource to one of `archivedSlugs`
+ * via its `#member`/`#admin`/`#owner` userset. Reads the full store once
+ * (paginated) and filters in memory — bounded by store size, not slug count,
+ * so a one-time bulk archival of hundreds of teams is a single scan rather
+ * than thousands of per-team list calls. Membership tuples (team as object)
+ * are never matched.
+ */
+async function readArchivedTeamGrantTuples(archivedSlugs: Set<string>): Promise<OpenFgaTupleKey[]> {
+  const grants: OpenFgaTupleKey[] = [];
+  let continuationToken: string | undefined;
+  do {
+    const page = await readOpenFgaTuples({ continuationToken, pageSize: 100 });
+    for (const entry of page.tuples) {
+      const key = entry.key;
+      if (archivedTeamSlugFromGrantSubject(key.user, archivedSlugs)) {
+        grants.push({ user: key.user, relation: key.relation, object: key.object });
+      }
+    }
+    continuationToken = page.continuationToken;
+  } while (continuationToken);
+  return grants;
+}
+
+export interface StripArchivedTeamGrantsResult {
+  /** Teams whose grants were considered (the input set size). */
+  teamsConsidered: number;
+  /** Grant tuples found in the store for those teams. */
+  tuplesFound: number;
+  /** Grant tuples OpenFGA acknowledged deleting. */
+  tuplesDeleted: number;
+  openFgaEnabled: boolean;
+}
+
+/**
+ * Strip all resource-grant tuples flowing through the `#member`/`#admin`/
+ * `#owner` userset of the given (archived) team slugs. Idempotent: re-running
+ * with the same slugs after a successful strip finds nothing and deletes
+ * nothing. The team membership roster (`user:<sub> -> team:<slug>`) is left
+ * intact so the archive is reversible.
+ *
+ * No-ops (and does not read the store) when `slugs` is empty or OpenFGA
+ * reconciliation is disabled, so callers can invoke it unconditionally on
+ * every sync without paying for a store scan when nothing was archived.
+ */
+export async function stripArchivedTeamResourceGrants(
+  slugs: Iterable<string>,
+): Promise<StripArchivedTeamGrantsResult> {
+  const archivedSlugs = new Set(Array.from(slugs).filter((slug) => typeof slug === "string" && slug.length > 0));
+  if (archivedSlugs.size === 0) {
+    return { teamsConsidered: 0, tuplesFound: 0, tuplesDeleted: 0, openFgaEnabled: true };
+  }
+  if (!isOpenFgaReconciliationEnabled()) {
+    return { teamsConsidered: archivedSlugs.size, tuplesFound: 0, tuplesDeleted: 0, openFgaEnabled: false };
+  }
+
+  const grants = await readArchivedTeamGrantTuples(archivedSlugs);
+  if (grants.length === 0) {
+    return { teamsConsidered: archivedSlugs.size, tuplesFound: 0, tuplesDeleted: 0, openFgaEnabled: true };
+  }
+
+  const result = await deleteExactOpenFgaTuples(grants);
+  return {
+    teamsConsidered: archivedSlugs.size,
+    tuplesFound: grants.length,
+    tuplesDeleted: result.deletes,
+    openFgaEnabled: result.enabled,
+  };
+}
+
+// Exported for unit tests — lets a test assert the subject-matching rule
+// (grant subject vs. membership object) without standing up an OpenFGA store.
+export const __test__ = { archivedTeamSlugFromGrantSubject };

--- a/ui/src/lib/rbac/identity-group-sync-planner.ts
+++ b/ui/src/lib/rbac/identity-group-sync-planner.ts
@@ -136,6 +136,20 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
   }
   const teams_to_create = Array.from(teamsToCreateBySlug.values());
 
+  const teams_to_update: Array<{ slug: string; name: string; source_group_id: string }> = [];
+  for (const match of ruleResult.matches) {
+    const existing = existingTeamBySlug.get(match.teamSlug);
+    if (existing && existing.name !== match.teamName) {
+      if (!teams_to_update.some((t) => t.slug === match.teamSlug)) {
+        teams_to_update.push({
+          slug: match.teamSlug,
+          name: match.teamName,
+          source_group_id: match.group.external_group_id,
+        });
+      }
+    }
+  }
+
   const skipped_users: IdentityGroupSyncDryRunResult["skipped_users"] = [];
   const desiredSources: TeamMembershipSource[] = [];
 
@@ -167,6 +181,7 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
         team_slug: match.teamSlug,
         user_subject: member.subject,
         user_email: member.email,
+        display_name: member.display_name,
         relationship: match.relationship,
         source_type: sourceTypeForProvider(match.group.provider_id),
         provider_id: match.group.provider_id,
@@ -192,6 +207,15 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
       ? new Set(input.groups.map((g) => g.external_group_id))
       : undefined,
   });
+  const existingActiveKeys = new Set(
+    input.existingMembershipSources
+      .filter((s) => s.status === "active")
+      .map((s) => sourceKey(s))
+  );
+  const membership_sources_to_refresh = desiredSources
+    .filter((s) => existingActiveKeys.has(sourceKey(s)))
+    .map((s) => ({ ...s, last_seen_at: input.now }));
+
   const safety_warnings = buildSafetyWarnings({
     existingSources: input.existingMembershipSources,
     desiredSources,
@@ -202,8 +226,10 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
     matched_groups: ruleResult.matches.map((match) => match.group),
     ignored_groups: ruleResult.ignored.map((ignored) => ignored.group),
     teams_to_create,
+    teams_to_update,
     membership_sources_to_add: reconciliation.sourcesToAdd,
     membership_sources_to_remove: reconciliation.sourcesToRemove,
+    membership_sources_to_refresh,
     tuple_writes: reconciliation.tupleWrites,
     tuple_deletes: reconciliation.tupleDeletes,
     skipped_users,

--- a/ui/src/lib/rbac/identity-group-sync-reconciler.ts
+++ b/ui/src/lib/rbac/identity-group-sync-reconciler.ts
@@ -4,6 +4,7 @@ IdentityGroupSyncDryRunResult,
 TeamMembershipSource,
 } from "@/types/identity-group-sync";
 
+import { stripArchivedTeamResourceGrants } from "./archived-team-grants";
 import {
 OpenFgaWriteError,
 writeOpenFgaTuples,
@@ -148,9 +149,25 @@ export async function applyIdentityGroupSyncPlan(
           actor: input.actor,
           now: input.now,
         });
+        // Archiving the Mongo doc is cosmetic on its own — OpenFGA never
+        // consults team.status. Strip the team's resource-grant tuples so an
+        // archived team stops granting `team:<slug>#member can_use ...`. Only
+        // strips teams we actually archived this run; the roster is kept so
+        // un-archiving can replay grants. Best-effort: the membership reconcile
+        // already committed, and the self-check can repair any grant that
+        // survives here.
+        if (teamsArchived > 0) {
+          const strip = await stripArchivedTeamResourceGrants(orphanedSlugs);
+          if (strip.tuplesDeleted > 0) {
+            console.log(
+              `[identity-group-sync] stripped ${strip.tuplesDeleted} resource-grant tuple(s) ` +
+                `from ${orphanedSlugs.size} archived team(s)`,
+            );
+          }
+        }
       } catch (archiveErr) {
         console.error(
-          "[identity-group-sync] phase 3 team archival failed; orphaned teams may remain active",
+          "[identity-group-sync] phase 3 team archival/grant-strip failed; orphaned teams may remain active",
           archiveErr,
         );
       }

--- a/ui/src/lib/rbac/identity-group-sync-reconciler.ts
+++ b/ui/src/lib/rbac/identity-group-sync-reconciler.ts
@@ -35,6 +35,7 @@ export interface ApplyIdentityGroupSyncPlanResult {
   tupleWrites: number;
   tupleDeletes: number;
   openFgaEnabled: boolean;
+  teamsArchived: number;
 }
 
 /**
@@ -116,6 +117,34 @@ export async function applyIdentityGroupSyncPlan(
       deletes: input.plan.tuple_deletes,
     });
 
+    // ── Phase 3: archive orphaned identity-sync teams ──────────────────────
+    // After memberships are removed, any identity_group_sync team that the
+    // planner flagged as "orphaned_team_membership" (no remaining managed
+    // memberships) gets archived. We only do this for teams the sync owns
+    // (source: "identity_group_sync") so manually-created teams are never
+    // touched. Failures here are logged but never thrown — the membership
+    // reconcile already succeeded; archival is best-effort cleanup.
+    const orphanedSlugs = new Set(
+      (input.plan.safety_warnings ?? [])
+        .filter((w) => w.code === "orphaned_team_membership" && w.team_slug)
+        .map((w) => w.team_slug as string),
+    );
+    let teamsArchived = 0;
+    if (orphanedSlugs.size > 0) {
+      try {
+        teamsArchived = await archiveOrphanedSyncTeams({
+          slugs: orphanedSlugs,
+          actor: input.actor,
+          now: input.now,
+        });
+      } catch (archiveErr) {
+        console.error(
+          "[identity-group-sync] phase 3 team archival failed; orphaned teams may remain active",
+          archiveErr,
+        );
+      }
+    }
+
     return {
       teamsCreated: phase1.teamsCreated,
       membershipSourcesAdded: input.plan.membership_sources_to_add.length,
@@ -123,6 +152,7 @@ export async function applyIdentityGroupSyncPlan(
       tupleWrites: openFgaResult.writes,
       tupleDeletes: openFgaResult.deletes,
       openFgaEnabled: openFgaResult.enabled,
+      teamsArchived,
     };
   } catch (err) {
     // Best-effort rollback. The Mongo team docs and membership-source
@@ -280,6 +310,26 @@ async function rollbackPhase1(input: {
   for (const slug of input.createdTeamSlugs) {
     await teams.deleteOne({ slug });
   }
+}
+
+/**
+ * Archive identity_group_sync teams that have no remaining active managed
+ * membership sources. Only touches teams with source "identity_group_sync"
+ * so manually-created teams are never auto-archived. Returns the count of
+ * teams actually updated.
+ */
+async function archiveOrphanedSyncTeams(input: {
+  slugs: Set<string>;
+  actor: string;
+  now: string;
+}): Promise<number> {
+  if (input.slugs.size === 0) return 0;
+  const teams = await getCollection<IdentitySyncTeam & Record<string, unknown>>("teams");
+  const result = await teams.updateMany(
+    { slug: { $in: Array.from(input.slugs) }, source: "identity_group_sync", status: { $ne: "archived" } },
+    { $set: { status: "archived", updated_by: input.actor, updated_at: new Date(input.now) } },
+  );
+  return result.modifiedCount;
 }
 
 // Re-export tuple types so callers that build plans don't have to

--- a/ui/src/lib/rbac/identity-group-sync-reconciler.ts
+++ b/ui/src/lib/rbac/identity-group-sync-reconciler.ts
@@ -32,6 +32,7 @@ export interface ApplyIdentityGroupSyncPlanResult {
   teamsCreated: number;
   membershipSourcesAdded: number;
   membershipSourcesRemoved: number;
+  membershipSourcesRefreshed: number;
   tupleWrites: number;
   tupleDeletes: number;
   openFgaEnabled: boolean;
@@ -106,6 +107,16 @@ export async function applyIdentityGroupSyncPlan(
       // left to keep in sync.
       upsertedSources.push(resolved);
     }
+    for (const source of input.plan.membership_sources_to_refresh ?? []) {
+      const resolved = {
+        ...source,
+        team_id: teamIdsBySlug.get(source.team_slug) ?? source.team_id,
+        last_applied_at: input.now,
+      };
+      await upsertTeamMembershipSource(resolved);
+      // Refresh operations are idempotent — do NOT add to upsertedSources
+      // so they are excluded from rollback tracking.
+    }
     for (const source of input.plan.membership_sources_to_remove) {
       await markTeamMembershipSourceRemoved(source, input.actor, input.now);
       // See above — no longer mirror the removal into teams.members[].
@@ -149,6 +160,7 @@ export async function applyIdentityGroupSyncPlan(
       teamsCreated: phase1.teamsCreated,
       membershipSourcesAdded: input.plan.membership_sources_to_add.length,
       membershipSourcesRemoved: input.plan.membership_sources_to_remove.length,
+      membershipSourcesRefreshed: (input.plan.membership_sources_to_refresh ?? []).length,
       tupleWrites: openFgaResult.writes,
       tupleDeletes: openFgaResult.deletes,
       openFgaEnabled: openFgaResult.enabled,
@@ -206,12 +218,15 @@ async function ensureIdentitySyncTeams(
 ): Promise<EnsureTeamsResult> {
   const teamIdsBySlug = new Map<string, string>();
   const createdTeamSlugsThisCall = new Set<string>();
-  if (input.plan.teams_to_create.length === 0) {
+  if (input.plan.teams_to_create.length === 0 && (!input.plan.teams_to_update || input.plan.teams_to_update.length === 0)) {
     return { teamsCreated: 0, teamIdsBySlug, createdTeamSlugsThisCall };
   }
 
   const teams = await getCollection<IdentitySyncTeam & Record<string, unknown>>("teams");
-  const slugs = Array.from(new Set(input.plan.teams_to_create.map((team) => team.slug)));
+  const slugs = Array.from(new Set([
+    ...input.plan.teams_to_create.map((team) => team.slug),
+    ...(input.plan.teams_to_update ?? []).map((team) => team.slug),
+  ]));
   const existing = await teams
     .find({ slug: { $in: slugs } })
     .project({ _id: 1, id: 1, slug: 1, name: 1 })
@@ -244,8 +259,18 @@ async function ensureIdentitySyncTeams(
       createdTeamSlugsThisCall.add(team.slug);
       teamsCreated += 1;
     }
+    // Update name for teams where Okta's name differs from stored name.
+    // This is inside the same try-catch so that if an updateOne throws,
+    // any teams inserted earlier in this call are rolled back before
+    // rethrowing (Phase 1 all-or-nothing guarantee).
+    for (const team of input.plan.teams_to_update ?? []) {
+      await teams.updateOne(
+        { slug: team.slug },
+        { $set: { name: team.name, updated_by: input.actor, updated_at: new Date(input.now) } }
+      );
+    }
   } catch (err) {
-    // Phase 1 self-rollback: a single insert failed mid-loop. Delete
+    // Phase 1 self-rollback: a single insert or update failed mid-loop. Delete
     // anything we already inserted in this call before rethrowing.
     await rollbackPhase1({ createdTeamSlugs: createdTeamSlugsThisCall }).catch(
       (rollbackErr) => {

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -21,6 +21,7 @@ import {
   updateIdpSyncRun,
 } from "@/lib/rbac/idp-sync-store";
 import { provisionShellUser } from "@/lib/rbac/keycloak-admin";
+import { stripArchivedTeamResourceGrants } from "@/lib/rbac/archived-team-grants";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
 import { getRbacCollection } from "./mongo-collections";
@@ -320,6 +321,24 @@ async function archiveAlreadyOrphanedSyncTeams(input: {
   }
   if (totalModified > 0) {
     console.log(`[IdpSync] orphan sweep archived ${totalModified} stale identity_group_sync team(s)`);
+    // Revoke the archived teams' resource-grant tuples so archival actually
+    // removes access (OpenFGA never checks team.status). Reads the store once
+    // and filters to these slugs, so it scales with store size rather than
+    // slug count. Best-effort — the self-check repairs anything left behind.
+    try {
+      const strip = await stripArchivedTeamResourceGrants(orphanedSlugs);
+      if (strip.tuplesDeleted > 0) {
+        console.log(
+          `[IdpSync] orphan sweep stripped ${strip.tuplesDeleted} resource-grant tuple(s) ` +
+            `from archived teams`,
+        );
+      }
+    } catch (stripErr) {
+      console.error(
+        "[IdpSync] orphan sweep grant-strip failed; archived teams may still grant access until self-check repair",
+        stripErr,
+      );
+    }
   }
   return totalModified;
 }

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -220,7 +220,8 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     });
     console.log(
       `[IdpSync] run ${runId} success: ${groups.length} groups, ` +
-        `+${result.membershipSourcesAdded}/-${result.membershipSourcesRemoved} memberships`
+        `+${result.membershipSourcesAdded}/-${result.membershipSourcesRemoved} memberships, ` +
+        `${result.teamsArchived} teams archived`
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -161,7 +161,7 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // skips everyone as `missing_subject`. Cached per run so a user appearing in
     // many groups is resolved once.
     const subCache = new Map<string, string | null>();
-    for (const group of groups as Array<{ members?: Array<{ email?: string; active?: boolean; subject?: string }> }>) {
+    for (const group of groups as Array<{ members?: Array<{ email?: string; active?: boolean; subject?: string; display_name?: string }> }>) {
       for (const member of group.members ?? []) {
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
@@ -171,9 +171,15 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
             // `POST /api/admin/users/provision-shell` endpoint the bots call
             // (issue #1781) — in-process, so no self-network hop. The caller's
             // own RBAC gate (route) or trusted context (scheduler) authorizes.
+            // Split "First Last" on first space; handles "Mary Jo Smith" → firstName="Mary", lastName="Jo Smith"
+            const nameParts = member.display_name?.trim().split(/\s+(.+)/) ?? [];
+            const firstName = nameParts[0] || undefined;
+            const lastName = nameParts[1] || undefined;
             const { sub } = await provisionShellUser({
               email,
               source: `idp-sync:${provider}`,
+              firstName,
+              lastName,
             });
             subCache.set(email, sub);
           } catch (err) {

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -23,6 +23,7 @@ import {
 import { provisionShellUser } from "@/lib/rbac/keycloak-admin";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
+import { getRbacCollection } from "./mongo-collections";
 import type { IdpSyncRun } from "./mongo-collections";
 
 interface TeamDocument {
@@ -210,11 +211,30 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
       partialFetch,
     });
 
+    const now = new Date().toISOString();
     const result = await applyIdentityGroupSyncPlan({
       plan,
       actor,
-      now: new Date().toISOString(),
+      now,
     });
+
+    // On a full fetch, sweep for already-orphaned identity_group_sync teams
+    // that pre-date this fix (their sources were previously removed but the
+    // team document was never archived). Phase 3 inside applyIdentityGroupSyncPlan
+    // only catches teams whose sources are removed in the current run; this
+    // catches everything that slipped through before.
+    let sweptArchived = 0;
+    if (!partialFetch) {
+      try {
+        sweptArchived = await archiveAlreadyOrphanedSyncTeams({ provider, actor, now });
+      } catch (sweepErr) {
+        console.error(
+          `[IdpSync] run ${runId}: orphan sweep failed; stale teams may remain active`,
+          sweepErr,
+        );
+      }
+    }
+    const totalArchived = result.teamsArchived + sweptArchived;
 
     await updateIdpSyncRun(runId, {
       status: "success",
@@ -227,7 +247,7 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     console.log(
       `[IdpSync] run ${runId} success: ${groups.length} groups, ` +
         `+${result.membershipSourcesAdded}/-${result.membershipSourcesRemoved} memberships, ` +
-        `${result.teamsArchived} teams archived`
+        `${totalArchived} teams archived (${sweptArchived} from sweep)`
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -242,4 +262,55 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
   } finally {
     clearInterval(heartbeat);
   }
+}
+
+/**
+ * Sweep for identity_group_sync teams that are already orphaned from previous
+ * syncs (their managed membership sources are all removed, but the team doc
+ * was never archived because the archival logic didn't exist yet). Only runs
+ * on full (non-filtered) fetches so we never archive teams that simply weren't
+ * in scope for a scoped sync.
+ *
+ * Strategy: find all non-archived identity_group_sync teams, then find which
+ * ones have at least one active managed membership source for this provider.
+ * Any team not in that second set gets archived.
+ */
+async function archiveAlreadyOrphanedSyncTeams(input: {
+  provider: string;
+  actor: string;
+  now: string;
+}): Promise<number> {
+  const teamsCol = await getCollection<TeamDocument & Record<string, unknown>>("teams");
+  const sourcesCol = await getRbacCollection<Record<string, unknown>>("teamMembershipSources");
+
+  // All non-archived identity_group_sync team slugs.
+  const syncTeams = await teamsCol
+    .find({ source: "identity_group_sync", status: { $ne: "archived" } })
+    .project({ slug: 1 })
+    .toArray();
+  if (syncTeams.length === 0) return 0;
+
+  const allSlugs = syncTeams.map((t) => t.slug as string).filter(Boolean);
+
+  // Which of those slugs have at least one active managed source for this provider?
+  const activeDocs = await sourcesCol
+    .distinct("team_slug", {
+      team_slug: { $in: allSlugs },
+      provider_id: input.provider,
+      managed: true,
+      status: "active",
+    });
+  const activeSlugs = new Set(activeDocs);
+
+  const orphanedSlugs = allSlugs.filter((slug) => !activeSlugs.has(slug));
+  if (orphanedSlugs.length === 0) return 0;
+
+  const result = await teamsCol.updateMany(
+    { slug: { $in: orphanedSlugs }, source: "identity_group_sync", status: { $ne: "archived" } },
+    { $set: { status: "archived", updated_by: input.actor, updated_at: new Date(input.now) } },
+  );
+  if (result.modifiedCount > 0) {
+    console.log(`[IdpSync] orphan sweep archived ${result.modifiedCount} stale identity_group_sync team(s): ${orphanedSlugs.join(", ")}`);
+  }
+  return result.modifiedCount;
 }

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -305,12 +305,21 @@ async function archiveAlreadyOrphanedSyncTeams(input: {
   const orphanedSlugs = allSlugs.filter((slug) => !activeSlugs.has(slug));
   if (orphanedSlugs.length === 0) return 0;
 
-  const result = await teamsCol.updateMany(
-    { slug: { $in: orphanedSlugs }, source: "identity_group_sync", status: { $ne: "archived" } },
-    { $set: { status: "archived", updated_by: input.actor, updated_at: new Date(input.now) } },
-  );
-  if (result.modifiedCount > 0) {
-    console.log(`[IdpSync] orphan sweep archived ${result.modifiedCount} stale identity_group_sync team(s): ${orphanedSlugs.join(", ")}`);
+  // Chunk to stay well under MongoDB's $in limit (MongoDB itself has no hard
+  // limit but the Node driver serializes BSON per-doc and large $in arrays
+  // can exceed the 16 MB document size limit — 500 is a safe batch size).
+  const BATCH_SIZE = 500;
+  let totalModified = 0;
+  for (let i = 0; i < orphanedSlugs.length; i += BATCH_SIZE) {
+    const batch = orphanedSlugs.slice(i, i + BATCH_SIZE);
+    const result = await teamsCol.updateMany(
+      { slug: { $in: batch }, source: "identity_group_sync", status: { $ne: "archived" } },
+      { $set: { status: "archived", updated_by: input.actor, updated_at: new Date(input.now) } },
+    );
+    totalModified += result.modifiedCount;
   }
-  return result.modifiedCount;
+  if (totalModified > 0) {
+    console.log(`[IdpSync] orphan sweep archived ${totalModified} stale identity_group_sync team(s)`);
+  }
+  return totalModified;
 }

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -719,16 +719,19 @@ function parseUserIdFromLocation(location: string | null): string | null {
  */
 export async function createFederatedShellUser(
   email: string,
-  attributes: Record<string, string[]> = {}
+  attributes: Record<string, string[]> = {},
+  name?: { firstName?: string; lastName?: string }
 ): Promise<string> {
   const emailLower = email.trim().toLowerCase();
-  const body = {
+  const body: Record<string, unknown> = {
     username: emailLower,
     email: emailLower,
     emailVerified: true,
     enabled: true,
     requiredActions: [],
     attributes,
+    ...(name?.firstName && { firstName: name.firstName }),
+    ...(name?.lastName && { lastName: name.lastName }),
   };
   const response = await adminFetch(`/users`, { method: "POST", body: JSON.stringify(body) });
 
@@ -748,17 +751,53 @@ export async function createFederatedShellUser(
   throw new Error(`createFederatedShellUser(${emailLower}): could not determine new user id`);
 }
 
+async function maybeUpdateUserName(
+  userId: string,
+  name: { firstName?: string; lastName?: string }
+): Promise<void> {
+  const existing = await getRealmUserByIdOrNull(userId);
+  if (!existing) return;
+  // Only patch if the user is missing a name entirely (shell user never had one set)
+  // OR if Okta has a different name
+  const needsUpdate =
+    (name.firstName && existing.firstName !== name.firstName) ||
+    (name.lastName && existing.lastName !== name.lastName);
+  if (!needsUpdate) return;
+  // Don't overwrite a manually-set name with nothing
+  if (!name.firstName && !name.lastName) return;
+  await updateUser(userId, {
+    ...(name.firstName && { firstName: name.firstName }),
+    ...(name.lastName && { lastName: name.lastName }),
+  });
+}
+
 /**
  * Resolve an email to a Keycloak `sub`, creating a federated shell user when no
  * account exists yet. Returns the sub plus whether it was newly created.
  */
 export async function resolveOrProvisionUserSub(
   email: string,
-  attributes: Record<string, string[]> = {}
+  attributes: Record<string, string[]> = {},
+  name?: { firstName?: string; lastName?: string }
 ): Promise<{ sub: string; created: boolean }> {
   const existing = await findUserIdByEmail(email);
-  if (existing) return { sub: existing, created: false };
-  const sub = await createFederatedShellUser(email, attributes);
+  if (existing) {
+    // If user exists but is missing a name, patch it. Non-fatal: a transient
+    // Keycloak error on the name update must not suppress the known sub or
+    // prevent RBAC assignments from being applied this sync run.
+    if (name?.firstName || name?.lastName) {
+      try {
+        await maybeUpdateUserName(existing, name);
+      } catch (err) {
+        console.warn(
+          `[KeycloakAdmin] maybeUpdateUserName(${existing}) failed (non-fatal):`,
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+    }
+    return { sub: existing, created: false };
+  }
+  const sub = await createFederatedShellUser(email, attributes, name);
   return { sub, created: true };
 }
 
@@ -778,6 +817,9 @@ export interface ProvisionShellUserInput {
    * `created_at` attributes. Ignored when the user already exists.
    */
   attributes?: Record<string, string[]>;
+  /** Display name from the IdP, split into firstName/lastName for Keycloak. */
+  firstName?: string;
+  lastName?: string;
 }
 
 export interface ProvisionShellUserResult {
@@ -817,7 +859,11 @@ export async function provisionShellUser(
     created_by: [source],
     created_at: [new Date().toISOString().replace(/\.\d{3}Z$/, "Z")],
   };
-  return resolveOrProvisionUserSub(email, attributes);
+  const name =
+    input.firstName || input.lastName
+      ? { firstName: input.firstName, lastName: input.lastName }
+      : undefined;
+  return resolveOrProvisionUserSub(email, attributes, name);
 }
 
 function exactEmailUserId(email: string, users: Array<Record<string, unknown>>): string | null {

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -653,6 +653,14 @@ function buildExpectedTuplesAndStaleReferences(
     });
     tuples.push(...teamGrants.tuples);
     staleReferences.push(...teamGrants.staleReferences);
+    // The agent reconciler also writes team:<ownerTeamSlug>#member manager for the
+    // owner team specifically (full can_manage for owner-team members). This is
+    // separate from the #admin manager tuple that teamGrantTuples emits for all
+    // teams. Without this, the tuple shows up as "unowned" after an ownership
+    // transfer because the self-check never expected it.
+    if (isValidOpenFgaId(agent.owner_team_slug) && resourceIndex.teamSlugs.has(agent.owner_team_slug)) {
+      tuples.push(expected("dynamic_agents.owner/shared teams", `team:${agent.owner_team_slug}#member`, "manager", object, resource));
+    }
     if (agent.visibility === "global") {
       tuples.push(expected("dynamic_agents.visibility", "user:*", "user", object, resource));
     }

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -407,6 +407,12 @@ function scopeResourceExists(type: string, id: string, resourceIndex: ResourceIn
 
 interface ResourceIndex {
   teamSlugs: Set<string>;
+  // Slugs whose team doc has status "archived". These stay in `teamSlugs` (so
+  // the membership roster is still recognized and not flagged as a deleted-team
+  // orphan), but they grant NOTHING: archiving strips a team's resource-grant
+  // tuples, so the self-check must neither expect those grants (else repair
+  // re-creates them) nor treat their absence as drift.
+  archivedTeamSlugs: Set<string>;
   agentIds: Set<string>;
   agentAccessByObject: Map<string, {
     label?: string;
@@ -432,6 +438,12 @@ interface ResourceIndex {
 
 function buildResourceIndex(input: RbacSelfCheckInventoryInput): ResourceIndex {
   const teamSlugs = new Set(input.teams.map((team) => team.slug).filter(isValidOpenFgaId));
+  const archivedTeamSlugs = new Set(
+    input.teams
+      .filter((team) => team.status === "archived")
+      .map((team) => team.slug)
+      .filter(isValidOpenFgaId),
+  );
   const agentAccessByObject = new Map<string, { label?: string; visibility?: string; teamSlugs: Set<string> }>();
   for (const agent of input.dynamicAgents) {
     const agentId = normalizeAgentId(agent);
@@ -487,6 +499,7 @@ function buildResourceIndex(input: RbacSelfCheckInventoryInput): ResourceIndex {
 
   return {
     teamSlugs,
+    archivedTeamSlugs,
     agentIds: new Set(input.dynamicAgents.map(normalizeAgentId).filter(isValidOpenFgaId)),
     agentAccessByObject,
     mcpServerIds: new Set(input.mcpServers.map(normalizeObjectId).filter(isValidOpenFgaId)),
@@ -1051,6 +1064,23 @@ function teamSlugFromUserset(user: string): string | null {
   return match?.[1] ?? null;
 }
 
+/**
+ * True when `tuple` grants a resource THROUGH an archived team's userset —
+ * i.e. its subject is `team:<archived-slug>#member|admin|owner`. Archiving a
+ * team strips exactly these tuples (see archived-team-grants.ts), so the
+ * self-check must (1) drop them from the expected set — otherwise "repair
+ * missing tuples" would immediately rewrite what archival just removed — and
+ * (2) flag any that still linger in OpenFGA as revocable orphan candidates.
+ *
+ * The team-as-OBJECT roster (`user:<sub> member team:<archived-slug>`) is NOT
+ * matched here: that membership is intentionally kept so un-archiving can
+ * replay grants, so it stays an expected tuple.
+ */
+function isArchivedTeamGrant(tuple: RbacSelfCheckTuple, archivedTeamSlugs: Set<string>): boolean {
+  const slug = teamSlugFromUserset(tuple.user);
+  return slug !== null && archivedTeamSlugs.has(slug);
+}
+
 function directTeamMembershipTuple(tuple: RbacSelfCheckTuple): { subject: string; teamSlug: string } | null {
   const userMatch = /^user:([^#]+)$/.exec(tuple.user);
   const objectMatch = /^team:([^#]+)$/.exec(tuple.object);
@@ -1137,6 +1167,26 @@ function orphanCandidateFinding(tuple: RbacSelfCheckTuple, resourceIndex: Resour
   }
 
   const teamSlug = teamSlugFromUserset(tuple.user);
+
+  // A grant flowing through an archived team's userset should not exist —
+  // archival strips these. If one lingers, it's still granting access
+  // (OpenFGA never checks team.status), so surface it as revocable. This is
+  // the self-check's safety net for the archive-time strip.
+  if (teamSlug && resourceIndex.archivedTeamSlugs.has(teamSlug)) {
+    return {
+      id: findingId("orphan", text),
+      severity: "orphan_candidate",
+      source: "openfga",
+      title: "Archived-team resource grant",
+      detail: `${text}. Team ${teamSlug} is archived, so it must not grant any resource access.`,
+      fix: "Revoke this tuple so the archived team stops granting access. Un-archive the team first if this grant should be restored.",
+      tuple,
+      repairable: false,
+      review_action: revokeReviewAction("The granting team is archived and must not confer access."),
+      resource: { type: "team", id: teamSlug },
+    };
+  }
+
   const activeAgentAccess = resourceIndex.agentAccessByObject.get(tuple.object);
   if (objectRef.type === "agent" && teamSlug && activeAgentAccess?.visibility === "global") {
     const agentLabel = activeAgentAccess.label ?? objectRef.id;
@@ -1324,7 +1374,13 @@ export function deriveRbacSelfCheckReport(
   const allExpectedTuples = uniqueTuples([
     ...sourceExpectedTuples,
     ...currentBaselineAccessTuples(input, actualKeys),
-  ]);
+  ])
+    // Archived teams grant nothing: drop any expected grant flowing through an
+    // archived team's `#member`/`#admin`/`#owner` userset. Keeping these would
+    // (a) report them as `missing` (archival stripped them) and (b) let the
+    // repair action rewrite the very tuples archival removed. The team-as-object
+    // roster is untouched, so membership stays expected and is not flagged.
+    .filter((tuple) => !isArchivedTeamGrant(tuple, resourceIndex.archivedTeamSlugs));
   const expectedTuples = allExpectedTuples.filter((tuple) => sourceInScope(tuple.source, scope));
   const staleReferences = allStaleReferences.filter((reference) => sourceInScope(reference.source, scope));
   const allExpectedKeys = new Set(allExpectedTuples.map(tupleKey));

--- a/ui/src/lib/rbac/team-membership-source-store.ts
+++ b/ui/src/lib/rbac/team-membership-source-store.ts
@@ -154,7 +154,19 @@ export async function upsertTeamMembershipSource(source: TeamMembershipSource): 
   const collection = await getRbacCollection<TeamMembershipSource & { team_slug: string }>(
     "teamMembershipSources"
   );
-  await collection.updateOne(membershipSourceFilter(source), { $set: source }, { upsert: true });
+  const { first_seen_at, created_at, created_by, ...mutableFields } = source;
+  await collection.updateOne(
+    membershipSourceFilter(source),
+    {
+      $set: mutableFields,
+      $setOnInsert: {
+        ...(first_seen_at !== undefined && { first_seen_at }),
+        ...(created_at !== undefined && { created_at }),
+        ...(created_by !== undefined && { created_by }),
+      },
+    },
+    { upsert: true }
+  );
 
   // Collapse stale orphans: when a user is removed and later re-added with a
   // different `relationship` (e.g. removed as member, re-added as admin), the

--- a/ui/src/types/identity-group-sync.ts
+++ b/ui/src/types/identity-group-sync.ts
@@ -92,6 +92,7 @@ export interface TeamMembershipSource {
   team_slug: string;
   user_subject?: string;
   user_email?: string;
+  display_name?: string;
   relationship: TeamRelationshipRole;
   source_type: TeamMembershipSourceType;
   provider_id?: string;
@@ -127,6 +128,8 @@ export interface IdentityGroupSyncDryRunResult {
   matched_groups: ExternalGroup[];
   ignored_groups: ExternalGroup[];
   teams_to_create: Array<{ slug: string; name: string; source_group_id: string }>;
+  teams_to_update: Array<{ slug: string; name: string; source_group_id: string }>;
+  membership_sources_to_refresh: TeamMembershipSource[];
   membership_sources_to_add: TeamMembershipSource[];
   membership_sources_to_remove: TeamMembershipSource[];
   tuple_writes: IdentityGroupSyncTuple[];

--- a/ui/src/types/teams.ts
+++ b/ui/src/types/teams.ts
@@ -20,7 +20,7 @@ export interface Team {
   slug: string;
   name: string;
   description?: string;
-  source?: 'manual' | 'identity_sync' | 'bootstrap' | 'migration';
+  source?: 'manual' | 'identity_sync' | 'identity_group_sync' | 'bootstrap' | 'migration';
   status?: 'active' | 'archived' | 'pending_review' | 'disabled';
   owner_id: string; // User email who created the team
   created_by?: string;


### PR DESCRIPTION
## Summary

- **fix(rebac):** search Slack channels by ID in the onboarding tab — `row.id` now included in the client-side substring filter alongside channel name
- **fix(admin):** prevent Okta pill text from overflowing rounded border — added `whitespace-nowrap` to `IdpSyncedBadge`
- **feat(dynamic-agents):** add search and pagination to agents list — search by name/description/ID, server-side pagination with prev/next UI
- **fix(credentials):** preserve `renewable` flag after token refresh and guard `needsAutoRefresh` — fixes auto-renew being incorrectly stamped false after refresh for providers that don't rotate their refresh token
- **fix(identity-sync):** archive orphaned `identity_group_sync` teams on full sync — teams whose Okta group was removed are now archived after membership reconciliation; also fixes `Team.source` type union
- **feat(idp-sync):** upsert user names and team/membership data from Okta — sync firstName/lastName into Keycloak, upsert team names in MongoDB, refresh membership `last_seen_at`/`display_name` on every pass, protect `first_seen_at` from being overwritten
- **test(idp-sync):** update sync-reconciler test to expect `membershipSourcesRefreshed` in reconciler result
- **fix(slack):** show saved SA name when caller lacks team membership — guard empty-state with `&& !value`; add `displayName` fallback prop
- **fix(admin):** wrap team name + IDP badge so long names don't hide pill — switch to `flex-wrap`; add `min-w-0` + `break-words` to `CardTitle`
- **fix(slack):** guard SA empty-state on `displayName` too — suppress empty state when either `value` or `displayName` is present
- **fix(service-accounts):** admins bypass team membership filter on GET — admin callers skip OpenFGA membership intersection when `?team=<slug>` is passed
- **fix(identity-sync):** sweep for already-orphaned sync teams on full sync — Phase 3 now also cleans up teams orphaned before this PR landed
- **fix(identity-sync):** chunk orphan sweep `updateMany` to avoid `$in` size limit
- **fix(admin):** cap metrics legend to top 5 and tooltip to top 3 series — custom Recharts Legend/Tooltip renderers prevent overflow with a "+N more" indicator
- **fix(ui):** prevent scope refs from overflowing modal bounds in unlinked access dialog — `min-w-0`, `shrink-0`, and `truncate` on flex children
- **fix(rbac):** expect owner-team `#member manager` tuple in self-check audit — adds the missing tuple to `teamGrantTuples()` so the self-check doesn't flag it as unexpected
- **feat(rbac):** archived teams grant no access, with self-check repair — revokes OpenFGA tuples on archive, hides archived teams from admin grid behind a toggle, self-check catches/repairs edge cases

## Test plan

- [ ] Slack onboarding tab: search by channel ID (e.g. `C12345`) returns matching channels
- [ ] Admin panel: Okta badge pill text does not wrap/overflow
- [ ] Dynamic agents list: search and pagination work correctly
- [ ] OAuth connections: `renewable` flag stays correct after token refresh; non-renewable connections are not auto-refreshed
- [ ] Okta sync: teams with no remaining managed memberships are archived after a full sync pass
- [ ] Okta sync: user first/last name updated in Keycloak; team names upserted in MongoDB
- [ ] Slack route config: saved SA name shown correctly when caller is not a member of the owning team
- [ ] Service accounts API: admin can fetch SAs for a team they're not a member of
- [ ] Admin metrics chart: legend capped at 5 series, tooltip capped at 3 — no overflow
- [ ] Unlinked access dialog: long scope refs truncate instead of overflowing modal
- [ ] Archiving a team revokes access; archived teams hidden from grid by default; self-check repairs edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)