### PR TITLE
fix(rbac): self-check should not expect manager grant for shared-only teams on agents

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.45 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.46 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.45 -f your-values.yaml'}
+                  {'    --version 0.5.46 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.45 -f your-values.yaml'}
+              {'    --version 0.5.46 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.46"
+version = "0.5.46-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/rbac/__tests__/self-check.test.ts
+++ b/ui/src/lib/rbac/__tests__/self-check.test.ts
@@ -468,6 +468,50 @@ describe("deriveRbacSelfCheckReport", () => {
     expect(report.findings.filter((f) => f.severity === "orphan_candidate")).toHaveLength(0);
   });
 
+  it("does not expect #admin manager for a shared-only team on an agent (sharing is use-only)", () => {
+    // Sharing an agent with a team grants use (`#member user`) only, never
+    // manage rights — even to that team's admins. The self-check must not
+    // expect `team:<shared>#admin manager` and must flag a lingering one as
+    // a revocable orphan, matching the write-side filter in
+    // openfga-agent-tools.ts (isSharedOnlyAdminManagerTuple).
+    const report = deriveRbacSelfCheckReport(baseInput({
+      teams: [
+        { slug: "owner-team", name: "Owner Team" },
+        { slug: "everyone", name: "Everyone" },
+      ],
+      dynamicAgents: [
+        {
+          _id: "csec-critical-alerts",
+          name: "CSEC Critical Alerts",
+          visibility: "team",
+          owner_team_slug: "owner-team",
+          shared_with_teams: ["everyone"],
+        },
+      ],
+      actualTuples: [
+        { user: "organization:caipe#admin", relation: "manager", object: "agent:csec-critical-alerts" },
+        { user: "team:owner-team#member", relation: "user", object: "agent:csec-critical-alerts" },
+        { user: "team:owner-team#admin", relation: "manager", object: "agent:csec-critical-alerts" },
+        { user: "team:owner-team#member", relation: "manager", object: "agent:csec-critical-alerts" },
+        { user: "team:everyone#member", relation: "user", object: "agent:csec-critical-alerts" },
+        // Lingering grant from before the use-only fix shipped — must be
+        // flagged as revocable, not expected as missing.
+        { user: "team:everyone#admin", relation: "manager", object: "agent:csec-critical-alerts" },
+      ],
+    }));
+
+    expect(report.summary.missing_tuples).toBe(0);
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "orphan_candidate",
+          review_action: expect.objectContaining({ type: "revoke_tuple" }),
+          tuple: { user: "team:everyone#admin", relation: "manager", object: "agent:csec-critical-alerts" },
+        }),
+      ]),
+    );
+  });
+
   it("labels membership tuples for deleted teams as stale deleted-team memberships", () => {
     const report = deriveRbacSelfCheckReport(baseInput({
       actualTuples: [

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -380,7 +380,13 @@ function teamGrantTuples(input: {
     for (const relation of input.memberRelations) {
       tuples.push(expected(input.source, `team:${teamSlug}#member`, relation, input.object, input.resource));
     }
-    tuples.push(expected(input.source, `team:${teamSlug}#admin`, "manager", input.object, input.resource));
+    // Sharing is use-only: only the owner team's admins get `manager` (can_manage).
+    // Mirrors the write-side filter in openfga-agent-tools.ts (isSharedOnlyAdminManagerTuple) —
+    // without this, self-check expects an `#admin manager` grant for every shared team and
+    // flags it as "missing" once the reconciler stops writing/keeps deleting it.
+    if (teamSlug === input.ownerTeamSlug) {
+      tuples.push(expected(input.source, `team:${teamSlug}#admin`, "manager", input.object, input.resource));
+    }
   }
   return { tuples, staleReferences };
 }

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.46"
+version = "0.5.46.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

The RBAC admin self-check's `teamGrantTuples()` helper (`ui/src/lib/rbac/self-check.ts`) expected a `team:<slug>#admin manager agent:<id>` tuple for every team in an agent's owner+shared set. A recent fix made sharing use-only: sharing an agent with a team grants use access only, never manage rights, even to that team's admins.

This restricts the `#admin manager` expectation to the owner team only, mirroring the `isSharedOnlyAdminManagerTuple` filter already applied in the write-side reconciler (`openfga-agent-tools.ts`). Adds a regression test covering a shared-only team's admin-manager tuple being correctly flagged as a revocable orphan instead of expected/missing.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)