### PR TITLE
feat(chart): add optional values-mcp-servers.yaml overlay

### DIFF
--- a/charts/ai-platform-engineering/values-agent-sre.yaml
+++ b/charts/ai-platform-engineering/values-agent-sre.yaml
@@ -1,0 +1,49 @@
+# Optional overlay: pre-configured SRE agent.
+#
+# Usage (include after values-mcp-servers.yaml to wire MCP endpoints):
+#   helm install caipe oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+#     -f values.yaml \
+#     -f values-mcp-servers.yaml \
+#     -f values-agent-sre.yaml
+#
+# The agent is disabled by default (enabled: false).
+# Enable it in your deployment-specific values:
+#
+#   caipe-ui:
+#     appConfig:
+#       agents:
+#         - id: sre
+#           enabled: true
+
+caipe-ui:
+  appConfig:
+    agents:
+      - id: "sre"
+        name: "SRE Agent"
+        description: "Site reliability assistant — incidents, deployments, on-call, logs, and infrastructure operations"
+        system_prompt: |
+          You are an SRE (Site Reliability Engineering) assistant. You help engineers
+          investigate incidents, manage deployments, query logs, and operate infrastructure.
+
+          You have access to tools for:
+          - Deployment management and rollout status (ArgoCD)
+          - Service catalog and ownership lookup (Backstage)
+          - Incident management and on-call schedules (PagerDuty)
+          - Log search and analysis (Splunk)
+          - Network diagnostics — ping, traceroute, DNS lookup (netutils)
+          - Cloud infrastructure — read-only CLI and EKS kubectl operations (AWS)
+
+          Guidelines:
+          - Prefer read-only operations unless the user explicitly requests a change.
+          - When investigating an incident, start with recent logs and deployment history.
+          - Summarize findings concisely; link to relevant dashboards or tickets when available.
+          - If a remediation action is destructive or irreversible, state the impact and ask for confirmation.
+        visibility: "global"
+        allowed_tools:
+          argocd: []
+          backstage: []
+          pagerduty: []
+          splunk: []
+          netutils: []
+          aws: []
+        enabled: false

--- a/charts/ai-platform-engineering/values-mcp-servers.yaml
+++ b/charts/ai-platform-engineering/values-mcp-servers.yaml
@@ -5,14 +5,17 @@
 #     -f values.yaml \
 #     -f values-mcp-servers.yaml
 #
-# All entries are disabled by default (enabled: false).
-# To activate a server, override enabled: true and set the correct endpoint
-# in your deployment-specific values file.
+# All entries are disabled by default (enabled: false) with no endpoint set.
+# To activate a server in your deployment-specific values:
 #
-# Endpoint pattern when using the bundled mcp-* subcharts:
-#   http://<release>-mcp-<tool>-mcp.<namespace>.svc.cluster.local:8000/mcp
-# Example for release=caipe, namespace=caipe:
-#   http://caipe-mcp-argocd-mcp.caipe.svc.cluster.local:8000/mcp
+#   caipe-ui:
+#     appConfig:
+#       mcp_servers:
+#         - id: argocd
+#           enabled: true
+#           endpoint: "http://<release>-mcp-argocd-mcp.<namespace>.svc.cluster.local:8000/mcp"
+#           # e.g. for release=caipe, namespace=caipe:
+#           # endpoint: "http://caipe-mcp-argocd-mcp.caipe.svc.cluster.local:8000/mcp"
 
 caipe-ui:
   appConfig:
@@ -22,74 +25,74 @@ caipe-ui:
         name: "ArgoCD"
         description: "ArgoCD application and deployment management"
         transport: "http"
-        endpoint: "http://<release>-mcp-argocd-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "backstage"
         name: "Backstage"
         description: "Backstage service catalog and developer portal"
         transport: "http"
-        endpoint: "http://<release>-mcp-backstage-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "pagerduty"
         name: "PagerDuty"
         description: "PagerDuty incident management — incidents, services, on-call schedules"
         transport: "http"
-        endpoint: "http://<release>-mcp-pagerduty-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "splunk"
         name: "Splunk"
         description: "Splunk log search and analysis"
         transport: "http"
-        endpoint: "http://<release>-mcp-splunk-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "netutils"
         name: "Network Utilities"
         description: "Network diagnostic tools — ping, traceroute, DNS lookup"
         transport: "http"
-        endpoint: "http://<release>-mcp-netutils-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       # ── DevOps / CI-CD ─────────────────────────────────────────────────────
       - id: "github"
         name: "GitHub"
         description: "GitHub repository operations — search, file read/write, branches, PRs, issues, workflow runs"
         transport: "http"
-        endpoint: "http://<release>-mcp-github-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "gitlab"
         name: "GitLab"
         description: "GitLab repository operations — projects, pipelines, merge requests"
         transport: "http"
-        endpoint: "http://<release>-mcp-gitlab-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "jira"
         name: "Jira"
         description: "Jira issue tracking and project management"
         transport: "http"
-        endpoint: "http://<release>-mcp-jira-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "confluence"
         name: "Confluence"
         description: "Confluence wiki and documentation search"
         transport: "http"
-        endpoint: "http://<release>-mcp-confluence-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       # ── Infrastructure ─────────────────────────────────────────────────────
       - id: "aws"
         name: "AWS"
         description: "AWS read-only CLI and EKS kubectl operations"
         transport: "http"
-        endpoint: "http://<release>-mcp-aws-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       # ── Collaboration ──────────────────────────────────────────────────────
       - id: "slack"
         name: "Slack"
         description: "Slack messaging and channel operations"
         transport: "http"
-        endpoint: "http://<release>-mcp-slack-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false
       - id: "webex"
         name: "Webex"
         description: "Webex messaging and spaces"
         transport: "http"
-        endpoint: "http://<release>-mcp-webex-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        endpoint: ""
         enabled: false

--- a/charts/ai-platform-engineering/values-mcp-servers.yaml
+++ b/charts/ai-platform-engineering/values-mcp-servers.yaml
@@ -1,0 +1,95 @@
+# Optional overlay: seed the CAIPE UI with pre-configured MCP server entries.
+#
+# Usage:
+#   helm install caipe oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+#     -f values.yaml \
+#     -f values-mcp-servers.yaml
+#
+# All entries are disabled by default (enabled: false).
+# To activate a server, override enabled: true and set the correct endpoint
+# in your deployment-specific values file.
+#
+# Endpoint pattern when using the bundled mcp-* subcharts:
+#   http://<release>-mcp-<tool>-mcp.<namespace>.svc.cluster.local:8000/mcp
+# Example for release=caipe, namespace=caipe:
+#   http://caipe-mcp-argocd-mcp.caipe.svc.cluster.local:8000/mcp
+
+caipe-ui:
+  appConfig:
+    mcp_servers:
+      # ── SRE / Platform Operations ──────────────────────────────────────────
+      - id: "argocd"
+        name: "ArgoCD"
+        description: "ArgoCD application and deployment management"
+        transport: "http"
+        endpoint: "http://<release>-mcp-argocd-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "backstage"
+        name: "Backstage"
+        description: "Backstage service catalog and developer portal"
+        transport: "http"
+        endpoint: "http://<release>-mcp-backstage-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "pagerduty"
+        name: "PagerDuty"
+        description: "PagerDuty incident management — incidents, services, on-call schedules"
+        transport: "http"
+        endpoint: "http://<release>-mcp-pagerduty-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "splunk"
+        name: "Splunk"
+        description: "Splunk log search and analysis"
+        transport: "http"
+        endpoint: "http://<release>-mcp-splunk-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "netutils"
+        name: "Network Utilities"
+        description: "Network diagnostic tools — ping, traceroute, DNS lookup"
+        transport: "http"
+        endpoint: "http://<release>-mcp-netutils-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      # ── DevOps / CI-CD ─────────────────────────────────────────────────────
+      - id: "github"
+        name: "GitHub"
+        description: "GitHub repository operations — search, file read/write, branches, PRs, issues, workflow runs"
+        transport: "http"
+        endpoint: "http://<release>-mcp-github-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "gitlab"
+        name: "GitLab"
+        description: "GitLab repository operations — projects, pipelines, merge requests"
+        transport: "http"
+        endpoint: "http://<release>-mcp-gitlab-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "jira"
+        name: "Jira"
+        description: "Jira issue tracking and project management"
+        transport: "http"
+        endpoint: "http://<release>-mcp-jira-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "confluence"
+        name: "Confluence"
+        description: "Confluence wiki and documentation search"
+        transport: "http"
+        endpoint: "http://<release>-mcp-confluence-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      # ── Infrastructure ─────────────────────────────────────────────────────
+      - id: "aws"
+        name: "AWS"
+        description: "AWS read-only CLI and EKS kubectl operations"
+        transport: "http"
+        endpoint: "http://<release>-mcp-aws-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      # ── Collaboration ──────────────────────────────────────────────────────
+      - id: "slack"
+        name: "Slack"
+        description: "Slack messaging and channel operations"
+        transport: "http"
+        endpoint: "http://<release>-mcp-slack-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false
+      - id: "webex"
+        name: "Webex"
+        description: "Webex messaging and spaces"
+        transport: "http"
+        endpoint: "http://<release>-mcp-webex-mcp.<namespace>.svc.cluster.local:8000/mcp"
+        enabled: false


### PR DESCRIPTION
## Summary

- Adds `values-mcp-servers.yaml` — opt-in overlay that seeds the CAIPE UI with 12 pre-configured MCP server entries (ArgoCD, Backstage, PagerDuty, Splunk, netutils, GitHub, GitLab, Jira, Confluence, AWS, Slack, Webex). All `enabled: false` by default.
- Adds `values-agent-sre.yaml` — opt-in overlay that pre-configures a generic SRE agent wired to the SRE/infra MCP servers above. Also `enabled: false` by default.
- `values.yaml` is **unchanged** — nothing is pre-seeded unless overlays are explicitly included.

## Usage

```bash
# MCP servers only
helm install caipe oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
  -f values.yaml \
  -f values-mcp-servers.yaml

# MCP servers + SRE agent
helm install caipe oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
  -f values.yaml \
  -f values-mcp-servers.yaml \
  -f values-agent-sre.yaml
```

Enable specific entries in your deployment overlay:

```yaml
caipe-ui:
  appConfig:
    mcp_servers:
      - id: github
        enabled: true
        endpoint: http://caipe-mcp-github-mcp.caipe.svc.cluster.local:8000/mcp
    agents:
      - id: sre
        enabled: true
```

## Test plan

- [ ] `helm template` without overlays — confirm `mcp_servers` and `agents` are empty by default
- [ ] `helm template -f values-mcp-servers.yaml` — confirm 12 MCP entries appear, all disabled
- [ ] `helm template -f values-mcp-servers.yaml -f values-agent-sre.yaml` — confirm SRE agent appears, disabled
- [ ] Verify no changes to existing installs that omit the overlays

🤖 Generated with [Claude Code](https://claude.com/claude-code)