### PR TITLE
feat(agentgateway): optional explicit stats/readiness bind addresses

### DIFF
--- a/charts/ai-platform-engineering/charts/agentgateway/values.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/values.yaml
@@ -34,6 +34,20 @@ service:
   port: 4000
   adminPort: 15000
   statsPort: 15020
+  # Optional: relocate the proxy's OWN stats + readiness bind addresses off
+  # agentgateway's built-in defaults (15020 / 15021). Leave this false to keep
+  # the previous behavior — the static config renders no statsAddr/readinessAddr
+  # and the proxy uses its defaults (fully backward compatible).
+  #
+  # Set true to bind stats -> statsPort and readiness -> readinessPort instead.
+  # This is required when running agentgateway WITH an Istio sidecar, because the
+  # sidecar reserves 15020 (pilot-agent status/metrics) and 15021 (health) and
+  # the two Envoy/proxy processes share one network namespace — leaving the
+  # proxy on the defaults collides and crash-loops ("Address already in use").
+  explicitBindAddrs: false
+  # Only used when explicitBindAddrs is true. Container port + rendered
+  # readinessAddr for the proxy's readiness server.
+  readinessPort: 15021
 
 ingress:
   enabled: false

--- a/charts/ai-platform-engineering/templates/agentgateway-static-config.yaml
+++ b/charts/ai-platform-engineering/templates/agentgateway-static-config.yaml
@@ -20,6 +20,9 @@ discover/sync flow already consumes.
 {{- $svc := $sub.service | default dict }}
 {{- $listenPort := $svc.port | default 4000 }}
 {{- $adminPort := $svc.adminPort | default 15000 }}
+{{- $explicitBindAddrs := $svc.explicitBindAddrs | default false }}
+{{- $statsPort := $svc.statsPort | default 15020 }}
+{{- $readinessPort := $svc.readinessPort | default 15021 }}
 {{- $static := $agw.static | default dict }}
 {{- $jwt := $static.jwtAuth | default dict }}
 {{- $extAuth := $agw.extAuth | default dict }}
@@ -108,6 +111,10 @@ data:
             {{- end }}
     config:
       adminAddr: {{ printf "0.0.0.0:%v" $adminPort | quote }}
+      {{- if $explicitBindAddrs }}
+      statsAddr: {{ printf "0.0.0.0:%v" $statsPort | quote }}
+      readinessAddr: {{ printf "0.0.0.0:%v" $readinessPort | quote }}
+      {{- end }}
       logging:
         level: info
         format: json

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.38 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.39 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.38 -f your-values.yaml'}
+                  {'    --version 0.5.39 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.38 -f your-values.yaml'}
+              {'    --version 0.5.39 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.39"
+version = "0.5.39-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.39"
+version = "0.5.39.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Adds an opt-in `agentgateway.service.explicitBindAddrs` flag (default `false`) that renders `statsAddr` and `readinessAddr` into the agentgateway static proxy config, derived from `statsPort` and a new `readinessPort` value.

## Why

By default the proxy binds its stats and readiness servers on its built-in `15020` / `15021`. Those collide with an Istio sidecar's reserved pilot-agent status (`15020`) and health (`15021`) ports when the proxy and the sidecar share a single pod network namespace — the proxy crash-loops with `Address already in use (os error 98)`.

Relocating the proxy's **own** stats/readiness binds off that range lets agentgateway run **with** an Istio sidecar, so the MCP data path (`:4000`) can be mTLS-terminated by the mesh instead of running sidecar-less plaintext.

## Backward compatibility

Additive and non-breaking:

- `explicitBindAddrs` defaults to `false`.
- With it off, the rendered static config is **byte-identical** to before — no `statsAddr`/`readinessAddr` keys are emitted and the proxy keeps its default binds.

Verified with `helm template`:

```yaml
# default (explicitBindAddrs: false) — unchanged
config:
  adminAddr: "0.0.0.0:15000"
  logging: { level: info, format: json }

# explicitBindAddrs: true, adminPort/statsPort/readinessPort = 9500/9520/9521
config:
  adminAddr: "0.0.0.0:9500"
  statsAddr: "0.0.0.0:9520"
  readinessAddr: "0.0.0.0:9521"
  logging: { level: info, format: json }
```

The existing deployment/service templates already derive the admin/stats container + service ports from `service.adminPort`/`service.statsPort`, so setting those alongside the flag relocates everything consistently.

## Test plan

- [x] `helm template` default render is byte-identical to prior output
- [x] `helm template` with the flag emits relocated `statsAddr`/`readinessAddr`
- [x] deployment container ports + service ports follow the overridden `adminPort`/`statsPort`