### PR TITLE
fix(keycloak): make init-idp.sh id lookups + redirector parsing robust on KC 26.x

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -61,6 +61,36 @@ json_field() {
   echo "$1" | grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:.*"\(.*\)"/\1/'
 }
 
+# --- helper: from a JSON array on stdin, print the "id" of the first object
+# whose <field> == <value> (empty string if none) ---------------------------
+# Keycloak 26.x returns admin-API list endpoints as single-line compact JSON,
+# which defeats line-oriented `grep -B<N> '"<name>"' | grep -o '"id"...'`
+# lookups: with no distinct preceding line, `-B<N>` matches nothing and the
+# outer grep falls back to the FIRST id in the whole array regardless of name.
+# This parses the JSON structurally instead (works for compact or pretty
+# output). The match value is passed via env, not string-interpolated into the
+# python source, so a value containing quotes/metacharacters can never break
+# the snippet or inject code. Malformed / non-list responses (e.g. curl -sf
+# swallowing an error body) degrade to empty output without aborting under
+# `set -eu`.
+json_id_by_field() {
+  MATCH_KEY="$1" MATCH_VALUE="$2" python3 -c '
+import json
+import os
+import sys
+
+try:
+    items = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(items, list):
+    sys.exit(0)
+key = os.environ["MATCH_KEY"]
+value = os.environ["MATCH_VALUE"]
+print(next((it.get("id", "") for it in items if isinstance(it, dict) and it.get(key) == value), ""))
+'
+}
+
 seed_personas_main() {
   echo "[init-idp] [spec-102] seeding personas in realm ${REALM} ..."
 
@@ -1053,12 +1083,7 @@ DEFAULT_REALM_ROLE="default-roles-${REALM}"
 echo "[init-idp] Ensuring offline_access is in ${DEFAULT_REALM_ROLE} ..."
 DEFAULT_ROLE_ID=$(curl -sf -H "${AUTH}" \
   "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
-  | python3 -c "import sys, json
-try:
-    roles = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-print(next((r['id'] for r in roles if r.get('name') == '${DEFAULT_REALM_ROLE}'), ''))")
+  | json_id_by_field "name" "${DEFAULT_REALM_ROLE}")
 
 if [ -n "${DEFAULT_ROLE_ID}" ]; then
   COMPOSITES=$(curl -sf -H "${AUTH}" \
@@ -1068,12 +1093,7 @@ if [ -n "${DEFAULT_ROLE_ID}" ]; then
   else
     OFFLINE_ROLE_ID=$(curl -sf -H "${AUTH}" \
       "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
-      | python3 -c "import sys, json
-try:
-    roles = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-print(next((r['id'] for r in roles if r.get('name') == 'offline_access'), ''))")
+      | json_id_by_field "name" "offline_access")
     if [ -n "${OFFLINE_ROLE_ID}" ]; then
       curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
         "${KC_URL}/admin/realms/${REALM}/roles-by-id/${DEFAULT_ROLE_ID}/composites" \
@@ -1451,7 +1471,7 @@ echo "[init-idp]   No Keycloak role mappers are created for IDP_ACCESS_GROUP or 
 # Keycloak's ID token/userinfo carry the user's name to downstream clients.
 echo "[init-idp] Ensuring standard profile scope mappers ..."
 PROFILE_SCOPE_ID=$(curl -sf -H "${AUTH}" "${KC_URL}/admin/realms/${REALM}/client-scopes" 2>/dev/null \
-  | grep -B1 '"profile"' | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"/\1/')
+  | json_id_by_field "name" "profile")
 
 if [ -n "${PROFILE_SCOPE_ID}" ]; then
   EXISTING_MAPPERS=$(curl -sf -H "${AUTH}" \
@@ -1495,7 +1515,7 @@ AUTH="Authorization: Bearer $(json_field "$(curl -sf -X POST "${KC_URL}/realms/m
 EXECUTIONS=$(curl -sf -H "${AUTH}" \
   "${KC_URL}/admin/realms/${REALM}/authentication/flows/first%20broker%20login/executions" 2>/dev/null || echo "[]")
 
-REVIEW_ID=$(echo "${EXECUTIONS}" | grep -B2 '"idp-review-profile"' | grep -o '"id" *: *"[^"]*"' | sed 's/.*"\([^"]*\)"/\1/' | head -1)
+REVIEW_ID=$(printf '%s' "${EXECUTIONS}" | json_id_by_field "providerId" "idp-review-profile")
 
 if [ -n "${REVIEW_ID}" ]; then
   # Keycloak 26.x requires providerId in the execution update payload

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -1053,7 +1053,12 @@ DEFAULT_REALM_ROLE="default-roles-${REALM}"
 echo "[init-idp] Ensuring offline_access is in ${DEFAULT_REALM_ROLE} ..."
 DEFAULT_ROLE_ID=$(curl -sf -H "${AUTH}" \
   "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
-  | grep -B1 "\"${DEFAULT_REALM_ROLE}\"" | grep -o '"id" *: *"[^"]*"' | sed 's/.*"\([^"]*\)"/\1/' | head -1)
+  | python3 -c "import sys, json
+try:
+    roles = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(next((r['id'] for r in roles if r.get('name') == '${DEFAULT_REALM_ROLE}'), ''))")
 
 if [ -n "${DEFAULT_ROLE_ID}" ]; then
   COMPOSITES=$(curl -sf -H "${AUTH}" \
@@ -1063,7 +1068,12 @@ if [ -n "${DEFAULT_ROLE_ID}" ]; then
   else
     OFFLINE_ROLE_ID=$(curl -sf -H "${AUTH}" \
       "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
-      | grep -B1 '"offline_access"' | grep -o '"id" *: *"[^"]*"' | sed 's/.*"\([^"]*\)"/\1/' | head -1)
+      | python3 -c "import sys, json
+try:
+    roles = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(next((r['id'] for r in roles if r.get('name') == 'offline_access'), ''))")
     if [ -n "${OFFLINE_ROLE_ID}" ]; then
       curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
         "${KC_URL}/admin/realms/${REALM}/roles-by-id/${DEFAULT_ROLE_ID}/composites" \
@@ -1580,24 +1590,33 @@ echo "[init-idp] Setting '${ALIAS}' as default IdP redirector in browser flow ..
 BROWSER_EXECS=$(curl -sf -H "${AUTH}" \
   "${KC_URL}/admin/realms/${REALM}/authentication/flows/browser/executions" 2>/dev/null || echo "[]")
 
-REDIR_INFO=$(printf '%s' "${BROWSER_EXECS}" | python3 -c '
+# Emit shell KEY=value assignments (shlex-quoted) and eval them, rather than
+# reading a tab-delimited line with `IFS=<tab> read`. Tab is an IFS whitespace
+# character, so `read` collapses consecutive tabs and drops empty fields — on a
+# fresh realm the redirector has no authenticationConfig yet (empty middle
+# field), which would shift every subsequent field and leave FORMS_ID empty and
+# REDIR_CONFIG_ID garbage. shlex.quote preserves empty strings intact.
+eval "$(printf '%s' "${BROWSER_EXECS}" | python3 -c '
 import json
+import shlex
 import sys
 
-executions = json.load(sys.stdin)
+try:
+    executions = json.load(sys.stdin)
+except Exception:
+    executions = []
 redirector = next((e for e in executions if e.get("providerId") == "identity-provider-redirector"), {})
 forms = next((e for e in executions if e.get("displayName") == "forms" or e.get("flowAlias") == "forms"), {})
-print("\t".join([
-    redirector.get("id", ""),
-    redirector.get("authenticationConfig") or "",
-    redirector.get("providerId") or "",
-    forms.get("id", ""),
-    forms.get("providerId") or "",
-]))
-')
-IFS='	' read -r REDIR_ID REDIR_CONFIG_ID REDIR_PROVIDER_ID FORMS_ID FORMS_PROVIDER_ID <<EOF
-${REDIR_INFO}
-EOF
+fields = {
+    "REDIR_ID": redirector.get("id", ""),
+    "REDIR_CONFIG_ID": redirector.get("authenticationConfig") or "",
+    "REDIR_PROVIDER_ID": redirector.get("providerId") or "",
+    "FORMS_ID": forms.get("id", ""),
+    "FORMS_PROVIDER_ID": forms.get("providerId") or "",
+}
+for key, value in fields.items():
+    print(f"{key}={shlex.quote(value)}")
+')"
 
 if [ -n "${REDIR_ID}" ]; then
   if [ -n "${REDIR_CONFIG_ID}" ]; then

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.38 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.39 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.38 -f your-values.yaml'}
+                  {'    --version 0.5.39 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.38 -f your-values.yaml'}
+              {'    --version 0.5.39 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.39"
+version = "0.5.39-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.39"
+version = "0.5.39.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Fixes a class of shell-parsing bugs in `charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh` that misbehave on a **fresh realm deploy** against Keycloak 26.x. All findings below were reproduced and the fixes verified end-to-end against a real Keycloak 26.3 container.

### Bug class 1 — `grep -B<N> '"<name>"'` id lookups return the wrong id

Keycloak 26.x returns admin-API list endpoints (`/roles`, `/client-scopes`, `/authentication/.../executions`) as **single-line compact JSON**. Several lookups did:

```sh
... | grep -B1 '"<name>"' | grep -o '"id" *: *"[^"]*"' | ... | head -1
```

With the whole array on one line, `grep -B<N>` has no distinct preceding line to anchor on, so the pipeline returns the **first** `id` in the array regardless of which name was searched. It only appears to work when the target happens to be first.

Four affected lookups, all on the fresh-deploy path:

| Lookup | Symptom when wrong |
| --- | --- |
| default realm role (`default-roles-<realm>`) | offline_access added to the wrong composite |
| `offline_access` role | wrong id used for the composite membership |
| `profile` client-scope | standard OIDC name mappers (given_name/family_name/name/preferred_username) created on the wrong scope → ID tokens miss name claims |
| `idp-review-profile` execution | wrong first-broker-login execution disabled, or the "Update Account Information" page left enabled on first SSO login |

**Fix:** a single `json_id_by_field` helper parses the array structurally (works for compact or pretty JSON), passes the match value via an environment variable (no string interpolation into the code, so quotes/metacharacters are safe and can't inject), and degrades to empty output on malformed/non-list responses instead of aborting under `set -eu`.

### Bug class 2 — `IFS=<tab> read` drops empty fields

The browser-flow redirector's 5 config values were emitted as a tab-delimited line and read with `IFS=<tab> read`. Tab is an **IFS-whitespace** character, so `read` collapses consecutive delimiters and drops empty fields. On a fresh realm the redirector has no `authenticationConfig` yet (empty middle field), which shifts every subsequent field — leaving the forms-execution id empty. As a result the `forms` execution is never set to `DISABLED` and no `defaultProvider` is written, so IdP auto-redirect is **not enforced**.

**Fix:** emit `shlex.quote`d `KEY=value` assignments from python and consume them with `eval`, preserving empty strings and removing all field-order / whitespace dependence.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified against a real **Keycloak 26.3** container (the version this chart pins):

- Confirmed `/roles`, `/client-scopes`, and flow-executions endpoints return single-line compact JSON, and that the old `grep -B<N>` lookups returned the wrong id (e.g. the `acr` scope instead of `profile`), while the new helper returns the correct id.
- Reproduced the redirector field-shift: old parsing left the forms id empty and mis-assigned the config id; new parsing yields all five fields correctly.
- Ran the fixed paths end-to-end: offline_access added to the default-role composite, `profile` scope resolved correctly, `idp-review-profile` set to `DISABLED`, and the redirector configured `REQUIRED` with `defaultProvider` set + `forms` `DISABLED`.
- Confirmed the `eval` + `shlex.quote` path is injection-safe (adversarial values stored as literal strings, no command execution).
- Ran the changed snippets under the production init image's shell (Chainguard wolfi-base **busybox `sh`** + python 3.13) — `python3` is an installed dependency of that image and the code is POSIX-sh compatible.
- `bash -n` and busybox `sh -n` both pass on the full script.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
