### PR TITLE
fix(rbac): register real Keycloak federated identity for Okta-sync users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.47-dev.1"
+version = "0.5.47-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/env.example
+++ b/ui/env.example
@@ -92,6 +92,13 @@ OIDC_REQUIRED_ADMIN_GROUP=
 # IDENTITY_SYNC_OKTA_OAUTH_CLIENT_ID=
 # IDENTITY_SYNC_OKTA_OAUTH_KEY_ID=
 # IDENTITY_SYNC_OKTA_OAUTH_PRIVATE_KEY=
+#
+# Keycloak identity-provider alias the sync should register federated-identity
+# links against, so synced users are treated as IdP-linked without requiring
+# an interactive SSO login first. Must match the alias configured on the
+# Keycloak realm's Okta broker (check Admin > Identity Providers). Defaults
+# to "okta".
+# IDENTITY_SYNC_OKTA_KEYCLOAK_IDP_ALIAS=okta
 
 # Support contact email for access requests and help
 # Displayed on unauthorized page and error screens

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/okta-directory-connector.test.ts
@@ -122,7 +122,13 @@ describe("Okta directory connector (SDK-based)", () => {
         display_name: "Engineering Platform Users",
         member_count: 1,
         members: [
-          { subject: undefined, email: "bob@example.test", display_name: "Bob Example", active: true },
+          {
+            subject: undefined,
+            email: "bob@example.test",
+            okta_user_id: "00u-bob",
+            display_name: "Bob Example",
+            active: true,
+          },
         ],
       }),
     ]);
@@ -170,8 +176,20 @@ describe("Okta directory connector (SDK-based)", () => {
     const [group] = await fetchOktaExternalGroups({ providerId: "okta-main" });
 
     expect(group.members).toEqual([
-      { subject: undefined, email: "gone@example.test", display_name: "gone@example.test", active: false },
-      { subject: undefined, email: "ok@example.test", display_name: "ok@example.test", active: true },
+      {
+        subject: undefined,
+        email: "gone@example.test",
+        okta_user_id: "u1",
+        display_name: "gone@example.test",
+        active: false,
+      },
+      {
+        subject: undefined,
+        email: "ok@example.test",
+        okta_user_id: "u2",
+        display_name: "ok@example.test",
+        active: true,
+      },
     ]);
   });
 

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -20,7 +20,7 @@ import {
   reapStaleIdpSyncRuns,
   updateIdpSyncRun,
 } from "@/lib/rbac/idp-sync-store";
-import { provisionShellUser } from "@/lib/rbac/keycloak-admin";
+import { linkFederatedIdentity, provisionShellUser } from "@/lib/rbac/keycloak-admin";
 import { stripArchivedTeamResourceGrants } from "@/lib/rbac/archived-team-grants";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
@@ -162,8 +162,21 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // subject (they only know the directory identity); without this the planner
     // skips everyone as `missing_subject`. Cached per run so a user appearing in
     // many groups is resolved once.
+    //
+    // For Okta specifically, also register a real Keycloak federated-identity
+    // link using the member's Okta user id — identical to what Keycloak's OIDC
+    // broker would write on an actual SSO login (Okta's default `sub` claim is
+    // its Users API `id`). Without this, sync-provisioned users have no
+    // federatedIdentities entry until they sign in once, which is what makes
+    // consumers that gate on "is this user federated" (e.g. the Slack bot's
+    // unlinked-fallback check) treat them as unlinked even though the directory
+    // sync already vouches for their identity.
+    const idpAlias = process.env.IDENTITY_SYNC_OKTA_KEYCLOAK_IDP_ALIAS?.trim() || "okta";
     const subCache = new Map<string, string | null>();
-    for (const group of groups as Array<{ members?: Array<{ email?: string; active?: boolean; subject?: string; display_name?: string }> }>) {
+    const linkedCache = new Set<string>();
+    for (const group of groups as Array<{
+      members?: Array<{ email?: string; active?: boolean; subject?: string; display_name?: string; okta_user_id?: string }>;
+    }>) {
       for (const member of group.members ?? []) {
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
@@ -194,6 +207,23 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
         }
         const sub = subCache.get(email);
         if (sub) member.subject = sub;
+        if (provider === "okta" && sub && member.okta_user_id && !linkedCache.has(email)) {
+          linkedCache.add(email);
+          try {
+            await linkFederatedIdentity(sub, idpAlias, {
+              userId: member.okta_user_id,
+              userName: email,
+            });
+          } catch (err) {
+            // Non-fatal: a federated-identity link failure must not block RBAC
+            // provisioning for this sync run. The user simply stays unlinked
+            // until the next successful sync or a real SSO login.
+            console.warn(
+              `[IdpSync] run ${runId}: failed to link federated identity for ${email} (sub=${sub}): ` +
+                (err instanceof Error ? err.message : String(err))
+            );
+          }
+        }
       }
     }
 

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -581,6 +581,32 @@ export async function getUserFederatedIdentities(
   }));
 }
 
+/**
+ * Register a federated-identity link for `userId` against IdP `alias`, using
+ * the same shape Keycloak's OIDC broker writes on a real SSO login
+ * (`federatedIdentities[].userId` = the broker's `sub`). Idempotent: Keycloak
+ * replaces any existing link for the same alias rather than erroring, so this
+ * is safe to call on every sync run. A 404 (user doesn't exist) is not
+ * swallowed — the caller has a stale id and should surface the error.
+ */
+export async function linkFederatedIdentity(
+  userId: string,
+  alias: string,
+  identity: { userId: string; userName: string }
+): Promise<void> {
+  const encUser = encodeURIComponent(userId);
+  const encAlias = encodeURIComponent(alias);
+  const response = await adminFetch(`/users/${encUser}/federated-identity/${encAlias}`, {
+    method: "POST",
+    body: JSON.stringify({
+      identityProvider: alias,
+      userId: identity.userId,
+      userName: identity.userName,
+    }),
+  });
+  await assertOk(response, `linkFederatedIdentity(${userId}, ${alias})`);
+}
+
 export async function assignRealmRolesToUser(
   userId: string,
   roles: KeycloakRole[]

--- a/ui/src/lib/rbac/okta-directory-connector.ts
+++ b/ui/src/lib/rbac/okta-directory-connector.ts
@@ -6,6 +6,14 @@ export type OktaExternalGroup = ExternalGroup & {
   members: Array<{
     subject?: string;
     email: string;
+    /**
+     * Okta's internal user id (the Users API `id` field). This is the same
+     * value Keycloak's OIDC broker stores as `federatedIdentities[].userId`
+     * after a real SSO login (Okta's default `sub` claim = the Users API
+     * `id`), so the sync runner can use it to register a live federated
+     * identity at provisioning time without waiting for an interactive login.
+     */
+    okta_user_id?: string;
     display_name?: string;
     active: boolean;
   }>;
@@ -154,6 +162,7 @@ async function collectGroupMembers(client: Client, groupId: string): Promise<Okt
       members.push({
         subject: undefined,
         email,
+        okta_user_id: user.id,
         display_name: oktaUserDisplayName(user),
         active: user.status !== "DEPROVISIONED" && user.status !== "SUSPENDED",
       });

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.47.dev1"
+version = "0.5.47.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Okta directory sync provisioned shell users in Keycloak but never gave them a `federatedIdentities` record — that record was previously only created by Keycloak's `idp-auto-link` authenticator during an actual interactive SSO login.
- This left sync-provisioned users showing up as IdP source "local", and caused any consumer that gates on `federatedIdentities` (e.g. the Slack bot's unlinked-fallback routing) to treat them as unverified/anonymous even though the directory sync already vouches for their identity.
- This PR has the sync capture each Okta member's Okta user id and register a real federated-identity link at provisioning time, producing a record identical to what a real SSO login would create.

## Changes
- `okta-directory-connector.ts`: capture each member's Okta user id (Users API `id`) alongside email during group-member collection.
- `idp-sync-runner.ts`: thread the Okta user id through to a new `linkFederatedIdentity` call per active member, using the Keycloak IdP alias from `IDENTITY_SYNC_OKTA_KEYCLOAK_IDP_ALIAS` (default `"okta"`). Failures are non-fatal and don't block RBAC provisioning for the run.
- `keycloak-admin.ts`: add `linkFederatedIdentity`, a thin wrapper around `POST /users/{id}/federated-identity/{alias}`. Idempotent — Keycloak replaces any existing link for that alias.
- `env.example`: document the new `IDENTITY_SYNC_OKTA_KEYCLOAK_IDP_ALIAS` variable.

## Verification
Confirmed against a live dev Keycloak+Okta pairing that Okta's Users API `id` matches the `sub` Keycloak's OIDC broker stores in `federatedIdentities[].userId` after a real SSO login — so this produces identical federated-identity records to a real login and does not introduce a duplicate-linkage risk on subsequent SSO.

**This branch is intended for dev testing before merge/deploy to prod** — opened as draft.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `npx jest` — 516 suites / 6467 tests pass
- [ ] Run a real Okta directory sync in dev and confirm synced users show a real `federatedIdentities` entry (not just `local`) in the admin UI
- [ ] Confirm the Slack bot no longer routes a sync-only (never logged in) user through the unlinked/anonymous fallback
- [ ] Have a synced user complete one real Okta SSO login and confirm no duplicate/broken federated-identity link results

🤖 Generated with [Claude Code](https://claude.com/claude-code)