### PR TITLE
fix(ui): sharing a dynamic agent with a team is use-only, not manage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.41-dev.1"
+version = "0.5.41-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/rbac/__tests__/openfga-agent-tools-shared-teams.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-agent-tools-shared-teams.test.ts
@@ -19,7 +19,7 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
     ownerTeamSlug: "platform",
   } as const;
 
-  it("writes member+admin tuples for every additional shared team (no member writer); owner team members also get manager", () => {
+  it("writes member+admin tuples for the owner team but use-only for shared teams (no member writer)", () => {
     const diff = buildAgentRelationshipTupleDiff({
       ...baseInput,
       nextSharedTeamSlugs: ["sre", "ops"],
@@ -32,16 +32,16 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
         { user: "team:platform#member", relation: "user", object: "agent:agent-test" },
         { user: "team:platform#member", relation: "manager", object: "agent:agent-test" },
         { user: "team:platform#admin", relation: "manager", object: "agent:agent-test" },
-        // shared team members only get user
+        // shared team members AND admins only get user — sharing is use-only
         { user: "team:sre#member", relation: "user", object: "agent:agent-test" },
-        { user: "team:sre#admin", relation: "manager", object: "agent:agent-test" },
         { user: "team:ops#member", relation: "user", object: "agent:agent-test" },
-        { user: "team:ops#admin", relation: "manager", object: "agent:agent-test" },
       ]),
     );
     expect(diff.writes).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ relation: "writer" }),
+        { user: "team:sre#admin", relation: "manager", object: "agent:agent-test" },
+        { user: "team:ops#admin", relation: "manager", object: "agent:agent-test" },
       ]),
     );
     expect(diff.deletes).toEqual(
@@ -49,6 +49,10 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
         { user: "team:platform#member", relation: "writer", object: "agent:agent-test" },
         { user: "team:sre#member", relation: "writer", object: "agent:agent-test" },
         { user: "team:ops#member", relation: "writer", object: "agent:agent-test" },
+        // stale/never-existed admin-manager grants for shared teams are
+        // always revoked defensively, whether or not they were ever written
+        { user: "team:sre#admin", relation: "manager", object: "agent:agent-test" },
+        { user: "team:ops#admin", relation: "manager", object: "agent:agent-test" },
       ]),
     );
   });
@@ -152,10 +156,10 @@ describe("buildAgentRelationshipTupleDiff: shared_with_teams", () => {
         "team:platform#member", // user
         "team:platform#member", // manager (owner team)
         "team:platform#admin",
-        "team:sre#member",
-        "team:sre#admin",
+        "team:sre#member", // shared team: use-only, no #admin manager
       ]),
     );
+    expect(teamSubjects).not.toContain("team:sre#admin");
     for (const subject of teamSubjects) {
       expect(subject).not.toMatch(/team:\s/);
       expect(subject).not.toMatch(/team:!/);

--- a/ui/src/lib/rbac/openfga-agent-tools.ts
+++ b/ui/src/lib/rbac/openfga-agent-tools.ts
@@ -161,8 +161,12 @@ export function buildAgentRelationshipTupleDiff(input: AgentToolTupleDiffInput):
   // Owner-team + shared-team grants are delegated to the shared
   // `buildTeamGrantTuples` primitive (spec 2026-06-03, US1 / FR-003). All
   // team members receive `user` (can_use / discover). Owner team members
-  // additionally receive `manager` (full can_manage access per CAIPE policy);
-  // shared team members require team admin (`manager`) or org admin to edit.
+  // additionally receive `manager` (full can_manage access per CAIPE policy).
+  // Shared teams are use-only: `buildTeamGrantTuples` also writes an
+  // `#admin manager` grant for every effective team (owner + shared), so we
+  // drop that write for teams that are shared-only (not the owner) below —
+  // sharing an agent with a team must never grant manage rights, even to
+  // that team's admins.
   const agentObject = `agent:${input.agentId}`;
   const teamGrants = buildTeamGrantTuples({
     object: agentObject,
@@ -172,8 +176,27 @@ export function buildAgentRelationshipTupleDiff(input: AgentToolTupleDiffInput):
     nextSharedTeamSlugs: input.nextSharedTeamSlugs,
     previousSharedTeamSlugs: input.previousSharedTeamSlugs,
   });
-  writes.push(...teamGrants.writes);
+  const isSharedOnlyAdminManagerTuple = (tuple: OpenFgaTupleKey) =>
+    tuple.relation === "manager" &&
+    tuple.user.endsWith("#admin") &&
+    tuple.user !== `team:${input.ownerTeamSlug}#admin`;
+  writes.push(...teamGrants.writes.filter((tuple) => !isSharedOnlyAdminManagerTuple(tuple)));
   deletes.push(...teamGrants.deletes);
+
+  // Explicitly revoke stale `#admin manager` grants for every currently (or
+  // previously) shared, non-owner team — covers teams shared before this
+  // fix shipped, and owner-team-demoted-to-shared transitions, neither of
+  // which `buildTeamGrantTuples` would otherwise clean up since the team
+  // stays in the effective set.
+  const sharedAdminManagerRevokeSlugs = new Set<string>();
+  for (const slug of [...(input.nextSharedTeamSlugs ?? []), ...(input.previousSharedTeamSlugs ?? [])]) {
+    if (isValidOpenFgaId(slug) && slug !== input.ownerTeamSlug) {
+      sharedAdminManagerRevokeSlugs.add(slug);
+    }
+  }
+  for (const slug of sharedAdminManagerRevokeSlugs) {
+    deletes.push({ user: `team:${slug}#admin`, relation: "manager", object: agentObject });
+  }
 
   // Owner team members get full management access (can_manage). Write for
   // the current owner team; delete for the previous owner when it changes

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.41.dev1"
+version = "0.5.41.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Sharing a dynamic agent with a team via the "Share with Teams" multi-select
also granted that team's admins the `manager` (`can_manage`) OpenFGA
relation, letting them edit, disable, or delete the agent. Only the owner
team should get manage rights — sharing with additional teams should only
ever grant `can_use`, regardless of admin status within that team.

`buildAgentRelationshipTupleDiff` (`ui/src/lib/rbac/openfga-agent-tools.ts`)
now drops the `#admin manager` write that `buildTeamGrantTuples` emits for
shared-only teams, and explicitly revokes any such grant (current or
previously shared) so pre-existing shared-team admin grants get cleaned up
on the next reconcile. Owner-team behavior is unchanged: its members
(including admins) still receive `manager`.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Test plan

- [x] `npx jest src/lib/rbac src/app/api/dynamic-agents` passes (1077 tests)
- [x] `npx eslint` clean on changed files
- [x] Updated `openfga-agent-tools-shared-teams.test.ts` to assert shared teams (and their admins) only receive `user`, never `manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)