### PR TITLE
feat(caipe-ui): show HITL input form inline in chat WorkflowRunCard

### DIFF
--- a/ui/e2e/rbac/_workflow-browser-fixtures.ts
+++ b/ui/e2e/rbac/_workflow-browser-fixtures.ts
@@ -329,6 +329,7 @@ export type WorkflowRunFixture = {
   started_at?: string;
   completed_at?: string;
   trigger_info?: { triggered_by?: string; user_email?: string };
+  shared_with_teams?: string[] | null;
   steps: Array<{
     type: "step";
     index: number;
@@ -338,6 +339,21 @@ export type WorkflowRunFixture = {
     error?: string | null;
     response?: string | null;
     attempts: number;
+    interrupt?: {
+      type: "input_required" | "tool_approval";
+      interruptId?: string;
+      prompt?: string;
+      fields?: Array<{
+        field_name: string;
+        field_label?: string;
+        field_type?: string;
+        field_values?: string[];
+        required?: boolean;
+      }>;
+      agent?: string;
+      toolName?: string;
+      toolArgs?: Record<string, unknown>;
+    } | null;
   }>;
   events?: Record<string, unknown[]>;
 };

--- a/ui/e2e/rbac/chat-workflow-run-card-hitl.spec.ts
+++ b/ui/e2e/rbac/chat-workflow-run-card-hitl.spec.ts
@@ -1,0 +1,481 @@
+// assisted-by claude code claude-sonnet-4-6
+// E2E tests for the inline HITL form in WorkflowRunCard (chat window).
+// Verifies that when a workflow run is waiting_for_input, the chat card
+// expands to show the MetadataInputForm directly, matching the agent HITL UX.
+
+import { expect, test } from "@playwright/test";
+
+import {
+  dismissReleaseUpgradeDialog,
+  expectChatComposerReady,
+  installChatBootMocks,
+  installTestSession,
+} from "./_helpers";
+import { mockedRbacEnabled } from "./_mocked-rbac";
+import {
+  buildDefaultWorkflowCatalog,
+  type WorkflowRunFixture,
+} from "./_workflow-browser-fixtures";
+
+const CONV_ID = "chat-workflow-hitl-conv";
+const RUN_ID = "wfrun-hitl-e2e";
+const AGENT_ID = "agent-sre-automation";
+const WORKFLOW_CONFIG_ID = "wf-global-mcp";
+
+function minimalSessionEnv() {
+  return {
+    baseUrl: process.env.CAIPE_UI_BASE_URL ?? "http://localhost:3000",
+    keycloakUrl: process.env.KEYCLOAK_URL ?? "http://localhost:7080",
+    keycloakRealm: process.env.KEYCLOAK_REALM ?? "caipe",
+    user: { email: "member@caipe.local", password: "" },
+  };
+}
+
+/** Shared route mocks for the chat conversation that contains a workflow run. */
+async function installChatWorkflowMocks(
+  page: Parameters<typeof installChatBootMocks>[0],
+  env: ReturnType<typeof minimalSessionEnv>,
+  runFixture: WorkflowRunFixture,
+) {
+  const now = new Date().toISOString();
+  const workflowConfig = buildDefaultWorkflowCatalog().find((w) => w._id === WORKFLOW_CONFIG_ID);
+
+  await installChatBootMocks(page, env, {
+    conversationId: CONV_ID,
+    ownerEmail: env.user.email,
+    agentId: AGENT_ID,
+  });
+
+  // Conversation messages — assistant message with start_workflow_run tool call
+  await page.route("**/api/chat/conversations**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+
+    if (path === `/api/chat/conversations/${CONV_ID}/messages` && method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            items: [
+              {
+                message_id: "msg-assistant-hitl",
+                role: "assistant",
+                content: "Starting workflow, will post results here.",
+                timestamp: now,
+                is_final: true,
+                stream_events: [
+                  {
+                    type: "tool_start",
+                    timestamp: now,
+                    toolData: {
+                      tool_call_id: "wf-hitl-tool-1",
+                      tool_name: "start_workflow_run",
+                      args: { workflow_config_id: WORKFLOW_CONFIG_ID },
+                    },
+                  },
+                  {
+                    type: "tool_end",
+                    timestamp: now,
+                    toolData: {
+                      tool_call_id: "wf-hitl-tool-1",
+                      result: JSON.stringify({
+                        run_id: RUN_ID,
+                        workflow_config_id: WORKFLOW_CONFIG_ID,
+                        workflow_name: "Global SRE workflow",
+                        status: "running",
+                      }),
+                    },
+                  },
+                ],
+              },
+            ],
+            total: 1,
+            page: 1,
+            page_size: 100,
+            has_more: false,
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === `/api/chat/conversations/${CONV_ID}` && method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            _id: CONV_ID,
+            title: "Workflow HITL chat",
+            client_type: "webui",
+            owner_id: env.user.email,
+            participants: [{ type: "agent", id: AGENT_ID }],
+            created_at: now,
+            updated_at: now,
+            metadata: { client_type: "webui", total_messages: 1 },
+            sharing: { is_public: false, shared_with: [], shared_with_teams: [], share_link_enabled: false },
+            tags: [],
+            is_archived: false,
+            is_pinned: false,
+            deleted_at: null,
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.route("**/api/dynamic-agents/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path === "/api/dynamic-agents/available" || path === "/api/dynamic-agents") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [{ _id: AGENT_ID, name: "SRE Agent", enabled: true }],
+        }),
+      });
+      return;
+    }
+    if (path === `/api/dynamic-agents/agents/${AGENT_ID}`) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            _id: AGENT_ID,
+            name: "SRE Agent",
+            enabled: true,
+            builtin_tools: { workflows: [WORKFLOW_CONFIG_ID] },
+          },
+        }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route("**/api/workflow-runs**", async (route) => {
+    const url = new URL(route.request().url());
+    if (route.request().method() === "GET" && url.searchParams.get("run_id") === RUN_ID) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(runFixture),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route("**/api/workflow-configs**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get("id") === WORKFLOW_CONFIG_ID) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(workflowConfig ?? { _id: WORKFLOW_CONFIG_ID, name: "Global SRE workflow" }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run the mocked WorkflowRunCard HITL regression.",
+    );
+    test.skip(!process.env.NEXTAUTH_SECRET, "NEXTAUTH_SECRET required for chat workflow SSR.");
+  });
+
+  test("shows inline MetadataInputForm when run is waiting_for_input with input_required interrupt", async ({ page }) => {
+    const env = minimalSessionEnv();
+
+    const waitingRun: WorkflowRunFixture = {
+      _id: RUN_ID,
+      workflow_config_id: WORKFLOW_CONFIG_ID,
+      workflow_name: "Global SRE workflow",
+      status: "waiting_for_input",
+      current_step_index: 0,
+      started_at: new Date().toISOString(),
+      steps: [
+        {
+          type: "step",
+          index: 0,
+          display_text: "Create LLM Key",
+          agent_id: AGENT_ID,
+          status: "waiting_for_input",
+          attempts: 1,
+          interrupt: {
+            type: "input_required",
+            interruptId: "interrupt-1",
+            prompt: "Please provide the details for your LLM API key",
+            agent: "SRE Agent",
+            fields: [
+              {
+                field_name: "key_type",
+                field_label: "Key Type",
+                field_type: "select",
+                field_values: ["individual", "team"],
+                required: true,
+              },
+              {
+                field_name: "model",
+                field_label: "Model",
+                field_type: "text",
+                required: true,
+              },
+            ],
+          },
+        },
+      ],
+      events: {},
+    };
+
+    await installChatWorkflowMocks(page, env, waitingRun);
+
+    await installTestSession(page, env, {
+      email: env.user.email,
+      subject: "playwright-hitl-sub",
+      role: "user",
+    });
+
+    await page.goto(`/chat/${CONV_ID}`, { waitUntil: "domcontentloaded" });
+    await dismissReleaseUpgradeDialog(page);
+    await expectChatComposerReady(page);
+
+    // The form title should be visible (not just a tiny badge)
+    await expect(page.getByText("Please provide the details for your LLM API key")).toBeVisible();
+
+    // Field labels should be visible
+    await expect(page.getByText("Key Type")).toBeVisible();
+    await expect(page.getByText("Model")).toBeVisible();
+
+    // Submit button should be present
+    await expect(page.getByRole("button", { name: /submit/i })).toBeVisible();
+
+    // The small card-style "Workflow Run" row should NOT be showing (form replaced it)
+    // The "Input required" label inside STATUS_CONFIG badge should not exist as a standalone card
+    await expect(page.getByText("Waiting for input")).not.toBeVisible();
+  });
+
+  test("shows inline tool_approval buttons when run is waiting_for_input with tool_approval interrupt", async ({ page }) => {
+    const env = minimalSessionEnv();
+
+    const toolApprovalRun: WorkflowRunFixture = {
+      _id: RUN_ID,
+      workflow_config_id: WORKFLOW_CONFIG_ID,
+      workflow_name: "Global SRE workflow",
+      status: "waiting_for_input",
+      current_step_index: 1,
+      started_at: new Date().toISOString(),
+      steps: [
+        {
+          type: "step",
+          index: 0,
+          display_text: "Analyze cluster",
+          agent_id: AGENT_ID,
+          status: "completed",
+          response: "Analysis done.",
+          attempts: 1,
+        },
+        {
+          type: "step",
+          index: 1,
+          display_text: "Apply patch",
+          agent_id: AGENT_ID,
+          status: "waiting_for_input",
+          attempts: 1,
+          interrupt: {
+            type: "tool_approval",
+            interruptId: "interrupt-2",
+            prompt: "Approve applying the patch?",
+            toolName: "kubectl_apply",
+            toolArgs: { namespace: "production", manifest: "deployment.yaml" },
+          },
+        },
+      ],
+      events: {},
+    };
+
+    await installChatWorkflowMocks(page, env, toolApprovalRun);
+
+    await installTestSession(page, env, {
+      email: env.user.email,
+      subject: "playwright-tool-approval-sub",
+      role: "user",
+    });
+
+    await page.goto(`/chat/${CONV_ID}`, { waitUntil: "domcontentloaded" });
+    await dismissReleaseUpgradeDialog(page);
+    await expectChatComposerReady(page);
+
+    // Tool approval header and tool name
+    await expect(page.getByText("Tool Approval Required")).toBeVisible();
+    await expect(page.getByText("kubectl_apply")).toBeVisible();
+
+    // Approve and Reject buttons
+    await expect(page.getByRole("button", { name: /approve/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /reject/i })).toBeVisible();
+  });
+
+  test("submitting the inline form calls the resume API and updates the card", async ({ page }) => {
+    const env = minimalSessionEnv();
+
+    const waitingRun: WorkflowRunFixture = {
+      _id: RUN_ID,
+      workflow_config_id: WORKFLOW_CONFIG_ID,
+      workflow_name: "Global SRE workflow",
+      status: "waiting_for_input",
+      current_step_index: 0,
+      started_at: new Date().toISOString(),
+      steps: [
+        {
+          type: "step",
+          index: 0,
+          display_text: "Confirm action",
+          agent_id: AGENT_ID,
+          status: "waiting_for_input",
+          attempts: 1,
+          interrupt: {
+            type: "input_required",
+            interruptId: "interrupt-3",
+            prompt: "Confirm to proceed",
+            fields: [
+              {
+                field_name: "confirmation",
+                field_label: "Confirmation",
+                field_type: "text",
+                required: true,
+              },
+            ],
+          },
+        },
+      ],
+      events: {},
+    };
+
+    const resumedRun: WorkflowRunFixture = {
+      ...waitingRun,
+      status: "running",
+      steps: [
+        {
+          ...waitingRun.steps[0],
+          status: "running",
+          interrupt: null,
+        },
+      ],
+    };
+
+    let resumeCallBody: unknown = null;
+    let pollCount = 0;
+
+    await installChatWorkflowMocks(page, env, waitingRun);
+
+    // Override workflow-runs GET to return resumed run after resume POST
+    await page.route(`**/api/workflow-runs/${RUN_ID}/resume`, async (route) => {
+      resumeCallBody = await route.request().postDataJSON();
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ status: "resumed" }) });
+    });
+
+    await page.route("**/api/workflow-runs**", async (route) => {
+      const url = new URL(route.request().url());
+      if (route.request().method() === "GET" && url.searchParams.get("run_id") === RUN_ID) {
+        pollCount++;
+        const fixture = pollCount > 1 ? resumedRun : waitingRun;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(fixture),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await installTestSession(page, env, {
+      email: env.user.email,
+      subject: "playwright-resume-sub",
+      role: "user",
+    });
+
+    await page.goto(`/chat/${CONV_ID}`, { waitUntil: "domcontentloaded" });
+    await dismissReleaseUpgradeDialog(page);
+    await expectChatComposerReady(page);
+
+    // Form is visible
+    await expect(page.getByText("Confirm to proceed")).toBeVisible();
+
+    // Fill in the confirmation field
+    await page.getByLabel("Confirmation").fill("yes");
+
+    // Submit
+    await page.getByRole("button", { name: /submit/i }).click();
+
+    // Resume endpoint was called with correct step_index and form values
+    await expect.poll(() => resumeCallBody).toMatchObject({
+      step_index: 0,
+      resume_data: expect.stringContaining("form_input"),
+    });
+
+    // After resume, card transitions to running state (form disappears)
+    await expect(page.getByText("Confirm to proceed")).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Running")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("shows normal compact card for running workflow (no form)", async ({ page }) => {
+    const env = minimalSessionEnv();
+
+    const runningRun: WorkflowRunFixture = {
+      _id: RUN_ID,
+      workflow_config_id: WORKFLOW_CONFIG_ID,
+      workflow_name: "Global SRE workflow",
+      status: "running",
+      current_step_index: 0,
+      started_at: new Date().toISOString(),
+      steps: [
+        {
+          type: "step",
+          index: 0,
+          display_text: "Step 1",
+          agent_id: AGENT_ID,
+          status: "running",
+          attempts: 1,
+        },
+      ],
+      events: {},
+    };
+
+    await installChatWorkflowMocks(page, env, runningRun);
+
+    await installTestSession(page, env, {
+      email: env.user.email,
+      subject: "playwright-running-sub",
+      role: "user",
+    });
+
+    await page.goto(`/chat/${CONV_ID}`, { waitUntil: "domcontentloaded" });
+    await dismissReleaseUpgradeDialog(page);
+    await expectChatComposerReady(page);
+
+    // Compact card shown
+    await expect(page.getByText("Global SRE workflow")).toBeVisible();
+    await expect(page.getByText("Running")).toBeVisible();
+
+    // No input form visible
+    await expect(page.getByRole("button", { name: /submit/i })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /approve/i })).not.toBeVisible();
+  });
+});

--- a/ui/src/components/chat/WorkflowRunCard.tsx
+++ b/ui/src/components/chat/WorkflowRunCard.tsx
@@ -4,10 +4,21 @@ import { cn } from "@/lib/utils";
 import { CheckCircle2,Clock,ExternalLink,Loader2,PauseCircle,Workflow,XCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback,useEffect,useState } from "react";
+import { MetadataInputForm,type InputField } from "@/components/chat/MetadataInputForm";
 
 interface WorkflowRunInfo {
   runId: string;
   workflowConfigId?: string;
+}
+
+interface StepInterrupt {
+  type: "input_required" | "tool_approval";
+  interruptId?: string;
+  prompt?: string;
+  fields?: unknown[];
+  agent?: string;
+  toolName?: string;
+  toolArgs?: Record<string, unknown>;
 }
 
 interface RunStatus {
@@ -21,6 +32,7 @@ interface RunStatus {
     status?: string;
     display_text?: string;
     response?: string;
+    interrupt?: StepInterrupt | null;
   }>;
 }
 
@@ -54,7 +66,7 @@ interface WorkflowRunCardProps {
 
 const STATUS_CONFIG = {
   running: { icon: Loader2, label: "Running", className: "text-sky-400 animate-spin", bg: "border-sky-500/30 bg-sky-500/5" },
-  waiting_for_input: { icon: PauseCircle, label: "Waiting for input", className: "text-amber-400", bg: "border-amber-500/30 bg-amber-500/5" },
+  waiting_for_input: { icon: PauseCircle, label: "Input required", className: "text-amber-400", bg: "border-amber-500/30 bg-amber-500/5" },
   completed: { icon: CheckCircle2, label: "Completed", className: "text-emerald-400", bg: "border-emerald-500/30 bg-emerald-500/5" },
   failed: { icon: XCircle, label: "Failed", className: "text-red-400", bg: "border-red-500/30 bg-red-500/5" },
   cancelled: { icon: XCircle, label: "Cancelled", className: "text-muted-foreground", bg: "border-border bg-muted/30" },
@@ -65,6 +77,7 @@ function RunCard({ runId }: { runId: string }) {
   const [status, setStatus] = useState<RunStatus | null>(null);
   const [configInfo, setConfigInfo] = useState<WorkflowConfigInfo | null>(null);
   const [hidden, setHidden] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -81,7 +94,6 @@ function RunCard({ runId }: { runId: string }) {
     }
   }, [runId]);
 
-  // Fetch workflow config name/description once we have the config ID
   useEffect(() => {
     if (!status?.workflow_config_id || configInfo) return;
     (async () => {
@@ -112,10 +124,31 @@ function RunCard({ runId }: { runId: string }) {
     return () => clearInterval(interval);
   }, [status, stopped, hidden, fetchStatus]);
 
+  const handleResume = useCallback(async (resumeData: string) => {
+    const waitingStepIndex = status?.steps?.findIndex((s) => s.status === "waiting_for_input") ?? -1;
+    if (waitingStepIndex < 0) return;
+    setIsSubmitting(true);
+    try {
+      await fetch(`/api/workflow-runs/${encodeURIComponent(runId)}/resume`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ step_index: waitingStepIndex, resume_data: resumeData }),
+      });
+      await fetchStatus();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [runId, status, fetchStatus]);
+
   if (hidden) return null;
 
   const cfg = status ? STATUS_CONFIG[status.status] || STATUS_CONFIG.running : null;
   const StatusIcon = cfg?.icon || Clock;
+  const isWaitingForInput = status?.status === "waiting_for_input";
+  const waitingStepIndex = status?.steps?.findIndex((s) => s.status === "waiting_for_input") ?? -1;
+  const waitingStep = waitingStepIndex >= 0 ? status?.steps?.[waitingStepIndex] : null;
+  const interrupt = waitingStep?.interrupt ?? null;
+
   const outputSummary =
     status && (status.status === "completed" || status.status === "failed")
       ? summarizeStepOutputs(status.steps)
@@ -125,6 +158,121 @@ function RunCard({ runId }: { runId: string }) {
       ? `${completedStepCount(status.steps)}/${status.steps.length} steps`
       : null;
 
+  // When waiting for input with interrupt data: render the form as primary UI (matches agent HITL style)
+  if (isWaitingForInput && interrupt) {
+    const workflowLabel = configInfo?.name
+      ? `Workflow: ${configInfo.name}${stepProgress ? ` · ${stepProgress}` : ""}`
+      : stepProgress
+        ? `Workflow · ${stepProgress}`
+        : "Workflow";
+    const interruptDescription = interrupt.agent
+      ? `Requested by ${interrupt.agent} · ${workflowLabel}`
+      : workflowLabel;
+
+    if (interrupt.type === "input_required") {
+      const fields = (interrupt.fields || []) as InputField[];
+      const effectiveFields: InputField[] = fields.length > 0
+        ? fields
+        : [{ field_name: "response", field_label: "Your response", field_type: "text", required: true }];
+
+      return (
+        <MetadataInputForm
+          messageId={`wf-card-${runId}-step-${waitingStepIndex}`}
+          title={interrupt.prompt || "Input Required"}
+          description={interruptDescription}
+          inputFields={effectiveFields}
+          onSubmit={(formData) => handleResume(JSON.stringify({ type: "form_input", values: formData }))}
+          onCancel={() => router.push(`/workflows/run/${runId}`)}
+          disabled={isSubmitting}
+        />
+      );
+    }
+
+    // tool_approval interrupt
+    return (
+      <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p className="text-sm font-semibold text-amber-500">Tool Approval Required</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{interruptDescription}</p>
+            {interrupt.prompt && (
+              <p className="text-xs text-foreground/80 mt-1">{interrupt.prompt}</p>
+            )}
+          </div>
+          <button
+            onClick={() => router.push(`/workflows/run/${runId}`)}
+            className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+            title="Open workflow run"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        {interrupt.toolName && (
+          <div className="rounded-md bg-muted/60 px-3 py-2 text-xs font-mono">
+            <span className="text-foreground/80">{interrupt.toolName}</span>
+            {interrupt.toolArgs && Object.keys(interrupt.toolArgs).length > 0 && (
+              <pre className="mt-1 text-[10px] text-muted-foreground whitespace-pre-wrap break-all">
+                {JSON.stringify(interrupt.toolArgs, null, 2)}
+              </pre>
+            )}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <button
+            disabled={isSubmitting}
+            onClick={() => handleResume(JSON.stringify({ type: "tool_approval", decision: "approve" }))}
+            className="flex-1 rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+          >
+            Approve
+          </button>
+          <button
+            disabled={isSubmitting}
+            onClick={() => handleResume(JSON.stringify({ type: "tool_approval", decision: "reject" }))}
+            className="flex-1 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Waiting but interrupt data not yet loaded: show a clear CTA
+  if (isWaitingForInput) {
+    return (
+      <div
+        className={cn("rounded-lg border p-3 space-y-2", cfg?.bg || "border-border bg-card/50")}
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10">
+            <Workflow className="h-4 w-4 text-primary" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium truncate">{configInfo?.name || "Workflow Run"}</span>
+              <PauseCircle className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+              <span className="text-xs font-medium text-amber-500">Input required</span>
+            </div>
+            {stepProgress && <span className="text-[10px] text-muted-foreground">{stepProgress}</span>}
+          </div>
+          <button
+            onClick={() => router.push(`/workflows/run/${runId}`)}
+            className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <button
+          onClick={() => router.push(`/workflows/run/${runId}`)}
+          className="w-full text-left text-xs font-medium text-amber-500 hover:text-amber-400 transition-colors"
+        >
+          Respond to workflow →
+        </button>
+      </div>
+    );
+  }
+
+  // Normal (running / completed / failed / cancelled) card
   return (
     <div
       className={cn(
@@ -166,7 +314,8 @@ function RunCard({ runId }: { runId: string }) {
 
 /**
  * Renders workflow run cards as a sidecar section in the chat timeline.
- * Each card polls for status updates every 10 seconds while running.
+ * When a run is waiting_for_input with an interrupt, the form renders
+ * inline matching the agent HITL style — no page navigation required.
  */
 export function WorkflowRunCard({ runs }: WorkflowRunCardProps) {
   if (runs.length === 0) return null;


### PR DESCRIPTION
## Summary

- When a workflow run is `waiting_for_input`, the chat card now renders the input form directly in the chat window, matching the existing agent HITL UX
- `input_required` interrupt: MetadataInputForm full-width, submits to `POST /api/workflow-runs/[id]/resume`
- `tool_approval` interrupt: amber panel with Approve/Reject buttons inline
- Falls back to a CTA card if interrupt data is not yet loaded
- Normal states: compact clickable card unchanged

## Files changed

- `WorkflowRunCard.tsx` — three render paths based on interrupt type
- `_workflow-browser-fixtures.ts` — added `interrupt` + `shared_with_teams` to `WorkflowRunFixture`
- `chat-workflow-run-card-hitl.spec.ts` — 4 new E2E tests

## Test plan

- [ ] `RUN_RBAC_REGRESSION=1 NEXTAUTH_SECRET=<secret> playwright test e2e/rbac/chat-workflow-run-card-hitl.spec.ts --config=playwright.rbac.config.ts`
- [ ] Workflow paused for input shows form in chat without clicking any link
- [ ] Submit transitions run to running, form disappears
- [ ] Tool approval renders Approve/Reject buttons inline
- [ ] Running workflow shows compact card only

Generated with Claude Code