### PR TITLE
fix(ui): scroll unlinked access modal body instead of overflowing

### DIFF
--- a/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
+++ b/ui/src/components/admin/UnlinkedServiceAccountModal.tsx
@@ -213,7 +213,7 @@ export function UnlinkedServiceAccountModal({
             Loading...
           </div>
         ) : (
-          <div className="space-y-4">
+          <div className="max-h-[65vh] overflow-y-auto space-y-4 pr-1">
             {error && (
               <div
                 className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"


### PR DESCRIPTION
## Summary
- The "Unlinked Access" modal (Platform Settings tab) had no scroll container around its scopes list + add-scope form, so a long scopes list grew the dialog past the viewport.
- Wrap the body in `max-h-[65vh] overflow-y-auto` — the same pattern already used by the Service Accounts "Manage" dialog — so only the body scrolls while the header/footer stay fixed.

## Test plan
- [x] `npx jest UnlinkedServiceAccountModal` — 15/15 passing
- [x] `npx eslint src/components/admin/UnlinkedServiceAccountModal.tsx` — clean
- [ ] Manual: open Admin → Platform Settings → "Manage Unlinked Access" with many scopes granted, confirm the list scrolls inside the dialog instead of overflowing the viewport