### PR TITLE
feat(slack-bot): enable SLACK_RBAC_ENABLED by default in chart

### DIFF
--- a/charts/ai-platform-engineering/charts/slack-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/values.yaml
@@ -90,6 +90,13 @@ config:
   CAIPE_PLATFORM_AUDIENCE: "caipe-platform"
   SLACK_JIT_CREATE_USER: "true"
   SLACK_JIT_ALLOWED_EMAIL_DOMAINS: ""
+  # OBO (On-Behalf-Of) identity enforcement. Requires MONGODB_URI,
+  # KEYCLOAK_REALM, KEYCLOAK_BOT_CLIENT_ID, and keycloakBot.clientSecretFromSecret
+  # to be wired. When enabled the bot exchanges each Slack user's identity for a
+  # user-scoped Keycloak token so requests hit the CAIPE BFF as the human caller
+  # rather than the bot service account — enabling per-user FGA grants and team
+  # membership checks. assisted-by claude code claude-sonnet-4-6
+  SLACK_RBAC_ENABLED: "true"
 
 # -- Cross-chart binding to the Keycloak bot client_secret.
 # When set, the pod's OAUTH2_CLIENT_SECRET env var is sourced via


### PR DESCRIPTION
## Summary

- Sets `SLACK_RBAC_ENABLED: "true"` as the default in the `slack-bot` chart `values.yaml`
- OBO (On-Behalf-Of) token exchange is now on by default: the bot resolves each Slack user's identity via Keycloak and sends BFF requests as the human user, not the bot service account

## Why this should be the default

Running as a service account was always a fallback for unconfigured deployments, not the intended identity model. With OBO enabled:
- Per-user FGA grants apply correctly
- Team membership checks work
- Audit logs reflect the actual human caller
- The 403 `pdp_denied` class of errors (where the SA has no grant but the user does) disappears

## Prerequisites

Operators must wire up:
- `MONGODB_URI` — for identity linking (`resolve_slack_user`, `auto_bootstrap_slack_user`)
- `KEYCLOAK_REALM`, `KEYCLOAK_BOT_CLIENT_ID` — token exchange endpoint config
- `keycloakBot.clientSecretFromSecret` — `KEYCLOAK_BOT_CLIENT_SECRET` from the Keycloak-managed bot secret

Operators that cannot meet these prerequisites should set `SLACK_RBAC_ENABLED: "false"` in their values override.

## Related

- cisco-eti/platform-apps-deployment#747 — wires these prerequisites for caipe-dev
- #2185 — channel-level SA fallback (safety net for unlinked users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)