### PR TITLE
fix(keycloak): reconcile public CLI client on upgrade, not just first boot

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -428,6 +428,149 @@ json.dump(client, sys.stdout)
 _reconcile_caipe_platform_client_secret
 
 # -------------------------------------------------------------------
+# Reconcile the public CLI client (caipe-cli / forge-cli).
+#
+# Background: the CLI client is a public authorization-code + PKCE
+# client that lets local developer CLIs (e.g. `dev-login`) mint a
+# real-user JWT with aud=caipe-platform. It ships in realm-config.json,
+# but Keycloak's `--import-realm` only imports on FIRST boot. On any
+# deployment with a persistent database (database.enabled=true), the
+# realm already exists on upgrade, so a newly-added client in
+# realm-config.json is NEVER created — login fails with "Client not
+# found". Every other client this platform relies on (caipe-ui,
+# caipe-platform, agentgateway, the bots) is instead reconciled
+# imperatively here via the Admin API, which runs on every
+# post-install/post-upgrade. This function brings the CLI client into
+# that same idempotent path so `helm upgrade` creates/updates it.
+#
+# The clientId, redirect URIs, web origins, and access-token lifespan
+# are configurable so downstream realms can rename the client
+# (e.g. forge-cli) and tune callbacks/session length. Defaults mirror
+# the caipe-cli definition in realm-config.json.
+#
+# assisted-by Claude:claude-opus-4-8
+# -------------------------------------------------------------------
+_reconcile_cli_client() {
+  local CLI_CLIENT_ID="${KEYCLOAK_CLI_CLIENT_ID:-caipe-cli}"
+  # Space- or comma-separated lists; defaults match realm-config.json.
+  local CLI_REDIRECT_URIS="${KEYCLOAK_CLI_REDIRECT_URIS:-http://localhost:8085 http://localhost:8085/* http://127.0.0.1:8085 http://127.0.0.1:8085/*}"
+  local CLI_WEB_ORIGINS="${KEYCLOAK_CLI_WEB_ORIGINS:-http://localhost:8085 http://127.0.0.1:8085}"
+  local CLI_ACCESS_TOKEN_LIFESPAN="${KEYCLOAK_CLI_ACCESS_TOKEN_LIFESPAN:-28800}"
+
+  echo "[init-idp] Reconciling public CLI client '${CLI_CLIENT_ID}' (authorization-code + PKCE) ..."
+  if [ -z "${AUTH:-}" ]; then
+    local _tok
+    _tok=$(curl -sf -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+      -d "grant_type=password&client_id=admin-cli&username=${KEYCLOAK_ADMIN:-admin}&password=${KEYCLOAK_ADMIN_PASSWORD:-admin}" 2>/dev/null \
+      | grep -o '"access_token" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+    if [ -z "${_tok}" ]; then
+      echo "[init-idp]   WARNING: could not acquire admin token — skipping CLI client reconcile."
+      return 0
+    fi
+    AUTH="Authorization: Bearer ${_tok}"
+  fi
+
+  # Build the desired client representation. Keycloak honours the
+  # defaultClientScopes/optionalClientScopes name arrays on both create
+  # and update, so we do not need to bind scopes via separate endpoints.
+  local DESIRED_JSON
+  DESIRED_JSON=$(CLI_CLIENT_ID="${CLI_CLIENT_ID}" \
+    CLI_REDIRECT_URIS="${CLI_REDIRECT_URIS}" \
+    CLI_WEB_ORIGINS="${CLI_WEB_ORIGINS}" \
+    CLI_ACCESS_TOKEN_LIFESPAN="${CLI_ACCESS_TOKEN_LIFESPAN}" \
+    python3 -c '
+import json
+import os
+
+
+def split(value):
+    return [item for item in value.replace(",", " ").split() if item]
+
+
+client = {
+    "clientId": os.environ["CLI_CLIENT_ID"],
+    "name": "CAIPE CLI",
+    "description": (
+        "Public OIDC client for local developer CLIs (authorization-code + "
+        "PKCE). Mints a real-user JWT with aud=caipe-platform accepted by "
+        "Dynamic Agents, AgentGateway, and MCP servers. No client secret; "
+        "PKCE S256 required."
+    ),
+    "enabled": True,
+    "publicClient": True,
+    "standardFlowEnabled": True,
+    "directAccessGrantsEnabled": False,
+    "serviceAccountsEnabled": False,
+    "authorizationServicesEnabled": False,
+    "redirectUris": split(os.environ["CLI_REDIRECT_URIS"]),
+    "webOrigins": split(os.environ["CLI_WEB_ORIGINS"]),
+    "protocol": "openid-connect",
+    "fullScopeAllowed": True,
+    "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "access.token.lifespan": str(int(os.environ["CLI_ACCESS_TOKEN_LIFESPAN"])),
+    },
+    "defaultClientScopes": ["profile", "email", "roles", "groups", "org"],
+    "optionalClientScopes": ["offline_access"],
+}
+print(json.dumps(client))
+' 2>/dev/null)
+
+  if [ -z "${DESIRED_JSON}" ]; then
+    echo "[init-idp]   WARNING: failed to render CLI client JSON (python3 required) — skipping."
+    return 0
+  fi
+
+  local CLI_CLIENT_UUID
+  CLI_CLIENT_UUID=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/clients?clientId=${CLI_CLIENT_ID}" 2>/dev/null \
+    | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"/\1/')
+
+  if [ -z "${CLI_CLIENT_UUID}" ]; then
+    echo "[init-idp]   Client '${CLI_CLIENT_ID}' not found — creating ..."
+    curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
+      "${KC_URL}/admin/realms/${REALM}/clients" \
+      -d "${DESIRED_JSON}" \
+      && echo "[init-idp]   Created CLI client '${CLI_CLIENT_ID}'." \
+      || echo "[init-idp]   WARNING: failed to create CLI client '${CLI_CLIENT_ID}'."
+  else
+    # Merge desired fields onto the existing representation so we keep
+    # the Keycloak-assigned id and any fields we do not manage, then PUT.
+    local EXISTING_JSON MERGED_JSON
+    EXISTING_JSON=$(curl -sf -H "${AUTH}" \
+      "${KC_URL}/admin/realms/${REALM}/clients/${CLI_CLIENT_UUID}" 2>/dev/null || echo "")
+    if [ -z "${EXISTING_JSON}" ]; then
+      echo "[init-idp]   WARNING: could not fetch existing CLI client — skipping update."
+      return 0
+    fi
+    MERGED_JSON=$(EXISTING_JSON="${EXISTING_JSON}" DESIRED_JSON="${DESIRED_JSON}" python3 -c '
+import json
+import os
+
+existing = json.loads(os.environ["EXISTING_JSON"])
+desired = json.loads(os.environ["DESIRED_JSON"])
+# Preserve Keycloak-managed identity; merge attributes rather than replace.
+attributes = existing.get("attributes") or {}
+attributes.update(desired.pop("attributes", {}))
+existing.update(desired)
+existing["attributes"] = attributes
+print(json.dumps(existing))
+' 2>/dev/null)
+    if [ -z "${MERGED_JSON}" ]; then
+      echo "[init-idp]   WARNING: failed to merge CLI client JSON — skipping update."
+      return 0
+    fi
+    curl -sf -X PUT -H "${AUTH}" -H "Content-Type: application/json" \
+      "${KC_URL}/admin/realms/${REALM}/clients/${CLI_CLIENT_UUID}" \
+      -d "${MERGED_JSON}" \
+      && echo "[init-idp]   Updated CLI client '${CLI_CLIENT_ID}' (public/PKCE/redirects/lifespan reconciled)." \
+      || echo "[init-idp]   WARNING: failed to update CLI client '${CLI_CLIENT_ID}'."
+  fi
+}
+
+_reconcile_cli_client
+
+# -------------------------------------------------------------------
 # Strict client-secret mode guard (init-idp scope: caipe-ui + caipe-platform).
 #
 # When KEYCLOAK_STRICT_CLIENT_SECRETS=true, attempt a client_credentials

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -470,9 +470,12 @@ _reconcile_cli_client() {
     AUTH="Authorization: Bearer ${_tok}"
   fi
 
-  # Build the desired client representation. Keycloak honours the
-  # defaultClientScopes/optionalClientScopes name arrays on both create
-  # and update, so we do not need to bind scopes via separate endpoints.
+  # Build the desired client representation. Keycloak binds the
+  # defaultClientScopes/optionalClientScopes name arrays only on CREATE
+  # (RepresentationToModel.createClient); updateClient does not re-bind
+  # scopes. That is safe here because caipe-cli's default scopes match
+  # the realm's defaultDefaultClientScopes, so an existing client keeps
+  # the right scopes without a separate scope-binding call.
   local DESIRED_JSON
   DESIRED_JSON=$(CLI_CLIENT_ID="${CLI_CLIENT_ID}" \
     CLI_REDIRECT_URIS="${CLI_REDIRECT_URIS}" \

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -813,6 +813,141 @@ seed_openfga_service_account_grants() {
 seed_openfga_service_account_grants
 
 # -------------------------------------------------------------------
+# Reconcile the public CLI client (caipe-cli / forge-cli).
+#
+# Background: the CLI client is a public authorization-code + PKCE
+# client that lets local developer CLIs (e.g. `dev-login`) mint a
+# real-user JWT with aud=caipe-platform. It ships in realm-config.json,
+# but Keycloak's `--import-realm` only imports on FIRST boot. On any
+# deployment with a persistent database (database.enabled=true), the
+# realm already exists on upgrade, so a newly-added client in
+# realm-config.json is NEVER created — login fails with "Client not
+# found".
+#
+# init-idp.sh has an identical reconcile, but that script runs only when
+# idp.enabled=true (default false). This copy lives on the always-on
+# init-token-exchange job (tokenExchange.enabled, default true) so the
+# CLI client is also reconciled on a fresh in-chart / local-Keycloak
+# install with no upstream IdP broker — the same dual-copy pattern the
+# OBO reconcile uses. Both paths are idempotent.
+#
+# The clientId, redirect URIs, web origins, and access-token lifespan
+# are configurable so downstream realms can rename the client
+# (e.g. forge-cli) and tune callbacks/session length. Defaults mirror
+# the caipe-cli definition in realm-config.json.
+#
+# assisted-by Claude:claude-opus-4-8
+# -------------------------------------------------------------------
+_reconcile_cli_client() {
+  CLI_CLIENT_ID="${KEYCLOAK_CLI_CLIENT_ID:-caipe-cli}"
+  # Space- or comma-separated lists; defaults match realm-config.json.
+  CLI_REDIRECT_URIS="${KEYCLOAK_CLI_REDIRECT_URIS:-http://localhost:8085 http://localhost:8085/* http://127.0.0.1:8085 http://127.0.0.1:8085/*}"
+  CLI_WEB_ORIGINS="${KEYCLOAK_CLI_WEB_ORIGINS:-http://localhost:8085 http://127.0.0.1:8085}"
+  CLI_ACCESS_TOKEN_LIFESPAN="${KEYCLOAK_CLI_ACCESS_TOKEN_LIFESPAN:-28800}"
+
+  echo "${TAG} Reconciling public CLI client '${CLI_CLIENT_ID}' (authorization-code + PKCE) ..."
+
+  # Build the desired client representation. Keycloak binds the
+  # defaultClientScopes/optionalClientScopes name arrays only on CREATE
+  # (RepresentationToModel.createClient); updateClient does not re-bind
+  # scopes. That is safe here because caipe-cli's default scopes match
+  # the realm's defaultDefaultClientScopes, so an existing client keeps
+  # the right scopes without a separate scope-binding call.
+  DESIRED_JSON=$(CLI_CLIENT_ID="${CLI_CLIENT_ID}" \
+    CLI_REDIRECT_URIS="${CLI_REDIRECT_URIS}" \
+    CLI_WEB_ORIGINS="${CLI_WEB_ORIGINS}" \
+    CLI_ACCESS_TOKEN_LIFESPAN="${CLI_ACCESS_TOKEN_LIFESPAN}" \
+    python3 -c '
+import json
+import os
+
+
+def split(value):
+    return [item for item in value.replace(",", " ").split() if item]
+
+
+client = {
+    "clientId": os.environ["CLI_CLIENT_ID"],
+    "name": "CAIPE CLI",
+    "description": (
+        "Public OIDC client for local developer CLIs (authorization-code + "
+        "PKCE). Mints a real-user JWT with aud=caipe-platform accepted by "
+        "Dynamic Agents, AgentGateway, and MCP servers. No client secret; "
+        "PKCE S256 required."
+    ),
+    "enabled": True,
+    "publicClient": True,
+    "standardFlowEnabled": True,
+    "directAccessGrantsEnabled": False,
+    "serviceAccountsEnabled": False,
+    "authorizationServicesEnabled": False,
+    "redirectUris": split(os.environ["CLI_REDIRECT_URIS"]),
+    "webOrigins": split(os.environ["CLI_WEB_ORIGINS"]),
+    "protocol": "openid-connect",
+    "fullScopeAllowed": True,
+    "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "access.token.lifespan": str(int(os.environ["CLI_ACCESS_TOKEN_LIFESPAN"])),
+    },
+    "defaultClientScopes": ["profile", "email", "roles", "groups", "org"],
+    "optionalClientScopes": ["offline_access"],
+}
+print(json.dumps(client))
+' 2>/dev/null)
+
+  if [ -z "${DESIRED_JSON}" ]; then
+    echo "${TAG}   WARNING: failed to render CLI client JSON (python3 required) — skipping."
+    return 0
+  fi
+
+  CLI_CLIENT_UUID=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/clients?clientId=${CLI_CLIENT_ID}" 2>/dev/null \
+    | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"/\1/')
+
+  if [ -z "${CLI_CLIENT_UUID}" ]; then
+    echo "${TAG}   Client '${CLI_CLIENT_ID}' not found — creating ..."
+    curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
+      "${KC_URL}/admin/realms/${REALM}/clients" \
+      -d "${DESIRED_JSON}" \
+      && echo "${TAG}   Created CLI client '${CLI_CLIENT_ID}'." \
+      || echo "${TAG}   WARNING: failed to create CLI client '${CLI_CLIENT_ID}'."
+  else
+    # Merge desired fields onto the existing representation so we keep
+    # the Keycloak-assigned id and any fields we do not manage, then PUT.
+    EXISTING_JSON=$(curl -sf -H "${AUTH}" \
+      "${KC_URL}/admin/realms/${REALM}/clients/${CLI_CLIENT_UUID}" 2>/dev/null || echo "")
+    if [ -z "${EXISTING_JSON}" ]; then
+      echo "${TAG}   WARNING: could not fetch existing CLI client — skipping update."
+      return 0
+    fi
+    MERGED_JSON=$(EXISTING_JSON="${EXISTING_JSON}" DESIRED_JSON="${DESIRED_JSON}" python3 -c '
+import json
+import os
+
+existing = json.loads(os.environ["EXISTING_JSON"])
+desired = json.loads(os.environ["DESIRED_JSON"])
+# Preserve Keycloak-managed identity; merge attributes rather than replace.
+attributes = existing.get("attributes") or {}
+attributes.update(desired.pop("attributes", {}))
+existing.update(desired)
+existing["attributes"] = attributes
+print(json.dumps(existing))
+' 2>/dev/null)
+    if [ -z "${MERGED_JSON}" ]; then
+      echo "${TAG}   WARNING: failed to merge CLI client JSON — skipping update."
+      return 0
+    fi
+    curl -sf -X PUT -H "${AUTH}" -H "Content-Type: application/json" \
+      "${KC_URL}/admin/realms/${REALM}/clients/${CLI_CLIENT_UUID}" \
+      -d "${MERGED_JSON}" \
+      && echo "${TAG}   Updated CLI client '${CLI_CLIENT_ID}' (public/PKCE/redirects/lifespan reconciled)." \
+      || echo "${TAG}   WARNING: failed to update CLI client '${CLI_CLIENT_ID}'."
+  fi
+}
+
+_reconcile_cli_client
+
+# -------------------------------------------------------------------
 # Strict client-secret mode guard (token-exchange scope: caipe-slack-bot
 # + caipe-webex-bot).
 #

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
@@ -114,6 +114,23 @@ spec:
                   name: {{ include "keycloak.platformClientSecretName" . }}
                   key: {{ .Values.platformClient.secretKey | default "OIDC_CLIENT_SECRET" | quote }}
             {{- end }}
+            {{- /* Public CLI client (caipe-cli / forge-cli) — reconciled
+                   imperatively by init-idp.sh so it lands on existing realms
+                   during upgrade, not only first-boot realm import. */}}
+            - name: KEYCLOAK_CLI_CLIENT_ID
+              value: {{ (.Values.cliClient).clientId | default "caipe-cli" | quote }}
+            {{- with (.Values.cliClient).accessTokenLifespan }}
+            - name: KEYCLOAK_CLI_ACCESS_TOKEN_LIFESPAN
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.cliClient).redirectUris }}
+            - name: KEYCLOAK_CLI_REDIRECT_URIS
+              value: {{ join " " . | quote }}
+            {{- end }}
+            {{- with (.Values.cliClient).webOrigins }}
+            - name: KEYCLOAK_CLI_WEB_ORIGINS
+              value: {{ join " " . | quote }}
+            {{- end }}
             - name: IDP_ACCESS_GROUP
               value: {{ .Values.idp.accessGroup | quote }}
             - name: IDP_ADMIN_GROUP

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-init-idp.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-init-idp.yaml
@@ -107,6 +107,23 @@ spec:
                   name: {{ include "keycloak.platformClientSecretName" . }}
                   key: {{ .Values.platformClient.secretKey | default "OIDC_CLIENT_SECRET" | quote }}
             {{- end }}
+            {{- /* Public CLI client (caipe-cli / forge-cli) — reconciled
+                   imperatively by init-idp.sh so it lands on existing realms
+                   during upgrade, not only first-boot realm import. */}}
+            - name: KEYCLOAK_CLI_CLIENT_ID
+              value: {{ (.Values.cliClient).clientId | default "caipe-cli" | quote }}
+            {{- with (.Values.cliClient).accessTokenLifespan }}
+            - name: KEYCLOAK_CLI_ACCESS_TOKEN_LIFESPAN
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.cliClient).redirectUris }}
+            - name: KEYCLOAK_CLI_REDIRECT_URIS
+              value: {{ join " " . | quote }}
+            {{- end }}
+            {{- with (.Values.cliClient).webOrigins }}
+            - name: KEYCLOAK_CLI_WEB_ORIGINS
+              value: {{ join " " . | quote }}
+            {{- end }}
             - name: IDP_ACCESS_GROUP
               value: {{ .Values.idp.accessGroup | quote }}
             - name: IDP_ADMIN_GROUP

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-init-token-exchange.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-init-token-exchange.yaml
@@ -51,6 +51,24 @@ spec:
               value: {{ .Values.tokenExchange.botClientId | quote }}
             - name: KC_SSL_REQUIRED
               value: {{ .Values.realm.sslRequired | quote }}
+            {{- /* Public CLI client (caipe-cli / forge-cli) — reconciled
+                   imperatively by init-token-exchange.sh so it lands on
+                   existing realms during upgrade even when idp.enabled=false
+                   (this job is always-on; job-init-idp is not). */}}
+            - name: KEYCLOAK_CLI_CLIENT_ID
+              value: {{ (.Values.cliClient).clientId | default "caipe-cli" | quote }}
+            {{- with (.Values.cliClient).accessTokenLifespan }}
+            - name: KEYCLOAK_CLI_ACCESS_TOKEN_LIFESPAN
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (.Values.cliClient).redirectUris }}
+            - name: KEYCLOAK_CLI_REDIRECT_URIS
+              value: {{ join " " . | quote }}
+            {{- end }}
+            {{- with (.Values.cliClient).webOrigins }}
+            - name: KEYCLOAK_CLI_WEB_ORIGINS
+              value: {{ join " " . | quote }}
+            {{- end }}
             {{- /* The script seeds each bot service account's OpenFGA grants
                    (e.g. read on system_config:platform_settings) so the bots
                    can make service-to-service reads against the BFF. The URL

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -144,6 +144,13 @@ uiClient:
 # single login lasts a full working session — 28800 = 8h, which matches the
 # realm ssoSessionIdleTimeout and avoids re-authenticating throughout the day.
 # Keep it <= ssoSessionMaxLifespan (86400). Omit to inherit the realm default.
+#
+# This client is reconciled imperatively by init-idp.sh on every
+# post-install/post-upgrade — NOT only via first-boot realm import. That
+# matters on persistent-database deployments (database.enabled=true): the
+# realm already exists on upgrade, so a client added to realm-config.json
+# alone would never be created and `dev-login` would hit "Client not found".
+# The init-idp Job creates/updates it from these values on each helm upgrade.
 cliClient:
   clientId: "caipe-cli"
   accessTokenLifespan: 28800

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.36 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.37 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.36 -f your-values.yaml'}
+                  {'    --version 0.5.37 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.36 -f your-values.yaml'}
+              {'    --version 0.5.37 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.37"
+version = "0.5.37-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.37"
+version = "0.5.37.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What & Why

The public CLI client (`caipe-cli` / `forge-cli`) is a public authorization-code + PKCE client that lets local developer CLIs (`dev-login`) mint a real-user JWT (`aud=caipe-platform`). It ships in `realm-config.json`, but Keycloak's `--import-realm` only imports the realm on **first boot**. On any install with a persistent database, the realm already exists on upgrade, so a newly-added client in `realm-config.json` is **never created** — login fails with **"Client not found"**.

Every other client the platform relies on (`caipe-ui`, `caipe-platform`, `agentgateway`, the bots) is reconciled imperatively via the Keycloak Admin API on every post-install/post-upgrade. This brings the CLI client onto that same idempotent path.

## How

- **`init-idp.sh`** — adds `_reconcile_cli_client` (create-or-update via Admin API). Runs on the idp-gated jobs (upstream-IdP installs).
- **`init-token-exchange.sh`** — adds an idempotent copy of the same reconcile. This job is **always-on** (`tokenExchange.enabled`, default `true`), so the client is also created/updated on a fresh in-chart / local-Keycloak install with **no upstream IdP** (`idp.enabled=false`, the default OSS shape) — where the idp-gated jobs never render. This mirrors the existing dual-copy pattern the OBO reconcile uses (see `docs/docs/security/rbac/architecture.md`). Both paths are idempotent.
- **`job-init-token-exchange.yaml`** — wires the `KEYCLOAK_CLI_*` env from the `cliClient` values (parity with `job-init-idp.yaml` / `job-auth-reconcile.yaml`).
- **`values.yaml`** — `cliClient` block (clientId, redirectUris, webOrigins, accessTokenLifespan). Only `clientId` is required to rename the client downstream (e.g. `forge-cli`); the rest fall back to `realm-config.json` defaults.

## Client shape

Matches `realm-config.json` field-for-field: `publicClient`, `standardFlowEnabled`, PKCE `S256`, `aud=caipe-platform` via the `profile` scope's audience mapper, 8h token lifespan, loopback callbacks on `:8085`. Scopes bind on create (Keycloak's `updateClient` doesn't re-bind scopes), which is correct here because the client's default scopes match the realm's `defaultDefaultClientScopes`.

## Testing

- `sh -n` on both scripts; embedded Python blocks `ast`-parse clean.
- `helm template` renders the `KEYCLOAK_CLI_*` env into the always-on token-exchange job with defaults (`caipe-cli`), a `forge-cli` override (custom lifespan/URIs), and `cliClient=null` (nil-safe fallback).
- Confirmed the idp-gated job still renders the CLI env when `idp.enabled=true`.
