### PR TITLE
fix(caipe-ui): use X-CAIPE-Provider-Token for Webex MCP credential source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.43-dev.1"
+version = "0.5.43-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/rbac/agentgateway-mcp-discovery.ts
+++ b/ui/src/lib/rbac/agentgateway-mcp-discovery.ts
@@ -58,6 +58,19 @@ export const BUILTIN_MCP_CREDENTIAL_SOURCES: Record<string, MCPCredentialSource[
       target: "header",
     },
   ],
+  // assisted-by claude code claude-sonnet-4-6
+  // webex (messaging) must use X-CAIPE-Provider-Token, not Authorization.
+  // Agentgateway jwtAuth validates Authorization as Keycloak JWT; the bridge
+  // then rewrites it to the resolved provider token for the upstream MCP pod.
+  webex: [
+    {
+      kind: "provider_connection",
+      name: "X-CAIPE-Provider-Token",
+      provider: "webex",
+      target: "header",
+      fallback_env: "WEBEX_TOKEN",
+    },
+  ],
   webex_meetings: [
     {
       kind: "provider_connection",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.43.dev1"
+version = "0.5.43.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Fixes 401 errors when Webex MCP sends notifications.

## Summary

- Adds webex to BUILTIN_MCP_CREDENTIAL_SOURCES using X-CAIPE-Provider-Token (not Authorization)
- Adds fallback_env: WEBEX_TOKEN for callers without a personal Webex OAuth connection
- The DB record on caipe-dev was also patched in-place

## Root Cause

Agentgateway jwtAuth validates Authorization as a Keycloak JWT. With name: "Authorization" the bridge passes that JWT through to the Webex MCP pod, which forwards it to webexapis.com and gets 401. The fix uses X-CAIPE-Provider-Token so agentgateway validates the JWT, then rewrites Authorization to the provider token before the upstream sees it.

## Test plan

- [ ] Trigger a workflow using the Webex post_message tool on caipe-dev — should succeed instead of 401
- [ ] Users with personal Webex OAuth should use their own token
- [ ] Users without a connection should fall back to WEBEX_TOKEN bot token

🤖 Generated with [Claude Code](https://claude.com/claude-code)