### PR TITLE
fix(rbac): make Okta IdP sync resilient to invalid names, already-linked identities, and event-loop stalls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.48-dev.1"
+version = "0.5.48-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
+++ b/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 // Unit tests for the IdP directory sync execution path. Focuses on the
 // runner's own logic added alongside Okta name/membership upserts: splitting
 // an Okta display_name into firstName/lastName for provisionShellUser,
@@ -17,6 +20,7 @@ const fetchExternalGroupsForProvider = jest.fn();
 const listIdentityGroupSyncRules = jest.fn();
 const listActiveTeamMembershipSourcesForProvider = jest.fn();
 const provisionShellUser = jest.fn();
+const linkFederatedIdentity = jest.fn();
 const planIdentityGroupSync = jest.fn();
 const applyIdentityGroupSyncPlan = jest.fn();
 const stripArchivedTeamResourceGrants = jest.fn();
@@ -53,6 +57,7 @@ jest.mock("@/lib/rbac/idp-sync-store", () => ({
 
 jest.mock("@/lib/rbac/keycloak-admin", () => ({
   provisionShellUser: (...args: unknown[]) => provisionShellUser(...args),
+  linkFederatedIdentity: (...args: unknown[]) => linkFederatedIdentity(...args),
 }));
 
 jest.mock("@/lib/rbac/archived-team-grants", () => ({
@@ -96,6 +101,7 @@ describe("idp-sync-runner", () => {
     listIdentityGroupSyncRules.mockResolvedValue([]);
     listActiveTeamMembershipSourcesForProvider.mockResolvedValue([]);
     provisionShellUser.mockResolvedValue({ sub: "sub-1", created: false });
+    linkFederatedIdentity.mockResolvedValue(undefined);
     planIdentityGroupSync.mockReturnValue({ matched_groups: [] });
     applyIdentityGroupSyncPlan.mockResolvedValue({
       teamsCreated: 0,
@@ -256,6 +262,97 @@ describe("idp-sync-runner", () => {
       expect(updateIdpSyncRun).toHaveBeenCalledWith("run-1", expect.objectContaining({ status: "success" }));
 
       warnSpy.mockRestore();
+    });
+  });
+
+  describe("executeSyncRun: Okta federated-identity linking", () => {
+    it("links each resolved Okta member once via linkFederatedIdentity", async () => {
+      fetchExternalGroupsForProvider.mockResolvedValue([
+        {
+          id: "g1",
+          name: "Group 1",
+          members: [{ email: "jane@example.com", active: true, display_name: "Jane Doe", okta_user_id: "okta-1" }],
+        },
+      ]);
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      expect(linkFederatedIdentity).toHaveBeenCalledWith("sub-1", "okta", {
+        userId: "okta-1",
+        userName: "jane@example.com",
+      });
+    });
+
+    it("does not warn when linkFederatedIdentity resolves normally (e.g. after a 409 already-linked no-op)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      fetchExternalGroupsForProvider.mockResolvedValue([
+        {
+          id: "g1",
+          name: "Group 1",
+          members: [{ email: "jane@example.com", active: true, display_name: "Jane Doe", okta_user_id: "okta-1" }],
+        },
+      ]);
+      linkFederatedIdentity.mockResolvedValue(undefined);
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("failed to link federated identity"));
+      warnSpy.mockRestore();
+    });
+
+    it("logs and continues when linkFederatedIdentity fails for a real (non-409) reason", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      fetchExternalGroupsForProvider.mockResolvedValue([
+        {
+          id: "g1",
+          name: "Group 1",
+          members: [{ email: "jane@example.com", active: true, display_name: "Jane Doe", okta_user_id: "okta-1" }],
+        },
+      ]);
+      linkFederatedIdentity.mockRejectedValue(new Error("linkFederatedIdentity failed: 500"));
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("failed to link federated identity for jane@example.com")
+      );
+      expect(updateIdpSyncRun).toHaveBeenCalledWith("run-1", expect.objectContaining({ status: "success" }));
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("executeSyncRun: event-loop yield cadence", () => {
+    it("yields to the event loop every 50 processed members so /api/health can interleave", async () => {
+      const members = Array.from({ length: 120 }, (_, i) => ({
+        email: `user${i}@example.com`,
+        active: true,
+        display_name: `User ${i}`,
+      }));
+      fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
+
+      const setImmediateSpy = jest.spyOn(global, "setImmediate");
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      // 120 members with MEMBERS_PER_YIELD=50 yields at the 50th and 100th member.
+      expect(setImmediateSpy).toHaveBeenCalledTimes(2);
+      setImmediateSpy.mockRestore();
+    });
+
+    it("never yields for a run with fewer members than the yield threshold", async () => {
+      const members = Array.from({ length: 10 }, (_, i) => ({
+        email: `user${i}@example.com`,
+        active: true,
+        display_name: `User ${i}`,
+      }));
+      fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
+
+      const setImmediateSpy = jest.spyOn(global, "setImmediate");
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      expect(setImmediateSpy).not.toHaveBeenCalled();
+      setImmediateSpy.mockRestore();
     });
   });
 

--- a/ui/src/lib/rbac/__tests__/keycloak-admin.test.ts
+++ b/ui/src/lib/rbac/__tests__/keycloak-admin.test.ts
@@ -207,4 +207,85 @@ describe("Keycloak admin user helpers", () => {
       linkFederatedIdentity("user-sub", "okta", { userId: "okta-id", userName: "jane@example.com" })
     ).rejects.toThrow(/linkFederatedIdentity/);
   });
+
+  it("resolves an existing mapper on 409 from createGroupRoleMapper instead of throwing", async () => {
+    const existingMapper = {
+      id: "mapper-1",
+      name: "okta-engineering-to-admin",
+      identityProviderAlias: "okta",
+      identityProviderMapper: "oidc-advanced-role-idp-mapper",
+    };
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(response({ errorMessage: "already exists" }, { status: 409 }))
+      .mockResolvedValueOnce(response([existingMapper]));
+
+    const { createGroupRoleMapper } = await import("../keycloak-admin");
+
+    const result = await createGroupRoleMapper("okta", "engineering", "admin");
+
+    expect(result).toEqual(existingMapper);
+  });
+
+  it("throws when createGroupRoleMapper gets a 409 but the mapper can't be found on re-query", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(response({ errorMessage: "already exists" }, { status: 409 }))
+      .mockResolvedValueOnce(response([]));
+
+    const { createGroupRoleMapper } = await import("../keycloak-admin");
+
+    await expect(createGroupRoleMapper("okta", "engineering", "admin")).rejects.toThrow(
+      /409 but mapper not found/
+    );
+  });
+
+  it("sanitizes an Okta display name before patching an existing user's missing name", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(
+        response([{ id: "existing-sub", email: "jane@example.com", username: "jane@example.com" }])
+      )
+      .mockResolvedValueOnce(response({ id: "existing-sub", email: "jane@example.com" }))
+      .mockResolvedValueOnce(response("", { status: 204 }));
+
+    const { resolveOrProvisionUserSub } = await import("../keycloak-admin");
+
+    await resolveOrProvisionUserSub("jane@example.com", {}, {
+      firstName: "Jane",
+      lastName: "Doe (Contractor)",
+    });
+
+    const patchCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([input, init]: [string | URL, RequestInit | undefined]) =>
+        String(input).endsWith("/users/existing-sub") && init?.method === "PUT"
+    );
+    expect(patchCall).toBeDefined();
+    expect(JSON.parse(patchCall![1]!.body as string)).toEqual(
+      expect.objectContaining({ firstName: "Jane", lastName: "Doe Contractor" })
+    );
+  });
+
+  it("does not patch an existing user whose sanitized name already matches", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(
+        response([{ id: "existing-sub", email: "jane@example.com", username: "jane@example.com" }])
+      )
+      .mockResolvedValueOnce(
+        response({ id: "existing-sub", email: "jane@example.com", firstName: "Jane", lastName: "Doe Contractor" })
+      );
+
+    const { resolveOrProvisionUserSub } = await import("../keycloak-admin");
+
+    await resolveOrProvisionUserSub("jane@example.com", {}, {
+      firstName: "Jane",
+      lastName: "Doe (Contractor)",
+    });
+
+    const patchCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([, init]: [string | URL, RequestInit | undefined]) => init?.method === "PUT"
+    );
+    expect(patchCall).toBeUndefined();
+  });
 });

--- a/ui/src/lib/rbac/__tests__/keycloak-admin.test.ts
+++ b/ui/src/lib/rbac/__tests__/keycloak-admin.test.ts
@@ -143,4 +143,68 @@ describe("Keycloak admin user helpers", () => {
       })
     );
   });
+
+  it("strips characters Keycloak's person-name validator rejects before creating a shell user", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(response("", { status: 201, headers: { Location: "http://keycloak/admin/realms/caipe/users/new-sub" } }));
+
+    const { createFederatedShellUser } = await import("../keycloak-admin");
+
+    await createFederatedShellUser("jane@example.com", {}, {
+      firstName: "Jane",
+      lastName: "Doe (Contractor)",
+    });
+
+    const createCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([input, init]: [string | URL, RequestInit | undefined]) =>
+        String(input).endsWith("/users") && init?.method === "POST"
+    );
+    expect(createCall).toBeDefined();
+    expect(JSON.parse(createCall![1]!.body as string)).toEqual(
+      expect.objectContaining({ firstName: "Jane", lastName: "Doe Contractor" })
+    );
+  });
+
+  it("omits lastName entirely when it sanitizes to nothing", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(response("", { status: 201, headers: { Location: "http://keycloak/admin/realms/caipe/users/new-sub" } }));
+
+    const { createFederatedShellUser } = await import("../keycloak-admin");
+
+    await createFederatedShellUser("jane@example.com", {}, { firstName: "Jane", lastName: "()" });
+
+    const createCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([input, init]: [string | URL, RequestInit | undefined]) =>
+        String(input).endsWith("/users") && init?.method === "POST"
+    );
+    const body = JSON.parse(createCall![1]!.body as string);
+    expect(body.firstName).toBe("Jane");
+    expect(body).not.toHaveProperty("lastName");
+  });
+
+  it("treats a 409 from linkFederatedIdentity as already-linked success", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(response({ errorMessage: "User is already linked with provider" }, { status: 409 }));
+
+    const { linkFederatedIdentity } = await import("../keycloak-admin");
+
+    await expect(
+      linkFederatedIdentity("user-sub", "okta", { userId: "okta-id", userName: "jane@example.com" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("still throws when linkFederatedIdentity fails for a non-409 reason", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response({ access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(response({ errorMessage: "not found" }, { status: 404 }));
+
+    const { linkFederatedIdentity } = await import("../keycloak-admin");
+
+    await expect(
+      linkFederatedIdentity("user-sub", "okta", { userId: "okta-id", userName: "jane@example.com" })
+    ).rejects.toThrow(/linkFederatedIdentity/);
+  });
 });

--- a/ui/src/lib/rbac/__tests__/keycloak-resource-sync.test.ts
+++ b/ui/src/lib/rbac/__tests__/keycloak-resource-sync.test.ts
@@ -98,4 +98,51 @@ describe('keycloak-resource-sync', () => {
     expect(mockGetKeycloakAdminToken).not.toHaveBeenCalled();
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it('logs loudly (not as a benign not-found) when the client lookup call itself fails', async () => {
+    process.env.KEYCLOAK_URL = 'http://keycloak';
+    mockGetKeycloakAdminToken.mockResolvedValue('admin-token');
+    (global.fetch as unknown as Mock).mockResolvedValueOnce({ ok: false, status: 403 });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { syncTaskResource } = await import('../keycloak-resource-sync');
+    await expect(
+      syncTaskResource('create', 'tid', 'Task Name', 'global')
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('403'));
+    errorSpy.mockRestore();
+  });
+
+  it('logs loudly when the delete-lookup call itself fails, instead of silently skipping', async () => {
+    process.env.KEYCLOAK_URL = 'http://keycloak';
+    mockGetKeycloakAdminToken.mockResolvedValue('admin-token');
+    (global.fetch as unknown as Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 'client-uuid-1' }] })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { syncTaskResource } = await import('../keycloak-resource-sync');
+    await expect(syncTaskResource('delete', 'tid', 'Task Name')).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('500'));
+    errorSpy.mockRestore();
+  });
+
+  it('logs create failures as errors (not warnings) so real failures are distinguishable from 409', async () => {
+    process.env.KEYCLOAK_URL = 'http://keycloak';
+    mockGetKeycloakAdminToken.mockResolvedValue('admin-token');
+    (global.fetch as unknown as Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 'client-uuid-1' }] })
+      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => 'invalid_token' });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { syncTaskResource } = await import('../keycloak-resource-sync');
+    await expect(
+      syncTaskResource('create', 'tid', 'Task Name', 'global')
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('401'));
+    errorSpy.mockRestore();
+  });
 });

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -174,10 +174,21 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     const idpAlias = process.env.IDENTITY_SYNC_OKTA_KEYCLOAK_IDP_ALIAS?.trim() || "okta";
     const subCache = new Map<string, string | null>();
     const linkedCache = new Set<string>();
+    // A cached-email hit (the common case in a large org with overlapping
+    // group memberships) skips every `await` below, so a long run of cache
+    // hits can otherwise monopolize the event loop for the CAIPE UI pod —
+    // the same process that serves the k8s liveness probe. Yield back to the
+    // loop periodically so a slow/large sync can't stall health checks into
+    // a pod restart.
+    let processedMembers = 0;
+    const MEMBERS_PER_YIELD = 50;
     for (const group of groups as Array<{
       members?: Array<{ email?: string; active?: boolean; subject?: string; display_name?: string; okta_user_id?: string }>;
     }>) {
       for (const member of group.members ?? []) {
+        if (++processedMembers % MEMBERS_PER_YIELD === 0) {
+          await new Promise((resolve) => setImmediate(resolve));
+        }
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
         if (!subCache.has(email)) {

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -584,10 +584,15 @@ export async function getUserFederatedIdentities(
 /**
  * Register a federated-identity link for `userId` against IdP `alias`, using
  * the same shape Keycloak's OIDC broker writes on a real SSO login
- * (`federatedIdentities[].userId` = the broker's `sub`). Idempotent: Keycloak
- * replaces any existing link for the same alias rather than erroring, so this
- * is safe to call on every sync run. A 404 (user doesn't exist) is not
- * swallowed — the caller has a stale id and should surface the error.
+ * (`federatedIdentities[].userId` = the broker's `sub`). Despite the docs, in
+ * practice Keycloak's link endpoint does not replace an existing link for the
+ * same alias — it 409s with "User is already linked with provider" instead.
+ * That means the desired end state (the user is linked) already holds, so it
+ * is treated as a no-op success rather than an error, matching the 409/404
+ * "already in desired state" handling used elsewhere in this file (e.g.
+ * {@link createFederatedShellUser}, {@link deleteRealmUser}). A 404 (user
+ * doesn't exist) is not swallowed — the caller has a stale id and should
+ * surface the error.
  */
 export async function linkFederatedIdentity(
   userId: string,
@@ -604,6 +609,7 @@ export async function linkFederatedIdentity(
       userName: identity.userName,
     }),
   });
+  if (response.status === 409) return;
   await assertOk(response, `linkFederatedIdentity(${userId}, ${alias})`);
 }
 
@@ -731,6 +737,21 @@ function parseUserIdFromLocation(location: string | null): string | null {
   return id || null;
 }
 
+// Keycloak's built-in `person-name-prohibited-characters` validator rejects
+// firstName/lastName containing any of these characters with
+// `error-person-name-invalid-character` (see
+// PersonNameProhibitedCharactersValidator.PATTERN upstream). Directory-sourced
+// names (e.g. Okta display names like "Jane Doe (Contractor)") can legitimately
+// contain them, so strip rather than reject — losing a stray character is
+// better than failing provisioning outright.
+const PERSON_NAME_PROHIBITED_CHARS = /[<>&"\v$%!#?§;*~/\\|^=[\]{}()\x00-\x1f\x7f]/g;
+
+function sanitizePersonNamePart(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const cleaned = value.replace(PERSON_NAME_PROHIBITED_CHARS, "").replace(/\s+/g, " ").trim();
+  return cleaned || undefined;
+}
+
 /**
  * Create a federated-only "shell" Keycloak user from an email so RBAC can be
  * granted before the person ever logs into CAIPE. Mirrors the Slack bot's
@@ -749,6 +770,8 @@ export async function createFederatedShellUser(
   name?: { firstName?: string; lastName?: string }
 ): Promise<string> {
   const emailLower = email.trim().toLowerCase();
+  const firstName = sanitizePersonNamePart(name?.firstName);
+  const lastName = sanitizePersonNamePart(name?.lastName);
   const body: Record<string, unknown> = {
     username: emailLower,
     email: emailLower,
@@ -756,8 +779,8 @@ export async function createFederatedShellUser(
     enabled: true,
     requiredActions: [],
     attributes,
-    ...(name?.firstName && { firstName: name.firstName }),
-    ...(name?.lastName && { lastName: name.lastName }),
+    ...(firstName && { firstName }),
+    ...(lastName && { lastName }),
   };
   const response = await adminFetch(`/users`, { method: "POST", body: JSON.stringify(body) });
 
@@ -783,17 +806,18 @@ async function maybeUpdateUserName(
 ): Promise<void> {
   const existing = await getRealmUserByIdOrNull(userId);
   if (!existing) return;
+  const firstName = sanitizePersonNamePart(name.firstName);
+  const lastName = sanitizePersonNamePart(name.lastName);
   // Only patch if the user is missing a name entirely (shell user never had one set)
   // OR if Okta has a different name
   const needsUpdate =
-    (name.firstName && existing.firstName !== name.firstName) ||
-    (name.lastName && existing.lastName !== name.lastName);
+    (firstName && existing.firstName !== firstName) || (lastName && existing.lastName !== lastName);
   if (!needsUpdate) return;
   // Don't overwrite a manually-set name with nothing
-  if (!name.firstName && !name.lastName) return;
+  if (!firstName && !lastName) return;
   await updateUser(userId, {
-    ...(name.firstName && { firstName: name.firstName }),
-    ...(name.lastName && { lastName: name.lastName }),
+    ...(firstName && { firstName }),
+    ...(lastName && { lastName }),
   });
 }
 

--- a/ui/src/lib/rbac/keycloak-admin.ts
+++ b/ui/src/lib/rbac/keycloak-admin.ts
@@ -374,6 +374,15 @@ export async function createGroupRoleMapper(
     method: "POST",
     body: JSON.stringify(payload),
   });
+
+  if (response.status === 409) {
+    // Mapper name is deterministic (alias-group-to-role), so a retry or a
+    // repeat sync of the same group→role mapping hits this every time — the
+    // desired state (the mapping exists) already holds. Resolve and return it.
+    const existing = (await listIdpMappers(alias)).find((m) => m.name === mapperName);
+    if (existing) return existing;
+    throw new Error(`createGroupRoleMapper(${mapperName}): 409 but mapper not found on re-query`);
+  }
   await assertOk(response, "createGroupRoleMapper");
   const text = await response.text();
   if (!text) {

--- a/ui/src/lib/rbac/keycloak-resource-sync.ts
+++ b/ui/src/lib/rbac/keycloak-resource-sync.ts
@@ -40,8 +40,13 @@ async function getClientUuid(clientId: string): Promise<string | null> {
   const qs = new URLSearchParams({ clientId });
   const response = await adminFetch(`/clients?${qs.toString()}`, { method: "GET" });
   if (!response.ok) {
-    console.warn(
-      `[KeycloakResourceSync] list clients failed: ${response.status} ${clientId}`
+    // This is a list endpoint: a client that doesn't exist returns 200 with an
+    // empty array, never a 404. A non-OK response here is always a real
+    // failure (bad/expired admin token, permissions, Keycloak down) — log it
+    // as an error, not as "client not found", so it isn't mistaken for the
+    // benign case downstream.
+    console.error(
+      `[KeycloakResourceSync] Keycloak admin API call failed while looking up client ${clientId}: ${response.status}`
     );
     return null;
   }
@@ -58,6 +63,12 @@ async function deleteResourceByName(clientUuid: string, resourceName: string): P
   const qs = new URLSearchParams({ name: resourceName });
   const listResponse = await adminFetch(`${basePath}?${qs.toString()}`, { method: "GET" });
   if (!listResponse.ok) {
+    // Same reasoning as getClientUuid: this list endpoint 200s with an empty
+    // array when nothing matches, so a non-OK response here means the lookup
+    // itself failed, not that the resource is already gone.
+    console.error(
+      `[KeycloakResourceSync] Keycloak admin API call failed while looking up resource ${resourceName} for deletion: ${listResponse.status}`
+    );
     return;
   }
   const rows = (await listResponse.json()) as Array<{ id?: string; name?: string }>;
@@ -103,10 +114,14 @@ async function syncCaipeResource(
   }
 
   try {
+    // `getClientUuid` returning null is ambiguous by design (it covers both
+    // "client genuinely doesn't exist" and "the lookup call itself failed",
+    // the latter already logged loudly with console.error above) — either
+    // way there's nothing more to do here, so skip the rest of the sync.
     const clientUuid = await getClientUuid(getAuthzClientId());
     if (!clientUuid) {
       console.warn(
-        `[KeycloakResourceSync] Authz client ${getAuthzClientId()} not found — skip`
+        `[KeycloakResourceSync] Authz client ${getAuthzClientId()} unresolved — skip ${opts.resourceName}`
       );
       return;
     }
@@ -137,7 +152,13 @@ async function syncCaipeResource(
     }
     if (!createResponse.ok) {
       const detail = await createResponse.text();
-      console.warn(
+      // Deliberately fire-and-forget: a Keycloak resource-sync failure must
+      // not block the task/skill create/update itself (see syncTaskResource /
+      // syncSkillResource callers). But this IS a real failure (auth expired,
+      // permission denied, Keycloak down) — log as an error, not a warning,
+      // so it's distinguishable from expected/benign outcomes and doesn't get
+      // silently missed.
+      console.error(
         `[KeycloakResourceSync] create ${opts.resourceName} failed: ${createResponse.status} ${detail.slice(0, 300)}`
       );
     }

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.48.dev1"
+version = "0.5.48.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fixes three reliability issues in the Okta IdP sync (background scheduler in the CAIPE UI pod):

1. **`error-person-name-invalid-character` 400s on user provisioning.** Directory display names like `"Jane Doe (Contractor)"` were passed straight to Keycloak's admin API as `firstName`/`lastName`, tripping Keycloak's built-in `person-name-prohibited-characters` validator (`^[^<>&"\v$%!#?§;*~/\\|^=[\]{}()\p{Cntrl}]+$`). Now stripped/sanitized before the create/update calls in `keycloak-admin.ts`.
2. **Noisy 409 "User is already linked with provider" warnings.** `linkFederatedIdentity` treated a 409 as a hard error and logged a warning every sync run for every already-linked user, even though the desired end state (linked) was already true. Now short-circuits on 409, matching the "already in desired state" precedent used elsewhere in the same file (`createFederatedShellUser`, `ensureUserByEmail`, `deleteRealmUser`).
3. **Sync work sharing the event loop with the pod's health check.** `executeSyncRun` runs on the same single Node event loop as `/api/health` (the k8s liveness/readiness probe). Cached member lookups skip every `await`, so a large org sync could run long uninterrupted stretches of synchronous work, adding latency to health check responses on a pod that's critical to all CAIPE operations. Added a periodic `setImmediate` yield every 50 processed members in the sync's per-member loop.

Branch is prefixed `prebuild/` to get a testable CI-built image for dev verification before merge.

## Type of Change

- [x] Bugfix

## Checklist

- [x] All code style checks pass (`npm run lint`)
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass (`npx jest` — 516 suites / 6471 tests)