### PR TITLE
revert: fix(ui): tolerate transient silent-refresh failures before forcing logout (#2220)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.51-dev.2"
+version = "0.5.51-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.51-dev.3"
+version = "0.5.51-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/__tests__/token-expiry-guard.test.tsx
+++ b/ui/src/components/__tests__/token-expiry-guard.test.tsx
@@ -82,7 +82,7 @@ describe('TokenExpiryGuard', () => {
       return undefined
     })
 
-    mockSignOut.mockClear().mockResolvedValue(undefined as any)
+    mockSignOut.mockResolvedValue(undefined as any)
   })
 
   afterEach(() => {
@@ -540,12 +540,8 @@ describe('TokenExpiryGuard', () => {
       expect(screen.queryByText(/attempting to refresh automatically/i)).not.toBeInTheDocument()
     })
 
-    it('should tolerate a single silent-refresh failure without logging out', async () => {
-      // Regression test: a lone transient failure (network blip, momentary
-      // server-side cache miss, etc.) must NOT tear down the session while
-      // the token still has plenty of time left — the whole point of the
-      // "Attempting to refresh automatically..." banner is that it keeps
-      // trying, not that it gives up on the very first hiccup.
+    it('should show a countdown and redirect through current-tab login if updateSession rejects', async () => {
+      window.history.pushState({}, '', '/apps/embed/kaleidoscope?view=study#report')
       const soonExpiry = Math.floor(Date.now() / 1000) + 240
       mockUpdateSession.mockRejectedValueOnce(new Error('Network error'))
 
@@ -563,52 +559,17 @@ describe('TokenExpiryGuard', () => {
 
       render(<TokenExpiryGuard />)
 
-      // Mount triggers the proactive silent refresh, which rejects once.
       await act(async () => { jest.advanceTimersByTime(0) })
 
-      expect(screen.queryByText(/sign-in needed/i)).not.toBeInTheDocument()
-      expect(mockSignOut).not.toHaveBeenCalled()
-      expect(screen.getByText(/session expiring soon/i)).toBeInTheDocument()
-
-      consoleSpy.mockRestore()
-    })
-
-    it('should force logout only after the token has expired and repeated refresh retries are exhausted', async () => {
-      window.history.pushState({}, '', '/apps/embed/kaleidoscope?view=study#report')
-      const pastExpiry = Math.floor(Date.now() / 1000) - 1 // already expired
-      mockUpdateSession.mockRejectedValue(new Error('Network error')) // always fails
-
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-
-      mockUseSession.mockReturnValue({
-        data: {
-          user: { name: 'Test User', email: 'test@example.com' },
-          expiresAt: pastExpiry,
-          hasRefreshToken: true,
-        } as any,
-        status: 'authenticated',
-        update: mockUpdateSession,
-      })
-
-      render(<TokenExpiryGuard />)
-
-      // Tick 1 (mount): expired reading #1 — still within the retry budget.
-      await act(async () => { jest.advanceTimersByTime(0) })
-      expect(screen.queryByText(/redirecting to login/i)).not.toBeInTheDocument()
-
-      // Tick 2 (+30s): expired reading #2 — still within the retry budget.
-      await act(async () => { jest.advanceTimersByTime(30000) })
-      expect(screen.queryByText(/redirecting to login/i)).not.toBeInTheDocument()
-      expect(mockSignOut).not.toHaveBeenCalled()
-
-      // Tick 3 (+30s): retry budget exhausted — now forces logout.
-      await act(async () => { jest.advanceTimersByTime(30000) })
       await waitFor(() => {
-        expect(screen.getByText(/session expired/i)).toBeInTheDocument()
+        expect(screen.getByText(/sign-in needed/i)).toBeInTheDocument()
         expect(screen.getByText(/redirecting to login in 5 seconds/i)).toBeInTheDocument()
       })
 
-      await act(async () => { jest.advanceTimersByTime(5000) })
+      await act(async () => { jest.advanceTimersByTime(1000) })
+      expect(screen.getByText(/redirecting to login in 4 seconds/i)).toBeInTheDocument()
+
+      await act(async () => { jest.advanceTimersByTime(4000) })
       expect(mockSignOut).toHaveBeenCalledWith({
         callbackUrl: '/login?session_expired=true&callbackUrl=%2Fapps%2Fembed%2Fkaleidoscope%3Fview%3Dstudy%23report',
       })

--- a/ui/src/components/token-expiry-guard.tsx
+++ b/ui/src/components/token-expiry-guard.tsx
@@ -16,25 +16,6 @@ const SESSION_CREDENTIAL_ERRORS = new Set([
   "RefreshTokenError",
   "AccessTokenMissing",
 ]);
-/**
- * How many consecutive 30s check cycles we tolerate seeing the token as
- * expired / access-token-missing before giving up and forcing a re-login.
- *
- * A single bad reading can be caused by a transient blip (a slow/aborted
- * `updateSession()` fetch, a brief server-side token-store cache miss, or the
- * client momentarily racing ahead of an in-flight refresh) even though the
- * underlying OIDC refresh token is still perfectly valid and the very next
- * check would see a healthy session. Forcing an immediate sign-out on the
- * first bad reading produces exactly the symptom users report as "the
- * auto-refresh banner shows but I still get logged out" — the session gets
- * torn down before a retry ever gets a chance to run.
- *
- * This counter is driven by wall-clock check cycles (not by whether
- * `updateSession()` happens to throw), so it always terminates within a
- * bounded time even if retries keep "succeeding" without actually resolving
- * the underlying problem.
- */
-const MAX_CONSECUTIVE_PROBLEM_TICKS = 3;
 
 /**
  * TokenExpiryGuard Component
@@ -63,13 +44,6 @@ export function TokenExpiryGuard() {
   const isRefreshingRef = useRef(false);
   /** Cooldown: timestamp of the last successful refresh to prevent rapid re-refresh loops. */
   const lastRefreshAtRef = useRef<number>(0);
-  /**
-   * Consecutive 30s check cycles that observed a bad token state (expired or
-   * access-token-missing). Reset to 0 whenever a check cycle sees a healthy
-   * token. See MAX_CONSECUTIVE_PROBLEM_TICKS for why this drives the
-   * give-up decision instead of individual `updateSession()` failures.
-   */
-  const consecutiveProblemTicksRef = useRef(0);
 
   const clearRedirectTimers = useCallback(() => {
     if (countdownIntervalRef.current) {
@@ -158,17 +132,13 @@ export function TokenExpiryGuard() {
       console.log("[TokenExpiryGuard] Silent refresh triggered successfully");
       return true;
     } catch (error) {
-      // Don't force a logout here — this may run during the proactive 5-minute
-      // warning window where plenty of time remains, or as a bounded retry
-      // from checkTokenExpiry. Callers decide whether/when to give up based on
-      // consecutiveProblemTicksRef so a single transient failure never directly
-      // tears down the session.
       console.error("[TokenExpiryGuard] Silent refresh failed:", error);
+      beginLoginCountdown("refresh_failed");
       return false;
     } finally {
       isRefreshingRef.current = false;
     }
-  }, [session?.hasRefreshToken, updateSession]);
+  }, [beginLoginCountdown, session?.hasRefreshToken, updateSession]);
 
   // Check token expiry
   const checkTokenExpiry = useCallback(() => {
@@ -181,35 +151,6 @@ export function TokenExpiryGuard() {
     }
 
     // Check if token refresh failed or the server-side token cache was lost.
-    //
-    // "AccessTokenMissing" can be transient — a momentary miss on the
-    // server-side token store (see auth-token-store.ts's short-TTL L1 cache
-    // falling through to MongoDB) rather than a genuinely dead session — so
-    // it gets one retry via the shared budget before we give up.
-    //
-    // "RefreshTokenExpired"/"RefreshTokenError", by contrast, are only ever
-    // set by the jwt() callback *after* it already tried the OIDC refresh_token
-    // grant and failed (auth-config.ts refreshAccessToken()). Once set, the
-    // server-side callback intentionally skips retrying
-    // ("Token refresh already failed, skipping refresh attempt") until a
-    // fresh login, so retrying client-side here would just loop forever
-    // without ever recovering — keep the original immediate-logout behavior
-    // for those two.
-    if (session.error === "AccessTokenMissing") {
-      consecutiveProblemTicksRef.current += 1;
-      console.error(
-        `[TokenExpiryGuard] Session credentials unavailable: ${session.error} ` +
-        `(tick ${consecutiveProblemTicksRef.current}/${MAX_CONSECUTIVE_PROBLEM_TICKS})`,
-      );
-      if (session.hasRefreshToken && consecutiveProblemTicksRef.current < MAX_CONSECUTIVE_PROBLEM_TICKS) {
-        if (!isRefreshingRef.current) {
-          void attemptSilentRefresh();
-        }
-      } else {
-        beginLoginCountdown("refresh_failed");
-      }
-      return;
-    }
     if (SESSION_CREDENTIAL_ERRORS.has(session.error ?? "")) {
       console.error(`[TokenExpiryGuard] Session credentials unavailable: ${session.error}`);
       beginLoginCountdown("refresh_failed");
@@ -236,34 +177,12 @@ export function TokenExpiryGuard() {
     // Update time remaining for display
     setTimeRemaining(formatTimeUntilExpiry(secondsUntilExpiry));
 
-    // Token has expired (per the client's current copy of the session).
-    //
-    // This does NOT necessarily mean the refresh token is dead — session.error
-    // would already have been set and caught above in that case. It's more
-    // often the client briefly racing ahead of an in-flight or just-completed
-    // server-side refresh (e.g. concurrent requests reading a stale cookie
-    // before the browser applies an updated Set-Cookie, per auth-config.ts's
-    // in-flight refresh dedup). Give the retry budget a chance to catch up
-    // before forcing a re-login.
+    // Token has expired
     if (isExpired) {
-      consecutiveProblemTicksRef.current += 1;
-      console.error(
-        `[TokenExpiryGuard] Token expired! Attempting recovery before logout... ` +
-        `(tick ${consecutiveProblemTicksRef.current}/${MAX_CONSECUTIVE_PROBLEM_TICKS})`,
-      );
-      if (session.hasRefreshToken && consecutiveProblemTicksRef.current < MAX_CONSECUTIVE_PROBLEM_TICKS) {
-        if (!isRefreshingRef.current) {
-          void attemptSilentRefresh();
-        }
-      } else {
-        beginLoginCountdown("expired");
-      }
+      console.error("[TokenExpiryGuard] Token expired! Forcing logout...");
+      beginLoginCountdown("expired");
       return;
     }
-
-    // Token state is healthy this cycle — clear the problem-tick counter so a
-    // future isolated blip gets the full retry budget again.
-    consecutiveProblemTicksRef.current = 0;
 
     // If the token was refreshed (expiresAt changed), clear the dismissed state
     // so the warning can show again for the next expiry cycle.

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.51.dev2"
+version = "0.5.51.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.51.dev3"
+version = "0.5.51.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Reverts #2220.

## Test plan

- [ ] Verify token expiry behavior reverts to pre-2220 state