### PR TITLE
feat(keycloak): add configurable caipe-cli public client for local dev tokens

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/realm-config.json
+++ b/charts/ai-platform-engineering/charts/keycloak/realm-config.json
@@ -136,6 +136,43 @@
       ]
     },
     {
+      "clientId": "caipe-cli",
+      "name": "CAIPE CLI",
+      "description": "Public OIDC client for local developer CLIs (authorization-code + PKCE). Mints a real-user JWT with aud=caipe-platform accepted by Dynamic Agents, AgentGateway, and MCP servers. No client secret; PKCE S256 required.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "redirectUris": [
+        "http://localhost:8085",
+        "http://localhost:8085/*",
+        "http://127.0.0.1:8085",
+        "http://127.0.0.1:8085/*"
+      ],
+      "webOrigins": [
+        "http://localhost:8085",
+        "http://127.0.0.1:8085"
+      ],
+      "protocol": "openid-connect",
+      "fullScopeAllowed": true,
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "access.token.lifespan": "28800"
+      },
+      "defaultClientScopes": [
+        "profile",
+        "email",
+        "roles",
+        "groups",
+        "org"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ]
+    },
+    {
       "clientId": "caipe-platform",
       "name": "CAIPE Platform Resource Server",
       "description": "Confidential service client — identity and token-exchange only; CAIPE authorization is enforced in OpenFGA.",

--- a/charts/ai-platform-engineering/charts/keycloak/templates/configmap-realm.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/configmap-realm.yaml
@@ -26,11 +26,29 @@ data:
       {{- $_ := set $roles "realm" $realmRoles -}}
       {{- $_ := set $realm "roles" $roles -}}
     {{- end -}}
+    {{- $cliClientId := (.Values.cliClient).clientId | default "caipe-cli" -}}
     {{- $clients := list -}}
     {{- range $client := $realm.clients -}}
       {{- if eq $client.clientId "caipe-ui" -}}
         {{- $_ := set $client "redirectUris" $.Values.uiClient.redirectUris -}}
         {{- $_ := set $client "webOrigins" $.Values.uiClient.webOrigins -}}
+      {{- end -}}
+      {{- if eq $client.clientId "caipe-cli" -}}
+        {{- /* Public CLI client for local-dev tokens; id, callbacks, and access
+               token lifespan are configurable so downstream realms can rename
+               it (e.g. forge-cli) and tune session length. */ -}}
+        {{- $_ := set $client "clientId" $cliClientId -}}
+        {{- with ($.Values.cliClient).redirectUris -}}
+          {{- $_ := set $client "redirectUris" . -}}
+        {{- end -}}
+        {{- with ($.Values.cliClient).webOrigins -}}
+          {{- $_ := set $client "webOrigins" . -}}
+        {{- end -}}
+        {{- with ($.Values.cliClient).accessTokenLifespan -}}
+          {{- $attrs := $client.attributes | default dict -}}
+          {{- $_ := set $attrs "access.token.lifespan" (printf "%d" (int .)) -}}
+          {{- $_ := set $client "attributes" $attrs -}}
+        {{- end -}}
       {{- end -}}
       {{- $clients = append $clients $client -}}
     {{- end -}}

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -130,6 +130,31 @@ uiClient:
       key: ""
       property: ""
 
+# ---------- CAIPE CLI OIDC client ----------
+# Public client (authorization-code + PKCE) that lets local developer CLIs mint
+# a real-user JWT with aud=caipe-platform — accepted by Dynamic Agents,
+# AgentGateway, and MCP servers in one login. No client secret.
+#
+# The client id is configurable so downstream realms can rename it to match
+# their branding (e.g. a realm named "forge" would set clientId: forge-cli).
+# Override redirectUris/webOrigins if your CLI uses a different loopback port.
+#
+# accessTokenLifespan (seconds) sets a per-client access-token lifespan so a
+# single login lasts a full working session — 28800 = 8h, which matches the
+# realm ssoSessionIdleTimeout and avoids re-authenticating throughout the day.
+# Keep it <= ssoSessionMaxLifespan (86400). Omit to inherit the realm default.
+cliClient:
+  clientId: "caipe-cli"
+  accessTokenLifespan: 28800
+  redirectUris:
+    - "http://localhost:8085"
+    - "http://localhost:8085/*"
+    - "http://127.0.0.1:8085"
+    - "http://127.0.0.1:8085/*"
+  webOrigins:
+    - "http://localhost:8085"
+    - "http://127.0.0.1:8085"
+
 # ---------- CAIPE platform OIDC client ----------
 # The realm import ships the `caipe-platform` confidential client with a
 # placeholder secret ("caipe-platform-dev-secret") so first-boot import works

--- a/deploy/keycloak/realm-config.example.json
+++ b/deploy/keycloak/realm-config.example.json
@@ -87,6 +87,43 @@
       ]
     },
     {
+      "clientId": "caipe-cli",
+      "name": "CAIPE CLI",
+      "description": "Public OIDC client for local developer CLIs (authorization-code + PKCE). Mints a real-user JWT with aud=caipe-platform accepted by Dynamic Agents, AgentGateway, and MCP servers. No client secret; PKCE S256 required.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "redirectUris": [
+        "http://localhost:8085",
+        "http://localhost:8085/*",
+        "http://127.0.0.1:8085",
+        "http://127.0.0.1:8085/*"
+      ],
+      "webOrigins": [
+        "http://localhost:8085",
+        "http://127.0.0.1:8085"
+      ],
+      "protocol": "openid-connect",
+      "fullScopeAllowed": true,
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "access.token.lifespan": "28800"
+      },
+      "defaultClientScopes": [
+        "profile",
+        "email",
+        "roles",
+        "groups",
+        "org"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ]
+    },
+    {
       "clientId": "caipe-platform",
       "name": "CAIPE Platform Resource Server",
       "description": "Confidential client — Authorization Services enabled (PDP-1 for UI/Slack RBAC)",


### PR DESCRIPTION
# Description

Adds a **public** OIDC client (`caipe-cli`) to the Keycloak `caipe` realm so local developer CLIs can obtain a **real-user** JWT via the browser authorization-code + PKCE flow — no client secret required.

Because the realm's `profile` scope carries the `caipe-platform` audience mapper, the minted access token is accepted by **Dynamic Agents**, **AgentGateway**, and **MCP servers** (e.g. RAG) in a single login. This closes the local-access gap for CAIPE 0.5, where the platform is now its own identity broker (Keycloak fronting the upstream IdP) rather than authenticating tools directly against the IdP.

Real-user tokens only — service accounts already have their own API-access flows and are out of scope here.

## What changed

- New `caipe-cli` client in both realm configs:
  - `publicClient: true`, `standardFlowEnabled: true`
  - PKCE `S256` required (`pkce.code.challenge.method`)
  - No direct-access-grants / service-accounts (browser authcode flow only)
  - Redirect URIs + web origins on `localhost:8085` / `127.0.0.1:8085` for the loopback callback
  - `access.token.lifespan: 28800` (8h) so one login lasts a working day (<= realm `ssoSessionMaxLifespan`)
  - Same `defaultClientScopes` as `caipe-ui`; `offline_access` optional for refresh tokens
- **Configurable** via a new `cliClient` values block (mirrors `uiClient`): `clientId`, `redirectUris`, `webOrigins`, `accessTokenLifespan`. `configmap-realm.yaml` patches these into the client at render time, so downstream realms can rename the client and tune session length **without forking the chart**. Defaults stay `caipe-cli` / `localhost:8085` / 8h.
- Files:
  - `charts/ai-platform-engineering/charts/keycloak/realm-config.json` — the client
  - `charts/ai-platform-engineering/charts/keycloak/templates/configmap-realm.yaml` — render-time id/callback/lifespan override
  - `charts/ai-platform-engineering/charts/keycloak/values.yaml` — `cliClient` block + docs
  - `deploy/keycloak/realm-config.example.json` — docker-compose realm mirror

## Verification

`helm template` renders correctly for both the default (`caipe-cli`, 8h) and an overridden client id + lifespan + custom redirect URIs; PKCE S256 and scopes propagate. Both JSON files validate. Exercised end-to-end against a local docker-compose stack: PKCE login → token (`aud=caipe-platform`) → `GET /api/user/accessible-agents` → create conversation → `POST /api/v1/chat/invoke` returned a live agent reply.

## Consumer

Any OAuth CLI doing authcode + PKCE against `.../realms/<realm>/protocol/openid-connect/{auth,token}` with the configured client id and a `localhost:8085` redirect works with this client.

## Type of Change

- [x] New Feature

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (values.yaml comments + client description fields)
- [x] All code style checks pass (helm template renders; both JSON files validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)