### PR TITLE
fix: port behavioral fixes from release/0.4.18-hotfix to main

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -71,7 +71,7 @@ class MiddlewareSpec:
 MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
     "model_retry": MiddlewareSpec(
         cls=ModelRetryMiddleware,
-        default_params={"max_retries": 5, "backoff_factor": 2.0, "on_failure": "continue"},
+        default_params={"max_retries": 5, "backoff_factor": 2.0, "on_failure": "error"},
         enabled_by_default=True,
         allow_multiple=False,
         label="Model Retry",
@@ -84,7 +84,7 @@ MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
     ),
     "tool_retry": MiddlewareSpec(
         cls=ToolRetryMiddleware,
-        default_params={"max_retries": 3, "backoff_factor": 2.0, "initial_delay": 2.0, "on_failure": "return_message"},
+        default_params={"max_retries": 3, "backoff_factor": 2.0, "initial_delay": 2.0, "on_failure": "continue"},
         enabled_by_default=True,
         allow_multiple=False,
         label="Tool Retry",
@@ -123,7 +123,7 @@ MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
     "context_editing": MiddlewareSpec(
         cls=ContextEditingMiddleware,
         default_params={"trigger": 100_000, "keep": 3},
-        enabled_by_default=False,
+        enabled_by_default=True,
         allow_multiple=False,
         label="Context Editing",
         description="Clears older tool outputs when approaching token limits",

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/agui_sse.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/agui_sse.py
@@ -279,7 +279,10 @@ class AGUIStreamEncoder(StreamEncoder):
         if not isinstance(data, tuple) or len(data) != 2:
             return []
 
-        msg_chunk, _metadata = data
+        msg_chunk, metadata = data
+
+        if LangGraphStreamHelper.is_summarization_chunk(msg_chunk, metadata):
+            return []
 
         if LangGraphStreamHelper.is_tool_message(msg_chunk):
             return []

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/custom_sse.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/custom_sse.py
@@ -151,7 +151,10 @@ class CustomStreamEncoder(StreamEncoder):
         if not isinstance(data, tuple) or len(data) != 2:
             return []
 
-        msg_chunk, _metadata = data
+        msg_chunk, metadata = data
+
+        if LangGraphStreamHelper.is_summarization_chunk(msg_chunk, metadata):
+            return []
 
         # Skip ToolMessage content (tool results, not for display)
         if LangGraphStreamHelper.is_tool_message(msg_chunk):

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
@@ -173,6 +173,15 @@ class LangGraphStreamHelper:
         return bool(getattr(msg, "tool_calls", None))
 
     @staticmethod
+    def is_summarization_chunk(msg: Any, metadata: Any) -> bool:
+        """Check if a chunk is Deep Agents internal summarization content."""
+        if isinstance(metadata, dict) and metadata.get("lc_source") == "summarization":
+            return True
+
+        additional_kwargs = getattr(msg, "additional_kwargs", None)
+        return isinstance(additional_kwargs, dict) and additional_kwargs.get("lc_source") == "summarization"
+
+    @staticmethod
     def extract_content(msg: Any) -> str:
         """Extract and normalize content from a message chunk.
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_middleware_defaults.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_middleware_defaults.py
@@ -1,0 +1,35 @@
+from langchain.agents.middleware.context_editing import ContextEditingMiddleware
+from langchain.agents.middleware.model_retry import ModelRetryMiddleware
+
+from dynamic_agents.services.middleware import (
+    build_middleware,
+    get_default_middleware_entries,
+    get_middleware_definitions,
+)
+
+
+def test_default_middleware_entries_enable_context_editing_and_raise_model_errors():
+    entries = {entry["type"]: entry for entry in get_default_middleware_entries()}
+
+    assert entries["model_retry"]["params"]["on_failure"] == "error"
+    assert entries["tool_retry"]["params"]["on_failure"] == "continue"
+    assert entries["context_editing"]["enabled"] is True
+    assert entries["context_editing"]["params"] == {"trigger": 100_000, "keep": 3}
+
+
+def test_middleware_definitions_mark_context_editing_enabled_by_default():
+    definitions = {definition["key"]: definition for definition in get_middleware_definitions()}
+
+    assert definitions["model_retry"]["default_params"]["on_failure"] == "error"
+    assert definitions["context_editing"]["enabled_by_default"] is True
+
+
+def test_build_middleware_uses_context_editing_guardrail_by_default():
+    stack = build_middleware(None, agent_name="test-agent", model_id="test-model")
+
+    model_retry = next(middleware for middleware in stack if isinstance(middleware, ModelRetryMiddleware))
+    context_editing = next(middleware for middleware in stack if isinstance(middleware, ContextEditingMiddleware))
+
+    assert model_retry.on_failure == "error"
+    assert context_editing.edits[0].trigger == 100_000
+    assert context_editing.edits[0].keep == 3

--- a/ai_platform_engineering/dynamic_agents/tests/test_sse_summarization_filter.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_sse_summarization_filter.py
@@ -1,0 +1,38 @@
+"""Tests for filtering Deep Agents internal summarization stream chunks."""
+
+from types import SimpleNamespace
+
+from dynamic_agents.services.stream_encoders.agui_sse import AGUIStreamEncoder
+from dynamic_agents.services.stream_encoders.custom_sse import CustomStreamEncoder
+
+
+def _chunk(content: str, *, additional_kwargs: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(content=content, additional_kwargs=additional_kwargs or {})
+
+
+def test_agui_sse_filters_summarization_metadata() -> None:
+    enc = AGUIStreamEncoder()
+
+    frames = enc._handle_messages((_chunk("internal summary"), {"lc_source": "summarization"}), ())
+
+    assert frames == []
+    assert enc.get_accumulated_content() == ""
+
+
+def test_custom_sse_filters_summarization_metadata() -> None:
+    enc = CustomStreamEncoder()
+
+    frames = enc._handle_messages((_chunk("internal summary"), {"lc_source": "summarization"}), ())
+
+    assert frames == []
+    assert enc.get_accumulated_content() == ""
+
+
+def test_agui_sse_filters_summary_message_marker() -> None:
+    enc = AGUIStreamEncoder()
+    summary_chunk = _chunk("internal summary", additional_kwargs={"lc_source": "summarization"})
+
+    frames = enc._handle_messages((summary_chunk, {}), ())
+
+    assert frames == []
+    assert enc.get_accumulated_content() == ""

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -1986,9 +1986,11 @@ def handle_message_events(body, say, client, context=None):
   if channel_config is None:
     return
 
-  # Skip thread replies; only root messages trigger the agent.
-  is_thread = event.get("thread_ts") is not None
-  if is_thread:
+  # Skip true thread replies (ts != thread_ts). Root messages can have
+  # thread_ts populated by Slack when a follow-up arrives before the socket
+  # event is delivered, so checking thread_ts is not None is too broad.
+  is_thread_reply = event.get("thread_ts") is not None and event.get("thread_ts") != event.get("ts")
+  if is_thread_reply:
     return
 
   # Skip @mentions — handled by handle_mention
@@ -2001,6 +2003,11 @@ def handle_message_events(body, say, client, context=None):
   sender_bot_user_id = None
   if is_bot:
     bot_username, sender_bot_user_id = utils.get_bot_info_by_id(bot_id)
+    if not bot_username:
+      logger.warning(f"bots.info lookup failed for bot_id={bot_id}, falling back to event username")
+      bot_username = event.get("username")
+      if not bot_username:
+        logger.warning(f"event.get('username') also returned nothing for bot_id={bot_id}; bot_list filtering may not work correctly")
 
   sender_user_id = event.get("user") if not is_bot else None
   matches = _match_channel_agents(
@@ -2326,7 +2333,6 @@ def handle_escalation_get_help(ack, body, client):
       user_id=user_id,
       escalation_config=esc_config,
       agent_id=vo_agent_id or "",
-      conversation_id=conversation_id,
     )
 
     # Mark conversation as escalated for admin dashboard resolution stats

--- a/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
@@ -10,6 +10,7 @@ Supports three configurable actions (all fire if enabled):
 """
 
 import re
+import uuid
 
 from loguru import logger
 
@@ -26,7 +27,6 @@ def execute_escalation(
   user_id: str,
   escalation_config: EscalationConfig,
   agent_id: str = "",
-  conversation_id: str = "",
 ):
   """Run all configured escalation actions.
 
@@ -39,7 +39,6 @@ def execute_escalation(
       user_id: Slack user ID of the person who triggered escalation.
       escalation_config: Parsed escalation configuration.
       agent_id: Agent ID for VictorOps AI queries (channel default).
-      conversation_id: Conversation UUID for VictorOps AI queries.
 
   Returns:
       List of result summary strings.
@@ -54,7 +53,6 @@ def execute_escalation(
       thread_ts,
       escalation_config.victorops.team,
       agent_id=agent_id,
-      conversation_id=conversation_id,
     )
     results.append(result)
 
@@ -81,26 +79,27 @@ def _ping_victorops_oncall(
   thread_ts: str,
   team: str,
   agent_id: str,
-  conversation_id: str,
 ) -> str:
   """Query the AI for VictorOps on-call via SSE, resolve to Slack user, and ping them."""
-  if not agent_id or not conversation_id:
-    logger.error(f"[{thread_ts}] VictorOps: missing agent_id or conversation_id")
+  if not agent_id:
+    logger.error(f"[{thread_ts}] VictorOps: missing agent_id")
     slack_client.chat_postMessage(
       channel=channel_id,
       thread_ts=thread_ts,
       text=f"Could not determine on-call for team *{team}*. Please check VictorOps manually.",
     )
-    return "victorops: missing agent_id or conversation_id"
+    return "victorops: missing agent_id"
 
   try:
     prompt = f"RESPOND IN 1 WORD THAT IS USER EMAIL. WHO IS ON CALL FOR TEAM {team}?"
     logger.info(f"[{thread_ts}] VictorOps: querying on-call for team {team} (agent={agent_id})")
     accumulated_text: list[str] = []
 
+    # Use a fresh conversation so the on-call lookup does not inherit the
+    # channel thread history, which can be very large and cause incorrect results.
     for event in sse_client.stream_chat(
       message=prompt,
-      conversation_id=conversation_id,
+      conversation_id=str(uuid.uuid4()),
       agent_id=agent_id,
     ):
       if event.type == SSEEventType.TEXT_MESSAGE_CONTENT and event.delta:

--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/server.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/server.py
@@ -46,6 +46,7 @@ class ScrapySettings(BaseModel):
 
   # Misc
   user_agent: Optional[str] = Field(None, description="Custom user agent string (defaults to Chrome-like UA)")
+  allow_non_public_urls: bool = Field(False, description="Allow crawling URLs that resolve to private/internal IP addresses. Disabled by default (SSRF protection). Only enable for datasources on internal networks.")
 
 
 # ============================================================================

--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/utils.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/utils.py
@@ -144,7 +144,7 @@ def is_publicly_routable_url(url: str) -> tuple[bool, str]:
   return is_publicly_routable_host(parsed.hostname or "")
 
 
-def sanitize_url(url: str) -> str:
+def sanitize_url(url: str, allow_non_public_urls: bool = False) -> str:
   url = url.strip()
   parsed = urlparse(url)  # Parse the URL
   if not parsed.scheme:  # Add default scheme if missing
@@ -153,10 +153,11 @@ def sanitize_url(url: str) -> str:
     raise ValueError(f"Invalid URL scheme. Only HTTP and HTTPS are supported, got: {parsed.scheme}")
   if not parsed.netloc:  # Validate that we have a netloc (domain)
     raise ValueError("Invalid URL: missing domain name")
-  hostname = parsed.hostname or ""
-  is_safe, reason = is_publicly_routable_host(hostname)
-  if not is_safe:
-    raise ValueError(f"Invalid URL: hostname '{hostname}' must resolve only to publicly routable IP addresses: {reason}")
+  if not allow_non_public_urls:
+    hostname = parsed.hostname or ""
+    is_safe, reason = is_publicly_routable_host(hostname)
+    if not is_safe:
+      raise ValueError(f"Invalid URL: hostname '{hostname}' must resolve only to publicly routable IP addresses: {reason}")
   url = parsed.geturl()  # Reconstruct the URL to ensure it's properly formatted
   return url
 

--- a/ai_platform_engineering/knowledge_bases/rag/common/tests/test_utils.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/tests/test_utils.py
@@ -72,3 +72,10 @@ def test_sanitize_url_rejects_unresolvable_hostname(monkeypatch):
 
   with pytest.raises(ValueError, match="could not be resolved"):
     sanitize_url("https://nonexistent.invalid/page")
+
+
+def test_sanitize_url_allows_private_when_flag_set(monkeypatch):
+  _patch_dns(monkeypatch, {"internal.example.com": ["10.1.2.3"]})
+
+  result = sanitize_url("https://internal.example.com/docs", allow_non_public_urls=True)
+  assert result == "https://internal.example.com/docs"

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_loader.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_loader.py
@@ -119,6 +119,7 @@ class ScrapyLoader:
         concurrent_requests=settings.concurrent_requests,
         respect_robots_txt=settings.respect_robots_txt,
         user_agent=settings.user_agent,
+        allow_non_public_urls=settings.allow_non_public_urls,
         ingestor_id=self.client.ingestor_id or "",
         datasource_name=getattr(self.datasource_info, "name", "") or "",
         reload_interval=reload_interval,

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -58,7 +58,7 @@ class SSRFProtectionMiddleware:
   def process_request(self, request: Request, spider):
     # assisted-by claude code claude-sonnet-4-6
     is_safe, reason = is_publicly_routable_url(request.url)
-    if is_safe:
+    if is_safe or getattr(spider, "allow_non_public_urls", False):
       return None
 
     error_msg = f"Blocked unsafe crawl URL because it must resolve only to publicly routable IP addresses ({reason}): {request.url}"
@@ -97,6 +97,7 @@ class WorkerSpider(Spider):
     self.follow_external = request.follow_external_links
     self.allowed_patterns = request.allowed_url_patterns or []
     self.denied_patterns = request.denied_url_patterns or []
+    self.allow_non_public_urls = request.allow_non_public_urls or False
 
     # Track the effective domain (may change after redirect for sitemap mode)
     self.effective_domain: str | None = None
@@ -207,7 +208,7 @@ class WorkerSpider(Spider):
       return True
 
     is_safe, reason = is_publicly_routable_url(url)
-    if is_safe:
+    if is_safe or self.allow_non_public_urls:
       return True
 
     error_msg = f"Blocked unsafe crawl URL because it must resolve only to publicly routable IP addresses ({reason}): {url}"

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/worker_types.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/worker_types.py
@@ -60,6 +60,7 @@ class CrawlRequest:
   concurrent_requests: int = 8
   respect_robots_txt: bool = True
   user_agent: str | None = None
+  allow_non_public_urls: bool = False
 
   # Metadata for document creation
   ingestor_id: str = ""

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -1501,7 +1501,7 @@ async def ingest_url(
   logger.info(f"Received URL ingestion request: {url_request.url}")
 
   # Sanitize URL
-  sanitized_url = sanitize_url(url_request.url)
+  sanitized_url = sanitize_url(url_request.url, url_request.settings.allow_non_public_urls)
   url_request.url = sanitized_url
 
   # Generate datasource ID and create datasource

--- a/ui/src/components/rag/IngestView.tsx
+++ b/ui/src/components/rag/IngestView.tsx
@@ -233,6 +233,7 @@ export default function IngestView() {
   const [concurrentRequests, setConcurrentRequests] = useState(30)
   const [respectRobotsTxt, setRespectRobotsTxt] = useState(true)
   const [followExternalLinks, setFollowExternalLinks] = useState(true)  // Default true since crawlMode defaults to sitemap
+  const [allowNonPublicUrls, setAllowNonPublicUrls] = useState(false)
   const [allowedUrlPatterns, setAllowedUrlPatterns] = useState('')
   const [deniedUrlPatterns, setDeniedUrlPatterns] = useState('')
   const [chunkSize, setChunkSize] = useState(10000)
@@ -916,6 +917,7 @@ export default function IngestView() {
               denied_url_patterns: deniedUrlPatterns ? deniedUrlPatterns.split('\n').filter(p => p.trim()) : null,
               chunk_size: chunkSize,
               chunk_overlap: chunkOverlap,
+              allow_non_public_urls: allowNonPublicUrls,
             } : undefined,
             // Per-datasource reload interval (null = use global default)
             reload_interval: ingestType === 'web' ? reloadInterval : undefined,
@@ -1427,6 +1429,17 @@ export default function IngestView() {
                                 </span>
                               </label>
                             )}
+                            <label className="flex items-center gap-2 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={allowNonPublicUrls}
+                                onChange={(e) => setAllowNonPublicUrls(e.target.checked)}
+                                className="rounded border-border text-primary focus:ring-primary h-4 w-4"
+                              />
+                              <span className="text-sm text-muted-foreground">
+                                Allow internal/private URLs (bypass SSRF protection)
+                              </span>
+                            </label>
                           </div>
 
                           {/* URL Patterns */}

--- a/ui/src/components/rag/api/index.ts
+++ b/ui/src/components/rag/api/index.ts
@@ -153,6 +153,7 @@ export interface ScrapySettings {
     chunk_size?: number;
     chunk_overlap?: number;
     user_agent?: string | null;
+    allow_non_public_urls?: boolean;
 }
 
 export const ingestUrl = async (params: {


### PR DESCRIPTION
# Description

Prod currently runs `release/0.4.18-hotfix` (per `../ai/helm/prod-values.yaml`), while `main` has moved on to 0.5.x. This PR audits every behavioral fix that landed on the hotfix branch and ports whatever main is still missing, so cutting the 0.5 prod release doesn't reintroduce already-fixed bugs.

Because `main` has diverged substantially from the hotfix branch (RBAC/team-ownership rework in RAG, restapi.py rewrite, additional hostname-resolution logic in the scrapy worker, etc.), these were **not** cherry-picked — each fix was re-applied against main's current code after confirming main didn't already have equivalent protection.

## Fixes ported

**Slack bot**
- Only skip true thread replies (`thread_ts != ts`). Root messages can have `thread_ts` populated by a Slack race condition, so the previous `thread_ts is not None` check silently dropped some root messages.
- Fall back to the event's `username` field when a `bots.info` lookup fails for cross-workspace bot messages, so `bot_list` filtering doesn't silently break.
- VictorOps on-call escalation now uses a fresh conversation id instead of the channel thread's id, so the on-call lookup doesn't inherit (and get confused by) very long thread history.

**Dynamic agents**
- Hardened default middleware stack: `model_retry` now surfaces errors (`on_failure: error` instead of `continue`), `tool_retry` no longer injects a synthetic message on failure (`on_failure: continue` instead of `return_message`), and `context_editing` is now enabled by default.
- SSE stream encoders (AGUI + custom) now filter out Deep Agents' internal summarization chunks (`lc_source == "summarization"`) instead of leaking them into the client stream as normal assistant content.

**RAG**
- Added an explicit opt-in (`allow_non_public_urls`, default `False`) to bypass SSRF protection when crawling a URL, for legitimate internal/intranet ingestion use cases. Threaded through `ScrapySettings`, `sanitize_url`, the ingest REST endpoint, `CrawlRequest`, the Scrapy SSRF middleware/spider, and a new checkbox in the ingest UI's crawl-behavior section.

## Deferred

Three deepagents-internals fixes on the hotfix branch (skill files v2 format, subagent namespace correlation, BackendProtocol passthrough) depend on deepagents 0.6.4; main is still on 0.4.7, so porting them now would not apply meaningfully. A follow-up GitHub issue tracks these plus a low-priority Bedrock client cleanup: #2128

## Type of Change

- [x] Bugfix
- [x] New Feature (SSRF opt-in bypass)

## Test plan

- [x] `uv run pytest` for `dynamic_agents` (full suite: 265 passed, 3 skipped, 1 pre-existing unrelated failure), `slack_bot` (502 passed), RAG `common`/`ingestors`/`server` (all passed; 5 pre-existing unrelated failures in ingestors confirmed present on pristine main)
- [x] `uv run ruff check` clean on all touched Python files
- [x] `npm run lint` clean (no new warnings) and `npm run build` succeeds for the UI change
- [ ] Manual verification of the SSRF opt-in checkbox against a live internal URL (not done in this environment)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass