### PR TITLE
fix(mcp-argocd): use server-side pagination in list tools

### DIFF
--- a/ai_platform_engineering/mcp/argocd/tests/test_applications_none_handling.py
+++ b/ai_platform_engineering/mcp/argocd/tests/test_applications_none_handling.py
@@ -37,7 +37,7 @@ async def test_list_applications_with_none_data():
         result = await list_applications(summary_only=True)
         print(f"Result: {result}")
         assert result["items"] == [], "Should return empty list for None items"
-        assert result["pagination"]["has_next"] == False, "Should have no next page for None items"
+        assert not result["pagination"]["has_next"], "Should have no next page for None items"
         assert result["summary_only"], "Should preserve summary_only flag"
         print("✓ None items handled correctly")
 
@@ -49,7 +49,7 @@ async def test_list_applications_with_none_data():
         result = await list_applications(summary_only=True)
         print(f"Result: {result}")
         assert result["items"] == [], "Should return empty list for empty items"
-        assert result["pagination"]["has_next"] == False, "Should have no next page for empty items"
+        assert not result["pagination"]["has_next"], "Should have no next page for empty items"
         print("✓ Empty items list handled correctly")
 
     # Test 4: Valid data with applications
@@ -78,7 +78,7 @@ async def test_list_applications_with_none_data():
         result = await list_applications(summary_only=True)
         print(f"Result: {result}")
         assert len(result["items"]) == 1, "Should return one application"
-        assert result["pagination"]["has_next"] == False, "Should have no next page for single item"
+        assert not result["pagination"]["has_next"], "Should have no next page for single item"
         assert result["items"][0]["name"] == "test-app", "Should extract application name correctly"
         print("✓ Valid data handled correctly")
 

--- a/ai_platform_engineering/mcp/argocd/tests/test_applications_none_handling.py
+++ b/ai_platform_engineering/mcp/argocd/tests/test_applications_none_handling.py
@@ -37,7 +37,7 @@ async def test_list_applications_with_none_data():
         result = await list_applications(summary_only=True)
         print(f"Result: {result}")
         assert result["items"] == [], "Should return empty list for None items"
-        assert result["pagination"]["total_items"] == 0, "Should return 0 total for None items"
+        assert result["pagination"]["has_next"] == False, "Should have no next page for None items"
         assert result["summary_only"], "Should preserve summary_only flag"
         print("✓ None items handled correctly")
 
@@ -49,7 +49,7 @@ async def test_list_applications_with_none_data():
         result = await list_applications(summary_only=True)
         print(f"Result: {result}")
         assert result["items"] == [], "Should return empty list for empty items"
-        assert result["pagination"]["total_items"] == 0, "Should return 0 total for empty items"
+        assert result["pagination"]["has_next"] == False, "Should have no next page for empty items"
         print("✓ Empty items list handled correctly")
 
     # Test 4: Valid data with applications
@@ -78,7 +78,7 @@ async def test_list_applications_with_none_data():
         result = await list_applications(summary_only=True)
         print(f"Result: {result}")
         assert len(result["items"]) == 1, "Should return one application"
-        assert result["pagination"]["total_items"] == 1, "Should return correct total"
+        assert result["pagination"]["has_next"] == False, "Should have no next page for single item"
         assert result["items"][0]["name"] == "test-app", "Should extract application name correctly"
         print("✓ Valid data handled correctly")
 

--- a/ai_platform_engineering/mcp/argocd/tests/test_projects.py
+++ b/ai_platform_engineering/mcp/argocd/tests/test_projects.py
@@ -82,7 +82,7 @@ async def test_project_list():
         result = await project_list(summary_only=True)
         print(f"Result: {result}")
         assert result["items"] == [], "Should return empty list"
-        assert result["pagination"]["has_next"] == False, "Should have no next page"
+        assert not result["pagination"]["has_next"], "Should have no next page"
         print("✓ Empty projects list handled correctly")
 
     print("\n✅ All project list tests passed!")

--- a/ai_platform_engineering/mcp/argocd/tests/test_projects.py
+++ b/ai_platform_engineering/mcp/argocd/tests/test_projects.py
@@ -82,7 +82,7 @@ async def test_project_list():
         result = await project_list(summary_only=True)
         print(f"Result: {result}")
         assert result["items"] == [], "Should return empty list"
-        assert result["pagination"]["total_items"] == 0, "Should return zero total"
+        assert result["pagination"]["has_next"] == False, "Should have no next page"
         print("✓ Empty projects list handled correctly")
 
     print("\n✅ All project list tests passed!")

--- a/ai_platform_engineering/mcp/argocd/tools/api_v1_applications.py
+++ b/ai_platform_engineering/mcp/argocd/tools/api_v1_applications.py
@@ -197,12 +197,16 @@ async def list_applications(
     # ArgoCD returns metadata.continue when there are more pages
     next_token = (data.get("metadata") or {}).get("continue", "")
 
+    remaining = (data.get("metadata") or {}).get("remainingItemCount")
+
     pagination_meta: Dict[str, Any] = {
         "page_size": page_size,
         "has_next": bool(next_token),
     }
     if next_token:
         pagination_meta["continue_token"] = next_token
+    if remaining is not None:
+        pagination_meta["remaining_items"] = remaining
 
     argocd_base_url = _get_argocd_base_url()
 

--- a/ai_platform_engineering/mcp/argocd/tools/api_v1_applications.py
+++ b/ai_platform_engineering/mcp/argocd/tools/api_v1_applications.py
@@ -131,11 +131,14 @@ async def list_applications(
     namespace: str = "",
     refresh: str = "",
     summary_only: bool = True,
-    page: int = 1,
     page_size: int = 20,
+    continue_token: str = "",
 ) -> Dict[str, Any]:
     """
-    List applications in ArgoCD with filtering and pagination options
+    List applications in ArgoCD with filtering and server-side pagination.
+
+    Uses ArgoCD's native limit/continue pagination so only one page of apps is
+    fetched per call — avoids transferring hundreds of apps in a single response.
 
     Args:
         project: Filter applications by project name
@@ -144,24 +147,27 @@ async def list_applications(
         namespace: Filter applications by namespace
         refresh: Forces application reconciliation if set to 'hard' or 'normal'
         summary_only: If True, return only summary information (default: True)
-        page: Page number (1-indexed, default: 1)
         page_size: Number of items per page (default: 20, max: 100)
+        continue_token: Opaque token from a previous response's pagination.continue_token
+                        to fetch the next page. Omit (or pass "") for the first page.
 
     Returns:
         Paginated list of applications with metadata:
         {
             "items": [...],
             "pagination": {
-                "page": 1,
                 "page_size": 20,
-                "total_items": 819,
-                "total_pages": 41,
                 "has_next": true,
-                "has_prev": false
+                "continue_token": "<opaque>"  // pass this to get the next page; absent on last page
             }
         }
     """
-    params = {}
+    page_size = min(100, max(1, page_size))
+
+    params: Dict[str, Any] = {"limit": page_size}
+
+    if continue_token:
+        params["continue"] = continue_token
 
     if project:
         params["project"] = project
@@ -183,72 +189,26 @@ async def list_applications(
     if not success:
         return {"error": data.get("error", "Failed to retrieve applications")}
 
-    # Handle None data
     if data is None:
         return {"error": "No data received from API"}
 
-    # Handle None items
-    if data.get("items") is None:
-        response = {
-            "items": [],
-            "pagination": {
-                "page": page,
-                "page_size": page_size,
-                "total_items": 0,
-                "total_pages": 0,
-                "has_next": False,
-                "has_prev": False
-            }
-        }
-        if summary_only:
-            response["summary_only"] = True
-        return response
+    items = data.get("items") or []
 
-    # Enforce pagination limits
-    page = max(1, page)  # Ensure page is at least 1
-    page_size = min(100, max(1, page_size))  # Enforce max 100 items per page
+    # ArgoCD returns metadata.continue when there are more pages
+    next_token = (data.get("metadata") or {}).get("continue", "")
 
-    all_items = data.get("items", [])
-    total_items = len(all_items)
-    total_pages = (total_items + page_size - 1) // page_size  # Ceiling division
-
-    # Calculate pagination slice
-    start_idx = (page - 1) * page_size
-    end_idx = start_idx + page_size
-
-    # Check if page is out of bounds
-    if start_idx >= total_items and total_items > 0:
-        return {
-            "error": f"Page {page} out of bounds. Total pages: {total_pages}",
-            "pagination": {
-                "page": page,
-                "page_size": page_size,
-                "total_items": total_items,
-                "total_pages": total_pages,
-                "has_next": False,
-                "has_prev": page > 1
-            }
-        }
-
-    paginated_items = all_items[start_idx:end_idx]
-
-    # Build pagination metadata
-    pagination_meta = {
-        "page": page,
+    pagination_meta: Dict[str, Any] = {
         "page_size": page_size,
-        "total_items": total_items,
-        "total_pages": total_pages,
-        "has_next": page < total_pages,
-        "has_prev": page > 1,
-        "showing_from": start_idx + 1 if paginated_items else 0,
-        "showing_to": start_idx + len(paginated_items)
+        "has_next": bool(next_token),
     }
+    if next_token:
+        pagination_meta["continue_token"] = next_token
 
-    # If summary_only is True, return only essential information
+    argocd_base_url = _get_argocd_base_url()
+
     if summary_only:
         summary_items = []
-        argocd_base_url = _get_argocd_base_url()
-        for app in paginated_items:
+        for app in items:
             app_name = app.get("metadata", {}).get("name", "")
             app_namespace = app.get("metadata", {}).get("namespace", "")
             summary_item = {
@@ -262,28 +222,23 @@ async def list_applications(
                 "health_status": app.get("status", {}).get("health", {}).get("status", ""),
                 "phase": app.get("status", {}).get("phase", ""),
             }
-            # Add ArgoCD link using common helper
             summary_item = _add_argocd_link_to_app(summary_item)
             summary_items.append(summary_item)
 
-        # Ensure base URL is in response
         return {
             "items": summary_items,
             "pagination": pagination_meta,
             "summary_only": True,
-            "argocd_base_url": argocd_base_url
+            "argocd_base_url": argocd_base_url,
         }
 
-    # Add ArgoCD links to full items using common helper
-    argocd_base_url = _get_argocd_base_url()
-    for app in paginated_items:
+    for app in items:
         _add_argocd_link_to_app(app)
 
-    # Ensure base URL is in response
     return {
-        "items": paginated_items,
+        "items": items,
         "pagination": pagination_meta,
-        "argocd_base_url": argocd_base_url
+        "argocd_base_url": argocd_base_url,
     }
 
 

--- a/ai_platform_engineering/mcp/argocd/tools/api_v1_applicationsets.py
+++ b/ai_platform_engineering/mcp/argocd/tools/api_v1_applicationsets.py
@@ -14,12 +14,12 @@ logger = logging.getLogger("mcp_tools")
 
 
 async def applicationset_list(
-    param_projects: List[str] = None, 
-    param_selector: str = None, 
-    param_appsetNamespace: str = None, 
+    param_projects: List[str] = None,
+    param_selector: str = None,
+    param_appsetNamespace: str = None,
     summary_only: bool = True,
-    page: int = 1,
-    page_size: int = 20
+    page_size: int = 20,
+    continue_token: str = "",
 ) -> Dict[str, Any]:
     '''
     List returns a paginated list of applicationsets.
@@ -29,27 +29,27 @@ async def applicationset_list(
         param_selector (str, optional): The selector to restrict the returned list to applications only with matched labels. Defaults to None.
         param_appsetNamespace (str, optional): The application set namespace. If not provided, defaults to the ArgoCD control plane namespace. Defaults to None.
         summary_only (bool, optional): If True, return only summary information (default: True).
-        page (int, optional): Page number (1-indexed, default: 1).
         page_size (int, optional): Number of items per page (default: 20, max: 100).
+        continue_token (str, optional): Opaque token from a previous response's
+            pagination.continue_token to fetch the next page. Omit for the first page.
 
     Returns:
         Dict[str, Any]: Paginated list of applicationsets with metadata:
         {
             "items": [...],
             "pagination": {
-                "page": 1,
                 "page_size": 20,
-                "total_items": 50,
-                "total_pages": 3,
                 "has_next": true,
-                "has_prev": false
+                "continue_token": "<opaque>"  // absent on last page
             }
         }
     '''
     logger.debug("Making GET request to /api/v1/applicationsets")
 
-    params = {}
-    data = {}
+    page_size = min(100, max(1, page_size))
+    params: Dict[str, Any] = {"limit": page_size}
+    if continue_token:
+        params["continue"] = continue_token
 
     if param_projects is not None:
         params["projects"] = str(param_projects).lower() if isinstance(param_projects, bool) else param_projects
@@ -62,8 +62,7 @@ async def applicationset_list(
             str(param_appsetNamespace).lower() if isinstance(param_appsetNamespace, bool) else param_appsetNamespace
         )
 
-    flat_body = {}
-    data = assemble_nested_body(flat_body)
+    data = assemble_nested_body({})
 
     success, response = await make_api_request("/api/v1/applicationsets", method="GET", params=params, data=data)
 
@@ -71,51 +70,24 @@ async def applicationset_list(
         logger.error(f"Request failed: {response.get('error')}")
         return {"error": response.get("error", "Request failed")}
 
-    # Enforce pagination limits
-    page = max(1, page)
-    page_size = min(100, max(1, page_size))
+    items = response.get("items") or []
+    next_token = (response.get("metadata") or {}).get("continue", "")
 
-    all_items = response.get("items", [])
-    total_items = len(all_items)
-    total_pages = (total_items + page_size - 1) // page_size
+    remaining = (response.get("metadata") or {}).get("remainingItemCount")
 
-    # Calculate pagination slice
-    start_idx = (page - 1) * page_size
-    end_idx = start_idx + page_size
-    
-    # Check if page is out of bounds
-    if start_idx >= total_items and total_items > 0:
-        return {
-            "error": f"Page {page} out of bounds. Total pages: {total_pages}",
-            "pagination": {
-                "page": page,
-                "page_size": page_size,
-                "total_items": total_items,
-                "total_pages": total_pages,
-                "has_next": False,
-                "has_prev": page > 1
-            }
-        }
-
-    paginated_items = all_items[start_idx:end_idx]
-
-    # Build pagination metadata
-    pagination_meta = {
-        "page": page,
+    pagination_meta: Dict[str, Any] = {
         "page_size": page_size,
-        "total_items": total_items,
-        "total_pages": total_pages,
-        "has_next": page < total_pages,
-        "has_prev": page > 1,
-        "showing_from": start_idx + 1 if paginated_items else 0,
-        "showing_to": start_idx + len(paginated_items)
+        "has_next": bool(next_token),
     }
+    if next_token:
+        pagination_meta["continue_token"] = next_token
+    if remaining is not None:
+        pagination_meta["remaining_items"] = remaining
 
-    # If summary_only is True, return only essential information
     if summary_only:
         summary_items = []
-        for appset in paginated_items:
-            summary_item = {
+        for appset in items:
+            summary_items.append({
                 "name": appset.get("metadata", {}).get("name", ""),
                 "namespace": appset.get("metadata", {}).get("namespace", ""),
                 "generation": appset.get("metadata", {}).get("generation", ""),
@@ -131,18 +103,17 @@ async def applicationset_list(
                 "sync_policy": appset.get("spec", {}).get("syncPolicy", {}),
                 "phase": appset.get("status", {}).get("phase", ""),
                 "conditions": appset.get("status", {}).get("conditions", []),
-            }
-            summary_items.append(summary_item)
+            })
 
         return {
             "items": summary_items,
             "pagination": pagination_meta,
-            "summary_only": True
+            "summary_only": True,
         }
 
     return {
-        "items": paginated_items,
-        "pagination": pagination_meta
+        "items": items,
+        "pagination": pagination_meta,
     }
 
 

--- a/ai_platform_engineering/mcp/argocd/tools/api_v1_clusters.py
+++ b/ai_platform_engineering/mcp/argocd/tools/api_v1_clusters.py
@@ -14,13 +14,13 @@ logger = logging.getLogger("mcp_tools")
 
 
 async def cluster_service__list(
-    param_server: str = None, 
-    param_name: str = None, 
-    param_id_type: str = None, 
+    param_server: str = None,
+    param_name: str = None,
+    param_id_type: str = None,
     param_id_value: str = None,
     summary_only: bool = True,
-    page: int = 1,
-    page_size: int = 20
+    page_size: int = 20,
+    continue_token: str = "",
 ) -> Dict[str, Any]:
     '''
     List returns a paginated list of clusters.
@@ -31,27 +31,27 @@ async def cluster_service__list(
         param_id_type (str, optional): Type of the specified cluster identifier ("server" - default, "name"). Defaults to None.
         param_id_value (str, optional): Value holds the cluster server URL or cluster name. Defaults to None.
         summary_only (bool, optional): If True, return only summary information (default: True).
-        page (int, optional): Page number (1-indexed, default: 1).
         page_size (int, optional): Number of items per page (default: 20, max: 100).
+        continue_token (str, optional): Opaque token from a previous response's
+            pagination.continue_token to fetch the next page. Omit for the first page.
 
     Returns:
         Dict[str, Any]: Paginated list of clusters with metadata:
         {
             "items": [...],
             "pagination": {
-                "page": 1,
                 "page_size": 20,
-                "total_items": 15,
-                "total_pages": 1,
                 "has_next": false,
-                "has_prev": false
+                "continue_token": "<opaque>"  // absent on last page
             }
         }
     '''
     logger.debug("Making GET request to /api/v1/clusters")
 
-    params = {}
-    data = {}
+    page_size = min(100, max(1, page_size))
+    params: Dict[str, Any] = {"limit": page_size}
+    if continue_token:
+        params["continue"] = continue_token
 
     if param_server is not None:
         params["server"] = str(param_server).lower() if isinstance(param_server, bool) else param_server
@@ -65,8 +65,7 @@ async def cluster_service__list(
     if param_id_value is not None:
         params["id_value"] = str(param_id_value).lower() if isinstance(param_id_value, bool) else param_id_value
 
-    flat_body = {}
-    data = assemble_nested_body(flat_body)
+    data = assemble_nested_body({})
 
     success, response = await make_api_request("/api/v1/clusters", method="GET", params=params, data=data)
 
@@ -74,51 +73,24 @@ async def cluster_service__list(
         logger.error(f"Request failed: {response.get('error')}")
         return {"error": response.get("error", "Request failed")}
 
-    # Enforce pagination limits
-    page = max(1, page)
-    page_size = min(100, max(1, page_size))
+    items = response.get("items") or []
+    next_token = (response.get("metadata") or {}).get("continue", "")
 
-    all_items = response.get("items", [])
-    total_items = len(all_items)
-    total_pages = (total_items + page_size - 1) // page_size
+    remaining = (response.get("metadata") or {}).get("remainingItemCount")
 
-    # Calculate pagination slice
-    start_idx = (page - 1) * page_size
-    end_idx = start_idx + page_size
-    
-    # Check if page is out of bounds
-    if start_idx >= total_items and total_items > 0:
-        return {
-            "error": f"Page {page} out of bounds. Total pages: {total_pages}",
-            "pagination": {
-                "page": page,
-                "page_size": page_size,
-                "total_items": total_items,
-                "total_pages": total_pages,
-                "has_next": False,
-                "has_prev": page > 1
-            }
-        }
-
-    paginated_items = all_items[start_idx:end_idx]
-
-    # Build pagination metadata
-    pagination_meta = {
-        "page": page,
+    pagination_meta: Dict[str, Any] = {
         "page_size": page_size,
-        "total_items": total_items,
-        "total_pages": total_pages,
-        "has_next": page < total_pages,
-        "has_prev": page > 1,
-        "showing_from": start_idx + 1 if paginated_items else 0,
-        "showing_to": start_idx + len(paginated_items)
+        "has_next": bool(next_token),
     }
+    if next_token:
+        pagination_meta["continue_token"] = next_token
+    if remaining is not None:
+        pagination_meta["remaining_items"] = remaining
 
-    # If summary_only is True, return only essential information
     if summary_only:
         summary_items = []
-        for cluster in paginated_items:
-            summary_item = {
+        for cluster in items:
+            summary_items.append({
                 "name": cluster.get("name", ""),
                 "server": cluster.get("server", ""),
                 "namespaces": cluster.get("namespaces", []),
@@ -130,18 +102,17 @@ async def cluster_service__list(
                 "server_version": cluster.get("info", {}).get("serverVersion", ""),
                 "connection_status": cluster.get("info", {}).get("connectionState", {}).get("status", ""),
                 "applications_count": cluster.get("info", {}).get("applicationsCount", 0),
-            }
-            summary_items.append(summary_item)
+            })
 
         return {
             "items": summary_items,
             "pagination": pagination_meta,
-            "summary_only": True
+            "summary_only": True,
         }
 
     return {
-        "items": paginated_items,
-        "pagination": pagination_meta
+        "items": items,
+        "pagination": pagination_meta,
     }
 
 

--- a/ai_platform_engineering/mcp/argocd/tools/api_v1_projects.py
+++ b/ai_platform_engineering/mcp/argocd/tools/api_v1_projects.py
@@ -14,10 +14,10 @@ logger = logging.getLogger("mcp_tools")
 
 
 async def project_list(
-    param_name: str = None, 
-    summary_only: bool = True, 
-    page: int = 1,
-    page_size: int = 20
+    param_name: str = None,
+    summary_only: bool = True,
+    page_size: int = 20,
+    continue_token: str = "",
 ) -> Dict[str, Any]:
     '''
     List returns a paginated list of projects.
@@ -25,33 +25,32 @@ async def project_list(
     Args:
         param_name (str, optional): Filter by project name. Defaults to None.
         summary_only (bool, optional): If True, return only summary information (default: True).
-        page (int, optional): Page number (1-indexed, default: 1).
         page_size (int, optional): Number of items per page (default: 20, max: 100).
+        continue_token (str, optional): Opaque token from a previous response's
+            pagination.continue_token to fetch the next page. Omit for the first page.
 
     Returns:
         Dict[str, Any]: Paginated list of projects with metadata:
         {
             "items": [...],
             "pagination": {
-                "page": 1,
                 "page_size": 20,
-                "total_items": 50,
-                "total_pages": 3,
                 "has_next": true,
-                "has_prev": false
+                "continue_token": "<opaque>"  // absent on last page
             }
         }
     '''
     logger.debug("Making GET request to /api/v1/projects")
 
-    params = {}
-    data = {}
+    page_size = min(100, max(1, page_size))
+    params: Dict[str, Any] = {"limit": page_size}
+    if continue_token:
+        params["continue"] = continue_token
 
     if param_name is not None:
         params["name"] = str(param_name).lower() if isinstance(param_name, bool) else param_name
 
-    flat_body = {}
-    data = assemble_nested_body(flat_body)
+    data = assemble_nested_body({})
 
     success, response = await make_api_request("/api/v1/projects", method="GET", params=params, data=data)
 
@@ -59,51 +58,24 @@ async def project_list(
         logger.error(f"Request failed: {response.get('error')}")
         return {"error": response.get("error", "Request failed")}
 
-    # Enforce pagination limits
-    page = max(1, page)
-    page_size = min(100, max(1, page_size))
+    items = response.get("items") or []
+    next_token = (response.get("metadata") or {}).get("continue", "")
 
-    all_items = response.get("items", [])
-    total_items = len(all_items)
-    total_pages = (total_items + page_size - 1) // page_size
+    remaining = (response.get("metadata") or {}).get("remainingItemCount")
 
-    # Calculate pagination slice
-    start_idx = (page - 1) * page_size
-    end_idx = start_idx + page_size
-    
-    # Check if page is out of bounds
-    if start_idx >= total_items and total_items > 0:
-        return {
-            "error": f"Page {page} out of bounds. Total pages: {total_pages}",
-            "pagination": {
-                "page": page,
-                "page_size": page_size,
-                "total_items": total_items,
-                "total_pages": total_pages,
-                "has_next": False,
-                "has_prev": page > 1
-            }
-        }
-
-    paginated_items = all_items[start_idx:end_idx]
-
-    # Build pagination metadata
-    pagination_meta = {
-        "page": page,
+    pagination_meta: Dict[str, Any] = {
         "page_size": page_size,
-        "total_items": total_items,
-        "total_pages": total_pages,
-        "has_next": page < total_pages,
-        "has_prev": page > 1,
-        "showing_from": start_idx + 1 if paginated_items else 0,
-        "showing_to": start_idx + len(paginated_items)
+        "has_next": bool(next_token),
     }
+    if next_token:
+        pagination_meta["continue_token"] = next_token
+    if remaining is not None:
+        pagination_meta["remaining_items"] = remaining
 
-    # If summary_only is True, return only essential information
     if summary_only:
         summary_items = []
-        for project in paginated_items:
-            summary_item = {
+        for project in items:
+            summary_items.append({
                 "name": project.get("metadata", {}).get("name", ""),
                 "description": project.get("spec", {}).get("description", ""),
                 "source_repos": project.get("spec", {}).get("sourceRepos", []),
@@ -117,18 +89,17 @@ async def project_list(
                 "creation_timestamp": project.get("metadata", {}).get("creationTimestamp", ""),
                 "generation": project.get("metadata", {}).get("generation", ""),
                 "resource_version": project.get("metadata", {}).get("resourceVersion", ""),
-            }
-            summary_items.append(summary_item)
+            })
 
         return {
             "items": summary_items,
             "pagination": pagination_meta,
-            "summary_only": True
+            "summary_only": True,
         }
 
     return {
-        "items": paginated_items,
-        "pagination": pagination_meta
+        "items": items,
+        "pagination": pagination_meta,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.47-dev.1"
+version = "0.5.47-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.47.dev1"
+version = "0.5.47.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- list_applications, project_list, cluster_service__list, and applicationset_list all fetched the entire collection in one request and sliced in Python
- With large deployments (983+ apps), the single chunked response caused `body error: error reading a body from connection` failures in agentgateway
- All four list tools now use ArgoCD native `?limit=N&continue=<token>` server-side pagination — each call only fetches the requested page

## Interface change

Old: `page + page_size` (page-number-based, fetches all then slices in Python)
New: `page_size + continue_token` (cursor-based, server-side limit)

Response pagination object:
- `page_size`: items returned this call
- `has_next`: true if more pages exist
- `continue_token`: pass back to get next page (absent on last page)
- `remaining_items`: items after this page when ArgoCD provides it

## Files changed

- `ai_platform_engineering/mcp/argocd/tools/api_v1_applications.py`
- `ai_platform_engineering/mcp/argocd/tools/api_v1_projects.py`
- `ai_platform_engineering/mcp/argocd/tools/api_v1_clusters.py`
- `ai_platform_engineering/mcp/argocd/tools/api_v1_applicationsets.py`

## Test plan
- `list_applications()` returns up to 20 apps and a `continue_token`
- `list_applications(continue_token=X)` returns the next 20 apps
- Last page has `has_next: false` and no `continue_token`
- Filters (`project`, `name`, `repo`) still work
- No more `body error` in agentgateway when paginating large app lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)