### PR TITLE
fix(slack-bot): remove stale user_allowed kwarg from SlackChannelRebacDecision

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py
@@ -82,3 +82,48 @@ def test_channel_grant_check_allows_when_channel_grant_exists() -> None:
 
     assert decision.channel_allowed is True
     assert decision.reason == "allowed"
+
+
+def test_check_channel_grant_pdp_unavailable_when_no_obo_token() -> None:
+    """check_channel_grant fails closed with pdp_unavailable when there's no OBO token.
+
+    Regression test: the fallback branch used to construct
+    SlackChannelRebacDecision(..., user_allowed=False), which crashed with a
+    TypeError since that field was removed from the dataclass.
+    """
+    evaluator = SlackChannelRebacEvaluator(base_url="http://caipe-ui")
+
+    decision = evaluator.check_channel_grant(
+        workspace_id="T123456789",
+        channel_id="C123456789",
+        agent_id="incident-agent",
+        obo_token=None,
+    )
+
+    assert decision.allowed is False
+    assert decision.channel_allowed is False
+    assert decision.reason == "pdp_unavailable"
+
+
+def test_post_pdp_unavailable_when_no_base_url_and_no_post_check(monkeypatch) -> None:
+    """_post fails closed with pdp_unavailable when no base_url and no post_check are configured.
+
+    Regression test: the fallback branch used to construct
+    SlackChannelRebacDecision(..., user_allowed=False), which crashed with a
+    TypeError since that field was removed from the dataclass.
+    """
+    monkeypatch.delenv("SLACK_REBAC_API_URL", raising=False)
+    monkeypatch.delenv("CAIPE_UI_URL", raising=False)
+    monkeypatch.delenv("CAIPE_API_URL", raising=False)
+
+    evaluator = SlackChannelRebacEvaluator(base_url="")
+
+    decision = evaluator._post(
+        "/api/integrations/slack/channels/T123456789/C123456789/access-check",
+        {"resource": {"type": "agent", "id": "incident-agent"}, "action": "use"},
+        "obo-token",
+    )
+
+    assert decision.allowed is False
+    assert decision.channel_allowed is False
+    assert decision.reason == "pdp_unavailable"

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_rebac.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_rebac.py
@@ -103,7 +103,6 @@ class SlackChannelRebacEvaluator:
             return SlackChannelRebacDecision(
                 allowed=False,
                 channel_allowed=False,
-                user_allowed=False,
                 reason="pdp_unavailable",
             )
         return _http_post_check(self.base_url, path, payload, token)
@@ -130,7 +129,6 @@ class SlackChannelRebacEvaluator:
             return SlackChannelRebacDecision(
                 allowed=False,
                 channel_allowed=False,
-                user_allowed=False,
                 reason="pdp_unavailable",
             )
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.41 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.42 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.41 -f your-values.yaml'}
+                  {'    --version 0.5.42 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.41 -f your-values.yaml'}
+              {'    --version 0.5.42 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.42"
+version = "0.5.42-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.42"
+version = "0.5.42.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- `SlackChannelRebacDecision` had its `user_allowed` field removed in a prior refactor, but two `pdp_unavailable` fallback constructions in `slack_rebac.py` still passed `user_allowed=False`, causing a `TypeError` at runtime.
- These fallback branches are hit when no base URL/post-check is configured, or when no OBO token is available for the check.
- Removed the stale kwarg from both call sites and added regression tests covering both fallback branches.

## Test plan
- [x] `uv run pytest ai_platform_engineering/integrations/slack_bot/tests/test_slack_channel_rebac.py -q` passes (5 tests, up from 3)
- [x] Confirmed the new tests fail against the pre-fix code with the original `TypeError`
- [x] Searched the slack_bot and webex_bot integrations for similar dataclass field/kwarg mismatches; none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)