### PR TITLE
fix(dynamic-agents): restore subagent timeline correlation

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/langgraph_helpers.py
@@ -89,36 +89,57 @@ class LangGraphStreamHelper:
 
         return (namespace, mode, data)
 
+    @staticmethod
+    def _extract_task_tool_calls(task_input: Any) -> list[dict]:
+        """Return the tool calls from a ``tasks``-mode chunk input.
+
+        LangGraph has emitted two shapes for this field:
+
+        - Before 1.2, a dict containing one call under ``tool_call``.
+        - Since 1.2, a list of tool-call dicts.
+
+        Normalize both shapes so namespace correlation remains compatible
+        across LangGraph versions. Unknown shapes yield an empty list.
+        """
+        if isinstance(task_input, dict):
+            tool_call = task_input.get("tool_call")
+            return [tool_call] if isinstance(tool_call, dict) else []
+        if isinstance(task_input, list):
+            return [tool_call for tool_call in task_input if isinstance(tool_call, dict)]
+        return []
+
     def _handle_tasks_chunk(self, data: Any) -> None:
         """Extract namespace UUID -> tool_call_id mapping from tasks events.
 
         LangGraph's ``tasks`` stream mode emits task metadata when a tool is
         invoked. For the ``task`` tool (subagent invocation), this contains:
         - id: The task UUID (used in namespace as "tools:{id}")
-        - input.tool_call.id: The tool_call_id from the original invocation
+        - a tool call carrying the original ``tool_call_id`` and name
 
         We build this mapping so subagent events can be correlated to their
-        ``tool_start`` events, which clients already have.
+        ``tool_start`` events, which clients already have. The shape of the
+        ``input`` field varies across LangGraph versions.
         """
         # Tasks data comes as a single dict per event, not a list
         if not isinstance(data, dict):
             return
 
         task_id = data.get("id")
-        task_input = data.get("input", {})
+        if not task_id:
+            return
 
-        # The tool_call info is nested under input.tool_call for tool executions
-        tool_call = task_input.get("tool_call", {}) if isinstance(task_input, dict) else {}
-        tool_call_id = tool_call.get("id")
-        tool_name = tool_call.get("name")
-
-        # Only create mapping for "task" tool calls (subagent invocations)
-        # Other tools don't spawn subgraphs with their own namespace
-        if task_id and tool_call_id and tool_name == "task":
+        # Only task tool calls spawn subgraphs with their own namespace.
+        for tool_call in self._extract_task_tool_calls(data.get("input")):
+            if tool_call.get("name") != "task":
+                continue
+            tool_call_id = tool_call.get("id")
+            if not tool_call_id:
+                continue
             namespace_key = f"tools:{task_id}"
             if namespace_key not in self._namespace_mapping:
                 self._namespace_mapping[namespace_key] = tool_call_id
                 logger.debug(f"[sse:tasks] Mapped {namespace_key} → {tool_call_id}")
+            break
 
     def correlate_namespace(self, namespace: tuple[str, ...]) -> tuple[str, ...]:
         """Correlate using internal namespace_mapping.

--- a/ai_platform_engineering/dynamic_agents/tests/test_agui_sse_namespace.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_agui_sse_namespace.py
@@ -194,3 +194,77 @@ class TestHandleMessagesNamespace:
 
             frames_2 = enc._handle_messages((chunk, {}), ("agent-A",))
             assert _namespace_values(frames_2) == []  # no redundant emit
+
+
+class TestTasksChunkNamespaceMapping:
+    """Cover task-input shapes emitted before and after LangGraph 1.2."""
+
+    TASK_ID = "abc123-def456"
+    TOOL_CALL_ID = "toolu_subagent_1"
+
+    def _legacy_dict_chunk(self) -> dict:
+        """LangGraph before 1.2 nests the tool call in an input dict."""
+        return {
+            "id": self.TASK_ID,
+            "name": "tools",
+            "input": {
+                "__type": "tool_call_with_context",
+                "tool_call": {
+                    "name": "task",
+                    "args": {"subagent_type": "worker", "description": "do work"},
+                    "id": self.TOOL_CALL_ID,
+                    "type": "tool_call",
+                },
+                "state": {"messages": []},
+            },
+        }
+
+    def _list_chunk(self) -> dict:
+        """LangGraph 1.2 and later emit a list of tool-call dicts."""
+        return {
+            "id": self.TASK_ID,
+            "name": "tools",
+            "input": [
+                {
+                    "name": "task",
+                    "args": {"subagent_type": "worker", "description": "do work"},
+                    "id": self.TOOL_CALL_ID,
+                    "type": "tool_call",
+                }
+            ],
+        }
+
+    def test_legacy_dict_shape_populates_mapping(self):
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(self._legacy_dict_chunk())
+        assert enc._helper._namespace_mapping == {f"tools:{self.TASK_ID}": self.TOOL_CALL_ID}
+
+    def test_list_shape_populates_mapping(self):
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(self._list_chunk())
+        assert enc._helper._namespace_mapping == {f"tools:{self.TASK_ID}": self.TOOL_CALL_ID}
+
+    def test_subagent_namespace_correlates_after_list_chunk(self):
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(self._list_chunk())
+        correlated = enc._helper.correlate_namespace((f"tools:{self.TASK_ID}",))
+        assert correlated == (self.TOOL_CALL_ID,)
+
+    def test_uncorrelated_subagent_namespace_falls_back_to_parent(self):
+        enc = AGUIStreamEncoder()
+        correlated = enc._helper.correlate_namespace((f"tools:{self.TASK_ID}",))
+        assert correlated == ()
+
+    def test_non_task_tool_calls_are_ignored(self):
+        enc = AGUIStreamEncoder()
+        chunk = self._list_chunk()
+        chunk["input"][0]["name"] = "get_weather"
+        enc._helper._handle_tasks_chunk(chunk)
+        assert enc._helper._namespace_mapping == {}
+
+    def test_result_chunk_without_tool_call_is_ignored(self):
+        enc = AGUIStreamEncoder()
+        enc._helper._handle_tasks_chunk(
+            {"id": self.TASK_ID, "name": "tools", "result": {"messages": []}, "interrupts": []}
+        )
+        assert enc._helper._namespace_mapping == {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.40-dev.1"
+version = "0.5.40-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.40.dev1"
+version = "0.5.40.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Ports the subagent namespace-correlation fix from #1683 to `main`. PR #2129 ported other `release/0.4.18-hotfix` behavior, including summarization filtering, but did not include this fix.

LangGraph 1.2 changed `tasks` stream inputs from a nested `input.tool_call` object to a list of tool-call objects. The dynamic-agent stream helper only understood the older shape, so it could not correlate subgraph namespaces with the parent `task` tool call. Unknown namespaces then collapsed to the root namespace, causing subagent content and tools to render in the top-level timeline.

This change:

- normalizes both pre-1.2 and 1.2+ task-input shapes;
- restores subagent namespace correlation without changing PR #2129's summarization filtering; and
- adds regression coverage for both shapes and the correlation fallback behavior.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `uv run pytest tests/test_agui_sse_namespace.py tests/test_sse_summarization_filter.py -q` — 19 passed
- `uv run ruff check src/dynamic_agents/services/stream_encoders/langgraph_helpers.py tests/test_agui_sse_namespace.py` — passed
- `git diff --check` — passed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
