### PR TITLE
fix(metrics): exclude per-component services from umbrella ServiceMonitor and expose openfga metrics port

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
             - name: playground
               containerPort: 3000
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /stores

--- a/charts/ai-platform-engineering/charts/openfga/templates/service.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/templates/service.yaml
@@ -19,5 +19,9 @@ spec:
       port: {{ .Values.service.playgroundPort }}
       targetPort: playground
       protocol: TCP
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
   selector:
     {{- include "openfga.selectorLabels" . | nindent 4 }}

--- a/charts/ai-platform-engineering/charts/openfga/values.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/values.yaml
@@ -22,6 +22,7 @@ service:
   httpPort: 8080
   grpcPort: 8081
   playgroundPort: 3000
+  metricsPort: 2112
 
 datastore:
   # memory is convenient for demos. Use postgres for persistent environments.

--- a/charts/ai-platform-engineering/templates/servicemonitor-openfga.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor-openfga.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-metrics
+  name: {{ .Release.Name }}-openfga-metrics
   labels:
     app.kubernetes.io/name: ai-platform-engineering
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -14,34 +14,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # Match services that expose /metrics on their http port. Services excluded
-  # by name have dedicated per-component ServiceMonitors targeting the correct
-  # port for their metrics endpoint:
-  #   - agentgateway: servicemonitor-agentgateway.yaml (admin port 15000)
-  #   - keycloak: servicemonitor-keycloak.yaml (management port 9000)
-  #   - openfga: servicemonitor-openfga.yaml (metrics port 2112)
-  # audit-service has no /metrics endpoint and is excluded entirely.
+  # OpenFGA exposes Prometheus metrics on the metrics port (2112) by default.
+  # A dedicated ServiceMonitor is used so this endpoint is only applied to
+  # openfga and does not generate failed scrape targets on other services.
   selector:
     matchLabels:
+      app.kubernetes.io/name: openfga
       app.kubernetes.io/instance: {{ .Release.Name }}
-    matchExpressions:
-      - key: app.kubernetes.io/component
-        operator: NotIn
-        values:
-          - mcp
-          - rag-server
-          - agent-ontology
-          - skill-scanner
-          - caipe-ui
-      - key: app.kubernetes.io/name
-        operator: NotIn
-        values:
-          - agentgateway
-          - keycloak
-          - openfga
-          - audit-service
   endpoints:
-    - port: http
+    - port: metrics
       path: {{ .Values.metrics.path | default "/metrics" }}
       interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}
@@ -57,4 +38,3 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
 {{- end }}
-


### PR DESCRIPTION
## Summary

- **`servicemonitor.yaml`**: Add a second `matchExpressions` entry excluding `agentgateway`, `keycloak`, `openfga`, and `audit-service` by `app.kubernetes.io/name`. These four services lack `app.kubernetes.io/component` labels, so the existing `NotIn` exclusion never matched them — Prometheus generated permanently-failing `TargetDown` targets because their `/metrics` endpoints are not on the `http` port the umbrella SM scrapes.
- **`openfga` deployment/service/values**: Expose the built-in Prometheus metrics port (2112) which OpenFGA serves by default.
- **`servicemonitor-openfga.yaml`**: New dedicated ServiceMonitor targeting OpenFGA's metrics port (2112) instead of the API port (8080).

Each excluded service now has a dedicated ServiceMonitor (or none for `audit-service` which has no `/metrics` endpoint):
- `agentgateway` → `servicemonitor-agentgateway.yaml` (admin port 15000)
- `keycloak` → `servicemonitor-keycloak.yaml` (management port 9000)
- `openfga` → `servicemonitor-openfga.yaml` (metrics port 2112)
- `audit-service` → excluded entirely (no metrics endpoint)

## Root cause

`app.kubernetes.io/component` is absent on these four services. A Kubernetes label selector with `NotIn` on a missing key evaluates to `true` (the key is not in the list), so the services were included in the umbrella SM despite the intent to exclude them. Adding a `NotIn` by `app.kubernetes.io/name` closes the gap cleanly without requiring label changes on the existing services.

## Test plan

- [ ] `helm template` renders all four dedicated SMs and the umbrella SM without errors
- [ ] `kubectl get servicemonitor -n sdp-ai` shows `caipe-metrics`, `caipe-agentgateway-metrics`, `caipe-keycloak-metrics`, and `caipe-openfga-metrics` after deployment
- [ ] Prometheus targets for `sdp-ai` namespace no longer show `TargetDown` for these four services
- [ ] OpenFGA pod exposes port 2112 and `/metrics` returns Prometheus-format output

🤖 Generated with [Claude Code](https://claude.com/claude-code)