### PR TITLE
fix(ui): paginate dynamic agents fetch in slack integration pickers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.46-dev.1"
+version = "0.5.46-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
+++ b/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
@@ -713,10 +713,18 @@ export function ConnectorAdminPanel({
   }, [selected, adapter]);
 
   const loadDynamicAgents = useCallback(async () => {
-    const res = await fetch("/api/dynamic-agents?enabled_only=true");
-    if (!res.ok) throw new Error(await res.text());
-    const data = apiData<{ items: DynamicAgentOption[] }>(await res.json());
-    setDynamicAgents(data.items ?? []);
+    const items: DynamicAgentOption[] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      const res = await fetch(`/api/dynamic-agents?enabled_only=true&page=${page}&page_size=100`);
+      if (!res.ok) throw new Error(await res.text());
+      const data = apiData<{ items: DynamicAgentOption[]; has_more?: boolean }>(await res.json());
+      items.push(...(data.items ?? []));
+      hasMore = Boolean(data.has_more);
+      page += 1;
+    }
+    setDynamicAgents(items);
   }, []);
 
   const loadTeams = useCallback(async () => {

--- a/ui/src/components/admin/rebac/SlackVictoropsAgentSetting.tsx
+++ b/ui/src/components/admin/rebac/SlackVictoropsAgentSetting.tsx
@@ -33,13 +33,26 @@ export function SlackVictoropsAgentSetting({ disabled = false }: { disabled?: bo
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [agentsRes, configRes] = await Promise.all([
-        fetch("/api/dynamic-agents?enabled_only=true").then((r) => r.json()).catch(() => ({ data: { items: [] } })),
+      const loadAllAgents = async (): Promise<DynamicAgentOption[]> => {
+        const items: DynamicAgentOption[] = [];
+        let page = 1;
+        let hasMore = true;
+        while (hasMore) {
+          const agentsRes = await fetch(`/api/dynamic-agents?enabled_only=true&page=${page}&page_size=100`)
+            .then((r) => r.json())
+            .catch(() => ({ data: { items: [] } }));
+          const pageItems: DynamicAgentOption[] = agentsRes?.data?.items ?? agentsRes?.items ?? [];
+          items.push(...pageItems);
+          hasMore = Boolean(agentsRes?.data?.has_more ?? agentsRes?.has_more);
+          page += 1;
+        }
+        return items;
+      };
+      const [items, configRes] = await Promise.all([
+        loadAllAgents(),
         fetch("/api/admin/platform-config").then((r) => r.json()).catch(() => ({ success: false })),
       ]);
       if (cancelled) return;
-      const items: DynamicAgentOption[] =
-        agentsRes?.data?.items ?? agentsRes?.items ?? [];
       setAgents(items);
       if (configRes?.success) {
         const id = (configRes.data?.slack_victorops_escalation_agent_id as string | null) ?? SUPERVISOR_VALUE;

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -51,7 +51,7 @@ beforeEach(() => {
         },
       });
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({
         data: {
           items: [
@@ -287,7 +287,7 @@ it("shows a loading spinner while self-service channels load", async () => {
     ) {
       return channelsPromise;
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({ data: { items: [] } });
     }
     return response({});
@@ -328,7 +328,7 @@ it("shows discovery loading while Find channels scans Slack", async () => {
     if (url.startsWith("/api/admin/slack/available-channels")) {
       return discoveryPromise;
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({
         data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] },
       });
@@ -463,7 +463,7 @@ it("preserves imported escalation/overthink/bots when editing a route (no data l
         },
       });
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({
         data: { items: [{ _id: "incident-agent", name: "Incident Agent" }] },
       });
@@ -603,7 +603,7 @@ it("renders the full per-channel/agent breakdown in the sync preview modal", asy
     ) {
       return response({ data: { channels: [] } });
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({ data: { items: [] } });
     }
     if (url === "/api/dynamic-agents/teams") {
@@ -947,7 +947,7 @@ it("discovers Slack channels even when no onboarding default team is configured"
     ) {
       return response({ data: { channels: [] } });
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({
         data: {
           items: [{ _id: "incident-agent", name: "Incident Agent" }],

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -62,7 +62,7 @@ function setupFetchMock() {
         },
       });
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({
         data: {
           items: [
@@ -248,7 +248,7 @@ it("shows the onboarding loading state while configured spaces seed the table", 
     ) {
       return spacesPromise;
     }
-    if (url === "/api/dynamic-agents?enabled_only=true") {
+    if (url.startsWith("/api/dynamic-agents?enabled_only=true")) {
       return response({ data: { items: [] } });
     }
     return response({});

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.46.dev1"
+version = "0.5.46.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- The Admin → Integrations → Slack panel's agent pickers (onboard channels section, and the configured channel route editor) only ever showed the first 20 agents, because the `/api/dynamic-agents` fetch omitted `page_size` and fell back to the endpoint's default page size of 20.
- With more than 20 dynamic agents configured, the remaining agents were silently missing from both pickers.
- `ConnectorAdminPanel.loadDynamicAgents` and `SlackVictoropsAgentSetting` now page through all results (`page_size=100`, following `has_more`) before populating the picker options.
- Updated the affected admin rebac tests to match the fetch URL by prefix instead of exact string match, since the request now includes `page`/`page_size` query params.

## Test plan
- [x] `npx eslint` passes on the changed files
- [x] `npx jest src/components/admin/rebac` — 69/69 tests pass
- [ ] Manually verify in the UI that Admin → Integrations → Slack shows all configured agents (>20) in both the onboarding picker and the configured-channel route editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)