### PR TITLE
fix(rbac): stop splitting Slack bot/user names on spaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.47-dev.1"
+version = "0.5.47-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/admin/rebac/slack/SlackUserTokenInput.tsx
+++ b/ui/src/components/admin/rebac/slack/SlackUserTokenInput.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect,useMemo,useState } from "react";
+import { useEffect,useState } from "react";
 
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { joinList,splitList } from "./slack-route-draft";
 
 interface SlackUserSuggestion {
   id: string;
@@ -21,13 +20,13 @@ export function SlackUserTokenInput({
   kind = "all",
 }: {
   label: string;
-  value: string;
-  onChange: (value: string) => void;
+  value: string[];
+  onChange: (value: string[]) => void;
   disabled: boolean;
   placeholder: string;
   kind?: "all" | "bots";
 }) {
-  const selectedIds = useMemo(() => splitList(value), [value]);
+  const selectedIds = value;
   const [query, setQuery] = useState("");
   const [suggestions, setSuggestions] = useState<SlackUserSuggestion[]>([]);
   const [lookupStatus, setLookupStatus] = useState<"idle" | "searching" | "ready" | "empty" | "error">("idle");
@@ -75,19 +74,19 @@ export function SlackUserTokenInput({
 
   const addUser = (user: SlackUserSuggestion) => {
     setKnownUsers((prev) => ({ ...prev, [user.id]: user }));
-    onChange(joinList([...selectedIds, user.id]));
+    onChange([...selectedIds, user.id]);
     setQuery("");
     closeLookup();
   };
 
   const addRawId = (id: string) => {
-    onChange(joinList([...selectedIds, id]));
+    onChange([...selectedIds, id]);
     setQuery("");
     closeLookup();
   };
 
   const removeId = (id: string) => {
-    onChange(joinList(selectedIds.filter((candidate) => candidate !== id)));
+    onChange(selectedIds.filter((candidate) => candidate !== id));
   };
 
   return (

--- a/ui/src/components/admin/rebac/slack/slack-route-draft.ts
+++ b/ui/src/components/admin/rebac/slack/slack-route-draft.ts
@@ -11,7 +11,7 @@ export const DEFAULT_OVERTHINK_SKIP_MARKERS = "DEFER, LOW_CONFIDENCE";
 export interface RouteSideDraft {
   enabled: boolean;
   listen: ListenMode;
-  allowList: string;
+  allowList: string[];
   overthinkEnabled: boolean;
   overthinkSkipMarkers: string;
   overthinkFollowupPrompt: string;
@@ -22,8 +22,8 @@ export interface RouteEscalationDraft {
   victoropsTeam: string;
   emojiEnabled: boolean;
   emojiName: string;
-  users: string;
-  deleteAdmins: string;
+  users: string[];
+  deleteAdmins: string[];
 }
 
 export interface RouteDraft {
@@ -44,7 +44,7 @@ export interface RouteDraft {
 }
 
 export function splitList(value: string): string[] {
-  return Array.from(new Set(value.split(/[\s,]+/).map((v) => v.trim()).filter(Boolean)));
+  return Array.from(new Set(value.split(",").map((v) => v.trim()).filter(Boolean)));
 }
 
 export function joinList(value: string[] | undefined): string {
@@ -55,7 +55,7 @@ export function emptySideDraft(listen: ListenMode = "mention"): RouteSideDraft {
   return {
     enabled: false,
     listen,
-    allowList: "",
+    allowList: [],
     overthinkEnabled: false,
     overthinkSkipMarkers: DEFAULT_OVERTHINK_SKIP_MARKERS,
     overthinkFollowupPrompt: "",
@@ -76,8 +76,8 @@ export function emptyRouteDraft(): RouteDraft {
       victoropsTeam: "",
       emojiEnabled: false,
       emojiName: "eyes",
-      users: "",
-      deleteAdmins: "",
+      users: [],
+      deleteAdmins: [],
     },
     executionMode: "obo_user",
     executionServiceAccountSub: "",
@@ -94,7 +94,7 @@ function sideToDraft(
   return {
     enabled: side.enabled !== false,
     listen: side.listen ?? fallbackListen,
-    allowList: joinList(side[listKey]),
+    allowList: side[listKey] ?? [],
     overthinkEnabled: Boolean(side.overthink?.enabled),
     overthinkSkipMarkers: joinList(side.overthink?.skip_markers) || DEFAULT_OVERTHINK_SKIP_MARKERS,
     overthinkFollowupPrompt: side.overthink?.followup_prompt ?? "",
@@ -120,8 +120,8 @@ export function routeToDraft(route: ItemAgentRoute): RouteDraft {
       victoropsTeam: esc?.victorops?.team ?? "",
       emojiEnabled: Boolean(esc?.emoji?.enabled),
       emojiName: esc?.emoji?.name ?? "eyes",
-      users: joinList(esc?.users),
-      deleteAdmins: joinList(esc?.delete_admins),
+      users: esc?.users ?? [],
+      deleteAdmins: esc?.delete_admins ?? [],
     },
     executionMode,
     executionServiceAccountSub: eid?.service_account_sub ?? "",
@@ -130,7 +130,7 @@ export function routeToDraft(route: ItemAgentRoute): RouteDraft {
 }
 
 function sideDraftToConfig(draft: RouteSideDraft, enabled: boolean, listKey: "user_list" | "bot_list"): RouteSideConfig {
-  const list = splitList(draft.allowList);
+  const list = draft.allowList;
   const overthink = draft.overthinkEnabled || draft.overthinkSkipMarkers || draft.overthinkFollowupPrompt
     ? {
         enabled: draft.overthinkEnabled,
@@ -151,8 +151,8 @@ export type DraftRoutePayload = ItemAgentRoute & { execution_identity?: SlackRou
 
 export function draftToRoute(draft: RouteDraft): DraftRoutePayload {
   const esc = draft.escalation;
-  const escalationUsers = splitList(esc.users);
-  const deleteAdmins = splitList(esc.deleteAdmins);
+  const escalationUsers = esc.users;
+  const deleteAdmins = esc.deleteAdmins;
   const escalation: RouteEscalationConfig | undefined = draft.escalationEnabled
     ? {
         ...(esc.victoropsEnabled || esc.victoropsTeam
@@ -205,8 +205,8 @@ export function routeDraftErrorMap(draft: RouteDraft): Record<string, string> {
     const esc = draft.escalation;
     const hasVictorops = esc.victoropsEnabled || esc.victoropsTeam.trim();
     const hasEmoji = esc.emojiEnabled || esc.emojiName.trim();
-    const hasUsers = splitList(esc.users).length > 0;
-    const hasDeleteAdmins = splitList(esc.deleteAdmins).length > 0;
+    const hasUsers = esc.users.length > 0;
+    const hasDeleteAdmins = esc.deleteAdmins.length > 0;
     if (!hasVictorops && !hasEmoji && !hasUsers && !hasDeleteAdmins) errors.escalation = "Configure at least one escalation action, or turn Escalation off.";
     if (esc.victoropsEnabled && !esc.victoropsTeam.trim()) errors.victoropsTeam = "VictorOps team is required.";
     if (esc.emojiEnabled && !esc.emojiName.trim()) errors.emojiName = "Emoji name is required.";

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.47.dev1"
+version = "0.5.47.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Slack route allow-lists (bots/users) and escalation user lists (ping users, delete admins) are now stored and edited as arrays end-to-end instead of comma/space-joined strings.
- A multi-word name like "My Bot" can no longer be parsed apart into separate entries ("My", "Bot") when typed into the token input or round-tripped through the route editor.
- `splitList`/`joinList` remain only for the free-text overthink skip-markers field, which is legitimately comma-separated.

## Test plan
- [x] `npx jest rebac --silent` — 197/197 tests pass
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` — succeeds
- [ ] Manually verify in a deployed UI: add a bot/user name containing a space to a Slack route and confirm it's stored as a single list entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)