### PR TITLE
fix(rbac): check slack channel FGA grant for service-account agent authz

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.47 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.48 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.47 -f your-values.yaml'}
+                  {'    --version 0.5.48 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.47 -f your-values.yaml'}
+              {'    --version 0.5.48 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.48"
+version = "0.5.48-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/chat/conversations/route.ts
+++ b/ui/src/app/api/chat/conversations/route.ts
@@ -303,11 +303,15 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   // Dynamic agent conversation — gate on agent-level can_use.
   // Service-account callers are graphed as `service_account:<sub>` (their grants
   // live under that type); see requireAgentUsePermission (spec 2026-06-05).
+  // For Slack-bot SA callers, also pass channel context so the channel-level
+  // FGA grant can authorize the request (FR-040).
+  const slackChannelId = typeof body.metadata?.channel_id === "string" ? body.metadata.channel_id : undefined;
   const denial = await requireAgentUsePermission({
     subject: session.sub,
     agentId: body.agent_id,
     email: user.email,
     isServiceAccount: session.isServiceAccount,
+    slackChannelId,
   });
   if (denial) {
     return denial;

--- a/ui/src/lib/rbac/openfga-agent-authz.ts
+++ b/ui/src/lib/rbac/openfga-agent-authz.ts
@@ -4,6 +4,7 @@ import { logOpenFgaRebacAuditEvent } from "./audit";
 import { withAuthzSpan } from "./authz-tracing";
 import { checkOpenFgaTuple } from "./openfga";
 import { listUserTeamSlugs } from "./openfga-team-membership";
+import { slackChannelSubjectId } from "./slack-channel-grant-store";
 
 export interface AgentUsePermissionInput {
   subject?: string;
@@ -23,6 +24,18 @@ export interface AgentUsePermissionInput {
    * time (FR-020 static access). assisted-by Claude claude-opus-4-8
    */
   isServiceAccount?: boolean;
+  /**
+   * Slack channel ID from the conversation metadata (e.g. "C0BGLJ9JU73").
+   * When provided alongside slackWorkspaceId, allows the authz check to
+   * verify the channel-level grant (`slack_channel:<workspace>--<channel>
+   * user agent:<agentId>`) for service-account callers. This covers the case
+   * where a channel has an agent route configured but the SA itself has no
+   * direct agent grant — the channel-level tuple is authoritative.
+   * assisted-by claude code claude-sonnet-4-6
+   */
+  slackChannelId?: string;
+  /** Slack workspace identifier (e.g. "CAIPE"). Paired with slackChannelId. */
+  slackWorkspaceId?: string;
 }
 
 const OPENFGA_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
@@ -58,6 +71,8 @@ export async function requireAgentUsePermission({
   correlationId,
   traceparent,
   isServiceAccount = false,
+  slackChannelId,
+  slackWorkspaceId,
 }: AgentUsePermissionInput): Promise<NextResponse | null> {
   if (!isValidOpenFgaId(subject)) {
     return authzResponse(
@@ -130,6 +145,26 @@ export async function requireAgentUsePermission({
             break;
           }
         }
+        // For service-account callers that include a Slack channel in the
+        // request context (e.g. the Slack bot calling on behalf of a channel
+        // that has an agent route configured), check the channel-level FGA
+        // grant: `slack_channel:<workspace>--<channelId> user agent:<agentId>`.
+        // This covers the common case where the channel has an explicit grant
+        // but the SA itself has no direct agent grant (FR-040).
+        // assisted-by claude code claude-sonnet-4-6
+        if (!allowed && isServiceAccount && slackChannelId) {
+          const channelSubjectId = slackChannelSubjectId(slackWorkspaceId || "", slackChannelId);
+          const channelDecision = await checkOpenFgaTuple({
+            user: `slack_channel:${channelSubjectId}`,
+            relation: "can_use",
+            object: `agent:${agentId}`,
+          });
+          if (channelDecision.allowed) {
+            allowed = true;
+            reasonCode = "ALLOW_DIRECT";
+          }
+        }
+
         // Phase 2.7 of spec 2026-05-24-derive-team-from-channel
         // (FR-038): if no direct grant exists, fall back to a
         // team-union probe. Today the Web UI only honors direct

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.48"
+version = "0.5.48.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- `requireAgentUsePermission` never consulted the `slack_channel:<workspace>--<channel> user agent:<id>` FGA tuple when the caller is a service account (SA), causing 403 `pdp_denied` even for channels with a correctly configured agent route
- Added `slackChannelId` / `slackWorkspaceId` params to `AgentUsePermissionInput`; when provided and the SA direct check fails, the channel-level FGA grant is checked as a fallback
- The conversation POST handler extracts `channel_id` from `body.metadata.channel_id` (sent by the Slack bot) and passes it to the authz check

## Root Cause

The Slack admin UI writes two things when a channel is assigned an agent:
1. MongoDB `slack_channel_agent_routes` row (used by the bot to pick the agent)
2. OpenFGA tuple `slack_channel:<workspace>--<channel> user agent:<id>` (intended to authorize SA callers)

But `requireAgentUsePermission` only checked `service_account:<sub> can_use agent:<id>` for SA callers — the channel-level tuple was written but never read on the authz path. SA callers get a 403 unless they have a *direct* per-SA grant or the agent has `user:*` (wildcard/org visibility).

## Test Plan
- [ ] Slack bot SA creates conversation for a channel with a route configured → 200 (was 403)
- [ ] Slack bot SA for a channel with NO route → still 403
- [ ] Human user (non-SA) auth path unchanged — team-union fallback still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)