### PR TITLE
feat: mint signed "local" agent context for CLI/MCP tool callers

### DIFF
--- a/.github/workflows/prebuild-manual.yml
+++ b/.github/workflows/prebuild-manual.yml
@@ -28,6 +28,7 @@ on:
           - slack-bot
           - webex-bot
           - rag
+          - openfga-bridge
 
 permissions:
   actions: read
@@ -54,6 +55,7 @@ jobs:
       slack_bot_changed: ${{ steps.pr.outputs.slack_bot_changed }}
       webex_bot_changed: ${{ steps.pr.outputs.webex_bot_changed }}
       rag_changed: ${{ steps.pr.outputs.rag_changed }}
+      openfga_bridge_changed: ${{ steps.pr.outputs.openfga_bridge_changed }}
       helm_changed: ${{ steps.pr.outputs.helm_changed }}
     steps:
       - name: Resolve PR metadata
@@ -166,6 +168,9 @@ jobs:
               ],
               rag: [
                 'ai_platform_engineering/knowledge_bases/rag/**',
+              ],
+              openfga_bridge: [
+                'deploy/openfga/bridge/**',
               ],
               helm: [
                 'charts/rag-stack/**',
@@ -328,6 +333,23 @@ jobs:
       packages: write
       pull-requests: write
     uses: ./.github/workflows/prebuild-rag.yml
+    with:
+      pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
+      head_ref: ${{ needs.resolve-pr.outputs.head_ref }}
+      head_sha: ${{ needs.resolve-pr.outputs.head_sha }}
+      base_ref: ${{ needs.resolve-pr.outputs.base_ref }}
+      base_sha: ${{ needs.resolve-pr.outputs.base_sha }}
+    secrets: inherit
+
+  prebuild-openfga-bridge:
+    name: OpenFGA Authz Bridge Image
+    needs: resolve-pr
+    if: ${{ needs.resolve-pr.outputs.target == 'openfga-bridge' || ((needs.resolve-pr.outputs.target == 'all' || needs.resolve-pr.outputs.target == 'docker') && needs.resolve-pr.outputs.openfga_bridge_changed == 'true') }}
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/prebuild-openfga-authz-bridge.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
       head_ref: ${{ needs.resolve-pr.outputs.head_ref }}

--- a/.github/workflows/prebuild-openfga-authz-bridge.yml
+++ b/.github/workflows/prebuild-openfga-authz-bridge.yml
@@ -1,0 +1,206 @@
+name: "[Prebuild] OpenFGA Authz Bridge Docker Build and Push"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'deploy/openfga/bridge/**'
+      - '.github/workflows/prebuild-openfga-authz-bridge.yml'
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to publish prebuild for'
+        required: true
+        type: number
+      head_ref:
+        description: 'PR head branch ref'
+        required: true
+        type: string
+      head_sha:
+        description: 'PR head commit SHA'
+        required: true
+        type: string
+      base_ref:
+        description: 'PR base branch ref'
+        required: true
+        type: string
+      base_sha:
+        description: 'PR base commit SHA'
+        required: false
+        type: string
+        default: ''
+
+env:
+  IMAGE_NAME: ${{ github.repository_owner }}/prebuild/openfga-authz-bridge
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: |
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      (
+        startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+        github.event.action != 'closed'
+      )
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH="$HEAD_REF"
+          BRANCH_NO_PREFIX="${BRANCH#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          PREBUILD_TAG="${BRANCH_SANITIZED}-${COMMIT_COUNT}"
+          echo "BRANCH_BARE=${BRANCH_SANITIZED}" >> "$GITHUB_ENV"
+          echo "PREBUILD_TAG=${PREBUILD_TAG}" >> "$GITHUB_ENV"
+          echo "prebuild_tag=${PREBUILD_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload building prebuild status
+        uses: ./.github/actions/prebuild-status
+        with:
+          pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
+          head_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+          head_ref: ${{ inputs.head_ref || github.head_ref }}
+          source: openfga-authz-bridge
+          type: docker
+          name: openfga-authz-bridge
+          repository: ghcr.io/${{ env.IMAGE_NAME }}
+          tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
+          ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          status: building
+          artifact_suffix: start
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.PREBUILD_TAG }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+
+      - name: Build and Push OpenFGA Authz Bridge Docker image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: deploy/openfga/bridge
+          file: deploy/openfga/bridge/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          provenance: false
+          sbom: false
+
+      - name: Upload final prebuild status
+        if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
+        uses: ./.github/actions/prebuild-status
+        with:
+          pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
+          head_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+          head_ref: ${{ inputs.head_ref || github.head_ref }}
+          source: openfga-authz-bridge
+          type: docker
+          name: openfga-authz-bridge
+          repository: ghcr.io/${{ env.IMAGE_NAME }}
+          tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
+          ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          artifact_suffix: final
+
+  cleanup-images:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
+    permissions:
+      contents: read
+      packages: write
+    env:
+      OWNER: ${{ github.repository_owner }}
+      PACKAGE_NAME: prebuild/openfga-authz-bridge
+    steps:
+      - name: Delete prebuild images for branch
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        with:
+          script: |
+            const owner = process.env.OWNER;
+            const rawBranch = process.env.HEAD_REF || '';
+            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
+            const sanitized = branchNoPrefix.replace(/\//g, '-');
+            const prefix = `${sanitized}-`;
+            const packageName = process.env.PACKAGE_NAME;
+            const packageType = 'container';
+            try {
+              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
+                org: owner,
+                package_type: packageType,
+                package_name: packageName,
+                per_page: 100,
+              });
+              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
+              for (const v of toDelete) {
+                await github.rest.packages.deletePackageVersionForOrg({
+                  org: owner,
+                  package_type: packageType,
+                  package_name: packageName,
+                  package_version_id: v.id,
+                });
+              }
+              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
+            } catch (e) {
+              if (e.status === 404) {
+                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
+              } else {
+                throw e;
+              }
+            }

--- a/deploy/openfga/bridge/main.py
+++ b/deploy/openfga/bridge/main.py
@@ -810,15 +810,23 @@ class OpenFgaAuthorizationService:
                 agent_id = agent_context.agent_id
 
                 # "local" contexts identify the caller acting as themselves —
-                # there is no separate delegated identity to bound, since the
-                # signed-in user's own `can_call mcp_gateway:list` check above
-                # (and the caller-keyed check below, when enabled) already
-                # gate everything this request is allowed to do. Skipping the
-                # agent:<id> can_use/can_call checks here isn't a broadened
-                # grant: a user with a Dynamic Agent configured to call the
-                # same tool already has this same reach today, just through
-                # different plumbing. See ui/lib/mcp-http-server-client.ts
-                # and deploy/openfga/model.fga's agent/tool relations.
+                # there is no separate delegated identity to bound, so we skip
+                # the agent:<id> can_use/can_call checks and rely on the
+                # caller-keyed tool check below to scope the request.
+                #
+                # IMPORTANT: that scoping holds ONLY when CALLER_TOOL_CHECK_ENABLED
+                # is on. With the flag off (the upstream chart default), the
+                # caller-keyed check below is skipped and a "local" context falls
+                # back to just the coarse `can_call mcp_gateway:list` gate above —
+                # which every onboarded user holds — granting reach to every tool
+                # on every MCP server. Unlike a Dynamic Agent (whose tool grants
+                # are explicitly enumerated per-agent), a "local" context has no
+                # other tool-scoping mechanism, so the no-broadened-grant property
+                # is conditional on the flag, not a structural invariant. This
+                # repo's dev/prod helm values set callerToolCheck.enabled: true,
+                # so the property holds in those deployments. See
+                # ui/lib/mcp-http-server-client.ts and deploy/openfga/model.fga's
+                # agent/tool relations.
                 if agent_context.kind != AGENT_CONTEXT_KIND_LOCAL:
                     agent_allowed = _check_openfga(user, "can_use", f"agent:{agent_id}")
                     exact_tool_allowed = _check_openfga(

--- a/deploy/openfga/bridge/main.py
+++ b/deploy/openfga/bridge/main.py
@@ -18,6 +18,7 @@ import time
 import uuid
 from concurrent import futures
 from pathlib import Path
+from typing import NamedTuple
 import importlib.util
 
 import grpc
@@ -57,6 +58,16 @@ BYPASS_SUBS = frozenset(
 )
 AGENT_CONTEXT_HMAC_SECRET = os.environ.get("CAIPE_AGENT_CONTEXT_HMAC_SECRET", "").strip()
 AGENT_CONTEXT_MAX_AGE_SECONDS = int(os.environ.get("CAIPE_AGENT_CONTEXT_MAX_AGE_SECONDS", "300"))
+# "local" contexts (minted by /api/mcp-servers/agent-context for CLI/local
+# callers, see ui/src/lib/mcp-http-server-client.ts) get a longer max age than
+# Dynamic Agent contexts: they're re-signed per MCP connection, not per
+# request (Claude Code/Codex cache MCP headers for a whole session), so a
+# short TTL would force a re-auth or a failed-then-retried tool call every
+# few minutes. They're safe to allow longer because they carry no delegated
+# authority — see the "local" branch in OpenFgaAuthorizationService.Check.
+AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS = int(
+    os.environ.get("CAIPE_AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS", "43200")  # 12h
+)
 # Caller-keyed tool-authorization rollout flag (FR-012c / SC-011 / T022a).
 # When OFF (default), the bridge keeps the legacy agent-only tool check so
 # enabling the new subject→tool check in a shared environment never silently
@@ -456,20 +467,50 @@ def _b64url_decode(text: str) -> bytes:
     return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
 
 
-def build_agent_context_header(agent_id: str, *, secret: str, now: int | None = None) -> tuple[str, str]:
+# "kind" values recognized in the signed agent-context payload. Absent for
+# older producers (Dynamic Agents runtime, the diagnostic test-tool route) —
+# those are treated as "dynamic", the pre-existing, fully-checked behavior.
+# "local" identifies a context minted for a CLI/local caller (see
+# ui/src/app/api/mcp-servers/agent-context/route.ts) acting as the signed-in
+# user themselves rather than as a delegated agent — see the "local" branch
+# in OpenFgaAuthorizationService.Check for what that changes.
+AGENT_CONTEXT_KIND_DYNAMIC = "dynamic"
+AGENT_CONTEXT_KIND_LOCAL = "local"
+_AGENT_CONTEXT_MAX_AGE_BY_KIND = {
+    AGENT_CONTEXT_KIND_DYNAMIC: AGENT_CONTEXT_MAX_AGE_SECONDS,
+    AGENT_CONTEXT_KIND_LOCAL: AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS,
+}
+
+
+class AgentContext(NamedTuple):
+    agent_id: str
+    kind: str
+
+
+def build_agent_context_header(
+    agent_id: str,
+    *,
+    secret: str,
+    now: int | None = None,
+    kind: str = AGENT_CONTEXT_KIND_DYNAMIC,
+) -> tuple[str, str]:
     """Build a signed agent context header pair for tests and diagnostics."""
     issued_at = int(now if now is not None else time.time())
+    max_age = _AGENT_CONTEXT_MAX_AGE_BY_KIND.get(kind, AGENT_CONTEXT_MAX_AGE_SECONDS)
     payload = {
         "agent_id": agent_id,
         "iat": issued_at,
-        "exp": issued_at + AGENT_CONTEXT_MAX_AGE_SECONDS,
+        "exp": issued_at + max_age,
+        "kind": kind,
     }
     encoded = _b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
     signature = hmac.new(secret.encode(), encoded.encode(), hashlib.sha256).hexdigest()
     return encoded, signature
 
 
-def _agent_id_from_context_headers(headers: dict[str, str], *, now: int | None = None) -> str | None:
+def _agent_context_from_headers(
+    headers: dict[str, str], *, now: int | None = None
+) -> AgentContext | None:
     if not AGENT_CONTEXT_HMAC_SECRET:
         return None
     encoded = headers.get("x-caipe-agent-context", "")
@@ -487,14 +528,28 @@ def _agent_id_from_context_headers(headers: dict[str, str], *, now: int | None =
         payload = json.loads(_b64url_decode(encoded))
     except Exception:
         return None
-    current = int(now if now is not None else time.time())
+
+    iat = payload.get("iat")
     exp = payload.get("exp")
     agent_id = payload.get("agent_id")
-    if not isinstance(exp, int) or exp < current:
+    kind = payload.get("kind", AGENT_CONTEXT_KIND_DYNAMIC)
+    if not isinstance(exp, int) or not isinstance(agent_id, str) or not agent_id:
         return None
-    if not isinstance(agent_id, str) or not agent_id:
+    if not isinstance(kind, str) or kind not in _AGENT_CONTEXT_MAX_AGE_BY_KIND:
         return None
-    return agent_id
+
+    current = int(now if now is not None else time.time())
+    if exp < current:
+        return None
+    # Defense in depth: even though the payload is signed by caipe-ui (the
+    # only holder of AGENT_CONTEXT_HMAC_SECRET), cap the lifetime a signer
+    # could claim to this kind's configured max age rather than trusting an
+    # arbitrary exp - iat span from the payload.
+    max_age = _AGENT_CONTEXT_MAX_AGE_BY_KIND[kind]
+    if isinstance(iat, int) and exp - iat > max_age:
+        return None
+
+    return AgentContext(agent_id=agent_id, kind=kind)
 
 
 def _request_body_text(request: CheckRequest) -> str:
@@ -735,8 +790,8 @@ class OpenFgaAuthorizationService:
                 )
             tool_call = mcp_tool_call_from_request(request)
             if allowed and tool_call and AGENT_CONTEXT_HMAC_SECRET:
-                agent_id = _agent_id_from_context_headers(headers)
-                if not agent_id:
+                agent_context = _agent_context_from_headers(headers)
+                if not agent_context:
                     _audit_decision(
                         request=request,
                         subject=sub,
@@ -752,50 +807,74 @@ class OpenFgaAuthorizationService:
                         code=PERMISSION_DENIED,
                         message="missing or invalid signed agent context",
                     )
-                agent_allowed = _check_openfga(user, "can_use", f"agent:{agent_id}")
-                exact_tool_allowed = _check_openfga(
-                    f"agent:{agent_id}",
-                    "can_call",
-                    f"tool:{tool_call[0]}/{tool_call[1]}",
-                )
-                wildcard_tool_allowed = False
-                if not exact_tool_allowed:
-                    wildcard_tool_allowed = _check_openfga(
+                agent_id = agent_context.agent_id
+
+                # "local" contexts identify the caller acting as themselves —
+                # there is no separate delegated identity to bound, since the
+                # signed-in user's own `can_call mcp_gateway:list` check above
+                # (and the caller-keyed check below, when enabled) already
+                # gate everything this request is allowed to do. Skipping the
+                # agent:<id> can_use/can_call checks here isn't a broadened
+                # grant: a user with a Dynamic Agent configured to call the
+                # same tool already has this same reach today, just through
+                # different plumbing. See ui/lib/mcp-http-server-client.ts
+                # and deploy/openfga/model.fga's agent/tool relations.
+                if agent_context.kind != AGENT_CONTEXT_KIND_LOCAL:
+                    agent_allowed = _check_openfga(user, "can_use", f"agent:{agent_id}")
+                    exact_tool_allowed = _check_openfga(
                         f"agent:{agent_id}",
                         "can_call",
-                        f"tool:{tool_call[0]}/*",
+                        f"tool:{tool_call[0]}/{tool_call[1]}",
                     )
-                if not agent_allowed:
+                    wildcard_tool_allowed = False
+                    if not exact_tool_allowed:
+                        wildcard_tool_allowed = _check_openfga(
+                            f"agent:{agent_id}",
+                            "can_call",
+                            f"tool:{tool_call[0]}/*",
+                        )
+                    if not agent_allowed:
+                        _audit_decision(
+                            request=request,
+                            subject=sub,
+                            user=user,
+                            relation="can_use",
+                            obj=f"agent:{agent_id}",
+                            outcome="deny",
+                            reason_code="DENY_AGENT_USE",
+                            duration_ms=(time.perf_counter() - start) * 1000,
+                        )
+                        return build_check_response(
+                            allowed=False,
+                            code=PERMISSION_DENIED,
+                            message="user lacks dynamic agent grant",
+                        )
+                    if not (exact_tool_allowed or wildcard_tool_allowed):
+                        _audit_decision(
+                            request=request,
+                            subject=sub,
+                            user=f"agent:{agent_id}",
+                            relation="can_call",
+                            obj=f"tool:{tool_call[0]}/{tool_call[1]}",
+                            outcome="deny",
+                            reason_code="DENY_AGENT_TOOL",
+                            duration_ms=(time.perf_counter() - start) * 1000,
+                        )
+                        return build_check_response(
+                            allowed=False,
+                            code=PERMISSION_DENIED,
+                            message="dynamic agent lacks agent tool grant",
+                        )
+                else:
                     _audit_decision(
                         request=request,
                         subject=sub,
                         user=user,
-                        relation="can_use",
-                        obj=f"agent:{agent_id}",
-                        outcome="deny",
-                        reason_code="DENY_AGENT_USE",
-                        duration_ms=(time.perf_counter() - start) * 1000,
-                    )
-                    return build_check_response(
-                        allowed=False,
-                        code=PERMISSION_DENIED,
-                        message="user lacks dynamic agent grant",
-                    )
-                if not (exact_tool_allowed or wildcard_tool_allowed):
-                    _audit_decision(
-                        request=request,
-                        subject=sub,
-                        user=f"agent:{agent_id}",
                         relation="can_call",
-                        obj=f"tool:{tool_call[0]}/{tool_call[1]}",
-                        outcome="deny",
-                        reason_code="DENY_AGENT_TOOL",
+                        obj=f"agent:{agent_id}",
+                        outcome="allow",
+                        reason_code="OK_LOCAL_AGENT_CONTEXT",
                         duration_ms=(time.perf_counter() - start) * 1000,
-                    )
-                    return build_check_response(
-                        allowed=False,
-                        code=PERMISSION_DENIED,
-                        message="dynamic agent lacks agent tool grant",
                     )
                 # Caller-keyed tool authorization (FR-012/012a/012b). The agent
                 # being allowed to call the tool is NOT sufficient — the calling

--- a/deploy/openfga/bridge/main.py
+++ b/deploy/openfga/bridge/main.py
@@ -66,7 +66,7 @@ AGENT_CONTEXT_MAX_AGE_SECONDS = int(os.environ.get("CAIPE_AGENT_CONTEXT_MAX_AGE_
 # few minutes. They're safe to allow longer because they carry no delegated
 # authority — see the "local" branch in OpenFgaAuthorizationService.Check.
 AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS = int(
-    os.environ.get("CAIPE_AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS", "43200")  # 12h
+    os.environ.get("CAIPE_AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS", "28800")  # 8h
 )
 # Caller-keyed tool-authorization rollout flag (FR-012c / SC-011 / T022a).
 # When OFF (default), the bridge keeps the legacy agent-only tool check so
@@ -871,7 +871,7 @@ class OpenFgaAuthorizationService:
                         subject=sub,
                         user=user,
                         relation="can_call",
-                        obj=f"agent:{agent_id}",
+                        obj=f"tool:{tool_call[0]}/{tool_call[1]}",
                         outcome="allow",
                         reason_code="OK_LOCAL_AGENT_CONTEXT",
                         duration_ms=(time.perf_counter() - start) * 1000,

--- a/deploy/openfga/bridge/tests/test_grpc_bridge.py
+++ b/deploy/openfga/bridge/tests/test_grpc_bridge.py
@@ -1,6 +1,9 @@
 import base64
+import hashlib
+import hmac
 import importlib.util
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -647,6 +650,188 @@ def test_request_caller_is_service_account_falls_back_to_bearer(monkeypatch: pyt
     no_meta = bridge.build_check_request(headers={"authorization": "Bearer t"})
     assert bridge.request_caller_is_service_account(no_meta, {"authorization": "Bearer t"}) is True
     assert bridge.request_caller_is_service_account(no_meta, {}) is False
+
+
+def test_local_agent_context_bypasses_agent_use_and_tool_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """kind="local" (see ui/src/app/api/mcp-servers/agent-context/route.ts) skips
+    the agent:<id> can_use/can_call checks entirely — the caller's own
+    can_call mcp_gateway:list grant is all that's required."""
+    bridge = _load_bridge_module()
+    checks: list[tuple[str, str, str]] = []
+    events: list[dict] = []
+
+    def _fake_check_openfga(user: str, relation: str, obj: str):
+        checks.append((user, relation, obj))
+        return (user, relation, obj) == ("user:user-sub-123", "can_call", "mcp_gateway:list")
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(bridge, "_check_openfga", _fake_check_openfga)
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **event: events.append(event), raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+    monkeypatch.setattr(bridge, "CALLER_TOOL_CHECK_ENABLED", False)
+
+    context_header, signature = bridge.build_agent_context_header(
+        "mcp-local-agent-abc123",
+        secret="test-secret",
+        kind=bridge.AGENT_CONTEXT_KIND_LOCAL,
+    )
+    request = bridge.build_check_request(
+        headers={
+            "authorization": "Bearer valid-token",
+            "x-caipe-agent-context": context_header,
+            "x-caipe-agent-context-signature": signature,
+        },
+        path="/mcp/jira",
+        method="POST",
+        body='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search"}}',
+    )
+
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.OK
+    # No agent:<id> can_use/can_call checks were performed.
+    assert checks == [("user:user-sub-123", "can_call", "mcp_gateway:list")]
+    assert any(event["reason_code"] == "OK_LOCAL_AGENT_CONTEXT" for event in events)
+
+
+def test_missing_kind_defaults_to_dynamic_and_still_enforces_agent_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backward compatibility: older producers (Dynamic Agents runtime, the
+    diagnostic test-tool route) never send "kind" — the bridge must keep
+    enforcing the full agent:<id> can_use/can_call checks for them."""
+    bridge = _load_bridge_module()
+
+    def _fake_check_openfga(user: str, relation: str, obj: str):
+        return (user, relation, obj) in {
+            ("user:user-sub-123", "can_call", "mcp_gateway:list"),
+            # Deliberately withhold can_use agent:<id> to prove it's still checked.
+        }
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(bridge, "_check_openfga", _fake_check_openfga)
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **_event: None, raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+
+    issued_at = int(time.time())
+    payload = {
+        "agent_id": "agent-test-april-2025",
+        "iat": issued_at,
+        "exp": issued_at + 300,
+        # no "kind" key at all
+    }
+    encoded = bridge._b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    signature = hmac.new(b"test-secret", encoded.encode(), hashlib.sha256).hexdigest()
+    request = bridge.build_check_request(
+        headers={
+            "authorization": "Bearer valid-token",
+            "x-caipe-agent-context": encoded,
+            "x-caipe-agent-context-signature": signature,
+        },
+        path="/mcp/jira",
+        method="POST",
+        body='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search"}}',
+    )
+
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.PERMISSION_DENIED
+    assert response.status.message == "user lacks dynamic agent grant"
+
+
+def test_agent_context_with_unknown_kind_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    bridge = _load_bridge_module()
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(
+        bridge,
+        "_check_openfga",
+        lambda user, relation, obj: (user, relation, obj) == ("user:user-sub-123", "can_call", "mcp_gateway:list"),
+    )
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **_event: None, raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+
+    issued_at = int(time.time())
+    payload = {
+        "agent_id": "agent-test-april-2025",
+        "iat": issued_at,
+        "exp": issued_at + 300,
+        "kind": "admin",
+    }
+    encoded = bridge._b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    signature = hmac.new(b"test-secret", encoded.encode(), hashlib.sha256).hexdigest()
+    request = bridge.build_check_request(
+        headers={
+            "authorization": "Bearer valid-token",
+            "x-caipe-agent-context": encoded,
+            "x-caipe-agent-context-signature": signature,
+        },
+        path="/mcp/jira",
+        method="POST",
+        body='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search"}}',
+    )
+
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.PERMISSION_DENIED
+    assert response.status.message == "missing or invalid signed agent context"
+
+
+def test_agent_context_claiming_lifetime_over_kind_max_age_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense in depth: even a validly-signed payload can't claim an exp - iat
+    span longer than its kind's configured max age."""
+    bridge = _load_bridge_module()
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(
+        bridge,
+        "_check_openfga",
+        lambda user, relation, obj: (user, relation, obj) == ("user:user-sub-123", "can_call", "mcp_gateway:list"),
+    )
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **_event: None, raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_LOCAL_MAX_AGE_SECONDS", 43200)
+    monkeypatch.setattr(
+        bridge,
+        "_AGENT_CONTEXT_MAX_AGE_BY_KIND",
+        {
+            bridge.AGENT_CONTEXT_KIND_DYNAMIC: bridge.AGENT_CONTEXT_MAX_AGE_SECONDS,
+            bridge.AGENT_CONTEXT_KIND_LOCAL: 43200,
+        },
+    )
+
+    issued_at = int(time.time())
+    payload = {
+        "agent_id": "mcp-local-agent-abc123",
+        "iat": issued_at,
+        "exp": issued_at + 43200 + 1,  # claims a lifetime 1s over the max age
+        "kind": bridge.AGENT_CONTEXT_KIND_LOCAL,
+    }
+    encoded = bridge._b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    signature = hmac.new(b"test-secret", encoded.encode(), hashlib.sha256).hexdigest()
+    request = bridge.build_check_request(
+        headers={
+            "authorization": "Bearer valid-token",
+            "x-caipe-agent-context": encoded,
+            "x-caipe-agent-context-signature": signature,
+        },
+        path="/mcp/jira",
+        method="POST",
+        body='{"jsonrpc":"2.0","method":"tools/call","params":{"name":"search"}}',
+    )
+
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.PERMISSION_DENIED
+    assert response.status.message == "missing or invalid signed agent context"
 
 
 def test_check_namespaces_service_account_from_metadata(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/deploy/openfga/bridge/tests/test_grpc_bridge.py
+++ b/deploy/openfga/bridge/tests/test_grpc_bridge.py
@@ -451,6 +451,25 @@ def _tools_call_request(bridge, *, tool_name: str, agent_id: str = "agent-test-a
     )
 
 
+def _local_tools_call_request(bridge, *, tool_name: str, agent_id: str = "mcp-local-agent-abc123"):
+    """Build a signed kind="local" tools/call CheckRequest (CLI/local caller path)."""
+    context_header, signature = bridge.build_agent_context_header(
+        agent_id,
+        secret="test-secret",
+        kind=bridge.AGENT_CONTEXT_KIND_LOCAL,
+    )
+    return bridge.build_check_request(
+        headers={
+            "authorization": "Bearer valid-token",
+            "x-caipe-agent-context": context_header,
+            "x-caipe-agent-context-signature": signature,
+        },
+        path="/mcp/jira",
+        method="POST",
+        body=f'{{"jsonrpc":"2.0","method":"tools/call","params":{{"name":"{tool_name}"}}}}',
+    )
+
+
 def test_caller_keyed_denies_user_with_agent_tool_but_no_caller_tool(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -694,7 +713,107 @@ def test_local_agent_context_bypasses_agent_use_and_tool_checks(
     assert response.status.code == bridge.OK
     # No agent:<id> can_use/can_call checks were performed.
     assert checks == [("user:user-sub-123", "can_call", "mcp_gateway:list")]
-    assert any(event["reason_code"] == "OK_LOCAL_AGENT_CONTEXT" for event in events)
+    local_allow = [e for e in events if e["reason_code"] == "OK_LOCAL_AGENT_CONTEXT"]
+    assert len(local_allow) == 1
+    # The audit event is scoped to the actual tool target (tool:<server>/<name>),
+    # not agent:<id> — so audit trails record which tool a local caller invoked.
+    assert local_allow[0]["resource_ref"] == "user:user-sub-123 can_call tool:jira/search"
+
+
+def test_local_agent_context_with_caller_check_denies_without_caller_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production-relevant path: kind="local" with CALLER_TOOL_CHECK_ENABLED=True
+    (as this repo's dev/prod helm values set it). A local caller who holds only
+    the coarse mcp_gateway:list grant — but NOT the per-tool grant — is denied.
+    This is the check the local branch's safety rests on when the flag is on."""
+    bridge = _load_bridge_module()
+    events: list[dict] = []
+
+    def _fake_check_openfga(user: str, relation: str, obj: str):
+        # Only the coarse gateway gate is held; no tool:jira/search or wildcard.
+        return (user, relation, obj) == ("user:user-sub-123", "can_call", "mcp_gateway:list")
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_claims", lambda _auth_header: {"sub": "user-sub-123"})
+    monkeypatch.setattr(bridge, "_check_openfga", _fake_check_openfga)
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **event: events.append(event), raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+    monkeypatch.setattr(bridge, "CALLER_TOOL_CHECK_ENABLED", True)
+
+    request = _local_tools_call_request(bridge, tool_name="search")
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.PERMISSION_DENIED
+    assert "caller lacks tool grant" in response.status.message
+    assert events[-1]["outcome"] == "deny"
+    assert events[-1]["reason_code"] == "DENY_CALLER_TOOL"
+    assert events[-1]["resource_ref"] == "user:user-sub-123 can_call tool:jira/search"
+
+
+def test_local_agent_context_with_caller_check_allows_with_exact_tool_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """kind="local" with CALLER_TOOL_CHECK_ENABLED=True and the caller holding the
+    exact per-tool grant → allowed, and the caller-keyed allow is audited."""
+    bridge = _load_bridge_module()
+    events: list[dict] = []
+
+    def _fake_check_openfga(user: str, relation: str, obj: str):
+        return (user, relation, obj) in {
+            ("user:user-sub-123", "can_call", "mcp_gateway:list"),
+            ("user:user-sub-123", "can_call", "tool:jira/search"),
+        }
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_claims", lambda _auth_header: {"sub": "user-sub-123"})
+    monkeypatch.setattr(bridge, "_check_openfga", _fake_check_openfga)
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **event: events.append(event), raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+    monkeypatch.setattr(bridge, "CALLER_TOOL_CHECK_ENABLED", True)
+
+    request = _local_tools_call_request(bridge, tool_name="search")
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.OK
+    caller_tool_allow = [
+        e
+        for e in events
+        if e["reason_code"] == "OK_CALLER_TOOL"
+        and e["resource_ref"] == "user:user-sub-123 can_call tool:jira/search"
+    ]
+    assert len(caller_tool_allow) == 1
+    assert caller_tool_allow[0]["outcome"] == "allow"
+
+
+def test_local_agent_context_with_caller_check_allows_with_wildcard_tool_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """kind="local" with CALLER_TOOL_CHECK_ENABLED=True and only a wildcard
+    tool:<server>/* grant (no exact tuple) → allowed via the wildcard fallback."""
+    bridge = _load_bridge_module()
+
+    def _fake_check_openfga(user: str, relation: str, obj: str):
+        # Exact tool:jira/search is deliberately withheld to force the wildcard path.
+        return (user, relation, obj) in {
+            ("user:user-sub-123", "can_call", "mcp_gateway:list"),
+            ("user:user-sub-123", "can_call", "tool:jira/*"),
+        }
+
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_subject", lambda _auth_header: "user-sub-123")
+    monkeypatch.setattr(bridge, "_decode_verified_bearer_claims", lambda _auth_header: {"sub": "user-sub-123"})
+    monkeypatch.setattr(bridge, "_check_openfga", _fake_check_openfga)
+    monkeypatch.setattr(bridge, "log_authz_decision", lambda **_event: None, raising=False)
+    monkeypatch.setattr(bridge, "BYPASS_SUBS", frozenset())
+    monkeypatch.setattr(bridge, "AGENT_CONTEXT_HMAC_SECRET", "test-secret")
+    monkeypatch.setattr(bridge, "CALLER_TOOL_CHECK_ENABLED", True)
+
+    request = _local_tools_call_request(bridge, tool_name="search")
+    response = bridge.OpenFgaAuthorizationService().Check(request, None)
+
+    assert response.status.code == bridge.OK
 
 
 def test_missing_kind_defaults_to_dynamic_and_still_enforces_agent_checks(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.55-dev.2"
+version = "0.5.55-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/mcp-servers/agent-context/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agent-context/__tests__/route.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment node
+ *
+ * Regression coverage for the multi-server agent-context minting endpoint.
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockFilterResourcesByPermission = jest.fn();
+const mockGetCollection = jest.fn();
+const mockWriteOpenFgaTuples = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    status: number;
+    code?: string;
+
+    constructor(message: string, status = 500, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => {
+        try {
+          return await handler(request);
+        } catch (err) {
+          const e = err as { status?: number; message: string; code?: string };
+          return Response.json(
+            { success: false, error: e.message, code: e.code },
+            { status: e.status ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  writeOpenFgaTuples: (...args: unknown[]) => mockWriteOpenFgaTuples(...args),
+}));
+
+function request(body?: Record<string, unknown>): NextRequest {
+  return new NextRequest(new URL("/api/mcp-servers/agent-context", "http://localhost:3000"), {
+    method: "POST",
+    headers: body === undefined ? { "content-length": "0" } : { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const session = {
+  sub: "user-sub",
+  role: "admin",
+  accessToken: "user-keycloak-token",
+};
+
+function mcpServer(id: string) {
+  return {
+    _id: id,
+    name: id,
+    transport: "http" as const,
+    endpoint: `http://agentgateway:4000/mcp/${id}`,
+    source: "agentgateway" as const,
+    enabled: true,
+  };
+}
+
+describe("POST /api/mcp-servers/agent-context", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET = "test-agent-context-secret";
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ session });
+    mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 3, deletes: 0 });
+  });
+
+  afterEach(() => {
+    delete process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET;
+  });
+
+  it("mints one context scoped to every server the caller can invoke when serverIds is omitted", async () => {
+    const toArray = jest.fn().mockResolvedValue([mcpServer("argocd"), mcpServer("jira")]);
+    mockGetCollection.mockResolvedValue({ find: jest.fn().mockReturnValue({ toArray }) });
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+
+    const { POST } = await import("../route");
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.server_ids.sort()).toEqual(["argocd", "jira"]);
+    expect(body.data.headers["X-CAIPE-Agent-Context"]).toEqual(expect.any(String));
+    expect(body.data.headers["X-CAIPE-Agent-Context-Signature"]).toEqual(expect.any(String));
+
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [
+        expect.objectContaining({ user: "user:user-sub", relation: "user" }),
+        expect.objectContaining({ relation: "caller", object: "tool:argocd/*" }),
+        expect.objectContaining({ relation: "caller", object: "tool:jira/*" }),
+      ],
+      deletes: [],
+    });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        expect.objectContaining({ object: "tool:argocd/*" }),
+        expect.objectContaining({ object: "tool:jira/*" }),
+      ]),
+    });
+  });
+
+  it("scopes the context to only the requested serverIds", async () => {
+    const toArray = jest.fn().mockResolvedValue([mcpServer("argocd")]);
+    const find = jest.fn().mockReturnValue({ toArray });
+    mockGetCollection.mockResolvedValue({ find });
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+
+    const { POST } = await import("../route");
+    const response = await POST(request({ serverIds: ["argocd"] }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.server_ids).toEqual(["argocd"]);
+    expect(find).toHaveBeenCalledWith({ _id: { $in: ["argocd"] }, enabled: true });
+  });
+
+  it("rejects with 403 when a requested serverId is not invokable by the caller", async () => {
+    const toArray = jest.fn().mockResolvedValue([mcpServer("argocd")]);
+    mockGetCollection.mockResolvedValue({ find: jest.fn().mockReturnValue({ toArray }) });
+    mockFilterResourcesByPermission.mockResolvedValue([]);
+
+    const { POST } = await import("../route");
+    const response = await POST(request({ serverIds: ["argocd"] }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain("argocd");
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when no serverIds are given and the caller can invoke nothing", async () => {
+    const toArray = jest.fn().mockResolvedValue([mcpServer("argocd")]);
+    mockGetCollection.mockResolvedValue({ find: jest.fn().mockReturnValue({ toArray }) });
+    mockFilterResourcesByPermission.mockResolvedValue([]);
+
+    const { POST } = await import("../route");
+    const response = await POST(request());
+
+    expect(response.status).toBe(404);
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when agent context signing is not configured", async () => {
+    delete process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET;
+    const toArray = jest.fn().mockResolvedValue([mcpServer("argocd")]);
+    mockGetCollection.mockResolvedValue({ find: jest.fn().mockReturnValue({ toArray }) });
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+
+    const { POST } = await import("../route");
+    const response = await POST(request({ serverIds: ["argocd"] }));
+
+    expect(response.status).toBe(503);
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([expect.objectContaining({ object: "tool:argocd/*" })]),
+    });
+  });
+
+  it("rejects a non-array serverIds body with 400", async () => {
+    const { POST } = await import("../route");
+    const response = await POST(request({ serverIds: "argocd" }));
+
+    expect(response.status).toBe(400);
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/mcp-servers/agent-context/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agent-context/__tests__/route.test.ts
@@ -80,6 +80,15 @@ function mcpServer(id: string) {
   };
 }
 
+function decodeAgentContextPayload(headers: Record<string, string>): {
+  agent_id: string;
+  kind: string;
+  iat: number;
+  exp: number;
+} {
+  return JSON.parse(Buffer.from(headers["X-CAIPE-Agent-Context"], "base64url").toString("utf8"));
+}
+
 describe("POST /api/mcp-servers/agent-context", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -105,22 +114,11 @@ describe("POST /api/mcp-servers/agent-context", () => {
     expect(body.data.server_ids.sort()).toEqual(["argocd", "jira"]);
     expect(body.data.headers["X-CAIPE-Agent-Context"]).toEqual(expect.any(String));
     expect(body.data.headers["X-CAIPE-Agent-Context-Signature"]).toEqual(expect.any(String));
+    expect(decodeAgentContextPayload(body.data.headers).kind).toBe("local");
 
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
-      writes: [
-        expect.objectContaining({ user: "user:user-sub", relation: "user" }),
-        expect.objectContaining({ relation: "caller", object: "tool:argocd/*" }),
-        expect.objectContaining({ relation: "caller", object: "tool:jira/*" }),
-      ],
-      deletes: [],
-    });
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
-      writes: [],
-      deletes: expect.arrayContaining([
-        expect.objectContaining({ object: "tool:argocd/*" }),
-        expect.objectContaining({ object: "tool:jira/*" }),
-      ]),
-    });
+    // No OpenFGA tuples are granted or revoked — a "local" context carries no
+    // delegated authority to bound, so there's nothing to write.
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
   });
 
   it("scopes the context to only the requested serverIds", async () => {
@@ -174,10 +172,7 @@ describe("POST /api/mcp-servers/agent-context", () => {
     const response = await POST(request({ serverIds: ["argocd"] }));
 
     expect(response.status).toBe(503);
-    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
-      writes: [],
-      deletes: expect.arrayContaining([expect.objectContaining({ object: "tool:argocd/*" })]),
-    });
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
   });
 
   it("rejects a non-array serverIds body with 400", async () => {

--- a/ui/src/app/api/mcp-servers/agent-context/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agent-context/__tests__/route.test.ts
@@ -114,7 +114,13 @@ describe("POST /api/mcp-servers/agent-context", () => {
     expect(body.data.server_ids.sort()).toEqual(["argocd", "jira"]);
     expect(body.data.headers["X-CAIPE-Agent-Context"]).toEqual(expect.any(String));
     expect(body.data.headers["X-CAIPE-Agent-Context-Signature"]).toEqual(expect.any(String));
-    expect(decodeAgentContextPayload(body.data.headers).kind).toBe("local");
+    const payload = decodeAgentContextPayload(body.data.headers);
+    expect(payload.kind).toBe("local");
+    // Local contexts get an 8h TTL (see AGENT_CONTEXT_TTL_SECONDS.local in
+    // mcp-http-server-client.ts) — guards against a regression back to 12h or
+    // an unbounded lifetime, since the exp is the only lifetime bound on a
+    // local context.
+    expect(payload.exp - payload.iat).toBe(60 * 60 * 8);
 
     // No OpenFGA tuples are granted or revoked — a "local" context carries no
     // delegated authority to bound, so there's nothing to write.

--- a/ui/src/app/api/mcp-servers/agent-context/route.ts
+++ b/ui/src/app/api/mcp-servers/agent-context/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Mint a short-lived signed agent context covering one or more MCP servers
+ * for CLI/local callers invoking tools directly through AgentGateway.
+ *
+ * AgentGateway's openfga-authz-bridge rejects tools/call requests with
+ * "missing or invalid signed agent context" once CAIPE_AGENT_CONTEXT_HMAC_SECRET
+ * is set, because that header pair is normally only produced by the Dynamic
+ * Agents runtime (or this UI's own diagnostic test-tool flow). A bare local
+ * client authenticates with a user's bearer token but has no way to produce
+ * that signature itself, since the HMAC secret must stay in-cluster. This
+ * route lets an authenticated user mint one context that authorizes calls
+ * against every server they request (or every server they can invoke, if
+ * none are requested), since the signature itself carries no per-server
+ * scope — scoping comes entirely from the OpenFGA `caller` tuples granted
+ * for the minted agent id before signing.
+ */
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { getCollection } from "@/lib/mongodb";
+import {
+  buildAgentContextHeaders,
+  grantDiagnosticAgentAccessForServers,
+  multiServerAgentContextId,
+  revokeDiagnosticAgentAccess,
+} from "@/lib/mcp-http-server-client";
+import { filterResourcesByPermission } from "@/lib/rbac/resource-authz";
+import type { MCPServerConfig } from "@/types/dynamic-agent";
+import { NextRequest } from "next/server";
+
+const COLLECTION_NAME = "mcp_servers";
+
+function readRequestedServerIds(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new ApiError("serverIds must be an array of strings", 400, "VALIDATION_ERROR");
+  }
+  const ids = value.map((entry) => entry.trim()).filter(Boolean);
+  return [...new Set(ids)];
+}
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const { session } = await getAuthFromBearerOrSession(request);
+  const body = request.headers.get("content-length") === "0" ? {} : ((await request.json().catch(() => ({}))) as Record<string, unknown>);
+  const requestedServerIds = readRequestedServerIds(body.serverIds);
+
+  const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
+  const candidateServers =
+    requestedServerIds !== undefined
+      ? await collection.find({ _id: { $in: requestedServerIds }, enabled: true }).toArray()
+      : await collection.find({ enabled: true }).toArray();
+
+  const invokableServers = await filterResourcesByPermission(session, candidateServers, {
+    type: "mcp_server",
+    action: "invoke",
+    id: (server: MCPServerConfig) => String(server._id),
+  });
+
+  if (requestedServerIds !== undefined) {
+    const invokableIds = new Set(invokableServers.map((server) => String(server._id)));
+    const missing = requestedServerIds.filter((id) => !invokableIds.has(id));
+    if (missing.length > 0) {
+      throw new ApiError(
+        `Not authorized to invoke MCP server(s): ${missing.join(", ")}`,
+        403,
+        "mcp_server#invoke",
+      );
+    }
+  } else if (invokableServers.length === 0) {
+    throw new ApiError("No invokable MCP servers found for this user.", 404, "NO_INVOKABLE_SERVERS");
+  }
+
+  const serverIds = invokableServers.map((server) => String(server._id));
+  const agentId = multiServerAgentContextId(session);
+  const tuples = await grantDiagnosticAgentAccessForServers(serverIds, agentId, session);
+
+  try {
+    const headers = buildAgentContextHeaders(agentId);
+    if (Object.keys(headers).length === 0) {
+      throw new ApiError(
+        "Agent context signing is not configured on this deployment.",
+        503,
+        "AGENT_CONTEXT_UNAVAILABLE",
+      );
+    }
+    return successResponse({ headers, server_ids: serverIds });
+  } finally {
+    await revokeDiagnosticAgentAccess(tuples, "mcp-servers-agent-context");
+  }
+});

--- a/ui/src/app/api/mcp-servers/agent-context/route.ts
+++ b/ui/src/app/api/mcp-servers/agent-context/route.ts
@@ -1,18 +1,28 @@
 /**
- * Mint a short-lived signed agent context covering one or more MCP servers
- * for CLI/local callers invoking tools directly through AgentGateway.
+ * Mint a signed "local" agent context covering one or more MCP servers, for
+ * CLI/local callers (e.g. a Claude Code or Codex MCP client) invoking tools
+ * directly through AgentGateway under the caller's own identity.
  *
  * AgentGateway's openfga-authz-bridge rejects tools/call requests with
  * "missing or invalid signed agent context" once CAIPE_AGENT_CONTEXT_HMAC_SECRET
  * is set, because that header pair is normally only produced by the Dynamic
  * Agents runtime (or this UI's own diagnostic test-tool flow). A bare local
  * client authenticates with a user's bearer token but has no way to produce
- * that signature itself, since the HMAC secret must stay in-cluster. This
- * route lets an authenticated user mint one context that authorizes calls
- * against every server they request (or every server they can invoke, if
- * none are requested), since the signature itself carries no per-server
- * scope — scoping comes entirely from the OpenFGA `caller` tuples granted
- * for the minted agent id before signing.
+ * that signature itself, since the HMAC secret must stay in-cluster.
+ *
+ * Unlike the Dynamic Agent / diagnostic flows, this route does NOT grant or
+ * revoke any OpenFGA tuples: the minted context is marked `kind: "local"`,
+ * and the bridge (deploy/openfga/bridge/main.py) skips the agent:<id>
+ * can_use/can_call checks entirely for that kind, since a local context
+ * grants no authority beyond what the signed-in caller already has via the
+ * `can_invoke`/caller-keyed checks it performs unconditionally on every
+ * request. That's what makes it safe to hand this context to a caller for
+ * use in later, separate requests — there's no tuple to expire out from
+ * under them (see the removed grant-then-immediately-revoke code this
+ * replaced, which broke every tools/call after the mint request returned).
+ * The signature's own `exp` (see buildAgentContextHeaders' "local" TTL) is
+ * the only lifetime bound left, chosen long enough to outlast a normal MCP
+ * client session/connection rather than to gate authorization.
  */
 
 import {
@@ -22,12 +32,7 @@ import {
   withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection } from "@/lib/mongodb";
-import {
-  buildAgentContextHeaders,
-  grantDiagnosticAgentAccessForServers,
-  multiServerAgentContextId,
-  revokeDiagnosticAgentAccess,
-} from "@/lib/mcp-http-server-client";
+import { buildAgentContextHeaders, localAgentContextId } from "@/lib/mcp-http-server-client";
 import { filterResourcesByPermission } from "@/lib/rbac/resource-authz";
 import type { MCPServerConfig } from "@/types/dynamic-agent";
 import { NextRequest } from "next/server";
@@ -75,20 +80,14 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   }
 
   const serverIds = invokableServers.map((server) => String(server._id));
-  const agentId = multiServerAgentContextId(session);
-  const tuples = await grantDiagnosticAgentAccessForServers(serverIds, agentId, session);
-
-  try {
-    const headers = buildAgentContextHeaders(agentId);
-    if (Object.keys(headers).length === 0) {
-      throw new ApiError(
-        "Agent context signing is not configured on this deployment.",
-        503,
-        "AGENT_CONTEXT_UNAVAILABLE",
-      );
-    }
-    return successResponse({ headers, server_ids: serverIds });
-  } finally {
-    await revokeDiagnosticAgentAccess(tuples, "mcp-servers-agent-context");
+  const agentId = localAgentContextId(session);
+  const headers = buildAgentContextHeaders(agentId, "local");
+  if (Object.keys(headers).length === 0) {
+    throw new ApiError(
+      "Agent context signing is not configured on this deployment.",
+      503,
+      "AGENT_CONTEXT_UNAVAILABLE",
+    );
   }
+  return successResponse({ headers, server_ids: serverIds });
 });

--- a/ui/src/lib/mcp-http-server-client.ts
+++ b/ui/src/lib/mcp-http-server-client.ts
@@ -12,7 +12,22 @@ import { writeOpenFgaTuples, type OpenFgaTupleKey } from "@/lib/rbac/openfga";
 import type { MCPServerConfig, MCPToolInfo } from "@/types/dynamic-agent";
 import type { NextRequest } from "next/server";
 
-const AGENT_CONTEXT_TTL_SECONDS = 300;
+// "local" contexts (minted by POST /api/mcp-servers/agent-context for CLI/
+// local callers, e.g. Claude Code's forge-rag MCP server) get a much longer
+// TTL than "dynamic" ones (Dynamic Agents runtime, the diagnostic test-tool
+// flow below). Those clients cache MCP headers for the life of a whole
+// session/connection rather than refreshing per request, so a short TTL
+// would force a re-auth or a failed-then-retried tool call every few
+// minutes. A longer TTL is safe here because the openfga-authz-bridge skips
+// the agent:<id> can_use/can_call checks entirely for "local" contexts —
+// they carry no delegated authority beyond what the signed-in user already
+// has, so there's no separate grant window to bound tightly. See the
+// "kind" handling in deploy/openfga/bridge/main.py.
+type AgentContextKind = "dynamic" | "local";
+const AGENT_CONTEXT_TTL_SECONDS: Record<AgentContextKind, number> = {
+  dynamic: 300,
+  local: 60 * 60 * 12,
+};
 
 type AuthSession = {
   sub?: string;
@@ -47,13 +62,16 @@ export function diagnosticAgentId(serverId: string, session: AuthSession): strin
   return `mcp-test-${serverId}-${hash}`.replace(/[^A-Za-z0-9._~@|*+=,/-]/g, "-").slice(0, 191);
 }
 
-export function multiServerAgentContextId(session: AuthSession): string {
+export function localAgentContextId(session: AuthSession): string {
   const subject = typeof session?.sub === "string" && session.sub.trim() ? session.sub.trim() : "unknown";
   const hash = crypto.createHash("sha256").update(subject).digest("hex").slice(0, 16);
-  return `mcp-agent-context-${hash}`.replace(/[^A-Za-z0-9._~@|*+=,/-]/g, "-").slice(0, 191);
+  return `mcp-local-agent-${hash}`.replace(/[^A-Za-z0-9._~@|*+=,/-]/g, "-").slice(0, 191);
 }
 
-export function buildAgentContextHeaders(agentId: string): Record<string, string> {
+export function buildAgentContextHeaders(
+  agentId: string,
+  kind: AgentContextKind = "dynamic",
+): Record<string, string> {
   const secret = process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET?.trim();
   if (!secret) return {};
 
@@ -61,7 +79,8 @@ export function buildAgentContextHeaders(agentId: string): Record<string, string
   const payload = {
     agent_id: agentId,
     iat: issuedAt,
-    exp: issuedAt + AGENT_CONTEXT_TTL_SECONDS,
+    exp: issuedAt + AGENT_CONTEXT_TTL_SECONDS[kind],
+    kind,
   };
   const encoded = b64url(JSON.stringify(payload));
   const signature = crypto.createHmac("sha256", secret).update(encoded).digest("hex");
@@ -105,22 +124,6 @@ export async function grantDiagnosticAgentAccess(
 ): Promise<OpenFgaTupleKey[]> {
   const writes = diagnosticOpenFgaTuples(serverId, agentId, session);
   if (!writes.length) return [];
-  await writeOpenFgaTuples({ writes, deletes: [] });
-  return writes;
-}
-
-export async function grantDiagnosticAgentAccessForServers(
-  serverIds: string[],
-  agentId: string,
-  session: AuthSession,
-): Promise<OpenFgaTupleKey[]> {
-  const subject = typeof session?.sub === "string" ? session.sub.trim() : "";
-  if (!subject || serverIds.length === 0) return [];
-
-  const writes: OpenFgaTupleKey[] = [{ user: `user:${subject}`, relation: "user", object: `agent:${agentId}` }];
-  for (const serverId of serverIds) {
-    writes.push({ user: `agent:${agentId}`, relation: "caller", object: `tool:${serverId}/*` });
-  }
   await writeOpenFgaTuples({ writes, deletes: [] });
   return writes;
 }

--- a/ui/src/lib/mcp-http-server-client.ts
+++ b/ui/src/lib/mcp-http-server-client.ts
@@ -47,7 +47,13 @@ export function diagnosticAgentId(serverId: string, session: AuthSession): strin
   return `mcp-test-${serverId}-${hash}`.replace(/[^A-Za-z0-9._~@|*+=,/-]/g, "-").slice(0, 191);
 }
 
-function buildAgentContextHeaders(agentId: string): Record<string, string> {
+export function multiServerAgentContextId(session: AuthSession): string {
+  const subject = typeof session?.sub === "string" && session.sub.trim() ? session.sub.trim() : "unknown";
+  const hash = crypto.createHash("sha256").update(subject).digest("hex").slice(0, 16);
+  return `mcp-agent-context-${hash}`.replace(/[^A-Za-z0-9._~@|*+=,/-]/g, "-").slice(0, 191);
+}
+
+export function buildAgentContextHeaders(agentId: string): Record<string, string> {
   const secret = process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET?.trim();
   if (!secret) return {};
 
@@ -99,6 +105,22 @@ export async function grantDiagnosticAgentAccess(
 ): Promise<OpenFgaTupleKey[]> {
   const writes = diagnosticOpenFgaTuples(serverId, agentId, session);
   if (!writes.length) return [];
+  await writeOpenFgaTuples({ writes, deletes: [] });
+  return writes;
+}
+
+export async function grantDiagnosticAgentAccessForServers(
+  serverIds: string[],
+  agentId: string,
+  session: AuthSession,
+): Promise<OpenFgaTupleKey[]> {
+  const subject = typeof session?.sub === "string" ? session.sub.trim() : "";
+  if (!subject || serverIds.length === 0) return [];
+
+  const writes: OpenFgaTupleKey[] = [{ user: `user:${subject}`, relation: "user", object: `agent:${agentId}` }];
+  for (const serverId of serverIds) {
+    writes.push({ user: `agent:${agentId}`, relation: "caller", object: `tool:${serverId}/*` });
+  }
   await writeOpenFgaTuples({ writes, deletes: [] });
   return writes;
 }

--- a/ui/src/lib/mcp-http-server-client.ts
+++ b/ui/src/lib/mcp-http-server-client.ts
@@ -26,7 +26,7 @@ import type { NextRequest } from "next/server";
 type AgentContextKind = "dynamic" | "local";
 const AGENT_CONTEXT_TTL_SECONDS: Record<AgentContextKind, number> = {
   dynamic: 300,
-  local: 60 * 60 * 12,
+  local: 60 * 60 * 8,
 };
 
 type AuthSession = {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.55.dev2"
+version = "0.5.55.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Problem

AgentGateway's `openfga-authz-bridge` rejects `tools/call` requests with `missing or invalid signed agent context` once `CAIPE_AGENT_CONTEXT_HMAC_SECRET` is set. That signed header pair was only ever produced by the Dynamic Agents runtime or the UI's own diagnostic test-tool flow. A bare local client (e.g. a Claude Code / Codex MCP headers helper authenticating with a user's bearer token) has no way to produce the HMAC signature — the signing secret must stay in-cluster by design — so local/CLI callers are locked out of MCP tools entirely.

## Use case

Let a CLI/local MCP client (Claude Code, Codex) call MCP tools through AgentGateway under the signed-in user's own identity — e.g. querying a `knowledge-base` (RAG) server for `search` / `fetch_document`.

## Solution

Add `POST /api/mcp-servers/agent-context`, which mints a signed **`kind: "local"`** agent context for the caller:

- Authenticates via the existing `getAuthFromBearerOrSession` dual-auth path (bearer JWT or session cookie).
- Accepts an optional `serverIds` array: if given, 403s unless the caller can invoke every listed server; if omitted, scopes to every enabled server the caller can invoke.
- Mints a short-lived signed context and returns the header set. **No OpenFGA tuples are granted or revoked** — this replaces the earlier grant-then-immediately-revoke design, which broke every `tools/call` after the mint request returned.

The bridge learns a `kind` discriminator:

- **`kind: "local"`** identifies the caller acting as themselves. It skips the `agent:<id>` `can_use`/`can_call` checks (there is no delegated agent identity to bound) and relies on the caller-keyed per-tool check, which follows the `CALLER_TOOL_CHECK_ENABLED` platform setting.
- **`kind: "dynamic"`** (and legacy contexts with no `kind`, for backward compatibility) keep the full agent-scoped checks.

Local contexts get an 8h TTL (vs. 300s for dynamic) since local MCP clients cache headers for a whole session; the signature `exp` is the only lifetime bound.

Also adds a per-PR prebuild image pipeline for the bridge (`prebuild-openfga-authz-bridge.yml` + `prebuild-manual.yml` fanout), matching the existing ui/dynamic-agents flows, so the bridge can be tested live on `prebuild/*` branches.

## Value

- Unblocks local/CLI MCP tool access under the caller's real identity, with no broadening of what that caller can already reach (when `CALLER_TOOL_CHECK_ENABLED` is on).
- Removes the grant/revoke race that made the previous approach unusable.
- Verified end-to-end against a prebuild deployment: mint → `initialize` → `tools/list` → `tools/call(search)` → `tools/call(fetch_document)` all succeed against a `knowledge-base` server.

## Type of Change

- [x] New Feature

## Checklist

- [x] Functionality documented (inline comments explain the `kind` handling and the flag-conditional safety property)
- [x] Code style checks pass (`npm run lint`, `npm run build`; `ruff`)
- [x] Covered by automated tests — bridge `test_grpc_bridge.py` (local-kind deny/allow under `CALLER_TOOL_CHECK_ENABLED`, exact + wildcard grants, audit `resource_ref` scoping) and `agent-context/__tests__/route.test.ts` (mint paths + 8h TTL)
