### PR TITLE
feat(ui): animate shared tab selectors

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.52 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.53 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.52 -f your-values.yaml'}
+                  {'    --version 0.5.53 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.52 -f your-values.yaml'}
+              {'    --version 0.5.53 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.53"
+version = "0.5.53-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/access-explorer.spec.ts
+++ b/ui/e2e/rbac/access-explorer.spec.ts
@@ -323,7 +323,7 @@ test.describe("mocked Access Explorer browser regression", () => {
     await gotoAccessExplorer(page);
 
     await expect(page).toHaveURL(/\/admin\?cat=security&tab=access-explorer$/);
-    await expect(page.getByRole("button", { name: "Security & Policy" })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("button", { name: "Security & Policy" })).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByRole("heading", { name: "Access Explorer" })).toHaveCount(0);
     await expect(page.getByTestId("access-explorer-search-stage")).toBeVisible();
     await expect(page.getByTestId("access-explorer-header")).toHaveCount(0);

--- a/ui/e2e/rbac/admin-settings-regression.spec.ts
+++ b/ui/e2e/rbac/admin-settings-regression.spec.ts
@@ -28,7 +28,7 @@ test.describe("mocked admin settings browser regression", () => {
     await page.goto("/admin", { waitUntil: "domcontentloaded" });
 
     await expect(page).toHaveURL(/\/admin\?cat=settings&tab=settings$/);
-    await expect(page.getByRole("button", { name: "Settings", exact: true })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("button", { name: "Settings", exact: true })).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByRole("tab", { name: "General" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -48,7 +48,7 @@ test.describe("mocked admin settings browser regression", () => {
     });
 
     await expect(page).toHaveURL(/\/admin\?cat=settings&tab=settings$/);
-    await expect(page.getByRole("button", { name: "Settings", exact: true })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("button", { name: "Settings", exact: true })).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByRole("tab", { name: "General" })).toHaveAttribute(
       "aria-selected",
       "true",

--- a/ui/e2e/rbac/identity-sync-regression.spec.ts
+++ b/ui/e2e/rbac/identity-sync-regression.spec.ts
@@ -156,7 +156,7 @@ test.describe("mocked identity sync browser regression", () => {
       waitUntil: "domcontentloaded",
     });
 
-    await expect(page.getByRole("button", { name: "Teams & Users" })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("button", { name: "Teams & Users" })).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByRole("tab", { name: "Identity Sync" })).toHaveAttribute(
       "aria-selected",
       "true",

--- a/ui/e2e/rbac/rbac-self-check.spec.ts
+++ b/ui/e2e/rbac/rbac-self-check.spec.ts
@@ -329,7 +329,7 @@ test.describe("mocked RBAC Self Check browser regression", () => {
       waitUntil: "domcontentloaded",
     });
 
-    await expect(page.getByRole("button", { name: "Security & Policy" })).toHaveClass(/bg-primary/);
+    await expect(page.getByRole("button", { name: "Security & Policy" })).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByRole("tab", { name: "Self Check" })).toHaveAttribute(
       "aria-selected",
       "true",

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -182,7 +182,17 @@ jest.mock('@/lib/api-client', () => ({
 }));
 
 jest.mock('framer-motion', () => ({
-  motion: { div: ({ children, ...props }: any) => <div {...props}>{children}</div> },
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    span: ({ animate, children, initial, layoutId, transition, ...props }: any) => {
+      void animate;
+      void initial;
+      void layoutId;
+      void transition;
+      return <span {...props}>{children}</span>;
+    },
+  },
+  useReducedMotion: () => false,
 }));
 
 const mockStatsResponse = {
@@ -737,7 +747,7 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByRole('button', { name: /viewing as target admin/i })).toBeInTheDocument();
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
+        expect(screen.getByRole('button', { name: 'Settings' })).toHaveAttribute('aria-pressed', 'true');
       });
       expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
         'General',
@@ -1025,7 +1035,7 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByText('Settings')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Settings' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^General$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1043,7 +1053,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Settings')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Settings' })).toHaveAttribute('aria-pressed', 'true');
       // An unknown tab value falls through to the first visible Settings tab
       // (General), which renders both the platform settings and the release
       // notes preference/config sections.
@@ -1092,7 +1102,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Integrations')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Integrations' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Integrations' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
         'Slack',
         'Webex',
@@ -1107,7 +1117,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Integrations')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Integrations' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Integrations' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Webex$/i })).toHaveAttribute('aria-selected', 'true');
       expect(screen.getByTestId('webex-integration-panel')).toBeInTheDocument();
     });
@@ -1118,7 +1128,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Settings')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Settings' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^General$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1136,7 +1146,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Access Explorer$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1161,7 +1171,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Settings')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Settings' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Settings' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^General$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1179,7 +1189,7 @@ describe('Admin Dashboard Page', () => {
       render(<AdminPage />);
 
       expect(await screen.findByText('Insights')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Insights' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Insights' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Statistics$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1197,7 +1207,7 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Access Explorer$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1215,7 +1225,7 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Self Check$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1230,7 +1240,7 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByText('Security & Policy')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Security & Policy' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Access Explorer$/i })).toHaveAttribute(
         'aria-selected',
         'true'
@@ -1250,7 +1260,7 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByText('Integrations')).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Integrations' })).toHaveClass('bg-primary');
+      expect(screen.getByRole('button', { name: 'Integrations' })).toHaveAttribute('aria-pressed', 'true');
       expect(screen.getByRole('tab', { name: /^Slack$/i })).toHaveAttribute(
         'aria-selected',
         'true'

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -51,6 +51,7 @@ DialogTitle,
 } from "@/components/ui/dialog";
 import { MultiSelect,TagInput } from "@/components/ui/multi-select";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { SlidingSelectorIndicator } from "@/components/ui/sliding-selector";
 import { Tabs,TabsContent,TabsList,TabsTrigger } from "@/components/ui/tabs";
 import { useAdminRole } from "@/hooks/use-admin-role";
 import { useAdminTabGates,type AdminTabGateSimulationTarget } from "@/hooks/useAdminTabGates";
@@ -565,6 +566,7 @@ function AdminPage() {
       ? initialCat
       : categoryForTab(activeTab)
   );
+  const categorySelectorLayoutId = React.useId();
 
   const tabGateValues = useMemo<Record<string, boolean>>(
     () => ({
@@ -1347,22 +1349,37 @@ function AdminPage() {
               router.replace(`${pathname}?${params.toString()}`, { scroll: false });
             }} className="space-y-4">
               {/* Category selector */}
-              <div className="flex flex-wrap gap-1.5">
+              <div
+                aria-label="Admin sections"
+                className="flex flex-wrap gap-1.5"
+                role="group"
+              >
                 {visibleCategories.map((cat) => {
                   const Icon = cat.icon;
                   const isActive = activeCategory === cat.key;
                   return (
                     <button
                       key={cat.key}
+                      type="button"
+                      aria-pressed={isActive}
                       onClick={() => handleCategoryChange(cat.key)}
-                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                      className={`relative isolate inline-flex items-center gap-1.5 overflow-hidden rounded-full px-3 py-1.5 text-xs font-medium transition-[color,transform,background-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-[0.98] motion-reduce:transform-none ${
                         isActive
-                          ? 'bg-primary text-primary-foreground shadow-sm'
+                          ? 'bg-transparent text-primary-foreground'
                           : 'bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground'
                       }`}
                     >
-                      <Icon className="h-3.5 w-3.5" />
-                      {cat.label}
+                      {isActive && (
+                        <SlidingSelectorIndicator
+                          className="admin-category-active-pill"
+                          layoutId={categorySelectorLayoutId}
+                          variant="liquid"
+                        />
+                      )}
+                      <span className="relative z-10 inline-flex items-center gap-1.5">
+                        <Icon className="h-3.5 w-3.5" />
+                        {cat.label}
+                      </span>
                     </button>
                   );
                 })}
@@ -1523,7 +1540,10 @@ function AdminPage() {
 
               {/* Filtered sub-tabs for the active category */}
               {visibleTabsForCategory.length > 0 && (
-                <TabsList className="flex w-full justify-start gap-0">
+                <TabsList
+                  className="flex w-full justify-start gap-0"
+                  indicatorScope={activeCategory}
+                >
                   {visibleTabsForCategory.map((t) => {
                     const Icon = t.icon;
                     return (

--- a/ui/src/components/skills/workspace/SkillWorkspace.tsx
+++ b/ui/src/components/skills/workspace/SkillWorkspace.tsx
@@ -695,6 +695,7 @@ export function SkillWorkspace({
           <TabsList
             className="mx-auto flex h-auto w-full max-w-3xl items-center justify-between gap-0 bg-transparent p-0"
             aria-label="Skill builder steps"
+            indicator="none"
           >
             {STEPS.map((s, idx) => {
               const Icon = s.icon;

--- a/ui/src/components/ui/__tests__/tabs.test.tsx
+++ b/ui/src/components/ui/__tests__/tabs.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent,render,screen } from "@testing-library/react";
+import React from "react";
+
+import { SlidingSelectorIndicator } from "@/components/ui/sliding-selector";
+import { Tabs,TabsList,TabsTrigger } from "@/components/ui/tabs";
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    span: ({
+      animate,
+      children,
+      initial,
+      layoutId,
+      transition,
+      ...props
+    }: React.ComponentProps<"span"> & {
+      animate?: { height?: number; width?: number; x?: number; y?: number };
+      initial?: unknown;
+      layoutId?: string;
+      transition?: { duration?: number; type?: string };
+    }) => {
+      void initial;
+      return (
+        <span
+          data-layout-id={layoutId}
+          data-position-x={animate?.x}
+          data-position-y={animate?.y}
+          data-transition-duration={transition?.duration}
+          data-transition-type={transition?.type}
+          {...props}
+        >
+          {children}
+        </span>
+      );
+    },
+  },
+  useReducedMotion: () => false,
+}));
+
+function ControlledTabs({
+  indicator,
+}: {
+  indicator?: "pill" | "underline" | "none";
+}) {
+  const [value, setValue] = React.useState("first");
+
+  return (
+    <Tabs value={value} onValueChange={setValue}>
+      <TabsList indicator={indicator}>
+        <TabsTrigger value="first">First</TabsTrigger>
+        <TabsTrigger value="second">Second</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}
+
+function activeIndicator(): HTMLElement | null {
+  return screen
+    .getByRole("tablist")
+    .querySelector('[data-slot="sliding-selector-indicator"]');
+}
+
+describe("Tabs sliding selector", () => {
+  it("uses a shared pill selector by default and moves it to the active tab", () => {
+    render(<ControlledTabs />);
+
+    const firstIndicator = activeIndicator();
+    expect(firstIndicator).toHaveAttribute("data-variant", "pill");
+    expect(firstIndicator).toHaveAttribute("data-transition-type", "tween");
+    expect(firstIndicator).toHaveAttribute("data-transition-duration", "0.24");
+    expect(
+      screen
+        .getByRole("tab", { name: "First" })
+        .querySelector('[data-slot="sliding-selector-indicator"]'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Second" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.getByRole("tab", { name: "Second" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(activeIndicator()).toBe(firstIndicator);
+    expect(activeIndicator()).not.toHaveAttribute("data-layout-id");
+  });
+
+  it("supports an animated underline for specialized tab headers", () => {
+    render(<ControlledTabs indicator="underline" />);
+
+    expect(activeIndicator()).toHaveAttribute("data-variant", "underline");
+  });
+
+  it("keeps the spring motion exclusive to the intentional liquid variant", () => {
+    const { container } = render(
+      <div className="relative">
+        <SlidingSelectorIndicator layoutId="liquid-test" variant="liquid" />
+      </div>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="sliding-selector-indicator"]'),
+    ).toHaveAttribute("data-transition-type", "spring");
+  });
+
+  it("allows non-navigation controls such as steppers to opt out", () => {
+    render(<ControlledTabs indicator="none" />);
+
+    expect(activeIndicator()).not.toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Second" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    expect(activeIndicator()).not.toBeInTheDocument();
+  });
+
+  it("resets the motion identity when a tab list changes navigation scope", () => {
+    const { rerender } = render(
+      <Tabs value="first">
+        <TabsList indicatorScope="settings">
+          <TabsTrigger value="first">First</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    const settingsIndicator = activeIndicator();
+
+    rerender(
+      <Tabs value="first">
+        <TabsList indicatorScope="people">
+          <TabsTrigger value="first">First</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    expect(activeIndicator()).not.toBe(settingsIndicator);
+  });
+
+  it("tracks uncontrolled Radix tab state", () => {
+    render(
+      <Tabs defaultValue="first">
+        <TabsList>
+          <TabsTrigger value="first">First</TabsTrigger>
+          <TabsTrigger value="second">Second</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Second" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    expect(screen.getByRole("tab", { name: "Second" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(activeIndicator()).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/sliding-selector.tsx
+++ b/ui/src/components/ui/sliding-selector.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { motion,useReducedMotion } from "framer-motion";
+
+export type SlidingSelectorVariant = "pill" | "liquid" | "underline";
+
+export interface SlidingSelectorBounds {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+interface SlidingSelectorIndicatorProps {
+  bounds?: SlidingSelectorBounds;
+  className?: string;
+  layoutId?: string;
+  variant?: SlidingSelectorVariant;
+}
+
+/**
+ * Shared active-state surface for navigation controls.
+ *
+ * Framer Motion moves the same layout element between items instead of
+ * mounting an unrelated background on every selection. Keeping the motion in
+ * this primitive gives every tab header the same timing and reduced-motion
+ * behaviour, while the liquid preset adds a softer spring for large pills.
+ */
+function SlidingSelectorIndicator({
+  bounds,
+  className,
+  layoutId,
+  variant = "pill",
+}: SlidingSelectorIndicatorProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  const transition = shouldReduceMotion
+    ? { duration: 0 }
+    : variant === "liquid"
+      ? { type: "spring" as const, stiffness: 300, damping: 23, mass: 0.9 }
+      : variant === "underline"
+        ? {
+            type: "tween" as const,
+            duration: 0.2,
+            ease: [0.22, 1, 0.36, 1] as const,
+          }
+        : {
+            type: "tween" as const,
+            duration: 0.24,
+            ease: [0.22, 1, 0.36, 1] as const,
+          };
+
+  return (
+    <motion.span
+      aria-hidden="true"
+      data-slot="sliding-selector-indicator"
+      data-variant={variant}
+      animate={
+        bounds
+          ? {
+              height: bounds.height,
+              width: bounds.width,
+              x: bounds.x,
+              y: bounds.y,
+            }
+          : undefined
+      }
+      initial={false}
+      layoutId={layoutId}
+      transition={transition}
+      className={cn(
+        "pointer-events-none absolute z-0",
+        variant === "pill" &&
+          cn(
+            bounds ? "left-0 top-0" : "inset-0",
+            "rounded-[inherit] bg-background shadow-sm ring-1 ring-border/50",
+          ),
+        variant === "liquid" &&
+          cn(
+            bounds ? "left-0 top-0" : "inset-0",
+            "overflow-hidden rounded-[inherit] bg-primary shadow-md ring-1 ring-white/15",
+          ),
+        variant === "underline" &&
+          cn(
+            bounds ? "left-0 top-0" : "inset-x-0 -bottom-px h-0.5",
+            "rounded-full bg-primary shadow-sm",
+          ),
+        className,
+      )}
+    >
+      {variant === "liquid" && (
+        <>
+          <span className="absolute inset-x-3 top-px h-px rounded-full bg-white/35" />
+          <span className="absolute -left-3 top-1/2 h-7 w-7 -translate-y-1/2 rounded-full bg-white/10 blur-md" />
+        </>
+      )}
+    </motion.span>
+  );
+}
+
+export { SlidingSelectorIndicator };

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -1,24 +1,174 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import {
+  SlidingSelectorIndicator,
+  type SlidingSelectorBounds,
+  type SlidingSelectorVariant,
+} from "@/components/ui/sliding-selector";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import * as React from "react";
 
-const Tabs = TabsPrimitive.Root;
+interface TabsMotionContextValue {
+  activeValue?: string;
+}
+
+const TabsMotionContext = React.createContext<TabsMotionContextValue | null>(null);
+
+type TabsProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>;
+
+/**
+ * Radix Tabs with a controlled mirror of its current value. TabsList uses that
+ * value to position one persistent indicator, so moving between any standard
+ * tab headers animates by default without shared-layout stretching.
+ */
+function Tabs({ defaultValue,onValueChange,value,...props }: TabsProps) {
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue);
+  const activeValue = value ?? uncontrolledValue;
+
+  const handleValueChange = React.useCallback(
+    (nextValue: string) => {
+      setUncontrolledValue(nextValue);
+      onValueChange?.(nextValue);
+    },
+    [onValueChange],
+  );
+
+  return (
+    <TabsMotionContext.Provider value={{ activeValue }}>
+      <TabsPrimitive.Root
+        {...props}
+        defaultValue={defaultValue}
+        value={value}
+        onValueChange={handleValueChange}
+      />
+    </TabsMotionContext.Provider>
+  );
+}
+Tabs.displayName = TabsPrimitive.Root.displayName;
+
+interface TabsListProps
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> {
+  /** Active selector style. Pill is the default for every standard tab header. */
+  indicator?: SlidingSelectorVariant | "none";
+  /** Optional colour/elevation overrides applied to the shared selector. */
+  indicatorClassName?: string;
+  /**
+   * Separates menus that reuse the same Tabs root. Change this value when the
+   * set of tabs represents a different navigation group so the selector does
+   * not travel between unrelated item positions.
+   */
+  indicatorScope?: string;
+}
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-));
+  TabsListProps
+>(({
+  children,
+  className,
+  indicator = "pill",
+  indicatorClassName,
+  indicatorScope,
+  ...props
+}, forwardedRef) => {
+  const motionContext = React.useContext(TabsMotionContext);
+  const listRef = React.useRef<React.ElementRef<typeof TabsPrimitive.List>>(null);
+  const scope = indicatorScope ?? "default";
+  const [positionedIndicator, setPositionedIndicator] = React.useState<{
+    bounds: SlidingSelectorBounds;
+    scope: string;
+  } | null>(null);
+
+  const setListRef = React.useCallback(
+    (node: React.ElementRef<typeof TabsPrimitive.List> | null) => {
+      listRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    },
+    [forwardedRef],
+  );
+
+  const measureActiveTrigger = React.useCallback(() => {
+    const list = listRef.current;
+    if (!list || indicator === "none") {
+      setPositionedIndicator(null);
+      return;
+    }
+
+    const activeTrigger = list.querySelector<HTMLElement>(
+      '[role="tab"][data-state="active"]',
+    );
+    if (!activeTrigger) {
+      setPositionedIndicator(null);
+      return;
+    }
+
+    const isUnderline = indicator === "underline";
+    const bounds: SlidingSelectorBounds = {
+      height: isUnderline ? 2 : activeTrigger.offsetHeight,
+      width: activeTrigger.offsetWidth,
+      x: activeTrigger.offsetLeft,
+      y: isUnderline
+        ? activeTrigger.offsetTop + activeTrigger.offsetHeight - 1
+        : activeTrigger.offsetTop,
+    };
+
+    setPositionedIndicator((current) => {
+      if (
+        current?.scope === scope &&
+        current.bounds.height === bounds.height &&
+        current.bounds.width === bounds.width &&
+        current.bounds.x === bounds.x &&
+        current.bounds.y === bounds.y
+      ) {
+        return current;
+      }
+      return { bounds, scope };
+    });
+  }, [indicator, scope]);
+
+  React.useLayoutEffect(() => {
+    measureActiveTrigger();
+  }, [children, measureActiveTrigger, motionContext?.activeValue]);
+
+  React.useLayoutEffect(() => {
+    const list = listRef.current;
+    if (!list || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(measureActiveTrigger);
+    observer.observe(list);
+    const activeTrigger = list.querySelector<HTMLElement>(
+      '[role="tab"][data-state="active"]',
+    );
+    if (activeTrigger) observer.observe(activeTrigger);
+    return () => observer.disconnect();
+  }, [measureActiveTrigger, motionContext?.activeValue]);
+
+  return (
+    <TabsPrimitive.List
+      ref={setListRef}
+      className={cn(
+        "relative isolate inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {indicator !== "none" && positionedIndicator?.scope === scope && (
+        <SlidingSelectorIndicator
+          key={scope}
+          bounds={positionedIndicator.bounds}
+          variant={indicator}
+          className={indicatorClassName}
+        />
+      )}
+      {children}
+    </TabsPrimitive.List>
+  );
+});
 TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
@@ -28,7 +178,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "relative z-10 inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground",
       className
     )}
     {...props}

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -660,31 +660,31 @@ export function UserMenu() {
 
           <Tabs value={systemTab} className="w-full" onValueChange={(val) => { setSystemTab(val); if (val === "rbac") fetchRbacPosture(); }}>
             <div className="px-6 pt-2 border-b border-border">
-              <TabsList className="bg-transparent h-auto p-0 gap-4">
+              <TabsList className="bg-transparent h-auto p-0 gap-4" indicator="underline">
                 <TabsTrigger
                   value="preferences"
-                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
+                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
                 >
                   <SlidersHorizontal className="h-3.5 w-3.5 mr-1.5" />
                   Preferences
                 </TabsTrigger>
                 <TabsTrigger
                   value="rbac"
-                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
+                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
                 >
                   <KeyRound className="h-3.5 w-3.5 mr-1.5" />
                   My RBAC
                 </TabsTrigger>
                 <TabsTrigger
                   value="oidc"
-                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
+                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
                 >
                   <Code className="h-3.5 w-3.5 mr-1.5" />
                   OIDC Token
                 </TabsTrigger>
                 <TabsTrigger
                   value="debug"
-                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
+                  className="px-1 pb-2 pt-1 rounded-none border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs font-medium"
                 >
                   <Bug className="h-3.5 w-3.5 mr-1.5" />
                   Debug

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.53"
+version = "0.5.53.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Add a shared animated selector to the UI tab primitives and use it across Admin and other tab headers.

- Move one persistent, measured selector between standard tabs to avoid shared-layout stretching and jitter.
- Add a liquid spring variant for the Admin category pills while keeping standard subtabs on a clean eased glide.
- Scope Admin subtab motion by category so selectors do not travel between unrelated menus.
- Respect reduced-motion preferences and preserve keyboard/Radix tab behavior.
- Keep specialized step navigation opted out and use the shared underline variant for Settings dialog tabs.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this PR does not change Helm charts.

## Testing

- `npm test -- --runInBand src/components/ui/__tests__/tabs.test.tsx` — 6 tests passed
- Focused Admin, Agents, Access Explorer, AI Review, and Credentials suites — 89 tests passed
- `tsc --noEmit`
- ESLint on changed UI and test files

Production `next build` could not complete in the sandbox because the configured Google Fonts were unavailable to download.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (not applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass for changed files
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass (focused suites pass; full suite not run)
