### PR TITLE
feat(agentgateway): fall back to caller Authorization for provider-token routes

### DIFF
--- a/charts/ai-platform-engineering/templates/agentgateway-mcp.yaml
+++ b/charts/ai-platform-engineering/templates/agentgateway-mcp.yaml
@@ -130,6 +130,9 @@ spec:
 ---
 # Per-request provider/identity token: rewrite X-CAIPE-Provider-Token into the
 # upstream Authorization header for MCPs that opt into caller-token passthrough.
+# When X-CAIPE-Provider-Token is absent/empty, fall back to the caller's existing
+# Authorization header (already validated by the gateway's jwtAuth) so direct
+# callers can use a plain Bearer token without setting the provider-token header.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -144,7 +147,7 @@ spec:
       request:
         set:
           - name: authorization
-            value: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+            value: 'default(request.headers["x-caipe-provider-token"], "") != "" ? "Bearer " + request.headers["x-caipe-provider-token"] : default(request.headers["authorization"], "")'
 {{- end }}
 {{- end }}
 {{- end }}
@@ -189,6 +192,9 @@ spec:
 ---
 # Per-request provider/identity token: rewrite X-CAIPE-Provider-Token into the
 # upstream Authorization header for MCPs that opt into caller-token passthrough.
+# When X-CAIPE-Provider-Token is absent/empty, fall back to the caller's existing
+# Authorization header (already validated by the gateway's jwtAuth) so direct
+# callers can use a plain Bearer token without setting the provider-token header.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -203,7 +209,7 @@ spec:
       request:
         set:
           - name: authorization
-            value: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+            value: 'default(request.headers["x-caipe-provider-token"], "") != "" ? "Bearer " + request.headers["x-caipe-provider-token"] : default(request.headers["authorization"], "")'
 {{- end }}
 {{- end }}
 {{- range $target := $extraMcpTargets }}
@@ -251,6 +257,9 @@ spec:
 ---
 # Per-request provider/identity token: rewrite X-CAIPE-Provider-Token into the
 # upstream Authorization header for MCPs that opt into caller-token passthrough.
+# When X-CAIPE-Provider-Token is absent/empty, fall back to the caller's existing
+# Authorization header (already validated by the gateway's jwtAuth) so direct
+# callers can use a plain Bearer token without setting the provider-token header.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -265,7 +274,7 @@ spec:
       request:
         set:
           - name: authorization
-            value: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+            value: 'default(request.headers["x-caipe-provider-token"], "") != "" ? "Bearer " + request.headers["x-caipe-provider-token"] : default(request.headers["authorization"], "")'
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/templates/agentgateway-static-config.yaml
+++ b/charts/ai-platform-engineering/templates/agentgateway-static-config.yaml
@@ -90,10 +90,14 @@ data:
                   # OAuth token (or org PAT fallback); the knowledge-base (RAG)
                   # route forwards the caller's user JWT or a caipe-platform
                   # service token.
+                  # When X-CAIPE-Provider-Token is absent/empty, fall back to the
+                  # caller's existing Authorization header (already validated by
+                  # the gateway's jwtAuth) so direct callers can use a plain
+                  # Bearer token without setting the provider-token header.
                   transformations:
                     request:
                       set:
-                        authorization: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
+                        authorization: 'default(request.headers["x-caipe-provider-token"], "") != "" ? "Bearer " + request.headers["x-caipe-provider-token"] : default(request.headers["authorization"], "")'
                   {{- end }}
                 {{- end }}
                 backends:

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -442,6 +442,7 @@ mcp-github:
       enabled: false
       protocol: StreamableHTTP
       # Rewrite X-CAIPE-Provider-Token into Authorization: Bearer for per-caller OAuth/PAT passthrough.
+      # Falls back to the caller's existing Authorization header when the provider-token header is unset.
       providerTokenAuth: true
 
 mcp-gitlab:
@@ -465,6 +466,7 @@ mcp-gitlab:
       enabled: false
       protocol: StreamableHTTP
       # Rewrite X-CAIPE-Provider-Token into Authorization: Bearer for per-caller OAuth/PAT passthrough.
+      # Falls back to the caller's existing Authorization header when the provider-token header is unset.
       providerTokenAuth: true
     env:
       STREAMABLE_HTTP: "true"


### PR DESCRIPTION
# Description

The AgentGateway `providerTokenAuth` transform **unconditionally** rewrites the upstream `Authorization` header from `X-CAIPE-Provider-Token`:

```
authorization: '"Bearer " + default(request.headers["x-caipe-provider-token"], "")'
```

This means any caller that authenticates with a plain `Authorization: Bearer <token>` — but does not also set `X-CAIPE-Provider-Token` — has its token replaced with a literal empty `Bearer `, and the upstream MCP (e.g. the RAG/knowledge-base server, which enforces its own OIDC) rejects it with a 401.

This is fine for the primary path (the runtime injects `X-CAIPE-Provider-Token`), but it makes direct callers — CLI clients, scripts, local development — awkward: they must duplicate their token into a second, non-obvious header.

## Change

Make the transform **prefer** `X-CAIPE-Provider-Token` when present, and otherwise **fall back** to the caller's existing (already gateway-validated) `Authorization` header, unchanged:

```
authorization: 'default(request.headers["x-caipe-provider-token"], "") != "" ? "Bearer " + request.headers["x-caipe-provider-token"] : default(request.headers["authorization"], "")'
```

- **Backward compatible** — whenever `X-CAIPE-Provider-Token` is set (the injected path), it still wins, byte-for-byte unchanged.
- **No new privilege** — the fallback token is the same one the gateway's `jwtAuth` already validated; the upstream independently re-validates it. A caller can only forward the identity they authenticated with.
- The raw provider token is `Bearer `-prefixed as before; the fallback `Authorization` value already carries its own `Bearer ` prefix, so it is forwarded as-is (no double prefix).

Applied to all four transform sites (3 Gateway-API policies in `agentgateway-mcp.yaml`, 1 in the standalone static config) plus the `values.yaml` comments. Verified with `helm template` in both `static` and `gateway-api` routing modes.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
