### PR TITLE
fix(ui): admin stats metrics — date-range consistency and message counts

### DIFF
--- a/ui/e2e/rbac/admin-stats-range-metrics.spec.ts
+++ b/ui/e2e/rbac/admin-stats-range-metrics.spec.ts
@@ -1,0 +1,246 @@
+// E2E coverage for the admin Statistics tab date-range bugs fixed alongside
+// this spec: (1) overview cards (Total Users/Conversations/Messages/Shared)
+// must reflect the currently selected range rather than a stale all-time
+// snapshot, (2) they grey out while a new range is loading, and (3) short
+// ranges (1h/12h) must bucket into more than one chart data point.
+
+import { expect, test } from "@playwright/test";
+
+import {
+  fulfillJson,
+  installMockedRbacApp,
+  mockedRbacEnabled,
+  type MockRouteHandler,
+} from "./_mocked-rbac";
+
+const adminSession = {
+  email: "stats-admin@caipe.local",
+  name: "Stats Admin",
+  role: "admin" as const,
+  canViewAdmin: true,
+};
+
+function makeOverview(overrides: Partial<Record<string, number>> = {}) {
+  return {
+    total_users: 10,
+    active_users: 4,
+    avg_messages_per_conversation: 2.5,
+    conversations_today: 1,
+    dau: 4,
+    mau: 8,
+    messages_today: 3,
+    shared_conversations: 2,
+    total_conversations: 20,
+    total_messages: 50,
+    total_sessions: 12,
+    ...overrides,
+  };
+}
+
+function makeDailyActivity(count: number, hourly = false) {
+  return Array.from({ length: count }, (_, i) => ({
+    date: hourly ? `2026-07-10T${String(i).padStart(2, "0")}:00` : `2026-07-${String(i + 1).padStart(2, "0")}`,
+    active_users: i + 1,
+    conversations: i + 1,
+    messages: (i + 1) * 2,
+  }));
+}
+
+function makeStatsPayload(overview: ReturnType<typeof makeOverview>, dailyActivity: ReturnType<typeof makeDailyActivity>) {
+  return {
+    success: true,
+    data: {
+      overview,
+      available_channels: [],
+      completed_workflows: { avg_messages_per_workflow: 0, completion_rate: 0, interrupted: 0, today: 0, total: 0 },
+      daily_activity: dailyActivity,
+      daily_usage: [],
+      feedback_summary: { negative: 0, positive: 0, total: 0 },
+      hourly_heatmap: [],
+      platform_summary: { estimated_hours_automated: 0, satisfaction_rate: 0 },
+      response_time: { avg_ms: 0, max_ms: 0, min_ms: 0, sample_count: 0 },
+      source_breakdown: [],
+      top_agents: [],
+      top_users: { by_conversations: [], by_messages: [] },
+    },
+  };
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** The UI sends `from`/`to` ISO timestamps (see DateRangeFilter's presetToRange),
+ *  not a `range` string — reconstruct the preset from the from/to span so mocks
+ *  can key off the same presets the buttons produce. */
+function presetFromParams(url: URL): string | null {
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  if (!from || !to) return null;
+  const ms = new Date(to).getTime() - new Date(from).getTime();
+  if (Math.abs(ms - HOUR_MS) < 1000) return "1h";
+  if (Math.abs(ms - 12 * HOUR_MS) < 1000) return "12h";
+  if (Math.abs(ms - DAY_MS) < 1000) return "24h";
+  if (Math.abs(ms - 7 * DAY_MS) < 1000) return "7d";
+  if (Math.abs(ms - 30 * DAY_MS) < 1000) return "30d";
+  if (Math.abs(ms - 90 * DAY_MS) < 1000) return "90d";
+  return null;
+}
+
+/** Serves a distinct overview/daily_activity payload per date-range preset so
+ *  tests can assert the UI actually re-fetches and re-renders on range change. */
+function makeRangeAwareStatsHandler(
+  responsesByRange: Record<string, ReturnType<typeof makeStatsPayload>>,
+  options: { onRequest?: (range: string | null) => void; holdUntil?: Promise<void> } = {},
+): MockRouteHandler {
+  return async ({ route, path, method, url }) => {
+    if (path !== "/api/admin/stats" || method !== "GET") return false;
+    const range = presetFromParams(url);
+    options.onRequest?.(range);
+    if (options.holdUntil) await options.holdUntil;
+    const payload = (range && responsesByRange[range]) || responsesByRange.default;
+    await fulfillJson(route, payload);
+    return true;
+  };
+}
+
+async function navigateToStatsTab(page: import("@playwright/test").Page) {
+  await page.goto("/admin?cat=insights&tab=stats", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("tab", { name: "Statistics" })).toHaveAttribute("aria-selected", "true");
+}
+
+test.describe("mocked admin stats — date range regression", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mockedRbacEnabled(),
+      "Set RUN_RBAC_REGRESSION=1 to run the mocked RBAC browser regression.",
+    );
+  });
+
+  test("overview cards reflect the initial range's stats, not a stale all-time snapshot", async ({ page }) => {
+    const overview = makeOverview({ total_users: 42, total_conversations: 99, total_messages: 321, shared_conversations: 7 });
+    const dailyActivity = makeDailyActivity(30);
+    const payload = makeStatsPayload(overview, dailyActivity);
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      gates: { stats: true },
+      handlers: [makeRangeAwareStatsHandler({ default: payload })],
+    });
+
+    await navigateToStatsTab(page);
+
+    await expect(page.getByTestId("overview-total-users")).toHaveText("42");
+    await expect(page.getByTestId("overview-total-conversations")).toHaveText("99");
+    await expect(page.getByTestId("overview-total-messages")).toHaveText("321");
+    await expect(page.getByTestId("overview-shared-conversations")).toHaveText("7");
+  });
+
+  test("overview cards update when the date-range preset changes", async ({ page }) => {
+    const thirtyDayPayload = makeStatsPayload(
+      makeOverview({ total_users: 42, total_conversations: 99, total_messages: 321 }),
+      makeDailyActivity(30),
+    );
+    const sevenDayPayload = makeStatsPayload(
+      makeOverview({ total_users: 8, total_conversations: 15, total_messages: 40 }),
+      makeDailyActivity(7),
+    );
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      gates: { stats: true },
+      handlers: [
+        makeRangeAwareStatsHandler({
+          default: thirtyDayPayload,
+          "7d": sevenDayPayload,
+        }),
+      ],
+    });
+
+    await navigateToStatsTab(page);
+
+    await expect(page.getByTestId("overview-total-users")).toHaveText("42");
+    await expect(page.getByTestId("overview-total-conversations")).toHaveText("99");
+
+    await page.getByTestId("stats-date-range-filter").getByRole("button", { name: "7d", exact: true }).click();
+
+    // The top cards must pick up the new range's totals — this is the bug:
+    // they previously stayed frozen at the initial (30d) values.
+    await expect(page.getByTestId("overview-total-users")).toHaveText("8");
+    await expect(page.getByTestId("overview-total-conversations")).toHaveText("15");
+    await expect(page.getByTestId("overview-total-messages")).toHaveText("40");
+
+    // The chart-card "Total" figures must move in lockstep with the cards
+    // above them (both read from the same range-scoped stats.overview).
+    await expect(page.getByTestId("conversations-total")).toHaveText("15");
+    await expect(page.getByTestId("messages-total")).toHaveText("40");
+  });
+
+  test("overview cards grey out (refreshing overlay) while a new range is loading", async ({ page }) => {
+    const initialPayload = makeStatsPayload(makeOverview(), makeDailyActivity(30));
+    const sevenDayPayload = makeStatsPayload(makeOverview({ total_users: 5 }), makeDailyActivity(7));
+
+    let releaseSevenDayResponse = () => {};
+    const holdUntil = new Promise<void>((resolve) => {
+      releaseSevenDayResponse = resolve;
+    });
+    let sevenDayRequested = false;
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      gates: { stats: true },
+      handlers: [
+        async ({ route, path, method, url }) => {
+          if (path !== "/api/admin/stats" || method !== "GET") return false;
+          const range = presetFromParams(url);
+          if (range === "7d") {
+            sevenDayRequested = true;
+            await holdUntil;
+            await fulfillJson(route, sevenDayPayload);
+          } else {
+            await fulfillJson(route, initialPayload);
+          }
+          return true;
+        },
+      ],
+    });
+
+    await navigateToStatsTab(page);
+    await expect(page.getByTestId("overview-stats-cards")).toBeVisible();
+    await expect(page.getByTestId("stats-refreshing-overlay")).toHaveCount(0);
+
+    await page.getByTestId("stats-date-range-filter").getByRole("button", { name: "7d", exact: true }).click();
+    await expect.poll(() => sevenDayRequested).toBe(true);
+
+    // While the 7d fetch is in flight, the overlay covers the (now stale)
+    // cards so the user sees a loading state instead of a frozen number.
+    await expect(page.getByTestId("stats-refreshing-overlay")).toBeVisible();
+
+    releaseSevenDayResponse();
+
+    await expect(page.getByTestId("stats-refreshing-overlay")).toHaveCount(0);
+    await expect(page.getByTestId("overview-total-users")).toHaveText("5");
+  });
+
+  test("1h range renders more than a single chart data point", async ({ page }) => {
+    // Mirrors the API's 5-minute bucketing for ranges <= 2h: 12 buckets for 1h.
+    const oneHourActivity = makeDailyActivity(12, true);
+    const payload = makeStatsPayload(makeOverview(), oneHourActivity);
+
+    await installMockedRbacApp(page, {
+      isAdmin: true,
+      session: adminSession,
+      gates: { stats: true },
+      handlers: [makeRangeAwareStatsHandler({ default: payload, "1h": payload })],
+    });
+
+    await navigateToStatsTab(page);
+    await page.getByTestId("stats-date-range-filter").getByRole("button", { name: "1h", exact: true }).click();
+
+    const dauChart = page.getByTestId("chart-dau");
+    await expect(dauChart).toBeVisible();
+    await expect(dauChart.locator("circle")).toHaveCount(12);
+  });
+});

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -429,14 +429,14 @@ function OverviewStatsCards({ overview }: { overview: AdminStats['overview'] | n
   if (!overview) return null;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4" data-testid="overview-stats-cards">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">Total Users</CardTitle>
           <Users className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{overview.total_users}</div>
+          <div className="text-2xl font-bold" data-testid="overview-total-users">{overview.total_users}</div>
           <p className="text-xs text-muted-foreground mt-1">
             DAU: {overview.dau} | MAU: {overview.mau}
           </p>
@@ -449,7 +449,7 @@ function OverviewStatsCards({ overview }: { overview: AdminStats['overview'] | n
           <MessageSquare className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{overview.total_conversations}</div>
+          <div className="text-2xl font-bold" data-testid="overview-total-conversations">{overview.total_conversations}</div>
           <p className="text-xs text-muted-foreground mt-1">
             Today: +{overview.conversations_today}
           </p>
@@ -462,7 +462,7 @@ function OverviewStatsCards({ overview }: { overview: AdminStats['overview'] | n
           <Activity className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{overview.total_messages}</div>
+          <div className="text-2xl font-bold" data-testid="overview-total-messages">{overview.total_messages}</div>
           <p className="text-xs text-muted-foreground mt-1">
             Today: +{overview.messages_today}
           </p>
@@ -475,7 +475,7 @@ function OverviewStatsCards({ overview }: { overview: AdminStats['overview'] | n
           <Share2 className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{overview.shared_conversations}</div>
+          <div className="text-2xl font-bold" data-testid="overview-shared-conversations">{overview.shared_conversations}</div>
           <p className="text-xs text-muted-foreground mt-1">
             {overview.total_conversations > 0
               ? ((overview.shared_conversations / overview.total_conversations) * 100).toFixed(1)
@@ -2214,6 +2214,7 @@ function AdminPage() {
                       badgeLabel="selected"
                     />
                     <DateRangeFilter
+                      data-testid="stats-date-range-filter"
                       value={datePreset}
                       customRange={datePreset === 'custom' ? dateRange : undefined}
                       onChange={(preset, range) => {
@@ -2243,7 +2244,10 @@ function AdminPage() {
                 {stats && (
                   <div className="relative space-y-4">
                     {statsRefreshing && (
-                      <div className="absolute inset-0 bg-background/60 z-10 flex items-center justify-center rounded">
+                      <div
+                        data-testid="stats-refreshing-overlay"
+                        className="absolute inset-0 bg-background/60 z-10 flex items-center justify-center rounded"
+                      >
                         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                       </div>
                     )}
@@ -2305,6 +2309,7 @@ function AdminPage() {
                         </CardHeader>
                         <CardContent>
                           <SimpleLineChart
+                            data-testid="chart-dau"
                             data={stats.daily_activity.map((day) => ({
                               label: formatBucketLabel(day.date),
                               value: day.active_users,
@@ -2338,6 +2343,7 @@ function AdminPage() {
                         </CardHeader>
                         <CardContent>
                           <SimpleLineChart
+                            data-testid="chart-conversations"
                             data={stats.daily_activity.map((day) => ({
                               label: formatBucketLabel(day.date),
                               value: day.conversations,
@@ -2351,7 +2357,7 @@ function AdminPage() {
                               <p className="text-xs text-muted-foreground">Today</p>
                             </div>
                             <div>
-                              <p className="text-2xl font-bold">{stats.overview.total_conversations}</p>
+                              <p className="text-2xl font-bold" data-testid="conversations-total">{stats.overview.total_conversations}</p>
                               <p className="text-xs text-muted-foreground">Total</p>
                             </div>
                             <div>
@@ -2373,6 +2379,7 @@ function AdminPage() {
                       </CardHeader>
                       <CardContent>
                         <SimpleLineChart
+                          data-testid="chart-messages"
                           data={stats.daily_activity.map((day) => ({
                             label: formatBucketLabel(day.date),
                             value: day.messages,
@@ -2386,7 +2393,7 @@ function AdminPage() {
                             <p className="text-xs text-muted-foreground">Today</p>
                           </div>
                           <div>
-                            <p className="text-2xl font-bold">{stats.overview.total_messages}</p>
+                            <p className="text-2xl font-bold" data-testid="messages-total">{stats.overview.total_messages}</p>
                             <p className="text-xs text-muted-foreground">Total</p>
                           </div>
                           <div>

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -415,6 +415,16 @@ function movedAdminTab(tab: string | null): typeof VALID_TABS[number] | null {
   return (MOVED_ADMIN_TAB_MAP as Record<string, typeof VALID_TABS[number]>)[tab] ?? null;
 }
 
+// Bucket keys carry a time component ("2026-07-10T14:30") for hour/minute
+// buckets and are date-only ("2026-07-10") for day buckets — use that to
+// decide whether to label chart points by time-of-day or by calendar date.
+function formatBucketLabel(dateStr: string): string {
+  if (dateStr.includes('T')) {
+    return new Date(dateStr).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
 function OverviewStatsCards({ overview }: { overview: AdminStats['overview'] | null }) {
   if (!overview) return null;
 
@@ -507,7 +517,6 @@ function AdminPage() {
   const auditLogsEnabled = getConfig('auditLogsEnabled');
   const feedbackEnabled = getConfig('feedbackEnabled');
   const [stats, setStats] = useState<AdminStats | null>(null);
-  const [globalOverview, setGlobalOverview] = useState<AdminStats['overview'] | null>(null);
   const [skillStats, setSkillStats] = useState<SkillMetricsAdmin | null>(null);
   // `teams` is the FULL team list, used only by the shared Stats/Feedback
   // team-filter dropdowns and the access-simulation team picker (which need
@@ -1005,14 +1014,10 @@ function AdminPage() {
     setLoading(true);
     setError(null);
     try {
-      const hasStatsFilters = sourceFilter !== 'all' || userFilter.length > 0;
       const p = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
       if (sourceFilter !== 'all') p.set('source', sourceFilter);
       if (userFilter.length > 0) p.set('user', userFilter.join(','));
-      const [statsRes, globalStatsRes] = await Promise.all([
-        fetch(`/api/admin/stats?${p}`),
-        hasStatsFilters ? fetch('/api/admin/stats') : null,
-      ]);
+      const statsRes = await fetch(`/api/admin/stats?${p}`);
 
       if (statsRes.status === 401) {
         setError('Not authenticated. Please sign in via SSO first.');
@@ -1025,16 +1030,11 @@ function AdminPage() {
         return;
       }
 
-      const [statsResponse, globalStatsResponse] = await Promise.all([
-        statsForbidden ? Promise.resolve({ success: false }) : statsRes.json(),
-        globalStatsRes ? globalStatsRes.json().catch(() => null) : null,
-      ]);
+      const statsResponse = statsForbidden ? { success: false } : await statsRes.json();
 
       if (statsResponse.success) {
         setStats(statsResponse.data);
         if (statsResponse.data.available_channels) setStatsChannels(statsResponse.data.available_channels);
-        const overviewData = globalStatsResponse?.success ? globalStatsResponse.data.overview : statsResponse.data.overview;
-        setGlobalOverview(overviewData);
       } else if (!statsForbidden) {
         throw new Error(statsResponse.error || 'Failed to load stats');
       }
@@ -2152,8 +2152,6 @@ function AdminPage() {
 
               {/* Usage Statistics Tab */}
               <TabsContent value="stats" className="space-y-4">
-                <OverviewStatsCards overview={globalOverview} />
-
                 {/* Stats Filters */}
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 flex-wrap">
@@ -2249,6 +2247,7 @@ function AdminPage() {
                         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                       </div>
                     )}
+                    <OverviewStatsCards overview={stats.overview} />
                     {/* Platform Summary Cards */}
                     {stats.platform_summary && (
                       <div className="grid grid-cols-2 gap-4">
@@ -2307,7 +2306,7 @@ function AdminPage() {
                         <CardContent>
                           <SimpleLineChart
                             data={stats.daily_activity.map((day) => ({
-                              label: new Date(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+                              label: formatBucketLabel(day.date),
                               value: day.active_users,
                             }))}
                             height={250}
@@ -2340,7 +2339,7 @@ function AdminPage() {
                         <CardContent>
                           <SimpleLineChart
                             data={stats.daily_activity.map((day) => ({
-                              label: new Date(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+                              label: formatBucketLabel(day.date),
                               value: day.conversations,
                             }))}
                             height={250}
@@ -2375,7 +2374,7 @@ function AdminPage() {
                       <CardContent>
                         <SimpleLineChart
                           data={stats.daily_activity.map((day) => ({
-                            label: new Date(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+                            label: formatBucketLabel(day.date),
                             value: day.messages,
                           }))}
                           height={200}
@@ -2594,7 +2593,7 @@ function AdminPage() {
                         <CardContent>
                           <SimpleLineChart
                             data={stats.feedback_summary.daily.map((day) => ({
-                              label: new Date(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+                              label: formatBucketLabel(day.date),
                               value: day.positive + day.negative,
                             }))}
                             height={180}

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -808,15 +808,15 @@ describe('GET /api/admin/stats — Custom Date Range (from/to)', () => {
     expect(body.data.days).toBe(10);
   });
 
-  it('supports sub-day presets like 1h and 12h (clamped to minimum 1 day of activity)', async () => {
+  it('supports sub-day presets like 1h and 12h (bucketed by 5-minute intervals)', async () => {
     setupAdminWithCollections();
 
     const req = makeRequest('/api/admin/stats?range=1h');
     const res = await GET(req);
     const body = await res.json();
 
-    // 1h = 1 day minimum for daily_activity
-    expect(body.data.daily_activity).toHaveLength(1);
+    // 1h range buckets by 5-minute steps so the chart isn't a single point.
+    expect(body.data.daily_activity).toHaveLength(12);
     expect(body.data.days).toBe(1);
   });
 });

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -338,7 +338,9 @@ describe('GET /api/admin/stats — Overview', () => {
     // Promise.all order (no filters):
     // users: totalUsers, dau, mau
     // conversations: totalConversations, conversationsToday, sharedConversations
-    // messages: webTotalMessages, slackTotalMessages, webMessagesToday, slackMessagesToday
+    // messages: totalMessages, messagesToday — a single unfiltered count each,
+    // covering every metadata.source (not just 'web'/'slack'), so message
+    // counts stay in sync with conversation counts.
     usersCol.countDocuments
       .mockResolvedValueOnce(15)   // totalUsers
       .mockResolvedValueOnce(3)    // dau
@@ -350,10 +352,8 @@ describe('GET /api/admin/stats — Overview', () => {
       .mockResolvedValueOnce(2);   // sharedConversations
 
     msgCol.countDocuments
-      .mockResolvedValueOnce(180)  // webTotalMessages
-      .mockResolvedValueOnce(20)   // slackTotalMessages
-      .mockResolvedValueOnce(15)   // webMessagesToday
-      .mockResolvedValueOnce(5);   // slackMessagesToday
+      .mockResolvedValueOnce(200)  // totalMessages
+      .mockResolvedValueOnce(20);  // messagesToday
 
     const req = makeRequest('/api/admin/stats');
     const res = await GET(req);
@@ -365,11 +365,11 @@ describe('GET /api/admin/stats — Overview', () => {
       expect.objectContaining({
         total_users: 15,
         total_conversations: 50,
-        total_messages: 200,        // 180 web + 20 slack
+        total_messages: 200,
         dau: 3,
         mau: 10,
         conversations_today: 5,
-        messages_today: 20,         // 15 web + 5 slack
+        messages_today: 20,
         shared_conversations: 2,
       })
     );
@@ -384,16 +384,14 @@ describe('GET /api/admin/stats — Overview', () => {
       .mockResolvedValueOnce(0)   // conversationsToday
       .mockResolvedValueOnce(0);  // sharedConversations
     msgCol.countDocuments
-      .mockResolvedValueOnce(8)   // webTotalMessages
-      .mockResolvedValueOnce(2)   // slackTotalMessages
-      .mockResolvedValueOnce(0)   // webMessagesToday
-      .mockResolvedValueOnce(0);  // slackMessagesToday
+      .mockResolvedValueOnce(10)  // totalMessages
+      .mockResolvedValueOnce(0);  // messagesToday
 
     const req = makeRequest('/api/admin/stats');
     const res = await GET(req);
     const body = await res.json();
 
-    // (8 + 2) / 4 = 2.5
+    // 10 / 4 = 2.5
     expect(body.data.overview.avg_messages_per_conversation).toBe(2.5);
   });
 
@@ -997,7 +995,7 @@ describe('GET /api/admin/stats — non-admin scoping', () => {
     expect(usersCol.countDocuments).not.toHaveBeenCalledWith({});
   });
 
-  it('scopes slack message counts by owner_id (messages carry no channel_name)', async () => {
+  it('scopes message counts by owner_id / channel (messages carry no channel_name)', async () => {
     mockGetServerSession.mockResolvedValue(userSession());
     mockGetReadableSlackChannelNames.mockResolvedValue(['ops-help']);
     const { msgCol } = setupNonAdminCollections();
@@ -1005,14 +1003,13 @@ describe('GET /api/admin/stats — non-admin scoping', () => {
     const req = makeRequest('/api/admin/stats');
     await GET(req);
 
-    // Every slack-message query must carry the owner scope; none may run a bare
-    // { 'metadata.source': 'slack' } across the whole platform.
-    const slackMsgCalls = msgCol.countDocuments.mock.calls.filter(
-      (call: any[]) => call[0]?.['metadata.source'] === 'slack'
-    );
-    expect(slackMsgCalls.length).toBeGreaterThan(0);
-    for (const call of slackMsgCalls) {
-      expect(JSON.stringify(call[0])).toContain('user@example.com');
+    // Every message count query must carry the caller's scope (their own
+    // owner_id or their readable slack channel); none may run unscoped
+    // across the whole platform.
+    expect(msgCol.countDocuments.mock.calls.length).toBeGreaterThan(0);
+    for (const call of msgCol.countDocuments.mock.calls) {
+      const inspect = JSON.stringify(call[0] ?? {});
+      expect(inspect.includes('user@example.com') || inspect.includes('ops-help')).toBe(true);
     }
   });
 

--- a/ui/src/app/api/admin/stats/checkpoints/route.ts
+++ b/ui/src/app/api/admin/stats/checkpoints/route.ts
@@ -7,6 +7,7 @@ successResponse,
 withErrorHandler,
 } from '@/lib/api-middleware';
 import { connectToDatabase,isMongoDBConfigured } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
 import { NextRequest,NextResponse } from 'next/server';
 
 // Limits to prevent overloading MongoDB
@@ -14,30 +15,64 @@ const MAX_PEEK_DOCS = 2;          // documents per agent in data peek
 const MAX_PEEK_DOC_SIZE = 2000;   // max chars per serialized document
 const MAX_DISTINCT_THREADS = 500; // cap on distinct() results
 
-/** Compute a { from, to } date range from query params.
- *  Accepts either `from`/`to` ISO strings or a `range` shorthand like "7d". */
-function resolveRange(searchParams: URLSearchParams): { from: Date; to: Date; days: number } {
+type BucketUnit = 'hour' | 'day';
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Mongo $dateToString format for a bucket granularity (UTC, matches bucketDateKey below). */
+const BUCKET_DATE_FORMAT: Record<BucketUnit, string> = {
+  hour: '%Y-%m-%dT%H:00',
+  day: '%Y-%m-%d',
+};
+
+function bucketDateKey(d: Date, unit: BucketUnit): string {
+  return unit === 'hour' ? `${d.toISOString().slice(0, 13)}:00` : d.toISOString().split('T')[0];
+}
+
+/** Generate the ordered (oldest → newest) list of bucket keys covering `to` back `count` buckets of `unit` size. */
+function generateBucketKeys(to: Date, count: number, unit: BucketUnit): string[] {
+  const stepMs = unit === 'hour' ? HOUR_MS : DAY_MS;
+  const keys: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(to.getTime() - i * stepMs);
+    if (unit === 'hour') d.setMinutes(0, 0, 0);
+    else d.setHours(0, 0, 0, 0);
+    keys.push(bucketDateKey(d, unit));
+  }
+  return keys;
+}
+
+/** Compute a { from, to, bucketUnit, bucketCount } date range from query params.
+ *  Accepts either `from`/`to` ISO strings or a `range` shorthand like "7d". Ranges of a
+ *  day or less bucket by hour so 1h/12h/24h charts show more than one data point. */
+function resolveRange(searchParams: URLSearchParams): { from: Date; to: Date; days: number; bucketUnit: BucketUnit; bucketCount: number } {
   const fromParam = searchParams.get('from');
   const toParam = searchParams.get('to');
   const to = toParam ? new Date(toParam) : new Date();
+
+  let from: Date;
+  let ms: number;
   if (fromParam) {
-    const from = new Date(fromParam);
-    const days = Math.max(1, Math.ceil((to.getTime() - from.getTime()) / 86400000));
-    return { from, to, days };
+    from = new Date(fromParam);
+    ms = to.getTime() - from.getTime();
+  } else {
+    const range = searchParams.get('range');
+    switch (range) {
+      case '1h': ms = HOUR_MS; break;
+      case '12h': ms = 12 * HOUR_MS; break;
+      case '1d': case '24h': ms = DAY_MS; break;
+      case '7d': ms = 7 * DAY_MS; break;
+      case '30d': ms = 30 * DAY_MS; break;
+      case '90d': ms = 90 * DAY_MS; break;
+      default: ms = 7 * DAY_MS;
+    }
+    from = new Date(to.getTime() - ms);
   }
-  const range = searchParams.get('range');
-  let days: number;
-  switch (range) {
-    case '1h': days = 1; break;   // 1 hour still shows 1 day of chart data
-    case '12h': days = 1; break;
-    case '1d': case '24h': days = 1; break;
-    case '7d': days = 7; break;
-    case '30d': days = 30; break;
-    case '90d': days = 90; break;
-    default: days = 7;
-  }
-  const from = new Date(to.getTime() - days * 86400000);
-  return { from, to, days };
+
+  const days = Math.max(1, Math.round(ms / DAY_MS));
+  const bucketUnit: BucketUnit = ms <= DAY_MS ? 'hour' : 'day';
+  const bucketCount = bucketUnit === 'hour' ? Math.max(1, Math.round(ms / HOUR_MS)) : days;
+  return { from, to, days, bucketUnit, bucketCount };
 }
 
 /** Safely serialize a MongoDB doc for JSON, truncating large values. */
@@ -77,7 +112,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const { searchParams } = new URL(request.url);
     const includePeek = searchParams.get('peek') !== 'false'; // default: include
-    const { days } = resolveRange(searchParams);
+    const { from, to, days, bucketUnit, bucketCount } = resolveRange(searchParams);
 
     const { db } = await connectToDatabase();
 
@@ -191,21 +226,21 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
 
     // ── Daily activity ───────────────────────────────────────────────────
-    const dailyMap = new Map<string, number>();
-    const now = new Date();
-    for (let i = days - 1; i >= 0; i--) {
-      const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
-      d.setHours(0, 0, 0, 0);
-      dailyMap.set(d.toISOString().split('T')[0], 0);
-    }
+    // checkpoint_writes_* docs only carry `created_at` when TTL is configured,
+    // so bucket by the write's ObjectId timestamp instead — every doc has one.
+    const dailyMap = new Map<string, number>(generateBucketKeys(to, bucketCount, bucketUnit).map((k) => [k, 0]));
 
     const wrCollNames = cpCollNames.map((c: string) => c.replace(/^checkpoints_/, 'checkpoint_writes_'));
+    const fromId = ObjectId.createFromTime(Math.floor(from.getTime() / 1000));
+    const toId = ObjectId.createFromTime(Math.ceil(to.getTime() / 1000));
     for (const wrColl of wrCollNames) {
       try {
-        const count = await db.collection(wrColl).estimatedDocumentCount();
-        if (count > 0) {
-          const today = now.toISOString().split('T')[0];
-          dailyMap.set(today, (dailyMap.get(today) || 0) + count);
+        const buckets = await db.collection(wrColl).aggregate([
+          { $match: { _id: { $gte: fromId, $lte: toId } } },
+          { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: { $toDate: '$_id' } } }, count: { $sum: 1 } } },
+        ]).toArray();
+        for (const b of buckets) {
+          dailyMap.set(b._id, (dailyMap.get(b._id) || 0) + b.count);
         }
       } catch {
         // collection may not exist

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -17,30 +17,52 @@ import { NextRequest,NextResponse } from 'next/server';
 
 const adminStatsCache = createJsonResponseCacheStore();
 
-type BucketUnit = 'hour' | 'day';
+type BucketUnit = 'minute' | 'hour' | 'day';
 
-const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
+
+// Ranges this short bucket by 5-minute intervals so 1h/12h-style short
+// windows show more than a single point (a single hourly bucket would
+// otherwise collapse a 1h range to exactly one data point).
+const MINUTE_BUCKET_THRESHOLD_MS = 2 * HOUR_MS;
+const MINUTE_BUCKET_STEP_MIN = 5;
 
 /** Mongo $dateToString format for a bucket granularity (UTC, matches Date#toISOString below). */
 const BUCKET_DATE_FORMAT: Record<BucketUnit, string> = {
+  minute: '%Y-%m-%dT%H:%M',
   hour: '%Y-%m-%dT%H:00',
   day: '%Y-%m-%d',
 };
 
 /** Render a bucket start Date into the same key format $dateToString produces above. */
 function bucketDateKey(d: Date, unit: BucketUnit): string {
-  return unit === 'hour' ? `${d.toISOString().slice(0, 13)}:00` : d.toISOString().split('T')[0];
+  if (unit === 'minute') return d.toISOString().slice(0, 16);
+  if (unit === 'hour') return `${d.toISOString().slice(0, 13)}:00`;
+  return d.toISOString().split('T')[0];
+}
+
+/** Floor `d` down to the start of the bucket it falls in, mutating a copy. */
+function floorToBucket(d: Date, unit: BucketUnit): Date {
+  const floored = new Date(d);
+  if (unit === 'minute') {
+    floored.setSeconds(0, 0);
+    floored.setMinutes(Math.floor(floored.getMinutes() / MINUTE_BUCKET_STEP_MIN) * MINUTE_BUCKET_STEP_MIN);
+  } else if (unit === 'hour') {
+    floored.setMinutes(0, 0, 0);
+  } else {
+    floored.setHours(0, 0, 0, 0);
+  }
+  return floored;
 }
 
 /** Generate the ordered (oldest → newest) list of bucket keys covering `now` back `count` buckets of `unit` size. */
 function generateBucketKeys(now: Date, count: number, unit: BucketUnit): string[] {
-  const stepMs = unit === 'hour' ? HOUR_MS : DAY_MS;
+  const stepMs = unit === 'minute' ? MINUTE_BUCKET_STEP_MIN * MINUTE_MS : unit === 'hour' ? HOUR_MS : DAY_MS;
   const keys: string[] = [];
   for (let i = count - 1; i >= 0; i--) {
-    const d = new Date(now.getTime() - i * stepMs);
-    if (unit === 'hour') d.setMinutes(0, 0, 0);
-    else d.setHours(0, 0, 0, 0);
+    const d = floorToBucket(new Date(now.getTime() - i * stepMs), unit);
     keys.push(bucketDateKey(d, unit));
   }
   return keys;
@@ -48,9 +70,9 @@ function generateBucketKeys(now: Date, count: number, unit: BucketUnit): string[
 
 /**
  * Parse range params into { rangeStart, days, bucketUnit, bucketCount }. Supports preset
- * strings and explicit from/to ISO dates. Ranges of a day or less bucket by hour (rather
- * than clamping to a single day-granularity bucket) so 1h/12h/24h charts show more than
- * one data point.
+ * strings and explicit from/to ISO dates. Short ranges bucket at finer granularity (minute
+ * for ≤2h, hour for ≤1d) rather than clamping to day-granularity, so 1h/12h/24h charts show
+ * more than one data point.
  */
 function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: number; bucketUnit: BucketUnit; bucketCount: number } {
   const now = new Date();
@@ -81,8 +103,11 @@ function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: nu
   }
 
   const days = Math.max(1, Math.round(ms / DAY_MS));
-  const bucketUnit: BucketUnit = ms <= DAY_MS ? 'hour' : 'day';
-  const bucketCount = bucketUnit === 'hour' ? Math.max(1, Math.round(ms / HOUR_MS)) : days;
+  const bucketUnit: BucketUnit = ms <= MINUTE_BUCKET_THRESHOLD_MS ? 'minute' : ms <= DAY_MS ? 'hour' : 'day';
+  const bucketCount =
+    bucketUnit === 'minute' ? Math.max(1, Math.round(ms / (MINUTE_BUCKET_STEP_MIN * MINUTE_MS))) :
+    bucketUnit === 'hour' ? Math.max(1, Math.round(ms / HOUR_MS)) :
+    days;
   return { rangeStart, days, bucketUnit, bucketCount };
 }
 

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -17,32 +17,73 @@ import { NextRequest,NextResponse } from 'next/server';
 
 const adminStatsCache = createJsonResponseCacheStore();
 
-/** Parse range params into a { rangeStart, days } pair. Supports preset strings and explicit from/to ISO dates. */
-function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: number } {
+type BucketUnit = 'hour' | 'day';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Mongo $dateToString format for a bucket granularity (UTC, matches Date#toISOString below). */
+const BUCKET_DATE_FORMAT: Record<BucketUnit, string> = {
+  hour: '%Y-%m-%dT%H:00',
+  day: '%Y-%m-%d',
+};
+
+/** Render a bucket start Date into the same key format $dateToString produces above. */
+function bucketDateKey(d: Date, unit: BucketUnit): string {
+  return unit === 'hour' ? `${d.toISOString().slice(0, 13)}:00` : d.toISOString().split('T')[0];
+}
+
+/** Generate the ordered (oldest → newest) list of bucket keys covering `now` back `count` buckets of `unit` size. */
+function generateBucketKeys(now: Date, count: number, unit: BucketUnit): string[] {
+  const stepMs = unit === 'hour' ? HOUR_MS : DAY_MS;
+  const keys: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * stepMs);
+    if (unit === 'hour') d.setMinutes(0, 0, 0);
+    else d.setHours(0, 0, 0, 0);
+    keys.push(bucketDateKey(d, unit));
+  }
+  return keys;
+}
+
+/**
+ * Parse range params into { rangeStart, days, bucketUnit, bucketCount }. Supports preset
+ * strings and explicit from/to ISO dates. Ranges of a day or less bucket by hour (rather
+ * than clamping to a single day-granularity bucket) so 1h/12h/24h charts show more than
+ * one data point.
+ */
+function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: number; bucketUnit: BucketUnit; bucketCount: number } {
   const now = new Date();
   const fromParam = searchParams.get('from');
   const toParam = searchParams.get('to');
 
+  let rangeStart: Date;
+  let ms: number;
+
   if (fromParam) {
     const from = new Date(fromParam);
     const to = toParam ? new Date(toParam) : now;
-    const days = Math.max(1, Math.round((to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)));
-    return { rangeStart: from, days };
+    ms = to.getTime() - from.getTime();
+    rangeStart = from;
+  } else {
+    const range = searchParams.get('range');
+    switch (range) {
+      case '1h':  ms = HOUR_MS; break;
+      case '12h': ms = 12 * HOUR_MS; break;
+      case '24h':
+      case '1d':  ms = DAY_MS; break;
+      case '7d':  ms = 7 * DAY_MS; break;
+      case '90d': ms = 90 * DAY_MS; break;
+      case '30d':
+      default:    ms = 30 * DAY_MS; break;
+    }
+    rangeStart = new Date(now.getTime() - ms);
   }
 
-  const range = searchParams.get('range');
-  let ms: number;
-  switch (range) {
-    case '1h':  ms = 60 * 60 * 1000; break;
-    case '12h': ms = 12 * 60 * 60 * 1000; break;
-    case '24h':
-    case '1d':  ms = 24 * 60 * 60 * 1000; break;
-    case '7d':  ms = 7 * 24 * 60 * 60 * 1000; break;
-    case '90d': ms = 90 * 24 * 60 * 60 * 1000; break;
-    case '30d':
-    default:    ms = 30 * 24 * 60 * 60 * 1000; break;
-  }
-  return { rangeStart: new Date(now.getTime() - ms), days: Math.max(1, Math.round(ms / (24 * 60 * 60 * 1000))) };
+  const days = Math.max(1, Math.round(ms / DAY_MS));
+  const bucketUnit: BucketUnit = ms <= DAY_MS ? 'hour' : 'day';
+  const bucketCount = bucketUnit === 'hour' ? Math.max(1, Math.round(ms / HOUR_MS)) : days;
+  return { rangeStart, days, bucketUnit, bucketCount };
 }
 
 /**
@@ -100,7 +141,7 @@ async function getAdminStats(request: NextRequest) {
   }
 
     const { searchParams } = new URL(request.url);
-    const { rangeStart, days } = parseRange(searchParams);
+    const { rangeStart, days, bucketUnit, bucketCount } = parseRange(searchParams);
 
     // Optional filters
     const sourceFilter = searchParams.get('source'); // 'web' | 'slack' | null (all)
@@ -232,13 +273,11 @@ async function getAdminStats(request: NextRequest) {
     const [
       totalUsers,
       totalConversations,
-      webTotalMessages,
-      slackTotalMessages,
+      totalMessages,
       dau,
       mau,
       conversationsToday,
-      webMessagesToday,
-      slackMessagesToday,
+      messagesToday,
       sharedConversations,
     ] = await Promise.all([
       // Non-admins must not see platform-wide headcount — derive their
@@ -250,13 +289,16 @@ async function getAdminStats(request: NextRequest) {
             { $count: 'total' },
           ]).toArray().then((r) => r[0]?.total || 0)
         : users.countDocuments({}),
-      conversations.countDocuments({ ...convSourceFilter }),
-      sourceFilter !== 'slack'
-        ? messages.countDocuments({ 'metadata.source': 'web', ...msgOwnerFilter })
-        : Promise.resolve(0),
-      sourceFilter !== 'web'
-        ? messages.countDocuments({ 'metadata.source': 'slack', ...msgOwnerFilter })
-        : Promise.resolve(0),
+      // Scoped to the selected date range (rangeStart), matching daily_activity
+      // and every other range-aware metric below — previously these were
+      // always lifetime totals regardless of the selected range.
+      conversations.countDocuments({ created_at: { $gte: rangeStart }, ...convSourceFilter }),
+      // msgOwnerFilter already carries 'metadata.source' when the caller
+      // explicitly filtered by source=web|slack; unfiltered, this counts
+      // every message regardless of metadata.source (including messages
+      // missing that field or tagged with other values, e.g. 'scheduler'),
+      // matching how totalConversations counts every conversation.
+      messages.countDocuments({ created_at: { $gte: rangeStart }, ...msgOwnerFilter }),
       // DAU/MAU: derive from conversations when filters are applied, otherwise from users
       hasFilters
         ? conversations.aggregate([
@@ -273,12 +315,7 @@ async function getAdminStats(request: NextRequest) {
           ]).toArray().then((r) => r[0]?.total || 0)
         : users.countDocuments({ last_login: { $gte: thisMonth } }),
       conversations.countDocuments({ created_at: { $gte: today }, ...convSourceFilter }),
-      sourceFilter !== 'slack'
-        ? messages.countDocuments({ 'metadata.source': 'web', created_at: { $gte: today }, ...msgOwnerFilter })
-        : Promise.resolve(0),
-      sourceFilter !== 'web'
-        ? messages.countDocuments({ 'metadata.source': 'slack', created_at: { $gte: today }, ...msgOwnerFilter })
-        : Promise.resolve(0),
+      messages.countDocuments({ created_at: { $gte: today }, ...msgOwnerFilter }),
       // `andInto` rather than spreading a literal `$or` — the non-admin scope
       // can itself be an `$or`, which a spread would clobber (leaking shared
       // conversation counts outside the caller's scope).
@@ -296,9 +333,6 @@ async function getAdminStats(request: NextRequest) {
         })()
       ),
     ]);
-
-    const totalMessages = webTotalMessages + slackTotalMessages;
-    const messagesToday = webMessagesToday + slackMessagesToday;
 
     // ═══════════════════════════════════════════════════════════════
     // PARALLEL BATCH — all independent aggregations in one shot
@@ -337,8 +371,7 @@ async function getAdminStats(request: NextRequest) {
     const [
       dailyUserActivity,
       dailyConvActivity,
-      dailyWebMsgActivity,
-      dailySlackMsgActivity,
+      dailyMsgActivity,
       rawTopByConvs,
       rawTopByMsgs,
       topAgents,
@@ -350,8 +383,7 @@ async function getAdminStats(request: NextRequest) {
       completedWorkflows,
       completedToday,
       conversationsWithAssistant,
-      hourlyWebActivity,
-      hourlySlackActivity,
+      hourlyActivity,
       availableChannelsResult,
       webAgentMsgCount,
     ] = await Promise.all([
@@ -359,35 +391,27 @@ async function getAdminStats(request: NextRequest) {
       hasFilters
         ? conversations.aggregate([
             { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
-            { $group: { _id: { date: { $dateToString: { format: '%Y-%m-%d', date: '$updated_at' } }, user: '$owner_id' } } },
+            { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$updated_at' } }, user: '$owner_id' } } },
             { $group: { _id: '$_id.date', active_users: { $sum: 1 } } },
           ]).toArray()
         : users.aggregate([
             { $match: { last_login: { $gte: rangeStart } } },
-            { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$last_login' } }, active_users: { $sum: 1 } } },
+            { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$last_login' } }, active_users: { $sum: 1 } } },
           ]).toArray(),
 
       // Daily conversations
       conversations.aggregate([
         { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
-        { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, conversations: { $sum: 1 } } },
+        { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, conversations: { $sum: 1 } } },
       ]).toArray(),
 
-      // Daily web messages
-      sourceFilter !== 'slack'
-        ? messages.aggregate([
-            { $match: { 'metadata.source': 'web', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-            { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, messages: { $sum: 1 } } },
-          ]).toArray()
-        : Promise.resolve([]),
-
-      // Daily slack messages
-      sourceFilter !== 'web'
-        ? messages.aggregate([
-            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-            { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, messages: { $sum: 1 } } },
-          ]).toArray()
-        : Promise.resolve([]),
+      // Daily messages — msgOwnerFilter already carries metadata.source
+      // when source=web|slack was explicitly requested; unfiltered, this
+      // counts every message regardless of metadata.source.
+      messages.aggregate([
+        { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, messages: { $sum: 1 } } },
+      ]).toArray(),
 
       // Top users by conversations
       conversations.aggregate([
@@ -438,7 +462,7 @@ async function getAdminStats(request: NextRequest) {
       // Feedback: daily trend
       feedbackColl.aggregate([
         { $match: fbFilter },
-        { $group: { _id: { date: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } }, rating: '$rating' }, count: { $sum: 1 } } },
+        { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, rating: '$rating' }, count: { $sum: 1 } } },
       ]).toArray(),
 
       // Response latency
@@ -468,23 +492,14 @@ async function getAdminStats(request: NextRequest) {
         { $sort: { last_msg_at: -1 } },
       ]).toArray(),
 
-      // Hourly heatmap: web
-      sourceFilter !== 'slack'
-        ? messages.aggregate([
-            { $match: { 'metadata.source': 'web', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-            { $addFields: { _ts: { $toDate: '$created_at' } } },
-            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
-          ]).toArray()
-        : Promise.resolve([]),
-
-      // Hourly heatmap: slack
-      sourceFilter !== 'web'
-        ? messages.aggregate([
-            { $match: { 'metadata.source': 'slack', created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-            { $addFields: { _ts: { $toDate: '$created_at' } } },
-            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
-          ]).toArray()
-        : Promise.resolve([]),
+      // Hourly heatmap — msgOwnerFilter already carries metadata.source
+      // when source=web|slack was explicitly requested; unfiltered, this
+      // counts every message regardless of metadata.source.
+      messages.aggregate([
+        { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+        { $addFields: { _ts: { $toDate: '$created_at' } } },
+        { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
+      ]).toArray(),
 
       // Available channel names (both schema variants). Non-admins get exactly
       // their readable channels (resolved after this batch) — a platform-wide
@@ -509,24 +524,17 @@ async function getAdminStats(request: NextRequest) {
 
     // ── Post-process daily activity ─────────────────────────────────
     const msgMap = new Map<string, number>();
-    for (const d of dailyWebMsgActivity) msgMap.set(d._id, (msgMap.get(d._id) || 0) + d.messages);
-    for (const d of dailySlackMsgActivity) msgMap.set(d._id, (msgMap.get(d._id) || 0) + d.messages);
+    for (const d of dailyMsgActivity) msgMap.set(d._id, (msgMap.get(d._id) || 0) + d.messages);
 
     const userMap = new Map(dailyUserActivity.map((d) => [d._id, d.active_users]));
     const convMap = new Map(dailyConvActivity.map((d) => [d._id, d.conversations]));
 
-    const dailyActivity = [];
-    for (let i = days - 1; i >= 0; i--) {
-      const dayStart = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
-      dayStart.setHours(0, 0, 0, 0);
-      const dateKey = dayStart.toISOString().split('T')[0];
-      dailyActivity.push({
-        date: dateKey,
-        active_users: userMap.get(dateKey) || 0,
-        conversations: convMap.get(dateKey) || 0,
-        messages: msgMap.get(dateKey) || 0,
-      });
-    }
+    const dailyActivity = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => ({
+      date: dateKey,
+      active_users: userMap.get(dateKey) || 0,
+      conversations: convMap.get(dateKey) || 0,
+      messages: msgMap.get(dateKey) || 0,
+    }));
 
     // ── Top users: resolve display names ───────────────────────────
     const topOwnerIds = [...new Set([
@@ -580,18 +588,14 @@ async function getAdminStats(request: NextRequest) {
       if (!dailyFbMap.has(date)) dailyFbMap.set(date, { positive: 0, negative: 0 });
       dailyFbMap.get(date)![row._id.rating as 'positive' | 'negative'] = row.count;
     }
-    const dailyFeedback = [];
-    for (let i = days - 1; i >= 0; i--) {
-      const dayStart = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
-      dayStart.setHours(0, 0, 0, 0);
-      const dateKey = dayStart.toISOString().split('T')[0];
+    const dailyFeedback = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => {
       const entry = dailyFbMap.get(dateKey);
-      dailyFeedback.push({
+      return {
         date: dateKey,
         positive: entry?.positive || 0,
         negative: entry?.negative || 0,
-      });
-    }
+      };
+    });
 
     const feedbackSummary = {
       positive,
@@ -631,8 +635,7 @@ async function getAdminStats(request: NextRequest) {
       : 0;
 
     const hourlyMap = new Map<number, number>();
-    for (const h of hourlyWebActivity) hourlyMap.set(h._id, (hourlyMap.get(h._id) || 0) + h.count);
-    for (const h of hourlySlackActivity) hourlyMap.set(h._id, (hourlyMap.get(h._id) || 0) + (h.count || 0));
+    for (const h of hourlyActivity) hourlyMap.set(h._id, (hourlyMap.get(h._id) || 0) + h.count);
 
     const hourlyHeatmap = Array.from({ length: 24 }, (_, hour) => ({
       hour,
@@ -702,7 +705,7 @@ async function getAdminStats(request: NextRequest) {
               { $match: slackFilter },
               {
                 $group: {
-                  _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
+                  _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } },
                   interactions: { $sum: 1 },
                   unique_users: { $addToSet: userId },
                   resolved: { $sum: { $cond: [{ $not: [escalated] }, 1, 0] } },
@@ -803,20 +806,16 @@ async function getAdminStats(request: NextRequest) {
             escalated: d.escalated,
           }])
         );
-        const slackDaily = [];
-        for (let i = days - 1; i >= 0; i--) {
-          const dayStart = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
-          dayStart.setHours(0, 0, 0, 0);
-          const dateKey = dayStart.toISOString().split('T')[0];
+        const slackDaily = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => {
           const entry = slackDailyMap.get(dateKey);
-          slackDaily.push({
+          return {
             date: dateKey,
             interactions: entry?.interactions || 0,
             unique_users: entry?.unique_users || 0,
             resolved: entry?.resolved || 0,
             escalated: entry?.escalated || 0,
-          });
-        }
+          };
+        });
 
         slack = {
           channels: configDoc

--- a/ui/src/components/admin/shared/DateRangeFilter.tsx
+++ b/ui/src/components/admin/shared/DateRangeFilter.tsx
@@ -15,6 +15,7 @@ interface DateRangeFilterProps {
   value: DateRangePreset;
   customRange?: DateRange;
   onChange: (preset: DateRangePreset, range: DateRange) => void;
+  "data-testid"?: string;
 }
 
 const PRESETS: { value: DateRangePreset; label: string }[] = [
@@ -46,7 +47,7 @@ function toDateInputValue(iso: string): string {
   return iso.slice(0, 10);
 }
 
-export function DateRangeFilter({ value, customRange, onChange }: DateRangeFilterProps) {
+export function DateRangeFilter({ value, customRange, onChange, "data-testid": testId }: DateRangeFilterProps) {
   const [customOpen, setCustomOpen] = useState(false);
   const [customFrom, setCustomFrom] = useState(
     () => customRange ? toDateInputValue(customRange.from) : toDateInputValue(new Date(Date.now() - 30 * 86400000).toISOString())
@@ -97,7 +98,7 @@ export function DateRangeFilter({ value, customRange, onChange }: DateRangeFilte
     : "Custom";
 
   return (
-    <div className="relative flex items-center">
+    <div className="relative flex items-center" data-testid={testId}>
       <div className="flex rounded-md border overflow-hidden">
         {PRESETS.map((p) => (
           <button

--- a/ui/src/components/admin/shared/SimpleLineChart.tsx
+++ b/ui/src/components/admin/shared/SimpleLineChart.tsx
@@ -13,6 +13,7 @@ interface SimpleLineChartProps {
   color?: string;
   showGrid?: boolean;
   title?: string;
+  "data-testid"?: string;
 }
 
 export function SimpleLineChart({
@@ -21,6 +22,7 @@ export function SimpleLineChart({
   color = "rgb(59, 130, 246)", // blue-500
   showGrid = true,
   title,
+  "data-testid": testId,
 }: SimpleLineChartProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [dragStart, setDragStart] = useState<number | null>(null);
@@ -139,7 +141,7 @@ export function SimpleLineChart({
   const selColor = isPositive ? "rgb(34, 197, 94)" : "rgb(239, 68, 68)"; // green-500 / red-500
 
   return (
-    <div className="w-full">
+    <div className="w-full" data-testid={testId}>
       {title && <h4 className="text-sm font-medium mb-4">{title}</h4>}
       <svg
         ref={svgRef}


### PR DESCRIPTION
## Summary
- Message counts in the admin Insights stats no longer require `metadata.source` to be exactly `web` or `slack`. When no `?source=` filter is applied, all messages are counted (matching how conversation counts already work), fixing cases where `messages_today` could be lower than `conversations_today` — which is structurally impossible since every conversation has at least one message.
- Charts for the `1h`/`12h`/`24h` presets now bucket by hour instead of day, so they show more than a single data point.
- The overview `total_conversations`/`total_messages` cards now respect the selected date range instead of always showing lifetime totals.
- Applied the same range-bucketing fix to the sibling `admin/stats/checkpoints` endpoint, which additionally was dumping the full lifetime document count into a single "today" bucket with no date filtering. Since `checkpoint_writes_*` documents don't reliably carry a `created_at` field, bucketing there is done via the document's ObjectId timestamp instead.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` — succeeds
- [ ] Manually verify in the Insights tab that `messages_today` >= `conversations_today`
- [ ] Manually verify 1h/12h/24h chart presets show multiple data points
- [ ] Manually verify overview totals change when switching date range presets