### PR TITLE
fix(workflows): keep workflow state read-only

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.39 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.40 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.39 -f your-values.yaml'}
+                  {'    --version 0.5.40 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.39 -f your-values.yaml'}
+              {'    --version 0.5.40 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.40"
+version = "0.5.40-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
@@ -110,7 +110,7 @@ describe("buildWorkflowContextPrefix", () => {
   it("treats deterministically populated workflow-state files as read-only investigation context", () => {
     expect(prompt).toContain("workflow engine deterministically populates `workflow-state/`");
     expect(prompt).toContain("Treat the entire directory as read-only");
-    expect(prompt).toContain("provided only as reference material for investigation");
+    expect(prompt).toContain("read-only reference material for investigation");
     expect(prompt).toContain(
       "Previous-step logs are stored under `workflow-state/step-{N}--{agent-id}/`",
     );
@@ -121,10 +121,10 @@ describe("buildWorkflowContextPrefix", () => {
     expect(prompt).toContain("Run `ls /`");
   });
 
-  it("keeps all agent-written files outside workflow-state", () => {
+  it("allows only the failure marker to be written under workflow-state", () => {
     expect(prompt).toContain("`/choices.txt`");
-    expect(prompt).toContain("`/workflow-step-2--release-agent-error.txt`");
-    expect(prompt).not.toContain("workflow-state/step-2--release-agent/error.txt");
+    expect(prompt).toContain("`workflow-state/step-2--release-agent/error.txt`");
+    expect(prompt).toContain("only path you may write under `workflow-state/`");
   });
 });
 

--- a/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
@@ -111,6 +111,9 @@ describe("buildWorkflowContextPrefix", () => {
     expect(prompt).toContain("workflow engine deterministically populates `workflow-state/`");
     expect(prompt).toContain("Treat the entire directory as read-only");
     expect(prompt).toContain("provided only as reference material for investigation");
+    expect(prompt).toContain(
+      "Previous-step logs are stored under `workflow-state/step-{N}--{agent-id}/`",
+    );
   });
 
   it("directs agents to inspect shared files at the filesystem root", () => {

--- a/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-engine-owner-subject.test.ts
@@ -13,7 +13,11 @@ jest.mock("@/lib/authz", () => ({ authorize: jest.fn() }));
 
 import { readEvents } from "@/lib/server/event-store";
 import type { StreamEvent } from "@/lib/streaming/types";
-import { resolveStepResponseText, runOwnerSubject } from "../workflow-engine";
+import {
+  buildWorkflowContextPrefix,
+  resolveStepResponseText,
+  runOwnerSubject,
+} from "../workflow-engine";
 
 const mockReadEvents = readEvents as jest.MockedFunction<typeof readEvents>;
 
@@ -89,6 +93,35 @@ describe("resolveStepResponseText", () => {
     ]);
 
     await expect(resolveStepResponseText("source-1", "")).resolves.toBe("Longer tool output");
+  });
+});
+
+describe("buildWorkflowContextPrefix", () => {
+  const prompt = buildWorkflowContextPrefix(
+    "Release workflow",
+    "Prepare and publish a release",
+    [],
+    1,
+    3,
+    "Publish the release notes",
+    "release-agent",
+  );
+
+  it("treats deterministically populated workflow-state files as read-only investigation context", () => {
+    expect(prompt).toContain("workflow engine deterministically populates `workflow-state/`");
+    expect(prompt).toContain("Treat the entire directory as read-only");
+    expect(prompt).toContain("provided only as reference material for investigation");
+  });
+
+  it("directs agents to inspect shared files at the filesystem root", () => {
+    expect(prompt).toContain("Other steps may write shared files at the filesystem root");
+    expect(prompt).toContain("Run `ls /`");
+  });
+
+  it("keeps all agent-written files outside workflow-state", () => {
+    expect(prompt).toContain("`/choices.txt`");
+    expect(prompt).toContain("`/workflow-step-2--release-agent-error.txt`");
+    expect(prompt).not.toContain("workflow-state/step-2--release-agent/error.txt");
   });
 });
 

--- a/ui/src/lib/server/workflow-engine.ts
+++ b/ui/src/lib/server/workflow-engine.ts
@@ -793,7 +793,7 @@ async function writeStepArtifactsToFs(
  * Build a workflow context prefix to prepend to the step's user prompt.
  * Provides the agent with workflow awareness, previous step context, and critical instructions.
  */
-function buildWorkflowContextPrefix(
+export function buildWorkflowContextPrefix(
   workflowName: string,
   workflowDescription: string | undefined,
   completedSteps: StepContext[],
@@ -810,20 +810,21 @@ function buildWorkflowContextPrefix(
   ctx += "A workflow is an automated multi-step pipeline where each step is handled by an agent. ";
   ctx += "You are one agent executing one step in this pipeline.\n\n";
 
-  // --- Investigating previous steps ---
-  ctx += "## Investigating Previous Steps\n";
-  ctx += "Artifacts from previous steps are stored in the filesystem under `workflow-state/step-{N}--{agent-id}/`.\n";
-  ctx += "You may use `ls` and `read_file` to inspect: user_prompt.txt, tool_calls.txt, agent_output.txt\n\n";
+  // --- Investigating workflow files ---
+  ctx += "## Investigating Workflow Files\n";
+  ctx += "The workflow engine deterministically populates `workflow-state/` after each step. Treat the entire directory as read-only: never create, modify, or delete files under `workflow-state/`. It is provided only as reference material for investigation.\n";
+  ctx += "Previous-step artifacts are stored under `workflow-state/step-{N}--{agent-id}/`. You may use `ls` and `read_file` to inspect user_prompt.txt, tool_calls.txt, and agent_output.txt.\n";
+  ctx += "Other steps may write shared files at the filesystem root, outside `workflow-state/`. Run `ls /` to discover those files when investigating previous work.\n\n";
 
   // --- Critical: User interaction ---
   ctx += "## Critical: User Interaction\n";
   ctx += "The user does NOT have access to this chat. All interaction with the user must happen through the `request_user_input` tool.\n";
-  ctx += "When a step must pass data to later steps, call `request_user_input` if needed, then persist outputs with `write_file` (for example `choices.txt` at the filesystem root).\n";
-  ctx += "If that tool is not available and you cannot proceed without user input, write the reason to error.txt and stop.\n\n";
+  ctx += "When a step must pass data to later steps, call `request_user_input` if needed, then persist outputs with `write_file` at the filesystem root (for example `/choices.txt`), never under `workflow-state/`.\n";
+  ctx += "If that tool is not available and you cannot proceed without user input, use the failure-reporting file below and stop.\n\n";
 
   // --- Critical: Reporting failure ---
   ctx += "## Critical: Reporting Failure\n";
-  ctx += `If you determine this step has failed or you cannot complete the task, write a brief explanation to \`workflow-state/step-${stepIndex + 1}--${agentId}/error.txt\` using \`write_file\`.\n`;
+  ctx += `If you determine this step has failed or you cannot complete the task, write a brief explanation to \`/workflow-step-${stepIndex + 1}--${agentId}-error.txt\` at the filesystem root using \`write_file\`.\n`;
   ctx += "The workflow engine will detect this file and mark the step as failed.\n\n";
 
   // --- Workflow identity ---
@@ -866,7 +867,7 @@ function buildWorkflowContextPrefix(
 }
 
 /**
- * Check if the agent wrote an error.txt file to signal step failure.
+ * Check if the agent wrote the reserved root-level error file to signal step failure.
  * Returns the error content if found, null otherwise.
  */
 async function checkAgentErrorFile(
@@ -875,10 +876,11 @@ async function checkAgentErrorFile(
   agentId: string,
   authHeaders: Record<string, string>,
 ): Promise<string | null> {
-  // Check both with and without leading slash (agents may write either way)
+  // Check both with and without leading slash (agents may write either way).
+  const errorFilename = `workflow-step-${stepIndex + 1}--${agentId}-error.txt`;
   const paths = [
-    `workflow-state/step-${stepIndex + 1}--${agentId}/error.txt`,
-    `/workflow-state/step-${stepIndex + 1}--${agentId}/error.txt`,
+    errorFilename,
+    `/${errorFilename}`,
   ];
   for (const path of paths) {
     try {
@@ -888,7 +890,16 @@ async function checkAgentErrorFile(
       );
       if (res.ok) {
         const body = await res.json();
-        return body?.content || "Agent reported failure (no details)";
+        const content = body?.content || "Agent reported failure (no details)";
+        try {
+          await fetch(
+            `${DA_SERVER_BASE_URL}/api/v1/files/content?fs_namespace=${encodeURIComponent(JSON.stringify(fsNamespace))}&path=${encodeURIComponent(path)}`,
+            { method: "DELETE", headers: authHeaders },
+          );
+        } catch {
+          // Best-effort cleanup; the failure signal has already been captured.
+        }
+        return content;
       }
     } catch {
       // File not found or network error — continue to next path
@@ -919,6 +930,18 @@ async function deleteStepArtifacts(
       } catch {
         // Ignore — file may not exist
       }
+    }
+  }
+
+  const errorFilename = `workflow-step-${stepIndex + 1}--${agentId}-error.txt`;
+  for (const path of [errorFilename, `/${errorFilename}`]) {
+    try {
+      await fetch(
+        `${DA_SERVER_BASE_URL}/api/v1/files/content?fs_namespace=${encodeURIComponent(JSON.stringify(fsNamespace))}&path=${encodeURIComponent(path)}`,
+        { method: "DELETE", headers: authHeaders },
+      );
+    } catch {
+      // Ignore — file may not exist
     }
   }
 }

--- a/ui/src/lib/server/workflow-engine.ts
+++ b/ui/src/lib/server/workflow-engine.ts
@@ -812,19 +812,20 @@ export function buildWorkflowContextPrefix(
 
   // --- Investigating workflow files ---
   ctx += "## Investigating Workflow Files\n";
-  ctx += "The workflow engine deterministically populates `workflow-state/` after each step. Treat the entire directory as read-only: never create, modify, or delete files under `workflow-state/`. It is provided only as reference material for investigation.\n";
+  ctx += "The workflow engine deterministically populates `workflow-state/` after each step. Treat the entire directory as read-only reference material for investigation, except for the step-specific error file described below. Never create, modify, or delete any other file under `workflow-state/`.\n";
   ctx += "Previous-step logs are stored under `workflow-state/step-{N}--{agent-id}/`. You may use `ls` and `read_file` to inspect user_prompt.txt, tool_calls.txt, and agent_output.txt.\n";
   ctx += "Other steps may write shared files at the filesystem root, outside `workflow-state/`. Run `ls /` to discover those files when investigating previous work.\n\n";
 
   // --- Critical: User interaction ---
   ctx += "## Critical: User Interaction\n";
   ctx += "The user does NOT have access to this chat. All interaction with the user must happen through the `request_user_input` tool.\n";
-  ctx += "When a step must pass data to later steps, call `request_user_input` if needed, then persist outputs with `write_file` at the filesystem root (for example `/choices.txt`), never under `workflow-state/`.\n";
+  ctx += "When a step must pass data to later steps, call `request_user_input` if needed, then persist outputs with `write_file` at the filesystem root (for example `/choices.txt`), never under `workflow-state/`; the failure marker below is the sole exception.\n";
   ctx += "If that tool is not available and you cannot proceed without user input, use the failure-reporting file below and stop.\n\n";
 
   // --- Critical: Reporting failure ---
   ctx += "## Critical: Reporting Failure\n";
-  ctx += `If you determine this step has failed or you cannot complete the task, write a brief explanation to \`/workflow-step-${stepIndex + 1}--${agentId}-error.txt\` at the filesystem root using \`write_file\`.\n`;
+  ctx += `If you determine this step has failed or you cannot complete the task, write a brief explanation to \`workflow-state/step-${stepIndex + 1}--${agentId}/error.txt\` using \`write_file\`.\n`;
+  ctx += "This error file is the only path you may write under `workflow-state/`.\n";
   ctx += "The workflow engine will detect this file and mark the step as failed.\n\n";
 
   // --- Workflow identity ---
@@ -867,7 +868,7 @@ export function buildWorkflowContextPrefix(
 }
 
 /**
- * Check if the agent wrote the reserved root-level error file to signal step failure.
+ * Check if the agent wrote an error.txt file to signal step failure.
  * Returns the error content if found, null otherwise.
  */
 async function checkAgentErrorFile(
@@ -876,11 +877,10 @@ async function checkAgentErrorFile(
   agentId: string,
   authHeaders: Record<string, string>,
 ): Promise<string | null> {
-  // Check both with and without leading slash (agents may write either way).
-  const errorFilename = `workflow-step-${stepIndex + 1}--${agentId}-error.txt`;
+  // Check both with and without leading slash (agents may write either way)
   const paths = [
-    errorFilename,
-    `/${errorFilename}`,
+    `workflow-state/step-${stepIndex + 1}--${agentId}/error.txt`,
+    `/workflow-state/step-${stepIndex + 1}--${agentId}/error.txt`,
   ];
   for (const path of paths) {
     try {
@@ -890,16 +890,7 @@ async function checkAgentErrorFile(
       );
       if (res.ok) {
         const body = await res.json();
-        const content = body?.content || "Agent reported failure (no details)";
-        try {
-          await fetch(
-            `${DA_SERVER_BASE_URL}/api/v1/files/content?fs_namespace=${encodeURIComponent(JSON.stringify(fsNamespace))}&path=${encodeURIComponent(path)}`,
-            { method: "DELETE", headers: authHeaders },
-          );
-        } catch {
-          // Best-effort cleanup; the failure signal has already been captured.
-        }
-        return content;
+        return body?.content || "Agent reported failure (no details)";
       }
     } catch {
       // File not found or network error — continue to next path
@@ -930,18 +921,6 @@ async function deleteStepArtifacts(
       } catch {
         // Ignore — file may not exist
       }
-    }
-  }
-
-  const errorFilename = `workflow-step-${stepIndex + 1}--${agentId}-error.txt`;
-  for (const path of [errorFilename, `/${errorFilename}`]) {
-    try {
-      await fetch(
-        `${DA_SERVER_BASE_URL}/api/v1/files/content?fs_namespace=${encodeURIComponent(JSON.stringify(fsNamespace))}&path=${encodeURIComponent(path)}`,
-        { method: "DELETE", headers: authHeaders },
-      );
-    } catch {
-      // Ignore — file may not exist
     }
   }
 }

--- a/ui/src/lib/server/workflow-engine.ts
+++ b/ui/src/lib/server/workflow-engine.ts
@@ -813,7 +813,7 @@ export function buildWorkflowContextPrefix(
   // --- Investigating workflow files ---
   ctx += "## Investigating Workflow Files\n";
   ctx += "The workflow engine deterministically populates `workflow-state/` after each step. Treat the entire directory as read-only: never create, modify, or delete files under `workflow-state/`. It is provided only as reference material for investigation.\n";
-  ctx += "Previous-step artifacts are stored under `workflow-state/step-{N}--{agent-id}/`. You may use `ls` and `read_file` to inspect user_prompt.txt, tool_calls.txt, and agent_output.txt.\n";
+  ctx += "Previous-step logs are stored under `workflow-state/step-{N}--{agent-id}/`. You may use `ls` and `read_file` to inspect user_prompt.txt, tool_calls.txt, and agent_output.txt.\n";
   ctx += "Other steps may write shared files at the filesystem root, outside `workflow-state/`. Run `ls /` to discover those files when investigating previous work.\n\n";
 
   // --- Critical: User interaction ---

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.40"
+version = "0.5.40.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Clarifies the workflow execution prompt so agents treat `workflow-state/` as deterministic, read-only investigation context.

- Tells agents not to create, modify, or delete files under `workflow-state/`, except for the existing step-specific `error.txt` failure marker.
- Directs agents to run `ls /` because previous steps may write shared files at the filesystem root.
- Keeps step output files at the filesystem root.
- Preserves the existing workflow failure-marker behavior and identifies `error.txt` as the sole writable exception.
- Adds focused prompt assertions.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- `jest src/lib/server/__tests__/workflow-engine-owner-subject.test.ts --runInBand` — 15 tests passed
- `eslint src/lib/server/workflow-engine.ts src/lib/server/__tests__/workflow-engine-owner-subject.test.ts`
- `git diff --check`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable (none)
- [x] Functionality is covered by automated tests
- [x] Relevant code style checks pass
- [x] Relevant tests pass
