### PR TITLE
fix(workflows): restore subagent HITL and live run status

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -860,7 +860,12 @@ class AgentRuntime:
 
         return tools
 
-    def _build_interrupt_config(self, tools: list, builtin_tool_names: set[str]) -> dict[str, Any]:
+    def _build_interrupt_config(
+        self,
+        tools: list,
+        builtin_tool_names: set[str],
+        agent_config: DynamicAgentConfig | None = None,
+    ) -> dict[str, Any]:
         """Build flattened interrupt_on config for deepagents.
 
         Converts the namespaced storage format (server_id -> {tool: config})
@@ -868,9 +873,16 @@ class AgentRuntime:
 
         Supports "*" wildcard to gate all tools in a namespace.
         "builtin" is the reserved namespace for non-MCP tools (no prefix).
+
+        Args:
+            tools: Tools available to the agent whose interrupt config is built.
+            builtin_tool_names: Names of built-in tools in ``tools``.
+            agent_config: Agent config that owns the tools. Defaults to the
+                parent runtime config; subagents must pass their own config.
         """
+        config = agent_config or self.config
         interrupt_config: dict[str, Any] = {}
-        for server_id, tools_map in self.config.interrupt_on.items():
+        for server_id, tools_map in (config.interrupt_on or {}).items():
             for tool_name, cfg in tools_map.items():
                 resolved_cfg = cfg.model_dump() if isinstance(cfg, InterruptConfig) else cfg
                 if tool_name == "*":
@@ -939,7 +951,12 @@ class AgentRuntime:
                 continue
 
             # Build MCP tools for subagent
-            subagent_tools = await self._build_subagent_tools(subagent_config)
+            subagent_tools, builtin_tool_names = await self._build_subagent_tools(subagent_config)
+            interrupt_config = self._build_interrupt_config(
+                subagent_tools,
+                builtin_tool_names,
+                agent_config=subagent_config,
+            )
 
             # System prompt from subagent config
             subagent_prompt = subagent_config.system_prompt
@@ -956,6 +973,7 @@ class AgentRuntime:
                 "system_prompt": subagent_prompt,
                 "tools": subagent_tools,
                 "model": subagent_llm,
+                "interrupt_on": interrupt_config,
                 "middleware": build_middleware(
                     subagent_config.features,
                     self._session_id,
@@ -976,14 +994,17 @@ class AgentRuntime:
 
         return subagents
 
-    async def _build_subagent_tools(self, subagent_config: DynamicAgentConfig) -> list:
+    async def _build_subagent_tools(
+        self,
+        subagent_config: DynamicAgentConfig,
+    ) -> tuple[list, set[str]]:
         """Build tools for a subagent (MCP tools + built-in tools).
 
         Args:
             subagent_config: The subagent's configuration
 
         Returns:
-            List of LangChain tools (MCP + built-in based on subagent config)
+            Tuple containing the LangChain tools and the names of built-in tools.
         """
         tools: list = []
 
@@ -1030,6 +1051,7 @@ class AgentRuntime:
         # 2. Add built-in tools based on subagent's config
         client_ctx = self._client_context.model_dump() if self._client_context else None
         builtin_tools = self._build_builtin_tools(self._user, subagent_config, client_context=client_ctx)
+        builtin_tool_names = {tool.name for tool in builtin_tools}
         if builtin_tools:
             tools.extend(builtin_tools)
 
@@ -1037,7 +1059,7 @@ class AgentRuntime:
         if tools:
             tools = wrap_tools_with_error_handling(tools, agent_name=subagent_config.name)
 
-        return tools
+        return tools, builtin_tool_names
 
     async def cleanup(self) -> None:
         """Cleanup all resources held by this runtime.

--- a/ai_platform_engineering/dynamic_agents/tests/test_subagent_hitl.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_subagent_hitl.py
@@ -1,0 +1,109 @@
+"""Regression tests for human-in-the-loop configuration on subagents."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dynamic_agents.models import (
+    BuiltinToolsConfig,
+    DynamicAgentConfig,
+    ModelConfig,
+    RequestUserInputToolConfig,
+    SubAgentRef,
+)
+from dynamic_agents.services.agent_runtime import AgentRuntime
+
+
+def _agent_config(
+    agent_id: str,
+    name: str,
+    *,
+    interrupt_enabled: bool,
+    subagents: list[SubAgentRef] | None = None,
+) -> DynamicAgentConfig:
+    return DynamicAgentConfig(
+        _id=agent_id,
+        name=name,
+        system_prompt=f"You are {name}.",
+        owner_id="owner@example.com",
+        model=ModelConfig(id="test-model", provider="openai"),
+        builtin_tools=BuiltinToolsConfig(
+            request_user_input=RequestUserInputToolConfig(enabled=True),
+        ),
+        interrupt_on={"builtin": {"request_user_input": interrupt_enabled}},
+        subagents=subagents or [],
+    )
+
+
+def test_resolved_subagent_includes_its_request_user_input_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom subagents must install HITL from their own config."""
+    subagent_ref = SubAgentRef(
+        agent_id="child-agent",
+        name="child",
+        description="Collect deployment details from the user.",
+    )
+    parent_config = _agent_config(
+        "parent-agent",
+        "Parent",
+        interrupt_enabled=False,
+        subagents=[subagent_ref],
+    )
+    child_config = _agent_config(
+        "child-agent",
+        "Child",
+        interrupt_enabled=True,
+    )
+
+    runtime = object.__new__(AgentRuntime)
+    runtime.config = parent_config
+    runtime._session_id = "conversation-1"
+    runtime._mongo_service = MagicMock()
+    runtime._mongo_service.get_agent.return_value = child_config
+
+    request_input_tool = MagicMock()
+    request_input_tool.name = "request_user_input"
+    runtime._build_subagent_tools = AsyncMock(
+        return_value=([request_input_tool], {"request_user_input"}),
+    )
+
+    monkeypatch.setattr(
+        "dynamic_agents.services.agent_runtime.get_llm",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "dynamic_agents.services.agent_runtime.build_middleware",
+        lambda *_args, **_kwargs: [],
+    )
+
+    resolved = asyncio.run(runtime._resolve_subagents([subagent_ref]))
+
+    assert len(resolved) == 1
+    assert resolved[0]["interrupt_on"] == {"request_user_input": True}
+
+
+def test_build_interrupt_config_uses_supplied_agent_config() -> None:
+    """The helper must not substitute the parent agent's HITL policy."""
+    runtime = object.__new__(AgentRuntime)
+    runtime.config = _agent_config(
+        "parent-agent",
+        "Parent",
+        interrupt_enabled=False,
+    )
+    child_config = _agent_config(
+        "child-agent",
+        "Child",
+        interrupt_enabled=True,
+    )
+    request_input_tool = MagicMock()
+    request_input_tool.name = "request_user_input"
+
+    result = runtime._build_interrupt_config(
+        [request_input_tool],
+        {"request_user_input"},
+        agent_config=child_config,
+    )
+
+    assert result == {"request_user_input": True}

--- a/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
+++ b/ui/src/app/api/__tests__/workflow-runs-rbac.test.ts
@@ -124,6 +124,21 @@ describe("workflow runs OpenFGA config access", () => {
     mockGetAuth.mockResolvedValue({ user: mockAuthUser, session: mockAuthSession });
   });
 
+  it("marks individual run polling responses as no-store", async () => {
+    const run = { _id: "run-1", workflow_config_id: "wf-visible", status: "running" };
+    const runCollection = {
+      findOne: jest.fn().mockResolvedValue(run),
+    };
+    mockGetCollection.mockResolvedValue(runCollection);
+    const { GET } = await import("../workflow-runs/route");
+
+    const response = await GET(request("/api/workflow-runs?run_id=run-1"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(await response.json()).toMatchObject(run);
+  });
+
   it("lists runs for OpenFGA-readable workflow configs without legacy team prefiltering", async () => {
     const runCollection = {
       deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -243,7 +243,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       eventsObj[stepIndex] = stepEvents;
     }
 
-    return NextResponse.json({ ...run, events: eventsObj }) as NextResponse;
+    return NextResponse.json(
+      { ...run, events: eventsObj },
+      { headers: { "Cache-Control": "no-store, max-age=0" } },
+    ) as NextResponse;
   }
 
   // Legacy: list runs for user

--- a/ui/src/components/chat/WorkflowRunCard.tsx
+++ b/ui/src/components/chat/WorkflowRunCard.tsx
@@ -24,7 +24,7 @@ interface StepInterrupt {
 interface RunStatus {
   _id: string;
   workflow_config_id: string;
-  status: "running" | "completed" | "failed" | "cancelled" | "waiting_for_input";
+  status: "pending" | "running" | "completed" | "failed" | "cancelled" | "waiting_for_input";
   started_at?: string;
   completed_at?: string;
   current_step_index?: number;
@@ -65,12 +65,17 @@ interface WorkflowRunCardProps {
 }
 
 const STATUS_CONFIG = {
+  pending: { icon: Clock, label: "Pending", className: "text-sky-400", bg: "border-sky-500/30 bg-sky-500/5" },
   running: { icon: Loader2, label: "Running", className: "text-sky-400 animate-spin", bg: "border-sky-500/30 bg-sky-500/5" },
   waiting_for_input: { icon: PauseCircle, label: "Input required", className: "text-amber-400", bg: "border-amber-500/30 bg-amber-500/5" },
   completed: { icon: CheckCircle2, label: "Completed", className: "text-emerald-400", bg: "border-emerald-500/30 bg-emerald-500/5" },
   failed: { icon: XCircle, label: "Failed", className: "text-red-400", bg: "border-red-500/30 bg-red-500/5" },
   cancelled: { icon: XCircle, label: "Cancelled", className: "text-muted-foreground", bg: "border-border bg-muted/30" },
 } as const;
+
+const TERMINAL_STATUSES = new Set<RunStatus["status"]>(["completed", "failed", "cancelled"]);
+const RUNNING_POLL_INTERVAL_MS = 2000;
+const IDLE_POLL_INTERVAL_MS = 10000;
 
 function RunCard({ runId }: { runId: string }) {
   const router = useRouter();
@@ -81,7 +86,9 @@ function RunCard({ runId }: { runId: string }) {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch(`/api/workflow-runs?run_id=${encodeURIComponent(runId)}`);
+      const res = await fetch(`/api/workflow-runs?run_id=${encodeURIComponent(runId)}`, {
+        cache: "no-store",
+      });
       if (res.status === 401 || res.status === 404) {
         setHidden(true);
         return;
@@ -106,23 +113,19 @@ function RunCard({ runId }: { runId: string }) {
     })();
   }, [status?.workflow_config_id, configInfo]);
 
-  const [stopped, setStopped] = useState(false);
-
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchStatus is async; setState only called after awaited fetch completes
     void fetchStatus();
   }, [fetchStatus]);
 
   useEffect(() => {
-    if (stopped || hidden) return;
-    if (status && status.status !== "running" && status.status !== "waiting_for_input") {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: conditional state update when status transitions to a terminal state
-      setStopped(true);
-      return;
-    }
-    const interval = setInterval(fetchStatus, status?.status === "running" ? 5000 : 10000);
+    if (hidden || (status && TERMINAL_STATUSES.has(status.status))) return;
+    const interval = setInterval(
+      fetchStatus,
+      status?.status === "running" ? RUNNING_POLL_INTERVAL_MS : IDLE_POLL_INTERVAL_MS,
+    );
     return () => clearInterval(interval);
-  }, [status, stopped, hidden, fetchStatus]);
+  }, [status, hidden, fetchStatus]);
 
   const handleResume = useCallback(async (resumeData: string) => {
     const waitingStepIndex = status?.steps?.findIndex((s) => s.status === "waiting_for_input") ?? -1;
@@ -314,6 +317,7 @@ function RunCard({ runId }: { runId: string }) {
 
 /**
  * Renders workflow run cards as a sidecar section in the chat timeline.
+ * Each card polls for status updates until the run reaches a terminal state.
  * When a run is waiting_for_input with an interrupt, the form renders
  * inline matching the agent HITL style — no page navigation required.
  */

--- a/ui/src/components/chat/__tests__/WorkflowRunCard.test.tsx
+++ b/ui/src/components/chat/__tests__/WorkflowRunCard.test.tsx
@@ -1,0 +1,106 @@
+import { act,render,screen,waitFor } from "@testing-library/react";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("lucide-react", () => ({
+  CheckCircle2: () => <span />,
+  Clock: () => <span />,
+  ExternalLink: () => <span />,
+  Loader2: () => <span />,
+  PauseCircle: () => <span />,
+  Workflow: () => <span />,
+  XCircle: () => <span />,
+}));
+
+import { WorkflowRunCard } from "../WorkflowRunCard";
+
+const RUNNING_RUN = {
+  _id: "run-1",
+  workflow_config_id: "workflow-1",
+  status: "running",
+  steps: [{ status: "running", display_text: "Check service" }],
+};
+
+const COMPLETED_RUN = {
+  ...RUNNING_RUN,
+  status: "completed",
+  steps: [{ status: "completed", display_text: "Check service", response: "Service is healthy" }],
+};
+
+function response(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe("WorkflowRunCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("refreshes a running workflow until its terminal status is rendered", async () => {
+    let runRequestCount = 0;
+    (global.fetch as jest.Mock).mockImplementation((input: string) => {
+      if (input.startsWith("/api/workflow-configs")) {
+        return Promise.resolve(response({ name: "Health check" }));
+      }
+
+      runRequestCount += 1;
+      return Promise.resolve(response(runRequestCount === 1 ? RUNNING_RUN : COMPLETED_RUN));
+    });
+
+    render(<WorkflowRunCard runs={[{ runId: "run-1" }]} />);
+
+    await screen.findByText("Running");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/workflow-runs?run_id=run-1",
+      { cache: "no-store" },
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+    });
+
+    await screen.findByText("Completed");
+    expect(screen.getByText("1/1 steps")).toBeInTheDocument();
+    expect(screen.getByText("Check service: Service is healthy")).toBeInTheDocument();
+
+    const requestsAtCompletion = runRequestCount;
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+    });
+    expect(runRequestCount).toBe(requestsAtCompletion);
+  });
+
+  it("keeps polling a pending workflow instead of treating it as terminal", async () => {
+    let runRequestCount = 0;
+    (global.fetch as jest.Mock).mockImplementation((input: string) => {
+      if (input.startsWith("/api/workflow-configs")) {
+        return Promise.resolve(response({ name: "Pending workflow" }));
+      }
+
+      runRequestCount += 1;
+      return Promise.resolve(response({ ...RUNNING_RUN, status: "pending" }));
+    });
+
+    render(<WorkflowRunCard runs={[{ runId: "run-1" }]} />);
+
+    await screen.findByText("Pending");
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+    });
+
+    await waitFor(() => expect(runRequestCount).toBe(2));
+  });
+});


### PR DESCRIPTION
# Description

Restore two broken workflow interactions: human-in-the-loop prompts from subagents and live workflow run status updates in chat.

## Subagent HITL

Subagents already received the `request_user_input` built-in tool, but their Deep Agents specifications omitted the subagent `interrupt_on` configuration. Without `HumanInTheLoopMiddleware`, the tool returned placeholder text instead of pausing, so the parent graph never exposed a pending checkpoint interrupt and the UI never received the form event.

This change:

- builds each subagent flattened interrupt policy from its tools and configuration;
- attaches that policy to the Deep Agents subagent specification;
- preserves the parent agent interrupt behavior; and
- adds regression tests proving the child policy is used when the parent policy differs.

## Workflow status card

The workflow card polled a cacheable run endpoint, so repeated requests could keep returning the initial `running` state until a full page refresh. Its polling guard also treated every state other than `running` and `waiting_for_input` as terminal.

This change:

- marks client polling requests and individual run API responses as `no-store`;
- polls active `running` runs every 2 seconds;
- continues polling `pending` and `waiting_for_input` runs;
- stops only for explicit terminal states: `completed`, `failed`, and `cancelled`; and
- adds component and API regression coverage for live status transitions and cache headers.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- 16 focused and adjacent dynamic-agent runtime tests passed:
  - `tests/test_subagent_hitl.py`
  - `tests/test_mongo_get_agent.py`
  - `tests/test_workflow_user_delegation.py`
  - `tests/test_chat_invoke_runtime_selection.py`
- `uv run ruff check src/dynamic_agents/services/agent_runtime.py tests/test_subagent_hitl.py` — passed
- 11 focused UI component and API tests passed:
  - `src/components/chat/__tests__/WorkflowRunCard.test.tsx`
  - `src/app/api/__tests__/workflow-runs-rbac.test.ts`
- ESLint passed for all touched UI files.
- `git diff --check` — passed
- Production UI build was attempted but could not complete in the local sandbox because the existing install is missing `@dagrejs/dagre` and Google Fonts are unreachable; neither error originates from this patch.

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
