### PR TITLE
feat(mcp-webex-meetings): add new mcp server for webex-meetings + allow oauth connector configuration from config

### DIFF
--- a/.github/agents.json
+++ b/.github/agents.json
@@ -24,7 +24,8 @@
     "scheduler",
     "splunk",
     "victorops",
-    "webex"
+    "webex",
+    "webex-meetings"
   ],
   "rag_components": [
     "agent-ontology",

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/config.yaml
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/config.yaml
@@ -102,6 +102,21 @@ mcp_servers:
         provider: pagerduty
         target: header
 
+  - description: Webex meeting, transcript, and recording tools
+    enabled: true
+    endpoint: ${WEBEX_MEETINGS_MCP_URL:-http://localhost:18013/mcp}
+    id: webex_meetings
+    name: Webex Meetings
+    transport: http
+    # Resolve the caller's Webex Connected App token. AgentGateway keeps the
+    # caller JWT in Authorization and rewrites this provider token into the
+    # Authorization header sent to the Webex Meetings MCP backend.
+    credential_sources:
+      - kind: provider_connection
+        name: X-CAIPE-Provider-Token
+        provider: webex
+        target: header
+
   - description: Knowledge Base tools
     enabled: true
     endpoint: ${RAG_SERVER_MCP_URL:-http://localhost:9446/mcp}

--- a/ai_platform_engineering/mcp/scheduler/pyproject.toml
+++ b/ai_platform_engineering/mcp/scheduler/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mcp_scheduler"
 description = "Generic cron-schedule MCP for CAIPE dynamic agents. Wraps caipe-scheduler's REST API as MCP tools so any agent can register/list/cancel scheduled chat fires of itself or other agents."
 authors = [
-    { name = "CNOE", email = "cnoe-developers@cisco.com" }
+    { email = "suwhang@cisco.com" }
 ]
 dynamic = [
     "version"

--- a/ai_platform_engineering/mcp/webex-meetings/Makefile
+++ b/ai_platform_engineering/mcp/webex-meetings/Makefile
@@ -1,0 +1,5 @@
+# Webex Meetings MCP Server Makefile
+
+AGENT_NAME = webex-meetings
+
+include ../mcp-common.mk

--- a/ai_platform_engineering/mcp/webex-meetings/README.md
+++ b/ai_platform_engineering/mcp/webex-meetings/README.md
@@ -1,11 +1,9 @@
 # mcp-webex-meetings
 
 Local MCP server that exposes the Webex Meetings / Transcripts / Recordings REST
-API as MCP tools. It mostly mirrors Cisco's official Webex Meetings MCP
+API as MCP tools. It mostly mirrors the official Webex Meetings MCP
 (`https://mcp.webexapis.com/mcp/webex-meeting`), with two local fallback helpers
-for stale/expired-series debugging. If Cisco enables agentic apps in the
-cisco.com Control Hub, the official-compatible tools can be pointed at Cisco's
-endpoint and the local fallback tools can be kept or removed deliberately.
+for stale/expired-series debugging.
 
 ## Authentication
 

--- a/ai_platform_engineering/mcp/webex-meetings/README.md
+++ b/ai_platform_engineering/mcp/webex-meetings/README.md
@@ -1,0 +1,62 @@
+# mcp-webex-meetings
+
+Local MCP server that exposes the Webex Meetings / Transcripts / Recordings REST
+API as MCP tools. It mostly mirrors Cisco's official Webex Meetings MCP
+(`https://mcp.webexapis.com/mcp/webex-meeting`), with two local fallback helpers
+for stale/expired-series debugging. If Cisco enables agentic apps in the
+cisco.com Control Hub, the official-compatible tools can be pointed at Cisco's
+endpoint and the local fallback tools can be kept or removed deliberately.
+
+## Authentication
+
+Per-user OAuth bearer, forwarded through MCP request headers.
+
+The dynamic-agents runtime resolves a caller-scoped Webex `provider_connection`
+from the Credentials > Connected Apps store and injects the token on
+`X-CAIPE-Provider-Token`. AgentGateway rewrites that header into
+`Authorization: Bearer <user-token>` before forwarding to this MCP server.
+For local/direct development, this MCP server also accepts
+`X-CAIPE-Provider-Token` directly.
+
+This MCP server simply pulls the inbound `authorization` header off the
+incoming request and forwards it to `https://webexapis.com/v1/...`. No token
+storage, no Mongo access, no refresh logic; that is all handled by the runtime
+and credential service.
+
+The built-in Webex OAuth connector requests the meeting schedule, participant,
+recording, transcript, and related Webex scopes required by these tools. Users
+with a Webex connection created before those scopes were added must reconnect
+the app so Webex can grant the expanded scope set.
+
+## Tools
+
+Mirrors Cisco's official Meetings MCP tool surface, plus local fallback helpers:
+
+- `webex_list_meetings` - list/search meetings with date filters
+- `webex_userhub_calendar` - best-effort User Hub calendar read for upcoming external-calendar occurrences
+- `webex_resolve_meeting_link` - resolve a Webex join/calendar link through `/v1/meetings` with secrets removed
+- `webex_get_meeting_status` - get a meeting + optional participants
+- `webex_create_meeting` - schedule a meeting
+- `webex_update_meeting` - patch a meeting
+- `webex_delete_meeting` - delete a scheduled meeting
+- `webex_list_recordings` - list recordings
+- `webex_list_transcripts` - list transcripts (and optionally inline-download VTT)
+
+There is currently no `webex_get_meeting_summary` tool because Webex does not
+publish a public meeting-summary REST endpoint. Use
+`webex_list_transcripts(download=true)` and summarize the transcript instead.
+
+`webex_userhub_calendar` intentionally uses the same per-user OAuth token against
+the Webex User Hub calendar feed, for example
+`https://cisco.webex.com/webappng/api/v1/mymeetings/calendarView`. Treat it as a
+best-effort fallback when public `/v1/meetings` rows look stale or expired: it can
+surface Office365/Google-backed future occurrences that the public Webex schedule
+API does not expose as `scheduledMeeting` rows.
+
+## Run locally
+
+```bash
+uv run python server.py --transport streamable-http --port 8000 --host 0.0.0.0
+```
+
+Tools are then reachable at `http://localhost:8000/mcp/`.

--- a/ai_platform_engineering/mcp/webex-meetings/__main__.py
+++ b/ai_platform_engineering/mcp/webex-meetings/__main__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+from mcp_webex_meetings import main
+
+if __name__ == "__main__":
+    main()

--- a/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/__about__.py
+++ b/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/__about__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+__version__ = "0.0.1"

--- a/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/__init__.py
+++ b/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+from .server import main
+
+__all__ = ["main"]

--- a/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/__main__.py
+++ b/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/__main__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+from mcp_webex_meetings import main
+
+if __name__ == "__main__":
+    main()

--- a/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/mcp_server.py
+++ b/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/mcp_server.py
@@ -1,0 +1,834 @@
+# Copyright 2026 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+import functools
+import logging
+from datetime import datetime, timezone
+from typing import Annotated, Any, Literal
+from urllib.parse import urlparse
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import httpx
+from fastmcp.server.dependencies import get_http_headers
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, INVALID_PARAMS, ErrorData
+from pydantic import BaseModel, ConfigDict, Field
+
+WEBEX_API_BASE = "https://webexapis.com/v1"
+USERHUB_DEFAULT_SITE = "https://cisco.webex.com"
+USERHUB_CALENDAR_PATH = "/webappng/api/v1/mymeetings/calendarView"
+SENSITIVE_KEY_SUBSTRINGS = ("password", "hostkey")
+
+logger = logging.getLogger(__name__)
+
+
+# Auth helper
+def _bearer_from_request() -> str:
+    """Pull the per-user Webex bearer token out of the inbound MCP request.
+
+    Normal AgentGateway traffic arrives here as ``Authorization: Bearer ...``
+    after the gateway rewrites ``X-CAIPE-Provider-Token``. Direct/local runtime
+    calls may pass ``X-CAIPE-Provider-Token`` through unchanged, so accept that
+    as a fallback and wrap it as a bearer token before forwarding to Webex.
+    """
+    # FastMCP strips non-standard/security-sensitive headers by default; opt in.
+    headers = get_http_headers(include={"authorization", "x-caipe-provider-token"})
+    auth = headers.get("authorization") or headers.get("Authorization")
+    provider_token = (
+        headers.get("x-caipe-provider-token")
+        or headers.get("X-CAIPE-Provider-Token")
+    )
+    if not auth and provider_token:
+        token = provider_token.strip()
+        auth = token if token.lower().startswith("bearer ") else f"Bearer {token}"
+    if not auth:
+        raise McpError(
+            ErrorData(
+                code=INVALID_PARAMS,
+                message=(
+                    "No per-user Webex token on inbound MCP request. "
+                    "Configure this server with a caller-scoped Webex "
+                    "provider_connection credential source."
+                ),
+            )
+        )
+    return auth
+
+
+# Pydantic arguments
+class ListMeetings(BaseModel):
+    from_iso: Annotated[
+        str | None,
+        Field(
+            description=(
+                "ISO-8601 lower bound for meeting start time, e.g. '2026-05-01T00:00:00Z'."
+            ),
+            default=None,
+        ),
+    ] = None
+    to_iso: Annotated[
+        str | None,
+        Field(
+            description="ISO-8601 upper bound for meeting start time.",
+            default=None,
+        ),
+    ] = None
+    host_email: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Restrict to meetings hosted by this Webex user. Caller must be "
+                "an admin or the user themselves to use this filter."
+            ),
+            default=None,
+        ),
+    ] = None
+    meeting_type: Annotated[
+        Literal["meetingSeries", "scheduledMeeting", "meeting"] | None,
+        Field(
+            description=(
+                "meetingSeries=recurring template; scheduledMeeting=one occurrence; "
+                "meeting=actual instance with state."
+            ),
+            default=None,
+        ),
+    ] = None
+    max_results: Annotated[
+        int,
+        Field(description="Max meetings to return (1-100).", default=20, ge=1, le=100),
+    ] = 20
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "List/search Webex meetings the authenticated user can see."
+        }
+    )
+
+
+class UserHubCalendar(BaseModel):
+    from_iso: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional ISO-8601 lower bound for occurrence start time. "
+                "Filtering is applied client-side after reading User Hub calendar rows."
+            ),
+            default=None,
+        ),
+    ] = None
+    to_iso: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional ISO-8601 upper bound for occurrence start time. "
+                "Filtering is applied client-side after reading User Hub calendar rows."
+            ),
+            default=None,
+        ),
+    ] = None
+    title: Annotated[
+        str | None,
+        Field(
+            description="Optional case-insensitive title/subject substring filter.",
+            default=None,
+        ),
+    ] = None
+    site_url: Annotated[
+        str,
+        Field(
+            description=(
+                "Webex site base URL for the signed-in user's User Hub calendar, "
+                "for example 'https://cisco.webex.com'."
+            ),
+            default=USERHUB_DEFAULT_SITE,
+        ),
+    ] = USERHUB_DEFAULT_SITE
+    meeting_list_type: Annotated[
+        str,
+        Field(
+            description=(
+                "User Hub meetingListType query value. Use 'All' for the broadest "
+                "calendar view, including external calendar-backed rows."
+            ),
+            default="All",
+        ),
+    ] = "All"
+    max_results: Annotated[
+        int,
+        Field(description="Maximum calendar rows to request (1-500).", default=200, ge=1, le=500),
+    ] = 200
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Read the signed-in user's Webex User Hub calendar feed. "
+                "Best-effort fallback for Office365/Google-backed future "
+                "occurrences that may not appear as public Webex scheduledMeeting rows."
+            )
+        }
+    )
+
+
+class ResolveMeetingLink(BaseModel):
+    web_link: Annotated[
+        str,
+        Field(
+            description=(
+                "Full Webex join/calendar link to resolve through the official "
+                "/v1/meetings?webLink=... API."
+            )
+        ),
+    ]
+    max_results: Annotated[
+        int,
+        Field(description="Maximum matching Webex meeting rows to return (1-100).", default=10, ge=1, le=100),
+    ] = 10
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Resolve a Webex meeting link to official Webex meeting metadata, "
+                "with password/host-key fields removed."
+            )
+        }
+    )
+
+
+class GetMeetingStatus(BaseModel):
+    meeting_id: Annotated[str, Field(description="Webex meeting ID.")]
+    include_participants: Annotated[
+        bool,
+        Field(
+            description="If true, also fetch the meeting participant list.",
+            default=False,
+        ),
+    ] = False
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Get a single Webex meeting's metadata; optionally include "
+                "participants via /v1/meetingParticipants."
+            )
+        }
+    )
+
+
+class CreateMeeting(BaseModel):
+    title: Annotated[str, Field(description="Meeting title (max 128 chars).")]
+    start: Annotated[str, Field(description="ISO-8601 start time, e.g. '2026-05-08T14:00:00Z'.")]
+    end: Annotated[str, Field(description="ISO-8601 end time.")]
+    agenda: Annotated[str | None, Field(default=None, description="Meeting agenda text.")] = None
+    invitees: Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description="List of invitee email addresses.",
+        ),
+    ] = None
+    recurrence: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "RFC 5545 RRULE string, e.g. 'FREQ=WEEKLY;BYDAY=MO;COUNT=10'."
+            ),
+        ),
+    ] = None
+    password: Annotated[
+        str | None,
+        Field(default=None, description="Optional meeting password."),
+    ] = None
+    enabled_auto_record_meeting: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Auto-record the meeting (transcripts require recording).",
+        ),
+    ] = False
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Schedule a new Webex meeting. Sends invites to invitees."
+        }
+    )
+
+
+class UpdateMeeting(BaseModel):
+    meeting_id: Annotated[str, Field(description="Webex meeting ID to update.")]
+    title: Annotated[str | None, Field(default=None)] = None
+    start: Annotated[str | None, Field(default=None)] = None
+    end: Annotated[str | None, Field(default=None)] = None
+    agenda: Annotated[str | None, Field(default=None)] = None
+    password: Annotated[str | None, Field(default=None)] = None
+    invitees: Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description=(
+                "Replacement invitee list; sends update emails to added/removed users."
+            ),
+        ),
+    ] = None
+    enabled_auto_record_meeting: Annotated[bool | None, Field(default=None)] = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Update an existing Webex meeting (PUT semantics)."
+        }
+    )
+
+
+class DeleteMeeting(BaseModel):
+    meeting_id: Annotated[str, Field(description="Webex meeting ID to delete.")]
+    send_email: Annotated[
+        bool,
+        Field(default=True, description="Send cancellation emails to invitees."),
+    ] = True
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Delete a scheduled Webex meeting."}
+    )
+
+
+class ListRecordings(BaseModel):
+    meeting_id: Annotated[
+        str | None,
+        Field(default=None, description="Filter recordings to a single meeting."),
+    ] = None
+    from_iso: Annotated[str | None, Field(default=None)] = None
+    to_iso: Annotated[str | None, Field(default=None)] = None
+    max_results: Annotated[int, Field(default=20, ge=1, le=100)] = 20
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "List Webex recordings the user has access to."
+        }
+    )
+
+
+class ListTranscripts(BaseModel):
+    meeting_id: Annotated[
+        str | None,
+        Field(default=None, description="Filter transcripts to a single meeting."),
+    ] = None
+    from_iso: Annotated[str | None, Field(default=None)] = None
+    to_iso: Annotated[str | None, Field(default=None)] = None
+    max_results: Annotated[int, Field(default=20, ge=1, le=100)] = 20
+    download: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=(
+                "If true, also download each transcript's body (may be slow) "
+                "and inline it as `body` on each item. Feed straight into "
+                "mcp_pod_meeting.parse_webex_vtt."
+            ),
+        ),
+    ] = False
+    download_format: Annotated[
+        Literal["vtt", "txt"],
+        Field(default="vtt", description="Body format when download=true."),
+    ] = "vtt"
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "List Webex meeting transcripts the user can see; optionally "
+                "inline-download each transcript body."
+            )
+        }
+    )
+
+
+# Error wrapper
+def _handle_errors(func):
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except McpError:
+            raise
+        except httpx.TimeoutException as e:
+            logger.error(f"webex_meetings timeout: {e}")
+            raise McpError(ErrorData(code=INTERNAL_ERROR, message="Webex API timeout."))
+        except httpx.HTTPStatusError as e:
+            logger.error(f"webex_meetings http {e.response.status_code}: {e.response.text[:300]}")
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=(
+                        f"Webex API HTTP {e.response.status_code}: "
+                        f"{e.response.text[:300]}"
+                    ),
+                )
+            )
+        except httpx.RequestError as e:
+            logger.error(f"webex_meetings request error: {e}")
+            raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Webex request error: {e}"))
+        except ValueError as e:
+            raise McpError(ErrorData(code=INVALID_PARAMS, message=str(e)))
+        except Exception as e:
+            logger.exception("webex_meetings unhandled exception")
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=f"Unhandled error in webex_meetings tool: {e}",
+                )
+            )
+
+    return wrapper
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_userhub_site_url(site_url: str | None) -> str:
+    raw = (site_url or USERHUB_DEFAULT_SITE).strip() or USERHUB_DEFAULT_SITE
+    if "://" not in raw:
+        raw = f"https://{raw}"
+    parsed = urlparse(raw)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not host:
+        raise ValueError("site_url must be an HTTPS Webex site URL.")
+    if host != "webex.com" and not host.endswith(".webex.com"):
+        raise ValueError("site_url must point to a Webex site host, e.g. https://cisco.webex.com.")
+    return f"https://{parsed.netloc}"
+
+
+def _webex_link_from_text(value: Any) -> str | None:
+    if not value:
+        return None
+    for token in str(value).replace("\n", " ").split():
+        candidate = token.strip(" <>[]()'\".,;")
+        parsed = urlparse(candidate)
+        host = (parsed.hostname or "").lower()
+        if parsed.scheme in {"http", "https"} and (
+            host == "webex.com" or host.endswith(".webex.com")
+        ):
+            return candidate
+    return None
+
+
+def _userhub_time_to_iso(value: Any) -> tuple[str | None, str | None, str | None]:
+    if isinstance(value, dict):
+        raw_datetime = value.get("dateTime") or value.get("datetime")
+        timezone_name = value.get("timeZone") or value.get("timezone")
+    elif isinstance(value, str):
+        raw_datetime = value
+        timezone_name = None
+    else:
+        return None, None, None
+
+    if not raw_datetime:
+        return None, timezone_name, None
+
+    raw_text = str(raw_datetime)
+    normalized = raw_text.replace(" ", "T", 1) if " " in raw_text and "T" not in raw_text else raw_text
+    parsed: datetime | None = None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+            try:
+                parsed = datetime.strptime(raw_text, fmt)
+                break
+            except ValueError:
+                continue
+
+    if parsed is None:
+        return raw_text, timezone_name, raw_text
+    if parsed.tzinfo is not None:
+        return parsed.isoformat(), timezone_name, raw_text
+    if timezone_name:
+        try:
+            return parsed.replace(tzinfo=ZoneInfo(timezone_name)).isoformat(), timezone_name, raw_text
+        except ZoneInfoNotFoundError:
+            return raw_text, timezone_name, raw_text
+    return raw_text, timezone_name, raw_text
+
+
+def _organizer_email(organizer: Any) -> str | None:
+    if not isinstance(organizer, dict):
+        return None
+    for key in ("email", "emailAddress", "mail", "userName"):
+        value = organizer.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _normalize_userhub_calendar_item(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        return {"raw": item}
+
+    start_iso, start_tz, start_raw = _userhub_time_to_iso(item.get("startTime") or item.get("start"))
+    end_iso, end_tz, end_raw = _userhub_time_to_iso(item.get("endTime") or item.get("end"))
+    subject = item.get("subject") or item.get("title")
+    location = item.get("location")
+
+    return {
+        "id": item.get("id"),
+        "seriesId": item.get("seriesId"),
+        "subject": subject,
+        "source": item.get("externalType") or item.get("source"),
+        "start": start_iso,
+        "end": end_iso,
+        "timezone": start_tz or end_tz,
+        "startRaw": start_raw,
+        "endRaw": end_raw,
+        "location": location,
+        "webLink": item.get("webLink") or _webex_link_from_text(location),
+        "organizerEmail": _organizer_email(item.get("organizer")),
+        "organizer": item.get("organizer"),
+        "occurrenceType": item.get("occurrenceType"),
+        "isCancelled": item.get("isCancelled"),
+        "isAllDay": item.get("isAllDay"),
+        "originalStartTime": item.get("originalStartTime"),
+    }
+
+
+def _sanitize_sensitive(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        clean: dict[str, Any] = {}
+        for key, value in obj.items():
+            key_lower = key.lower()
+            if any(part in key_lower for part in SENSITIVE_KEY_SUBSTRINGS):
+                continue
+            clean[key] = _sanitize_sensitive(value)
+        return clean
+    if isinstance(obj, list):
+        return [_sanitize_sensitive(value) for value in obj]
+    return obj
+
+
+def _extract_items(payload: Any) -> list[Any] | None:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return None
+    for key in ("items", "data", "meetings", "meetingList", "calendarItems", "entries"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+    return None
+
+
+# Tool registration
+def register_tools(server) -> None:
+    """Register all Webex Meetings tools on the FastMCP server."""
+
+    logger.info("Registering webex_meetings tools (REST proxy)")
+
+    async def _request(
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        bearer = _bearer_from_request()
+        headers = {
+            "Authorization": bearer,
+            "Accept": "application/json",
+        }
+        if json is not None:
+            headers["Content-Type"] = "application/json"
+        # New client per call so each request is fully independent and we
+        # don't leak the Authorization header across users.
+        async with httpx.AsyncClient(base_url=WEBEX_API_BASE, timeout=30.0) as client:
+            resp = await client.request(method, path, params=params, json=json, headers=headers)
+            resp.raise_for_status()
+            if resp.status_code == 204 or not resp.content:
+                return {"ok": True}
+            ctype = resp.headers.get("content-type", "")
+            if "application/json" in ctype:
+                return resp.json()
+            return {"ok": True, "body": resp.text}
+
+    async def _userhub_calendar_request(site_url: str, params: dict[str, Any]) -> Any:
+        bearer = _bearer_from_request()
+        headers = {
+            "Authorization": bearer,
+            "Accept": "application/json",
+        }
+        base_url = _normalize_userhub_site_url(site_url)
+        async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
+            resp = await client.get(USERHUB_CALENDAR_PATH, params=params, headers=headers)
+            resp.raise_for_status()
+            try:
+                return resp.json()
+            except ValueError as e:
+                raise ValueError(
+                    "User Hub calendar endpoint did not return JSON. "
+                    "Check that site_url is the user's Webex site, e.g. https://cisco.webex.com."
+                ) from e
+
+    @server.tool(name="webex_list_meetings")
+    @_handle_errors
+    async def list_meetings(args: ListMeetings) -> dict[str, Any]:
+        """List/search Webex meetings."""
+        params: dict[str, Any] = {"max": args.max_results}
+        if args.from_iso:
+            params["from"] = args.from_iso
+        if args.to_iso:
+            params["to"] = args.to_iso
+        if args.host_email:
+            params["hostEmail"] = args.host_email
+        if args.meeting_type:
+            params["meetingType"] = args.meeting_type
+        return await _request("GET", "/meetings", params=params)
+
+    @server.tool(name="webex_userhub_calendar")
+    @_handle_errors
+    async def userhub_calendar(args: UserHubCalendar) -> dict[str, Any]:
+        """Read the user's Webex User Hub calendar feed."""
+        params: dict[str, Any] = {
+            "meetingListType": args.meeting_list_type,
+            "limit": args.max_results,
+        }
+        payload = await _userhub_calendar_request(args.site_url, params=params)
+        raw_items = _extract_items(payload)
+        if raw_items is None:
+            shape = (
+                {"type": "dict", "keys": sorted(payload.keys())[:20]}
+                if isinstance(payload, dict)
+                else {"type": type(payload).__name__}
+            )
+            return {
+                "items": [],
+                "rawCount": 0,
+                "filteredCount": 0,
+                "siteUrl": _normalize_userhub_site_url(args.site_url),
+                "meetingListType": args.meeting_list_type,
+                "unexpectedShape": shape,
+                "note": (
+                    "User Hub calendar feed is best-effort/internal and may include "
+                    "external calendar rows not present in public Webex schedule APIs."
+                ),
+            }
+
+        from_dt = _parse_iso_datetime(args.from_iso)
+        to_dt = _parse_iso_datetime(args.to_iso)
+        if args.from_iso and from_dt is None:
+            raise ValueError("from_iso must be an ISO-8601 datetime with timezone, e.g. 2026-06-12T00:00:00Z.")
+        if args.to_iso and to_dt is None:
+            raise ValueError("to_iso must be an ISO-8601 datetime with timezone, e.g. 2026-06-26T00:00:00Z.")
+        title_filter = (args.title or "").casefold()
+        normalized_items: list[dict[str, Any]] = []
+        for raw_item in raw_items:
+            normalized = _normalize_userhub_calendar_item(raw_item)
+            subject = str(normalized.get("subject") or "")
+            if title_filter and title_filter not in subject.casefold():
+                continue
+            start_dt = _parse_iso_datetime(normalized.get("start"))
+            if start_dt is not None:
+                if from_dt is not None and start_dt < from_dt:
+                    continue
+                if to_dt is not None and start_dt >= to_dt:
+                    continue
+            normalized_items.append(normalized)
+
+        normalized_items.sort(key=lambda item: item.get("start") or "")
+        return {
+            "items": normalized_items,
+            "rawCount": len(raw_items),
+            "filteredCount": len(normalized_items),
+            "siteUrl": _normalize_userhub_site_url(args.site_url),
+            "meetingListType": args.meeting_list_type,
+            "note": (
+                "User Hub calendar feed is best-effort/internal and may include "
+                "Office365/Google-backed occurrences that are not exposed as public "
+                "Webex scheduledMeeting rows. Resolve Webex links separately before "
+                "treating a calendar row as official Webex metadata."
+            ),
+        }
+
+    @server.tool(name="webex_resolve_meeting_link")
+    @_handle_errors
+    async def resolve_meeting_link(args: ResolveMeetingLink) -> dict[str, Any]:
+        """Resolve a Webex link through the official meetings API."""
+        parsed = urlparse(args.web_link)
+        host = (parsed.hostname or "").lower()
+        if parsed.scheme not in {"http", "https"} or (
+            host != "webex.com" and not host.endswith(".webex.com")
+        ):
+            raise ValueError("web_link must be a Webex HTTP(S) URL.")
+
+        payload = await _request(
+            "GET",
+            "/meetings",
+            params={"webLink": args.web_link, "max": args.max_results},
+        )
+        sanitized = _sanitize_sensitive(payload)
+        if isinstance(sanitized, dict):
+            sanitized["queryWebLink"] = args.web_link
+            sanitized["note"] = (
+                "Resolved through the official Webex /v1/meetings API; "
+                "password and host-key fields were removed."
+            )
+            return sanitized
+        return {
+            "items": sanitized,
+            "queryWebLink": args.web_link,
+            "note": (
+                "Resolved through the official Webex /v1/meetings API; "
+                "password and host-key fields were removed."
+            ),
+        }
+
+    @server.tool(name="webex_get_meeting_status")
+    @_handle_errors
+    async def get_meeting_status(args: GetMeetingStatus) -> dict[str, Any]:
+        """Get a single Webex meeting's metadata + optional participants."""
+        meeting = await _request("GET", f"/meetings/{args.meeting_id}")
+        if args.include_participants:
+            try:
+                participants = await _request(
+                    "GET",
+                    "/meetingParticipants",
+                    params={"meetingId": args.meeting_id, "max": 100},
+                )
+                meeting["participants"] = participants.get("items", participants)
+            except McpError:
+                # Participants list is best-effort; not every meeting state has them.
+                meeting["participants"] = []
+        return meeting
+
+    @server.tool(name="webex_create_meeting")
+    @_handle_errors
+    async def create_meeting(args: CreateMeeting) -> dict[str, Any]:
+        """Schedule a new Webex meeting."""
+        body: dict[str, Any] = {
+            "title": args.title,
+            "start": args.start,
+            "end": args.end,
+            "enabledAutoRecordMeeting": args.enabled_auto_record_meeting,
+        }
+        if args.agenda is not None:
+            body["agenda"] = args.agenda
+        if args.invitees:
+            body["invitees"] = [{"email": e} for e in args.invitees]
+        if args.recurrence:
+            body["recurrence"] = args.recurrence
+        if args.password:
+            body["password"] = args.password
+        return await _request("POST", "/meetings", json=body)
+
+    @server.tool(name="webex_update_meeting")
+    @_handle_errors
+    async def update_meeting(args: UpdateMeeting) -> dict[str, Any]:
+        """Update an existing Webex meeting (PUT semantics)."""
+        # Webex PUT requires the full body; fetch current first, then merge.
+        current = await _request("GET", f"/meetings/{args.meeting_id}")
+        body: dict[str, Any] = {
+            "title": args.title or current.get("title"),
+            "start": args.start or current.get("start"),
+            "end": args.end or current.get("end"),
+        }
+        for src_field, body_field in (
+            ("agenda", "agenda"),
+            ("password", "password"),
+            ("enabled_auto_record_meeting", "enabledAutoRecordMeeting"),
+        ):
+            value = getattr(args, src_field)
+            if value is not None:
+                body[body_field] = value
+            elif body_field in current:
+                body[body_field] = current[body_field]
+        if args.invitees is not None:
+            body["invitees"] = [{"email": e} for e in args.invitees]
+        elif "invitees" in current:
+            body["invitees"] = current["invitees"]
+        return await _request("PUT", f"/meetings/{args.meeting_id}", json=body)
+
+    @server.tool(name="webex_delete_meeting")
+    @_handle_errors
+    async def delete_meeting(args: DeleteMeeting) -> dict[str, Any]:
+        """Delete a scheduled Webex meeting."""
+        params = {"sendEmail": "true" if args.send_email else "false"}
+        return await _request(
+            "DELETE", f"/meetings/{args.meeting_id}", params=params
+        )
+
+    @server.tool(name="webex_list_recordings")
+    @_handle_errors
+    async def list_recordings(args: ListRecordings) -> dict[str, Any]:
+        """List Webex meeting recordings."""
+        params: dict[str, Any] = {"max": args.max_results}
+        if args.meeting_id:
+            params["meetingId"] = args.meeting_id
+        if args.from_iso:
+            params["from"] = args.from_iso
+        if args.to_iso:
+            params["to"] = args.to_iso
+        return await _request("GET", "/recordings", params=params)
+
+    @server.tool(name="webex_list_transcripts")
+    @_handle_errors
+    async def list_transcripts(args: ListTranscripts) -> dict[str, Any]:
+        """List Webex transcripts; optionally download each body inline."""
+        params: dict[str, Any] = {"max": args.max_results}
+        if args.meeting_id:
+            params["meetingId"] = args.meeting_id
+        if args.from_iso:
+            params["from"] = args.from_iso
+        if args.to_iso:
+            params["to"] = args.to_iso
+        listing = await _request("GET", "/meetingTranscripts", params=params)
+        items = listing.get("items", []) if isinstance(listing, dict) else []
+        if args.download and items:
+            bearer = _bearer_from_request()
+            async with httpx.AsyncClient(
+                base_url=WEBEX_API_BASE, timeout=60.0
+            ) as client:
+                for item in items:
+                    tid = item.get("id")
+                    if not tid:
+                        continue
+                    try:
+                        # NOTE: Webex's transcript download endpoint returns
+                        # 406 Not Acceptable if you send a strict text/vtt or
+                        # text/plain Accept header. Send Accept: */* and let
+                        # the server pick (it returns text either way).
+                        r = await client.get(
+                            f"/meetingTranscripts/{tid}/download",
+                            params={"format": args.download_format},
+                            headers={
+                                "Authorization": bearer,
+                                "Accept": "*/*",
+                            },
+                        )
+                        r.raise_for_status()
+                        item["body"] = r.text
+                        item["bodyFormat"] = args.download_format
+                    except httpx.HTTPStatusError as e:
+                        item["body"] = None
+                        item["bodyError"] = (
+                            f"HTTP {e.response.status_code}: {e.response.text[:200]}"
+                        )
+            listing["items"] = items
+        return listing
+
+    # NOTE: webex_get_meeting_summary was removed. The Cisco /v1/meetings/summaries
+    # endpoint we mirrored doesn't exist on the public Webex REST API. Webex
+    # parses the path as /v1/meetings/{id}/ where id="summaries" and 400s with
+    # "Invalid meeting id". The agent should rely on webex_list_transcripts
+    # (download=true) + LLM summarization for now. Re-add this tool once Cisco
+    # publishes a real public AI-summary endpoint.
+
+    logger.info("Registered webex_meetings tools")

--- a/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/server.py
+++ b/ai_platform_engineering/mcp/webex-meetings/mcp_webex_meetings/server.py
@@ -1,0 +1,87 @@
+# Copyright 2026 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import sys
+from typing import Literal
+
+import click
+from mcp.server.fastmcp.server import FastMCP
+
+from .mcp_server import register_tools
+
+InputTransport = Literal["stdio", "sse", "http", "streamable-http"]
+RuntimeTransport = Literal["stdio", "sse", "streamable-http"]
+
+
+@click.command()
+@click.option(
+    "--port",
+    default=8000,
+    help="Port to listen on for HTTP/SSE",
+    envvar="MCP_PORT",
+)
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "sse", "http", "streamable-http"]),
+    default="streamable-http",
+    envvar="MCP_MODE",
+    help=(
+        "Transport. Per-user OAuth requires HTTP/SSE so the runtime can "
+        "inject the Authorization header per request; stdio is rejected."
+    ),
+)
+@click.option(
+    "--host",
+    default="0.0.0.0",
+    help="Host interface to bind",
+    envvar="MCP_HOST",
+)
+@click.option("-v", "--verbose", count=True)
+def main(verbose: int, transport: InputTransport, port: int, host: str) -> None:
+    """Entry point for the Webex Meetings MCP server.
+
+    Auth model: this server has no static token. The dynamic-agents runtime
+    injects an ``Authorization: Bearer <user-token>`` header on every MCP
+    request (resolved from the caller's Webex provider_connection).
+    Each tool pulls that header off the inbound request and forwards it
+    untouched to webexapis.com.
+    """
+    level = logging.INFO
+    if verbose == 1:
+        level = logging.INFO
+    elif verbose >= 2:
+        level = logging.DEBUG
+    logging.basicConfig(level=level, stream=sys.stderr)
+    logger = logging.getLogger(__name__)
+
+    if transport == "http":
+        selected: RuntimeTransport = "streamable-http"
+    else:
+        selected = transport  # type: ignore[assignment]
+
+    if selected == "stdio":
+        raise SystemExit(
+            "mcp-webex-meetings does not support stdio transport: per-user "
+            "OAuth requires HTTP/SSE so the runtime can inject "
+            "Authorization headers per request."
+        )
+
+    log_level: Literal["INFO", "DEBUG"] = "DEBUG" if level == logging.DEBUG else "INFO"
+
+    logger.info("Starting Webex Meetings MCP server")
+    logger.info("Transport: %s, host: %s:%s", selected, host, port)
+
+    server = FastMCP(
+        name="mcp-webex-meetings",
+        host=host,
+        port=port,
+        debug=level == logging.DEBUG,
+        log_level=log_level,
+    )
+    register_tools(server)
+    server.run(transport=selected)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_platform_engineering/mcp/webex-meetings/pyproject.toml
+++ b/ai_platform_engineering/mcp/webex-meetings/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = [
     "version"
 ]
 readme = "README.md"
-keywords = ["webex", "meetings", "mcp", "llm"]
+keywords = ["webex", "meetings", "mcp"]
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "click==8.3.1",

--- a/ai_platform_engineering/mcp/webex-meetings/pyproject.toml
+++ b/ai_platform_engineering/mcp/webex-meetings/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mcp_webex_meetings"
 description = "Local MCP server proxying Webex Meetings/Transcripts/Recordings REST API. Tool surface mirrors Cisco's official Webex Meetings MCP for drop-in replacement."
 authors = [
-    { name = "CNOE", email = "cnoe-developers@cisco.com" }
+    { email = "suwhang@cisco.com" }
 ]
 dynamic = [
     "version"

--- a/ai_platform_engineering/mcp/webex-meetings/pyproject.toml
+++ b/ai_platform_engineering/mcp/webex-meetings/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "mcp_webex_meetings"
+description = "Local MCP server proxying Webex Meetings/Transcripts/Recordings REST API. Tool surface mirrors Cisco's official Webex Meetings MCP for drop-in replacement."
+authors = [
+    { name = "CNOE", email = "cnoe-developers@cisco.com" }
+]
+dynamic = [
+    "version"
+]
+readme = "README.md"
+keywords = ["webex", "meetings", "mcp", "llm"]
+requires-python = ">=3.13,<3.14"
+dependencies = [
+    "click==8.3.1",
+    "mcp==1.27.1",
+    "pydantic==2.12.5",
+    "httpx==0.28.1",
+    "python-dotenv==1.2.2",
+    "fastmcp==3.2.4",
+    "typing-extensions==4.15.0",
+]
+
+[tool.uv]
+constraint-dependencies = ["uv==0.11.6"]
+
+[dependency-groups]
+dev = [
+    "pyright==1.1.408",
+    "ruff==0.15.1",
+    "pytest==9.0.3",
+    "pytest-asyncio==1.3.0",
+    "hatch==1.16.3",
+]
+
+[tool.hatch.version]
+path = "mcp_webex_meetings/__about__.py"
+
+[project.scripts]
+mcp-server-webex-meetings = "mcp_webex_meetings:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+
+[tool.hatch.build.targets.wheel]
+packages = ["mcp_webex_meetings"]

--- a/ai_platform_engineering/mcp/webex-meetings/server.py
+++ b/ai_platform_engineering/mcp/webex-meetings/server.py
@@ -1,0 +1,7 @@
+"""Container entry point for the Webex Meetings MCP server."""
+
+from mcp_webex_meetings import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_platform_engineering/mcp/webex-meetings/tests/test_auth.py
+++ b/ai_platform_engineering/mcp/webex-meetings/tests/test_auth.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from mcp.shared.exceptions import McpError
+
+from mcp_webex_meetings import mcp_server
+
+
+def test_bearer_from_request_prefers_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mcp_server,
+        "get_http_headers",
+        lambda **_kwargs: {
+            "authorization": "Bearer webex-oauth",
+            "x-caipe-provider-token": "fallback-token",
+        },
+    )
+
+    assert mcp_server._bearer_from_request() == "Bearer webex-oauth"
+
+
+def test_bearer_from_request_wraps_provider_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mcp_server,
+        "get_http_headers",
+        lambda **_kwargs: {"x-caipe-provider-token": "webex-oauth"},
+    )
+
+    assert mcp_server._bearer_from_request() == "Bearer webex-oauth"
+
+
+def test_bearer_from_request_fails_without_user_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_server, "get_http_headers", lambda **_kwargs: {})
+
+    with pytest.raises(McpError):
+        mcp_server._bearer_from_request()

--- a/ai_platform_engineering/mcp/webex-meetings/uv.lock
+++ b/ai_platform_engineering/mcp/webex-meetings/uv.lock
@@ -1,0 +1,1374 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[manifest]
+constraints = [{ name = "uv", specifier = "==0.11.6" }]
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+]
+
+[[package]]
+name = "backports-zstd"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b1/36a5182ce1d8ef9ef32bff69037bd28b389bbdb66338f8069e61da7028cb/backports_zstd-1.3.0.tar.gz", hash = "sha256:e8b2d68e2812f5c9970cabc5e21da8b409b5ed04e79b4585dbffa33e9b45ebe2", size = 997138, upload-time = "2025-12-29T17:28:06.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/7d/53e8da5950cdfc5e8fe23efd5165ce2f4fed5222f9a3292e0cdb03dd8c0d/backports_zstd-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e86e03e3661900955f01afed6c59cae9baa63574e3b66896d99b7de97eaffce9", size = 435463, upload-time = "2025-12-29T17:26:42.152Z" },
+    { url = "https://files.pythonhosted.org/packages/da/78/f98e53870f7404071a41e3d04f2ff514302eeeb3279d931d02b220f437aa/backports_zstd-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:41974dcacc9824c1effe1c8d2f9d762bcf47d265ca4581a3c63321c7b06c61f0", size = 361740, upload-time = "2025-12-29T17:26:43.377Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ed/2c64706205a944c9c346d95c17f632d4e3468db3ce60efb6f5caa7c0dcae/backports_zstd-1.3.0-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:3090a97738d6ce9545d3ca5446df43370928092a962cbc0153e5445a947e98ed", size = 505651, upload-time = "2025-12-29T17:26:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7b/22998f691dc6e0c7e6fa81d611eb4b1f6a72fb27327f322366d4a7ca8fb3/backports_zstd-1.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddc874638abf03ea1ff3b0525b4a26a8d0adf7cb46a448c3449f08e4abc276b3", size = 475859, upload-time = "2025-12-29T17:26:45.722Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/78/0cde898339a339530e5f932634872d2d64549969535447a48d3b98959e11/backports_zstd-1.3.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:db609e57b8ed88b3472930c87e93c08a4bbd5ffeb94608cd9c7c6f0ac0e166c6", size = 581339, upload-time = "2025-12-29T17:26:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1d/e0973e0eebe678c12c146473af2c54cda8a3e63b179785ca1a20727ad69c/backports_zstd-1.3.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f13033a3dd95f323c067199f2e61b4589a7880188ef4ef356c7ffbdb78a9f11", size = 642182, upload-time = "2025-12-29T17:26:48.545Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a2/ac67e79e137eb98aead66c7162bafe3cffcb82ef9cdeb6367ec18d88fbce/backports_zstd-1.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c4c7bcda5619a754726e7f5b391827f5efbe4bed8e62e9ec7490d42bff18aa6", size = 490807, upload-time = "2025-12-29T17:26:49.789Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/3514b1d065801ae7dce05246e9389003ed8fb1d7c3d71f85aa07a80f41e6/backports_zstd-1.3.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:884a94c40f27affe986f394f219a4fd3cbbd08e1cff2e028d29d467574cd266e", size = 566103, upload-time = "2025-12-29T17:26:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/03/10ddb54cbf032e5fe390c0776d3392611b1fc772d6c3cb5a9bcdff4f915f/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:497f5765126f11a5b3fd8fedfdae0166d1dd867e7179b8148370a3313d047197", size = 481614, upload-time = "2025-12-29T17:26:52.255Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/13/21efa7f94c41447f43aee1563b05fc540a235e61bce4597754f6c11c2e97/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a6ff6769948bb29bba07e1c2e8582d5a9765192a366108e42d6581a458475881", size = 509207, upload-time = "2025-12-29T17:26:53.496Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e7/12da9256d9e49e71030f0ff75e9f7c258e76091a4eaf5b5f414409be6a57/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1623e5bff1acd9c8ef90d24fc548110f20df2d14432bfe5de59e76fc036824ef", size = 585765, upload-time = "2025-12-29T17:26:54.99Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/59ca9cb4e7be1e59331bb792e8ef1331828efe596b1a2f8cbbc4e3f70d75/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:622c28306dcc429c8f2057fc4421d5722b1f22968d299025b35d71b50cfd4e03", size = 563852, upload-time = "2025-12-29T17:26:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ee/5a3eaed9a73bdf2c35dc0c7adc0616a99588e0de28f5ab52f3e0caaaa96f/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09a2785e410ed2e812cb39b684ef5eb55083a5897bfd0e6f5de3bbd2c6345f70", size = 632549, upload-time = "2025-12-29T17:26:57.598Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b9/c823633afc48a1ac56d6ad34289c8f51b0234685142531bfa8197ca91777/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ade1f4127fdbe36a02f8067d75aa79c1ea1c8a306bf63c7b818bb7b530e1beaa", size = 495104, upload-time = "2025-12-29T17:26:58.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/8f/6f7030f18fa7307f87b0f57108a50a3a540b6350e2486d1739c0567629a3/backports_zstd-1.3.0-cp313-cp313-win32.whl", hash = "sha256:668e6fb1805b825cb7504c71436f7b28d4d792bb2663ee901ec9a2bb15804437", size = 288447, upload-time = "2025-12-29T17:27:00.036Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/b1df1bbbe4e6d3ffd364d0bcffdeb6c4361115c1eccd91238dbdd0c07fec/backports_zstd-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:385bdadf0ea8fe6ba780a95e4c7d7f018db7bafdd630932f0f9f0fad05d608ff", size = 313664, upload-time = "2025-12-29T17:27:01.267Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0f/60918fe4d3f2881de8f4088d73be4837df9e4c6567594109d355a2d548b6/backports_zstd-1.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:4321a8a367537224b3559fe7aeb8012b98aea2a60a737e59e51d86e2e856fe0a", size = 288678, upload-time = "2025-12-29T17:27:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/35f423c0bcd85020d5e7be6ab8d7517843e3e4441071beb5c3bd8c5216cb/backports_zstd-1.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:10057d66fa4f0a7d3f6419ffb84b4fe61088da572e3ac4446134a1c8089e4166", size = 436155, upload-time = "2025-12-29T17:27:03.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/14/e504daea24e8916f14ecbc223c354b558d8410cfc846606668ab91d96b38/backports_zstd-1.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4abf29d706ba05f658ca0247eb55675bcc00e10f12bca15736e45b05f1f2d2dc", size = 362436, upload-time = "2025-12-29T17:27:05.076Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f7/06e178dbab7edb88c2872aebd68b54137e07a169eba1aeedf614014f7036/backports_zstd-1.3.0-cp313-cp313t-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:127b0d73c745b0684da3d95c31c0939570810dad8967dfe8231eea8f0e047b2f", size = 507600, upload-time = "2025-12-29T17:27:06.254Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f1/2ce499b81c4389d6fa1eeea7e76f6e0bad48effdbb239da7cbcdaaf24b76/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0205ef809fb38bb5ca7f59fa03993596f918768b9378fb7fbd8a68889a6ce028", size = 475496, upload-time = "2025-12-29T17:27:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/c82a586f2866aabf3a601a521af3c58756d83d98b724fda200016ac5e7e2/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c389b667b0b07915781aa28beabf2481f11a6062a1a081873c4c443b98601a7", size = 580919, upload-time = "2025-12-29T17:27:09.1Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a3/eb5d9b7c4cb69d1b8ccd011abe244ba6815693b70bed07ed4b77ddda4535/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8e7ac5ef693d49d6fb35cd7bbb98c4762cfea94a8bd2bf2ab112027004f70b11", size = 639913, upload-time = "2025-12-29T17:27:10.433Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2c/7296b99df79d9f31174a99c81c1964a32de8996ce2b3068f5bc66b413615/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d5543945aae2a76a850b23f283249424f535de6a622d6002957b7d971e6a36d", size = 494800, upload-time = "2025-12-29T17:27:11.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fc/b8ae6e104ba72d20cd5f9dfd9baee36675e89c81d432434927967114f30f/backports_zstd-1.3.0-cp313-cp313t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e38be15ebce82737deda2c9410c1f942f1df9da74121049243a009810432db75", size = 570396, upload-time = "2025-12-29T17:27:13.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/56/60a7a9de7a5bc951ea1106358b413c95183c93480394f3abc541313c8679/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3e3f58c76f4730607a4e0130d629173aa114ae72a5c8d3d5ad94e1bf51f18d8", size = 481980, upload-time = "2025-12-29T17:27:14.317Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bb/93fc1e8e81b8ecba58b0e53a14f7b44375cf837db6354410998f0c4cb6ff/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b808bf889722d889b792f7894e19c1f904bb0e9092d8c0eb0787b939b08bad9a", size = 511358, upload-time = "2025-12-29T17:27:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0f/b165c2a6080d22306975cd86ce97270208493f31a298867e343110570370/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f7be27d56f2f715bcd252d0c65c232146d8e1e039c7e2835b8a3ad3dc88bc508", size = 585492, upload-time = "2025-12-29T17:27:16.986Z" },
+    { url = "https://files.pythonhosted.org/packages/26/76/85b4bde76e982b24a7eb57a2fb9868807887bef4d2114a3654a6530a67ef/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:cbe341c7fcc723893663a37175ba859328b907a4e6d2d40a4c26629cc55efb67", size = 568309, upload-time = "2025-12-29T17:27:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/83/64/9490667827a320766fb883f358a7c19171fdc04f19ade156a8c341c36967/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:b4116a9e12dfcd834dd9132cf6a94657bf0d328cba5b295f26de26ea0ae1adc8", size = 630518, upload-time = "2025-12-29T17:27:19.525Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/43/258587233b728bbff457bdb0c52b3e08504c485a8642b3daeb0bdd5a76bc/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1049e804cc8754290b24dab383d4d6ed0b7f794ad8338813ddcb3907d15a89d0", size = 499429, upload-time = "2025-12-29T17:27:21.063Z" },
+    { url = "https://files.pythonhosted.org/packages/32/04/cfab76878f360f124dbb533779e1e4603c801a0f5ada72ae5c742b7c4d7d/backports_zstd-1.3.0-cp313-cp313t-win32.whl", hash = "sha256:7d3f0f2499d2049ec53d2674c605a4b3052c217cc7ee49c05258046411685adc", size = 289389, upload-time = "2025-12-29T17:27:22.287Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ff/dbcfb6c9c922ab6d98f3d321e7d0c7b34ecfa26f3ca71d930fe1ef639737/backports_zstd-1.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:eb2f8fab0b1ea05148394cb34a9e543a43477178765f2d6e7c84ed332e34935e", size = 314776, upload-time = "2025-12-29T17:27:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4b/82e4baae3117806639fe1c693b1f2f7e6133a7cefd1fa2e38018c8edcd68/backports_zstd-1.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c66ad9eb5bfbe28c2387b7fc58ddcdecfb336d6e4e60bcba1694a906c1f21a6c", size = 289315, upload-time = "2025-12-29T17:27:24.601Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/7b/1755ed2c6bfabd1d98b37ae73152f8dcf94aa40fee119d163c19ed484704/cachetools-7.0.6.tar.gz", hash = "sha256:e5d524d36d65703a87243a26ff08ad84f73352adbeafb1cde81e207b456aaf24", size = 37526, upload-time = "2026-04-20T19:02:23.289Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/c4/cf76242a5da1410917107ff14551764aa405a5fd10cd10cf9a5ca8fa77f4/cachetools-7.0.6-py3-none-any.whl", hash = "sha256:4e94956cfdd3086f12042cdd29318f5ced3893014f7d0d059bf3ead3f85b7f8b", size = 13976, upload-time = "2026-04-20T19:02:21.187Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fa/eff8f1abae783bade9b5e9bafafd0040d4dbf51988f9384bfdc0326ba1fc/cyclopts-4.11.0.tar.gz", hash = "sha256:1ffcb9990dbd56b90da19980d31596de9e99019980a215a5d76cf88fe452e94d", size = 170690, upload-time = "2026-04-23T00:23:36.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/37/197db187c260d24d4be1f09d427f59f3fb9a89bcf1354e23865c7bff7607/cyclopts-4.11.0-py3-none-any.whl", hash = "sha256:34318e3823b44b5baa754a5e37ec70a5c17dc81c65e4295ed70e17bc1aeae50d", size = 208494, upload-time = "2026-04-23T00:23:34.948Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hatch"
+version = "1.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-zstd" },
+    { name = "click" },
+    { name = "hatchling" },
+    { name = "httpx" },
+    { name = "hyperlink" },
+    { name = "keyring" },
+    { name = "packaging" },
+    { name = "pexpect" },
+    { name = "platformdirs" },
+    { name = "pyproject-hooks" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "tomli-w" },
+    { name = "tomlkit" },
+    { name = "userpath" },
+    { name = "uv" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c1/976b807478878d31d467dd17b9fe642962f292e16ed13c34b593c0453fde/hatch-1.16.3.tar.gz", hash = "sha256:2a50ecc912adfc8122cd2ccdcc15254cdef829e5d158be9014180cd7f0fb7ea9", size = 5219621, upload-time = "2026-01-21T01:36:19.822Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/b4/5c5fa4ca8c59e7ef0a224ff10e6336e73ca61c5e0eff09ee691441c9275f/hatch-1.16.3-py3-none-any.whl", hash = "sha256:f5169025cf1cdfe981366eb96127cab1d1bc59f5f2acb87c4cc308c25d95a4b1", size = 141305, upload-time = "2026-01-21T01:36:18.13Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz", hash = "sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6", size = 55656, upload-time = "2026-02-23T19:42:06.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl", hash = "sha256:50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0", size = 76356, upload-time = "2026-02-23T19:42:05.197Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "hyperlink"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/86/cfee6dd25843bec0760f456599a4f7e7e40221a934b9229fda0662c859bc/jsonschema_path-0.4.6.tar.gz", hash = "sha256:c89eb635f4d497c9ac328eeff359c489755838806a7d033510a692e9576f5c4b", size = 15302, upload-time = "2026-04-27T18:57:08.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/43/3d3065c05a04bb550c143bfbb8e4fd7022cd327e1082bf257bac74923783/jsonschema_path-0.4.6-py3-none-any.whl", hash = "sha256:451354b5311fa955c3144e6e4e255388c751c0121c5570ec5bb9291dd42d08c9", size = 19565, upload-time = "2026-04-27T18:57:06.792Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
+name = "mcp-webex-meetings"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "hatch" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = "==8.3.1" },
+    { name = "fastmcp", specifier = "==3.2.4" },
+    { name = "httpx", specifier = "==0.28.1" },
+    { name = "mcp", specifier = "==1.27.1" },
+    { name = "pydantic", specifier = "==2.12.5" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "typing-extensions", specifier = "==4.15.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "hatch", specifier = "==1.16.3" },
+    { name = "pyright", specifier = "==1.1.408" },
+    { name = "pytest", specifier = "==9.0.3" },
+    { name = "pytest-asyncio", specifier = "==1.3.0" },
+    { name = "ruff", specifier = "==0.15.1" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/dc/4e6ac71b511b141cf626357a3946679abeba4cf67bc7cc5a17920f31e10d/ruff-0.15.1.tar.gz", hash = "sha256:c590fe13fb57c97141ae975c03a1aedb3d3156030cabd740d6ff0b0d601e203f", size = 4540855, upload-time = "2026-02-12T23:09:09.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/bf/e6e4324238c17f9d9120a9d60aa99a7daaa21204c07fcd84e2ef03bb5fd1/ruff-0.15.1-py3-none-linux_armv6l.whl", hash = "sha256:b101ed7cf4615bda6ffe65bdb59f964e9f4a0d3f85cbf0e54f0ab76d7b90228a", size = 10367819, upload-time = "2026-02-12T23:09:03.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/c8f89d32e7912269d38c58f3649e453ac32c528f93bb7f4219258be2e7ed/ruff-0.15.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:939c995e9277e63ea632cc8d3fae17aa758526f49a9a850d2e7e758bfef46602", size = 10798618, upload-time = "2026-02-12T23:09:22.928Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0f/1d0d88bc862624247d82c20c10d4c0f6bb2f346559d8af281674cf327f15/ruff-0.15.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d83466455fdefe60b8d9c8df81d3c1bbb2115cede53549d3b522ce2bc703899", size = 10148518, upload-time = "2026-02-12T23:08:58.339Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c8/291c49cefaa4a9248e986256df2ade7add79388fe179e0691be06fae6f37/ruff-0.15.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9457e3c3291024866222b96108ab2d8265b477e5b1534c7ddb1810904858d16", size = 10518811, upload-time = "2026-02-12T23:09:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/f5707440e5ae43ffa5365cac8bbb91e9665f4a883f560893829cf16a606b/ruff-0.15.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:92c92b003e9d4f7fbd33b1867bb15a1b785b1735069108dfc23821ba045b29bc", size = 10196169, upload-time = "2026-02-12T23:09:17.306Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ff/26ddc8c4da04c8fd3ee65a89c9fb99eaa5c30394269d424461467be2271f/ruff-0.15.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fe5c41ab43e3a06778844c586251eb5a510f67125427625f9eb2b9526535779", size = 10990491, upload-time = "2026-02-12T23:09:25.503Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/00/50920cb385b89413f7cdb4bb9bc8fc59c1b0f30028d8bccc294189a54955/ruff-0.15.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66a6dd6df4d80dc382c6484f8ce1bcceb55c32e9f27a8b94c32f6c7331bf14fb", size = 11843280, upload-time = "2026-02-12T23:09:19.88Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6d/2f5cad8380caf5632a15460c323ae326f1e1a2b5b90a6ee7519017a017ca/ruff-0.15.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a4a42cbb8af0bda9bcd7606b064d7c0bc311a88d141d02f78920be6acb5aa83", size = 11274336, upload-time = "2026-02-12T23:09:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/1d/5f56cae1d6c40b8a318513599b35ea4b075d7dc1cd1d04449578c29d1d75/ruff-0.15.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ab064052c31dddada35079901592dfba2e05f5b1e43af3954aafcbc1096a5b2", size = 11137288, upload-time = "2026-02-12T23:09:07.475Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/20/6f8d7d8f768c93b0382b33b9306b3b999918816da46537d5a61635514635/ruff-0.15.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5631c940fe9fe91f817a4c2ea4e81f47bee3ca4aa646134a24374f3c19ad9454", size = 11070681, upload-time = "2026-02-12T23:08:55.43Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/67/d640ac76069f64cdea59dba02af2e00b1fa30e2103c7f8d049c0cff4cafd/ruff-0.15.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:68138a4ba184b4691ccdc39f7795c66b3c68160c586519e7e8444cf5a53e1b4c", size = 10486401, upload-time = "2026-02-12T23:09:27.927Z" },
+    { url = "https://files.pythonhosted.org/packages/65/3d/e1429f64a3ff89297497916b88c32a5cc88eeca7e9c787072d0e7f1d3e1e/ruff-0.15.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:518f9af03bfc33c03bdb4cb63fabc935341bb7f54af500f92ac309ecfbba6330", size = 10197452, upload-time = "2026-02-12T23:09:12.147Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/e2c3bade17dad63bf1e1c2ffaf11490603b760be149e1419b07049b36ef2/ruff-0.15.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:da79f4d6a826caaea95de0237a67e33b81e6ec2e25fc7e1993a4015dffca7c61", size = 10693900, upload-time = "2026-02-12T23:09:34.418Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/27/fdc0e11a813e6338e0706e8b39bb7a1d61ea5b36873b351acee7e524a72a/ruff-0.15.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3dd86dccb83cd7d4dcfac303ffc277e6048600dfc22e38158afa208e8bf94a1f", size = 11227302, upload-time = "2026-02-12T23:09:36.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.4.28.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/88fdebf242bc7bc4957c96c5358a2b2b0f07e5001401906783a521ea9f54/trove_classifiers-2026.4.28.13.tar.gz", hash = "sha256:c85bb8a53c3de7330d1699b844ed9fb809a602a09ac15dc79ad6d1a509be0676", size = 17035, upload-time = "2026-04-28T13:45:41.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/bb/fbdc4e57731efb86b4209ffdd2519520782bf27b3c961beac3e5c20d2b87/trove_classifiers-2026.4.28.13-py3-none-any.whl", hash = "sha256:8f4b1eb4e16296b57d612965444f87a83861cc989a0451ac97fe4265ddef03b8", size = 14216, upload-time = "2026-04-28T13:45:39.943Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
+]
+
+[[package]]
+name = "userpath"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz", hash = "sha256:6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815", size = 11140, upload-time = "2024-02-29T21:39:08.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl", hash = "sha256:2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d", size = 9065, upload-time = "2024-02-29T21:39:07.551Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/f3/8aceeab67ea69805293ab290e7ca8cc1b61a064d28b8a35c76d8eba063dd/uv-0.11.6.tar.gz", hash = "sha256:e3b21b7e80024c95ff339fcd147ac6fc3dd98d3613c9d45d3a1f4fd1057f127b", size = 4073298, upload-time = "2026-04-09T12:09:01.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/fe/4b61a3d5ad9d02e8a4405026ccd43593d7044598e0fa47d892d4dafe44c9/uv-0.11.6-py3-none-linux_armv6l.whl", hash = "sha256:ada04dcf89ddea5b69d27ac9cdc5ef575a82f90a209a1392e930de504b2321d6", size = 23780079, upload-time = "2026-04-09T12:08:56.609Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/d27519a9e1a5ffee9d71af1a811ad0e19ce7ab9ae815453bef39dd479389/uv-0.11.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5be013888420f96879c6e0d3081e7bcf51b539b034a01777041934457dfbedf3", size = 23214721, upload-time = "2026-04-09T12:09:32.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/4399fa8b882bd7e0efffc829f73ab24d117d490a93e6bc7104a50282b854/uv-0.11.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ffa5dc1cbb52bdce3b8447e83d1601a57ad4da6b523d77d4b47366db8b1ceb18", size = 21750109, upload-time = "2026-04-09T12:09:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/32/07/5a12944c31c3dda253632da7a363edddb869ed47839d4d92a2dc5f546c93/uv-0.11.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:bfb107b4dade1d2c9e572992b06992d51dd5f2136eb8ceee9e62dd124289e825", size = 23551146, upload-time = "2026-04-09T12:09:10.439Z" },
+    { url = "https://files.pythonhosted.org/packages/79/5b/2ec8b0af80acd1016ed596baf205ddc77b19ece288473b01926c4a9cf6db/uv-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:9e2fe7ce12161d8016b7deb1eaad7905a76ff7afec13383333ca75e0c4b5425d", size = 23331192, upload-time = "2026-04-09T12:09:34.792Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7d/eea35935f2112b21c296a3e42645f3e4b1aa8bcd34dcf13345fbd55134b7/uv-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ed9c6f70c25e8dfeedddf4eddaf14d353f5e6b0eb43da9a14d3a1033d51d915", size = 23337686, upload-time = "2026-04-09T12:09:18.522Z" },
+    { url = "https://files.pythonhosted.org/packages/21/47/2584f5ab618f6ebe9bdefb2f765f2ca8540e9d739667606a916b35449eec/uv-0.11.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d68a013e609cebf82077cbeeb0809ed5e205257814273bfd31e02fc0353bbfc2", size = 25008139, upload-time = "2026-04-09T12:09:03.983Z" },
+    { url = "https://files.pythonhosted.org/packages/95/81/497ae5c1d36355b56b97dc59f550c7e89d0291c163a3f203c6f341dff195/uv-0.11.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:93f736dddca03dae732c6fdea177328d3bc4bf137c75248f3d433c57416a4311", size = 25712458, upload-time = "2026-04-09T12:09:07.598Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1c/74083238e4fab2672b63575b9008f1ea418b02a714bcfcf017f4f6a309b6/uv-0.11.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e96a66abe53fced0e3389008b8d2eff8278cfa8bb545d75631ae8ceb9c929aba", size = 24915507, upload-time = "2026-04-09T12:08:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ee/e14fe10ba455a823ed18233f12de6699a601890905420b5c504abf115116/uv-0.11.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b096311b2743b228df911a19532b3f18fa420bf9530547aecd6a8e04bbfaccd", size = 24971011, upload-time = "2026-04-09T12:08:54.016Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/7b9c83eaadf98e343317ff6384a7227a4855afd02cdaf9696bcc71ee6155/uv-0.11.6-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:904d537b4a6e798015b4a64ff5622023bd4601b43b6cd1e5f423d63471f5e948", size = 23640234, upload-time = "2026-04-09T12:09:15.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/75ccdd23e76ff1703b70eb82881cd5b4d2a954c9679f8ef7e0136ef2cfab/uv-0.11.6-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:4ed8150c26b5e319381d75ae2ce6aba1e9c65888f4850f4e3b3fa839953c90a5", size = 24452664, upload-time = "2026-04-09T12:09:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/86/ace80fe47d8d48b5e3b5aee0b6eb1a49deaacc2313782870250b3faa36f5/uv-0.11.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1c9218c8d4ac35ca6e617fb0951cc0ab2d907c91a6aea2617de0a5494cf162c0", size = 24494599, upload-time = "2026-04-09T12:09:37.368Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2d/4b642669b56648194f026de79bc992cbfc3ac2318b0a8d435f3c284934e8/uv-0.11.6-py3-none-musllinux_1_1_i686.whl", hash = "sha256:9e211c83cc890c569b86a4183fcf5f8b6f0c7adc33a839b699a98d30f1310d3a", size = 24159150, upload-time = "2026-04-09T12:09:13.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/24/7eecd76fe983a74fed1fc700a14882e70c4e857f1d562a9f2303d4286c12/uv-0.11.6-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:d2a1d2089afdf117ad19a4c1dd36b8189c00ae1ad4135d3bfbfced82342595cf", size = 25164324, upload-time = "2026-04-09T12:08:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e0/bbd4ba7c2e5067bbba617d87d306ec146889edaeeaa2081d3e122178ca08/uv-0.11.6-py3-none-win32.whl", hash = "sha256:6e8344f38fa29f85dcfd3e62dc35a700d2448f8e90381077ef393438dcd5012e", size = 22865693, upload-time = "2026-04-09T12:09:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/33/1983ce113c538a856f2d620d16e39691962ecceef091a84086c5785e32e5/uv-0.11.6-py3-none-win_amd64.whl", hash = "sha256:a28bea69c1186303d1200f155c7a28c449f8a4431e458fcf89360cc7ef546e40", size = 25371258, upload-time = "2026-04-09T12:09:40.52Z" },
+    { url = "https://files.pythonhosted.org/packages/35/01/be0873f44b9c9bc250fcbf263367fcfc1f59feab996355bcb6b52fff080d/uv-0.11.6-py3-none-win_arm64.whl", hash = "sha256:a78f6d64b9950e24061bc7ec7f15ff8089ad7f5a976e7b65fcadce58fe02f613", size = 23869585, upload-time = "2026-04-09T12:09:29.425Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+]

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -131,6 +131,15 @@ dependencies:
         parent: global.enabledSubAgents.webex
   - name: mcp-server
     version: 0.5.36 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    alias: mcp-webex-meetings
+    tags:
+      - mcp-webex-meetings
+      - complete
+    import-values:
+      - child: agentExports.data
+        parent: global.enabledSubAgents.webex-meetings
+  - name: mcp-server
+    version: 0.5.36 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: mcp-netutils
     tags:
       - mcp-netutils

--- a/charts/ai-platform-engineering/charts/caipe-ui/README.md
+++ b/charts/ai-platform-engineering/charts/caipe-ui/README.md
@@ -12,7 +12,36 @@ Common values:
 - `config`: non-sensitive environment variables
 - `existingSecret`: existing Secret mounted with `envFrom`
 - `externalSecrets`: optional ExternalSecret integration
+- `oauthConnectors`: arbitrary OAuth connectors bootstrapped into the credential store
 - `appConfig.models`: model selector entries
 - `appConfig.mcp_servers`: dynamic-agent MCP server bootstrap entries
 
 See `values.yaml` for the complete value schema.
+
+## Declarative OAuth connectors
+
+Use `oauthConnectors` to provision the same connectors that an administrator can
+create under **Credentials → Connected Apps**:
+
+```yaml
+caipe-ui:
+  oauthConnectors:
+    - provider: webex_secondary
+      name: Webex Secondary
+      clientIdEnv: WEBEX_SECONDARY_CLIENT_ID
+      clientSecretEnv: WEBEX_SECONDARY_CLIENT_SECRET
+      authorizationUrl: https://webexapis.com/v1/authorize
+      tokenUrl: https://webexapis.com/v1/access_token
+      scopes:
+        - spark:mcp
+        - meeting:schedules_read
+      redirectUri: https://caipe.example.com/api/credentials/oauth/webex_secondary/callback
+  existingSecret: caipe-ui-secrets
+```
+
+`clientIdEnv` and `clientSecretEnv` refer to keys mounted from `existingSecret`
+or `externalSecrets`; secret values are never rendered into the ConfigMap. A
+non-empty list is bootstrapped automatically and upserted by `provider` at every
+UI startup. Declarative entries override legacy fixed-provider environment
+bootstrap entries. Removing an entry does not delete or disable the connector
+already stored in MongoDB.

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/configmap.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/configmap.yaml
@@ -4,6 +4,49 @@
 {{- $schedulerRunnerBase := printf "%s-keycloak" .Release.Name | trunc 46 | trimSuffix "-" -}}
 {{- $schedulerRunnerSecretName = printf "%s-scheduler-runner" $schedulerRunnerBase -}}
 {{- end -}}
+{{- $oauthConnectors := .Values.oauthConnectors | default list -}}
+{{- $oauthProviders := dict -}}
+{{- range $index, $connector := $oauthConnectors -}}
+{{- if not (kindIs "map" $connector) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d] must be an object" $index) -}}
+{{- end -}}
+{{- if hasKey $connector "clientSecret" -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].clientSecret is not allowed; use clientSecretEnv with existingSecret or externalSecrets" $index) -}}
+{{- end -}}
+{{- $provider := required (printf "caipe-ui.oauthConnectors[%d].provider is required" $index) $connector.provider -}}
+{{- if hasKey $oauthProviders $provider -}}
+{{- fail (printf "caipe-ui.oauthConnectors provider %q is configured more than once" $provider) -}}
+{{- end -}}
+{{- $_ := set $oauthProviders $provider true -}}
+{{- $_ := required (printf "caipe-ui.oauthConnectors[%d].name is required" $index) $connector.name -}}
+{{- $_ := required (printf "caipe-ui.oauthConnectors[%d].authorizationUrl is required" $index) $connector.authorizationUrl -}}
+{{- $_ := required (printf "caipe-ui.oauthConnectors[%d].tokenUrl is required" $index) $connector.tokenUrl -}}
+{{- if not (hasKey $connector "scopes") -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].scopes is required" $index) -}}
+{{- end -}}
+{{- if not (kindIs "slice" $connector.scopes) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].scopes must be a list" $index) -}}
+{{- end -}}
+{{- if and (hasKey $connector "pkce") (not (kindIs "bool" $connector.pkce)) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].pkce must be a boolean" $index) -}}
+{{- end -}}
+{{- $pkce := $connector.pkce | default false -}}
+{{- if and (not $connector.clientId) (not $connector.clientIdEnv) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d] requires clientId or clientIdEnv" $index) -}}
+{{- end -}}
+{{- if and $connector.clientId $connector.clientIdEnv -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d] must set only one of clientId or clientIdEnv" $index) -}}
+{{- end -}}
+{{- if and (not $pkce) (not $connector.clientSecretEnv) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].clientSecretEnv is required unless pkce is true" $index) -}}
+{{- end -}}
+{{- range $field := list "clientIdEnv" "clientSecretEnv" -}}
+{{- $envName := index $connector $field | default "" -}}
+{{- if and $envName (not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $envName)) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].%s must be a valid environment variable name" $index $field) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,6 +80,9 @@ data:
   {{- end }}
   {{- if and $schedulerEnabled (not (hasKey .Values.config "SCHEDULER_ENABLED")) }}
   SCHEDULER_ENABLED: "true"
+  {{- end }}
+  {{- if and (gt (len $oauthConnectors) 0) (not (hasKey .Values.config "CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON")) }}
+  CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: {{ mustToJson $oauthConnectors | quote }}
   {{- end }}
   {{- /* Okta directory sync — flatten the structured `oktaSync:` block
          (Backstage-style) into IDENTITY_SYNC_OKTA_* env vars. Only the

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -278,6 +278,8 @@ config:
   # Bootstrap global OAuth connectors from server env at startup. In
   # Kubernetes, provide provider client IDs/secrets/redirect URIs through
   # externalSecrets below; in Docker Compose, provide them through .env.
+  # This flag controls the legacy fixed-provider environment variables. A
+  # non-empty oauthConnectors list below is always bootstrapped.
   CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS: "false"
   # Standalone skill-scanner microservice (cisco-ai-defense/skill-scanner).
   # Set when global.skillScanner.enabled=true on the parent chart so the
@@ -338,6 +340,30 @@ config:
   # Server-side user identity via JWT — same flag as backend.
   # When true, the UI stops prefixing messages with "by user: email".
   ENABLE_USER_INFO_TOOL: "false"
+
+# Declarative OAuth connectors to upsert into the credential store at UI
+# startup. Entries are keyed by `provider`; an entry here overrides the legacy
+# fixed-provider environment bootstrap for the same provider. Removing an entry
+# does not delete or disable an existing MongoDB connector.
+#
+# Client secrets must never be placed in this list. `clientSecretEnv` names an
+# environment variable supplied through `existingSecret` or `externalSecrets`.
+# `clientId` is non-sensitive and may be inline; use `clientIdEnv` instead when
+# it is also supplied by the Secret. Set `pkce: true` for public clients that do
+# not have a client secret. When redirectUri is omitted, the UI derives
+# `${NEXTAUTH_URL}/api/credentials/oauth/<provider>/callback`.
+oauthConnectors: []
+  # - provider: "webex_secondary"
+  #   name: "Webex Secondary"
+  #   clientIdEnv: "WEBEX_SECONDARY_CLIENT_ID"
+  #   clientSecretEnv: "WEBEX_SECONDARY_CLIENT_SECRET"
+  #   authorizationUrl: "https://webexapis.com/v1/authorize"
+  #   tokenUrl: "https://webexapis.com/v1/access_token"
+  #   scopes:
+  #     - "spark:mcp"
+  #     - "meeting:schedules_read"
+  #     - "meeting:transcripts_read"
+  #   redirectUri: "https://caipe.example.com/api/credentials/oauth/webex_secondary/callback"
 
 # Name of a pre-existing Kubernetes Secret to mount as environment variables.
 # Use this when managing secrets outside the chart (e.g. via extraDeploy, CI/CD, or manual creation).

--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -177,7 +177,9 @@ global.agentgateway.knowledgeBaseTarget, global.agentgateway.extraMcpTargets.
 {{- $mcp := $agentValues.mcp | default dict -}}
 {{- $sub := $mcp.agentgateway | default dict -}}
 {{- if $sub.enabled -}}
-{{- $entry := dict "id" $name "pathPrefix" (printf "/mcp/%s" $name) "host" (printf "%s-mcp-%s-mcp.%s.svc.cluster.local" $root.Release.Name $name $ns) "port" ($mcp.port | default 8000) "protocol" ($sub.protocol | default "StreamableHTTP") -}}
+{{- $targetId := $sub.id | default $name -}}
+{{- $pathPrefix := $sub.pathPrefix | default (printf "/mcp/%s" $targetId) -}}
+{{- $entry := dict "id" $targetId "pathPrefix" $pathPrefix "host" (printf "%s-mcp-%s-mcp.%s.svc.cluster.local" $root.Release.Name $name $ns) "port" ($mcp.port | default 8000) "protocol" ($sub.protocol | default "StreamableHTTP") -}}
 {{- if eq (include "ai-platform-engineering.agentgatewayProviderTokenAuth" $sub) "true" -}}
 {{- $_ := set $entry "providerTokenAuth" true -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/templates/agentgateway-mcp.yaml
+++ b/charts/ai-platform-engineering/templates/agentgateway-mcp.yaml
@@ -92,7 +92,8 @@ spec:
 {{- $mcpServiceName := printf "%s-%s-mcp" $.Release.Name $agentKey }}
 {{- $mcpHost := printf "%s.%s.svc.cluster.local" $mcpServiceName $.Release.Namespace }}
 {{- $protocol := $agw.protocol | default "StreamableHTTP" }}
-{{- $pathPrefix := printf "/mcp/%s" $name }}
+{{- $targetId := $agw.id | default $name }}
+{{- $pathPrefix := $agw.pathPrefix | default (printf "/mcp/%s" $targetId) }}
 {{- $routeName := printf "%s-mcp-route" $name }}
 {{- $backendName := printf "%s-mcp-backend" $name }}
 ---

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -16,6 +16,7 @@ tags:
   mcp-splunk: false
   mcp-victorops: false
   mcp-webex: false
+  mcp-webex-meetings: false
   mcp-netutils: false
   rag-stack: false
   slack-bot: false

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -635,6 +635,29 @@ mcp-webex:
       enabled: false
       protocol: StreamableHTTP
 
+mcp-webex-meetings:
+  nameOverride: "mcp-webex-meetings"
+  mcpSecrets:
+    requiresSecret: false
+  mcp:
+    image:
+      repository: "ghcr.io/cnoe-io/mcp-webex-meetings"
+      # tag defaults to .Chart.AppVersion when not specified
+      tag: ""
+      pullPolicy: "IfNotPresent"
+    mode: "http"
+    port: 8000
+    agentgateway:
+      enabled: true
+      id: webex_meetings
+      pathPrefix: /mcp/webex_meetings
+      protocol: StreamableHTTP
+      credential_sources:
+        - kind: provider_connection
+          name: X-CAIPE-Provider-Token
+          provider: webex
+          target: header
+
 mcp-komodor:
   nameOverride: "mcp-komodor"
   image:
@@ -774,7 +797,9 @@ caipe-ui:
     CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
     # Bootstrap global OAuth connectors from server env at startup. In
     # Kubernetes, provide provider client IDs/secrets/redirect URIs through
-    # externalSecrets; in Docker Compose, provide them through .env.
+    # externalSecrets; in Docker Compose, provide them through .env. This flag
+    # controls the legacy fixed-provider variables; oauthConnectors below is
+    # always bootstrapped when non-empty.
     CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS: "false"
     # Standalone skill-scanner microservice (cisco-ai-defense/skill-scanner).
     # Active when global.skillScanner.enabled=true. Leave empty to use the
@@ -844,6 +869,25 @@ caipe-ui:
     # SOURCE_URL: "https://github.com/your-org/your-repo"
     # Enable Prometheus metrics
     # PROMETHEUS_URL: "http://prometheus-server.monitoring.svc.cluster.local:9090"
+
+  # Arbitrary OAuth connectors to upsert at UI startup. Client secrets are not
+  # accepted inline: clientSecretEnv must reference a key supplied through
+  # caipe-ui.existingSecret or caipe-ui.externalSecrets. Entries are keyed by
+  # provider, and configured entries override the legacy fixed-env bootstrap.
+  # Removing an entry does not delete or disable an existing connector.
+  oauthConnectors: []
+    # - provider: "webex_secondary"
+    #   name: "Webex Secondary"
+    #   clientIdEnv: "WEBEX_SECONDARY_CLIENT_ID"
+    #   clientSecretEnv: "WEBEX_SECONDARY_CLIENT_SECRET"
+    #   authorizationUrl: "https://webexapis.com/v1/authorize"
+    #   tokenUrl: "https://webexapis.com/v1/access_token"
+    #   scopes:
+    #     - "spark:mcp"
+    #     - "meeting:schedules_read"
+    #     - "meeting:transcripts_read"
+    #   # Defaults to ${NEXTAUTH_URL}/api/credentials/oauth/<provider>/callback.
+    #   redirectUri: "https://caipe.example.com/api/credentials/oauth/webex_secondary/callback"
 
   # ── Okta directory sync (Identity Sync admin tab) ──────────────────────────
   # Structured config modeled after the Backstage Okta entity provider. The

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -355,6 +355,33 @@ services:
       - all-agents
       - mcp-servers
 
+  mcp-webex-meetings:
+    build:
+      context: .
+      dockerfile: build/agents/Dockerfile.mcp
+      args:
+        - AGENT_NAME=webex-meetings
+    image: ghcr.io/cnoe-io/mcp-webex-meetings:${IMAGE_TAG:-localtag}
+    container_name: mcp-webex-meetings
+    env_file: [.env]
+    ports: ["18013:8000"]
+    volumes:
+      - ./ai_platform_engineering/mcp/webex-meetings:/app/ai_platform_engineering/mcp/webex-meetings
+    environment:
+      - MCP_MODE=http
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.socket(); s.settimeout(1); result=s.connect_ex(('localhost', 8000)); s.close(); exit(0 if result == 0 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    profiles:
+      - webex-meetings
+      - all-agents
+      - mcp-servers
+
   mcp-victorops:
     build:
       context: .

--- a/docs/docs/integrations/webex-meetings-mcp.md
+++ b/docs/docs/integrations/webex-meetings-mcp.md
@@ -1,0 +1,236 @@
+---
+sidebar_position: 3
+---
+
+# Webex Meetings MCP
+
+The Webex Meetings MCP exposes per-user Webex meeting, participant, recording,
+and transcript operations to Dynamic Agents. It runs as one shared MCP service,
+but each tool call uses the connected Webex account of the caller.
+
+## Authentication flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant UI as CAIPE UI
+  participant D as Dynamic Agents
+  participant G as AgentGateway
+  participant M as Webex Meetings MCP
+  participant W as Webex REST API
+
+  U->>UI: Connect Webex with OAuth
+  UI->>UI: Store encrypted provider connection
+  U->>D: Chat with an authorized agent
+  D->>UI: Resolve caller's Webex connection
+  UI-->>D: Short-lived provider access token
+  D->>G: Caller JWT + X-CAIPE-Provider-Token
+  G->>M: Authorization: Bearer provider-token
+  M->>W: Authorization: Bearer provider-token
+  W-->>M: Meeting data
+```
+
+The CAIPE caller JWT remains in the request `Authorization` header until
+AgentGateway authorizes the tool call. The provider token is carried separately
+in `X-CAIPE-Provider-Token`. AgentGateway then rewrites the provider token into
+the upstream `Authorization` header for the MCP server.
+
+The MCP service does not store OAuth credentials or query MongoDB. Credential
+storage, refresh, and caller-scoped connection selection belong to the CAIPE UI
+credential service and Dynamic Agents runtime.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `webex_list_meetings` | List or search meetings |
+| `webex_userhub_calendar` | Best-effort User Hub calendar lookup |
+| `webex_resolve_meeting_link` | Resolve a Webex join link through the meetings API |
+| `webex_get_meeting_status` | Read meeting details and optional participants |
+| `webex_create_meeting` | Schedule a meeting |
+| `webex_update_meeting` | Update a scheduled meeting |
+| `webex_delete_meeting` | Delete a scheduled meeting |
+| `webex_list_recordings` | List meeting recordings |
+| `webex_list_transcripts` | List and optionally download transcripts |
+
+## Minimum Webex scopes
+
+The local MCP calls the Webex REST API directly. For read-only meeting listing
+and lookup, the minimum is `meeting:schedules_read`. To support the MCP's full
+tool surface, enable the scopes required by the capabilities you expose:
+
+| Scope | Required by |
+|---|---|
+| `meeting:schedules_read` | List/get meetings, resolve links, and read the current meeting before an update |
+| `meeting:schedules_write` | Create, update, and delete meetings |
+| `meeting:participants_read` | Optional participant expansion in `webex_get_meeting_status` |
+| `meeting:recordings_read` | `webex_list_recordings` |
+| `meeting:transcripts_read` | `webex_list_transcripts` and transcript downloads |
+
+Add `spark:people_read` when CAIPE should display the connected user's Webex
+profile through `/v1/people/me`. This scope is useful for the Connected Apps UI,
+but the meeting tools themselves do not require it.
+
+The following scopes are not required by the current local MCP:
+
+- `spark:mcp` is for the Webex-hosted MCP service, not this local REST proxy.
+- `meeting:summaries_read` is unnecessary because this MCP has no summary tool.
+- Messaging, membership, room, admin, compliance, and write scopes unrelated to
+  the tools above should not be requested unless another integration needs them.
+
+`webex_userhub_calendar` calls a best-effort Webex User Hub endpoint rather than
+a public Webex REST resource. Webex does not publish a separate OAuth scope
+contract for that endpoint, so do not treat it as a guaranteed integration API.
+
+Every scope in an OAuth authorization request must also be enabled on the Webex
+Integration in the Webex developer portal. Otherwise Webex returns
+`invalid_scope`. After changing scopes, restart the UI so deployment-configured
+connectors are reconciled, then reconnect the Webex account to obtain a token
+with the new grants.
+
+See the Webex documentation for the
+[Meetings API scopes](https://developer.webex.com/meeting/docs/meetings).
+
+## Helm configuration
+
+This example enables the MCP, provisions a Webex OAuth provider, routes tool
+calls through AgentGateway, and registers the MCP with Dynamic Agents. Replace
+the release name, namespace, public URL, and secret store values for your
+environment.
+
+```yaml
+tags:
+  caipe-ui: true
+  dynamic-agents: true
+  mcp-webex-meetings: true
+
+global:
+  agentgateway:
+    enabled: true
+
+mcp-webex-meetings:
+  nameOverride: mcp-webex-meetings
+  mcpSecrets:
+    requiresSecret: false
+  mcp:
+    mode: http
+    port: 8000
+    agentgateway:
+      enabled: true
+      id: webex_meetings
+      pathPrefix: /mcp/webex_meetings
+      protocol: StreamableHTTP
+      credential_sources:
+        - kind: provider_connection
+          name: X-CAIPE-Provider-Token
+          provider: webex
+          target: header
+
+caipe-ui:
+  config:
+    CAIPE_CREDENTIALS_ENABLED: "true"
+    CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS: "false"
+
+  oauthConnectors:
+    - provider: webex
+      name: Webex
+      clientIdEnv: WEBEX_CLIENT_ID
+      clientSecretEnv: WEBEX_CLIENT_SECRET
+      authorizationUrl: https://webexapis.com/v1/authorize
+      tokenUrl: https://webexapis.com/v1/access_token
+      redirectUri: https://caipe.example.com/api/credentials/oauth/webex/callback
+      scopes:
+        - meeting:schedules_read
+        - meeting:schedules_write
+        - meeting:participants_read
+        - meeting:recordings_read
+        - meeting:transcripts_read
+        - spark:people_read
+
+  externalSecrets:
+    enabled: true
+    secretStoreRef:
+      name: vault
+      kind: ClusterSecretStore
+    data:
+      - secretKey: WEBEX_CLIENT_ID
+        remoteRef:
+          key: projects/caipe/oauth-connectors
+          property: WEBEX_CLIENT_ID
+      - secretKey: WEBEX_CLIENT_SECRET
+        remoteRef:
+          key: projects/caipe/oauth-connectors
+          property: WEBEX_CLIENT_SECRET
+
+  appConfig:
+    mcp_servers:
+      - id: webex_meetings
+        name: Webex Meetings
+        description: Webex meeting, recording, and transcript tools
+        transport: http
+        enabled: true
+        endpoint: http://caipe-agentgateway:4000/mcp/webex_meetings
+        source: agentgateway
+        agentgateway_endpoint: http://caipe-agentgateway:4000/mcp/webex_meetings
+        agentgateway_target_endpoint: http://caipe-mcp-webex-meetings-mcp.caipe.svc.cluster.local:8000/mcp
+        credential_sources:
+          - kind: provider_connection
+            name: X-CAIPE-Provider-Token
+            provider: webex
+            target: header
+```
+
+The redirect URI path must use the same provider ID as `provider`. Register that
+exact URI on the Webex Integration before users connect.
+
+## Multiple provider variants
+
+Multiple logical MCP entries can share the same Webex Meetings pod. Give each
+OAuth connector a unique provider ID, then use that ID in the MCP row's
+`credential_sources`:
+
+```yaml
+caipe-ui:
+  oauthConnectors:
+    - provider: webex_secondary
+      name: Webex Secondary
+      clientIdEnv: WEBEX_SECONDARY_CLIENT_ID
+      clientSecretEnv: WEBEX_SECONDARY_CLIENT_SECRET
+      authorizationUrl: https://webexapis.com/v1/authorize
+      tokenUrl: https://webexapis.com/v1/access_token
+      redirectUri: https://caipe.example.com/api/credentials/oauth/webex_secondary/callback
+      scopes:
+        - meeting:schedules_read
+        - meeting:schedules_write
+        - meeting:participants_read
+        - meeting:recordings_read
+        - meeting:transcripts_read
+
+  appConfig:
+    mcp_servers:
+      - id: webex_meetings_secondary
+        name: Webex Meetings Secondary
+        transport: http
+        enabled: true
+        endpoint: http://caipe-agentgateway:4000/mcp/webex_meetings_secondary
+        agentgateway_target_endpoint: http://caipe-mcp-webex-meetings-mcp.caipe.svc.cluster.local:8000/mcp
+        credential_sources:
+          - kind: provider_connection
+            name: X-CAIPE-Provider-Token
+            provider: webex_secondary
+            target: header
+
+global:
+  agentgateway:
+    extraMcpTargets:
+      - id: webex_meetings_secondary
+        host: caipe-mcp-webex-meetings-mcp.caipe.svc.cluster.local
+        port: 8000
+        pathPrefix: /mcp/webex_meetings_secondary
+        protocol: StreamableHTTP
+        providerTokenAuth: true
+```
+
+This creates a second credential and routing identity, not a second MCP
+Deployment. Agents select a variant by listing its MCP server ID under
+`allowed_tools`.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -277,6 +277,7 @@ const sidebars: SidebarsConfig = {
           items: [
             { type: 'doc', id: 'integrations/slack-bot', label: 'Slack Bot' },
             { type: 'doc', id: 'integrations/webex-bot', label: 'Webex Bot' },
+            { type: 'doc', id: 'integrations/webex-meetings-mcp', label: 'Webex Meetings MCP' },
             { type: 'doc', id: 'api/webex-integration', label: 'Webex Bot RBAC API' },
             { type: 'doc', id: 'integrations/cli', label: 'CAIPE CLI' },
           ],

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.35 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.36 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.35 -f your-values.yaml'}
+                  {'    --version 0.5.36 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.35 -f your-values.yaml'}
+              {'    --version 0.5.36 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.36"
+version = "0.5.36-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/tests/test_agentgateway_provider_token_auth.py
+++ b/tests/test_agentgateway_provider_token_auth.py
@@ -97,6 +97,24 @@ def test_static_extra_mcp_target_derives_provider_token_auth_from_credentials() 
     ] == '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
 
 
+def test_static_webex_meetings_route_uses_webex_provider_token() -> None:
+    docs = _helm_template(
+        "global.agentgateway.routingMode=static",
+        "global.agentgateway.knowledgeBaseTarget.enabled=false",
+        "tags.mcp-webex-meetings=true",
+        "mcp-webex-meetings.mcp.agentgateway.enabled=true",
+    )
+
+    route = _static_route(_static_config(docs), "/mcp/webex_meetings")
+
+    assert route["backends"][0]["mcp"]["targets"][0]["mcp"]["host"] == (
+        "http://test-mcp-webex-meetings-mcp.default.svc.cluster.local:8000/mcp"
+    )
+    assert route["policies"]["transformations"]["request"]["set"][
+        "authorization"
+    ] == '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+
+
 def test_gateway_api_provider_token_policy_follows_declarative_flag() -> None:
     docs = _helm_template(
         "global.agentgateway.routingMode=gateway-api",
@@ -118,3 +136,24 @@ def test_gateway_api_provider_token_policy_follows_declarative_flag() -> None:
 
     assert "github-provider-token-auth" not in names
     assert "custom-provider-provider-token-auth" in names
+
+
+def test_gateway_api_webex_meetings_uses_public_route_id() -> None:
+    docs = _helm_template(
+        "global.agentgateway.routingMode=gateway-api",
+        "global.agentgateway.knowledgeBaseTarget.enabled=false",
+        "tags.mcp-webex-meetings=true",
+        "mcp-webex-meetings.mcp.agentgateway.enabled=true",
+    )
+
+    route = next(
+        doc
+        for doc in docs
+        if doc.get("kind") == "HTTPRoute"
+        and doc.get("metadata", {}).get("name") == "webex-meetings-mcp-route"
+    )
+
+    assert route["spec"]["rules"][0]["matches"][0]["path"]["value"] == (
+        "/mcp/webex_meetings"
+    )
+    assert "webex-meetings-provider-token-auth" in _policy_names(docs)

--- a/tests/test_caipe_ui_oauth_connectors.py
+++ b/tests/test_caipe_ui_oauth_connectors.py
@@ -1,0 +1,95 @@
+"""Helm coverage for declarative CAIPE UI OAuth connectors."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHART = REPO_ROOT / "charts" / "ai-platform-engineering" / "charts" / "caipe-ui"
+
+
+def _render(values: dict) -> subprocess.CompletedProcess[str]:
+    base_values = {
+        "global": {
+            "vpa": {"enabled": False},
+            "agentgateway": {"enabled": False},
+            "image": {"tag": "test"},
+        },
+        "oktaSync": {"enabled": False},
+    }
+    base_values.update(values)
+    return subprocess.run(
+        ["helm", "template", "oauth-test", str(CHART), "-f", "-"],
+        input=yaml.safe_dump(base_values),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _documents(rendered: str) -> list[dict]:
+    return [document for document in yaml.safe_load_all(rendered) if document]
+
+
+def test_renders_declarative_oauth_connectors_without_secret_values() -> None:
+    connector = {
+        "provider": "acme",
+        "name": "Acme Cloud",
+        "clientIdEnv": "ACME_OAUTH_CLIENT_ID",
+        "clientSecretEnv": "ACME_OAUTH_CLIENT_SECRET",
+        "authorizationUrl": "https://identity.acme.example.com/oauth/authorize",
+        "tokenUrl": "https://identity.acme.example.com/oauth/token",
+        "scopes": ["projects.read", "projects.write"],
+    }
+    result = _render(
+        {
+            "existingSecret": "caipe-ui-secrets",
+            "oauthConnectors": [connector],
+        }
+    )
+
+    assert result.returncode == 0, result.stderr
+    documents = _documents(result.stdout)
+    config_map = next(
+        document
+        for document in documents
+        if document["kind"] == "ConfigMap"
+        and document["metadata"]["name"].endswith("-caipe-ui-config")
+    )
+    assert json.loads(
+        config_map["data"]["CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON"]
+    ) == [connector]
+    assert "ACME_OAUTH_CLIENT_SECRET" in result.stdout
+    assert "acme-secret-value" not in result.stdout
+
+    deployment = next(document for document in documents if document["kind"] == "Deployment")
+    assert {"secretRef": {"name": "caipe-ui-secrets"}} in deployment["spec"]["template"][
+        "spec"
+    ]["containers"][0]["envFrom"]
+
+
+def test_rejects_inline_oauth_client_secrets() -> None:
+    result = _render(
+        {
+            "oauthConnectors": [
+                {
+                    "provider": "acme",
+                    "name": "Acme Cloud",
+                    "clientId": "acme-client",
+                    "clientSecret": "acme-secret-value",
+                    "authorizationUrl": "https://identity.acme.example.com/oauth/authorize",
+                    "tokenUrl": "https://identity.acme.example.com/oauth/token",
+                    "scopes": ["projects.read"],
+                }
+            ]
+        }
+    )
+
+    assert result.returncode != 0
+    assert ".clientSecret is not allowed" in result.stderr
+

--- a/tests/test_mcp_dockerfile_venv_layout.py
+++ b/tests/test_mcp_dockerfile_venv_layout.py
@@ -18,6 +18,7 @@ EXPECTED_SHARED_DOCKERFILE_MCPS = {
   "mcp-splunk": "splunk",
   "mcp-victorops": "victorops",
   "mcp-webex": "webex",
+  "mcp-webex-meetings": "webex-meetings",
 }
 
 

--- a/ui/src/app/api/credentials/oauth/[provider_key]/__tests__/route.test.ts
+++ b/ui/src/app/api/credentials/oauth/[provider_key]/__tests__/route.test.ts
@@ -180,6 +180,36 @@ describe("/api/credentials/oauth/[provider_key]", () => {
     expect(text).toContain("caipe.oauth.connection");
   });
 
+  it("completes a deploy-configured provider through a shared callback URL", async () => {
+    mockCompleteConnection.mockResolvedValue({
+      id: "provider-connection-1",
+      provider: "webex_secondary",
+      status: "connected",
+    });
+    const { createOAuthStateCookie, oauthStateCookieName } = await import("@/lib/credentials/oauth-state");
+    const cookie = createOAuthStateCookie({
+      providerKey: "webex_secondary",
+      ownerId: "alice-sub",
+      state: "state-1",
+      codeVerifier: "verifier-1",
+    });
+    const { GET } = await import("../callback/route");
+    const response = await GET(
+      new Request("http://localhost/api/credentials/oauth/webex/callback?code=code-1&state=state-1", {
+        headers: { cookie: `${oauthStateCookieName("webex_secondary")}=${cookie}` },
+      }) as never,
+      { params: Promise.resolve({ provider_key: "webex" }) },
+    );
+
+    expect(mockCompleteConnection).toHaveBeenCalledWith({
+      providerKey: "webex_secondary",
+      owner: { type: "user", id: "alice-sub" },
+      code: "code-1",
+      codeVerifier: "verifier-1",
+    });
+    expect(response.headers.get("set-cookie")).toContain("caipe_oauth_state_webex_secondary=;");
+  });
+
   it("renders a branded Webex failure page for provider OAuth errors", async () => {
     const { GET } = await import("../callback/route");
     const response = await GET(

--- a/ui/src/app/api/credentials/oauth/[provider_key]/callback/route.ts
+++ b/ui/src/app/api/credentials/oauth/[provider_key]/callback/route.ts
@@ -6,7 +6,11 @@ getAuthFromBearerOrSession,
 withErrorHandler,
 } from "@/lib/api-middleware";
 import { getProviderConnectionService } from "@/lib/credentials/oauth-service-factory";
-import { oauthStateCookieName,parseOAuthStateCookie } from "@/lib/credentials/oauth-state";
+import {
+  oauthStateCookieName,
+  parseOAuthStateCookie,
+  type OAuthStatePayload,
+} from "@/lib/credentials/oauth-state";
 import { getCredentialFeatureConfig } from "@/lib/feature-flags/credentials";
 
 function assertFeatureEnabled(): void {
@@ -15,13 +19,33 @@ function assertFeatureEnabled(): void {
   }
 }
 
-function cookieValue(headers: Headers, name: string): string | null {
+function resolveCallbackState(
+  headers: Headers,
+  callbackProviderKey: string,
+  state: string,
+): { providerKey: string; parsedState: OAuthStatePayload } | null {
   const cookie = headers.get("cookie");
   if (!cookie) return null;
-  for (const part of cookie.split(";")) {
-    const [key, ...value] = part.trim().split("=");
-    if (key === name) {
-      return value.join("=");
+
+  const directCookieName = oauthStateCookieName(callbackProviderKey);
+  const candidates = cookie
+    .split(";")
+    .map((part) => {
+      const [name, ...rawValue] = part.trim().split("=");
+      return { name, value: rawValue.join("=") };
+    })
+    .filter(({ name, value }) => name.startsWith("caipe_oauth_state_") && Boolean(value))
+    .sort((left, right) => Number(right.name === directCookieName) - Number(left.name === directCookieName));
+
+  for (const candidate of candidates) {
+    try {
+      const parsedState = parseOAuthStateCookie(candidate.value);
+      if (parsedState.state === state) {
+        return { providerKey: parsedState.providerKey, parsedState };
+      }
+    } catch {
+      // Ignore stale or invalid state cookies and continue looking for the
+      // signed state that matches this callback response.
     }
   }
   return null;
@@ -137,7 +161,7 @@ function completionPage(input: {
 
 export const GET = withErrorHandler(async (request: NextRequest, context?: { params: Promise<{ provider_key: string }> }) => {
   assertFeatureEnabled();
-  const { provider_key: providerKey } = await context!.params;
+  const { provider_key: callbackProviderKey } = await context!.params;
   const { session, user } = await getAuthFromBearerOrSession(request);
   const ownerId = typeof session.sub === "string" ? session.sub : "";
   if (!ownerId) {
@@ -147,9 +171,9 @@ export const GET = withErrorHandler(async (request: NextRequest, context?: { par
   const url = new URL(request.url);
   const providerError = url.searchParams.get("error");
   if (providerError) {
-    const provider = providerBranding(providerKey);
+    const provider = providerBranding(callbackProviderKey);
     return completionPage({
-      providerKey,
+      providerKey: callbackProviderKey,
       status: "error",
       title: "Connection failed",
       message: `${provider.name} returned ${providerError}. You can close this window.`,
@@ -157,13 +181,15 @@ export const GET = withErrorHandler(async (request: NextRequest, context?: { par
   }
   const code = url.searchParams.get("code") ?? "";
   const state = url.searchParams.get("state") ?? "";
-  const stateCookie = cookieValue(request.headers, oauthStateCookieName(providerKey));
-  if (!code || !state || !stateCookie) {
+  if (!code || !state) {
     throw new ApiError("OAuth callback is missing state or code", 400, "INVALID_OAUTH_CALLBACK");
   }
-  const parsedState = parseOAuthStateCookie(stateCookie);
+  const resolvedState = resolveCallbackState(request.headers, callbackProviderKey, state);
+  if (!resolvedState) {
+    throw new ApiError("OAuth callback is missing state or code", 400, "INVALID_OAUTH_CALLBACK");
+  }
+  const { providerKey, parsedState } = resolvedState;
   if (
-    parsedState.providerKey !== providerKey ||
     parsedState.ownerId !== ownerId ||
     parsedState.state !== state
   ) {

--- a/ui/src/lib/credentials/__tests__/oauth-bootstrap.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-bootstrap.test.ts
@@ -142,6 +142,107 @@ describe("OAuth connector env bootstrap", () => {
     ]);
   });
 
+  it("builds arbitrary deploy-configured connectors and resolves secret env references", () => {
+    const inputs = buildOAuthConnectorBootstrapInputs({
+      NEXTAUTH_URL: "https://caipe.example.com",
+      ACME_OAUTH_CLIENT_ID: "acme-client",
+      ACME_OAUTH_CLIENT_SECRET: "acme-secret",
+      CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+        {
+          provider: "acme",
+          name: "Acme Cloud",
+          clientIdEnv: "ACME_OAUTH_CLIENT_ID",
+          clientSecretEnv: "ACME_OAUTH_CLIENT_SECRET",
+          authorizationUrl: "https://identity.acme.example.com/oauth/authorize",
+          tokenUrl: "https://identity.acme.example.com/oauth/token",
+          scopes: ["projects.read", "projects.write"],
+        },
+        {
+          provider: "public-acme",
+          name: "Acme Public Client",
+          clientId: "public-client",
+          pkce: true,
+          authorizationUrl: "https://identity.acme.example.com/oauth/authorize",
+          tokenUrl: "https://identity.acme.example.com/oauth/token",
+          scopes: ["profile"],
+          redirectUri: "https://caipe.example.com/custom/callback",
+        },
+      ]),
+    });
+
+    expect(inputs).toEqual([
+      {
+        provider: "acme",
+        name: "Acme Cloud",
+        clientId: "acme-client",
+        clientSecret: "acme-secret",
+        authorizationUrl: "https://identity.acme.example.com/oauth/authorize",
+        tokenUrl: "https://identity.acme.example.com/oauth/token",
+        scopes: ["projects.read", "projects.write"],
+        redirectUri: "https://caipe.example.com/api/credentials/oauth/acme/callback",
+      },
+      {
+        provider: "public-acme",
+        name: "Acme Public Client",
+        clientId: "public-client",
+        pkce: true,
+        authorizationUrl: "https://identity.acme.example.com/oauth/authorize",
+        tokenUrl: "https://identity.acme.example.com/oauth/token",
+        scopes: ["profile"],
+        redirectUri: "https://caipe.example.com/custom/callback",
+      },
+    ]);
+  });
+
+  it("lets deploy-configured connectors override legacy bootstrap for the same provider", () => {
+    const inputs = buildOAuthConnectorBootstrapInputs({
+      WEBEX_CLIENT_ID: "legacy-webex-client",
+      WEBEX_CLIENT_SECRET: "legacy-webex-secret",
+      WEBEX_REDIRECT_URI: "https://caipe.example.com/api/credentials/oauth/webex/callback",
+      DECLARATIVE_WEBEX_SECRET: "declarative-webex-secret",
+      CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+        {
+          provider: "webex",
+          name: "Declarative Webex",
+          clientId: "declarative-webex-client",
+          clientSecretEnv: "DECLARATIVE_WEBEX_SECRET",
+          authorizationUrl: "https://webexapis.com/v1/authorize",
+          tokenUrl: "https://webexapis.com/v1/access_token",
+          scopes: ["spark:mcp"],
+          redirectUri: "https://caipe.example.com/api/credentials/oauth/webex/callback",
+        },
+      ]),
+    });
+
+    expect(inputs).toEqual([
+      expect.objectContaining({
+        provider: "webex",
+        name: "Declarative Webex",
+        clientId: "declarative-webex-client",
+        clientSecret: "declarative-webex-secret",
+        scopes: ["spark:mcp"],
+      }),
+    ]);
+  });
+
+  it("rejects deploy-configured connectors whose referenced secret env is missing", () => {
+    expect(() =>
+      buildOAuthConnectorBootstrapInputs({
+        CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+          {
+            provider: "acme",
+            name: "Acme Cloud",
+            clientId: "acme-client",
+            clientSecretEnv: "ACME_OAUTH_CLIENT_SECRET",
+            authorizationUrl: "https://identity.acme.example.com/oauth/authorize",
+            tokenUrl: "https://identity.acme.example.com/oauth/token",
+            scopes: ["projects.read"],
+          },
+        ]),
+      }),
+    ).toThrow("references missing environment variable ACME_OAUTH_CLIENT_SECRET");
+  });
+
   it("normalizes legacy local GitHub and Webex callback URLs to the CAIPE UI callback route", () => {
     const inputs = buildOAuthConnectorBootstrapInputs({
       NEXTAUTH_URL: "http://localhost:3000",
@@ -195,6 +296,37 @@ describe("OAuth connector env bootstrap", () => {
       service,
     });
     expect(service.upsertConnector).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps a configured connector without the legacy enable flag", async () => {
+    const service = {
+      upsertConnector: jest.fn<UpsertConnector>(async (input) => connectorMetadata(input)),
+    };
+
+    await expect(
+      bootstrapOAuthConnectorsFromEnv({
+        env: {
+          ACME_OAUTH_CLIENT_SECRET: "acme-secret",
+          CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+            {
+              provider: "acme",
+              name: "Acme Cloud",
+              clientId: "acme-client",
+              clientSecretEnv: "ACME_OAUTH_CLIENT_SECRET",
+              authorizationUrl: "https://identity.acme.example.com/oauth/authorize",
+              tokenUrl: "https://identity.acme.example.com/oauth/token",
+              scopes: ["projects.read"],
+              redirectUri: "https://caipe.example.com/api/credentials/oauth/acme/callback",
+            },
+          ]),
+        },
+        service,
+      }),
+    ).resolves.toBe(1);
+
+    expect(service.upsertConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "acme", clientSecret: "acme-secret" }),
+    );
   });
 
   it("continues bootstrapping remaining providers when one provider fails validation", async () => {

--- a/ui/src/lib/credentials/oauth-bootstrap.ts
+++ b/ui/src/lib/credentials/oauth-bootstrap.ts
@@ -1,7 +1,10 @@
 import { BUILT_IN_OAUTH_CONNECTORS } from "./built-in-oauth-connectors";
-import type { CreateConnectorInput,OAuthConnectorService } from "./oauth-service";
+import type { CreateConnectorInput, OAuthConnectorService } from "./oauth-service";
 
 type Env = Record<string, string | undefined>;
+type ConfiguredConnector = Record<string, unknown>;
+
+const CONFIGURED_CONNECTORS_ENV = "CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON";
 
 interface BootstrapProviderEnv {
   provider: "github" | "atlassian" | "webex" | "pagerduty" | "gitlab";
@@ -59,12 +62,12 @@ function canonicalCallbackBase(env: Env): string {
   return value(env, "NEXTAUTH_URL") ?? "http://localhost:3000";
 }
 
-function canonicalProviderCallback(provider: BootstrapProviderEnv["provider"], env: Env): string {
+function canonicalProviderCallback(provider: string, env: Env): string {
   return `${canonicalCallbackBase(env).replace(/\/$/, "")}/api/credentials/oauth/${provider}/callback`;
 }
 
 function normalizeRedirectUri(
-  provider: BootstrapProviderEnv["provider"],
+  provider: string,
   redirectUri: string,
   env: Env,
 ): string {
@@ -100,8 +103,134 @@ function scopesForProvider(
     .filter(Boolean);
 }
 
+function configuredString(
+  connector: ConfiguredConnector,
+  field: string,
+  index: number,
+  options: { required?: boolean } = {},
+): string | null {
+  const candidate = connector[field];
+  if (candidate === undefined || candidate === null || candidate === "") {
+    if (options.required) {
+      throw new Error(`OAuth connector at index ${index} requires ${field}`);
+    }
+    return null;
+  }
+  if (typeof candidate !== "string" || !candidate.trim()) {
+    throw new Error(`OAuth connector at index ${index} has an invalid ${field}`);
+  }
+  return candidate.trim();
+}
+
+function configuredEnvValue(
+  connector: ConfiguredConnector,
+  inlineField: string,
+  envField: string,
+  env: Env,
+  index: number,
+): string {
+  const inlineValue = configuredString(connector, inlineField, index);
+  const envName = configuredString(connector, envField, index);
+  if (inlineValue && envName) {
+    throw new Error(
+      `OAuth connector at index ${index} must set only one of ${inlineField} or ${envField}`,
+    );
+  }
+  if (inlineValue) {
+    return inlineValue;
+  }
+  if (!envName) {
+    throw new Error(`OAuth connector at index ${index} requires ${inlineField} or ${envField}`);
+  }
+  const resolved = value(env, envName);
+  if (!resolved) {
+    throw new Error(
+      `OAuth connector at index ${index} references missing environment variable ${envName}`,
+    );
+  }
+  return resolved;
+}
+
+function configuredScopes(connector: ConfiguredConnector, index: number): string[] {
+  const scopes = connector.scopes;
+  if (!Array.isArray(scopes)) {
+    throw new Error(`OAuth connector at index ${index} requires scopes to be an array`);
+  }
+  return scopes.map((scope, scopeIndex) => {
+    if (typeof scope !== "string" || !scope.trim()) {
+      throw new Error(
+        `OAuth connector at index ${index} has an invalid scope at index ${scopeIndex}`,
+      );
+    }
+    return scope.trim();
+  });
+}
+
+function buildConfiguredOAuthConnectorBootstrapInputs(env: Env): CreateConnectorInput[] {
+  const serialized = value(env, CONFIGURED_CONNECTORS_ENV);
+  if (!serialized) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    throw new Error(`${CONFIGURED_CONNECTORS_ENV} must contain valid JSON`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${CONFIGURED_CONNECTORS_ENV} must contain a JSON array`);
+  }
+
+  const providers = new Set<string>();
+  return parsed.map((candidate, index) => {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      throw new Error(`OAuth connector at index ${index} must be an object`);
+    }
+    const connector = candidate as ConfiguredConnector;
+    const provider = configuredString(connector, "provider", index, { required: true })!;
+    if (providers.has(provider)) {
+      throw new Error(`OAuth connector provider ${provider} is configured more than once`);
+    }
+    providers.add(provider);
+
+    const pkceValue = connector.pkce;
+    if (pkceValue !== undefined && typeof pkceValue !== "boolean") {
+      throw new Error(`OAuth connector at index ${index} has an invalid pkce value`);
+    }
+    const pkce = pkceValue === true;
+    const clientSecretEnv = configuredString(connector, "clientSecretEnv", index);
+    let clientSecret: string | undefined;
+    if (!pkce) {
+      if (!clientSecretEnv) {
+        throw new Error(`OAuth connector at index ${index} requires clientSecretEnv`);
+      }
+      clientSecret = value(env, clientSecretEnv) ?? undefined;
+      if (!clientSecret) {
+        throw new Error(
+          `OAuth connector at index ${index} references missing environment variable ${clientSecretEnv}`,
+        );
+      }
+    }
+
+    const redirectUri = configuredString(connector, "redirectUri", index)
+      ?? canonicalProviderCallback(provider, env);
+    return {
+      name: configuredString(connector, "name", index, { required: true })!,
+      provider,
+      clientId: configuredEnvValue(connector, "clientId", "clientIdEnv", env, index),
+      ...(clientSecret ? { clientSecret } : {}),
+      authorizationUrl: configuredString(connector, "authorizationUrl", index, { required: true })!,
+      tokenUrl: configuredString(connector, "tokenUrl", index, { required: true })!,
+      scopes: configuredScopes(connector, index),
+      redirectUri: normalizeRedirectUri(provider, redirectUri, env),
+      ...(pkce ? { pkce: true } : {}),
+    };
+  });
+}
+
 export function buildOAuthConnectorBootstrapInputs(env: Env = process.env): CreateConnectorInput[] {
-  const inputs: CreateConnectorInput[] = [];
+  const legacyInputs: CreateConnectorInput[] = [];
   for (const providerEnv of PROVIDER_ENV) {
     const descriptor = BUILT_IN_OAUTH_CONNECTORS.find(
       (candidate) => candidate.provider === providerEnv.provider,
@@ -112,7 +241,7 @@ export function buildOAuthConnectorBootstrapInputs(env: Env = process.env): Crea
     if (!descriptor || !clientId || !clientSecret || !redirectUri) {
       continue;
     }
-    inputs.push({
+    legacyInputs.push({
       name: descriptor.name,
       provider: descriptor.provider,
       clientId,
@@ -123,7 +252,12 @@ export function buildOAuthConnectorBootstrapInputs(env: Env = process.env): Crea
       redirectUri: normalizeRedirectUri(providerEnv.provider, redirectUri, env),
     });
   }
-  return inputs;
+  const configuredInputs = buildConfiguredOAuthConnectorBootstrapInputs(env);
+  const configuredProviders = new Set(configuredInputs.map((input) => input.provider));
+  return [
+    ...legacyInputs.filter((input) => !configuredProviders.has(input.provider)),
+    ...configuredInputs,
+  ];
 }
 
 export async function bootstrapOAuthConnectorsFromEnv(options?: {
@@ -131,10 +265,14 @@ export async function bootstrapOAuthConnectorsFromEnv(options?: {
   service?: Pick<OAuthConnectorService, "upsertConnector">;
 }): Promise<number> {
   const env = options?.env ?? process.env;
-  if (!enabled(env.CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS)) {
+  const hasConfiguredConnectors = Boolean(value(env, CONFIGURED_CONNECTORS_ENV));
+  if (!enabled(env.CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS) && !hasConfiguredConnectors) {
     return 0;
   }
   const inputs = buildOAuthConnectorBootstrapInputs(env);
+  if (inputs.length === 0) {
+    return 0;
+  }
   const service = options?.service ?? await (async () => {
     const { getOAuthConnectorService } = await import("./oauth-service-factory");
     return getOAuthConnectorService();

--- a/ui/src/lib/rbac/__tests__/agentgateway-mcp-discovery.test.ts
+++ b/ui/src/lib/rbac/__tests__/agentgateway-mcp-discovery.test.ts
@@ -313,6 +313,17 @@ describe("AgentGateway MCP discovery", () => {
     ]);
   });
 
+  it("attaches the caller's Webex connection to webex_meetings", () => {
+    expect(builtinCredentialSourcesFor("webex_meetings")).toEqual([
+      {
+        kind: "provider_connection",
+        name: "X-CAIPE-Provider-Token",
+        provider: "webex",
+        target: "header",
+      },
+    ]);
+  });
+
   it("omits credential_sources for targets with no built-in mapping", () => {
     const target: AgentGatewayMcpDiscoveryTarget = {
       id: "argocd",

--- a/ui/src/lib/rbac/agentgateway-mcp-discovery.ts
+++ b/ui/src/lib/rbac/agentgateway-mcp-discovery.ts
@@ -58,6 +58,14 @@ export const BUILTIN_MCP_CREDENTIAL_SOURCES: Record<string, MCPCredentialSource[
       target: "header",
     },
   ],
+  webex_meetings: [
+    {
+      kind: "provider_connection",
+      name: "X-CAIPE-Provider-Token",
+      provider: "webex",
+      target: "header",
+    },
+  ],
   "knowledge-base": [
     {
       kind: "caller_token",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.36"
+version = "0.5.36.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

- Add a new mcp server for webex meetings. This only works using webex integration / impersonation.
- Also allow oauth connectors to be configured through the values file during deployment (UI configmap). Admin is already allowed to add these connectors through UI, so we should also support through config.
- New docs page explaining how to setup
- Disabled by default

Tested in grid.dev and working well.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
