### PR TITLE
fix(ci): fix docs-snapshot push auth + retry on race

### DIFF
--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -123,6 +123,8 @@ jobs:
               exit 0
             fi
             echo "Push rejected (attempt ${attempt}/3) — rebasing on current main and retrying..."
+            # Random 5-15s backoff so two concurrent runners don't collide on retry
+            sleep $((RANDOM % 11 + 5))
             git fetch origin main
             git rebase origin/main
           done

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -112,6 +112,19 @@ jobs:
           # or review. The Docusaurus build was already validated above, so the only
           # change landing here is the validated published-versions list (and any
           # legitimately-changed current-version Helm reference pages).
-          git push origin HEAD:main
-
-          echo "Pushed docs version ${NEW_VERSION} to main."
+          #
+          # Retry loop: two concurrent tag-triggered runs (e.g. 0.5.44 and a dev tag)
+          # can both reach this step at the same time. The second push will be rejected
+          # because main moved. Rebasing and retrying is safe — the only files touched
+          # are published-versions.json and helm-docs, both idempotent on the same tag.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "Pushed docs version ${NEW_VERSION} to main (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}/3) — rebasing on current main and retrying..."
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "Failed to push after 3 attempts."
+          exit 1

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -91,9 +91,14 @@ jobs:
       - name: Commit and push to main
         env:
           NEW_VERSION: ${{ steps.versions.outputs.new_version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name  "caipe-ci-release[bot]"
           git config user.email "287317642+caipe-ci-release[bot]@users.noreply.github.com"
+
+          # persist-credentials: false means the checkout step does not configure
+          # git credentials. Wire the App token into the remote URL so git push works.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/cnoe-io/ai-platform-engineering.git"
 
           # Only the published-versions list (and any current-version helm docs that
           # legitimately changed) are committed — versioned_docs is never committed.


### PR DESCRIPTION
## Root cause

The docs-snapshot workflow (`[Docs] Publish Version (bump list)`) has been failing with exit code 128 on every release since 0.5.22 (Jun 25). This is why the docs version dropdown is stuck on **0.5.21**.

The cause: `fix(ci): resolve zizmor findings` (f24f49dec) added `persist-credentials: false` to the `actions/checkout` step for security. This is correct — but it also means git has no credentials for the subsequent `git push`, so every push exits 128 (auth failure).

## Fix

1. **Auth fix (primary)**: Wire the GitHub App token into the remote URL before pushing:
   ```bash
   git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/cnoe-io/ai-platform-engineering.git"
   ```
   This is the standard pattern for `persist-credentials: false` workflows that need to push.

2. **Race condition retry (secondary)**: Add a retry loop with random backoff for cases where two concurrent tag-triggered runs both try to push to main at the same time (the second push fails with "rejected — non-fast-forward"). This was the original intent of this PR.

## Effect

After merge: the docs-snapshot workflow will succeed, `published-versions.json` will be updated for all future releases, and the version dropdown in the docs site will start advancing again.

Versions 0.5.22–0.5.45 that missed the snapshot will need to be backfilled via `workflow_dispatch` with `version` inputs (or a single bulk update to `published-versions.json`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)