### PR TITLE
feat(ui): raise RBAC repair batch limit to 10000 tuples

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.41 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.42 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.41 -f your-values.yaml'}
+                  {'    --version 0.5.42 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.41 -f your-values.yaml'}
+              {'    --version 0.5.42 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.42"
+version = "0.5.42-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/rebac/self-check/route.ts
+++ b/ui/src/app/api/admin/rebac/self-check/route.ts
@@ -25,6 +25,7 @@ import type {
 import { withRebacAdminAuth,withRebacViewAuth } from "../_lib";
 
 const BULK_REVOKE_REVIEW_LIMIT = 5000;
+const REPAIR_BATCH_LIMIT = 10000;
 const DEFAULT_SLACK_WORKSPACE = "CAIPE";
 const DEFAULT_WEBEX_WORKSPACE = "Cisco";
 
@@ -504,7 +505,10 @@ export const POST = withErrorHandler(async (request: NextRequest) =>
       ? body.sources.filter((source): source is string => typeof source === "string" && source.trim().length > 0)
       : undefined;
 
-    const before = await runRbacSelfCheck({ checks });
+    const before = await runRbacSelfCheck({
+      checks,
+      maxFindings: REPAIR_BATCH_LIMIT,
+    });
     const writes = repairableMissingTuples(before, sources);
     const result = await writeOpenFgaTuples({ writes, deletes: [] });
     const after = await runRbacSelfCheck({ checks });

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.42"
+version = "0.5.42.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Raises the number of missing OpenFGA tuples that can be repaired in a single RBAC self-check repair pass from 500 to 10000, without changing how many rows the findings UI renders.

Previously, repairing missing tuples reused the same `MAX_FINDINGS` cap (500) that limits how many findings are returned to the admin UI's findings list. This meant a repair pass could never fix more than 500 missing tuples at a time, even though the OpenFGA write path is already chunked into batches of 100 and can handle much larger volumes.

This adds a repair-specific `REPAIR_BATCH_LIMIT` (10000) used only for computing which tuples are missing and repairable during a repair action. The report returned to the UI afterward (and the `GET` view route used to populate the findings list) still uses the default 500-finding cap, so the UI never renders more than 500 rows.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)