### PR TITLE
fix(rbac): bootstrap member baseline for directory-synced users

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.49 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.50 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.49 -f your-values.yaml'}
+                  {'    --version 0.5.50 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.49 -f your-values.yaml'}
+              {'    --version 0.5.50 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/admin/rebac/self-check/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/rebac/self-check/__tests__/route.test.ts
@@ -292,3 +292,38 @@ it("cleans stale service account scopes and Webex grants for missing resources",
     applied_tuple_deletes: 2,
   });
 });
+
+it("raises the repair scan's finding cap when maxFindings is supplied", async () => {
+  mockRepairableMissingTuples.mockReturnValue([]);
+  mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 0, deletes: 0 });
+
+  const { POST } = await import("../route");
+  const response = await POST(request({ maxFindings: 10000 }));
+
+  expect(response.status).toBe(200);
+  // First call is the "before" scan used to compute repairable tuples: it must
+  // carry the raised cap so a large backfill isn't truncated to the default.
+  expect(mockRunRbacSelfCheck).toHaveBeenNthCalledWith(1, { checks: undefined, maxFindings: 10000 });
+});
+
+it("clamps an oversized repair limit to the ceiling", async () => {
+  mockRepairableMissingTuples.mockReturnValue([]);
+  mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 0, deletes: 0 });
+
+  const { POST } = await import("../route");
+  const response = await POST(request({ maxFindings: 5_000_000 }));
+
+  expect(response.status).toBe(200);
+  expect(mockRunRbacSelfCheck).toHaveBeenNthCalledWith(1, { checks: undefined, maxFindings: 100_000 });
+});
+
+it("omits maxFindings from the repair scan when none is supplied", async () => {
+  mockRepairableMissingTuples.mockReturnValue([]);
+  mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 0, deletes: 0 });
+
+  const { POST } = await import("../route");
+  const response = await POST(request({}));
+
+  expect(response.status).toBe(200);
+  expect(mockRunRbacSelfCheck).toHaveBeenNthCalledWith(1, { checks: undefined });
+});

--- a/ui/src/app/api/admin/rebac/self-check/route.ts
+++ b/ui/src/app/api/admin/rebac/self-check/route.ts
@@ -25,6 +25,12 @@ import type {
 import { withRebacAdminAuth,withRebacViewAuth } from "../_lib";
 
 const BULK_REVOKE_REVIEW_LIMIT = 5000;
+// Upper bound on how many missing tuples a single repair pass may consider.
+// A large org backfilling the member baseline for every directory-synced user
+// can have far more than the default 500 missing tuples, so admins may raise
+// the cap up to this ceiling to repair everyone in one pass instead of paging
+// through it 500 at a time.
+const MAX_REPAIR_LIMIT = 100_000;
 const DEFAULT_SLACK_WORKSPACE = "CAIPE";
 const DEFAULT_WEBEX_WORKSPACE = "Cisco";
 
@@ -111,6 +117,17 @@ function parseChecks(value: unknown): string[] | undefined {
       .filter(Boolean);
   }
   return undefined;
+}
+
+/**
+ * Parse an admin-supplied repair limit, capping how many missing tuples one
+ * repair pass considers. Returns undefined (self-check's own default applies)
+ * for absent/invalid values, and clamps to [1, MAX_REPAIR_LIMIT] otherwise.
+ */
+function parseRepairLimit(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.min(Math.floor(parsed), MAX_REPAIR_LIMIT);
 }
 
 export const GET = withErrorHandler(async (request: NextRequest) =>
@@ -394,8 +411,11 @@ export const POST = withErrorHandler(async (request: NextRequest) =>
       checks?: unknown;
       tuple?: unknown;
       tuples?: unknown;
+      maxFindings?: unknown;
+      limit?: unknown;
     };
     const checks = parseChecks(body.checks);
+    const repairLimit = parseRepairLimit(body.maxFindings ?? body.limit);
 
     if (body.action === "revoke_tuple") {
       if (!isTuple(body.tuple)) {
@@ -504,7 +524,12 @@ export const POST = withErrorHandler(async (request: NextRequest) =>
       ? body.sources.filter((source): source is string => typeof source === "string" && source.trim().length > 0)
       : undefined;
 
-    const before = await runRbacSelfCheck({ checks });
+    // Raise the finding cap for the repair scan when an admin asks for it, so a
+    // large backfill (e.g. the member baseline for every directory-synced user)
+    // can be repaired in one pass instead of 500 tuples at a time. The orphan
+    // limit is left at its default — this control is about repairing missing
+    // grants, not surfacing more unowned tuples.
+    const before = await runRbacSelfCheck({ checks, ...(repairLimit ? { maxFindings: repairLimit } : {}) });
     const writes = repairableMissingTuples(before, sources);
     const result = await writeOpenFgaTuples({ writes, deletes: [] });
     const after = await runRbacSelfCheck({ checks });

--- a/ui/src/components/admin/security/RbacSelfCheckTab.tsx
+++ b/ui/src/components/admin/security/RbacSelfCheckTab.tsx
@@ -909,7 +909,7 @@ export function RbacSelfCheckTab({ isAdmin }: RbacSelfCheckTabProps) {
             placeholder="Max (500)"
             title="Max missing tuples to repair in one pass. Leave blank for the default of 500; raise it to backfill a large synced population in a single pass."
             disabled={actionBusy}
-            className="h-9 w-24 rounded-md border border-border/80 bg-background px-2 text-sm"
+            className="h-9 w-32 rounded-md border border-border/80 bg-background px-2 text-sm"
           />
           <Button
             type="button"

--- a/ui/src/components/admin/security/RbacSelfCheckTab.tsx
+++ b/ui/src/components/admin/security/RbacSelfCheckTab.tsx
@@ -495,6 +495,11 @@ export function RbacSelfCheckTab({ isAdmin }: RbacSelfCheckTabProps) {
   const [revokingKey, setRevokingKey] = useState<string | null>(null);
   const [bulkRevoking, setBulkRevoking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // How many missing tuples a single "Repair Missing Tuples" pass may write.
+  // Empty string means "use the server default". Backfilling the member
+  // baseline for a large directory-synced population can exceed the default
+  // 500, so admins can raise this to repair everyone in one pass.
+  const [repairLimit, setRepairLimit] = useState("");
   const [matrixDialogOpen, setMatrixDialogOpen] = useState(false);
   const [selectedCheckIds, setSelectedCheckIds] = useState<Set<RbacSelfCheckId>>(
     () => new Set(RBAC_SELF_CHECK_IDS),
@@ -590,10 +595,15 @@ export function RbacSelfCheckTab({ isAdmin }: RbacSelfCheckTabProps) {
     setRepairing(true);
     setError(null);
     try {
+      const parsedLimit = Number(repairLimit);
+      const limitExtra =
+        repairLimit.trim() && Number.isFinite(parsedLimit) && parsedLimit > 0
+          ? { maxFindings: Math.floor(parsedLimit) }
+          : {};
       const response = await fetch("/api/admin/rebac/self-check", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: requestBodyForChecks(selectedChecks),
+        body: requestBodyForChecks(selectedChecks, limitExtra),
       });
       if (!response.ok) {
         throw new Error(`Repair failed with ${response.status}`);
@@ -616,7 +626,7 @@ export function RbacSelfCheckTab({ isAdmin }: RbacSelfCheckTabProps) {
     } finally {
       setRepairing(false);
     }
-  }, [selectedChecks]);
+  }, [selectedChecks, repairLimit]);
 
   const revokeTuple = useCallback(async (finding: RbacSelfCheckFinding) => {
     if (!finding.tuple) return;
@@ -890,6 +900,17 @@ export function RbacSelfCheckTab({ isAdmin }: RbacSelfCheckTabProps) {
             {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
             Audit Selected
           </Button>
+          <input
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={repairLimit}
+            onChange={(event) => setRepairLimit(event.target.value)}
+            placeholder="Max (500)"
+            title="Max missing tuples to repair in one pass. Leave blank for the default of 500; raise it to backfill a large synced population in a single pass."
+            disabled={actionBusy}
+            className="h-9 w-24 rounded-md border border-border/80 bg-background px-2 text-sm"
+          />
           <Button
             type="button"
             onClick={repairMissing}

--- a/ui/src/lib/rbac/__tests__/event-loop-yield.test.ts
+++ b/ui/src/lib/rbac/__tests__/event-loop-yield.test.ts
@@ -1,0 +1,76 @@
+import { loopYieldEvery, maybeYield, yieldToEventLoop } from "../event-loop-yield";
+
+describe("event-loop-yield", () => {
+  const originalEnv = process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+    else process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = originalEnv;
+  });
+
+  describe("loopYieldEvery", () => {
+    it("defaults to 500 when the env var is unset", () => {
+      delete process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+      expect(loopYieldEvery()).toBe(500);
+    });
+
+    it("honors a valid override", () => {
+      process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = "25";
+      expect(loopYieldEvery()).toBe(25);
+    });
+
+    it("floors fractional overrides", () => {
+      process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = "7.9";
+      expect(loopYieldEvery()).toBe(7);
+    });
+
+    it("falls back to the default for invalid or sub-1 values", () => {
+      for (const bad of ["0", "-4", "abc", ""]) {
+        process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = bad;
+        expect(loopYieldEvery()).toBe(500);
+      }
+    });
+  });
+
+  describe("yieldToEventLoop", () => {
+    it("uses setImmediate when available", async () => {
+      // jsdom (this test env) has NO setImmediate, which is why the sync path
+      // originally threw ReferenceError here; inject a stub to exercise the
+      // Node-runtime branch and confirm it's the scheduler that gets called.
+      const stub = jest.fn((cb: () => void) => setTimeout(cb, 0));
+      (globalThis as { setImmediate?: unknown }).setImmediate = stub;
+      try {
+        await expect(yieldToEventLoop()).resolves.toBeUndefined();
+        expect(stub).toHaveBeenCalledTimes(1);
+      } finally {
+        delete (globalThis as { setImmediate?: unknown }).setImmediate;
+      }
+    });
+
+    it("falls back to setTimeout when setImmediate is unavailable", async () => {
+      // The jsdom env has no setImmediate; the fallback must schedule a
+      // macrotask instead of throwing ReferenceError.
+      expect((globalThis as { setImmediate?: unknown }).setImmediate).toBeUndefined();
+      await expect(yieldToEventLoop()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("maybeYield", () => {
+    it("only yields when count is a positive multiple of every", async () => {
+      // jsdom has no setImmediate, so yieldToEventLoop uses the setTimeout
+      // fallback; spy on it to count macrotask scheduling.
+      const spy = jest.spyOn(globalThis, "setTimeout");
+      try {
+        spy.mockClear();
+        await maybeYield(0, 3); // count 0 → never yields
+        await maybeYield(1, 3);
+        await maybeYield(2, 3);
+        expect(spy).not.toHaveBeenCalled();
+        await maybeYield(3, 3); // multiple → yields
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+});

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/membership-reconciler.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/membership-reconciler.test.ts
@@ -18,8 +18,8 @@ function source(overrides: Partial<TeamMembershipSource>): TeamMembershipSource 
 }
 
 describe("team membership source reconciler", () => {
-  it("adds new managed sources and materializes user-team tuples", () => {
-    const result = reconcileTeamMembershipSources({
+  it("adds new managed sources and materializes user-team tuples", async () => {
+    const result = await reconcileTeamMembershipSources({
       existingSources: [],
       desiredSources: [
         source({
@@ -41,8 +41,8 @@ describe("team membership source reconciler", () => {
     ]);
   });
 
-  it("removes only managed sources and preserves manual access", () => {
-    const result = reconcileTeamMembershipSources({
+  it("removes only managed sources and preserves manual access", async () => {
+    const result = await reconcileTeamMembershipSources({
       existingSources: [
         source({ source_type: "manual", managed: false }),
         source({ source_type: "oidc_claim", managed: true, sync_rule_id: "rule-platform" }),
@@ -63,8 +63,8 @@ describe("team membership source reconciler", () => {
     expect(result.tupleDeletes).toEqual([]);
   });
 
-  it("deletes the user-team tuple when the last active source is removed", () => {
-    const result = reconcileTeamMembershipSources({
+  it("deletes the user-team tuple when the last active source is removed", async () => {
+    const result = await reconcileTeamMembershipSources({
       existingSources: [source({ source_type: "oidc_claim", managed: true })],
       desiredSources: [],
       now: "2026-05-12T01:00:00.000Z",
@@ -79,7 +79,7 @@ describe("team membership source reconciler", () => {
     ]);
   });
 
-  it("re-emits tuple writes for RETAINED existing sources, not just adds (self-heal)", () => {
+  it("re-emits tuple writes for RETAINED existing sources, not just adds (self-heal)", async () => {
     // Regression for the interrupted-sync drift: a prior run upserted the
     // Mongo source row but its OpenFGA write never landed (pod SIGKILLed
     // mid-reconcile). On the next run the row is "existing" + still desired,
@@ -93,7 +93,7 @@ describe("team membership source reconciler", () => {
       sync_rule_id: "rule-platform",
       external_group_id: "platform",
     });
-    const result = reconcileTeamMembershipSources({
+    const result = await reconcileTeamMembershipSources({
       existingSources: [stranded],
       desiredSources: [stranded],
       now: "2026-05-12T01:00:00.000Z",
@@ -112,7 +112,7 @@ describe("team membership source reconciler", () => {
     ]);
   });
 
-  it("collapses duplicate (user, relation, team) across multiple retained sources", () => {
+  it("collapses duplicate (user, relation, team) across multiple retained sources", async () => {
     // A user can hold the same access via two sources (e.g. manual + okta).
     // The re-emitted write set must dedupe so we don't send the same tuple
     // twice to OpenFGA in one diff.
@@ -123,7 +123,7 @@ describe("team membership source reconciler", () => {
       sync_rule_id: "rule-platform",
       external_group_id: "platform",
     });
-    const result = reconcileTeamMembershipSources({
+    const result = await reconcileTeamMembershipSources({
       existingSources: [manual, okta],
       desiredSources: [manual, okta],
       now: "2026-05-12T01:00:00.000Z",

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/performance.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/performance.test.ts
@@ -3,7 +3,7 @@ import type { ExternalGroup, IdentityGroupSyncRule } from "@/types/identity-grou
 import { planIdentityGroupSync } from "../../identity-group-sync-planner";
 
 describe("identity group sync performance", () => {
-  it("plans a 500-group dry run within an interactive budget", () => {
+  it("plans a 500-group dry run within an interactive budget", async () => {
     const rule: IdentityGroupSyncRule = {
       id: "rule-platform",
       provider_id: "oidc-claims",
@@ -39,7 +39,7 @@ describe("identity group sync performance", () => {
     })) as Array<ExternalGroup & { members: Array<{ subject: string; email: string; display_name: string; active: boolean }> }>;
 
     const started = performance.now();
-    const result = planIdentityGroupSync({
+    const result = await planIdentityGroupSync({
       groups,
       rules: [rule],
       existingTeams: [],

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/rule-matcher.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/rule-matcher.test.ts
@@ -35,8 +35,8 @@ function group(displayName: string, id = displayName): ExternalGroup {
 }
 
 describe("identity group rule matcher", () => {
-  it("matches enabled rules by priority and renders deterministic team targets", () => {
-    const result = evaluateIdentityGroupRules({
+  it("matches enabled rules by priority and renders deterministic team targets", async () => {
+    const result = await evaluateIdentityGroupRules({
       groups: [group("Engineering Platform Admins")],
       rules: [baseRule],
       existingTeamSlugs: [],
@@ -56,8 +56,8 @@ describe("identity group rule matcher", () => {
     expect(result.conflicts).toEqual([]);
   });
 
-  it("ignores excluded groups before include matching", () => {
-    const result = evaluateIdentityGroupRules({
+  it("ignores excluded groups before include matching", async () => {
+    const result = await evaluateIdentityGroupRules({
       groups: [group("Engineering Platform Contractors")],
       rules: [baseRule],
       existingTeamSlugs: [],
@@ -73,8 +73,8 @@ describe("identity group rule matcher", () => {
     ]);
   });
 
-  it("matches generated slugs to existing teams instead of treating them as conflicts", () => {
-    const result = evaluateIdentityGroupRules({
+  it("matches generated slugs to existing teams instead of treating them as conflicts", async () => {
+    const result = await evaluateIdentityGroupRules({
       groups: [group("Engineering Platform Users")],
       rules: [baseRule],
       existingTeamSlugs: ["platform"],

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/sync-planner.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/sync-planner.test.ts
@@ -49,8 +49,8 @@ const group: ExternalGroup & {
 };
 
 describe("identity group sync dry-run planner", () => {
-  it("plans team creation, membership sources, skipped users, and member tuples", () => {
-    const result = planIdentityGroupSync({
+  it("plans team creation, membership sources, skipped users, and member tuples", async () => {
+    const result = await planIdentityGroupSync({
       groups: [group],
       rules: [rule],
       existingTeams: [],
@@ -86,8 +86,8 @@ describe("identity group sync dry-run planner", () => {
     ]);
   });
 
-  it("queues a team rename when the stored team name differs from the IdP group name", () => {
-    const result = planIdentityGroupSync({
+  it("queues a team rename when the stored team name differs from the IdP group name", async () => {
+    const result = await planIdentityGroupSync({
       groups: [group],
       rules: [rule],
       existingTeams: [{ id: "platform-id", slug: "platform", name: "Old Platform Name" }],
@@ -102,7 +102,7 @@ describe("identity group sync dry-run planner", () => {
     expect(result.teams_to_create).toEqual([]);
   });
 
-  it("stamps last_seen_at on membership_sources_to_refresh for unchanged active memberships", () => {
+  it("stamps last_seen_at on membership_sources_to_refresh for unchanged active memberships", async () => {
     const existingSource: TeamMembershipSource = {
       team_id: "platform-id",
       team_slug: "platform",
@@ -122,7 +122,7 @@ describe("identity group sync dry-run planner", () => {
       created_at: "2026-04-01T00:00:00.000Z",
     };
 
-    const result = planIdentityGroupSync({
+    const result = await planIdentityGroupSync({
       groups: [group],
       rules: [rule],
       existingTeams: [{ id: "platform-id", slug: "platform", name: "Platform" }],
@@ -141,7 +141,7 @@ describe("identity group sync dry-run planner", () => {
     expect(result.membership_sources_to_add).toEqual([]);
   });
 
-  it("surfaces safety warnings for disruptive managed membership removals", () => {
+  it("surfaces safety warnings for disruptive managed membership removals", async () => {
     const existingSources = [
       {
         team_id: "platform-id",
@@ -159,7 +159,7 @@ describe("identity group sync dry-run planner", () => {
       },
     ];
 
-    const result = planIdentityGroupSync({
+    const result = await planIdentityGroupSync({
       groups: [],
       rules: [rule],
       existingTeams: [{ id: "platform-id", slug: "platform", name: "Platform" }],
@@ -188,7 +188,7 @@ describe("identity group sync dry-run planner", () => {
     );
   });
 
-  it("deduplicates team creation when multiple claim groups target the same missing team", () => {
+  it("deduplicates team creation when multiple claim groups target the same missing team", async () => {
     const adminGroup = {
       ...group,
       external_group_id: "gid-caipe-admins",
@@ -201,7 +201,7 @@ describe("identity group sync dry-run planner", () => {
       role_map: { Admins: "admin", Users: "member" },
     };
 
-    const result = planIdentityGroupSync({
+    const result = await planIdentityGroupSync({
       groups: [group, adminGroup],
       rules: [adminRule],
       existingTeams: [],

--- a/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
+++ b/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
@@ -332,38 +332,100 @@ describe("idp-sync-runner", () => {
     });
   });
 
-  describe("executeSyncRun: event-loop yield cadence", () => {
-    it("yields to the event loop every 50 processed members so /api/health can interleave", async () => {
-      const members = Array.from({ length: 120 }, (_, i) => ({
+  describe("executeSyncRun: member resolution is fanned out, not serial", () => {
+    it("resolves members concurrently rather than one await at a time", async () => {
+      const members = Array.from({ length: 40 }, (_, i) => ({
         email: `user${i}@example.com`,
         active: true,
         display_name: `User ${i}`,
       }));
       fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
 
-      const setImmediateSpy = jest.spyOn(global, "setImmediate");
+      // Track how many provisionShellUser calls are in flight simultaneously.
+      // A strictly sequential loop would never exceed 1; the concurrency pool
+      // should keep several outstanding at once.
+      let inFlight = 0;
+      let maxInFlight = 0;
+      provisionShellUser.mockImplementation(async ({ email }: { email: string }) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setImmediate(resolve));
+        inFlight -= 1;
+        return { sub: `sub-${email}`, created: false };
+      });
 
       await executeSyncRun("run-1", "okta", "admin");
 
-      // 120 members with MEMBERS_PER_YIELD=50 yields at the 50th and 100th member.
-      expect(setImmediateSpy).toHaveBeenCalledTimes(2);
-      setImmediateSpy.mockRestore();
+      expect(provisionShellUser).toHaveBeenCalledTimes(40);
+      expect(maxInFlight).toBeGreaterThan(1);
     });
 
-    it("never yields for a run with fewer members than the yield threshold", async () => {
-      const members = Array.from({ length: 10 }, (_, i) => ({
-        email: `user${i}@example.com`,
-        active: true,
-        display_name: `User ${i}`,
-      }));
-      fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
+    it("honors IDENTITY_SYNC_MEMBER_CONCURRENCY as the parallelism ceiling", async () => {
+      const prev = process.env.IDENTITY_SYNC_MEMBER_CONCURRENCY;
+      process.env.IDENTITY_SYNC_MEMBER_CONCURRENCY = "4";
+      try {
+        const members = Array.from({ length: 20 }, (_, i) => ({
+          email: `user${i}@example.com`,
+          active: true,
+          display_name: `User ${i}`,
+        }));
+        fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
 
-      const setImmediateSpy = jest.spyOn(global, "setImmediate");
+        let inFlight = 0;
+        let maxInFlight = 0;
+        provisionShellUser.mockImplementation(async ({ email }: { email: string }) => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((resolve) => setImmediate(resolve));
+          inFlight -= 1;
+          return { sub: `sub-${email}`, created: false };
+        });
+
+        await executeSyncRun("run-1", "okta", "admin");
+
+        expect(maxInFlight).toBeLessThanOrEqual(4);
+        expect(maxInFlight).toBeGreaterThan(1);
+      } finally {
+        if (prev === undefined) delete process.env.IDENTITY_SYNC_MEMBER_CONCURRENCY;
+        else process.env.IDENTITY_SYNC_MEMBER_CONCURRENCY = prev;
+      }
+    });
+  });
+
+  describe("executeSyncRun: baseline bootstrap runs before team-membership apply", () => {
+    it("grants the member baseline before the slower plan/apply so MCP access lands first", async () => {
+      const members = [
+        { email: "a@example.com", active: true, display_name: "A" },
+        { email: "b@example.com", active: true, display_name: "B" },
+      ];
+      fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
+      provisionShellUser.mockImplementation(async ({ email }: { email: string }) => ({
+        sub: `sub-${email}`,
+        created: false,
+      }));
+
+      const order: string[] = [];
+      reconcileSyncedUsersBaselineAccess.mockImplementation(async () => {
+        order.push("baseline");
+        return { status: "completed", subject_count: 2, tuple_write_count: 0 };
+      });
+      applyIdentityGroupSyncPlan.mockImplementation(async () => {
+        order.push("apply");
+        return {
+          teamsCreated: 0,
+          membershipSourcesAdded: 0,
+          membershipSourcesRemoved: 0,
+          membershipSourcesRefreshed: 0,
+          tupleWrites: 0,
+          tupleDeletes: 0,
+          openFgaEnabled: true,
+          teamsArchived: 0,
+        };
+      });
 
       await executeSyncRun("run-1", "okta", "admin");
 
-      expect(setImmediateSpy).not.toHaveBeenCalled();
-      setImmediateSpy.mockRestore();
+      expect(order).toEqual(["baseline", "apply"]);
     });
   });
 

--- a/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
+++ b/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
@@ -392,6 +392,67 @@ describe("idp-sync-runner", () => {
     });
   });
 
+  describe("executeSyncRun: synchronous member passes yield to the event loop", () => {
+    it("yields during the dedupe and stamp passes so k8s health probes can interleave", async () => {
+      const prev = process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+      // Yield every 3 members so a small fixture still trips the yield path.
+      process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = "3";
+      try {
+        // 8 members across two groups. Both the dedupe pass and the stamp pass
+        // walk all 8, so with yieldEvery=3 each pass yields at member 3 and 6:
+        // 2 yields per pass, 4 total. mapWithConcurrency also uses setImmediate
+        // internally, so we assert a lower bound rather than an exact count.
+        const members = Array.from({ length: 8 }, (_, i) => ({
+          email: `user${i}@example.com`,
+          active: true,
+          display_name: `User ${i}`,
+        }));
+        fetchExternalGroupsForProvider.mockResolvedValue([
+          { id: "g1", name: "Group 1", members: members.slice(0, 4) },
+          { id: "g2", name: "Group 2", members: members.slice(4) },
+        ]);
+
+        const setImmediateSpy = jest.spyOn(global, "setImmediate");
+
+        await executeSyncRun("run-1", "okta", "admin");
+
+        // At least the 4 yields from the two synchronous passes.
+        expect(setImmediateSpy.mock.calls.length).toBeGreaterThanOrEqual(4);
+        setImmediateSpy.mockRestore();
+      } finally {
+        if (prev === undefined) delete process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+        else process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = prev;
+      }
+    });
+
+    it("does not yield in the synchronous passes when member count is below the threshold", async () => {
+      const prev = process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+      process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = "1000";
+      try {
+        const members = Array.from({ length: 5 }, (_, i) => ({
+          email: `user${i}@example.com`,
+          active: true,
+          display_name: `User ${i}`,
+        }));
+        fetchExternalGroupsForProvider.mockResolvedValue([{ id: "g1", name: "Group 1", members }]);
+
+        const setImmediateSpy = jest.spyOn(global, "setImmediate");
+        try {
+          await executeSyncRun("run-1", "okta", "admin");
+          // Both sync passes walk 5 members with a threshold of 1000, so neither
+          // trips the yield. mapWithConcurrency does not use setImmediate, so the
+          // only source of a call would be a sync pass — hence exactly zero.
+          expect(setImmediateSpy).not.toHaveBeenCalled();
+        } finally {
+          setImmediateSpy.mockRestore();
+        }
+      } finally {
+        if (prev === undefined) delete process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY;
+        else process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY = prev;
+      }
+    });
+  });
+
   describe("executeSyncRun: baseline bootstrap runs before team-membership apply", () => {
     it("grants the member baseline before the slower plan/apply so MCP access lands first", async () => {
       const members = [

--- a/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
+++ b/ui/src/lib/rbac/__tests__/idp-sync-runner.test.ts
@@ -24,6 +24,7 @@ const linkFederatedIdentity = jest.fn();
 const planIdentityGroupSync = jest.fn();
 const applyIdentityGroupSyncPlan = jest.fn();
 const stripArchivedTeamResourceGrants = jest.fn();
+const reconcileSyncedUsersBaselineAccess = jest.fn();
 
 jest.mock("@/lib/mongodb", () => ({
   getCollection: (...args: unknown[]) => getCollection(...args),
@@ -58,6 +59,11 @@ jest.mock("@/lib/rbac/idp-sync-store", () => ({
 jest.mock("@/lib/rbac/keycloak-admin", () => ({
   provisionShellUser: (...args: unknown[]) => provisionShellUser(...args),
   linkFederatedIdentity: (...args: unknown[]) => linkFederatedIdentity(...args),
+}));
+
+jest.mock("@/lib/rbac/login-openfga-bootstrap", () => ({
+  reconcileSyncedUsersBaselineAccess: (...args: unknown[]) =>
+    reconcileSyncedUsersBaselineAccess(...args),
 }));
 
 jest.mock("@/lib/rbac/archived-team-grants", () => ({
@@ -112,6 +118,11 @@ describe("idp-sync-runner", () => {
       tupleDeletes: 0,
       openFgaEnabled: true,
       teamsArchived: 0,
+    });
+    reconcileSyncedUsersBaselineAccess.mockResolvedValue({
+      status: "completed",
+      subject_count: 0,
+      tuple_write_count: 0,
     });
   });
 
@@ -401,6 +412,76 @@ describe("idp-sync-runner", () => {
       expect(planIdentityGroupSync).not.toHaveBeenCalled();
 
       errorSpy.mockRestore();
+    });
+  });
+
+  describe("executeSyncRun: baseline OpenFGA bootstrap for synced users", () => {
+    it("bootstraps the member baseline for every resolved subject, deduped across groups", async () => {
+      fetchExternalGroupsForProvider.mockResolvedValue([
+        { id: "g1", name: "Group 1", members: [{ email: "a@example.com", active: true, display_name: "A" }] },
+        {
+          id: "g2",
+          name: "Group 2",
+          members: [
+            { email: "a@example.com", active: true, display_name: "A" },
+            { email: "b@example.com", active: true, display_name: "B" },
+          ],
+        },
+      ]);
+      provisionShellUser.mockImplementation(async ({ email }: { email: string }) => ({
+        sub: email === "a@example.com" ? "sub-a" : "sub-b",
+        created: false,
+      }));
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      // One resolved sub per unique email — no duplicate sub-a from the two groups.
+      expect(reconcileSyncedUsersBaselineAccess).toHaveBeenCalledTimes(1);
+      const passed = reconcileSyncedUsersBaselineAccess.mock.calls[0][0] as string[];
+      expect(new Set(passed)).toEqual(new Set(["sub-a", "sub-b"]));
+    });
+
+    it("excludes members whose subject never resolved", async () => {
+      fetchExternalGroupsForProvider.mockResolvedValue([
+        {
+          id: "g1",
+          name: "Group 1",
+          members: [
+            { email: "ok@example.com", active: true, display_name: "OK" },
+            { email: "broken@example.com", active: true, display_name: "Broken" },
+          ],
+        },
+      ]);
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      provisionShellUser.mockImplementation(async ({ email }: { email: string }) => {
+        if (email === "broken@example.com") throw new Error("keycloak unreachable");
+        return { sub: "sub-ok", created: false };
+      });
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      const passed = reconcileSyncedUsersBaselineAccess.mock.calls[0][0] as string[];
+      expect(passed).toEqual(["sub-ok"]);
+      warnSpy.mockRestore();
+    });
+
+    it("still records success when baseline bootstrap fails (best-effort, non-fatal)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      fetchExternalGroupsForProvider.mockResolvedValue([
+        { id: "g1", name: "Group 1", members: [{ email: "a@example.com", active: true, display_name: "A" }] },
+      ]);
+      reconcileSyncedUsersBaselineAccess.mockResolvedValue({
+        status: "failed",
+        subject_count: 1,
+        tuple_write_count: 0,
+        warning: "openfga down",
+      });
+
+      await executeSyncRun("run-1", "okta", "admin");
+
+      expect(updateIdpSyncRun).toHaveBeenCalledWith("run-1", expect.objectContaining({ status: "success" }));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("baseline OpenFGA bootstrap failed"));
+      warnSpy.mockRestore();
     });
   });
 });

--- a/ui/src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts
+++ b/ui/src/lib/rbac/__tests__/login-openfga-bootstrap.test.ts
@@ -449,4 +449,65 @@ describe("login OpenFGA bootstrap", () => {
     expect(result.status).toBe("skipped");
     expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
   });
+
+  describe("reconcileSyncedUsersBaselineAccess (directory-sync baseline bootstrap)", () => {
+    it("writes the org-member baseline (incl. mcp_gateway:list) for each synced subject", async () => {
+      mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 20, deletes: 0 });
+      const { reconcileSyncedUsersBaselineAccess } = await import("../login-openfga-bootstrap");
+
+      const result = await reconcileSyncedUsersBaselineAccess(["sub-a", "sub-b"]);
+
+      expect(result.status).toBe("completed");
+      expect(result.subject_count).toBe(2);
+      // Member baseline only (no admin tuples), and it includes the coarse
+      // gateway gate grant that AgentGateway's ext_authz requires.
+      expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+        writes: expect.arrayContaining([
+          { user: "user:sub-a", relation: "member", object: "organization:grid" },
+          { user: "user:sub-a", relation: "caller", object: "mcp_gateway:list" },
+          { user: "user:sub-b", relation: "member", object: "organization:grid" },
+          { user: "user:sub-b", relation: "caller", object: "mcp_gateway:list" },
+        ]),
+        deletes: [],
+      });
+      // Never grants admin baselines from a directory sync.
+      const writtenObjects = mockWriteOpenFgaTuples.mock.calls[0][0].writes.map(
+        (t: { relation: string }) => t.relation
+      );
+      expect(writtenObjects).not.toContain("admin");
+      expect(writtenObjects).not.toContain("manager");
+    });
+
+    it("dedupes repeated subjects and skips blank ones", async () => {
+      const { reconcileSyncedUsersBaselineAccess } = await import("../login-openfga-bootstrap");
+
+      const result = await reconcileSyncedUsersBaselineAccess(["sub-a", "sub-a", "  ", ""]);
+
+      expect(result.subject_count).toBe(1);
+      const users = new Set(
+        mockWriteOpenFgaTuples.mock.calls[0][0].writes.map((t: { user: string }) => t.user)
+      );
+      expect(users).toEqual(new Set(["user:sub-a"]));
+    });
+
+    it("is a no-op with no resolved subjects", async () => {
+      const { reconcileSyncedUsersBaselineAccess } = await import("../login-openfga-bootstrap");
+
+      const result = await reconcileSyncedUsersBaselineAccess([]);
+
+      expect(result.status).toBe("skipped");
+      expect(result.subject_count).toBe(0);
+      expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
+    });
+
+    it("never throws — returns failed on OpenFGA write error", async () => {
+      mockWriteOpenFgaTuples.mockRejectedValue(new Error("openfga down"));
+      const { reconcileSyncedUsersBaselineAccess } = await import("../login-openfga-bootstrap");
+
+      const result = await reconcileSyncedUsersBaselineAccess(["sub-a"]);
+
+      expect(result.status).toBe("failed");
+      expect(result.warning).toContain("openfga down");
+    });
+  });
 });

--- a/ui/src/lib/rbac/__tests__/self-check.test.ts
+++ b/ui/src/lib/rbac/__tests__/self-check.test.ts
@@ -8,6 +8,11 @@ jest.mock("@/lib/rbac/openfga", () => ({
   readOpenFgaTuples: jest.fn(),
 }));
 
+import {
+  baselineAdminTuples,
+  baselineMemberTuples,
+} from "@/lib/rbac/baseline-access";
+
 import { deriveRbacSelfCheckReport, repairableMissingTuples, type RbacSelfCheckInventoryInput } from "../self-check";
 
 function baseInput(overrides: Partial<RbacSelfCheckInventoryInput> = {}): RbacSelfCheckInventoryInput {
@@ -128,13 +133,66 @@ describe("deriveRbacSelfCheckReport", () => {
       ],
     }));
 
-    expect(report.expected_by_source.baseline_access).toBe(4);
+    // An admin user's full member + admin baseline is authoritative, so every
+    // baseline grant is expected (not just the four present in actualTuples).
+    // The org-admin AgentGateway manager tuple is keyed on organization:caipe#admin,
+    // which is not in actualTuples here, so it is not added.
+    const expectedAdminBaseline =
+      baselineMemberTuples("sri-sub").length + baselineAdminTuples("sri-sub").length;
+    expect(report.expected_by_source.baseline_access).toBe(expectedAdminBaseline);
+    // The present tuples are all owned, so none are flagged as orphan candidates.
     expect(report.summary.orphan_candidates).toBe(0);
     expect(report.findings).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           severity: "orphan_candidate",
           tuple: expect.objectContaining({ user: "user:sri-sub" }),
+        }),
+      ]),
+    );
+  });
+
+  it("flags a synced user's missing member baseline (incl. mcp_gateway:list) as repairable", () => {
+    // A user provisioned by directory sync who never interactively logged into
+    // the web UI holds no baseline tuples. The member baseline is authoritative,
+    // so every member grant — including the mcp_gateway:list caller tuple the
+    // AgentGateway coarse gate requires — must be reported missing and repairable.
+    const report = deriveRbacSelfCheckReport(baseInput({
+      users: [
+        {
+          email: "synced@example.com",
+          keycloak_sub: "synced-sub",
+          metadata: { role: "user" },
+        },
+      ],
+      actualTuples: [],
+    }));
+
+    const memberBaseline = baselineMemberTuples("synced-sub");
+    expect(report.status).toBe("fail");
+    expect(report.summary.missing_tuples).toBe(memberBaseline.length);
+    // The gateway-gate tuple specifically must be flagged and repairable.
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "missing",
+          source: "baseline_access",
+          repairable: true,
+          tuple: { user: "user:synced-sub", relation: "caller", object: "mcp_gateway:list" },
+        }),
+      ]),
+    );
+    expect(repairableMissingTuples(report)).toEqual(
+      expect.arrayContaining([
+        { user: "user:synced-sub", relation: "caller", object: "mcp_gateway:list" },
+      ]),
+    );
+    // A member (non-admin) user must not have admin baseline grants forced in.
+    expect(report.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "missing",
+          tuple: { user: "user:synced-sub", relation: "admin", object: "organization:caipe" },
         }),
       ]),
     );

--- a/ui/src/lib/rbac/__tests__/sync-progress.test.ts
+++ b/ui/src/lib/rbac/__tests__/sync-progress.test.ts
@@ -1,0 +1,68 @@
+import { startStageProgress } from "../sync-progress";
+
+describe("sync-progress", () => {
+  function collect() {
+    const lines: string[] = [];
+    return { log: (m: string) => lines.push(m), lines };
+  }
+
+  it("logs a header with the total up front", () => {
+    const { log, lines } = collect();
+    startStageProgress("resolve members", 100, log);
+    expect(lines[0]).toBe("[IdpSync] resolve members: 100 to process");
+  });
+
+  it("emits roughly one line every 5% plus a final 100% line", () => {
+    const { log, lines } = collect();
+    const p = startStageProgress("resolve members", 100, log);
+    for (let done = 1; done <= 100; done++) p.tick(done);
+    p.done();
+
+    const pctLines = lines.filter((l) => l.includes("%"));
+    // 19 mid-stage boundaries (5%..95%) + one final 100% line.
+    expect(pctLines).toHaveLength(20);
+    expect(pctLines[0]).toBe("[IdpSync] resolve members: 5% (5/100)");
+    expect(pctLines.at(-1)).toBe("[IdpSync] resolve members: 100% (100/100) complete");
+  });
+
+  it("never emits a mid-stage line at or past the total (done owns 100%)", () => {
+    const { log, lines } = collect();
+    const p = startStageProgress("stamp subjects", 40, log);
+    for (let done = 1; done <= 40; done++) p.tick(done);
+    // Before done(): no line should claim 100%.
+    expect(lines.some((l) => l.includes("100%"))).toBe(false);
+    p.done();
+    expect(lines.at(-1)).toBe("[IdpSync] stamp subjects: 100% (40/40) complete");
+  });
+
+  it("logs the header but stays silent for an empty stage", () => {
+    const { log, lines } = collect();
+    const p = startStageProgress("dedupe members", 0, log);
+    p.tick(0);
+    p.done();
+    expect(lines).toEqual(["[IdpSync] dedupe members: 0 to process"]);
+  });
+
+  it("done() is idempotent", () => {
+    const { log, lines } = collect();
+    const p = startStageProgress("apply", 10, log);
+    p.done();
+    p.done();
+    expect(lines.filter((l) => l.includes("100%"))).toHaveLength(1);
+  });
+
+  it("still fires ~5% boundaries when tick is called in concurrent bursts", () => {
+    // mapWithConcurrency resolves out of strict order; ticks arrive as a rising
+    // counter but not one-at-a-time. A jump that crosses several boundaries
+    // still logs (once) rather than being skipped.
+    const { log, lines } = collect();
+    const p = startStageProgress("resolve members", 200, log);
+    p.tick(50); // jumps straight past 5/10/.../25% boundaries
+    p.tick(120);
+    p.done();
+    const pctLines = lines.filter((l) => l.includes("%"));
+    expect(pctLines).toContain("[IdpSync] resolve members: 25% (50/200)");
+    expect(pctLines).toContain("[IdpSync] resolve members: 60% (120/200)");
+    expect(pctLines.at(-1)).toBe("[IdpSync] resolve members: 100% (200/200) complete");
+  });
+});

--- a/ui/src/lib/rbac/event-loop-yield.ts
+++ b/ui/src/lib/rbac/event-loop-yield.ts
@@ -1,0 +1,44 @@
+// Cooperative event-loop yielding for large synchronous loops.
+//
+// The directory-sync path (rule matching, planning, membership reconcile) runs
+// in the same Node process that serves this pod's k8s liveness/readiness
+// probes. A full-directory sync can iterate over hundreds of thousands of
+// members/sources with no awaited I/O, and an unbroken CPU loop that long stops
+// the event loop from ever running the probe handler — k8s then SIGKILLs the
+// pod (exit 137). Handing control back via `setImmediate` every N iterations
+// lets any pending probe callback run between chunks.
+
+// Iterations of a purely-synchronous loop to run before yielding. Each covered
+// iteration is a cheap in-memory op, so a small threshold costs almost nothing
+// while keeping probes responsive. Tunable via env so tests can exercise the
+// yield without a huge fixture.
+const DEFAULT_LOOP_YIELD_EVERY = 500;
+
+export function loopYieldEvery(): number {
+  const fromEnv = Number(process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY);
+  if (Number.isFinite(fromEnv) && fromEnv >= 1) return Math.floor(fromEnv);
+  return DEFAULT_LOOP_YIELD_EVERY;
+}
+
+export function yieldToEventLoop(): Promise<void> {
+  // `setImmediate` is the cheapest macrotask yield in Node (the sync path's real
+  // runtime) and lets a pending probe callback run before the next chunk. It is
+  // NOT a browser/jsdom global, so fall back to `setTimeout(0)` where it's
+  // absent (e.g. the jsdom test env) — both hand control back to the loop.
+  const scheduleMacrotask =
+    typeof setImmediate === "function"
+      ? setImmediate
+      : (cb: () => void) => setTimeout(cb, 0);
+  return new Promise((resolve) => scheduleMacrotask(() => resolve()));
+}
+
+/**
+ * Await a yield to the event loop every `every` calls. Increment a counter you
+ * own and pass it in; when `count % every === 0` this hands the loop back.
+ * Keeping the counter caller-side lets a single budget span nested loops.
+ */
+export async function maybeYield(count: number, every: number = loopYieldEvery()): Promise<void> {
+  if (count > 0 && count % every === 0) {
+    await yieldToEventLoop();
+  }
+}

--- a/ui/src/lib/rbac/identity-group-rule-matcher.ts
+++ b/ui/src/lib/rbac/identity-group-rule-matcher.ts
@@ -4,6 +4,7 @@ IdentityGroupSyncRule,
 TeamRelationshipRole,
 } from "@/types/identity-group-sync";
 
+import { loopYieldEvery, maybeYield } from "./event-loop-yield";
 import { normalizeTeamSlug } from "./team-slugs";
 
 export interface IdentityGroupRuleMatch {
@@ -64,15 +65,18 @@ function roleFromCapture(
   return rule.role_map[roleLabel] ?? null;
 }
 
-export function evaluateIdentityGroupRules(
+export async function evaluateIdentityGroupRules(
   input: EvaluateIdentityGroupRulesInput
-): EvaluateIdentityGroupRulesResult {
+): Promise<EvaluateIdentityGroupRulesResult> {
   const matches: IdentityGroupRuleMatch[] = [];
   const ignored: IgnoredIdentityGroup[] = [];
   const conflicts: IdentityGroupRuleConflict[] = [];
   const rules = [...input.rules].sort((a, b) => a.priority - b.priority);
 
+  const yieldEvery = loopYieldEvery();
+  let processed = 0;
   for (const group of input.groups) {
+    await maybeYield(++processed, yieldEvery);
     let resolved = false;
     for (const rule of rules) {
       if (!rule.enabled || rule.review_status === "disabled") {

--- a/ui/src/lib/rbac/identity-group-sync-planner.ts
+++ b/ui/src/lib/rbac/identity-group-sync-planner.ts
@@ -6,6 +6,7 @@ IdentityGroupSyncSafetyWarning,
 TeamMembershipSource,
 } from "@/types/identity-group-sync";
 
+import { loopYieldEvery, maybeYield } from "./event-loop-yield";
 import { evaluateIdentityGroupRules } from "./identity-group-rule-matcher";
 import { reconcileTeamMembershipSources } from "./membership-reconciler";
 
@@ -60,13 +61,16 @@ function sourceKey(source: TeamMembershipSource): string {
   ].join("\n");
 }
 
-function buildSafetyWarnings(input: {
+async function buildSafetyWarnings(input: {
   existingSources: TeamMembershipSource[];
   desiredSources: TeamMembershipSource[];
   sourcesToRemove: TeamMembershipSource[];
-}): IdentityGroupSyncSafetyWarning[] {
+}): Promise<IdentityGroupSyncSafetyWarning[]> {
   const warnings: IdentityGroupSyncSafetyWarning[] = [];
   if (input.sourcesToRemove.length === 0) return warnings;
+
+  const yieldEvery = loopYieldEvery();
+  let processed = 0;
 
   if (input.sourcesToRemove.length > LARGE_REMOVAL_WARNING_THRESHOLD) {
     warnings.push({
@@ -78,7 +82,9 @@ function buildSafetyWarnings(input: {
     });
   }
 
-  for (const source of input.sourcesToRemove.filter((source) => source.relationship === "admin")) {
+  for (const source of input.sourcesToRemove) {
+    await maybeYield(++processed, yieldEvery);
+    if (source.relationship !== "admin") continue;
     warnings.push({
       code: "admin_membership_removal",
       severity: "blocker",
@@ -89,19 +95,29 @@ function buildSafetyWarnings(input: {
     });
   }
 
+  // Precompute the set of team slugs that still have an active managed member
+  // after this reconcile, so the orphan check below is an O(1) lookup per
+  // removed source instead of an O(removals × activeAfter) nested scan — which
+  // at full-directory scale pinned the event loop.
   const removedKeys = new Set(input.sourcesToRemove.map(sourceKey));
-  const activeAfter = [
-    ...input.existingSources.filter((source) => source.status === "active" && !removedKeys.has(sourceKey(source))),
-    ...input.desiredSources.filter((source) => source.status === "active"),
-  ];
-  for (const source of input.sourcesToRemove) {
-    const hasRemainingManagedMember = activeAfter.some(
-      (remaining) => remaining.managed && remaining.team_slug === source.team_slug
-    );
-    if (hasRemainingManagedMember) continue;
-    if (warnings.some((warning) => warning.code === "orphaned_team_membership" && warning.team_slug === source.team_slug)) {
-      continue;
+  const teamsWithRetainedManagedMember = new Set<string>();
+  const addRetained = async (sources: TeamMembershipSource[], requireNotRemoved: boolean) => {
+    for (const source of sources) {
+      await maybeYield(++processed, yieldEvery);
+      if (source.status !== "active" || !source.managed) continue;
+      if (requireNotRemoved && removedKeys.has(sourceKey(source))) continue;
+      teamsWithRetainedManagedMember.add(source.team_slug);
     }
+  };
+  await addRetained(input.existingSources, true);
+  await addRetained(input.desiredSources, false);
+
+  const orphanWarnedTeams = new Set<string>();
+  for (const source of input.sourcesToRemove) {
+    await maybeYield(++processed, yieldEvery);
+    if (teamsWithRetainedManagedMember.has(source.team_slug)) continue;
+    if (orphanWarnedTeams.has(source.team_slug)) continue;
+    orphanWarnedTeams.add(source.team_slug);
     warnings.push({
       code: "orphaned_team_membership",
       severity: "warning",
@@ -114,10 +130,19 @@ function buildSafetyWarnings(input: {
   return warnings;
 }
 
-export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): IdentityGroupSyncDryRunResult {
+export async function planIdentityGroupSync(
+  input: PlanIdentityGroupSyncInput
+): Promise<IdentityGroupSyncDryRunResult> {
+  // A full-directory plan iterates over every matched group's members (hundreds
+  // of thousands at org scale) with no awaited I/O. Yield to the event loop
+  // periodically across these loops so the pod's k8s liveness probe still runs
+  // and the pod isn't SIGKILLed mid-plan.
+  const yieldEvery = loopYieldEvery();
+  let processed = 0;
+
   const allowTeamCreation = input.allowTeamCreation ?? true;
   const existingTeamBySlug = new Map(input.existingTeams.map((team) => [team.slug, team]));
-  const ruleResult = evaluateIdentityGroupRules({
+  const ruleResult = await evaluateIdentityGroupRules({
     groups: input.groups,
     rules: input.rules,
     existingTeamSlugs: input.existingTeams.map((team) => team.slug),
@@ -160,6 +185,7 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
     }
     const teamId = team?.id ?? match.teamSlug;
     for (const member of (match.group as ExternalGroupWithMembers).members ?? []) {
+      await maybeYield(++processed, yieldEvery);
       if (!member.active) {
         skipped_users.push({
           source_group_id: match.group.external_group_id,
@@ -197,7 +223,7 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
     }
   }
 
-  const reconciliation = reconcileTeamMembershipSources({
+  const reconciliation = await reconcileTeamMembershipSources({
     existingSources: input.existingMembershipSources,
     desiredSources,
     now: input.now,
@@ -216,7 +242,7 @@ export function planIdentityGroupSync(input: PlanIdentityGroupSyncInput): Identi
     .filter((s) => existingActiveKeys.has(sourceKey(s)))
     .map((s) => ({ ...s, last_seen_at: input.now }));
 
-  const safety_warnings = buildSafetyWarnings({
+  const safety_warnings = await buildSafetyWarnings({
     existingSources: input.existingMembershipSources,
     desiredSources,
     sourcesToRemove: reconciliation.sourcesToRemove,

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -58,6 +58,25 @@ function memberResolveConcurrency(): number {
   return DEFAULT_MEMBER_RESOLVE_CONCURRENCY;
 }
 
+// How many iterations of a purely-synchronous loop (no per-item await) to run
+// before handing the event loop back. The dedupe and subject-stamp passes touch
+// every member in every group, so on a large org (e.g. ~8k members across
+// thousands of groups) an unbroken loop can starve the k8s health probes served
+// by this same process. `setImmediate` lets any pending probe callback run
+// between chunks. Each iteration here is a cheap in-memory op, so a small
+// threshold costs almost nothing while keeping probes responsive — 500 gives
+// well over a dozen evenly-spaced yields on a full directory. Tunable via env so
+// tests can exercise the yield without a huge member count.
+const DEFAULT_SYNC_LOOP_YIELD_EVERY = 500;
+function syncLoopYieldEvery(): number {
+  const fromEnv = Number(process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY);
+  if (Number.isFinite(fromEnv) && fromEnv >= 1) return Math.floor(fromEnv);
+  return DEFAULT_SYNC_LOOP_YIELD_EVERY;
+}
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 async function listExistingTeams(): Promise<Array<{ id: string; slug: string; name: string }>> {
   const col = await getCollection<TeamDocument>("teams");
   const teams = await col.find({}).project({ id: 1, slug: 1, name: 1 }).toArray();
@@ -202,9 +221,12 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // them once, so we dedupe by email before doing any Keycloak work. We keep
     // the first active occurrence (its display name / Okta id) as the record to
     // provision from.
+    const yieldEvery = syncLoopYieldEvery();
     const uniqueMembers = new Map<string, SyncMember>();
+    let dedupeSeen = 0;
     for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
+        if (++dedupeSeen % yieldEvery === 0) await yieldToEventLoop();
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
         if (!uniqueMembers.has(email)) uniqueMembers.set(email, member);
@@ -280,8 +302,10 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // Stamp the resolved subject onto every member object in every group so the
     // planner (which reads `member.subject`) sees them. This is a second pass
     // because a user can appear in many groups but is only resolved once above.
+    let stampSeen = 0;
     for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
+        if (++stampSeen % yieldEvery === 0) await yieldToEventLoop();
         const email = member.email?.trim().toLowerCase();
         if (!email) continue;
         const sub = subCache.get(email);

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -21,6 +21,7 @@ import {
   updateIdpSyncRun,
 } from "@/lib/rbac/idp-sync-store";
 import { linkFederatedIdentity, provisionShellUser } from "@/lib/rbac/keycloak-admin";
+import { reconcileSyncedUsersBaselineAccess } from "@/lib/rbac/login-openfga-bootstrap";
 import { stripArchivedTeamResourceGrants } from "@/lib/rbac/archived-team-grants";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
@@ -259,6 +260,32 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
       actor,
       now,
     });
+
+    // Grant the org-member baseline (incl. the `mcp_gateway:list` caller tuple
+    // that AgentGateway's coarse ext_authz gate requires) to every user this
+    // run resolved to a Keycloak `sub`. The membership reconcile above only
+    // writes team tuples; without this, a user provisioned purely by directory
+    // sync — who never interactively logged into the web UI — would hold team
+    // tuples but lack the gateway-gate grant and get zero MCP tools. Running it
+    // for the full resolved set (not just newly-added memberships) on every run
+    // is idempotent (writeOpenFgaTuples drops already-present tuples) and
+    // backfills users provisioned before this fix. Best-effort: never throws,
+    // so a bootstrap hiccup can't fail the reconcile that already committed.
+    const resolvedSubjects = Array.from(subCache.values()).filter(
+      (sub): sub is string => Boolean(sub)
+    );
+    const baseline = await reconcileSyncedUsersBaselineAccess(resolvedSubjects);
+    if (baseline.status === "failed") {
+      console.warn(
+        `[IdpSync] run ${runId}: baseline OpenFGA bootstrap failed for ` +
+          `${baseline.subject_count} synced user(s): ${baseline.warning ?? "unknown error"}`
+      );
+    } else if (baseline.tuple_write_count > 0) {
+      console.log(
+        `[IdpSync] run ${runId}: baseline OpenFGA bootstrap wrote ` +
+          `${baseline.tuple_write_count} tuple(s) across ${baseline.subject_count} synced user(s)`
+      );
+    }
 
     // On a full fetch, sweep for already-orphaned identity_group_sync teams
     // that pre-date this fix (their sources were previously removed but the

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/rbac/idp-sync-store";
 import { linkFederatedIdentity, provisionShellUser } from "@/lib/rbac/keycloak-admin";
 import { reconcileSyncedUsersBaselineAccess } from "@/lib/rbac/login-openfga-bootstrap";
+import { mapWithConcurrency } from "@/lib/rbac/openfga";
 import { stripArchivedTeamResourceGrants } from "@/lib/rbac/archived-team-grants";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
@@ -33,6 +34,28 @@ interface TeamDocument {
   _id?: unknown;
   slug: string;
   name: string;
+}
+
+// Directory member as returned by a connector, before we resolve its subject.
+interface SyncMember {
+  email?: string;
+  active?: boolean;
+  subject?: string;
+  display_name?: string;
+  okta_user_id?: string;
+}
+
+// How many directory members to resolve/provision against Keycloak in parallel.
+// The member-resolution phase is the longest part of a large sync (two Keycloak
+// admin calls per distinct user), so we fan it out instead of awaiting each in
+// series. Bounded so we don't open thousands of simultaneous Keycloak calls;
+// tunable via env. Each worker awaits I/O, which also keeps the event loop
+// responsive for the pod's k8s health probes (no explicit yield needed).
+const DEFAULT_MEMBER_RESOLVE_CONCURRENCY = 16;
+function memberResolveConcurrency(): number {
+  const fromEnv = Number(process.env.IDENTITY_SYNC_MEMBER_CONCURRENCY);
+  if (Number.isFinite(fromEnv) && fromEnv >= 1) return Math.floor(fromEnv);
+  return DEFAULT_MEMBER_RESOLVE_CONCURRENCY;
 }
 
 async function listExistingTeams(): Promise<Array<{ id: string; slug: string; name: string }>> {
@@ -173,70 +196,125 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // unlinked-fallback check) treat them as unlinked even though the directory
     // sync already vouches for their identity.
     const idpAlias = process.env.IDENTITY_SYNC_OKTA_KEYCLOAK_IDP_ALIAS?.trim() || "okta";
-    const subCache = new Map<string, string | null>();
-    const linkedCache = new Set<string>();
-    // A cached-email hit (the common case in a large org with overlapping
-    // group memberships) skips every `await` below, so a long run of cache
-    // hits can otherwise monopolize the event loop for the CAIPE UI pod —
-    // the same process that serves the k8s liveness probe. Yield back to the
-    // loop periodically so a slow/large sync can't stall health checks into
-    // a pod restart.
-    let processedMembers = 0;
-    const MEMBERS_PER_YIELD = 50;
-    for (const group of groups as Array<{
-      members?: Array<{ email?: string; active?: boolean; subject?: string; display_name?: string; okta_user_id?: string }>;
-    }>) {
+
+    // Collect one representative member per unique email up front. A user in an
+    // org typically appears in many groups; we only want to provision and link
+    // them once, so we dedupe by email before doing any Keycloak work. We keep
+    // the first active occurrence (its display name / Okta id) as the record to
+    // provision from.
+    const uniqueMembers = new Map<string, SyncMember>();
+    for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
-        if (++processedMembers % MEMBERS_PER_YIELD === 0) {
-          await new Promise((resolve) => setImmediate(resolve));
-        }
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
-        if (!subCache.has(email)) {
-          try {
-            // Shares the canonical JIT provisioning logic with the BFF
-            // `POST /api/admin/users/provision-shell` endpoint the bots call
-            // (issue #1781) — in-process, so no self-network hop. The caller's
-            // own RBAC gate (route) or trusted context (scheduler) authorizes.
-            // Split "First Last" on first space; handles "Mary Jo Smith" → firstName="Mary", lastName="Jo Smith"
-            const nameParts = member.display_name?.trim().split(/\s+(.+)/) ?? [];
-            const firstName = nameParts[0] || undefined;
-            const lastName = nameParts[1] || undefined;
-            const { sub } = await provisionShellUser({
-              email,
-              source: `idp-sync:${provider}`,
-              firstName,
-              lastName,
-            });
-            subCache.set(email, sub);
-          } catch (err) {
-            console.warn(
-              `[IdpSync] run ${runId}: failed to resolve/provision ${email}: ` +
-                (err instanceof Error ? err.message : String(err))
-            );
-            subCache.set(email, null);
-          }
-        }
-        const sub = subCache.get(email);
-        if (sub) member.subject = sub;
-        if (provider === "okta" && sub && member.okta_user_id && !linkedCache.has(email)) {
-          linkedCache.add(email);
-          try {
-            await linkFederatedIdentity(sub, idpAlias, {
-              userId: member.okta_user_id,
-              userName: email,
-            });
-          } catch (err) {
-            // Non-fatal: a federated-identity link failure must not block RBAC
-            // provisioning for this sync run. The user simply stays unlinked
-            // until the next successful sync or a real SSO login.
-            console.warn(
-              `[IdpSync] run ${runId}: failed to link federated identity for ${email} (sub=${sub}): ` +
-                (err instanceof Error ? err.message : String(err))
-            );
-          }
+        if (!uniqueMembers.has(email)) uniqueMembers.set(email, member);
+      }
+    }
+
+    // Resolve each unique member's email to a Keycloak `sub`, JIT-creating a
+    // federated shell user when none exists yet, so RBAC can be granted before
+    // the person ever logs into CAIPE. Connectors return members without a
+    // subject (they only know the directory identity); without this the planner
+    // skips everyone as `missing_subject`.
+    //
+    // For Okta specifically, also register a real Keycloak federated-identity
+    // link using the member's Okta user id — identical to what Keycloak's OIDC
+    // broker would write on an actual SSO login (Okta's default `sub` claim is
+    // its Users API `id`). Without this, sync-provisioned users have no
+    // federatedIdentities entry until they sign in once, which is what makes
+    // consumers that gate on "is this user federated" (e.g. the Slack bot's
+    // unlinked-fallback check) treat them as unlinked even though the directory
+    // sync already vouches for their identity.
+    //
+    // Fanned out across `memberResolveConcurrency()` workers rather than awaited
+    // one member at a time — this is the longest phase of a large sync (two
+    // Keycloak calls per user). Each worker is I/O-bound, so the pool also keeps
+    // the event loop responsive for the pod's k8s health probes without an
+    // explicit yield.
+    const subCache = new Map<string, string | null>();
+    const emails = Array.from(uniqueMembers.keys());
+    await mapWithConcurrency(emails, memberResolveConcurrency(), async (email) => {
+      const member = uniqueMembers.get(email)!;
+      let sub: string | null = null;
+      try {
+        // Shares the canonical JIT provisioning logic with the BFF
+        // `POST /api/admin/users/provision-shell` endpoint the bots call
+        // (issue #1781) — in-process, so no self-network hop. The caller's
+        // own RBAC gate (route) or trusted context (scheduler) authorizes.
+        // Split "First Last" on first space; handles "Mary Jo Smith" → firstName="Mary", lastName="Jo Smith"
+        const nameParts = member.display_name?.trim().split(/\s+(.+)/) ?? [];
+        const firstName = nameParts[0] || undefined;
+        const lastName = nameParts[1] || undefined;
+        const resolved = await provisionShellUser({
+          email,
+          source: `idp-sync:${provider}`,
+          firstName,
+          lastName,
+        });
+        sub = resolved.sub;
+      } catch (err) {
+        console.warn(
+          `[IdpSync] run ${runId}: failed to resolve/provision ${email}: ` +
+            (err instanceof Error ? err.message : String(err))
+        );
+      }
+      subCache.set(email, sub);
+      if (provider === "okta" && sub && member.okta_user_id) {
+        try {
+          await linkFederatedIdentity(sub, idpAlias, {
+            userId: member.okta_user_id,
+            userName: email,
+          });
+        } catch (err) {
+          // Non-fatal: a federated-identity link failure must not block RBAC
+          // provisioning for this sync run. The user simply stays unlinked
+          // until the next successful sync or a real SSO login.
+          console.warn(
+            `[IdpSync] run ${runId}: failed to link federated identity for ${email} (sub=${sub}): ` +
+              (err instanceof Error ? err.message : String(err))
+          );
         }
       }
+    });
+
+    // Stamp the resolved subject onto every member object in every group so the
+    // planner (which reads `member.subject`) sees them. This is a second pass
+    // because a user can appear in many groups but is only resolved once above.
+    for (const group of groups as Array<{ members?: SyncMember[] }>) {
+      for (const member of group.members ?? []) {
+        const email = member.email?.trim().toLowerCase();
+        if (!email) continue;
+        const sub = subCache.get(email);
+        if (sub) member.subject = sub;
+      }
+    }
+
+    // Grant the org-member baseline (incl. the `mcp_gateway:list` caller tuple
+    // that AgentGateway's coarse ext_authz gate requires) to every user this
+    // run resolved to a Keycloak `sub` — BEFORE the slower team-membership
+    // reconcile. A user provisioned purely by directory sync, who never
+    // interactively logged into the web UI, would otherwise lack the
+    // gateway-gate grant and get zero MCP tools. Doing it here means every
+    // synced user has working MCP access as early as possible, independent of
+    // how long the team-membership plan/apply takes. Running it for the full
+    // resolved set (not just newly-added memberships) on every run is
+    // idempotent (writeOpenFgaTuples drops already-present tuples) and backfills
+    // users provisioned before this fix. Best-effort: never throws, so a
+    // bootstrap hiccup can't block the membership reconcile that follows.
+    const resolvedSubjects = Array.from(subCache.values()).filter(
+      (sub): sub is string => Boolean(sub)
+    );
+    const baseline = await reconcileSyncedUsersBaselineAccess(resolvedSubjects);
+    if (baseline.status === "failed") {
+      console.warn(
+        `[IdpSync] run ${runId}: baseline OpenFGA bootstrap failed for ` +
+          `${baseline.subject_count} synced user(s): ${baseline.warning ?? "unknown error"}`
+      );
+    } else if (baseline.tuple_write_count > 0) {
+      console.log(
+        `[IdpSync] run ${runId}: baseline OpenFGA bootstrap wrote ` +
+          `${baseline.tuple_write_count} tuple(s) across ${baseline.subject_count} synced user(s)`
+      );
     }
 
     // A group filter means `groups` is only a subset of the directory, so the
@@ -260,32 +338,6 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
       actor,
       now,
     });
-
-    // Grant the org-member baseline (incl. the `mcp_gateway:list` caller tuple
-    // that AgentGateway's coarse ext_authz gate requires) to every user this
-    // run resolved to a Keycloak `sub`. The membership reconcile above only
-    // writes team tuples; without this, a user provisioned purely by directory
-    // sync — who never interactively logged into the web UI — would hold team
-    // tuples but lack the gateway-gate grant and get zero MCP tools. Running it
-    // for the full resolved set (not just newly-added memberships) on every run
-    // is idempotent (writeOpenFgaTuples drops already-present tuples) and
-    // backfills users provisioned before this fix. Best-effort: never throws,
-    // so a bootstrap hiccup can't fail the reconcile that already committed.
-    const resolvedSubjects = Array.from(subCache.values()).filter(
-      (sub): sub is string => Boolean(sub)
-    );
-    const baseline = await reconcileSyncedUsersBaselineAccess(resolvedSubjects);
-    if (baseline.status === "failed") {
-      console.warn(
-        `[IdpSync] run ${runId}: baseline OpenFGA bootstrap failed for ` +
-          `${baseline.subject_count} synced user(s): ${baseline.warning ?? "unknown error"}`
-      );
-    } else if (baseline.tuple_write_count > 0) {
-      console.log(
-        `[IdpSync] run ${runId}: baseline OpenFGA bootstrap wrote ` +
-          `${baseline.tuple_write_count} tuple(s) across ${baseline.subject_count} synced user(s)`
-      );
-    }
 
     // On a full fetch, sweep for already-orphaned identity_group_sync teams
     // that pre-date this fix (their sources were previously removed but the

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -24,6 +24,7 @@ import { linkFederatedIdentity, provisionShellUser } from "@/lib/rbac/keycloak-a
 import { reconcileSyncedUsersBaselineAccess } from "@/lib/rbac/login-openfga-bootstrap";
 import { mapWithConcurrency } from "@/lib/rbac/openfga";
 import { loopYieldEvery, maybeYield } from "@/lib/rbac/event-loop-yield";
+import { startStageProgress } from "@/lib/rbac/sync-progress";
 import { stripArchivedTeamResourceGrants } from "@/lib/rbac/archived-team-grants";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
@@ -205,16 +206,27 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // the first active occurrence (its display name / Okta id) as the record to
     // provision from.
     const yieldEvery = loopYieldEvery();
+    const totalMemberships = (groups as Array<{ members?: SyncMember[] }>).reduce(
+      (sum, group) => sum + (group.members?.length ?? 0),
+      0
+    );
+    console.log(
+      `[IdpSync] run ${runId}: fetched ${groups.length} group(s), ${totalMemberships} membership row(s)`
+    );
+
+    const dedupeProgress = startStageProgress("dedupe members", totalMemberships);
     const uniqueMembers = new Map<string, SyncMember>();
     let dedupeSeen = 0;
     for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
         await maybeYield(++dedupeSeen, yieldEvery);
+        dedupeProgress.tick(dedupeSeen);
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
         if (!uniqueMembers.has(email)) uniqueMembers.set(email, member);
       }
     }
+    dedupeProgress.done();
 
     // Resolve each unique member's email to a Keycloak `sub`, JIT-creating a
     // federated shell user when none exists yet, so RBAC can be granted before
@@ -238,6 +250,12 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // explicit yield.
     const subCache = new Map<string, string | null>();
     const emails = Array.from(uniqueMembers.keys());
+    console.log(
+      `[IdpSync] run ${runId}: resolving ${emails.length} unique member(s) ` +
+        `at concurrency ${memberResolveConcurrency()}`
+    );
+    const resolveProgress = startStageProgress("resolve members", emails.length);
+    let resolved = 0;
     await mapWithConcurrency(emails, memberResolveConcurrency(), async (email) => {
       const member = uniqueMembers.get(email)!;
       let sub: string | null = null;
@@ -280,21 +298,26 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
           );
         }
       }
+      resolveProgress.tick(++resolved);
     });
+    resolveProgress.done();
 
     // Stamp the resolved subject onto every member object in every group so the
     // planner (which reads `member.subject`) sees them. This is a second pass
     // because a user can appear in many groups but is only resolved once above.
+    const stampProgress = startStageProgress("stamp subjects", totalMemberships);
     let stampSeen = 0;
     for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
         await maybeYield(++stampSeen, yieldEvery);
+        stampProgress.tick(stampSeen);
         const email = member.email?.trim().toLowerCase();
         if (!email) continue;
         const sub = subCache.get(email);
         if (sub) member.subject = sub;
       }
     }
+    stampProgress.done();
 
     // Grant the org-member baseline (incl. the `mcp_gateway:list` caller tuple
     // that AgentGateway's coarse ext_authz gate requires) to every user this
@@ -310,6 +333,10 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // bootstrap hiccup can't block the membership reconcile that follows.
     const resolvedSubjects = Array.from(subCache.values()).filter(
       (sub): sub is string => Boolean(sub)
+    );
+    console.log(
+      `[IdpSync] run ${runId}: bootstrapping baseline OpenFGA access for ` +
+        `${resolvedSubjects.length} resolved subject(s)`
     );
     const baseline = await reconcileSyncedUsersBaselineAccess(resolvedSubjects);
     if (baseline.status === "failed") {
@@ -329,6 +356,11 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // for groups we didn't look at). Without a filter it's a full snapshot.
     const partialFetch = Boolean(groupFilter);
 
+    console.log(
+      `[IdpSync] run ${runId}: planning group sync over ${groups.length} group(s), ` +
+        `${rules.length} rule(s), ${existingMembershipSources.length} existing membership source(s)` +
+        (partialFetch ? " (partial fetch)" : "")
+    );
     const plan = await planIdentityGroupSync({
       groups,
       rules,
@@ -338,13 +370,20 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
       actor,
       partialFetch,
     });
+    console.log(
+      `[IdpSync] run ${runId}: plan ready — ${plan.matched_groups?.length ?? 0} matched group(s), ` +
+        `+${plan.membership_sources_to_add?.length ?? 0}/-${plan.membership_sources_to_remove?.length ?? 0} membership source(s), ` +
+        `${plan.teams_to_create?.length ?? 0} team(s) to create`
+    );
 
     const now = new Date().toISOString();
+    console.log(`[IdpSync] run ${runId}: applying plan`);
     const result = await applyIdentityGroupSyncPlan({
       plan,
       actor,
       now,
     });
+    console.log(`[IdpSync] run ${runId}: plan applied`);
 
     // On a full fetch, sweep for already-orphaned identity_group_sync teams
     // that pre-date this fix (their sources were previously removed but the

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -23,6 +23,7 @@ import {
 import { linkFederatedIdentity, provisionShellUser } from "@/lib/rbac/keycloak-admin";
 import { reconcileSyncedUsersBaselineAccess } from "@/lib/rbac/login-openfga-bootstrap";
 import { mapWithConcurrency } from "@/lib/rbac/openfga";
+import { loopYieldEvery, maybeYield } from "@/lib/rbac/event-loop-yield";
 import { stripArchivedTeamResourceGrants } from "@/lib/rbac/archived-team-grants";
 import { listActiveTeamMembershipSourcesForProvider } from "@/lib/rbac/team-membership-source-store";
 
@@ -58,24 +59,6 @@ function memberResolveConcurrency(): number {
   return DEFAULT_MEMBER_RESOLVE_CONCURRENCY;
 }
 
-// How many iterations of a purely-synchronous loop (no per-item await) to run
-// before handing the event loop back. The dedupe and subject-stamp passes touch
-// every member in every group, so on a large org (e.g. ~8k members across
-// thousands of groups) an unbroken loop can starve the k8s health probes served
-// by this same process. `setImmediate` lets any pending probe callback run
-// between chunks. Each iteration here is a cheap in-memory op, so a small
-// threshold costs almost nothing while keeping probes responsive — 500 gives
-// well over a dozen evenly-spaced yields on a full directory. Tunable via env so
-// tests can exercise the yield without a huge member count.
-const DEFAULT_SYNC_LOOP_YIELD_EVERY = 500;
-function syncLoopYieldEvery(): number {
-  const fromEnv = Number(process.env.IDENTITY_SYNC_LOOP_YIELD_EVERY);
-  if (Number.isFinite(fromEnv) && fromEnv >= 1) return Math.floor(fromEnv);
-  return DEFAULT_SYNC_LOOP_YIELD_EVERY;
-}
-function yieldToEventLoop(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
 
 async function listExistingTeams(): Promise<Array<{ id: string; slug: string; name: string }>> {
   const col = await getCollection<TeamDocument>("teams");
@@ -221,12 +204,12 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // them once, so we dedupe by email before doing any Keycloak work. We keep
     // the first active occurrence (its display name / Okta id) as the record to
     // provision from.
-    const yieldEvery = syncLoopYieldEvery();
+    const yieldEvery = loopYieldEvery();
     const uniqueMembers = new Map<string, SyncMember>();
     let dedupeSeen = 0;
     for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
-        if (++dedupeSeen % yieldEvery === 0) await yieldToEventLoop();
+        await maybeYield(++dedupeSeen, yieldEvery);
         const email = member.email?.trim().toLowerCase();
         if (!member.active || !email) continue;
         if (!uniqueMembers.has(email)) uniqueMembers.set(email, member);
@@ -305,7 +288,7 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     let stampSeen = 0;
     for (const group of groups as Array<{ members?: SyncMember[] }>) {
       for (const member of group.members ?? []) {
-        if (++stampSeen % yieldEvery === 0) await yieldToEventLoop();
+        await maybeYield(++stampSeen, yieldEvery);
         const email = member.email?.trim().toLowerCase();
         if (!email) continue;
         const sub = subCache.get(email);
@@ -346,7 +329,7 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     // for groups we didn't look at). Without a filter it's a full snapshot.
     const partialFetch = Boolean(groupFilter);
 
-    const plan = planIdentityGroupSync({
+    const plan = await planIdentityGroupSync({
       groups,
       rules,
       existingTeams,

--- a/ui/src/lib/rbac/login-openfga-bootstrap.ts
+++ b/ui/src/lib/rbac/login-openfga-bootstrap.ts
@@ -1,6 +1,8 @@
 import { getCollection } from "@/lib/mongodb";
 import {
+  baselineMemberTuples,
   effectiveBaselineBootstrapTuples,
+  getBaselineFgaProfile,
   getBaselineFgaProfileBundle,
   type TeamBaselineProfileOverride,
 } from "@/lib/rbac/baseline-access";
@@ -187,5 +189,85 @@ export async function reconcileLoginOpenFgaAccess(
       `[LoginOpenFGA] Failed to bootstrap OpenFGA access for ${input.email ?? subject}: ${warning}`
     );
     return { status: "failed", tuple_write_count: 0, warning };
+  }
+}
+
+export interface SyncedBaselineBootstrapResult {
+  status: LoginOpenFgaBootstrapStatus;
+  subject_count: number;
+  tuple_write_count: number;
+  warning?: string;
+}
+
+/**
+ * Grant the global org-member baseline (the same grants an interactive web
+ * login writes via `reconcileLoginOpenFgaAccess`, incl. the `mcp-gateway-call`
+ * grant `user:<sub> caller mcp_gateway:list`) to a set of subjects resolved by
+ * a background directory sync.
+ *
+ * Why this exists: the directory-sync path only ever writes team-membership
+ * tuples (`user:<sub> <relation> team:<slug>`). It never wrote the member
+ * baseline, so a user who was provisioned purely by Okta sync — and never
+ * interactively signed into the web UI — held team tuples but lacked the
+ * `mcp_gateway:list` caller tuple that AgentGateway's coarse ext_authz gate
+ * requires. Those users passed auth, minted OBO tokens, then got
+ * `DENY_NO_CAPABILITY` at the gateway and saw zero MCP tools. This closes that
+ * gap so RBAC is granted before the person ever logs into CAIPE.
+ *
+ * Scope: member baseline only. Org-admin status is not derivable from a
+ * directory sync (there is no trustworthy admin signal in a group membership),
+ * so admin baselines remain owned by the interactive-login / bootstrap-admin
+ * paths. Team profile overrides likewise stay a login-time concern; this writes
+ * the global member baseline so every synced user clears the coarse gate.
+ *
+ * Idempotent + self-healing: `writeOpenFgaTuples` reads each candidate tuple
+ * back and drops the ones already stored, so re-emitting the baseline for every
+ * resolved subject on every sync run performs zero writes in steady state while
+ * still backfilling any user who is missing it. This is what lets a routine
+ * sync of already-synced users repair the entire affected population.
+ *
+ * Best-effort: never throws. Callers (the sync runner) treat baseline bootstrap
+ * as non-fatal so a bootstrap hiccup can't fail the membership reconcile that
+ * already committed.
+ */
+export async function reconcileSyncedUsersBaselineAccess(
+  subjects: Iterable<string>
+): Promise<SyncedBaselineBootstrapResult> {
+  const uniqueSubjects: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of subjects) {
+    const subject = raw?.trim();
+    if (!subject || seen.has(subject)) continue;
+    seen.add(subject);
+    uniqueSubjects.push(subject);
+  }
+
+  if (uniqueSubjects.length === 0) {
+    return { status: "skipped", subject_count: 0, tuple_write_count: 0 };
+  }
+
+  try {
+    const profile = await getBaselineFgaProfile();
+    const writes = uniqueSubjects.flatMap((subject) => baselineMemberTuples(subject, profile));
+    if (writes.length === 0) {
+      return { status: "skipped", subject_count: uniqueSubjects.length, tuple_write_count: 0 };
+    }
+    const result = await writeOpenFgaTuples({ writes, deletes: [] });
+    return {
+      status: "completed",
+      subject_count: uniqueSubjects.length,
+      tuple_write_count: result.writes,
+    };
+  } catch (error) {
+    const warning = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[LoginOpenFGA] Failed to bootstrap baseline OpenFGA access for ${uniqueSubjects.length} synced user(s): ${warning}`
+    );
+    return {
+      status: "failed",
+      subject_count: uniqueSubjects.length,
+      tuple_write_count: 0,
+      warning,
+    };
   }
 }

--- a/ui/src/lib/rbac/membership-reconciler.ts
+++ b/ui/src/lib/rbac/membership-reconciler.ts
@@ -1,5 +1,6 @@
 import type { TeamMembershipSource } from "@/types/identity-group-sync";
 
+import { loopYieldEvery, maybeYield } from "./event-loop-yield";
 import type { OpenFgaTupleKey } from "./openfga";
 
 export interface ReconcileTeamMembershipSourcesInput {
@@ -62,28 +63,51 @@ function uniqueTuples(tuples: Array<OpenFgaTupleKey | null>): OpenFgaTupleKey[] 
   return out;
 }
 
-export function reconcileTeamMembershipSources(
+export async function reconcileTeamMembershipSources(
   input: ReconcileTeamMembershipSourcesInput
-): ReconcileTeamMembershipSourcesResult {
-  const existingActive = input.existingSources.filter((source) => source.status === "active");
-  const existingBySource = new Map(existingActive.map((source) => [sourceKey(source), source]));
-  const desiredBySource = new Map(input.desiredSources.map((source) => [sourceKey(source), source]));
+): Promise<ReconcileTeamMembershipSourcesResult> {
+  // A full-directory reconcile walks hundreds of thousands of sources across
+  // several passes with no awaited I/O; yield to the event loop periodically so
+  // the pod's k8s liveness probe (served by this same process) still gets a
+  // turn and the pod isn't SIGKILLed mid-reconcile.
+  const yieldEvery = loopYieldEvery();
+  let processed = 0;
 
-  const sourcesToAdd = input.desiredSources.filter((source) => !existingBySource.has(sourceKey(source)));
-  const sourcesToRemove = existingActive
-    .filter((source) => source.managed && !desiredBySource.has(sourceKey(source)))
+  const existingActive: TeamMembershipSource[] = [];
+  const existingBySource = new Map<string, TeamMembershipSource>();
+  for (const source of input.existingSources) {
+    await maybeYield(++processed, yieldEvery);
+    if (source.status !== "active") continue;
+    existingActive.push(source);
+    existingBySource.set(sourceKey(source), source);
+  }
+
+  const desiredBySource = new Map<string, TeamMembershipSource>();
+  const sourcesToAdd: TeamMembershipSource[] = [];
+  for (const source of input.desiredSources) {
+    await maybeYield(++processed, yieldEvery);
+    const key = sourceKey(source);
+    desiredBySource.set(key, source);
+    if (!existingBySource.has(key)) sourcesToAdd.push(source);
+  }
+
+  const sourcesToRemove: TeamMembershipSource[] = [];
+  for (const source of existingActive) {
+    await maybeYield(++processed, yieldEvery);
+    if (!source.managed || desiredBySource.has(sourceKey(source))) continue;
     // Scope guard: when the caller observed only a subset of groups (e.g. a
     // group filter), never remove memberships for groups outside that subset —
     // their absence from `desiredSources` just means we didn't look, not that
     // the membership is gone. Rows with no external_group_id (defensive) are
     // only removable in a full reconcile.
-    .filter((source) => {
-      if (!input.observedGroupIds) return true; // full snapshot: remove freely
-      return source.external_group_id
+    if (input.observedGroupIds) {
+      const inScope = source.external_group_id
         ? input.observedGroupIds.has(source.external_group_id)
         : false;
-    })
-    .map((source) => ({ ...source, status: "removed" as const, removed_at: input.now }));
+      if (!inScope) continue;
+    }
+    sourcesToRemove.push({ ...source, status: "removed" as const, removed_at: input.now });
+  }
 
   // Tuple writes cover EVERY membership that should hold a live tuple after
   // this reconcile — the retained existing sources plus the newly-added ones —
@@ -99,28 +123,31 @@ export function reconcileTeamMembershipSources(
   // stored, so a steady-state sync performs zero actual writes. uniqueTuples
   // collapses multiple sources that map to the same (user, relation, team).
   const removedKeys = new Set(sourcesToRemove.map((source) => sourceKey(source)));
-  const activeAfterReconcile = [
-    ...existingActive.filter((source) => !removedKeys.has(sourceKey(source))),
-    ...sourcesToAdd,
-  ];
+  const survivingSources: TeamMembershipSource[] = [];
+  for (const source of existingActive) {
+    await maybeYield(++processed, yieldEvery);
+    if (!removedKeys.has(sourceKey(source))) survivingSources.push(source);
+  }
+  const activeAfterReconcile = [...survivingSources, ...sourcesToAdd];
   const tupleWrites = uniqueTuples(
     activeAfterReconcile
       .filter((source) => source.status === "active" && source.user_subject)
       .map(memberTuple)
   );
 
+  // A removed source's tuple must only be deleted when NO surviving (retained,
+  // not-removed) active source still grants the same (user, relation, team)
+  // access — otherwise we'd revoke a tuple another membership source still
+  // backs. Precompute the set of access keys that survive the reconcile so this
+  // is an O(1) lookup per removed source; the previous nested `.some()` scan was
+  // O(n²) over existingActive × sourcesToRemove and, at full-directory scale
+  // (hundreds of thousands of sources), pinned the event loop long enough to
+  // trip the pod's liveness probe.
+  const survivingAccessKeys = new Set(survivingSources.map((source) => accessKey(source)));
   const tupleDeletes = uniqueTuples(
     sourcesToRemove
       .filter((source) => source.user_subject)
-      .filter((source) => {
-        const otherActiveSource = existingActive.some(
-          (existing) =>
-            sourceKey(existing) !== sourceKey(source) &&
-            accessKey(existing) === accessKey(source) &&
-            !sourcesToRemove.some((removed) => sourceKey(removed) === sourceKey(existing))
-        );
-        return !otherActiveSource;
-      })
+      .filter((source) => !survivingAccessKeys.has(accessKey(source)))
       .map(memberTuple)
   );
 

--- a/ui/src/lib/rbac/oidc-claim-reconciler.ts
+++ b/ui/src/lib/rbac/oidc-claim-reconciler.ts
@@ -113,7 +113,7 @@ export async function reconcileOidcClaimGroupsForUser(input: {
     }),
   ]);
 
-  const plan = planIdentityGroupSync({
+  const plan = await planIdentityGroupSync({
     groups: groupsToExternalGroupsForUser({
       providerId,
       groups: input.groups,

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -3,7 +3,13 @@
 import type { Document,Filter } from "mongodb";
 
 import { getCollection } from "@/lib/mongodb";
-import { baselineAdminTuples,baselineMemberTuples } from "@/lib/rbac/baseline-access";
+import {
+  baselineAdminTuples,
+  baselineMemberTuples,
+  defaultBaselineFgaProfile,
+  getBaselineFgaProfile,
+  type BaselineFgaProfile,
+} from "@/lib/rbac/baseline-access";
 import {
   RBAC_SELF_CHECK_IDS,
   normalizeRbacSelfCheckIds,
@@ -218,6 +224,7 @@ export interface RbacSelfCheckInventoryInput {
   tasks: TaskDoc[];
   mcpToolCatalog: ToolCatalogDoc[];
   platformConfig?: PlatformConfigDoc | null;
+  baselineProfile?: BaselineFgaProfile;
   generatedAt?: string;
 }
 
@@ -549,6 +556,7 @@ function currentBaselineAccessTuples(
   actualKeys: Set<string>,
 ): ExpectedTuple[] {
   const tuples: ExpectedTuple[] = [];
+  const profile = input.baselineProfile ?? defaultBaselineFgaProfile();
   const agentGatewayAdminTuple = {
     user: `${organizationObjectId()}#admin`,
     relation: "manager",
@@ -569,18 +577,39 @@ function currentBaselineAccessTuples(
     const subject = userSubject(user);
     if (!subject) continue;
     const role = userRole(user);
-    const adminTuples = baselineAdminTuples(subject);
-    const hasCurrentAdminBaseline = adminTuples.some((tuple) => actualKeys.has(tupleKey(tuple)));
-    const ownsAdminBaseline = role === "admin" || (role === null && hasCurrentAdminBaseline);
     const resource = {
       type: "user",
       id: subject,
       label: user.name ?? user.email ?? subject,
     };
 
-    for (const tuple of [...baselineMemberTuples(subject), ...(ownsAdminBaseline ? adminTuples : [])]) {
-      if (!actualKeys.has(tupleKey(tuple))) continue;
+    // The member baseline is authoritative for every active user: it is always
+    // expected, so a user who was provisioned but never interactively logged
+    // into the web UI (e.g. an Okta directory-sync user) has their MISSING
+    // member grants — including the `mcp_gateway:list` caller tuple that
+    // AgentGateway's coarse ext_authz gate requires — flagged as `missing` and
+    // made repairable. Previously these tuples were only expected when already
+    // present in OpenFGA, so the self-check could never surface or repair a
+    // user who was missing them, which is exactly how sync-only users ended up
+    // with zero MCP tools.
+    for (const tuple of baselineMemberTuples(subject, profile)) {
       tuples.push(expected("baseline_access", tuple.user, tuple.relation, tuple.object, resource));
+    }
+
+    // The admin baseline is authoritative only for users Mongo marks as admin
+    // (there is no trustworthy admin signal otherwise). For a user whose role
+    // is unknown we don't force-repair admin grants; we only recognize the ones
+    // already present so they are not mis-reported as orphan candidates.
+    const adminTuples = baselineAdminTuples(subject, profile);
+    if (role === "admin") {
+      for (const tuple of adminTuples) {
+        tuples.push(expected("baseline_access", tuple.user, tuple.relation, tuple.object, resource));
+      }
+    } else if (role === null && adminTuples.some((tuple) => actualKeys.has(tupleKey(tuple)))) {
+      for (const tuple of adminTuples) {
+        if (!actualKeys.has(tupleKey(tuple))) continue;
+        tuples.push(expected("baseline_access", tuple.user, tuple.relation, tuple.object, resource));
+      }
     }
   }
   return uniqueTuples(tuples);
@@ -1509,6 +1538,7 @@ export async function runRbacSelfCheck(options: RbacSelfCheckOptions = {}): Prom
     tasks,
     mcpToolCatalog,
     platformConfigRows,
+    baselineProfile,
   ] = await Promise.all([
     readAllOpenFgaTuples(),
     loadCollection<TeamDoc>("teams", { status: { $ne: "deleted" } }),
@@ -1538,6 +1568,7 @@ export async function runRbacSelfCheck(options: RbacSelfCheckOptions = {}): Prom
     loadCollection<TaskDoc>("task_configs"),
     loadCollection<ToolCatalogDoc>("mcp_tool_catalog"),
     loadCollection<PlatformConfigDoc>("platform_config", { _id: "platform_settings" } as unknown as Filter<PlatformConfigDoc>),
+    getBaselineFgaProfile(),
   ]);
 
   return deriveRbacSelfCheckReport(
@@ -1561,6 +1592,7 @@ export async function runRbacSelfCheck(options: RbacSelfCheckOptions = {}): Prom
       tasks,
       mcpToolCatalog,
       platformConfig: platformConfigRows[0] ?? null,
+      baselineProfile,
     },
     options,
   );

--- a/ui/src/lib/rbac/sync-progress.ts
+++ b/ui/src/lib/rbac/sync-progress.ts
@@ -1,0 +1,56 @@
+// Lightweight, side-effect-free progress logging for the long phases of a
+// directory sync (dedupe, member resolution, stamping, planning, applying).
+//
+// A full-directory sync spends minutes inside phases that otherwise emit no
+// log lines, which makes "is it still working or wedged?" impossible to answer
+// from the pod logs alone. `startStageProgress` emits one line with the total
+// work count when a phase begins and then roughly one line every 5% (plus a
+// final 100% line), so each stage shows steady movement.
+//
+// This is purely observational — it never changes what work runs, so adding or
+// removing it can't affect the outcome of a sync.
+
+// How many progress lines to emit across a stage (20 → ~every 5%).
+const PROGRESS_INTERVALS = 20;
+
+export interface StageProgress {
+  /** Report cumulative items completed; logs when a ~5% boundary is crossed. */
+  tick(done: number): void;
+  /** Emit the final 100% line (idempotent). */
+  done(): void;
+}
+
+/**
+ * Begin a progress-logged stage. Logs a "<total> to process" header
+ * immediately, returns a handle whose `tick(done)` logs at ~5% boundaries and
+ * whose `done()` logs the closing 100% line. A `total` of 0 logs the header and
+ * then no-ops, so an empty stage is visible but silent afterward.
+ */
+export function startStageProgress(
+  stage: string,
+  total: number,
+  log: (message: string) => void = console.log
+): StageProgress {
+  log(`[IdpSync] ${stage}: ${total} to process`);
+  const step = Math.max(1, Math.floor(total / PROGRESS_INTERVALS));
+  let lastLogged = 0;
+  let finished = false;
+  return {
+    tick(done: number) {
+      if (total <= 0 || done <= 0) return;
+      // Log only when we've advanced at least one 5% step since the last line,
+      // and never emit a mid-stage line at/after the total (done() owns 100%).
+      if (done < total && done - lastLogged >= step) {
+        lastLogged = done;
+        log(`[IdpSync] ${stage}: ${Math.floor((done / total) * 100)}% (${done}/${total})`);
+      }
+    },
+    done() {
+      if (finished) return;
+      finished = true;
+      if (total > 0) {
+        log(`[IdpSync] ${stage}: 100% (${total}/${total}) complete`);
+      }
+    },
+  };
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Problem

The baseline OpenFGA grants a user needs to pass AgentGateway's coarse MCP `ext_authz` gate — specifically the `mcp-gateway-call` grant (`user:<sub> caller mcp_gateway:list`) — were only ever written by the interactive web-login path (`reconcileLoginOpenFgaAccess` / `repairCurrentUserBaseline` in `login-openfga-bootstrap.ts`).

The directory-sync path (`idp-sync-runner.ts` → `identity-group-sync-reconciler.ts` → `membership-reconciler.ts`) only ever writes team-membership tuples (`user:<sub> <relation> team:<slug>`). It never wrote the member baseline.

As a result, a user provisioned purely by directory sync who has **never interactively signed into the web UI** (e.g. users who only ever interact through a chat integration or a CLI client) ends up with team-membership tuples but **no** `mcp_gateway:list` caller tuple. Such a user authenticates fine and mints OBO tokens fine, then gets `DENY_NO_CAPABILITY` at the gateway and sees **zero MCP tools**.

## Fix

- Add `reconcileSyncedUsersBaselineAccess(subjects)` to `login-openfga-bootstrap.ts`. It writes the **global org-member baseline** (the same member grants an interactive login writes, including `mcp-gateway-call`) for each supplied subject.
  - **Member baseline only.** Org-admin status is not derivable from a directory sync, so admin baselines remain owned by the interactive-login / bootstrap-admin paths. Team profile overrides likewise remain a login-time concern.
- Call it from `executeSyncRun` for **every subject the run resolved to a Keycloak `sub`** (the full resolved set, not just newly-added memberships).

### Why this is safe to run every sync

`writeOpenFgaTuples` reads each candidate tuple back and drops the ones already stored, so re-emitting the baseline for every resolved subject on every run performs zero writes in steady state while still **backfilling** any user provisioned before this change. A routine sync of already-synced users therefore repairs the entire affected population.

The call is **best-effort and never throws** — a bootstrap hiccup cannot fail the membership reconcile that already committed; the failure is logged and the run still records success.

## Tests

- `login-openfga-bootstrap.test.ts`: new suite for `reconcileSyncedUsersBaselineAccess` — writes member baseline (incl. `mcp_gateway:list`) per subject, no admin tuples, dedupe/blank handling, no-op on empty input, and never-throws-on-write-error.
- `idp-sync-runner.test.ts`: new suite — baseline bootstrap invoked with the deduped resolved subject set, excludes members whose subject never resolved, and the run still records success when bootstrap fails.

All affected suites pass (32 tests); `tsc --noEmit` and `eslint` clean on the changed files.