### PR TITLE
fix(webex-wdm): refresh WDM device on ConnectionClosedError to avoid stale webSocketUrl loop

### DIFF
--- a/ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py
@@ -476,3 +476,68 @@ def test_handle_connection_failure_stops_refreshing_after_limit(
 
     assert session.deleted == []
     assert runtime._handshake_refresh_attempts == MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS
+
+
+def test_handle_connection_failure_refreshes_device_on_connection_closed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from websockets.exceptions import ConnectionClosedError
+
+    async def _instant_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runtime = _runtime()
+    runtime._device_url = "https://wdm/devices/stale"
+    session = _FakeSession(
+        devices=[
+            {
+                "name": "CAIPE-Webex-Bot",
+                "url": "https://wdm/devices/stale",
+                "webSocketUrl": "wss://mercury/stale",
+            }
+        ],
+        new_device={"url": "https://wdm/devices/fresh", "webSocketUrl": "wss://mercury/fresh"},
+    )
+
+    async def _run() -> int:
+        return await runtime._handle_connection_failure(session, ConnectionClosedError(None, None), 1)
+
+    retry_delay = asyncio.run(_run())
+
+    assert session.deleted == ["https://wdm/devices/stale"]
+    assert runtime._handshake_refresh_attempts == 1
+    assert retry_delay == 2
+
+
+def test_handle_connection_failure_stops_refreshing_connection_closed_error_after_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from websockets.exceptions import ConnectionClosedError
+
+    async def _instant_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runtime = _runtime()
+    runtime._handshake_refresh_attempts = MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS
+    runtime._device_url = "https://wdm/devices/stale"
+    session = _FakeSession(
+        devices=[
+            {
+                "name": "CAIPE-Webex-Bot",
+                "url": "https://wdm/devices/stale",
+                "webSocketUrl": "wss://mercury/stale",
+            }
+        ]
+    )
+
+    async def _run() -> None:
+        await runtime._handle_connection_failure(session, ConnectionClosedError(None, None), 4)
+
+    asyncio.run(_run())
+
+    assert session.deleted == []
+    assert runtime._handshake_refresh_attempts == MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS

--- a/ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/tests/test_webex_wdm.py
@@ -541,3 +541,72 @@ def test_handle_connection_failure_stops_refreshing_connection_closed_error_afte
 
     assert session.deleted == []
     assert runtime._handshake_refresh_attempts == MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS
+
+
+def test_handle_connection_failure_refreshes_device_on_connection_closed_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mercury's graceful close (code 1000/1001) raises ConnectionClosedOK, a sibling
+    # of ConnectionClosedError (not a subclass) — must be covered too, since a clean
+    # server-side close is exactly the case where the cached webSocketUrl expiring
+    # is most plausible.
+    from websockets.exceptions import ConnectionClosedOK
+
+    async def _instant_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runtime = _runtime()
+    runtime._device_url = "https://wdm/devices/stale"
+    session = _FakeSession(
+        devices=[
+            {
+                "name": "CAIPE-Webex-Bot",
+                "url": "https://wdm/devices/stale",
+                "webSocketUrl": "wss://mercury/stale",
+            }
+        ],
+        new_device={"url": "https://wdm/devices/fresh", "webSocketUrl": "wss://mercury/fresh"},
+    )
+
+    async def _run() -> int:
+        return await runtime._handle_connection_failure(session, ConnectionClosedOK(None, None), 1)
+
+    retry_delay = asyncio.run(_run())
+
+    assert session.deleted == ["https://wdm/devices/stale"]
+    assert runtime._handshake_refresh_attempts == 1
+    assert retry_delay == 2
+
+
+def test_handle_connection_failure_stops_refreshing_connection_closed_ok_after_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from websockets.exceptions import ConnectionClosedOK
+
+    async def _instant_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runtime = _runtime()
+    runtime._handshake_refresh_attempts = MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS
+    runtime._device_url = "https://wdm/devices/stale"
+    session = _FakeSession(
+        devices=[
+            {
+                "name": "CAIPE-Webex-Bot",
+                "url": "https://wdm/devices/stale",
+                "webSocketUrl": "wss://mercury/stale",
+            }
+        ]
+    )
+
+    async def _run() -> None:
+        await runtime._handle_connection_failure(session, ConnectionClosedOK(None, None), 4)
+
+    asyncio.run(_run())
+
+    assert session.deleted == []
+    assert runtime._handshake_refresh_attempts == MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS

--- a/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
@@ -316,6 +316,18 @@ class WebexWdmRuntime:
                 type(exc).__name__,
                 retry_delay,
             )
+            # assisted-by claude code claude-sonnet-4-6
+            # A clean ConnectionClosedError means the server closed the socket — the
+            # cached webSocketUrl may have expired.  Force a fresh device registration
+            # so the next connect gets a valid URL instead of looping on a stale one.
+            from websockets.exceptions import ConnectionClosedError  # noqa: PLC0415
+
+            if (
+                isinstance(exc, ConnectionClosedError)
+                and self._handshake_refresh_attempts < MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS
+            ):
+                self._handshake_refresh_attempts += 1
+                await self._refresh_wdm_device(session)
 
         await asyncio.sleep(retry_delay)
         return min(retry_delay * 2, 60)

--- a/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
@@ -316,7 +316,6 @@ class WebexWdmRuntime:
                 type(exc).__name__,
                 retry_delay,
             )
-            # assisted-by claude code claude-sonnet-4-6
             # A clean ConnectionClosedError means the server closed the socket — the
             # cached webSocketUrl may have expired.  Force a fresh device registration
             # so the next connect gets a valid URL instead of looping on a stale one.

--- a/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
+++ b/ai_platform_engineering/integrations/webex_bot/webex_wdm.py
@@ -316,13 +316,15 @@ class WebexWdmRuntime:
                 type(exc).__name__,
                 retry_delay,
             )
-            # A clean ConnectionClosedError means the server closed the socket — the
-            # cached webSocketUrl may have expired.  Force a fresh device registration
-            # so the next connect gets a valid URL instead of looping on a stale one.
-            from websockets.exceptions import ConnectionClosedError  # noqa: PLC0415
+            # The server closed the socket post-handshake (ConnectionClosedOK for a
+            # graceful 1000/1001 close, ConnectionClosedError for anything else) — the
+            # cached webSocketUrl may have expired either way.  Force a fresh device
+            # registration so the next connect gets a valid URL instead of looping on
+            # a stale one.
+            from websockets.exceptions import ConnectionClosed  # noqa: PLC0415
 
             if (
-                isinstance(exc, ConnectionClosedError)
+                isinstance(exc, ConnectionClosed)
                 and self._handshake_refresh_attempts < MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS
             ):
                 self._handshake_refresh_attempts += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.61-dev.2"
+version = "0.5.61-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.61.dev2"
+version = "0.5.61.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- When the Webex Mercury server closes a WebSocket cleanly (`ConnectionClosedError`), the cached `webSocketUrl` may have expired
- Previously the bot reconnected using the same stale URL, causing a tight drop-reconnect-drop loop and missed messages during each gap
- Fix: treat `ConnectionClosedError` the same as a 4xx handshake error — call `_refresh_wdm_device()` to delete the stale registration and force a fresh one on the next connect
- The existing `MAX_WDM_HANDSHAKE_REFRESH_ATTEMPTS` cap (3) prevents an unbounded refresh loop

## Root cause

`_handle_connection_failure()` only refreshed the WDM device on HTTP 4xx handshake errors (`WDM_HANDSHAKE_REFRESH_STATUSES`). A clean server-side close (`ConnectionClosedError`) fell into the `else` branch with no device refresh — so the bot would loop reconnecting to the expired `webSocketUrl` indefinitely.

## Test plan

- [ ] Deploy to a dev/staging environment and send messages to the bot
- [ ] Verify bot responds within one reconnect cycle after a forced disconnect
- [ ] Confirm `_handshake_refresh_attempts` resets to 0 on a successful connect (already done at line 190)
- [ ] Verify that after 3 `ConnectionClosedError` drops without a successful connect, no further device refreshes occur (cap respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)