### PR TITLE
fix(servicemonitor): exclude openfga init job pods from openfga ServiceMonitor

### DIFF
--- a/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
@@ -104,6 +104,9 @@ spec:
             - name: admin
               containerPort: {{ .Values.service.adminPort }}
               protocol: TCP
+            - name: stats
+              containerPort: {{ .Values.service.statsPort }}
+              protocol: TCP
           readinessProbe:
             tcpSocket:
               port: http

--- a/charts/ai-platform-engineering/charts/agentgateway/templates/service.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       port: {{ .Values.service.adminPort }}
       targetPort: admin
       protocol: TCP
+    - name: stats
+      port: {{ .Values.service.statsPort }}
+      targetPort: stats
+      protocol: TCP
   selector:
     {{- include "agentgateway.selectorLabels" . | nindent 4 }}

--- a/charts/ai-platform-engineering/charts/agentgateway/values.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/values.yaml
@@ -33,6 +33,7 @@ service:
   type: ClusterIP
   port: 4000
   adminPort: 15000
+  statsPort: 15020
 
 ingress:
   enabled: false

--- a/charts/ai-platform-engineering/templates/servicemonitor-agentgateway.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor-agentgateway.yaml
@@ -14,15 +14,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  # agentgateway exposes /metrics on the admin port (15000), not the http port (4000).
-  # A dedicated ServiceMonitor is used so the admin endpoint is only applied to
-  # agentgateway and does not generate failed scrape targets on other services.
+  # agentgateway exposes /metrics on the stats port (15020), not the http port (4000)
+  # or admin port (15000, which is the admin UI). A dedicated ServiceMonitor is used
+  # so the stats endpoint is only applied to agentgateway.
   selector:
     matchLabels:
       app.kubernetes.io/name: agentgateway
       app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
-    - port: admin
+    - port: stats
       path: {{ .Values.metrics.path | default "/metrics" }}
       interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}

--- a/charts/ai-platform-engineering/templates/servicemonitor-openfga.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor-openfga.yaml
@@ -21,18 +21,18 @@ spec:
     matchLabels:
       app.kubernetes.io/name: openfga
       app.kubernetes.io/instance: {{ .Release.Name }}
-    matchExpressions:
-      - key: job-name
-        operator: DoesNotExist
   endpoints:
     - port: metrics
       path: {{ .Values.metrics.path | default "/metrics" }}
       interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}
-      {{- with .Values.metrics.serviceMonitor.relabelings }}
       relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_label_job_name]
+          action: drop
+          regex: .+
+        {{- with .Values.metrics.serviceMonitor.relabelings }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/ai-platform-engineering/templates/servicemonitor-openfga.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor-openfga.yaml
@@ -21,6 +21,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: openfga
       app.kubernetes.io/instance: {{ .Release.Name }}
+    matchExpressions:
+      - key: job-name
+        operator: DoesNotExist
   endpoints:
     - port: metrics
       path: {{ .Values.metrics.path | default "/metrics" }}


### PR DESCRIPTION
## Summary

The openfga init Job pod carries the same `app.kubernetes.io/name: openfga` and `app.kubernetes.io/instance: <release>` labels as the main Deployment pod. This causes the `caipe-openfga-metrics` ServiceMonitor (added in #2106) to also target the completed init pod IP — resulting in a scrape timeout because the init pod does not serve port 2112.

**Fix**: Add `matchExpressions: [{key: job-name, operator: DoesNotExist}]` to the ServiceMonitor selector. Deployment pods do not have a `job-name` label; Job-spawned pods always do. This cleanly scopes scraping to the Deployment pod only.

## Root cause

Kubernetes Jobs automatically add a `job-name` label to every pod they spawn. Deployment pods do not receive this label. Selecting on `DoesNotExist` for `job-name` is therefore a reliable way to exclude any Job pod from a ServiceMonitor targeting a Deployment.

## Test plan

- [ ] `helm template` renders `caipe-openfga-metrics` ServiceMonitor with the `matchExpressions` clause
- [ ] After deployment: `kubectl get servicemonitor caipe-openfga-metrics -n sdp-ai -o yaml` shows the `DoesNotExist` expression
- [ ] Prometheus target `serviceMonitor/sdp-ai/caipe-openfga-metrics/0` shows the Deployment pod IP (not the completed init pod IP)
- [ ] No `TargetDown` alert for `caipe-openfga-metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)