### PR TITLE
docs(releases): add release blog posts and changelog entries for 0.5.53, 0.5.54, 0.5.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.55 (2026-07-17)
+
+### Feat
+
+- support multiple Webex bots and 1:1 direct messages (#2184)
+- **platform**: add per-surface default agents for web, Slack, and Webex (#2233)
+
 ## 0.5.54-dev.3 (2026-07-17)
 
 ### Feat
@@ -13,6 +20,22 @@
 - **platform**: add per-surface default agents (#2233)
 
 ## 0.5.54 (2026-07-16)
+
+### Feat
+
+- **ui**: improve admin access preview and default agents (#2218)
+- **ui**: animate shared tab selectors (#2217)
+
+### Fix
+
+- **admin-users**: create team_membership_sources index at boot, not via migration
+- **admin-users**: drop stray teams dep causing double-fetch on Users tab
+- **admin-users**: paginate team membership lookup in Mongo, not Node
+- **admin-users**: page team-scoped Keycloak lookups for plain members
+- **slack-bot**: resolve channel_id from view.private_metadata for modal submits
+- **slack-bot**: bind OBO token in feedback/retry/escalation handlers
+- **slack-bot**: register conversation before VictorOps on-call lookup
+- **ui**: eliminate lint violations and enforce CI (#2211)
 
 ## 0.5.53-dev.5 (2026-07-16)
 
@@ -54,6 +77,17 @@
 - **ui**: animate shared tab selectors (#2217)
 
 ## 0.5.53 (2026-07-15)
+
+### Feat
+
+- **keycloak**: configurable SSO session lifetime, default 7d idle / 14d max
+- **ui**: add 'Choose agent' button alongside 'Resume with default agent' in deprecated-agent banner
+
+### Fix
+
+- **ui**: remove AccessTokenMissing dead code and clear auth flag on recovery
+- **ui**: patch Zustand store after re-linking deprecated-agent conversation
+- **ui**: show history and resume CTA for deprecated-agent conversations
 
 ## 0.5.52-dev.2 (2026-07-15)
 

--- a/docs/releases/2026-07-15-release-0-5-53.md
+++ b/docs/releases/2026-07-15-release-0-5-53.md
@@ -1,0 +1,71 @@
+---
+slug: release-0.5.53
+title: "Release 0.5.53 — Configurable Session Lifetime and Deprecated-Agent Recovery"
+date: 2026-07-15
+authors: [sriaradhyula, cisco-erilutz, subbaksh]
+tags: [release]
+---
+
+> Released: 2026-07-15
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.53`
+> Previous release: 0.5.52
+
+## Highlights
+
+0.5.53 extends default SSO session lifetimes so users are no longer signed out after eight hours of inactivity, and improves the experience when an agent has been deprecated — users can now pick a replacement or pick up a conversation where they left off without losing context.
+
+<!-- truncate -->
+
+## New Features
+
+### Longer default session lifetime
+
+The default Keycloak SSO session lifetime increases from 8 hours idle / 24 hours maximum to **7 days idle / 14 days maximum**. Users who authenticate via an external identity provider (such as Duo SSO) are no longer forced to sign in again each day as long as they stay active within the window.
+
+The idle timeout resets on each page visit, so a working user will not be interrupted. Operators can tune the values to match their organization's policy without modifying the chart — see the upgrade guide below.
+
+### Deprecated-agent recovery
+
+When a conversation is linked to an agent that has since been deprecated, the UI now shows the full conversation history and offers two clear recovery paths:
+
+- **Choose agent** — opens the agent selector so the user can link the conversation to a different agent and continue.
+- **Resume with default agent** — re-links to the platform default in one click.
+
+Previously, deprecated-agent conversations showed a partial view with no clear way forward.
+
+## Bug Fixes
+
+- **Session recovery**: Clearing a stale auth flag on successful token recovery prevents a stale error state from appearing after silent refresh completes.
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.52.
+
+---
+
+## Upgrade Guide: 0.5.52 → 0.5.53
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.52 and 0.5.53.
+
+### Session lifetime behavior
+
+The updated SSO defaults take effect the next time `keycloak-init` runs (on pod start for Helm deployments, or `docker compose run --rm keycloak-init` for Compose). Existing realms that were already initialized retain their previous values until init-idp is re-applied.
+
+To customize the limits without changing the chart, set any of these in your `values.yaml` under the `keycloak` subchart env block, or in `.env` for Compose:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KEYCLOAK_SSO_SESSION_IDLE_TIMEOUT` | `604800` (7 d) | Idle timeout in seconds |
+| `KEYCLOAK_SSO_SESSION_MAX_LIFESPAN` | `1209600` (14 d) | Absolute max session length in seconds |
+| `KEYCLOAK_ACCESS_TOKEN_LIFESPAN` | `3600` (1 h) | Access-token TTL in seconds |
+
+### Upgrade Runbook
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.53 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-16-release-0-5-54.md
+++ b/docs/releases/2026-07-16-release-0-5-54.md
@@ -1,0 +1,79 @@
+---
+slug: release-0.5.54
+title: "Release 0.5.54 — Admin Access Preview and Slack Bot Reliability"
+date: 2026-07-16
+authors: [sriaradhyula, suwhang-cisco, cisco-erilutz]
+tags: [release]
+---
+
+> Released: 2026-07-16
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.54`
+> Previous release: 0.5.53
+
+## Highlights
+
+0.5.54 delivers a fully rebuilt admin access preview that accurately simulates what any user or team can see without touching their session, consolidates default agent settings into a single organized surface, and fixes a set of Slack bot reliability issues that were causing escalation and on-call flows to fail silently.
+
+<!-- truncate -->
+
+## New Features
+
+### Admin access preview rebuilt
+
+The **View As** mode in Admin now provides an accurate, read-only simulation of any user or team's effective access. The admin's own session is never modified — no target-user token is minted, and no state is altered. The preview reflects the selected subject's navigation access, data visibility, and team membership exactly as they would experience it.
+
+Administrators can switch preview subjects without stale data from the previous subject carrying over.
+
+([#2218](https://github.com/cnoe-io/ai-platform-engineering/pull/2218))
+
+### Consolidated default agent settings
+
+The Settings surface now has a single **Default Agent** card. Each user can set a personal default for the web interface via a compact dropdown, and administrators see a clearly separated section for platform-wide controls. The platform default is shown as the fallback option in the personal selector, so the effective resolution is always visible.
+
+The Import Agents action moves into the admin-only Agents tab, where it belongs.
+
+([#2218](https://github.com/cnoe-io/ai-platform-engineering/pull/2218))
+
+### Animated tab navigation
+
+Tab selectors across the Admin surface now animate smoothly using a shared measured indicator. The indicator moves between tabs on the same navigation level without stretching or jitter. A reduced-motion preference disables the animation. Keyboard and accessibility behavior is unchanged.
+
+([#2217](https://github.com/cnoe-io/ai-platform-engineering/pull/2217))
+
+## Bug Fixes
+
+### Admin user list performance
+
+The Users and Teams admin page no longer fetches all members and then filters in the browser. Lookups are now paginated and scoped to the team in Mongo and Keycloak, which significantly reduces load time for organizations with large user bases.
+
+- Team membership index is created at service startup rather than via a migration step.
+- Team-scoped Keycloak lookups are paginated to avoid hitting response size limits.
+
+### Slack bot escalation and feedback reliability
+
+Several Slack bot action handlers — feedback, retry, escalation — were failing because they could not resolve which conversation to associate the action with. The fixes ensure the correct conversation identity is resolved before any downstream call:
+
+- Modal submit handlers now read the conversation reference from the correct field in the submission payload.
+- Feedback, retry, and escalation handlers attach the correct access token before making downstream calls.
+- On-call lookup via escalation paths now registers the conversation first, preventing dropped events when the lookup fires before the conversation exists.
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.53.
+
+---
+
+## Upgrade Guide: 0.5.53 → 0.5.54
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.53 and 0.5.54. Drop-in upgrade.
+
+### Upgrade Runbook
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.54 \
+  -f your-values.yaml
+```

--- a/docs/releases/2026-07-17-release-0-5-55.md
+++ b/docs/releases/2026-07-17-release-0-5-55.md
@@ -1,0 +1,160 @@
+---
+slug: release-0.5.55
+title: "Release 0.5.55 — Multiple Webex Bots and Per-Surface Default Agents"
+date: 2026-07-17
+authors: [sriaradhyula, suwhang-cisco, cisco-erilutz, subbaksh]
+tags: [release]
+---
+
+> Released: 2026-07-17
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.55`
+> Previous release: 0.5.54
+
+## Highlights
+
+0.5.55 significantly expands the Webex integration: a single deployment can now host multiple distinct Webex bots, each routing to different agents and enforcing independent direct-message access policies. Separately, users can now set independent default agents for the web interface, Slack, and Webex rather than sharing one platform-wide DM default.
+
+**Webex bot operators:** this release changes the bot configuration format. See the upgrade guide for migration steps.
+
+<!-- truncate -->
+
+## New Features
+
+### Multiple Webex bots on one deployment
+
+Operators can now configure any number of Webex bot identities within a single platform deployment. Each bot is independent:
+
+- Routes its group spaces to a designated agent and team.
+- Enforces its own direct-message access policy: `disabled`, `allowlist`, or open to all users.
+- Carries its own bot token, so each identity authenticates separately.
+
+This makes it possible, for example, to have a general-purpose bot in shared spaces and a restricted bot for a specific team — both running on the same platform.
+
+**Legacy migration**: Existing space-to-agent assignments created before this release do not carry a bot identity. A **Legacy Migration** tab in the Admin UI lists all spaces in this state so operators can assign them to the correct bot before cutting over.
+
+([#2184](https://github.com/cnoe-io/ai-platform-engineering/pull/2184))
+
+### Per-surface default agents
+
+Users can now set independent default agents for each surface they use:
+
+- **Web** — the agent that opens when starting a new conversation in the browser.
+- **Slack** — the agent that handles direct messages to the Slack bot.
+- **Webex** — the agent that handles direct messages to a Webex bot.
+
+Slack and Webex selectors appear only when those integrations are active on the platform. The platform-wide default remains the fallback for any surface without a personal preference. Admins set the platform default from Admin > Settings > Agents.
+
+The legacy shared DM default is retired. Existing selections fall back to the platform default automatically; an optional cleanup migration is available from the Admin tracked-migrations UI.
+
+([#2233](https://github.com/cnoe-io/ai-platform-engineering/pull/2233))
+
+## Breaking Changes
+
+### Webex bot configuration format changed
+
+The previous flat env-var approach for Webex bot defaults (`WEBEX_DEFAULT_TEAM_SLUG`, `WEBEX_DEFAULT_AGENT_ID`, `WEBEX_AUTO_ASSIGN_UNMAPPED_SPACES`) is replaced by a structured `bots` array in Helm values. See the upgrade guide below.
+
+**This only affects deployments with `tags.webex-bot: true`.** Deployments that do not run the Webex bot are unaffected.
+
+---
+
+## Upgrade Guide: 0.5.54 → 0.5.55
+
+### Helm Values Changes
+
+#### Webex bot multi-bot configuration (breaking for webex-bot users)
+
+The following env vars are **removed** from the `webex-bot` subchart:
+
+| Removed key | Replacement |
+|-------------|-------------|
+| `WEBEX_DEFAULT_TEAM_SLUG` | `webex-bot.bots[*].spaces.defaultTeamSlug` |
+| `WEBEX_DEFAULT_AGENT_ID` | `webex-bot.bots[*].spaces.defaultAgentId` or `webex-bot.bots[*].directMessages.defaultAgentId` |
+| `WEBEX_AUTO_ASSIGN_UNMAPPED_SPACES` | replaced by per-bot `spaces.accessMode` |
+
+The new configuration uses a `bots` array. Each entry describes one bot identity:
+
+**Before (0.5.54)**:
+```yaml
+webex-bot:
+  env:
+    WEBEX_DEFAULT_TEAM_SLUG: "platform"
+    WEBEX_DEFAULT_AGENT_ID: "agent-platform"
+    WEBEX_AUTO_ASSIGN_UNMAPPED_SPACES: "false"
+```
+
+**After (0.5.55)**:
+```yaml
+webex-bot:
+  bots:
+    - id: "primary"
+      name: "Platform Bot"
+      tokenEnv: "WEBEX_BOT_TOKEN"   # env var holding the bot token in your secret
+      spaces:
+        accessMode: "all_spaces"       # or "allowlist"
+        defaultTeamSlug: "platform"
+        defaultAgentId: "agent-platform"
+      directMessages:
+        accessMode: "all_users"        # or "disabled" or "allowlist"
+        defaultAgentId: "agent-platform"
+```
+
+#### Per-surface default agent migration (optional)
+
+The legacy `dm_default_agent_id` field in user preferences is retired. Existing values fall back to the platform default automatically — no action required. To clean up the retired field from the database, run the **`user_preferences_default_agent_cleanup_v1`** migration from Admin > Tracked Migrations after upgrading.
+
+### Upgrade Runbook
+
+#### 1. Update your values.yaml
+
+If you run the Webex bot (`tags.webex-bot: true`), replace the removed env vars with the new `bots` array as shown above.
+
+#### 2. Upgrade the chart
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.55 \
+  -f your-values.yaml
+```
+
+#### 3. Assign legacy Webex spaces (Webex bot only)
+
+After the upgrade, open Admin > Integrations > Legacy Migration and assign any unattributed spaces to the correct bot.
+
+#### 4. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+### Full Values Diff
+
+<details>
+<summary>Raw diff (0.5.54 → 0.5.55)</summary>
+
+```diff
+-    WEBEX_DEFAULT_TEAM_SLUG: ""
+-    WEBEX_DEFAULT_AGENT_ID: ""
+     WEBEX_THREAD_CONTEXT_ENABLED: "true"
+     WEBEX_THREAD_CONTEXT_MAX_MESSAGES: "10"
+     WEBEX_THREAD_CONTEXT_MAX_CHARS: "4000"
+-    WEBEX_AUTO_ASSIGN_UNMAPPED_SPACES: "false"
+-    WEBEX_DEFAULT_TEAM_SLUG: ""
+-    WEBEX_DEFAULT_AGENT_ID: ""
++  # One runtime pod can host multiple bot identities. Each bot owns its group
++  # space and direct-message policy. Automatic modes require both defaults.
++  bots: []
++    # - id: "primary"
++    #   name: "Primary bot"
++    #   tokenEnv: "PRIMARY_WEBEX_BOT_TOKEN"
++    #   spaces:
++    #     accessMode: "all_spaces"
++    #     defaultTeamSlug: "platform"
++    #     defaultAgentId: "agent-platform"
++    #   directMessages:
++    #     accessMode: "all_users"
++    #     defaultAgentId: "agent-personal"
+```
+
+</details>


### PR DESCRIPTION
# Description

Adds the missing release blog posts for 0.5.53, 0.5.54, and 0.5.55, and fills in the previously-empty stable entries in CHANGELOG.md.

**Blog posts added** (`docs/releases/`):
- **0.5.53** — Configurable SSO session lifetime (7d idle / 14d max), deprecated-agent recovery UX (Choose agent button, history + resume CTA)
- **0.5.54** — Rebuilt admin View-As access preview, consolidated default agent settings, admin-users pagination fixes, Slack bot escalation/feedback reliability fixes
- **0.5.55** — Multiple Webex bots per deployment (one pod, many identities), per-surface default agents (Web / Slack / Webex independent defaults); includes breaking-change migration guide for webex-bot operators

**CHANGELOG.md**:
- Added `## 0.5.55 (2026-07-17)` stable entry (was missing entirely)
- Populated `## 0.5.53` and `## 0.5.54` stable entries with aggregated feat/fix content from their dev releases (previously empty)

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable — documentation only.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass