### PR TITLE
fix(dynamic-agents): sanitize MCP server_id for Bedrock tool names and fast-fail on non-retryable errors

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -65,6 +65,7 @@ from dynamic_agents.services.mcp_client import (
     get_tools_with_resilience,
     mcp_credential_connect_warning,
     resolve_mcp_connections_credential_refs,
+    sanitize_server_id_for_prefix,
     wrap_tools_with_error_handling,
 )
 from dynamic_agents.services.middleware import ToolResultInvariantMiddleware, build_middleware
@@ -916,6 +917,7 @@ class AgentRuntime:
         config = agent_config or self.config
         interrupt_config: dict[str, Any] = {}
         for server_id, tools_map in (config.interrupt_on or {}).items():
+            safe_id = sanitize_server_id_for_prefix(server_id)
             for tool_name, cfg in tools_map.items():
                 resolved_cfg = cfg.model_dump() if isinstance(cfg, InterruptConfig) else cfg
                 if tool_name == "*":
@@ -924,12 +926,12 @@ class AgentRuntime:
                             if t.name in builtin_tool_names:
                                 interrupt_config[t.name] = resolved_cfg
                     else:
-                        prefix = f"{server_id}_"
+                        prefix = f"{safe_id}_"
                         for t in tools:
                             if t.name not in builtin_tool_names and t.name.startswith(prefix):
                                 interrupt_config[t.name] = resolved_cfg
                 else:
-                    full_name = tool_name if server_id == "builtin" else f"{server_id}_{tool_name}"
+                    full_name = tool_name if server_id == "builtin" else f"{safe_id}_{tool_name}"
                     interrupt_config[full_name] = resolved_cfg
         return interrupt_config
 

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
@@ -31,6 +31,31 @@ logger = logging.getLogger(__name__)
 
 
 CALLER_PROVIDER_NOT_CONNECTED = "caller_provider_not_connected"
+
+# Bedrock ConverseStream requires tool names to match [a-zA-Z0-9_-]+.
+# MCP server IDs used as prefixes may contain other characters (e.g. "$SLACK").
+_TOOL_NAME_INVALID_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_server_id_for_prefix(server_id: str) -> str:
+    """Return a Bedrock-safe version of server_id for use as a tool name prefix.
+
+    Bedrock's ConverseStream API requires tool names to match [a-zA-Z0-9_-]+.
+    When server_id is used as a prefix (e.g. "$SLACK_conversations_history"),
+    any character outside that set causes a ValidationException. Replace invalid
+    chars with underscores.
+    """
+    sanitized = _TOOL_NAME_INVALID_CHARS.sub("_", server_id)
+    if sanitized != server_id:
+        logger.warning(
+            "MCP server_id %r contains characters invalid in Bedrock tool names; "
+            "sanitized to %r for tool name prefix",
+            server_id,
+            sanitized,
+        )
+    return sanitized
+
+
 TOP_LEVEL_UNION_SCHEMA_KEYS = ("oneOf", "anyOf", "allOf")
 
 _PROVIDER_DISPLAY_NAMES: dict[str, str] = {
@@ -353,7 +378,10 @@ def build_mcp_connections(
             agent_gateway_url
             and server.transport in (TransportType.HTTP, TransportType.SSE)
         )
-        connections[server_id] = build_mcp_connection_config(
+        # Use sanitized server_id as the connection key so MultiServerMCPClient
+        # produces tool names that are valid Bedrock ConverseStream names.
+        safe_id = sanitize_server_id_for_prefix(server_id)
+        connections[safe_id] = build_mcp_connection_config(
             server,
             agent_gateway_url=agent_gateway_url if use_gateway else None,
             auth_bearer=auth_bearer,
@@ -671,13 +699,15 @@ def filter_tools_by_allowed(
     allowed_names: set[str] = set()
 
     for server_id, value in allowed_tools.items():
+        # Sanitize server_id to match the prefix used in build_mcp_connections.
+        safe_id = sanitize_server_id_for_prefix(server_id)
         if value is False:
             # Explicitly disabled — skip entirely
             continue
         elif value is True:
             # All tools from this server
             for tool in all_tools:
-                if tool.name.startswith(f"{server_id}_"):
+                if tool.name.startswith(f"{safe_id}_"):
                     allowed_names.add(tool.name)
         elif isinstance(value, list):
             if not value:
@@ -688,12 +718,12 @@ def filter_tools_by_allowed(
                     server_id,
                 )
                 for tool in all_tools:
-                    if tool.name.startswith(f"{server_id}_"):
+                    if tool.name.startswith(f"{safe_id}_"):
                         allowed_names.add(tool.name)
             else:
                 # Specific tools only
                 for tool_name in value:
-                    namespaced = f"{server_id}_{tool_name}"
+                    namespaced = f"{safe_id}_{tool_name}"
                     allowed_names.add(namespaced)
 
     # Filter and validate tools

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -161,7 +161,7 @@ def _should_retry_model_call(exc: Exception) -> bool:
     return not any(token in msg for token in _BEDROCK_NON_RETRYABLE)
 
 
-class BrightModelRetryMiddleware(ModelRetryMiddleware):
+class SelectiveModelRetryMiddleware(ModelRetryMiddleware):
     """ModelRetryMiddleware that skips retrying permanent Bedrock errors.
 
     Bedrock ValidationExceptions for "input too long" or invalid tool name
@@ -225,7 +225,7 @@ class MiddlewareSpec:
 # then optional add-ons.
 MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
     "model_retry": MiddlewareSpec(
-        cls=BrightModelRetryMiddleware,
+        cls=SelectiveModelRetryMiddleware,
         default_params={"max_retries": 5, "backoff_factor": 2.0, "on_failure": "error"},
         enabled_by_default=True,
         allow_multiple=False,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -142,6 +142,39 @@ class ToolResultInvariantMiddleware(AgentMiddleware):
         return await handler(request.override(messages=patched_messages))
 
 
+_BEDROCK_NON_RETRYABLE = (
+    "input is too long for requested model",
+    "member must satisfy regular expression pattern",
+    "validationexception",
+)
+
+
+def _should_retry_model_call(exc: Exception) -> bool:
+    """Return False for Bedrock ValidationExceptions that are never retryable.
+
+    Bedrock raises ValidationException for both permanent errors (context too
+    long, invalid tool name chars) and transient ones. Permanent errors will
+    fail on every attempt, so retrying wastes quota and adds latency. We
+    detect them by inspecting the error message.
+    """
+    msg = str(exc).lower()
+    return not any(token in msg for token in _BEDROCK_NON_RETRYABLE)
+
+
+class BrightModelRetryMiddleware(ModelRetryMiddleware):
+    """ModelRetryMiddleware that skips retrying permanent Bedrock errors.
+
+    Bedrock ValidationExceptions for "input too long" or invalid tool name
+    constraints are permanent — retrying them burns quota with no chance of
+    success. This subclass passes a retry_on predicate that lets
+    ModelRetryMiddleware fast-fail on those errors.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("retry_on", _should_retry_model_call)
+        super().__init__(**kwargs)
+
+
 class InterruptAwareToolRetryMiddleware(ToolRetryMiddleware):
     """Retry ordinary tool failures without swallowing LangGraph control flow.
 
@@ -192,7 +225,7 @@ class MiddlewareSpec:
 # then optional add-ons.
 MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
     "model_retry": MiddlewareSpec(
-        cls=ModelRetryMiddleware,
+        cls=BrightModelRetryMiddleware,
         default_params={"max_retries": 5, "backoff_factor": 2.0, "on_failure": "error"},
         enabled_by_default=True,
         allow_multiple=False,

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.49 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.50 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.49 -f your-values.yaml'}
+                  {'    --version 0.5.50 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.49 -f your-values.yaml'}
+              {'    --version 0.5.50 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Fixes two `ChatBedrockConverse` `ValidationException` failure modes reported in issue #2204.

**Bug 1 — Invalid MCP server_id characters in tool names (`$SLACK_conversations_history`)**

Bedrock ConverseStream requires tool names matching `[a-zA-Z0-9_-]+`. When an MCP server is registered with `server_id = "$SLACK"`, `langchain-mcp-adapters` prefixes all tool names with that id, producing names Bedrock rejects. Added `sanitize_server_id_for_prefix()` in `mcp_client.py` that replaces invalid characters with underscores before use as a prefix. Applied in `build_mcp_connections`, `filter_tools_by_allowed`, and `_build_interrupt_config`.

**Bug 2 — 5x retry loop on permanent Bedrock errors**

`ModelRetryMiddleware` retried all LLM failures including permanent ones like "input too long" and "member must satisfy regular expression pattern". Added `SelectiveModelRetryMiddleware` with a `retry_on` predicate that fast-fails on those error tokens instead of burning ~30s on retries that can never succeed.

## Test plan

- [ ] Verify `sanitize_server_id_for_prefix("$SLACK")` returns `"__SLACK"` and logs a warning
- [ ] Verify agents with `$SLACK` server_id no longer produce `ValidationException` from tool name rejection
- [ ] Verify permanent Bedrock errors (input too long, regex pattern) fail immediately without 5 retries
- [ ] Verify transient errors still retry with exponential backoff
- [ ] Check MongoDB `agent_configs` collection for `server_id = "$SLACK"` entries — likely an unevaluated env var at import time; see [#2204](https://github.com/cnoe-io/ai-platform-engineering/issues/2204) for the data fix query

## Related

Closes #2204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
