### PR TITLE
fix(rbac): chunk OpenFGA batch-check calls over the 50-check limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.46-dev.1"
+version = "0.5.46-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/rbac/__tests__/openfga-batch-check-chunking.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-batch-check-chunking.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for OpenFGA batch-check chunking.
+ *
+ * Why this matters: OpenFGA's HTTP `/batch-check` endpoint caps each call
+ * at 50 checks by default (`max_checks_per_batch_check`). The admin-tab-gates
+ * fallback (`hasAccessibleSlackChannel`/`hasAccessibleWebexSpace`) fans a
+ * (can_read, can_manage) check out over every active
+ * channel_team_mappings/webex_space_team_mappings row — 26+ active rows
+ * already exceeds the limit. The un-chunked call failed outright, and the
+ * caller's blanket try/catch silently treated every check as denied,
+ * hiding the Slack/Webex admin tab for non-admin users who had valid
+ * per-channel grants. This test pins the chunking fix.
+ */
+
+import { batchCheckOpenFgaTuples, type OpenFgaTupleKey } from "../openfga";
+
+function tuple(i: number): OpenFgaTupleKey {
+  return {
+    user: `user:u-${i}`,
+    relation: i % 2 === 0 ? "can_read" : "can_manage",
+    object: `slack_channel:CAIPE--C${i}`,
+  };
+}
+
+describe("batchCheckOpenFgaTuples (chunked)", () => {
+  const ORIGINAL_FETCH = global.fetch;
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.OPENFGA_HTTP = "http://openfga.test";
+    process.env.OPENFGA_STORE_NAME = "caipe-openfga-test";
+    delete process.env.OPENFGA_STORE_ID;
+    delete process.env.OPENFGA_MAX_CHECKS_PER_BATCH;
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  /**
+   * Wire a fake `fetch` that resolves store discovery (GET /stores) the
+   * same way production does — only OPENFGA_HTTP is set, no
+   * OPENFGA_STORE_ID override — then delegates /batch-check calls to the
+   * per-test callback.
+   */
+  function mockFetch(batchCheckBehavior: (body: { checks: Array<{ tuple_key: OpenFgaTupleKey; correlation_id: string }> }) => Response | Promise<Response>) {
+    const batchCheckBodies: unknown[] = [];
+    const fetchMock = jest.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/stores") && (!init || init.method === "GET" || !init.method)) {
+        return new Response(
+          JSON.stringify({ stores: [{ id: "store-id", name: "caipe-openfga-test" }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (u.includes("/batch-check")) {
+        const body = init?.body ? JSON.parse(String(init.body)) : { checks: [] };
+        batchCheckBodies.push(body);
+        return batchCheckBehavior(body);
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+    return { fetchMock, batchCheckBodies };
+  }
+
+  it("issues a single /batch-check call for <= 50 tuples", async () => {
+    const tuples = Array.from({ length: 50 }, (_, i) => tuple(i));
+    const { batchCheckBodies } = mockFetch((body) => {
+      const result: Record<string, { allowed: boolean }> = {};
+      body.checks.forEach((c) => { result[c.correlation_id] = { allowed: true }; });
+      return new Response(JSON.stringify({ result }), { status: 200 });
+    });
+
+    const results = await batchCheckOpenFgaTuples(tuples);
+
+    expect(batchCheckBodies).toHaveLength(1);
+    expect(results).toHaveLength(50);
+    expect(results.every(Boolean)).toBe(true);
+  });
+
+  it("splits 174 tuples (the prod channel_team_mappings scale) into four <=50 chunks", async () => {
+    // Mirrors the real bug: 174 active channel_team_mappings rows x 2
+    // checks (can_read, can_manage) = 348 tuples. Using 174 tuples directly
+    // here to keep the test focused on the chunking boundary math.
+    const tuples = Array.from({ length: 174 }, (_, i) => tuple(i));
+    const { batchCheckBodies } = mockFetch((body) => {
+      const result: Record<string, { allowed: boolean }> = {};
+      // Only tuple index 100 (arbitrary) is actually granted, to prove
+      // results map back to the right tuple across chunk boundaries.
+      body.checks.forEach((c) => {
+        result[c.correlation_id] = { allowed: c.tuple_key.object === "slack_channel:CAIPE--C100" };
+      });
+      return new Response(JSON.stringify({ result }), { status: 200 });
+    });
+
+    const results = await batchCheckOpenFgaTuples(tuples);
+
+    expect(batchCheckBodies).toHaveLength(4);
+    const chunkSizes = (batchCheckBodies as Array<{ checks: unknown[] }>).map((b) => b.checks.length);
+    expect(chunkSizes).toEqual([50, 50, 50, 24]);
+    expect(results).toHaveLength(174);
+    expect(results.filter(Boolean)).toEqual([true]);
+    expect(results[100]).toBe(true);
+  });
+
+  it("propagates a chunk failure instead of silently denying every check", async () => {
+    const tuples = Array.from({ length: 60 }, (_, i) => tuple(i));
+    let callIndex = 0;
+    mockFetch(() => {
+      callIndex += 1;
+      if (callIndex === 2) {
+        return new Response("exceeded_checks_limit", { status: 400 });
+      }
+      return new Response(JSON.stringify({ result: {} }), { status: 200 });
+    });
+
+    await expect(batchCheckOpenFgaTuples(tuples)).rejects.toThrow(
+      /OpenFGA batch-check failed: 400/,
+    );
+  });
+
+  it("respects OPENFGA_MAX_CHECKS_PER_BATCH when set to a smaller value", async () => {
+    process.env.OPENFGA_MAX_CHECKS_PER_BATCH = "10";
+    const tuples = Array.from({ length: 25 }, (_, i) => tuple(i));
+    const { batchCheckBodies } = mockFetch((body) => {
+      const result: Record<string, { allowed: boolean }> = {};
+      body.checks.forEach((c) => { result[c.correlation_id] = { allowed: false }; });
+      return new Response(JSON.stringify({ result }), { status: 200 });
+    });
+
+    const results = await batchCheckOpenFgaTuples(tuples);
+
+    expect(batchCheckBodies).toHaveLength(3);
+    const chunkSizes = (batchCheckBodies as Array<{ checks: unknown[] }>).map((b) => b.checks.length);
+    expect(chunkSizes).toEqual([10, 10, 5]);
+    expect(results).toHaveLength(25);
+  });
+});

--- a/ui/src/lib/rbac/openfga.ts
+++ b/ui/src/lib/rbac/openfga.ts
@@ -475,22 +475,31 @@ function tupleKeyFilter(tuple?: Partial<OpenFgaTupleKey>): Partial<OpenFgaTupleK
 }
 
 /**
- * Send multiple Check requests in a single HTTP call via the OpenFGA
- * /batch-check endpoint (available since OpenFGA v1.8). Returns a boolean
- * array in the same order as the input tuples. Falls back gracefully: if
- * OPENFGA_HTTP is unset or batch-check is unavailable, callers should use
- * checkOpenFgaTuple() instead.
+ * OpenFGA's HTTP `/batch-check` endpoint caps each call at 50 checks by
+ * default (`max_checks_per_batch_check`). Callers that fan a check out
+ * over an unbounded collection (e.g. one row per Mongo document) can
+ * easily exceed this — the call then fails outright, and a caller with a
+ * blanket try/catch around the whole batch silently treats every check
+ * as denied instead of just the ones over the limit.
+ *
+ * Configurable via `OPENFGA_MAX_CHECKS_PER_BATCH` for environments that
+ * tune the server-side limit; defaults to 50 to match the stock server.
  */
-export async function batchCheckOpenFgaTuples(tuples: OpenFgaTupleKey[]): Promise<boolean[]> {
-  if (tuples.length === 0) return [];
-  if (isUnsafeRbacBypassEnabled()) {
-    warnUnsafeRbacBypassEnabled("openfga.batch-check");
-    return tuples.map(() => true);
-  }
-  const baseUrl = openFgaHttpUrl();
-  if (!baseUrl) throw new Error("OPENFGA_HTTP is not set");
-  const storeId = await getOpenFgaStoreId();
+const DEFAULT_OPENFGA_BATCH_CHECK_LIMIT = 50;
 
+function openFgaBatchCheckLimit(): number {
+  const fromEnv = Number(process.env.OPENFGA_MAX_CHECKS_PER_BATCH);
+  if (Number.isFinite(fromEnv) && fromEnv > 0 && fromEnv <= 50) {
+    return Math.floor(fromEnv);
+  }
+  return DEFAULT_OPENFGA_BATCH_CHECK_LIMIT;
+}
+
+async function postOpenFgaBatchCheck(
+  baseUrl: string,
+  storeId: string,
+  tuples: OpenFgaTupleKey[],
+): Promise<boolean[]> {
   const checks = tuples.map((tuple, i) => ({
     tuple_key: tuple,
     correlation_id: String(i),
@@ -506,6 +515,37 @@ export async function batchCheckOpenFgaTuples(tuples: OpenFgaTupleKey[]): Promis
   }
   const body = (await response.json()) as { result: Record<string, { allowed?: boolean }> };
   return tuples.map((_, i) => Boolean(body.result[String(i)]?.allowed));
+}
+
+/**
+ * Send multiple Check requests via the OpenFGA /batch-check endpoint
+ * (available since OpenFGA v1.8), chunking to stay under the server's
+ * per-call check limit. Returns a boolean array in the same order as the
+ * input tuples. Falls back gracefully: if OPENFGA_HTTP is unset or
+ * batch-check is unavailable, callers should use checkOpenFgaTuple()
+ * instead.
+ */
+export async function batchCheckOpenFgaTuples(tuples: OpenFgaTupleKey[]): Promise<boolean[]> {
+  if (tuples.length === 0) return [];
+  if (isUnsafeRbacBypassEnabled()) {
+    warnUnsafeRbacBypassEnabled("openfga.batch-check");
+    return tuples.map(() => true);
+  }
+  const baseUrl = openFgaHttpUrl();
+  if (!baseUrl) throw new Error("OPENFGA_HTTP is not set");
+  const storeId = await getOpenFgaStoreId();
+
+  const limit = openFgaBatchCheckLimit();
+  if (tuples.length <= limit) {
+    return postOpenFgaBatchCheck(baseUrl, storeId, tuples);
+  }
+
+  const chunkResults = await Promise.all(
+    Array.from({ length: Math.ceil(tuples.length / limit) }, (_, i) =>
+      postOpenFgaBatchCheck(baseUrl, storeId, tuples.slice(i * limit, (i + 1) * limit)),
+    ),
+  );
+  return chunkResults.flat();
 }
 
 export async function checkOpenFgaTuple(tuple: OpenFgaTupleKey): Promise<OpenFgaCheckResult> {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.46.dev1"
+version = "0.5.46.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- `hasAccessibleSlackChannel` / `hasAccessibleWebexSpace` (both in `ui/src/app/api/rbac/admin-tab-gates/route.ts`) fan out 2 OpenFGA checks (`can_read`, `can_manage`) per active `channel_team_mappings` / `webex_space_team_mappings` row into one `batchCheckOpenFgaTuples` call.
- OpenFGA's `/batch-check` endpoint caps each call at 50 checks by default (`max_checks_per_batch_check`). With more than 25 active rows, the call fails outright — and the caller's blanket `try { ... } catch { return false; }` silently treats every check as denied.
- Observed in prod: 174 active `channel_team_mappings` rows → 348 checks in one call, well past the limit. This hid the Slack admin tab for a team member who had a confirmed `can_manage` grant directly in OpenFGA on their channel.
- `batchCheckOpenFgaTuples` (`ui/src/lib/rbac/openfga.ts`) now chunks tuples into `<=50`-sized batches (configurable via `OPENFGA_MAX_CHECKS_PER_BATCH`) and issues them concurrently, returning results in original order — mirroring the existing write-side `chunkOpenFgaDiff` pattern.

## Test plan

- [x] New unit tests (`ui/src/lib/rbac/__tests__/openfga-batch-check-chunking.test.ts`) mock store discovery (`GET /stores`, matching real deployments where only `OPENFGA_HTTP` is set) and cover: single call ≤50, chunking at prod scale (174 tuples → 4 chunks), chunk-failure propagation (not swallowed to `false`), and `OPENFGA_MAX_CHECKS_PER_BATCH` override.
- [x] Existing `openfga-chunking.test.ts` and `admin-tab-gates` route tests still pass.
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in touched files).
- [x] `npm run build` — succeeds.
- [ ] Branch is `prebuild/` prefixed to trigger a CI Docker build — verify the fix directly in prod before merging (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)