### PR TITLE
fix(slack-bot): register conversation before VictorOps on-call lookup

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_escalation_victorops_conversation.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_escalation_victorops_conversation.py
@@ -1,0 +1,86 @@
+# Copyright 2025 CNOE Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: VictorOps on-call lookup must register its conversation.
+
+`_ping_victorops_oncall` streams a one-off "who is on-call" prompt through
+`sse_client.stream_chat()` using a conversation_id that is never registered
+with the server via `create_conversation()`. The server's
+`/api/v1/chat/stream/start` endpoint 404s ("Conversation not found") for any
+conversation_id it doesn't recognize, so every VictorOps escalation failed
+with the generic "Could not determine on-call" fallback message regardless
+of whether the on-call lookup itself would have succeeded.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+_SLACK_BOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(_SLACK_BOT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SLACK_BOT_DIR))
+
+from sse_client import SSEEvent, SSEEventType  # noqa: E402
+from utils.escalation import _ping_victorops_oncall  # noqa: E402
+
+
+def _sse_client_stub(oncall_email: str) -> MagicMock:
+    sse_client = MagicMock()
+    sse_client.create_conversation.return_value = {
+        "conversation_id": "registered-conv-id",
+        "created": True,
+    }
+    sse_client.stream_chat.return_value = iter(
+        [
+            SSEEvent(type=SSEEventType.TEXT_MESSAGE_CONTENT, delta=oncall_email),
+            SSEEvent(type=SSEEventType.RUN_FINISHED),
+        ]
+    )
+    return sse_client
+
+
+def test_ping_victorops_oncall_registers_conversation_before_streaming():
+    sse_client = _sse_client_stub("oncall@example.com")
+    slack_client = MagicMock()
+    slack_client.users_lookupByEmail.return_value = {"user": {"id": "UONCALL"}}
+
+    result = _ping_victorops_oncall(
+        sse_client,
+        slack_client,
+        channel_id="C123",
+        thread_ts="1.1",
+        team="SCS Search Services",
+        agent_id="victorops-oncall",
+    )
+
+    sse_client.create_conversation.assert_called_once()
+    assert sse_client.create_conversation.call_args.kwargs["agent_id"] == "victorops-oncall"
+
+    # stream_chat must use the conversation_id create_conversation returned,
+    # not an ad hoc, unregistered id.
+    sse_client.stream_chat.assert_called_once()
+    assert sse_client.stream_chat.call_args.kwargs["conversation_id"] == "registered-conv-id"
+
+    assert result == "victorops: pinged oncall@example.com (<@UONCALL>)"
+
+
+def test_ping_victorops_oncall_reports_error_when_stream_chat_fails():
+    sse_client = _sse_client_stub("oncall@example.com")
+    sse_client.stream_chat.side_effect = Exception(
+        'SSE request failed: 404 {"success":false,"error":"Conversation not found","code":"conversation#write"}'
+    )
+    slack_client = MagicMock()
+
+    result = _ping_victorops_oncall(
+        sse_client,
+        slack_client,
+        channel_id="C123",
+        thread_ts="1.1",
+        team="SCS Search Services",
+        agent_id="victorops-oncall",
+    )
+
+    assert result.startswith("victorops: error")
+    slack_client.chat_postMessage.assert_called_once()
+    assert "Could not determine on-call" in slack_client.chat_postMessage.call_args.kwargs["text"]

--- a/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
@@ -10,7 +10,6 @@ Supports three configurable actions (all fire if enabled):
 """
 
 import re
-import uuid
 
 from loguru import logger
 
@@ -95,11 +94,19 @@ def _ping_victorops_oncall(
     logger.info(f"[{thread_ts}] VictorOps: querying on-call for team {team} (agent={agent_id})")
     accumulated_text: list[str] = []
 
-    # Use a fresh conversation so the on-call lookup does not inherit the
-    # channel thread history, which can be very large and cause incorrect results.
+    # Register a fresh conversation (no idempotency_key) so the on-call lookup
+    # does not inherit the channel thread history, which can be very large and
+    # cause incorrect results, and so stream_chat has a conversation_id the
+    # server actually knows about.
+    conv_result = sse_client.create_conversation(
+      title="VictorOps on-call lookup",
+      agent_id=agent_id,
+    )
+    conversation_id = conv_result["conversation_id"]
+
     for event in sse_client.stream_chat(
       message=prompt,
-      conversation_id=str(uuid.uuid4()),
+      conversation_id=conversation_id,
       agent_id=agent_id,
     ):
       if event.type == SSEEventType.TEXT_MESSAGE_CONTENT and event.delta:

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.51 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.52 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.51 -f your-values.yaml'}
+                  {'    --version 0.5.52 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.51 -f your-values.yaml'}
+              {'    --version 0.5.52 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.52"
+version = "0.5.52-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.52"
+version = "0.5.52.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- `_ping_victorops_oncall` generates a fresh `conversation_id` via `uuid.uuid4()` before querying the AI for who's on-call, so the lookup doesn't inherit the channel's (potentially very large) thread history.
- However, it never registers that id with the server via `create_conversation()` before streaming against it with `stream_chat()`. Every lookup's `stream_chat()` call fails with a 404 (`"Conversation not found"`), so every VictorOps escalation silently falls back to `"Could not determine on-call for team X. Please check VictorOps manually."` — regardless of whether the on-call lookup itself would have succeeded.
- Fix: call `sse_client.create_conversation()` first (no `idempotency_key`, so it's always a fresh conversation) and stream against the `conversation_id` it returns, instead of an ad hoc unregistered UUID.

Added regression tests covering both the successful lookup path (asserts `create_conversation` is called before `stream_chat`, and `stream_chat` uses the returned `conversation_id`) and the failure path.

## Test plan

- [x] Added `test_escalation_victorops_conversation.py` — verified it fails against the pre-fix code (mocked `stream_chat` 404 matches the observed production error) and passes against the fix
- [x] Full `slack_bot` test suite passes (526 tests)
- [ ] Configure a channel with VictorOps escalation enabled, trigger a "Get help" escalation, and confirm the on-call ping succeeds instead of falling back to the manual-check message

🤖 Generated with [Claude Code](https://claude.com/claude-code)