### PR TITLE
fix(ci): scope GitHub App token permissions in prebuild artifact comment workflow

### DIFF
--- a/.github/workflows/prebuild-artifact-comment.yml
+++ b/.github/workflows/prebuild-artifact-comment.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BUILD_APP_ID }}
           private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
+          permission-actions: read
+          permission-issues: write
+          permission-pull-requests: read
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6


### PR DESCRIPTION
## Summary
- `prebuild-artifact-comment.yml` minted a GitHub App token via `create-github-app-token` without restricting its `permission-*` inputs, so the token inherited the App's full blanket installation permissions instead of just what the reconciler script uses.
- zizmor flagged this as "dangerous use of GitHub App tokens: app token inherits blanket installation permissions" (job-level `permissions:` only governs the default `GITHUB_TOKEN`, not App tokens minted in a step).
- Scoped the `create-github-app-token` step down to `permission-actions: read`, `permission-issues: write`, `permission-pull-requests: read` — matching exactly what `.github/scripts/reconcile-prebuild-artifacts.py` calls (list workflow runs/artifacts + download artifact zips, create/update/delete PR issue comments, read PR head SHA). No `contents` calls exist in the script, so that permission is omitted.
- Mirrors the identical, already-passing pattern used for the same App/script shape in `coverage-comment.yml`.

Pre-existing on `main` (unrelated to any other recent PR); noticed via a zizmor CI run: https://github.com/cnoe-io/ai-platform-engineering/actions/runs/29760336842/job/88413078389

## Test plan
- [x] `uvx --from zizmor==1.25.2 zizmor --min-severity high --min-confidence high .github/workflows/prebuild-artifact-comment.yml` → no findings (matches the repo's zizmor CI gate)
- [x] Confirmed the script's actual GitHub API calls against the granted permissions (no over- or under-scoping)
