### PR TITLE
fix(slack-bot): profile and fix slow Slack event routing (unfiltered OpenFGA read)

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -66,6 +66,33 @@ def _msg_link(channel_id: str, ts: str) -> str:
     return ""
   return f" {_WORKSPACE_URL}/archives/{channel_id}/p{ts.replace('.', '')}"
 
+
+def _ingestion_lag_ms(event: dict) -> int | None:
+  """Milliseconds between Slack's event timestamp and now.
+
+  ``event["ts"]`` is the wall-clock time Slack assigned when the message was
+  sent, so this measures true end-to-end lag (Slack delivery + our own
+  queueing/processing), not just time spent inside this process. Used to
+  profile where multi-minute response delays accumulate — Slack delivery,
+  our RBAC/routing pipeline, or agent dispatch — without hand-correlating
+  raw event timestamps against logs after the fact.
+  """
+  send_ts = event.get("ts")
+  try:
+    send_ts = float(send_ts)
+  except (TypeError, ValueError):
+    return None
+  return int((time.time() - send_ts) * 1000)
+
+
+def _log_stage(event: dict, stage: str, **extra) -> None:
+  """Emit a single structured timing line for pipeline-stage profiling."""
+  fields = " ".join(f"{k}={v}" for k, v in extra.items())
+  logger.info(
+    "[{}] stage={} ingestion_lag_ms={} {}",
+    event.get("ts"), stage, _ingestion_lag_ms(event), fields,
+  )
+
 # 098 Enterprise RBAC enforcement
 RBAC_ENABLED = os.environ.get("SLACK_RBAC_ENABLED", "false").lower() == "true"
 
@@ -1022,6 +1049,7 @@ def rbac_global_middleware(body, context, next, logger):
     5. Stores the OBO access token and user_sub on the Bolt context
        for per-handler RBAC checks.
     """
+    _log_stage(body.get("event", {}), "middleware_entry")
     if not RBAC_ENABLED:
         next()
         return
@@ -1113,6 +1141,7 @@ def rbac_global_middleware(body, context, next, logger):
     is_command = bool(body.get("command"))
 
     loop = None
+    _rbac_t0 = time.monotonic()
     try:
         loop = asyncio.new_event_loop()
         rbac_status = loop.run_until_complete(
@@ -1122,6 +1151,10 @@ def rbac_global_middleware(body, context, next, logger):
                 context,
                 require_mapping=not (is_mention or is_command),
             )
+        )
+        logger.info(
+            "[{}] stage=rbac_enrich_context_done duration_ms={} status={}",
+            event.get("ts"), int((time.monotonic() - _rbac_t0) * 1000), rbac_status,
         )
     except Exception as exc:
         logger.error("Failed to resolve Slack user %s — denying request: %s", slack_user_id, exc)
@@ -1221,6 +1254,7 @@ def rbac_global_middleware(body, context, next, logger):
 @app.event("app_mention")
 def handle_mention(event, say, client, context=None):
   """Handle @mentions of the bot to query CAIPE."""
+  _log_stage(event, "handle_mention_entry")
   try:
     # Wall-clock start for `_track_interaction(response_time_ms=...)` below.
     t0 = time.monotonic()
@@ -1525,6 +1559,7 @@ def _route_to_agent(event, say, client, channel_config, agent_match, is_bot, bot
   authorization check and by `_bind_obo_for_handler()` so OBO tokens flow into
   MCP calls. Both default to no-ops when RBAC is disabled.
   """
+  _log_stage(event, "route_to_agent_entry", agent_id=agent_match.agent_id if agent_match else None)
   try:
     t0 = time.monotonic()
 
@@ -2004,6 +2039,7 @@ def handle_message_events(body, say, client, context=None):
   event = body.get("event")
   if not event:
     return
+  _log_stage(event, "handle_message_events_entry")
 
   subtype = event.get("subtype")
   if subtype in ("message_deleted", "message_changed", "channel_join", "channel_leave"):
@@ -2047,6 +2083,7 @@ def handle_message_events(body, say, client, context=None):
         logger.warning(f"event.get('username') also returned nothing for bot_id={bot_id}; bot_list filtering may not work correctly")
 
   sender_user_id = event.get("user") if not is_bot else None
+  _match_t0 = time.monotonic()
   matches = _match_channel_agents(
     channel_id,
     channel_config,
@@ -2056,6 +2093,10 @@ def handle_message_events(body, say, client, context=None):
     user_id=sender_user_id,
     listen="message",
     workspace_id=_event_workspace_id(event),
+  )
+  logger.info(
+    "[{}] stage=match_channel_agents_done duration_ms={} matched={}",
+    event.get("ts"), int((time.monotonic() - _match_t0) * 1000), bool(matches),
   )
   if not matches:
     mode = slack_agent_route_mode()

--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -88,7 +88,7 @@ def _ingestion_lag_ms(event: dict) -> int | None:
 def _log_stage(event: dict, stage: str, **extra) -> None:
   """Emit a single structured timing line for pipeline-stage profiling."""
   fields = " ".join(f"{k}={v}" for k, v in extra.items())
-  logger.info(
+  logger.debug(
     "[{}] stage={} ingestion_lag_ms={} {}",
     event.get("ts"), stage, _ingestion_lag_ms(event), fields,
   )
@@ -1152,7 +1152,7 @@ def rbac_global_middleware(body, context, next, logger):
                 require_mapping=not (is_mention or is_command),
             )
         )
-        logger.info(
+        logger.debug(
             "[{}] stage=rbac_enrich_context_done duration_ms={} status={}",
             event.get("ts"), int((time.monotonic() - _rbac_t0) * 1000), rbac_status,
         )
@@ -2094,7 +2094,7 @@ def handle_message_events(body, say, client, context=None):
     listen="message",
     workspace_id=_event_workspace_id(event),
   )
-  logger.info(
+  logger.debug(
     "[{}] stage=match_channel_agents_done duration_ms={} matched={}",
     event.get("ts"), int((time.monotonic() - _match_t0) * 1000), bool(matches),
   )

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_slack_agent_routes.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_slack_agent_routes.py
@@ -269,7 +269,15 @@ def test_resolver_defaults_to_internal_openfga_url_when_env_is_unset(monkeypatch
     )
 
     assert [match.agent_id for match in matches] == ["tuple-backed-agent"]
-    assert post_calls == [("http://openfga:8080/stores/store-1/read", {"page_size": 100})]
+    assert post_calls == [
+        (
+            "http://openfga:8080/stores/store-1/read",
+            {
+                "page_size": 100,
+                "tuple_key": {"user": "slack_channel:CAIPE--C123", "relation": "user", "object": "agent:"},
+            },
+        )
+    ]
 
 
 def test_resolver_records_openfga_read_failures_to_audit_service(monkeypatch) -> None:

--- a/ai_platform_engineering/integrations/slack_bot/utils/slack_agent_routes.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/slack_agent_routes.py
@@ -194,12 +194,15 @@ class SlackAgentRouteResolver:
         try:
             store_id = _openfga_store_id(base_url)
             workspace_ref = slack_workspace_ref(workspace_id)
+            channel_subject = f"slack_channel:{workspace_ref}--{channel_id}"
             agent_ids: list[str] = []
             seen: set[str] = set()
             continuation_token: str | None = None
             while True:
-                channel_subject = f"slack_channel:{workspace_ref}--{channel_id}"
-                body: dict[str, Any] = {"page_size": 100}
+                body: dict[str, Any] = {
+                    "page_size": 100,
+                    "tuple_key": {"user": channel_subject, "relation": "user", "object": "agent:"},
+                }
                 if continuation_token:
                     body["continuation_token"] = continuation_token
                 response = requests.post(

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.49 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.50 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.49 -f your-values.yaml'}
+                  {'    --version 0.5.50 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.49 -f your-values.yaml'}
+              {'    --version 0.5.50 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.50"
+version = "0.5.50.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Adds lightweight stage-timing logs (at `DEBUG` level) across the Slack event pipeline — middleware entry, RBAC context enrichment, mention/message handler entry, `_route_to_agent` entry, and channel-match duration — to make it possible to profile where delays accumulate between Slack event receipt and agent dispatch.
- Each log line includes `ingestion_lag_ms`, computed from Slack's own event timestamp vs. wall-clock time, so end-to-end lag (delivery + internal processing) is visible without manually correlating raw event timestamps against logs after the fact.
- **Fixes a real perf bug found using this logging**: `SlackAgentRouteResolver._load_openfga_agent_ids()` queried OpenFGA's `/read` endpoint with no `tuple_key` filter, so OpenFGA returned *every* tuple in the store (paginated 100 at a time) and the code filtered client-side for the one channel subject it actually wanted. The fix adds a `tuple_key` filter (`user`, `relation`, `object` type) so OpenFGA filters server-side instead.

## Before / after

We were seeing multi-minute delays between a user's Slack message and the bot's response, even though the underlying agent/LLM call itself completed in well under a minute once invoked. Adding the stage-timing logs (this PR) pinpointed nearly all of the delay to a single call: `_match_channel_agents` → `_load_openfga_agent_ids`.

Measured channel-matching duration, before and after the OpenFGA filter fix, on a live deployment:

| | Before | After |
|---|---|---|
| Channel-match duration (`match_channel_agents_done`) | 30–75 seconds per lookup | 0–77 milliseconds per lookup |
| Behavior under load | Degraded further as the OpenFGA tuple store grew over time (more tuples → slower full-table scan) | Flat and fast regardless of store size, since OpenFGA now does the filtering |

Root cause: OpenFGA's `/read` endpoint returns the entire tuple store when no `tuple_key` filter is supplied. The unfiltered call meant every single Slack message triggered a full paginated scan of the whole ReBAC relationship store, filtered client-side for one subject. Filtering server-side turns that into a single indexed lookup.

Once the underlying bug was fixed, the stage-timing logs were moved from `INFO` to `DEBUG` so they stay silent in normal operation (most deployments run at `INFO`) but remain available by bumping the log level if this pipeline needs to be profiled again in the future.

## Test plan
- [x] `ruff check` passes
- [x] Full `slack_bot` test suite passes (519 passed)
- [x] Verified the new filtered OpenFGA request against a live OpenFGA instance (read-only queries): the request shape is accepted, returns the correct tuple for a channel with an active route, returns an empty result (no error) for a channel with none, and completes in ~0.5s versus the previous 30-75s
- [x] Deployed to a test environment and confirmed the new `stage=...` log lines appear with sane `ingestion_lag_ms`/`duration_ms` values during normal traffic, and that channel-match duration dropped to sub-100ms after the fix