### PR TITLE
docs(releases): add missing release notes 0.5.36–0.5.43; update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.5.45 (2026-07-09)
+
+### Fix
+
+- **ci**: replace bitshift backoff with multiply to avoid heredoc parse error in Docker builds (#2153)
+
+## 0.5.44 (2026-07-09)
+
+### Feat
+
+- **workflows**: restore subagent HITL and live run status (#2142)
+
+### Fix
+
+- **caipe-ui**: use X-CAIPE-Provider-Token for Webex MCP credential source (#2150)
+- **ci**: add exponential backoff for apk retries in all Wolfi Dockerfiles (#2153)
+- **docs**: add missing workflows feature doc to fix Docusaurus broken link (#2153)
+
 ## 0.5.43-dev.2 (2026-07-09)
 
 ### Fix

--- a/docs/releases/2026-07-04-release-0-5-36.md
+++ b/docs/releases/2026-07-04-release-0-5-36.md
@@ -1,0 +1,47 @@
+---
+slug: release-0.5.36
+title: "Release 0.5.36 — Scheduler MCP and CronJob Service"
+date: 2026-07-04
+authors: [suwhang-cisco]
+tags: [release]
+---
+
+> Released: 2026-07-04
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.36`
+> Previous release: 0.5.35
+
+## Highlights
+
+0.5.36 introduces a Scheduler MCP server that lets agents create and manage scheduled jobs backed by Kubernetes CronJobs. Agents can now schedule recurring or one-shot workflow executions without manual intervention.
+
+<!-- truncate -->
+
+## New Features
+
+### Scheduler MCP server
+
+A new `mcp-scheduler` server exposes tools for creating, listing, updating, and deleting scheduled jobs. Each job is stored as a Kubernetes CronJob in the platform namespace, with CAIPE identity-based ownership so only the creating user (or team members) can manage their schedules. The scheduler chart is included in the umbrella chart and disabled by default.
+
+([#2114](https://github.com/cnoe-io/ai-platform-engineering/pull/2114))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.35.
+
+---
+
+## Upgrade Guide: 0.5.35 → 0.5.36
+
+No values changes required unless you want to enable the scheduler:
+
+```yaml
+scheduler:
+  enabled: true
+```
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.36 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-06-release-0-5-37.md
+++ b/docs/releases/2026-07-06-release-0-5-37.md
@@ -1,0 +1,46 @@
+---
+slug: release-0.5.37
+title: "Release 0.5.37 — Webex Meetings MCP Server"
+date: 2026-07-06
+authors: [suwhang-cisco]
+tags: [release]
+---
+
+> Released: 2026-07-06
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.37`
+> Previous release: 0.5.36
+
+## Highlights
+
+0.5.37 adds a new Webex Meetings MCP server and extends the OAuth connector configuration so providers can be wired up from the platform config YAML without requiring a UI restart.
+
+<!-- truncate -->
+
+## New Features
+
+### Webex Meetings MCP server
+
+A new `mcp-webex-meetings` server gives agents access to Webex Meetings: list recordings, fetch transcripts, search meeting history, and more. Authentication uses the same OAuth connector flow as the existing Webex messaging MCP. The server is included in the umbrella chart under the `mcp-server` sub-chart with a `webex-meetings` agent name.
+
+([#2117](https://github.com/cnoe-io/ai-platform-engineering/pull/2117))
+
+### OAuth connector configuration from platform config
+
+OAuth connectors can now be declared in the platform config YAML (`PROJECTS_ONBOARDING_CONFIG_PATH`) alongside other onboarding providers, making it possible to pre-wire provider credentials at deploy time.
+
+([#2117](https://github.com/cnoe-io/ai-platform-engineering/pull/2117))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.36.
+
+---
+
+## Upgrade Guide: 0.5.36 → 0.5.37
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.37 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-06-release-0-5-38.md
+++ b/docs/releases/2026-07-06-release-0-5-38.md
@@ -1,0 +1,48 @@
+---
+slug: release-0.5.38
+title: "Release 0.5.38 — Keycloak Upgrade Reconciliation, Import Agents from YAML"
+date: 2026-07-06
+authors: [cisco-erilutz]
+tags: [release]
+---
+
+> Released: 2026-07-06
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.38`
+> Previous release: 0.5.37
+
+## Highlights
+
+0.5.38 fixes a Keycloak upgrade regression that left the public CLI client un-reconciled after the first boot, and adds an "Import from YAML config" adoption flow so existing agent configurations can be migrated into the platform without re-creating them by hand.
+
+<!-- truncate -->
+
+## Bug Fixes
+
+### Keycloak: reconcile public CLI client on every upgrade
+
+The `init-idp.sh` script previously ran the public CLI client reconciliation only on first boot. On chart upgrades the step was skipped, leaving stale redirect URIs and PKCE settings if the values had changed. Fixed so the reconciliation runs on every Helm upgrade.
+
+([#2122](https://github.com/cnoe-io/ai-platform-engineering/pull/2122))
+
+## New Features
+
+### Import agents from YAML config
+
+A new "Import from YAML config" card in the Admin → Settings → Dynamic Agents tab lets operators paste or upload an existing `config.yaml` agent manifest. The UI diffs it against live agents and shows an adopt/overwrite flow, preserving team grants and existing secrets.
+
+([#2126](https://github.com/cnoe-io/ai-platform-engineering/pull/2126))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.37.
+
+---
+
+## Upgrade Guide: 0.5.37 → 0.5.38
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.38 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-07-release-0-5-39.md
+++ b/docs/releases/2026-07-07-release-0-5-39.md
@@ -1,0 +1,74 @@
+---
+slug: release-0.5.39
+title: "Release 0.5.39 — Workflow Run Sharing, Webex Markdown, RBAC Regression Coverage"
+date: 2026-07-07
+authors: [sriaradhyula, cisco-erilutz, dabcoder, subbaksh]
+tags: [release]
+---
+
+> Released: 2026-07-07
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.39`
+> Previous release: 0.5.38
+
+## Highlights
+
+0.5.39 is a significant release: workflow runs can now be shared with teams for collaborative debugging, Webex bot supports markdown-only messages, the OpenFGA migrate job hook delete policy is configurable, and the full mocked-RBAC Playwright suite now runs in CI.
+
+<!-- truncate -->
+
+## New Features
+
+### Workflow run sharing
+
+Workflow runs can now be shared with one or more teams via a new Share button on the run detail page. Shared runs are accessible (read + resume) to all members of the selected teams through the existing OpenFGA `task:<run_id>` access model. The run list also surfaces team-shared runs for members.
+
+([#2113](https://github.com/cnoe-io/ai-platform-engineering/pull/2113))
+
+### Webex bot: markdown-only messages
+
+The Webex bot now accepts messages that contain only markdown formatting (no plain-text fallback required). This fixes formatting loss when agents send rich responses.
+
+([#2127](https://github.com/cnoe-io/ai-platform-engineering/pull/2127))
+
+## Bug Fixes
+
+### Behavioral fixes ported from 0.4.18-hotfix
+
+Several stability and correctness fixes from the 0.4.18 hotfix branch were back-ported to main.
+
+([#2129](https://github.com/cnoe-io/ai-platform-engineering/pull/2129))
+
+### OpenFGA migrate job hook delete policy configurable
+
+`values.yaml` now exposes `openfga.migrate.argocdHookDeletePolicy` (default `HookSucceeded`) so operators can keep the migrate job pod for debugging without modifying the chart.
+
+([#2130](https://github.com/cnoe-io/ai-platform-engineering/pull/2130))
+
+## CI
+
+### Full mocked-RBAC Playwright suite in CI
+
+The complete Playwright RBAC test suite (previously run only locally or on demand) now executes on every PR via a dedicated `caipe-ui-tests` workflow using a mocked RBAC backend.
+
+([#2123](https://github.com/cnoe-io/ai-platform-engineering/pull/2123))
+
+### Workflow and knowledge base feature docs
+
+Added documentation pages for Workflows and Knowledge Bases under `docs/docs/features/`.
+
+([#2089](https://github.com/cnoe-io/ai-platform-engineering/pull/2089))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.38.
+
+---
+
+## Upgrade Guide: 0.5.38 → 0.5.39
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.39 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-07-release-0-5-40.md
+++ b/docs/releases/2026-07-07-release-0-5-40.md
@@ -1,0 +1,48 @@
+---
+slug: release-0.5.40
+title: "Release 0.5.40 — Keycloak 26.x Robustness, AgentGateway Bind Address Config"
+date: 2026-07-07
+authors: [cisco-erilutz, sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-07
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.40`
+> Previous release: 0.5.39
+
+## Highlights
+
+0.5.40 hardens Keycloak initialization for KC 26.x deployments and adds optional explicit bind-address configuration for AgentGateway's stats and readiness endpoints.
+
+<!-- truncate -->
+
+## Bug Fixes
+
+### Keycloak: robust init-idp.sh for KC 26.x
+
+`init-idp.sh` ID lookups and redirector URL parsing broke on Keycloak 26.x due to changed REST response shapes. Fixed with defensive parsing that works across KC 24–26.
+
+([#2133](https://github.com/cnoe-io/ai-platform-engineering/pull/2133))
+
+## New Features
+
+### AgentGateway: optional explicit stats/readiness bind addresses
+
+The AgentGateway deployment now accepts `statsBindAddress` and `readinessBindAddress` values, allowing operators to override the default `0.0.0.0` binding — useful in dual-stack or restricted-network environments.
+
+([#2131](https://github.com/cnoe-io/ai-platform-engineering/pull/2131))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.39.
+
+---
+
+## Upgrade Guide: 0.5.39 → 0.5.40
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.40 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-08-release-0-5-41.md
+++ b/docs/releases/2026-07-08-release-0-5-41.md
@@ -1,0 +1,52 @@
+---
+slug: release-0.5.41
+title: "Release 0.5.41 — Workflow State Read-Only, Subagent Timeline, OpenFGA Init Hook"
+date: 2026-07-08
+authors: [subbaksh, sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-08
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.41`
+> Previous release: 0.5.40
+
+## Highlights
+
+0.5.41 fixes two workflow engine regressions — workflow state is now correctly read-only during execution and subagent messages are correlated to their parent timeline — and adds `argocdHookDeletePolicy` support to the OpenFGA init job.
+
+<!-- truncate -->
+
+## Bug Fixes
+
+### Workflow state kept read-only during execution
+
+A regression caused workflow state to be mutated mid-run, producing incorrect intermediate results. The state is now treated as immutable during execution; mutations go through the proper write path only at transition points.
+
+([#2134](https://github.com/cnoe-io/ai-platform-engineering/pull/2134))
+
+### Subagent timeline correlation restored
+
+Subagent messages were no longer correlated to their parent workflow run in the chat timeline, appearing as unrelated events. Fixed by restoring the span ID propagation that connects subagent output to the triggering parent step.
+
+([#2140](https://github.com/cnoe-io/ai-platform-engineering/pull/2140))
+
+### OpenFGA init job: argocdHookDeletePolicy support
+
+The `job-init.yaml` Helm template now respects the `openfga.init.argocdHookDeletePolicy` value (matching the existing migrate job support added in 0.5.39), allowing operators to retain the init pod for debugging.
+
+([#2141](https://github.com/cnoe-io/ai-platform-engineering/pull/2141))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.40.
+
+---
+
+## Upgrade Guide: 0.5.40 → 0.5.41
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.41 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-08-release-0-5-42.md
+++ b/docs/releases/2026-07-08-release-0-5-42.md
@@ -1,0 +1,52 @@
+---
+slug: release-0.5.42
+title: "Release 0.5.42 — Okta Sync Throttling, Slack Agent Pagination, Team Share Fix"
+date: 2026-07-08
+authors: [cisco-erilutz]
+tags: [release]
+---
+
+> Released: 2026-07-08
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.42`
+> Previous release: 0.5.41
+
+## Highlights
+
+0.5.42 fixes three operational regressions: large Okta org syncs now throttle correctly instead of crashing, the Slack bot paginates past the first page of accessible agents, and sharing a dynamic agent with a team correctly grants use-only access (not manage).
+
+<!-- truncate -->
+
+## Bug Fixes
+
+### Okta sync: error handling and throttling for large orgs
+
+The Okta identity group sync was failing silently or crashing on orgs with hundreds of groups. Added per-request error handling, exponential backoff on rate-limit responses, and progress logging so large syncs complete reliably.
+
+([#2143](https://github.com/cnoe-io/ai-platform-engineering/pull/2143))
+
+### Slack bot: paginate accessible agents beyond first page
+
+The Slack bot's accessible-agents lookup was capped at the first API page (~20 agents). Deployments with more agents showed an incomplete list. Fixed with full cursor pagination.
+
+([#2144](https://github.com/cnoe-io/ai-platform-engineering/pull/2144))
+
+### Dynamic agent team share grants use-only, not manage
+
+Sharing a dynamic agent with a team was incorrectly granting the `manage` OpenFGA relation instead of `use`. Team members could see and invoke the agent but should not be able to edit or delete it. Fixed to grant the `use` relation only.
+
+([#2145](https://github.com/cnoe-io/ai-platform-engineering/pull/2145))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.41.
+
+---
+
+## Upgrade Guide: 0.5.41 → 0.5.42
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.42 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-09-release-0-5-43.md
+++ b/docs/releases/2026-07-09-release-0-5-43.md
@@ -1,0 +1,48 @@
+---
+slug: release-0.5.43
+title: "Release 0.5.43 — Inline HITL Form in Chat, Slack Bot Fix"
+date: 2026-07-09
+authors: [sriaradhyula, cisco-erilutz]
+tags: [release]
+---
+
+> Released: 2026-07-09
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.43`
+> Previous release: 0.5.42
+
+## Highlights
+
+0.5.43 delivers the inline HITL (human-in-the-loop) input form directly in the chat timeline and fixes a Slack bot crash introduced by a stale keyword argument.
+
+<!-- truncate -->
+
+## New Features
+
+### Inline HITL input form in WorkflowRunCard
+
+Workflow runs that reach a `waiting_for_input` interrupt state now render the input form inline inside the chat message card — no page navigation required. The form matches the agent HITL panel style and submits via the existing interrupt resume API.
+
+([#2148](https://github.com/cnoe-io/ai-platform-engineering/pull/2148))
+
+## Bug Fixes
+
+### Slack bot: remove stale user_allowed kwarg
+
+`SlackChannelRebacDecision` was being called with a `user_allowed` keyword argument that no longer exists in the updated signature, causing a `TypeError` crash on channel-authorization checks.
+
+([#2152](https://github.com/cnoe-io/ai-platform-engineering/pull/2152))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.42.
+
+---
+
+## Upgrade Guide: 0.5.42 → 0.5.43
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.43 \
+  -f your-values.yaml
+```


### PR DESCRIPTION
Adds curated `docs/releases/` files for all releases missing the "What's new" dialog content (0.5.36–0.5.43), and prepends 0.5.44 and 0.5.45 entries to `CHANGELOG.md`.

| Version | Key content |
|---------|-------------|
| 0.5.36 | Scheduler MCP server |
| 0.5.37 | Webex Meetings MCP server |
| 0.5.38 | Keycloak upgrade reconciliation, Import agents from YAML |
| 0.5.39 | Workflow run sharing, Webex markdown, RBAC Playwright CI |
| 0.5.40 | Keycloak 26.x robustness, AgentGateway bind address config |
| 0.5.41 | Workflow state read-only, subagent timeline, OpenFGA init hook |
| 0.5.42 | Okta sync throttling, Slack agent pagination, team share fix |
| 0.5.43 | Inline HITL form in chat, Slack bot stale kwarg fix |