### PR TITLE
fix(slack-bot): paginate accessible agents list beyond first page

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_accessible_agents_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_accessible_agents_client.py
@@ -1,0 +1,170 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``slack_bot/utils/accessible_agents_client.py``.
+
+Covers multi-page fetching against the BFF ``/api/user/accessible-agents``
+route: accumulating agents across pages, stopping at ``total``, stopping
+on an empty page, and the safety cap on pages fetched.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ai_platform_engineering.integrations.slack_bot.utils.accessible_agents_client import (
+    AccessibleAgentsClient,
+)
+
+
+class _FakeResponse:
+    """Drop-in for urllib.urlopen context manager."""
+
+    def __init__(self, status: int, payload: dict[str, Any] | bytes | None):
+        self.status = status
+        self.code = status
+        if isinstance(payload, bytes):
+            self._raw = payload
+        elif payload is None:
+            self._raw = b""
+        else:
+            self._raw = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+def _page_payload(agents: list[dict[str, str]], total: int) -> dict[str, Any]:
+    return {"success": True, "data": {"agents": agents, "total": total}}
+
+
+def _agent(agent_id: str) -> dict[str, str]:
+    return {"id": agent_id, "name": agent_id, "description": ""}
+
+
+def _requested_pages(mock_open: MagicMock) -> list[int]:
+    pages = []
+    for call in mock_open.call_args_list:
+        request = call.args[0]
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(request.full_url).query)
+        pages.append(int(query["page"][0]))
+    return pages
+
+
+class TestAccessibleAgentsClientPagination:
+    def test_fetches_all_pages_until_total_reached(self) -> None:
+        client = AccessibleAgentsClient(base_url="http://bff.local")
+        page_1 = [_agent(f"agent-{i}") for i in range(100)]
+        page_2 = [_agent(f"agent-{i}") for i in range(100, 170)]
+        responses = [
+            _FakeResponse(200, _page_payload(page_1, total=170)),
+            _FakeResponse(200, _page_payload(page_2, total=170)),
+        ]
+
+        with patch.object(
+            AccessibleAgentsClient, "_open", MagicMock(side_effect=responses)
+        ) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is True
+        assert len(result.agents) == 170
+        assert result.agents[0].id == "agent-0"
+        assert result.agents[-1].id == "agent-169"
+        assert mock_open.call_count == 2
+        assert _requested_pages(mock_open) == [1, 2]
+
+    def test_single_page_when_total_fits(self) -> None:
+        client = AccessibleAgentsClient(base_url="http://bff.local")
+        agents = [_agent("github"), _agent("jira")]
+
+        with patch.object(
+            AccessibleAgentsClient,
+            "_open",
+            MagicMock(return_value=_FakeResponse(200, _page_payload(agents, total=2))),
+        ) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is True
+        assert len(result.agents) == 2
+        assert mock_open.call_count == 1
+
+    def test_stops_on_empty_page_even_if_total_not_reached(self) -> None:
+        client = AccessibleAgentsClient(base_url="http://bff.local")
+        page_1 = [_agent("github")]
+        responses = [
+            _FakeResponse(200, _page_payload(page_1, total=170)),
+            _FakeResponse(200, _page_payload([], total=170)),
+        ]
+
+        with patch.object(
+            AccessibleAgentsClient, "_open", MagicMock(side_effect=responses)
+        ) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is True
+        assert len(result.agents) == 1
+        assert mock_open.call_count == 2
+
+    def test_safety_cap_stops_after_max_pages(self) -> None:
+        client = AccessibleAgentsClient(base_url="http://bff.local")
+
+        def _never_ending_page(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+            return _FakeResponse(200, _page_payload([_agent("x")], total=10_000))
+
+        with patch.object(
+            AccessibleAgentsClient, "_open", MagicMock(side_effect=_never_ending_page)
+        ) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is True
+        assert mock_open.call_count == 10
+        assert len(result.agents) == 10
+
+    def test_failure_on_a_later_page_returns_unavailable(self) -> None:
+        client = AccessibleAgentsClient(base_url="http://bff.local")
+        page_1 = [_agent(f"agent-{i}") for i in range(100)]
+        responses = [
+            _FakeResponse(200, _page_payload(page_1, total=170)),
+            _FakeResponse(502, None),
+        ]
+
+        with patch.object(
+            AccessibleAgentsClient, "_open", MagicMock(side_effect=responses)
+        ) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is False
+        assert result.agents == []
+        assert mock_open.call_count == 2
+
+    def test_no_base_url_returns_unavailable_without_request(self) -> None:
+        client = AccessibleAgentsClient(base_url="")
+        with patch.object(AccessibleAgentsClient, "_open", MagicMock()) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is False
+        assert result.agents == []
+        mock_open.assert_not_called()
+
+    def test_missing_total_falls_back_to_page_length(self) -> None:
+        client = AccessibleAgentsClient(base_url="http://bff.local")
+        payload = {"success": True, "data": {"agents": [_agent("github")]}}
+
+        with patch.object(
+            AccessibleAgentsClient,
+            "_open",
+            MagicMock(return_value=_FakeResponse(200, payload)),
+        ) as mock_open:
+            result = client.list_agents(bearer_token="tok")
+
+        assert result.available is True
+        assert len(result.agents) == 1
+        assert mock_open.call_count == 1

--- a/ai_platform_engineering/integrations/slack_bot/utils/accessible_agents_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/accessible_agents_client.py
@@ -4,12 +4,11 @@ Phase 2 of spec 2026-05-24-derive-team-from-channel. Used by the
 ``/{cmd}-list`` slash command (Slack) and the ``list`` text command
 (Webex) to show the signed-in user which agents they can dispatch to.
 
-The BFF route is paginated (default 25, max 100); the bot only ever
-asks for one page (default 25) per ``/list`` invocation to keep the
-ephemeral reply small. Larger lists are paginated client-side via
-follow-up ``/list page=N`` arg parsing (not implemented in Phase 2;
-left as a Phase 3 follow-up if anyone actually has >25 accessible
-agents).
+The BFF route is paginated (default 25, max 100 per page). This client
+walks every page (at ``_MAX_PAGE_SIZE`` per request) and accumulates
+the full accessible-agents list, up to a ``_MAX_PAGES`` safety cap, so
+deployments with more than one page of accessible agents still see
+everything in ``/list`` rather than only the first page.
 """
 
 from __future__ import annotations
@@ -21,9 +20,15 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 logger = logging.getLogger("caipe.slack_bot.accessible_agents_client")
+
+_MAX_PAGE_SIZE = 100
+# Safety cap on pages fetched per /list invocation, independent of whatever
+# `total` the BFF reports, so a malfunctioning/inconsistent BFF response
+# can't send this client into an unbounded fetch loop.
+_MAX_PAGES = 10
 
 
 @dataclass(frozen=True)
@@ -70,22 +75,45 @@ class AccessibleAgentsClient:
         return urllib.request.urlopen(request, timeout=timeout)  # noqa: S310
 
     def list_agents(
-        self, *, bearer_token: str, page_size: int = 25
+        self, *, bearer_token: str, page_size: int = _MAX_PAGE_SIZE
     ) -> AccessibleAgentsResult:
-        """Fetch the user's accessible agents.
+        """Fetch all of the user's accessible agents, across BFF pages.
 
         Returns ``AccessibleAgentsResult(available=False)`` on any
         failure (no base URL, missing token, network, 5xx, malformed
-        JSON). Callers MUST translate that to a "temporarily
-        unavailable" reply rather than spinning forever.
+        JSON) encountered on any page. Callers MUST translate that to
+        a "temporarily unavailable" reply rather than spinning
+        forever.
         """
         if not self._base_url or not bearer_token:
             return _UNAVAILABLE
 
-        size = max(1, min(100, page_size))
+        size = max(1, min(_MAX_PAGE_SIZE, page_size))
+        agents: List[AccessibleAgent] = []
+        page = 1
+        while page <= _MAX_PAGES:
+            fetched = self._fetch_page(
+                bearer_token=bearer_token, page=page, page_size=size
+            )
+            if fetched is None:
+                return _UNAVAILABLE
+            page_agents, total = fetched
+            if not page_agents:
+                break
+            agents.extend(page_agents)
+            if len(agents) >= total:
+                break
+            page += 1
+
+        return AccessibleAgentsResult(agents=agents, available=True)
+
+    def _fetch_page(
+        self, *, bearer_token: str, page: int, page_size: int
+    ) -> Optional[Tuple[List[AccessibleAgent], int]]:
+        """Fetch a single page. Returns ``None`` on failure."""
         url = (
             f"{self._base_url}/api/user/accessible-agents"
-            f"?{urllib.parse.urlencode({'page_size': size})}"
+            f"?{urllib.parse.urlencode({'page': page, 'page_size': page_size})}"
         )
         request = urllib.request.Request(
             url,
@@ -106,18 +134,18 @@ class AccessibleAgentsClient:
                     logger.info(
                         "accessible_agents BFF non-2xx (status=%s)", status
                     )
-                    return _UNAVAILABLE
+                    return None
                 raw = response.read()
         except urllib.error.HTTPError as exc:
             logger.info("accessible_agents BFF HTTPError status=%s", exc.code)
-            return _UNAVAILABLE
+            return None
         except (OSError, urllib.error.URLError) as exc:
             logger.info(
                 "accessible_agents BFF unreachable (%s): %s",
                 type(exc).__name__,
                 exc,
             )
-            return _UNAVAILABLE
+            return None
 
         try:
             payload = json.loads(raw)
@@ -125,16 +153,19 @@ class AccessibleAgentsClient:
             logger.info(
                 "accessible_agents BFF returned malformed JSON: %s", exc
             )
-            return _UNAVAILABLE
+            return None
 
         if not isinstance(payload, dict):
-            return _UNAVAILABLE
+            return None
         data = payload.get("data")
         if not isinstance(data, dict):
-            return _UNAVAILABLE
+            return None
         items = data.get("agents")
         if not isinstance(items, list):
-            return _UNAVAILABLE
+            return None
+        total = data.get("total")
+        if not isinstance(total, int):
+            total = len(items)
 
         agents: List[AccessibleAgent] = []
         for item in items:
@@ -156,4 +187,4 @@ class AccessibleAgentsClient:
                     ),
                 )
             )
-        return AccessibleAgentsResult(agents=agents, available=True)
+        return agents, total

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.41-dev.1"
+version = "0.5.41-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.41.dev1"
+version = "0.5.41.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

The Slack `/list` command (and the `AccessibleAgentsClient` it's built on) only ever fetched page 1 (25 agents) from the BFF `/api/user/accessible-agents` route. Deployments with more than 25 accessible agents per user never saw the rest — the client didn't loop through pages.

`list_agents()` now walks all BFF pages (100 per request, the BFF's max page size) and accumulates results, stopping once it reaches the reported `total` or hits an empty page. A 10-page safety cap prevents unbounded fetching if the BFF ever returns an inconsistent `total`. Public method signature and return type are unchanged, so no caller changes were needed.

Scope: Slack side only. The Webex bot has an equivalent client with the same limitation but is intentionally left untouched here.

Follow-up to consider separately: with very large accessible-agent lists, the formatted `/list` ephemeral reply could approach Slack's message size limits. Not addressed in this PR — flagging for a future look if it becomes an issue in practice.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass