### PR TITLE
fix(auth): revoke stale OIDC admin grants

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.49 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.50 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.49 -f your-values.yaml'}
+                  {'    --version 0.5.50 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.49 -f your-values.yaml'}
+              {'    --version 0.5.50 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -884,6 +884,7 @@ describe('getAuthenticatedUser', () => {
         $set: expect.objectContaining({
           keycloak_sub: 'test-keycloak-sub',
           'metadata.keycloak_sub': 'test-keycloak-sub',
+          'metadata.role': 'user',
         }),
       }),
       { upsert: true }

--- a/ui/src/lib/__tests__/auth-config.test.ts
+++ b/ui/src/lib/__tests__/auth-config.test.ts
@@ -29,6 +29,11 @@ jest.mock('@/lib/rbac/oidc-claim-reconciler', () => ({
   reconcileOidcClaimGroupsForUser: (...args: unknown[]) => mockReconcileOidcClaimGroupsForUser(...args),
 }))
 
+const mockReconcileLoginOpenFgaAccess = jest.fn()
+jest.mock('@/lib/rbac/login-openfga-bootstrap', () => ({
+  reconcileLoginOpenFgaAccess: (...args: unknown[]) => mockReconcileLoginOpenFgaAccess(...args),
+}))
+
 import {
   hasRequiredGroup,
   isAdminUser,
@@ -121,6 +126,8 @@ function makeRefreshFetchMock(opts: {
 describe('auth-config', () => {
   beforeEach(() => {
     mockReconcileOidcClaimGroupsForUser.mockReset()
+    mockReconcileLoginOpenFgaAccess.mockReset()
+    mockReconcileLoginOpenFgaAccess.mockResolvedValue({ status: 'completed', tuple_write_count: 0 })
     _resetServerTokenStore()
   })
 
@@ -790,6 +797,40 @@ describe('auth-config', () => {
       // Note: role promotion (user→admin) requires OIDC_REQUIRED_ADMIN_GROUP to be
       // set at module LOAD time. That constant is evaluated once at import; env changes
       // in beforeEach arrive too late. Role promotion is covered in isAdminUser unit tests.
+    })
+
+    it('should demote a stale admin role and reconcile durable grants from refreshed claims', async () => {
+      const now = Math.floor(Date.now() / 1000)
+
+      mockDecodeJwt.mockReturnValue({
+        sub: 'sub-former-admin',
+        email: 'former-admin@example.com',
+        groups: ['caipe-users'],
+      })
+
+      const result = await (authOptions.callbacks!.jwt! as (...args: unknown[]) => Promise<unknown>)({
+        token: {
+          sub: 'sub-former-admin',
+          email: 'former-admin@example.com',
+          accessToken: 'at',
+          idToken: 'old-idt',
+          refreshToken: 'rt',
+          expiresAt: now + 60,
+          groupsCheckedAt: now - 5 * 60 * 60,
+          isAuthorized: true,
+          role: 'admin',
+        },
+      })
+
+      expect(result.role).toBe('user')
+      expect(mockReconcileLoginOpenFgaAccess).toHaveBeenCalledWith(expect.objectContaining({
+        subject: 'sub-former-admin',
+        email: 'former-admin@example.com',
+        isAuthorized: true,
+        isAdmin: false,
+        isBootstrapAdmin: false,
+        isOidcAdmin: false,
+      }))
     })
 
     it('should NOT re-evaluate groups when less than 4 hours have passed', async () => {

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -280,6 +280,7 @@ async function persistKeycloakSubMapping(
         $set: {
           keycloak_sub: keycloakSub,
           'metadata.keycloak_sub': keycloakSub,
+          'metadata.role': user.role === 'admin' ? 'admin' : 'user',
           updated_at: now,
         },
         $setOnInsert: {
@@ -289,7 +290,6 @@ async function persistKeycloakSubMapping(
           last_login: now,
           'metadata.sso_provider': 'keycloak',
           'metadata.sso_id': keycloakSub,
-          'metadata.role': user.role === 'admin' ? 'admin' : 'user',
         },
       },
       { upsert: true }

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -205,6 +205,26 @@ async function reconcileLoginGroupsFromClaims(input: {
   }
 }
 
+async function reconcileLoginAdminAccess(input: {
+  subject?: string;
+  email?: string;
+  isAuthorized: boolean;
+  isAdmin: boolean;
+  isBootstrapAdmin: boolean;
+  isOidcAdmin: boolean;
+  oidcProviderId: string;
+}): Promise<void> {
+  try {
+    const { reconcileLoginOpenFgaAccess } = await import("@/lib/rbac/login-openfga-bootstrap");
+    await reconcileLoginOpenFgaAccess({
+      ...input,
+      oidcAdminGroup: REQUIRED_ADMIN_GROUP,
+    });
+  } catch (error) {
+    console.warn("[Auth] Login OpenFGA bootstrap failed:", error);
+  }
+}
+
 function hasConfiguredGroup(groups: string[], requiredGroup: string): boolean {
   if (!requiredGroup) return false;
   const requiredLower = requiredGroup.toLowerCase();
@@ -615,6 +635,7 @@ export const authOptions: NextAuthOptions = {
         const email = profileData.email as string | undefined;
         const adminViaBootstrap = isBootstrapAdmin(email);
         const adminViaGroup = isAdminUser(groups);
+        const providerId = resolveLoginProviderId(profileData);
         token.role = adminViaBootstrap || adminViaGroup ? 'admin' : 'user';
 
         if (adminViaBootstrap) {
@@ -641,25 +662,22 @@ export const authOptions: NextAuthOptions = {
           (profileData.name as string | undefined) ??
           (profileData.preferred_username as string | undefined);
 
-        await import("@/lib/rbac/login-openfga-bootstrap")
-          .then(({ reconcileLoginOpenFgaAccess }) =>
-            reconcileLoginOpenFgaAccess({
-              subject,
-              email,
-              isAuthorized: token.isAuthorized === true,
-              isAdmin: token.role === "admin",
-            })
-          )
-          .catch((error) => {
-            console.warn("[Auth] Login OpenFGA bootstrap failed:", error);
-          });
+        await reconcileLoginAdminAccess({
+          subject,
+          email,
+          isAuthorized: token.isAuthorized === true,
+          isAdmin: token.role === "admin",
+          isBootstrapAdmin: adminViaBootstrap,
+          isOidcAdmin: adminViaGroup,
+          oidcProviderId: providerId,
+        });
 
         await reconcileLoginGroupsFromClaims({
           subject,
           email,
           displayName,
           groups,
-          providerId: resolveLoginProviderId(profileData),
+          providerId,
         });
       }
 
@@ -720,14 +738,49 @@ export const authOptions: NextAuthOptions = {
             if (shouldRecheckGroups) {
               try {
                 const claims = decodeJwt(refreshedToken.idToken as string);
-                const groups = extractGroups(claims as Record<string, unknown>);
-                cacheOidcClaimGroups(token.sub as string | undefined, groups);
+                const claimData = claims as Record<string, unknown>;
+                const groups = extractGroups(claimData);
+                const subject =
+                  (claimData.sub as string | undefined) ??
+                  (refreshedToken.sub as string | undefined) ??
+                  (token.sub as string | undefined);
+                const email =
+                  (claimData.email as string | undefined) ??
+                  (refreshedToken.email as string | undefined) ??
+                  (token.email as string | undefined);
+                const displayName =
+                  (claimData.name as string | undefined) ??
+                  (claimData.preferred_username as string | undefined);
+                const isAuthorized = hasRequiredGroup(groups);
+                const adminViaBootstrap = isBootstrapAdmin(email);
+                const adminViaGroup = isAdminUser(groups);
+                const providerId = resolveLoginProviderId(claimData);
+                cacheOidcClaimGroups(subject, groups);
                 console.log(`[Auth] Re-evaluating groups from refreshed id_token (last checked ${Math.round((now - lastGroupCheck) / 3600)}h ago), count: ${groups.length}`);
+
+                await reconcileLoginAdminAccess({
+                  subject,
+                  email,
+                  isAuthorized,
+                  isAdmin: adminViaBootstrap || adminViaGroup,
+                  isBootstrapAdmin: adminViaBootstrap,
+                  isOidcAdmin: adminViaGroup,
+                  oidcProviderId: providerId,
+                });
+                await reconcileLoginGroupsFromClaims({
+                  subject,
+                  email,
+                  displayName,
+                  groups,
+                  providerId,
+                });
+
                 return {
                   ...refreshedToken,
-                  isAuthorized: hasRequiredGroup(groups),
-                  role: refreshedToken.role === 'admin' ? 'admin' : 'user',
+                  isAuthorized,
+                  role: adminViaBootstrap || adminViaGroup ? 'admin' : 'user',
                   canViewAdmin: canViewAdminDashboard(groups),
+                  canAccessDynamicAgents: canAccessDynamicAgents(groups),
                   groupsCheckedAt: now,
                 };
               } catch (err) {

--- a/ui/src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts
+++ b/ui/src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts
@@ -28,6 +28,7 @@ function stubTeamMembershipSources(rows: Record<string, unknown>[]) {
     find: jest.fn(() => ({
       toArray: jest.fn().mockResolvedValue(rows),
     })),
+    updateMany: jest.fn().mockResolvedValue({ matchedCount: 1, modifiedCount: 1 }),
     updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
     deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
   };
@@ -404,8 +405,16 @@ describe("login OpenFGA bootstrap", () => {
     });
     // Membership source upserted
     expect(mockSources.updateOne).toHaveBeenCalledWith(
-      expect.objectContaining({ team_slug: "super-admins", user_subject: "sub-admin" }),
-      expect.objectContaining({ $set: expect.objectContaining({ relationship: "admin", status: "active" }) }),
+      expect.objectContaining({
+        team_slug: "super-admins",
+        user_subject: "sub-admin",
+        source_type: "oidc_claim",
+        provider_id: "oidc-claims",
+        external_group_id: "configured-admin-group",
+      }),
+      expect.objectContaining({
+        $set: expect.objectContaining({ relationship: "admin", managed: true, status: "active" }),
+      }),
       { upsert: true },
     );
   });
@@ -436,7 +445,157 @@ describe("login OpenFGA bootstrap", () => {
     expect(mockSources.updateOne).not.toHaveBeenCalled();
   });
 
-  it("does not bootstrap users who failed the OIDC admission gate", async () => {
+  it("revokes legacy login-bootstrap membership and direct admin tuples after OIDC demotion", async () => {
+    const mockSources = stubTeamMembershipSources([
+      {
+        team_id: "team-super-admins",
+        team_slug: "super-admins",
+        user_email: "former-admin@example.com",
+        user_subject: "sub-former-admin",
+        relationship: "admin",
+        source_type: "manual",
+        managed: false,
+        status: "active",
+        created_by: "login-bootstrap",
+      },
+    ]);
+    mockGetRbacCollection.mockImplementation(async (key: string) => {
+      if (key === "teamMembershipSources") return mockSources;
+      throw new Error(`unexpected rbac collection ${key}`);
+    });
+
+    const { reconcileLoginOpenFgaAccess } = await import("../login-openfga-bootstrap");
+    const result = await reconcileLoginOpenFgaAccess({
+      subject: "sub-former-admin",
+      email: "former-admin@example.com",
+      isAuthorized: true,
+      isAdmin: false,
+      isBootstrapAdmin: false,
+      isOidcAdmin: false,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(mockSources.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        team_slug: "super-admins",
+        status: "active",
+        created_by: { $in: ["oidc-admin-login-reconciliation", "login-bootstrap"] },
+      }),
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          status: "removed",
+          removed_by: "oidc-admin-login-reconciliation",
+        }),
+      }),
+    );
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        { user: "user:sub-former-admin", relation: "admin", object: "team:super-admins" },
+        { user: "user:sub-former-admin", relation: "member", object: "team:super-admins" },
+      ]),
+    });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: expect.arrayContaining([
+        { user: "user:sub-former-admin", relation: "member", object: "organization:grid" },
+      ]),
+      deletes: expect.arrayContaining([
+        { user: "user:sub-former-admin", relation: "admin", object: "organization:grid" },
+        { user: "user:sub-former-admin", relation: "manager", object: "admin_surface:rag_datasources" },
+      ]),
+    });
+  });
+
+  it("preserves independently recorded manual super-admin membership after OIDC demotion", async () => {
+    const mockSources = stubTeamMembershipSources([
+      {
+        team_id: "team-super-admins",
+        team_slug: "super-admins",
+        user_email: "manual-admin@example.com",
+        user_subject: "sub-manual-admin",
+        relationship: "admin",
+        source_type: "manual",
+        managed: false,
+        status: "active",
+        created_by: "platform-owner@example.com",
+      },
+    ]);
+    mockGetRbacCollection.mockImplementation(async (key: string) => {
+      if (key === "teamMembershipSources") return mockSources;
+      throw new Error(`unexpected rbac collection ${key}`);
+    });
+
+    const { reconcileLoginOpenFgaAccess } = await import("../login-openfga-bootstrap");
+    await reconcileLoginOpenFgaAccess({
+      subject: "sub-manual-admin",
+      email: "manual-admin@example.com",
+      isAuthorized: true,
+      isAdmin: false,
+      isBootstrapAdmin: false,
+      isOidcAdmin: false,
+    });
+
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        expect.objectContaining({ object: "team:super-admins" }),
+      ]),
+    });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: expect.any(Array),
+      deletes: [],
+    });
+  });
+
+  it("preserves bootstrap-admin access while retiring absent OIDC provenance", async () => {
+    const mockSources = stubTeamMembershipSources([]);
+    mockGetRbacCollection.mockImplementation(async (key: string) => {
+      if (key === "teamMembershipSources") return mockSources;
+      throw new Error(`unexpected rbac collection ${key}`);
+    });
+
+    const { reconcileLoginOpenFgaAccess } = await import("../login-openfga-bootstrap");
+    await reconcileLoginOpenFgaAccess({
+      subject: "sub-bootstrap-admin",
+      email: "bootstrap-admin@example.com",
+      isAuthorized: true,
+      isAdmin: true,
+      isBootstrapAdmin: true,
+      isOidcAdmin: false,
+    });
+
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        expect.objectContaining({ object: "team:super-admins" }),
+      ]),
+    });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: expect.arrayContaining([
+        { user: "user:sub-bootstrap-admin", relation: "admin", object: "organization:grid" },
+      ]),
+      deletes: [],
+    });
+  });
+
+  it("revokes stale admin access even when the OIDC admission gate fails", async () => {
+    const mockSources = stubTeamMembershipSources([
+      {
+        team_id: "team-super-admins",
+        team_slug: "super-admins",
+        user_email: "outsider@example.com",
+        user_subject: "sub-outsider",
+        relationship: "admin",
+        source_type: "manual",
+        managed: false,
+        status: "active",
+        created_by: "login-bootstrap",
+      },
+    ]);
+    mockGetRbacCollection.mockImplementation(async (key: string) => {
+      if (key === "teamMembershipSources") return mockSources;
+      throw new Error(`unexpected rbac collection ${key}`);
+    });
     const { reconcileLoginOpenFgaAccess } = await import("../login-openfga-bootstrap");
 
     const result = await reconcileLoginOpenFgaAccess({
@@ -446,7 +605,12 @@ describe("login OpenFGA bootstrap", () => {
       isAdmin: true,
     });
 
-    expect(result.status).toBe("skipped");
-    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
+    expect(result.status).toBe("completed");
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        { user: "user:sub-outsider", relation: "admin", object: "organization:grid" },
+      ]),
+    });
   });
 });

--- a/ui/src/lib/rbac/login-openfga-bootstrap.ts
+++ b/ui/src/lib/rbac/login-openfga-bootstrap.ts
@@ -1,5 +1,6 @@
 import { getCollection } from "@/lib/mongodb";
 import {
+  adminBaselineGrantDefinitions,
   effectiveBaselineBootstrapTuples,
   getBaselineFgaProfileBundle,
   type TeamBaselineProfileOverride,
@@ -27,9 +28,16 @@ export interface LoginOpenFgaBootstrapInput {
   email?: string;
   isAuthorized: boolean;
   isAdmin: boolean;
+  isBootstrapAdmin?: boolean;
+  isOidcAdmin?: boolean;
+  oidcAdminGroup?: string;
+  oidcProviderId?: string;
 }
 
 const OPENFGA_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~@|*+=,/-]{0,191}$/;
+// assisted-by Codex Codex-sonnet-4-6
+const OIDC_ADMIN_RECONCILER = "oidc-admin-login-reconciliation";
+const LEGACY_LOGIN_BOOTSTRAP = "login-bootstrap";
 
 function normalizeDefaultAgentId(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -51,8 +59,10 @@ async function defaultAgentTuple(): Promise<OpenFgaTupleKey[]> {
 }
 
 interface TeamDoc {
+  _id?: unknown;
   slug?: string;
   name?: string;
+  created_at?: Date;
   baseline_profile_overrides?: {
     member_profile_id?: string;
     admin_profile_id?: string;
@@ -125,61 +135,140 @@ async function teamOverridesForLogin(email: string | undefined): Promise<TeamBas
   }
 }
 
-async function ensureSuperAdminTeamMembership(subject: string, email: string | undefined): Promise<void> {
-  try {
-    await writeTeamMembershipTuples(subject, SUPER_ADMINS_TEAM_SLUG, mongoRoleToOpenFgaRelations("admin"), "assign");
+function loginManagedAdminSource(source: TeamMembershipSource): boolean {
+  return source.created_by === OIDC_ADMIN_RECONCILER || source.created_by === LEGACY_LOGIN_BOOTSTRAP;
+}
 
-    const teams = await getCollection<{ _id: unknown; created_at?: Date }>("teams");
-    const team = await teams.findOne({ slug: SUPER_ADMINS_TEAM_SLUG } as never);
-    const teamId = team?._id ? String(team._id) : SUPER_ADMINS_TEAM_SLUG;
-    const now = new Date().toISOString();
-    const normalizedEmail = email?.trim().toLowerCase() ?? "";
+function sourceIdentityFilter(subject: string, email: string | undefined): Record<string, unknown>[] {
+  const filters: Record<string, unknown>[] = [{ user_subject: subject }];
+  const normalizedEmail = email?.trim().toLowerCase();
+  if (normalizedEmail) filters.push({ user_email: normalizedEmail });
+  return filters;
+}
 
-    const source: TeamMembershipSource = {
-      team_id: teamId,
+async function reconcileOidcSuperAdminMembership(input: {
+  subject: string;
+  email?: string;
+  shouldHaveOidcAdmin: boolean;
+  preserveBootstrapAdmin: boolean;
+  oidcAdminGroup?: string;
+  oidcProviderId?: string;
+}): Promise<{ hasIndependentAdminSource: boolean; hadLoginManagedAdminSource: boolean }> {
+  const sources = await getRbacCollection<TeamMembershipSource>("teamMembershipSources");
+  const identityFilter = sourceIdentityFilter(input.subject, input.email);
+  const recordedSources = await sources
+    .find({
       team_slug: SUPER_ADMINS_TEAM_SLUG,
-      user_email: normalizedEmail,
-      user_subject: subject,
-      source_type: "manual",
       relationship: "admin",
-      managed: false,
+      $or: identityFilter,
+    })
+    .toArray();
+  const activeSources = recordedSources.filter((source) => source.status === "active");
+  const hasIndependentAdminSource = activeSources.some((source) => !loginManagedAdminSource(source));
+  const hadLoginManagedAdminSource = recordedSources.some(loginManagedAdminSource);
+
+  if (input.shouldHaveOidcAdmin) {
+    const teams = await getCollection<TeamDoc>("teams");
+    const team = await teams.findOne({ slug: SUPER_ADMINS_TEAM_SLUG });
+    const now = new Date().toISOString();
+    const source: TeamMembershipSource = {
+      team_id: team?._id ? String(team._id) : SUPER_ADMINS_TEAM_SLUG,
+      team_slug: SUPER_ADMINS_TEAM_SLUG,
+      user_email: input.email?.trim().toLowerCase(),
+      user_subject: input.subject,
+      relationship: "admin",
+      source_type: "oidc_claim",
+      provider_id: input.oidcProviderId?.trim() || "oidc-claims",
+      external_group_id: input.oidcAdminGroup?.trim() || "configured-admin-group",
+      managed: true,
       status: "active",
-      created_by: "login-bootstrap",
+      created_by: OIDC_ADMIN_RECONCILER,
       created_at: now,
       first_seen_at: now,
       last_seen_at: now,
       last_applied_at: now,
     };
     await upsertTeamMembershipSource(source);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[LoginOpenFGA] Failed to add ${email ?? subject} to super-admins team: ${message}`);
+    await writeTeamMembershipTuples(
+      input.subject,
+      SUPER_ADMINS_TEAM_SLUG,
+      mongoRoleToOpenFgaRelations("admin"),
+      "assign",
+    );
+    return { hasIndependentAdminSource, hadLoginManagedAdminSource: true };
   }
+
+  await sources.updateMany(
+    {
+      team_slug: SUPER_ADMINS_TEAM_SLUG,
+      relationship: "admin",
+      status: "active",
+      created_by: { $in: [OIDC_ADMIN_RECONCILER, LEGACY_LOGIN_BOOTSTRAP] },
+      $or: identityFilter,
+    },
+    {
+      $set: {
+        status: "removed",
+        removed_by: OIDC_ADMIN_RECONCILER,
+        removed_at: new Date().toISOString(),
+      },
+    },
+  );
+
+  if (
+    hadLoginManagedAdminSource &&
+    !input.preserveBootstrapAdmin &&
+    !hasIndependentAdminSource
+  ) {
+    await writeTeamMembershipTuples(
+      input.subject,
+      SUPER_ADMINS_TEAM_SLUG,
+      mongoRoleToOpenFgaRelations("admin"),
+      "remove",
+    );
+  }
+
+  return { hasIndependentAdminSource, hadLoginManagedAdminSource };
 }
 
 export async function reconcileLoginOpenFgaAccess(
   input: LoginOpenFgaBootstrapInput
 ): Promise<LoginOpenFgaBootstrapResult> {
   const subject = input.subject?.trim();
-  if (!input.isAuthorized || !subject) {
+  if (!subject) {
     return { status: "skipped", tuple_write_count: 0 };
   }
 
-  const bundle = await getBaselineFgaProfileBundle();
-  const writes = effectiveBaselineBootstrapTuples({
-    subject,
-    isAdmin: input.isAdmin,
-    bundle,
-    teamOverrides: await teamOverridesForLogin(input.email),
-  });
-  writes.push(...(await defaultAgentTuple()));
-
-  if (input.isAdmin) {
-    await ensureSuperAdminTeamMembership(subject, input.email);
-  }
-
   try {
-    const result = await writeOpenFgaTuples({ writes, deletes: [] });
+    const effectiveAdmin = input.isAuthorized && input.isAdmin;
+    const isOidcAdmin = input.isOidcAdmin ?? input.isAdmin;
+    const superAdminReconciliation = await reconcileOidcSuperAdminMembership({
+      subject,
+      email: input.email,
+      shouldHaveOidcAdmin: input.isAuthorized && isOidcAdmin,
+      preserveBootstrapAdmin: input.isBootstrapAdmin === true,
+      oidcAdminGroup: input.oidcAdminGroup,
+      oidcProviderId: input.oidcProviderId,
+    });
+    const bundle = await getBaselineFgaProfileBundle();
+    const writes = input.isAuthorized
+      ? effectiveBaselineBootstrapTuples({
+          subject,
+          isAdmin: effectiveAdmin,
+          bundle,
+          teamOverrides: await teamOverridesForLogin(input.email),
+        })
+      : [];
+    if (input.isAuthorized) writes.push(...(await defaultAgentTuple()));
+
+    const deletes =
+      effectiveAdmin ||
+      input.isBootstrapAdmin === true ||
+      superAdminReconciliation.hasIndependentAdminSource ||
+      !superAdminReconciliation.hadLoginManagedAdminSource
+        ? []
+        : adminBaselineGrantDefinitions().map((definition) => definition.tuple(subject));
+    const result = await writeOpenFgaTuples({ writes, deletes });
     return { status: "completed", tuple_write_count: result.writes };
   } catch (error) {
     const warning = error instanceof Error ? error.message : String(error);

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fixes #2188.

OIDC/AD-group admin access is now reconciled against current claims instead of being materialized permanently.

## What changed

- Store login-derived super-admin membership as a managed `oidc_claim` source with provider and group provenance.
- Retire both new provenance-aware sources and legacy `created_by: "login-bootstrap"` sources when the configured admin group is absent.
- Remove the corresponding Super Admins membership and direct admin baseline tuples only when login reconciliation owns the grant.
- Preserve `BOOTSTRAP_ADMIN_EMAILS` access and independently recorded manual Super Admins memberships.
- Recompute `token.role` from refreshed OIDC claims and reconcile durable OpenFGA state during the four-hour group recheck.
- Reconcile `users.metadata.role` on subsequent authenticated requests instead of setting it only on insert.

## Root cause

The login bootstrap wrote AD-group admins into the Super Admins team as unmanaged manual membership and wrote direct admin baseline tuples. Later non-admin logins had no inverse operation. The refreshed-token path also retained the previous admin role instead of deriving it from current group claims.

That left OpenFGA organization-admin access active even when the current session/avatar correctly showed `user`.

## User impact

Removing a user from the configured OIDC admin group now revokes login-derived Admin and Knowledge Base administration privileges after a new login or refreshed-claim reconciliation. Manual and break-glass administrator access remains intact.

## Validation

- `npm test -- --runInBand src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts src/lib/__tests__/auth-config.test.ts src/lib/__tests__/api-middleware.test.ts` — 181 tests passed
- `npm run lint` — 0 errors; repository-wide pre-existing warnings remain
- `npm run build` — passed; existing Turbopack NFT trace warning remains
- `git diff --check` — passed

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
