### PR TITLE
fix(slack): recover self-resolution state after restart

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/app.py
+++ b/ai_platform_engineering/integrations/slack_bot/app.py
@@ -2218,35 +2218,57 @@ def _flag_human_assisted_if_foreign(event, client) -> None:
 
   This is the self-resolution disqualifier: if anyone other than the thread's
   originator answers, the originator did not self-serve. Observe-only — never
-  posts. Gated on the thread being bot-owned so we never create a conversation
-  for a thread the bot never engaged, and deduped in-process so a chatty thread
-  PATCHes at most once.
+  posts. The durable conversation lookup recovers ownership and originator
+  metadata after a bot restart without using the create/upsert endpoint, so an
+  unrelated Slack thread can never create a phantom conversation. The local
+  caches remain fast-path/dedup hints only.
   """
   thread_ts = event.get("thread_ts")
   sender_id = event.get("user")
-  if not thread_ts or not sender_id:
-    return
-
-  # Only threads the bot already engaged have an owner + a conversation row.
-  if session_manager.get_thread_owner(thread_ts) is None:
-    return
-
-  originator_id = session_manager.get_thread_originator(thread_ts)
-  # Unknown originator (e.g. cache lost across restart before any mention) —
-  # can't attribute, so leave the thread as-is rather than guess.
-  if originator_id is None or sender_id == originator_id:
-    return
-
-  if session_manager.is_human_assisted(thread_ts):
-    return
-
   channel_id = event.get("channel")
+  if not thread_ts or not sender_id or not channel_id:
+    return
+
+  # Originator replies are the overwhelmingly common path and need no durable
+  # lookup while the cache is warm. A persisted human-assisted flag is also
+  # mirrored locally after the first observation/PATCH.
+  cached_originator_id = session_manager.get_thread_originator(thread_ts)
+  if cached_originator_id == sender_id or session_manager.is_human_assisted(thread_ts):
+    return
+
   try:
-    conversation_id = _resolve_conversation_id(
-      thread_ts,
-      channel_id,
-      agent_id=session_manager.get_thread_owner(thread_ts) or "",
-    )
+    conversation = sse_client.get_conversation_by_idempotency_key(thread_ts)
+    if conversation is None:
+      return
+
+    metadata = conversation.get("metadata", {})
+    conversation_id = conversation.get("conversation_id")
+    owner_id = metadata.get("thread_owner_agent_id")
+    originator_id = metadata.get("originator_slack_user_id")
+
+    # Both anchors are written only for a real Slack conversation after the
+    # bot successfully responds. Require an exact channel match as a second
+    # guard around the integration idempotency key.
+    if (
+      not isinstance(conversation_id, str)
+      or not isinstance(owner_id, str)
+      or not isinstance(originator_id, str)
+      or not conversation_id
+      or not owner_id
+      or not originator_id
+      or metadata.get("channel_id") != channel_id
+    ):
+      return
+
+    session_manager.set_thread_owner(thread_ts, owner_id)
+    session_manager.set_thread_originator(thread_ts, originator_id)
+
+    if metadata.get("human_assisted") is True:
+      session_manager.set_human_assisted(thread_ts)
+      return
+    if sender_id == originator_id:
+      return
+
     sse_client.update_conversation_metadata(conversation_id, {"human_assisted": True})
     session_manager.set_human_assisted(thread_ts)
     logger.info(f"[{thread_ts}] Human-assisted: reply from {sender_id} (originator {originator_id}){_msg_link(channel_id, thread_ts)}")

--- a/ai_platform_engineering/integrations/slack_bot/sse_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/sse_client.py
@@ -324,6 +324,52 @@ class SSEClient:
       "metadata": conversation.get("metadata", {}),
     }
 
+  def get_conversation_by_idempotency_key(
+    self,
+    idempotency_key: str,
+  ) -> Optional[Dict[str, Any]]:
+    """Look up an existing Slack conversation without creating one.
+
+    Calls the read-only conversation lookup endpoint. ``None`` means no active
+    Slack conversation exists for the key; other HTTP failures are surfaced so
+    callers can distinguish an absent thread from a failed lookup.
+    """
+    url = f"{self.base_url}/api/chat/conversations/lookup"
+    headers = self._get_headers()
+    headers["Accept"] = "application/json"
+
+    with httpx.Client(timeout=30) as client:
+      response = client.get(
+        url,
+        params={
+          "idempotency_key": idempotency_key,
+          "client_type": "slack",
+        },
+        headers=headers,
+      )
+
+    if response.status_code == 404:
+      return None
+    if response.status_code != 200:
+      logger.error(
+        "Failed to look up conversation: status={} body={}",
+        response.status_code,
+        response.text[:500],
+      )
+      raise Exception(f"Failed to look up conversation: HTTP {response.status_code}")
+
+    data = response.json()
+    result = data.get("data", data)
+    conversation = result.get("conversation", {})
+    conversation_id = conversation.get("_id", "")
+    if not conversation_id:
+      raise Exception("Conversation lookup response did not include an ID")
+
+    return {
+      "conversation_id": conversation_id,
+      "metadata": conversation.get("metadata", {}),
+    }
+
   def update_conversation_metadata(
     self,
     conversation_id: str,

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_human_assisted_resolution.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_human_assisted_resolution.py
@@ -62,20 +62,33 @@ def _reply_event(*, thread_ts="111.222", ts="111.900", user="U_OTHER", channel="
     return {"thread_ts": thread_ts, "ts": ts, "user": user, "channel": channel}
 
 
+def _existing_conversation(**metadata_overrides: object) -> dict[str, object]:
+    return {
+        "conversation_id": "conv-1",
+        "metadata": {
+            "channel_id": "C123",
+            "thread_owner_agent_id": "test-agent",
+            "originator_slack_user_id": "U_ORIG",
+            **metadata_overrides,
+        },
+    }
+
+
 class TestFlagHumanAssistedIfForeign:
     def test_foreign_reply_flags_thread(self, monkeypatch):
         app = _load_slack_app(monkeypatch)
         with patch.object(app, "session_manager") as sm, \
-             patch.object(app, "sse_client") as sse, \
-             patch.object(app, "_resolve_conversation_id", return_value="conv-1") as resolve:
-            sm.get_thread_owner.return_value = "test-agent"
+             patch.object(app, "sse_client") as sse:
             sm.get_thread_originator.return_value = "U_ORIG"
             sm.is_human_assisted.return_value = False
+            sse.get_conversation_by_idempotency_key.return_value = _existing_conversation()
 
             app._flag_human_assisted_if_foreign(_reply_event(user="U_OTHER"), Mock())
 
-            resolve.assert_called_once()
+            sse.get_conversation_by_idempotency_key.assert_called_once_with("111.222")
             sse.update_conversation_metadata.assert_called_once_with("conv-1", {"human_assisted": True})
+            sm.set_thread_owner.assert_called_once_with("111.222", "test-agent")
+            sm.set_thread_originator.assert_called_once_with("111.222", "U_ORIG")
             sm.set_human_assisted.assert_called_once_with("111.222")
 
     def test_originator_reply_does_not_flag(self, monkeypatch):
@@ -88,28 +101,49 @@ class TestFlagHumanAssistedIfForeign:
 
             app._flag_human_assisted_if_foreign(_reply_event(user="U_ORIG"), Mock())
 
+            sse.get_conversation_by_idempotency_key.assert_not_called()
             sse.update_conversation_metadata.assert_not_called()
             sm.set_human_assisted.assert_not_called()
 
-    def test_non_bot_owned_thread_skipped(self, monkeypatch):
-        """No thread owner ⇒ bot never engaged ⇒ never create a phantom conversation."""
+    def test_cache_cold_after_restart_uses_durable_anchors(self, monkeypatch):
+        app = _load_slack_app(monkeypatch)
+        with patch.object(app, "session_manager") as sm, \
+             patch.object(app, "sse_client") as sse:
+            sm.get_thread_originator.return_value = None
+            sm.is_human_assisted.return_value = False
+            sse.get_conversation_by_idempotency_key.return_value = _existing_conversation()
+
+            app._flag_human_assisted_if_foreign(_reply_event(user="U_OTHER"), Mock())
+
+            sse.update_conversation_metadata.assert_called_once_with("conv-1", {"human_assisted": True})
+            sm.set_thread_owner.assert_called_once_with("111.222", "test-agent")
+            sm.set_thread_originator.assert_called_once_with("111.222", "U_ORIG")
+
+    def test_unknown_thread_does_not_create_phantom_conversation(self, monkeypatch):
         app = _load_slack_app(monkeypatch)
         with patch.object(app, "session_manager") as sm, \
              patch.object(app, "sse_client") as sse, \
              patch.object(app, "_resolve_conversation_id") as resolve:
-            sm.get_thread_owner.return_value = None
+            sm.get_thread_originator.return_value = None
+            sm.is_human_assisted.return_value = False
+            sse.get_conversation_by_idempotency_key.return_value = None
 
             app._flag_human_assisted_if_foreign(_reply_event(), Mock())
 
-            resolve.assert_not_called()
+            sse.get_conversation_by_idempotency_key.assert_called_once_with("111.222")
+            sse.create_conversation.assert_not_called()
             sse.update_conversation_metadata.assert_not_called()
+            resolve.assert_not_called()
 
-    def test_unknown_originator_skipped(self, monkeypatch):
+    def test_incomplete_durable_anchors_are_skipped(self, monkeypatch):
         app = _load_slack_app(monkeypatch)
         with patch.object(app, "session_manager") as sm, \
              patch.object(app, "sse_client") as sse:
-            sm.get_thread_owner.return_value = "test-agent"
             sm.get_thread_originator.return_value = None
+            sm.is_human_assisted.return_value = False
+            sse.get_conversation_by_idempotency_key.return_value = _existing_conversation(
+                thread_owner_agent_id="",
+            )
 
             app._flag_human_assisted_if_foreign(_reply_event(), Mock())
 
@@ -119,10 +153,39 @@ class TestFlagHumanAssistedIfForeign:
         app = _load_slack_app(monkeypatch)
         with patch.object(app, "session_manager") as sm, \
              patch.object(app, "sse_client") as sse:
-            sm.get_thread_owner.return_value = "test-agent"
             sm.get_thread_originator.return_value = "U_ORIG"
             sm.is_human_assisted.return_value = True
 
             app._flag_human_assisted_if_foreign(_reply_event(user="U_OTHER"), Mock())
+
+            sse.get_conversation_by_idempotency_key.assert_not_called()
+            sse.update_conversation_metadata.assert_not_called()
+
+    def test_persisted_human_assisted_skips_duplicate_patch(self, monkeypatch):
+        app = _load_slack_app(monkeypatch)
+        with patch.object(app, "session_manager") as sm, \
+             patch.object(app, "sse_client") as sse:
+            sm.get_thread_originator.return_value = None
+            sm.is_human_assisted.return_value = False
+            sse.get_conversation_by_idempotency_key.return_value = _existing_conversation(
+                human_assisted=True,
+            )
+
+            app._flag_human_assisted_if_foreign(_reply_event(), Mock())
+
+            sse.update_conversation_metadata.assert_not_called()
+            sm.set_human_assisted.assert_called_once_with("111.222")
+
+    def test_channel_mismatch_is_skipped(self, monkeypatch):
+        app = _load_slack_app(monkeypatch)
+        with patch.object(app, "session_manager") as sm, \
+             patch.object(app, "sse_client") as sse:
+            sm.get_thread_originator.return_value = None
+            sm.is_human_assisted.return_value = False
+            sse.get_conversation_by_idempotency_key.return_value = _existing_conversation(
+                channel_id="C_OTHER",
+            )
+
+            app._flag_human_assisted_if_foreign(_reply_event(channel="C123"), Mock())
 
             sse.update_conversation_metadata.assert_not_called()

--- a/ai_platform_engineering/integrations/slack_bot/tests/test_sse_client.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_sse_client.py
@@ -5,7 +5,7 @@
 import json
 import uuid
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from ai_platform_engineering.integrations.slack_bot.sse_client import (
   SSEClient,
@@ -116,6 +116,51 @@ class TestSSEClientInit:
     client = SSEClient("http://example.com")
     headers = client._get_headers()
     assert "Authorization" not in headers
+
+
+class TestSSEClientConversationLookup:
+  """Tests for the read-only idempotency-key lookup."""
+
+  @patch("ai_platform_engineering.integrations.slack_bot.sse_client.httpx.Client")
+  def test_returns_existing_conversation(self, http_client):
+    response = Mock(status_code=200)
+    response.json.return_value = {
+      "success": True,
+      "data": {
+        "conversation": {
+          "_id": "conv-1",
+          "metadata": {"originator_slack_user_id": "U_ORIG"},
+        },
+      },
+    }
+    transport = http_client.return_value.__enter__.return_value
+    transport.get.return_value = response
+    client = SSEClient("http://example.com")
+
+    result = client.get_conversation_by_idempotency_key("111.222")
+
+    assert result == {
+      "conversation_id": "conv-1",
+      "metadata": {"originator_slack_user_id": "U_ORIG"},
+    }
+    transport.get.assert_called_once_with(
+      "http://example.com/api/chat/conversations/lookup",
+      params={"idempotency_key": "111.222", "client_type": "slack"},
+      headers={
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-Client-Source": "slack-bot",
+      },
+    )
+
+  @patch("ai_platform_engineering.integrations.slack_bot.sse_client.httpx.Client")
+  def test_returns_none_when_conversation_does_not_exist(self, http_client):
+    response = Mock(status_code=404)
+    transport = http_client.return_value.__enter__.return_value
+    transport.get.return_value = response
+    client = SSEClient("http://example.com")
+
+    assert client.get_conversation_by_idempotency_key("111.222") is None
 
 
 class TestSSEClientParseEvent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.55-dev.5"
+version = "0.5.55-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/__tests__/chat-conversation-lookup.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversation-lookup.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockGetCollection = jest.fn();
+const mockRequireConversationResourcePermission = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) =>
+      mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) =>
+      Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          return Response.json(
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+            },
+            { status: (error as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock("@/lib/rbac/conversation-implicit-authz", () => ({
+  requireConversationResourcePermission: (...args: unknown[]) =>
+    mockRequireConversationResourcePermission(...args),
+}));
+
+function request(query = "idempotency_key=111.222"): NextRequest {
+  return new NextRequest(
+    new URL(`/api/chat/conversations/lookup?${query}`, "http://localhost:3000"),
+  );
+}
+
+const conversation = {
+  _id: "11111111-1111-4111-8111-111111111111",
+  title: "Example conversation",
+  client_type: "slack",
+  owner_id: "test-user@example.com",
+  idempotency_key: "111.222",
+  metadata: {
+    channel_id: "C123",
+    originator_slack_user_id: "U_ORIG",
+    thread_owner_agent_id: "primary",
+  },
+};
+
+describe("GET /api/chat/conversations/lookup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      user: { email: "service-account@example.com" },
+      session: { sub: "service-account-sub", isServiceAccount: true },
+    });
+    mockRequireConversationResourcePermission.mockResolvedValue(undefined);
+  });
+
+  it("returns an authorized existing Slack conversation without creating one", async () => {
+    const findOne = jest.fn().mockResolvedValue(conversation);
+    mockGetCollection.mockResolvedValue({ findOne });
+    const { GET } = await import("../chat/conversations/lookup/route");
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(findOne).toHaveBeenCalledWith({
+      idempotency_key: "111.222",
+      client_type: "slack",
+      $or: [{ deleted_at: null }, { deleted_at: { $exists: false } }],
+    });
+    expect(mockRequireConversationResourcePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ isServiceAccount: true }),
+      "service-account@example.com",
+      conversation,
+      "read",
+    );
+    expect(body.data.conversation).toEqual({
+      _id: conversation._id,
+      client_type: "slack",
+      metadata: conversation.metadata,
+    });
+  });
+
+  it("returns 404 without mutating when the key is unknown", async () => {
+    const findOne = jest.fn().mockResolvedValue(null);
+    mockGetCollection.mockResolvedValue({ findOne });
+    const { GET } = await import("../chat/conversations/lookup/route");
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(404);
+    expect(mockRequireConversationResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("enforces per-conversation read permission", async () => {
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(conversation),
+    });
+    mockRequireConversationResourcePermission.mockRejectedValue(
+      Object.assign(new Error("Permission denied"), { statusCode: 403 }),
+    );
+    const { GET } = await import("../chat/conversations/lookup/route");
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects a missing idempotency key before querying MongoDB", async () => {
+    const { GET } = await import("../chat/conversations/lookup/route");
+
+    const response = await GET(request(""));
+
+    expect(response.status).toBe(400);
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown client type", async () => {
+    const { GET } = await import("../chat/conversations/lookup/route");
+
+    const response = await GET(
+      request("idempotency_key=111.222&client_type=unknown"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/chat/conversations/lookup/route.ts
+++ b/ui/src/app/api/chat/conversations/lookup/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/chat/conversations/lookup
+ *
+ * Resolve an existing conversation by its integration idempotency key without
+ * creating one. This is used by stateless integrations that need to recover
+ * durable conversation metadata after a process restart.
+ */
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
+import { requireConversationResourcePermission } from "@/lib/rbac/conversation-implicit-authz";
+import type { ClientType, Conversation } from "@/types/mongodb";
+import { VALID_CLIENT_TYPES } from "@/types/mongodb";
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_IDEMPOTENCY_KEY_LENGTH = 256;
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "MongoDB not configured",
+        code: "MONGODB_NOT_CONFIGURED",
+      },
+      { status: 503 },
+    );
+  }
+
+  const { user, session } = await getAuthFromBearerOrSession(request);
+  const url = new URL(request.url);
+  const idempotencyKey = url.searchParams.get("idempotency_key")?.trim() ?? "";
+  const clientType = (url.searchParams.get("client_type")?.trim() || "slack") as ClientType;
+
+  if (!idempotencyKey || idempotencyKey.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+    throw new ApiError("A valid idempotency_key is required", 400);
+  }
+  if (!VALID_CLIENT_TYPES.includes(clientType)) {
+    throw new ApiError(`Invalid client_type: "${clientType}"`, 400);
+  }
+
+  const conversations = await getCollection<Conversation>("conversations");
+  const conversation = await conversations.findOne({
+    idempotency_key: idempotencyKey,
+    client_type: clientType,
+    $or: [{ deleted_at: null }, { deleted_at: { $exists: false } }],
+  });
+
+  if (!conversation) {
+    throw new ApiError("Conversation not found", 404);
+  }
+
+  await requireConversationResourcePermission(session, user.email, conversation, "read");
+
+  return successResponse({
+    conversation: {
+      _id: conversation._id,
+      client_type: conversation.client_type,
+      metadata: conversation.metadata ?? {},
+    },
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.55.dev5"
+version = "0.5.55.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Follow-up to #2209.

Slack self-resolution detection kept its thread owner and originator in process-local caches. After a bot restart or cache expiry, an ordinary non-mention reply from another human was ignored, so the conversation could remain incorrectly classified as self-resolved.

This change:

- Adds an authenticated, read-only conversation lookup by integration idempotency key.
- Gates lookup results with the existing per-conversation read permission.
- Recovers the persisted Slack channel, thread owner, originator, and human-assisted state after restart.
- Validates the stored channel and both durable anchors before updating metadata.
- Removes create/upsert calls from the observe-only reply path, so an unknown Slack thread cannot create a phantom conversation.

## Validation

- `uv run ruff check`
- Slack bot suite: 553 passed
- Lookup route tests: 5 passed
- `npm run lint`
- `npm exec tsc -- --noEmit`
- `npm run build`

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
