### PR TITLE
fix(openfga): make migrate job hook delete policy configurable

### DIFF
--- a/charts/ai-platform-engineering/charts/openfga/templates/job-migrate.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/templates/job-migrate.yaml
@@ -8,7 +8,10 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    helm.sh/hook-delete-policy: {{ .Values.migrate.helmHookDeletePolicy | default "before-hook-creation,hook-succeeded" | quote }}
+    {{- with .Values.migrate.argocdHookDeletePolicy }}
+    argocd.argoproj.io/hook-delete-policy: {{ . | quote }}
+    {{- end }}
 spec:
   backoffLimit: {{ .Values.migrate.backoffLimit }}
   template:

--- a/charts/ai-platform-engineering/charts/openfga/values.yaml
+++ b/charts/ai-platform-engineering/charts/openfga/values.yaml
@@ -36,6 +36,8 @@ datastore:
 migrate:
   enabled: true
   backoffLimit: 6
+  helmHookDeletePolicy: "before-hook-creation,hook-succeeded"
+  argocdHookDeletePolicy: "BeforeHookCreation,HookSucceeded"
 
 playground:
   enabled: false


### PR DESCRIPTION
## Summary

- The `openfga-migrate` PreSync Job had only `helm.sh/hook-delete-policy: before-hook-creation` but no `argocd.argoproj.io/hook-delete-policy`. ArgoCD attaches a `hook-finalizer` to the job and then loops: it deletes the job via `BeforeHookCreation` on each sync reconcile before the finalizer can clear, so the job never reaches `Succeeded` and the sync stalls indefinitely.
- Mirrors the pattern introduced for the Keycloak init-idp/init-token-exchange jobs in #2051: expose `helmHookDeletePolicy` and `argocdHookDeletePolicy` in `values.yaml` with defaults of `before-hook-creation,hook-succeeded` / `BeforeHookCreation,HookSucceeded`.

## Test plan

- [ ] Deploy with `openfga.datastore.engine=postgres` — confirm migrate job completes and ArgoCD sync reaches `Succeeded` without looping
- [ ] Verify `argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded` annotation is present on the rendered Job
- [ ] Override `migrate.argocdHookDeletePolicy` to confirm it is templated correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)