### PR TITLE
fix(workflows): resume subagent HITL timelines

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -30,6 +30,7 @@ from langchain.agents.middleware.pii import PIIMiddleware
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
 from langchain.agents.middleware.tool_selection import LLMToolSelectorMiddleware
+from langgraph.errors import GraphBubbleUp
 
 from dynamic_agents.services.llm import get_configured_llm
 
@@ -42,6 +43,30 @@ from dynamic_agents.metrics import MetricsAgentMiddleware
 from dynamic_agents.models import FeaturesConfig, MiddlewareEntry
 
 logger = logging.getLogger(__name__)
+
+
+class InterruptAwareToolRetryMiddleware(ToolRetryMiddleware):
+    """Retry ordinary tool failures without swallowing LangGraph control flow.
+
+    Nested subagent interrupts bubble through the parent ``task`` tool as
+    ``GraphBubbleUp`` exceptions. The stock retry middleware treats those as
+    failures, relaunches the subagent, and eventually converts the interrupt
+    into an error ``ToolMessage``. Raising from the retry predicate preserves
+    LangGraph's checkpoint-and-resume behavior while retaining the configured
+    retry policy for real tool exceptions.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        retry_on = kwargs.pop("retry_on", (Exception,))
+
+        def retry_non_control_flow(exc: Exception) -> bool:
+            if isinstance(exc, GraphBubbleUp):
+                raise exc
+            if callable(retry_on):
+                return retry_on(exc)
+            return isinstance(exc, retry_on)
+
+        super().__init__(retry_on=retry_non_control_flow, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +108,7 @@ MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
         },
     ),
     "tool_retry": MiddlewareSpec(
-        cls=ToolRetryMiddleware,
+        cls=InterruptAwareToolRetryMiddleware,
         default_params={"max_retries": 3, "backoff_factor": 2.0, "initial_delay": 2.0, "on_failure": "continue"},
         enabled_by_default=True,
         allow_multiple=False,

--- a/ai_platform_engineering/dynamic_agents/tests/test_middleware_defaults.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_middleware_defaults.py
@@ -2,6 +2,7 @@ from langchain.agents.middleware.context_editing import ContextEditingMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 
 from dynamic_agents.services.middleware import (
+    InterruptAwareToolRetryMiddleware,
     build_middleware,
     get_default_middleware_entries,
     get_middleware_definitions,
@@ -28,8 +29,12 @@ def test_build_middleware_uses_context_editing_guardrail_by_default():
     stack = build_middleware(None, agent_name="test-agent", model_id="test-model")
 
     model_retry = next(middleware for middleware in stack if isinstance(middleware, ModelRetryMiddleware))
+    tool_retry = next(
+        middleware for middleware in stack if isinstance(middleware, InterruptAwareToolRetryMiddleware)
+    )
     context_editing = next(middleware for middleware in stack if isinstance(middleware, ContextEditingMiddleware))
 
     assert model_retry.on_failure == "error"
+    assert tool_retry.max_retries == 3
     assert context_editing.edits[0].trigger == 100_000
     assert context_editing.edits[0].keep == 3

--- a/ai_platform_engineering/dynamic_agents/tests/test_subagent_hitl.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_subagent_hitl.py
@@ -1,9 +1,15 @@
 """Regression tests for human-in-the-loop configuration on subagents."""
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from deepagents import create_deep_agent
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command
 
 from dynamic_agents.models import (
     BuiltinToolsConfig,
@@ -13,6 +19,22 @@ from dynamic_agents.models import (
     SubAgentRef,
 )
 from dynamic_agents.services.agent_runtime import AgentRuntime
+from dynamic_agents.services.builtin_tools import create_request_user_input_tool
+from dynamic_agents.services.middleware import InterruptAwareToolRetryMiddleware
+
+
+class _ToolCallingFakeModel(FakeMessagesListChatModel):
+    """Deterministic model that accepts the tool binding used by create_agent."""
+
+    def bind_tools(
+        self,
+        tools: Any,
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> "_ToolCallingFakeModel":
+        del tools, tool_choice, kwargs
+        return self
 
 
 def _agent_config(
@@ -107,3 +129,111 @@ def test_build_interrupt_config_uses_supplied_agent_config() -> None:
     )
 
     assert result == {"request_user_input": True}
+
+
+def test_parent_tool_retry_preserves_nested_subagent_interrupt_and_resume() -> None:
+    """A subagent GraphInterrupt must checkpoint instead of retrying `task`."""
+    parent_model = _ToolCallingFakeModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {
+                            "description": "Ask the user for a project name.",
+                            "subagent_type": "child",
+                        },
+                        "id": "task-1",
+                    }
+                ],
+            ),
+            AIMessage(content="Parent received the child result."),
+        ]
+    )
+    child_model = _ToolCallingFakeModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "request_user_input",
+                        "args": {
+                            "prompt": "Choose a project name",
+                            "fields": [
+                                {
+                                    "field_name": "project_name",
+                                    "field_label": "Project name",
+                                    "field_type": "text",
+                                    "required": True,
+                                }
+                            ],
+                        },
+                        "id": "input-1",
+                    }
+                ],
+            ),
+            AIMessage(content="Child received the project name."),
+        ]
+    )
+    graph = create_deep_agent(
+        model=parent_model,
+        tools=[],
+        checkpointer=MemorySaver(),
+        middleware=[
+            InterruptAwareToolRetryMiddleware(
+                max_retries=3,
+                initial_delay=0,
+                backoff_factor=0,
+                jitter=False,
+                on_failure="continue",
+            )
+        ],
+        subagents=[
+            {
+                "name": "child",
+                "description": "Collects a project name.",
+                "system_prompt": "Ask for a project name using request_user_input.",
+                "model": child_model,
+                "tools": [create_request_user_input_tool()],
+                "interrupt_on": {"request_user_input": True},
+            }
+        ],
+    )
+    config = {"configurable": {"thread_id": "subagent-hitl-thread"}}
+
+    graph.invoke({"messages": [HumanMessage(content="Start")]}, config=config)
+
+    state = graph.get_state(config)
+    assert len(state.interrupts) == 1
+    assert child_model.i == 1
+    action = state.interrupts[0].value["action_requests"][0]
+    assert action["name"] == "request_user_input"
+
+    result = graph.invoke(
+        Command(
+            resume={
+                "decisions": [
+                    {
+                        "type": "edit",
+                        "edited_action": {
+                            "name": "request_user_input",
+                            "args": {
+                                "prompt": action["args"]["prompt"],
+                                "fields": [
+                                    {
+                                        **action["args"]["fields"][0],
+                                        "value": "alpha",
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                ]
+            }
+        ),
+        config=config,
+    )
+
+    assert not graph.get_state(config).interrupts
+    assert result["messages"][-1].content == "Parent received the child result."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.45-dev.1"
+version = "0.5.45-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -12,6 +12,7 @@ import { APIClientError } from "@/lib/api-client";
 import { authErrorToastTitle,type AuthError } from "@/lib/auth-error";
 import { getConfig } from "@/lib/config";
 import { fetchEphemeralFileContent } from "@/lib/ephemeral-files";
+import { createSubagentResumeSeedEvents } from "@/lib/resume-subagent-context";
 import { createStreamAdapter,StreamError,type StreamCallbacks } from "@/lib/streaming";
 import { createStreamEvent,FILE_TOOL_NAMES,TODO_TOOL_NAME,type StreamEvent } from "@/lib/streaming/types";
 import { cn,deduplicateByKey } from "@/lib/utils";
@@ -1252,8 +1253,16 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
     const resumeAgentId = pendingUserInput.agentId;
     setPendingUserInput(null);
 
-    // Clear previous turn's events before starting resume stream
+    // Resume continues the existing LangGraph task namespace, but the server
+    // does not repeat its parent `task` start. Seed active task starts into the
+    // new turn so resumed child events retain their subagent timeline.
+    const resumeSeedEvents = createSubagentResumeSeedEvents(
+      getActiveConversation()?.streamEvents ?? [],
+    );
     clearStreamEvents(activeConversationId);
+    for (const event of resumeSeedEvents) {
+      addStreamEvent(event, activeConversationId);
+    }
 
     // Create protocol-agnostic adapter for resume
     const adapter = createStreamAdapter({
@@ -1306,8 +1315,8 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
       setConversationStreaming(activeConversationId, null);
     }
   }, [pendingUserInput, activeConversationId, accessToken, agentProtocol, addMessage, updateMessage,
-      appendToMessage, setConversationStreaming,
-      clearStreamEvents, buildStreamCallbacks, finalizeStreamLoop]);
+      appendToMessage, addStreamEvent, setConversationStreaming,
+      clearStreamEvents, getActiveConversation, buildStreamCallbacks, finalizeStreamLoop]);
 
   // Handle tool approval decisions (approve/reject/edit)
   // Shows cards sequentially; only resumes after all tools are decided.
@@ -1351,7 +1360,13 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
     const resumeAgentId = pendingToolApproval.agentId;
     setPendingToolApproval(null);
 
+    const resumeSeedEvents = createSubagentResumeSeedEvents(
+      getActiveConversation()?.streamEvents ?? [],
+    );
     clearStreamEvents(activeConversationId);
+    for (const event of resumeSeedEvents) {
+      addStreamEvent(event, activeConversationId);
+    }
 
     const adapter = createStreamAdapter({
       protocol: agentProtocol as "custom" | "agui",
@@ -1416,7 +1431,8 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
       setConversationStreaming(activeConversationId, null);
     }
   }, [pendingToolApproval, activeConversationId, accessToken, agentProtocol, addMessage, updateMessage,
-      setConversationStreaming, clearStreamEvents, buildStreamCallbacks, finalizeStreamLoop]);
+      addStreamEvent, setConversationStreaming, clearStreamEvents, getActiveConversation,
+      buildStreamCallbacks, finalizeStreamLoop]);
 
   // Handle slash command detection in input
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/ui/src/lib/__tests__/da-timeline-manager.test.ts
+++ b/ui/src/lib/__tests__/da-timeline-manager.test.ts
@@ -1,0 +1,49 @@
+import { createTimelineManager } from "@/lib/da-timeline-manager";
+import type { SubagentSegment } from "@/types/dynamic-agent-timeline";
+
+function getSubagent(manager: ReturnType<typeof createTimelineManager>): SubagentSegment {
+  const segment = manager.getGroupedData().segments.find((item) => item.type === "subagent");
+  expect(segment?.type).toBe("subagent");
+  return segment as SubagentSegment;
+}
+
+describe("TimelineManager resumed subagents", () => {
+  it("renders buffered subagent content immediately while streaming", () => {
+    const manager = createTimelineManager();
+    manager.pushToolStart(
+      {
+        tool_name: "task",
+        tool_call_id: "task-1",
+        args: { subagent_type: "agent-test-2", description: "Collect fruit" },
+      },
+      [],
+    );
+
+    manager.pushContent("The child is still working", ["task-1"]);
+
+    const subagent = getSubagent(manager);
+    expect(subagent.info).toMatchObject({
+      id: "task-1",
+      agentId: "agent-test-2",
+      status: "running",
+    });
+    expect(subagent.segments).toContainEqual(
+      expect.objectContaining({ type: "content", text: "The child is still working" }),
+    );
+  });
+
+  it("creates a placeholder instead of dropping resume-only namespaced content", () => {
+    const manager = createTimelineManager();
+
+    manager.pushContent("Resumed child output", ["task-from-checkpoint"]);
+
+    expect(getSubagent(manager)).toMatchObject({
+      info: { id: "task-from-checkpoint", name: "subagent", status: "running" },
+      segments: [expect.objectContaining({ type: "content", text: "Resumed child output" })],
+    });
+
+    manager.pushToolEnd("task-from-checkpoint", []);
+
+    expect(getSubagent(manager).info.status).toBe("completed");
+  });
+});

--- a/ui/src/lib/__tests__/resume-subagent-context.test.ts
+++ b/ui/src/lib/__tests__/resume-subagent-context.test.ts
@@ -1,0 +1,50 @@
+import { createSubagentResumeSeedEvents } from "@/lib/resume-subagent-context";
+import { createStreamEvent } from "@/lib/streaming/types";
+
+describe("createSubagentResumeSeedEvents", () => {
+  it("carries only active root subagent tasks into a resume turn", () => {
+    const events = [
+      createStreamEvent("tool_start", {
+        tool_name: "task",
+        tool_call_id: "active-task",
+        args: { subagent_type: "agent-test-2", description: "Collect fruit" },
+        namespace: [],
+      }),
+      // AG-UI sends a second tool-start callback when args finish streaming.
+      createStreamEvent("tool_start", {
+        tool_name: "task",
+        tool_call_id: "active-task",
+        args: { subagent_type: "agent-test-2", description: "Collect fruit" },
+        namespace: [],
+      }),
+      createStreamEvent("tool_start", {
+        tool_name: "task",
+        tool_call_id: "completed-task",
+        args: { subagent_type: "agent-test-1" },
+        namespace: [],
+      }),
+      createStreamEvent("tool_end", {
+        tool_call_id: "completed-task",
+        namespace: [],
+      }),
+      createStreamEvent("tool_start", {
+        tool_name: "request_user_input",
+        tool_call_id: "child-tool",
+        namespace: ["active-task"],
+      }),
+    ];
+
+    const seeds = createSubagentResumeSeedEvents(events);
+
+    expect(seeds).toHaveLength(1);
+    expect(seeds[0]).toMatchObject({
+      type: "tool_start",
+      namespace: [],
+      toolData: {
+        tool_name: "task",
+        tool_call_id: "active-task",
+        args: { subagent_type: "agent-test-2", description: "Collect fruit" },
+      },
+    });
+  });
+});

--- a/ui/src/lib/da-timeline-manager.ts
+++ b/ui/src/lib/da-timeline-manager.ts
@@ -18,7 +18,6 @@ ContentSegment,
 StatusSegment,
 StatusType,
 SubagentInfo,
-SubagentSegment,
 TimelineData,
 TimelineSegment,
 TimelineStats,
@@ -95,6 +94,61 @@ export class TimelineManager {
     }
   }
 
+  /** Ensure resumed namespaced events always have a visible subagent owner. */
+  private ensureSubagent(
+    subagentId: string,
+    args: Record<string, unknown> = {},
+    startedAt: Date = new Date(),
+  ): SubagentState {
+    const existing = this.subagents.get(subagentId);
+    if (existing) {
+      const subagentType = args.subagent_type as string | undefined;
+      const description = args.description as string | undefined;
+      if (subagentType && (!existing.info.agentId || existing.info.name === "subagent")) {
+        existing.info.name = subagentType;
+        existing.info.agentId = subagentType;
+      }
+      if (description && !existing.info.purpose) {
+        existing.info.purpose = description;
+      }
+      const existingTool = this.rootToolMap.get(subagentId);
+      if (existingTool && Object.keys(args).length > 0) {
+        existingTool.args = args;
+      }
+      return existing;
+    }
+
+    const subagentState: SubagentState = {
+      info: {
+        id: subagentId,
+        name: (args.subagent_type as string) || "subagent",
+        agentId: args.subagent_type as string,
+        purpose: args.description as string,
+        status: "running",
+      },
+      segments: [],
+      toolMap: new Map(),
+      lastToolEndIndex: -1,
+    };
+    this.subagents.set(subagentId, subagentState);
+    this.subagentContentBuffers.set(subagentId, "");
+    this.subagentContentIds.set(subagentId, 0);
+    this.rootToolMap.set(subagentId, {
+      id: subagentId,
+      name: SUBAGENT_TOOL_NAME,
+      args,
+      status: "running",
+      startedAt,
+    });
+    this.rootSegments.push({
+      type: "subagent",
+      id: subagentId,
+      info: subagentState.info,
+      segments: subagentState.segments,
+    });
+    return subagentState;
+  }
+
   // ═══════════════════════════════════════════════════════════════
   // Event Handlers
   // ═══════════════════════════════════════════════════════════════
@@ -111,6 +165,7 @@ export class TimelineManager {
     } else {
       // Subagent content - buffer it
       const subagentId = namespace[0];
+      this.ensureSubagent(subagentId);
       const buffer = this.subagentContentBuffers.get(subagentId) || "";
       this.subagentContentBuffers.set(subagentId, buffer + text);
     }
@@ -126,63 +181,11 @@ export class TimelineManager {
     // Check if this is a subagent invocation (task tool)
     if (toolData.tool_name === SUBAGENT_TOOL_NAME) {
       const subagentId = toolData.tool_call_id;
-
-      // DEDUP GUARD: If we already have this subagent, update its info if args
-      // are now available (AG-UI: args arrive in TOOL_CALL_ARGS after TOOL_CALL_START)
-      if (this.subagents.has(subagentId)) {
-        const existing = this.subagents.get(subagentId)!;
-        const args = toolData.args || {};
-        const subagentType = args.subagent_type as string | undefined;
-        const description = args.description as string | undefined;
-        if (subagentType && (!existing.info.agentId || existing.info.name === "subagent")) {
-          existing.info.name = subagentType;
-          existing.info.agentId = subagentType;
-        }
-        if (description && !existing.info.purpose) {
-          existing.info.purpose = description;
-        }
-        return;
-      }
-
-      // Flush any pending root content before subagent
-      this.flushRootContent();
-
-      // Create subagent entry
       const args = toolData.args || {};
-
-      const subagentState: SubagentState = {
-        info: {
-          id: subagentId,
-          name: (args.subagent_type as string) || "subagent",
-          agentId: args.subagent_type as string,
-          purpose: args.description as string,
-          status: "running",
-        },
-        segments: [],
-        toolMap: new Map(),
-        lastToolEndIndex: -1,
-      };
-      this.subagents.set(subagentId, subagentState);
-      this.subagentContentBuffers.set(subagentId, "");
-      this.subagentContentIds.set(subagentId, 0);
-
-      // Add subagent segment to root timeline
-      const segment: SubagentSegment = {
-        type: "subagent",
-        id: subagentId,
-        info: subagentState.info,
-        segments: subagentState.segments, // Reference, will be updated
-      };
-      this.rootSegments.push(segment);
-
-      // Also track in rootToolMap for tool_end handling
-      this.rootToolMap.set(subagentId, {
-        id: subagentId,
-        name: SUBAGENT_TOOL_NAME,
-        args,
-        status: "running",
-        startedAt: now,
-      });
+      if (!this.subagents.has(subagentId)) {
+        this.flushRootContent();
+      }
+      this.ensureSubagent(subagentId, args, now);
     } else if (namespace.length === 0) {
       // DEDUP GUARD: If we already have this tool, update its args if they
       // are now available (AG-UI streams args via TOOL_CALL_ARGS after start).
@@ -215,37 +218,35 @@ export class TimelineManager {
     } else {
       // Subagent tool
       const subagentId = namespace[0];
-      const subagent = this.subagents.get(subagentId);
-      if (subagent) {
-        // DEDUP GUARD: If we already have this tool, update its args if they
-        // are now available (AG-UI streams args via TOOL_CALL_ARGS after start).
-        if (subagent.toolMap.has(toolData.tool_call_id)) {
-          const existing = subagent.toolMap.get(toolData.tool_call_id)!;
-          if (toolData.args) {
-            existing.args = toolData.args;
-          }
-          return;
+      const subagent = this.ensureSubagent(subagentId);
+      // DEDUP GUARD: If we already have this tool, update its args if they
+      // are now available (AG-UI streams args via TOOL_CALL_ARGS after start).
+      if (subagent.toolMap.has(toolData.tool_call_id)) {
+        const existing = subagent.toolMap.get(toolData.tool_call_id)!;
+        if (toolData.args) {
+          existing.args = toolData.args;
         }
-
-        // Flush subagent content first
-        this.flushSubagentContent(subagentId);
-
-        const tool: ToolInfo = {
-          id: toolData.tool_call_id,
-          name: toolData.tool_name,
-          args: toolData.args,
-          status: "running",
-          startedAt: now,
-        };
-        subagent.toolMap.set(toolData.tool_call_id, tool);
-
-        const segment: ToolSegment = {
-          type: "tool",
-          id: toolData.tool_call_id,
-          data: tool,
-        };
-        subagent.segments.push(segment);
+        return;
       }
+
+      // Flush subagent content first
+      this.flushSubagentContent(subagentId);
+
+      const tool: ToolInfo = {
+        id: toolData.tool_call_id,
+        name: toolData.tool_name,
+        args: toolData.args,
+        status: "running",
+        startedAt: now,
+      };
+      subagent.toolMap.set(toolData.tool_call_id, tool);
+
+      const segment: ToolSegment = {
+        type: "tool",
+        id: toolData.tool_call_id,
+        data: tool,
+      };
+      subagent.segments.push(segment);
     }
   }
 
@@ -469,7 +470,26 @@ export class TimelineManager {
         // This content is after the last tool - it's part of final answer
         finalAnswerParts.push(seg.text);
       } else {
-        segments.push(seg);
+        if (seg.type === "subagent") {
+          const liveBuffer = this.subagentContentBuffers.get(seg.id) || "";
+          if (liveBuffer.trim()) {
+            segments.push({
+              ...seg,
+              segments: [
+                ...seg.segments,
+                {
+                  type: "content",
+                  id: `${seg.id}-content-live`,
+                  text: liveBuffer,
+                },
+              ],
+            });
+          } else {
+            segments.push(seg);
+          }
+        } else {
+          segments.push(seg);
+        }
       }
     }
     

--- a/ui/src/lib/resume-subagent-context.ts
+++ b/ui/src/lib/resume-subagent-context.ts
@@ -1,0 +1,36 @@
+import { createStreamEvent,isToolStartData,type StreamEvent } from "@/lib/streaming/types";
+
+/**
+ * Build seed events for subagent tasks that were still running when a turn
+ * paused for human input.
+ *
+ * Resume streams continue the existing LangGraph task namespace, but do not
+ * repeat the parent `task` tool start. A new assistant turn therefore needs
+ * this small piece of prior context so its timeline can attach resumed child
+ * events to the correct subagent.
+ */
+export function createSubagentResumeSeedEvents(events: StreamEvent[]): StreamEvent[] {
+  const activeTasks = new Map<string, { args?: Record<string, unknown> }>();
+
+  for (const event of events) {
+    if (event.type === "tool_start" && isToolStartData(event.toolData)) {
+      if (event.namespace.length === 0 && event.toolData.tool_name === "task") {
+        activeTasks.set(event.toolData.tool_call_id, { args: event.toolData.args });
+      }
+      continue;
+    }
+
+    if (event.type === "tool_end" && event.toolData) {
+      activeTasks.delete(event.toolData.tool_call_id);
+    }
+  }
+
+  return [...activeTasks.entries()].map(([toolCallId, task]) =>
+    createStreamEvent("tool_start", {
+      tool_name: "task",
+      tool_call_id: toolCallId,
+      args: task.args,
+      namespace: [],
+    }),
+  );
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.45.dev1"
+version = "0.5.45.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Follow-up to #2142. This fixes the remaining subagent human-in-the-loop resume path.

- Preserve nested LangGraph interrupts through the parent tool-retry middleware instead of treating control flow as a tool failure and launching the subagent four times.
- Seed active root `task` events into the new assistant turn before processing a resume stream, because the server resumes the existing namespace without repeating the parent task start.
- Create a defensive placeholder for resume-only subagent namespaces and expose buffered child content immediately, so the UI renders the resumed subagent timeline instead of only showing the parent as thinking.
- Add backend and UI regressions for a real parent-to-subagent `request_user_input` interrupt/resume and resumed timeline rendering.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `uv run ruff check src/dynamic_agents/services/middleware.py tests/test_subagent_hitl.py tests/test_middleware_defaults.py`
- `uv run pytest tests/test_subagent_hitl.py tests/test_middleware_defaults.py -q` — 6 passed
- `npm test -- --runInBand src/lib/__tests__/resume-subagent-context.test.ts src/lib/__tests__/da-timeline-manager.test.ts src/components/chat/__tests__/DynamicAgentTimeline.test.tsx src/components/chat/__tests__/WorkflowRunCard.test.tsx` — 4 suites / 6 tests passed
- Touched-file ESLint passes with no errors. Existing warnings remain in `DynamicAgentChatPanel.tsx`.
- Project-wide `npx tsc --noEmit` remains blocked outside this diff by stale `.next/dev/types/validator.ts` route references and the existing missing `@dagrejs/dagre` dependency in `AccessExplorerTab.tsx`.

## Pre-release Helm Charts (Optional)

No chart changes. The `prebuild/` branch triggers container image builds for deployment testing.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing related PR has been referenced
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks for changed files pass
- [x] New code contribution is covered by automated tests
- [x] Focused backend and UI tests pass
