### PR TITLE
fix(helm): auto-wire OpenFGA/RBAC env vars and validate dependencies (#2252)

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/configmap.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/configmap.yaml
@@ -19,7 +19,9 @@ data:
   # `SKILL_SCANNER_URL`. Plain literals pass through unchanged because `tpl`
   # is a no-op when the template body has no actions.
   {{- range $key, $value := .Values.config }}
+  {{- if not (eq (toString $value) "") }}
   {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+  {{- end }}
   {{- end }}
   {{- /* R1 upstream fix (May 2026): when an operator wires up the
          Keycloak Admin REST client via keycloakAdminClient.secretName,
@@ -65,4 +67,23 @@ data:
   {{- if .Values.oktaSync.groupFilter }}
   IDENTITY_SYNC_OKTA_GROUP_FILTER: {{ .Values.oktaSync.groupFilter | quote }}
   {{- end }}
+  {{- end }}
+  {{- /* OpenFGA / Keycloak IdP identity sync — default OIDC group claim wiring
+         when login-time reconciliation is enabled. Operators may override any
+         key via caipe-ui.config. Mirror keycloak.idp into caipe-ui.keycloakIdp
+         when Keycloak brokers an upstream IdP (e.g. duo-sso). */ -}}
+  {{- $openfgaIntent := or (eq (toString (index .Values.config "OPENFGA_RECONCILE_ENABLED" | default "")) "true") (eq (toString (index .Values.config "IDENTITY_SYNC_LOGIN_CLAIMS_ENABLED" | default "")) "true") (index .Values.config "BOOTSTRAP_ADMIN_EMAILS" | default "") -}}
+  {{- if and $openfgaIntent (not (hasKey .Values.config "IDENTITY_SYNC_OIDC_CLAIM_PROVIDER_ID")) }}
+  IDENTITY_SYNC_OIDC_CLAIM_PROVIDER_ID: "oidc-claims"
+  {{- end }}
+  {{- if and $openfgaIntent (not (hasKey .Values.config "OIDC_GROUP_CLAIM")) }}
+  OIDC_GROUP_CLAIM: "members,groups"
+  {{- end }}
+  {{- $idp := .Values.keycloakIdp | default dict -}}
+  {{- if and $idp.enabled (not (hasKey .Values.config "OIDC_IDP_HINT")) }}
+  OIDC_IDP_HINT: {{ $idp.alias | default "duo-sso" | quote }}
+  {{- end }}
+  {{- $agwEnabled := dig "agentgateway" "enabled" false (.Values.global | default dict) -}}
+  {{- if and $agwEnabled (not (hasKey .Values.config "OIDC_EXTRA_AUDIENCES")) }}
+  OIDC_EXTRA_AUDIENCES: "caipe-platform"
   {{- end }}

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ index .Values.config "OIDC_DISCOVERY_URL" | default (printf "http://%s-keycloak:8080/realms/%s" .Release.Name (index .Values.config "KEYCLOAK_REALM" | default "caipe")) | quote }}
             - name: SLACK_BOT_ADMIN_TOKEN_URL
               value: {{ index .Values.config "SLACK_BOT_ADMIN_TOKEN_URL" | default (printf "http://%s-keycloak:8080/realms/%s/protocol/openid-connect/token" .Release.Name (index .Values.config "KEYCLOAK_REALM" | default "caipe")) | quote }}
+            - name: WEBEX_BOT_ADMIN_TOKEN_URL
+              value: {{ index .Values.config "WEBEX_BOT_ADMIN_TOKEN_URL" | default (printf "http://%s-keycloak:8080/realms/%s/protocol/openid-connect/token" .Release.Name (index .Values.config "KEYCLOAK_REALM" | default "caipe")) | quote }}
             - name: OPENFGA_HTTP
               value: {{ index .Values.config "OPENFGA_HTTP" | default (printf "http://%s-openfga:8080" .Release.Name) | quote }}
             - name: SLACK_BOT_ADMIN_URL

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -413,6 +413,13 @@ existingSecret: ""
 # Leave `secretName` empty in standalone caipe-ui dev installs (where
 # the BFF talks to an external Keycloak via its own credentials in
 # `existingSecret` or `OIDC_CLIENT_SECRET`).
+#
+# Mirror `keycloak.idp` from the umbrella chart when Keycloak brokers an
+# upstream IdP — enables auto-wiring of OIDC_IDP_HINT in the ConfigMap.
+keycloakIdp:
+  enabled: false
+  alias: "duo-sso"
+
 keycloakAdminClient:
   # Name of the K8s Secret holding the Keycloak Admin REST client_secret.
   # Defaults to "" in the standalone subchart; the umbrella sets this to

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
@@ -101,6 +101,20 @@ True when metrics run on a port different from the main service port.
 {{- and .Values.service.metricsPort (ne (int .Values.service.metricsPort) (int .Values.service.port)) -}}
 {{- end -}}
 
+{{/*
+AgentGateway MCP URL — mirrors caipe-ui deployment defaults (#2252).
+*/}}
+{{- define "dynamic-agents.agentgateway.enabled" -}}
+{{- dig "agentgateway" "enabled" false (.Values.global | default dict) -}}
+{{- end -}}
+
+{{- define "dynamic-agents.agentgateway.mcpUrl" -}}
+{{- $agwStatic := eq (dig "agentgateway" "routingMode" "static" (.Values.global | default dict)) "static" -}}
+{{- $host := ternary (printf "%s-agentgateway" .Release.Name) (printf "%s-agentgateway-proxy" .Release.Name) $agwStatic -}}
+{{- $port := ternary 4000 (int (dig "agentgateway" "proxyPort" 8080 (.Values.global | default dict))) $agwStatic -}}
+{{- printf "http://%s:%v" $host $port -}}
+{{- end -}}
+
 {/*
 Resolve maintained CAIPE image repositories for release vs pre-release channels.
 

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/deployment.yaml
@@ -59,6 +59,18 @@ spec:
               value: {{ index .Values.config "KEYCLOAK_URL" | default (printf "http://%s-keycloak:8080" .Release.Name) | quote }}
             - name: OPENFGA_HTTP
               value: {{ index .Values.config "OPENFGA_HTTP" | default (printf "http://%s-openfga:8080" .Release.Name) | quote }}
+            - name: CAIPE_API_URL
+              value: {{ index .Values.config "CAIPE_API_URL" | default (printf "http://%s-caipe-ui:3000" .Release.Name) | quote }}
+            - name: AUTHZ_SERVICE_URL
+              value: {{ index .Values.config "AUTHZ_SERVICE_URL" | default (printf "http://%s-caipe-ui:3000" .Release.Name) | quote }}
+            - name: OPENFGA_STORE_NAME
+              value: {{ index .Values.config "OPENFGA_STORE_NAME" | default "caipe-openfga" | quote }}
+            {{- if eq (include "dynamic-agents.agentgateway.enabled" .) "true" }}
+            - name: AGENT_GATEWAY_URL
+              value: {{ index .Values.config "AGENT_GATEWAY_URL" | default (include "dynamic-agents.agentgateway.mcpUrl" .) | quote }}
+            - name: USE_IMPERSONATION_TOKENS
+              value: {{ index .Values.config "USE_IMPERSONATION_TOKENS" | default "true" | quote }}
+            {{- end }}
             - name: CREDENTIAL_API_URL
               value: {{ index .Values.config "CREDENTIAL_API_URL" | default (printf "http://%s-caipe-ui:3000/api/credentials" .Release.Name) | quote }}
             - name: AUDIT_SERVICE_URL

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -166,7 +166,9 @@ config:
   CAIPE_CREDENTIALS_ENABLED: "false"
   CREDENTIAL_API_URL: ""
   CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
-  USE_IMPERSONATION_TOKENS: "false"
+  # When AgentGateway is enabled, the Deployment defaults this to "true" unless
+  # explicitly set here. Leave empty to accept the gateway-aware default.
+  USE_IMPERSONATION_TOKENS: ""
   # Agent runtime TTL in seconds (purged after this much inactivity)
   AGENT_RUNTIME_TTL_SECONDS: "60"
   # Set to "true" to enable multi-turn conversation history via POST /invoke.

--- a/charts/ai-platform-engineering/templates/_wiring.tpl
+++ b/charts/ai-platform-engineering/templates/_wiring.tpl
@@ -1,0 +1,54 @@
+{{/*
+Release-scoped internal service URLs and feature gates for OpenFGA / RBAC stack.
+See cnoe-io/ai-platform-engineering#2252.
+*/}}
+
+{{- define "ai-platform-engineering.openfga.enabled" -}}
+{{- if hasKey .Values "openfga" -}}
+{{- .Values.openfga.enabled | default false -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "ai-platform-engineering.agentgateway.enabled" -}}
+{{- $top := .Values.agentgateway.enabled | default false -}}
+{{- $global := dig "agentgateway" "enabled" false (.Values.global | default dict) -}}
+{{- or $top $global -}}
+{{- end -}}
+
+{{- define "ai-platform-engineering.openfga.httpUrl" -}}
+{{- printf "http://%s-openfga:8080" .Release.Name -}}
+{{- end -}}
+
+{{- define "ai-platform-engineering.caipeUi.clusterUrl" -}}
+{{- printf "http://%s-caipe-ui:3000" .Release.Name -}}
+{{- end -}}
+
+{{- define "ai-platform-engineering.agentgateway.mcpUrl" -}}
+{{- $agwStatic := eq (dig "agentgateway" "routingMode" "static" (.Values.global | default dict)) "static" -}}
+{{- $host := ternary (printf "%s-agentgateway" .Release.Name) (printf "%s-agentgateway-proxy" .Release.Name) $agwStatic -}}
+{{- $port := ternary 4000 (int (dig "agentgateway" "proxyPort" 8080 (.Values.global | default dict))) $agwStatic -}}
+{{- printf "http://%s:%v" $host $port -}}
+{{- end -}}
+
+{{- define "ai-platform-engineering.openfga.storeName" -}}
+{{- dig "openfga" "init" "storeName" "caipe-openfga" .Values -}}
+{{- end -}}
+
+{{/*
+Fail helm template when RBAC/login bootstrap is enabled without OpenFGA.
+Evaluated from the parent chart release context only.
+*/}}
+{{- define "ai-platform-engineering.validate.openfgaDependencies" -}}
+{{- $openfgaOn := eq (include "ai-platform-engineering.openfga.enabled" .) "true" -}}
+{{- $uiCfg := index .Values "caipe-ui" "config" | default dict -}}
+{{- $identityOn := or (eq (toString (index $uiCfg "IDENTITY_SYNC_LOGIN_CLAIMS_ENABLED" | default "")) "true") (index $uiCfg "BOOTSTRAP_ADMIN_EMAILS" | default "") -}}
+{{- if and (not $openfgaOn) $identityOn -}}
+{{- fail "openfga.enabled must be true when caipe-ui.config sets BOOTSTRAP_ADMIN_EMAILS or IDENTITY_SYNC_LOGIN_CLAIMS_ENABLED=true (login-time OpenFGA reconcile required)" -}}
+{{- end -}}
+{{- $agwOn := eq (include "ai-platform-engineering.agentgateway.enabled" .) "true" -}}
+{{- if and $agwOn (not $openfgaOn) -}}
+{{- fail "agentgateway.enabled requires openfga.enabled (AgentGateway ext_authz uses OpenFGA PDP)" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/ai-platform-engineering/templates/release-validations.yaml
+++ b/charts/ai-platform-engineering/templates/release-validations.yaml
@@ -1,0 +1,6 @@
+{{/*
+Parent-chart install validation. Included in the manifest set so `helm template`
+evaluates fail() helpers without creating cluster resources.
+See cnoe-io/ai-platform-engineering#2252.
+*/}}
+{{- $_ := include "ai-platform-engineering.validate.openfgaDependencies" . -}}

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -889,6 +889,12 @@ caipe-ui:
     #   redirectUri: "https://caipe.example.com/api/credentials/oauth/webex_secondary/callback"
 
   # ── Okta directory sync (Identity Sync admin tab) ──────────────────────────
+  # Mirror `keycloak.idp` here when Keycloak brokers an upstream IdP so the
+  # UI auto-wires OIDC_IDP_HINT and login-time group-claim sync defaults.
+  keycloakIdp:
+    enabled: false
+    alias: "duo-sso"
+
   # Structured config modeled after the Backstage Okta entity provider. The
   # chart flattens this into IDENTITY_SYNC_OKTA_* env vars on the caipe-ui
   # Deployment (non-sensitive → ConfigMap; sensitive → Secret) so the app can


### PR DESCRIPTION
## Summary

Closes the deployment foot-guns tracked in #2252 where OpenFGA / AgentGateway / identity sync were partially enabled but critical env vars were left for every environment to set manually — causing silent admin failure, chat `503 PDP_UNAVAILABLE`, MCP Servers fetch errors, and OIDC groups not syncing to teams.

### Changes

**Parent chart**
- `templates/_wiring.tpl` — shared helpers + `helm template` validation
- `templates/release-validations.yaml` — fail when `IDENTITY_SYNC_LOGIN_CLAIMS_ENABLED` / `BOOTSTRAP_ADMIN_EMAILS` is set without `openfga.enabled`, or when AgentGateway is on without OpenFGA
- `caipe-ui.keycloakIdp` values block (mirror `keycloak.idp` for `OIDC_IDP_HINT` auto-wiring)

**caipe-ui**
- ConfigMap: skip empty-string keys; default identity-sync OIDC vars when OpenFGA reconcile / login claims / bootstrap admins are configured
- Deployment: auto-wire `WEBEX_BOT_ADMIN_TOKEN_URL` (mirror existing Slack wiring)

**dynamic-agents**
- Deployment: auto-wire `AUTHZ_SERVICE_URL`, `CAIPE_API_URL`, `OPENFGA_STORE_NAME`
- When `global.agentgateway.enabled`: auto-wire `AGENT_GATEWAY_URL`, default `USE_IMPERSONATION_TOKENS=true`
- Values: `USE_IMPERSONATION_TOKENS` default changed to empty (accept gateway-aware Deployment default)

### Symptoms fixed

| Symptom | Root cause addressed |
|---------|---------------------|
| Chat 503 / `PDP_UNAVAILABLE` | `AUTHZ_SERVICE_URL` now derived on dynamic-agents |
| MCP Servers fetch failed | `AGENT_GATEWAY_URL` on dynamic-agents when gateway enabled |
| OIDC groups not → teams | `OIDC_GROUP_CLAIM`, `IDENTITY_SYNC_OIDC_CLAIM_PROVIDER_ID` defaults |
| Webex space discovery empty | `WEBEX_BOT_ADMIN_TOKEN_URL` auto-wired |
| Bootstrap admin JWT but no super-admin UI | `helm template` fails when OpenFGA missing but identity sync on |

### Deployment reference

Full values matrix and caipe-demo debugging notes:
https://github.com/cisco-eti/platform-apps-deployment/blob/feat/caipe-demo-match-prod-identity/applications/caipe/vm/caipe-demo/extras/UPSTREAM-CHART-FIXES.md

## Test plan

- [x] `helm template` caipe-ui subchart — identity sync ConfigMap keys render
- [x] `helm template` dynamic-agents subchart — `AUTHZ_SERVICE_URL`, `AGENT_GATEWAY_URL` render
- [x] `helm template` parent chart — validation fails without `openfga.enabled` when identity sync on
- [x] `helm template` parent chart — succeeds with `openfga.enabled=true` + `agentgateway.enabled=true`
- [ ] CI chart lint / snapshot tests (if applicable)


Made with [Cursor](https://cursor.com)