### PR TITLE
feat(dynamic-agents): make metrics port configurable

### DIFF
--- a/ai_platform_engineering/dynamic_agents/README.md
+++ b/ai_platform_engineering/dynamic_agents/README.md
@@ -75,6 +75,9 @@ Create a `.env` file in the `dynamic_agents` directory:
 HOST=0.0.0.0
 PORT=8001
 DEBUG=false
+# Serve /metrics on a dedicated port instead of PORT (default: unset, same port as PORT).
+# Useful when the main API port is on strict mTLS but metrics scrapers need a permissive port.
+# METRICS_PORT=9001
 
 # MongoDB
 MONGODB_URI=mongodb://localhost:27017
@@ -141,6 +144,7 @@ The API documentation is available at:
 |----------|-------------|---------|
 | `HOST` | Server bind address | `0.0.0.0` |
 | `PORT` | Server port | `8001` |
+| `METRICS_PORT` | Dedicated port for `/metrics` (0 = same as `PORT`) | `0` |
 | `DEBUG` | Enable debug mode / hot reload / dev auth bypass | `false` |
 | `MONGODB_URI` | MongoDB connection string | `mongodb://localhost:27017` |
 | `MONGODB_DATABASE` | Database name | `caipe` |

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
@@ -35,6 +35,14 @@ class Settings(BaseSettings):
     port: int = 8001
     debug: bool = False
 
+    # Metrics
+    # Port for the /metrics endpoint. When 0 (default) or equal to `port`,
+    # metrics are served on the main API port (current behavior, unchanged).
+    # Set to a different port to serve metrics on a dedicated port — e.g. to
+    # keep the main API port on strict mTLS while leaving the metrics port in
+    # mTLS-permissive mode for scrapers that don't support mTLS client certs.
+    metrics_port: int = 0
+
     # MongoDB
     # Full URI takes precedence; if not set, built from components
     mongodb_uri: str = "mongodb://localhost:27017"

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/main.py
@@ -135,7 +135,13 @@ def create_app() -> FastAPI:
     # Prometheus HTTP metrics middleware (from main). Mounted BEFORE the
     # JWT auth middleware so failed-auth and CORS-preflight requests are
     # still observable.
-    app.add_middleware(PrometheusHTTPMiddleware)
+    # When METRICS_PORT is set to a port other than the main API port,
+    # /metrics is served by a separate standalone server (see below) instead
+    # of on the main port — e.g. to keep the main port on strict mTLS while
+    # leaving the metrics port permissive for scrapers that don't support
+    # mTLS client certs.
+    serve_metrics_on_main_port = settings.metrics_port in (0, settings.port)
+    app.add_middleware(PrometheusHTTPMiddleware, serve_metrics=serve_metrics_on_main_port)
 
     # Spec 102 Phase 8 / T103: validate incoming Bearer JWTs against
     # Keycloak and bind current_user_token so the MCP httpx factory can
@@ -194,20 +200,23 @@ def create_app() -> FastAPI:
     # ai_platform_engineering.utils.auth.metrics are scrapeable. The
     # endpoint is intentionally NOT auth-gated (standard /metrics
     # convention; restrict via NetworkPolicy in production).
-    try:
-        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
-        from starlette.responses import Response
+    # Skipped when METRICS_PORT moves /metrics to a dedicated port (see
+    # serve_metrics_on_main_port above and run_metrics_server below).
+    if serve_metrics_on_main_port:
+        try:
+            from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+            from starlette.responses import Response
 
-        @app.get("/metrics", include_in_schema=False)
-        async def metrics() -> Response:
-            return Response(
-                content=generate_latest(),
-                media_type=CONTENT_TYPE_LATEST,
+            @app.get("/metrics", include_in_schema=False)
+            async def metrics() -> Response:
+                return Response(
+                    content=generate_latest(),
+                    media_type=CONTENT_TYPE_LATEST,
+                )
+        except ImportError:
+            logger.warning(
+                "prometheus_client not installed; /metrics endpoint disabled"
             )
-    except ImportError:
-        logger.warning(
-            "prometheus_client not installed; /metrics endpoint disabled"
-        )
 
     return app
 
@@ -220,6 +229,17 @@ if __name__ == "__main__":
     import uvicorn
 
     settings = get_settings()
+
+    # Serve /metrics on its own port when METRICS_PORT differs from the main
+    # API port (see serve_metrics_on_main_port in create_app). Uses
+    # prometheus_client's own WSGI server, started in a background thread,
+    # against the same default collector registry the app's metrics use.
+    if settings.metrics_port and settings.metrics_port != settings.port:
+        from prometheus_client import start_http_server
+
+        start_http_server(settings.metrics_port, addr=settings.host)
+        logger.info("Metrics server listening on %s:%s/metrics", settings.host, settings.metrics_port)
+
     uvicorn.run(
         "dynamic_agents.main:app",
         host=settings.host,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/metrics/http_middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/metrics/http_middleware.py
@@ -22,16 +22,22 @@ _EXCLUDED = frozenset({"/health", "/ready", "/healthz", "/", "/metrics"})
 class PrometheusHTTPMiddleware(BaseHTTPMiddleware):
     """Serves ``/metrics`` and records request duration + active gauge."""
 
-    def __init__(self, app: ASGIApp, metrics_path: str = "/metrics") -> None:
+    def __init__(self, app: ASGIApp, metrics_path: str = "/metrics", serve_metrics: bool = True) -> None:
         super().__init__(app)
         self._metrics_path = metrics_path
-        logger.info("PrometheusHTTPMiddleware initialised, metrics at %s", metrics_path)
+        self._serve_metrics_inline = serve_metrics
+        logger.info(
+            "PrometheusHTTPMiddleware initialised, metrics at %s (inline=%s)",
+            metrics_path,
+            serve_metrics,
+        )
 
     async def dispatch(self, request: Request, call_next) -> Response:
         path = request.url.path
 
-        # Serve metrics endpoint directly
-        if path == self._metrics_path:
+        # Serve metrics endpoint directly, unless metrics are served on a
+        # dedicated port instead (see dynamic_agents.main / METRICS_PORT).
+        if path == self._metrics_path and self._serve_metrics_inline:
             return self._serve_metrics()
 
         # Skip tracking for health/root

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
@@ -82,6 +82,25 @@ Determine if ingress is enabled - global takes precedence
 {{- .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- end -}}
 
+{{/*
+Effective metrics port. 0 (default) means metrics are served on the main
+service port, so this resolves to service.port in that case.
+*/}}
+{{- define "dynamic-agents.metricsPort" -}}
+{{- if and .Values.service.metricsPort (ne (int .Values.service.metricsPort) 0) -}}
+{{- .Values.service.metricsPort -}}
+{{- else -}}
+{{- .Values.service.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+True when metrics run on a port different from the main service port.
+*/}}
+{{- define "dynamic-agents.metricsPortSeparate" -}}
+{{- and .Values.service.metricsPort (ne (int .Values.service.metricsPort) (int .Values.service.port)) -}}
+{{- end -}}
+
 {/*
 Resolve maintained CAIPE image repositories for release vs pre-release channels.
 

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/deployment.yaml
@@ -47,7 +47,14 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if eq (include "dynamic-agents.metricsPortSeparate" .) "true" }}
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+              protocol: TCP
+            {{- end }}
           env:
+            - name: METRICS_PORT
+              value: {{ .Values.service.metricsPort | default 0 | quote }}
             - name: KEYCLOAK_URL
               value: {{ index .Values.config "KEYCLOAK_URL" | default (printf "http://%s-keycloak:8080" .Release.Name) | quote }}
             - name: OPENFGA_HTTP

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/service.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if eq (include "dynamic-agents.metricsPortSeparate" .) "true" }}
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "dynamic-agents.selectorLabels" . | nindent 4 }}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -52,6 +52,12 @@ securityContext:
 service:
   type: ClusterIP
   port: 8001
+  # Dedicated port for the /metrics endpoint. 0 (default) serves metrics on
+  # `port` above — current behavior, unchanged. Set to a different port to
+  # split metrics onto its own container/service port, e.g. so the main API
+  # port can run strict mTLS while metrics stays on a permissive port for
+  # scrapers that don't support mTLS client certs.
+  metricsPort: 0
 
 # Ingress configuration
 ingress:

--- a/charts/ai-platform-engineering/templates/servicemonitor-dynamic-agents.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor-dynamic-agents.yaml
@@ -1,0 +1,43 @@
+{{- $daPort := index .Values "dynamic-agents" "service" "port" | default 8001 | int }}
+{{- $daMetricsPort := index .Values "dynamic-agents" "service" "metricsPort" | default 0 | int }}
+{{- if and .Values.metrics.serviceMonitor.enabled (ne $daMetricsPort 0) (ne $daMetricsPort $daPort) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-dynamic-agents-metrics
+  labels:
+    app.kubernetes.io/name: ai-platform-engineering
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # dynamic-agents.service.metricsPort is set to a port different from the
+  # main service port, so /metrics moved to its own "metrics" service port
+  # (see charts/dynamic-agents/templates/service.yaml). A dedicated
+  # ServiceMonitor is used so this endpoint is only applied to dynamic-agents.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dynamic-agents
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.metrics.path | default "/metrics" }}
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ai-platform-engineering/templates/servicemonitor.yaml
+++ b/charts/ai-platform-engineering/templates/servicemonitor.yaml
@@ -1,3 +1,6 @@
+{{- $daPort := index .Values "dynamic-agents" "service" "port" | default 8001 | int }}
+{{- $daMetricsPort := index .Values "dynamic-agents" "service" "metricsPort" | default 0 | int }}
+{{- $daMetricsSeparate := and (ne $daMetricsPort 0) (ne $daMetricsPort $daPort) }}
 {{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -20,6 +23,8 @@ spec:
   #   - agentgateway: servicemonitor-agentgateway.yaml (admin port 15000)
   #   - keycloak: servicemonitor-keycloak.yaml (management port 9000)
   #   - openfga: servicemonitor-openfga.yaml (metrics port 2112)
+  #   - dynamic-agents (only when dynamic-agents.service.metricsPort is set
+  #     to a port different from the main port): servicemonitor-dynamic-agents.yaml
   # audit-service has no /metrics endpoint and is excluded entirely.
   selector:
     matchLabels:
@@ -40,6 +45,9 @@ spec:
           - keycloak
           - openfga
           - audit-service
+          {{- if $daMetricsSeparate }}
+          - dynamic-agents
+          {{- end }}
   endpoints:
     - port: http
       path: {{ .Values.metrics.path | default "/metrics" }}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -1065,6 +1065,12 @@ dynamic-agents:
     pullPolicy: "IfNotPresent"
   service:
     port: 8001
+    # Dedicated port for /metrics. 0 (default) serves metrics on `port`
+    # above — unchanged from current behavior. Set to a different port to
+    # split metrics onto its own port, e.g. so the main API port can run
+    # strict mTLS while metrics stays permissive for scrapers that don't
+    # support mTLS client certs.
+    metricsPort: 0
   # ConfigMap for non-sensitive configuration
   config:
     # ─── Keycloak / OIDC (REQUIRED for Bearer token validation) ─────────

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1049,6 +1049,9 @@ services:
       - OPENFGA_STORE_ID=${OPENFGA_STORE_ID:-}
       - AUTHZ_TRACING_ENABLED=${AUTHZ_TRACING_ENABLED:-false}
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}
+      # Dedicated /metrics port. 0 (default) serves metrics on the main API
+      # port — current behavior, unchanged.
+      - METRICS_PORT=${DYNAMIC_AGENTS_METRICS_PORT:-0}
 
     healthcheck:
       # Use /healthz (matches FastAPI route in routes/health.py and the Helm chart probes).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -535,6 +535,9 @@ services:
       # Runtime configuration
       - AGENT_RUNTIME_TTL_SECONDS=${AGENT_RUNTIME_TTL_SECONDS:-3600}
       - CORS_ORIGINS=${DYNAMIC_AGENTS_CORS_ORIGINS:-["*"]}
+      # Dedicated /metrics port. 0 (default) serves metrics on the main API
+      # port — current behavior, unchanged.
+      - METRICS_PORT=${DYNAMIC_AGENTS_METRICS_PORT:-0}
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.50 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.51 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.50 -f your-values.yaml'}
+                  {'    --version 0.5.51 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.50 -f your-values.yaml'}
+              {'    --version 0.5.51 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.51"
+version = "0.5.51-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.51"
+version = "0.5.51.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Adds a `METRICS_PORT` setting (env var / Helm value) so the dynamic-agents Prometheus `/metrics` endpoint can be served on a dedicated port, separate from the main API port.

**Motivation:** this unblocks running the main API port under strict mTLS while keeping the metrics port in permissive mode, for scrapers that don't support mTLS client certs.

Defaults to `0`, which serves metrics on the main port — identical to current behavior. **Non-breaking.**

### Changes

- `config.py`: new `metrics_port` setting (env `METRICS_PORT`), default `0`
- `main.py`: skips the in-process `/metrics` route(s) and starts a standalone `prometheus_client` HTTP server on `METRICS_PORT` when it differs from the main port
- `http_middleware.py`: `PrometheusHTTPMiddleware` gains a `serve_metrics` flag so it stops serving `/metrics` inline once it's moved to its own port
- Helm (`dynamic-agents` chart): new `service.metricsPort` value (default `0`); adds a second named `metrics` container/service port when set; adds a dedicated `ServiceMonitor` (mirrors the existing openfga/agentgateway pattern) — the generic `ServiceMonitor` excludes dynamic-agents once metrics moves to its own port
- `docker-compose.yaml`: passes through `METRICS_PORT` (default `0`)

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

Built and ran dynamic-agents locally via `docker-compose.dev.yaml` (source-built image, not the published release), covering both `METRICS_PORT` states:

**Default (`METRICS_PORT` unset/`0`) — unchanged behavior:**
- `GET /metrics` on the main API port → `200`, valid Prometheus text output
- `GET /health` → `200`
- Log line confirms inline serving: `PrometheusHTTPMiddleware initialised, metrics at /metrics (inline=True)`

**Dedicated port (`METRICS_PORT=9101`):**
- `GET /metrics` on port `9101` → `200`, valid Prometheus text output
- `GET /metrics` on the main API port → `404` (no longer served inline)
- `GET /health` on the main API port → `200` (main app unaffected)
- Log lines confirm the split: `Metrics server listening on 0.0.0.0:9101/metrics` and `PrometheusHTTPMiddleware initialised, metrics at /metrics (inline=False)`

Also verified with `helm template` that the ServiceMonitor setup correctly tracks the port change:
- `service.metricsPort=0` (default): only the generic ServiceMonitor exists, scraping dynamic-agents on the `http` port — unchanged
- `service.metricsPort=9101`: a dedicated `<release>-dynamic-agents-metrics` ServiceMonitor is rendered targeting the new `metrics` Service/container port, and the generic ServiceMonitor's selector excludes `dynamic-agents` by name so it isn't double-scraped on the wrong port

Note: `docker-compose.dev.yaml` (used for local source-build development) doesn't yet pass `METRICS_PORT` through to the container or publish a dedicated host port — added that passthrough as part of this PR so local dev can exercise the feature too.

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (README env var table updated)
- [x] All code style checks pass (`ruff check`)
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass (one pre-existing unrelated failure confirmed on `main`)
