### PR TITLE
fix(dynamic-agents): repair general-purpose tool results

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -22,6 +22,7 @@ from deepagents import create_deep_agent
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import StoreBackend
 from deepagents.middleware.skills import SkillsMiddleware
+from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 from jinja2 import ChainableUndefined, TemplateSyntaxError
 from jinja2.sandbox import SandboxedEnvironment, SecurityError
 from langgraph.checkpoint.memory import MemorySaver
@@ -66,7 +67,7 @@ from dynamic_agents.services.mcp_client import (
     resolve_mcp_connections_credential_refs,
     wrap_tools_with_error_handling,
 )
-from dynamic_agents.services.middleware import build_middleware
+from dynamic_agents.services.middleware import ToolResultInvariantMiddleware, build_middleware
 from dynamic_agents.services.skills import build_skills_files, detect_missing_skills, load_skills
 
 if TYPE_CHECKING:
@@ -87,6 +88,34 @@ def _sanitize_agent_name(name: str) -> str:
     We replace disallowed characters with underscores.
     """
     return re.sub(r"[\s<|\\/>]+", "_", name)
+
+
+def _with_general_purpose_tool_result_recovery(
+    subagents: list[dict[str, Any]],
+    *,
+    model: Any,
+    tools: list[Any],
+    interrupt_on: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Override Deep Agents' built-in subagent with request-time history repair.
+
+    Deep Agents does not apply the parent agent's custom middleware to its
+    built-in ``general-purpose`` subagent. An explicit same-name specification
+    suppresses that default while preserving the public ``task`` tool contract.
+    """
+    recovered_general_purpose = {
+        **GENERAL_PURPOSE_SUBAGENT,
+        "tools": tools,
+        "model": model,
+        "interrupt_on": interrupt_on,
+        "middleware": [ToolResultInvariantMiddleware()],
+    }
+    configured_subagents = [
+        subagent
+        for subagent in subagents
+        if subagent.get("name") != GENERAL_PURPOSE_SUBAGENT["name"]
+    ]
+    return [*configured_subagents, recovered_general_purpose]
 
 
 # Module-level restricted Jinja2 sandbox for system prompt rendering.
@@ -734,6 +763,13 @@ class AgentRuntime:
         else:
             backend = None  # defaults to StateBackend
 
+        deep_agent_subagents = _with_general_purpose_tool_result_recovery(
+            subagents,
+            model=llm,
+            tools=tools,
+            interrupt_on=interrupt_config,
+        )
+
         self._graph = create_deep_agent(
             model=llm,
             tools=tools,
@@ -743,7 +779,7 @@ class AgentRuntime:
             store=self._store,
             backend=backend,
             name=safe_name,
-            subagents=subagents if subagents else None,
+            subagents=deep_agent_subagents,
             interrupt_on=interrupt_config,
             middleware=middleware_stack,
         )

--- a/ai_platform_engineering/dynamic_agents/tests/test_general_purpose_tool_result_invariant.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_general_purpose_tool_result_invariant.py
@@ -1,0 +1,115 @@
+"""Regression coverage for the built-in general-purpose subagent."""
+
+from typing import Any
+
+import pytest
+from deepagents import create_deep_agent
+from deepagents.middleware.subagents import SubAgentMiddleware
+from langchain_core.callbacks.manager import CallbackManagerForLLMRun
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatResult
+from pydantic import Field
+
+from dynamic_agents.services.agent_runtime import _with_general_purpose_tool_result_recovery
+from dynamic_agents.services.middleware import ToolResultInvariantMiddleware
+
+
+class _CapturingFakeModel(FakeMessagesListChatModel):
+    """Record the messages that reach the subagent model."""
+
+    captured_messages: list[list[BaseMessage]] = Field(default_factory=list)
+
+    def bind_tools(
+        self,
+        tools: Any,
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> "_CapturingFakeModel":
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.captured_messages.append(list(messages))
+        return super()._generate(messages, stop, run_manager, **kwargs)
+
+
+def test_general_purpose_recovery_override_is_applied_last() -> None:
+    configured_subagent = {"name": "configured-agent"}
+    conflicting_subagent = {"name": "general-purpose", "middleware": []}
+
+    result = _with_general_purpose_tool_result_recovery(
+        [configured_subagent, conflicting_subagent],
+        model=object(),
+        tools=[],
+        interrupt_on={},
+    )
+
+    assert result[0] is configured_subagent
+    assert [subagent["name"] for subagent in result] == ["configured-agent", "general-purpose"]
+    assert result[-1]["name"] == "general-purpose"
+    assert isinstance(result[-1]["middleware"][0], ToolResultInvariantMiddleware)
+
+
+@pytest.mark.asyncio
+async def test_general_purpose_subagent_repairs_content_block_orphan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processed_subagents: list[dict[str, Any]] = []
+
+    class _CapturingSubAgentMiddleware(SubAgentMiddleware):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            processed_subagents.extend(self._get_subagents())
+
+    monkeypatch.setattr(
+        "deepagents.graph.SubAgentMiddleware",
+        _CapturingSubAgentMiddleware,
+    )
+    model = _CapturingFakeModel(responses=[AIMessage(content="Recovered response")])
+    subagent_specs = _with_general_purpose_tool_result_recovery(
+        [],
+        model=model,
+        tools=[],
+        interrupt_on={},
+    )
+    create_deep_agent(
+        model=model,
+        tools=[],
+        subagents=subagent_specs,
+    )
+
+    assert [subagent["name"] for subagent in processed_subagents] == ["general-purpose"]
+
+    result = await processed_subagents[0]["runnable"].ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    content=[
+                        {
+                            "type": "tool_use",
+                            "id": "orphaned-call",
+                            "name": "read_file",
+                            "input": {"file_path": "history.md"},
+                        }
+                    ]
+                ),
+                HumanMessage(content="Continue the interrupted conversation."),
+            ]
+        }
+    )
+
+    assert result["messages"][-1].content == "Recovered response"
+    captured = model.captured_messages[0]
+    tool_result = next(message for message in captured if isinstance(message, ToolMessage))
+    orphaned_call = next(message for message in captured if isinstance(message, AIMessage))
+    assert tool_result.tool_call_id == "orphaned-call"
+    assert captured.index(tool_result) == captured.index(orphaned_call) + 1
+    assert tool_result.status == "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.49-dev.1"
+version = "0.5.49-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.49.dev1"
+version = "0.5.49.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Follow-up to merged PR #2182.

The original invariant was attached to the parent Dynamic Agent and configured subagents, but Deep Agents builds its reserved `general-purpose` subagent independently. That runnable therefore retained only the narrower upstream `PatchToolCallsMiddleware`, which does not repair legacy content-block, invalid, or misordered tool calls.

This change:

- explicitly overrides the reserved `general-purpose` subagent using Deep Agents' supported same-name override path;
- preserves the default model, tools, prompt, and interrupt behavior;
- adds `ToolResultInvariantMiddleware` to that subagent's model requests;
- removes any conflicting reserved-name configuration before appending the recovery override;
- adds an integration regression against Deep Agents' processed subagent runnable.

A malformed historical checkpoint can now be repaired whether the next Bedrock call occurs in the parent agent, a configured subagent, or the built-in general-purpose subagent.

Closes #2183.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `uv run ruff check .`
- `uv run pytest -q -k 'not test_get_server_injects_builtin_when_empty_list'`
  - 285 passed, 3 skipped, 1 deselected
- Focused general-purpose, invariant, and subagent tests
  - 13 passed
- Live Docker Compose smoke after restarting Dynamic Agents
  - real BFF → parent `task` → `general-purpose` child → `wait` → parent response
  - child and parent markers returned successfully
  - namespace correlated to the parent task tool-call ID
  - no `ValidationException` or missing-`toolResult` event
  - cleanup verified conversations `0`, checkpoints `0`, writes `0`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
