### PR TITLE
feat(ui): lock MCP servers from seed after Repair AgentGateway

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.55-dev.5"
+version = "0.5.55-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
@@ -425,4 +425,81 @@ describe("AgentGateway MCP server discovery API", () => {
       { type: "mcp_server", id: "agentgateway", action: "admin" },
     );
   });
+
+  it("locks synced MCP servers from APP_CONFIG seed when lock_from_seed is true", async () => {
+    const insertOne = jest.fn();
+    const updateOne = jest.fn();
+    mockGetCollection.mockResolvedValue({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          {
+            _id: "jira",
+            name: "Jira",
+            transport: "http",
+            endpoint: "http://mcp-jira:8000/mcp",
+            enabled: true,
+          },
+        ]),
+      }),
+      insertOne,
+      updateOne: updateOne.mockResolvedValue({ matchedCount: 1 }),
+      findOne: jest.fn().mockResolvedValue({
+        _id: "jira",
+        name: "Jira",
+        transport: "http",
+        endpoint: "http://mcp-jira:8000/mcp",
+        enabled: true,
+      }),
+    });
+    const { POST } = await import("../sync/route");
+
+    const response = await POST(
+      request("/api/mcp-servers/agentgateway/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ lock_from_seed: true }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "rag" },
+      {
+        $set: expect.objectContaining({
+          seed_config_locked: true,
+          seed_config_locked_at: expect.any(String),
+          seed_config_locked_by: "admin-sub",
+        }),
+      },
+    );
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "jira" },
+      {
+        $set: expect.objectContaining({
+          seed_config_locked: true,
+          seed_config_locked_at: expect.any(String),
+          seed_config_locked_by: "admin-sub",
+        }),
+      },
+    );
+    expect(body.data).toMatchObject({
+      seed_locked: expect.arrayContaining(["rag", "jira"]),
+      summary: expect.objectContaining({ seed_locked: 2 }),
+    });
+  });
+
+  it("rejects non-boolean lock_from_seed values", async () => {
+    const { POST } = await import("../sync/route");
+
+    await expect(
+      POST(
+        request("/api/mcp-servers/agentgateway/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lock_from_seed: "yes" }),
+        }),
+      ),
+    ).rejects.toThrow("lock_from_seed must be a boolean");
+  });
 });

--- a/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
@@ -32,8 +32,40 @@ export async function fetchAgentGatewayMcpDiscovery(): Promise<AgentGatewayMcpDi
   return buildAgentGatewayMcpDiscovery(config, existingServers);
 }
 
-export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
+export type SyncAgentGatewayMcpServersOptions = {
+  ids?: string[];
+  /** When true, synced MCP servers are excluded from APP_CONFIG_PATH seed overwrites. */
+  lockFromSeed?: boolean;
+  lockedBy?: string;
+};
+
+async function lockMcpServersFromSeed(
+  collection: Awaited<ReturnType<typeof getCollection<MCPServerConfig>>>,
+  serverIds: string[],
+  lockedBy?: string,
+): Promise<string[]> {
+  const now = new Date().toISOString();
+  const locked: string[] = [];
+  for (const id of serverIds) {
+    const result = await collection.updateOne({ _id: id } as never, {
+      $set: {
+        seed_config_locked: true,
+        seed_config_locked_at: now,
+        ...(lockedBy ? { seed_config_locked_by: lockedBy } : {}),
+      },
+    } as never);
+    if (result.matchedCount > 0) {
+      locked.push(id);
+    }
+  }
+  return locked;
+}
+
+export async function syncSelectedAgentGatewayMcpServers(
+  options: SyncAgentGatewayMcpServersOptions = {},
+) {
   const discovery = await fetchAgentGatewayMcpDiscovery();
+  const ids = options.ids;
   const selectedIds = new Set(
     ids && ids.length > 0 ? ids : discovery.targets.map((target) => target.id),
   );
@@ -92,11 +124,21 @@ export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
     }
   }
 
+  const seed_locked =
+    options.lockFromSeed === true
+      ? await lockMcpServersFromSeed(
+          collection,
+          [...added, ...migrated, ...refreshed],
+          options.lockedBy,
+        )
+      : [];
+
   return {
     added,
     migrated,
     refreshed,
     skipped,
+    seed_locked,
     summary: {
       added: added.length,
       existing: discovery.targets.filter((target) => target.status === "existing").length,
@@ -104,6 +146,7 @@ export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
       refreshed: refreshed.length,
       conflicts: conflicts.length,
       skipped: skipped.length,
+      seed_locked: seed_locked.length,
     },
     conflicts,
     migration_warnings,

--- a/ui/src/app/api/mcp-servers/agentgateway/sync/route.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/sync/route.ts
@@ -27,7 +27,14 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   ) {
     throw new ApiError("ids must be an array of AgentGateway MCP target IDs", 400);
   }
+  if (body.lock_from_seed !== undefined && typeof body.lock_from_seed !== "boolean") {
+    throw new ApiError("lock_from_seed must be a boolean", 400);
+  }
 
-  const result = await syncSelectedAgentGatewayMcpServers(body.ids);
+  const result = await syncSelectedAgentGatewayMcpServers({
+    ids: body.ids,
+    lockFromSeed: body.lock_from_seed === true,
+    lockedBy: body.lock_from_seed === true ? String(session.sub ?? "").trim() || undefined : undefined,
+  });
   return successResponse(result);
 });

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -215,6 +215,7 @@ export function MCPServersTab({
     AgentGatewayMigrationWarning[]
   >([]);
   const [agentGatewaySyncing, setAgentGatewaySyncing] = React.useState(false);
+  const [agentGatewayRepairConfirmOpen, setAgentGatewayRepairConfirmOpen] = React.useState(false);
   const [agentGatewayMessage, setAgentGatewayMessage] = React.useState<string | null>(null);
   const [agentGatewayError, setAgentGatewayError] = React.useState<string | null>(null);
   const [testingServer, setTestingServer] = React.useState<MCPServerConfigWithPermissions | null>(null);
@@ -460,7 +461,7 @@ export function MCPServersTab({
     }
   };
 
-  const handleSyncAgentGateway = async () => {
+  const handleSyncAgentGateway = async (lockFromSeed: boolean) => {
     setAgentGatewaySyncing(true);
     setAgentGatewayError(null);
     setAgentGatewayMessage(null);
@@ -469,7 +470,7 @@ export function MCPServersTab({
       const response = await fetch("/api/mcp-servers/agentgateway/sync", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ lock_from_seed: lockFromSeed }),
       });
       const data = await response.json();
       if (!data.success) {
@@ -478,10 +479,15 @@ export function MCPServersTab({
       const addedCount = data.data.added?.length || 0;
       const migratedCount = data.data.migrated?.length || 0;
       const refreshedCount = data.data.refreshed?.length || 0;
+      const seedLockedCount = data.data.seed_locked?.length || 0;
+      const lockSuffix =
+        lockFromSeed && seedLockedCount > 0
+          ? ` ${seedLockedCount} server${seedLockedCount === 1 ? "" : "s"} excluded from APP_CONFIG seed overwrites.`
+          : "";
       setAgentGatewayMessage(
         `Added ${addedCount}, migrated ${migratedCount}, and refreshed ${refreshedCount} MCP server${
           addedCount + migratedCount + refreshedCount === 1 ? "" : "s"
-        } from AgentGateway.`,
+        } from AgentGateway.${lockSuffix}`,
       );
       setAgentGatewayMigrationWarnings(data.data.migration_warnings || []);
       await fetchServers();
@@ -489,6 +495,7 @@ export function MCPServersTab({
       setAgentGatewayError(errorMessage(err, "Failed to sync AgentGateway MCP servers"));
     } finally {
       setAgentGatewaySyncing(false);
+      setAgentGatewayRepairConfirmOpen(false);
     }
   };
 
@@ -622,7 +629,7 @@ export function MCPServersTab({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={handleSyncAgentGateway}
+                onClick={() => setAgentGatewayRepairConfirmOpen(true)}
                 disabled={agentGatewaySyncing}
                 title="Admin repair: re-import built-in AgentGateway MCP routes and repair stale registrations"
               >
@@ -758,6 +765,15 @@ export function MCPServersTab({
                                 title="Registered from AgentGateway discovery"
                               >
                                 AgentGateway
+                              </Badge>
+                            )}
+                            {server.seed_config_locked && (
+                              <Badge
+                                variant="outline"
+                                className="gap-1 bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/30"
+                                title="Excluded from APP_CONFIG seed overwrites after Repair AgentGateway"
+                              >
+                                Seed locked
                               </Badge>
                             )}
                           </div>
@@ -1010,6 +1026,43 @@ export function MCPServersTab({
           </div>
         )}
       </CardContent>
+      <Dialog open={agentGatewayRepairConfirmOpen} onOpenChange={setAgentGatewayRepairConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Repair AgentGateway MCP servers?</DialogTitle>
+            <DialogDescription>
+              This re-imports AgentGateway MCP routes into MongoDB and repairs stale registrations.
+              Synced servers will be marked seed locked so APP_CONFIG startup seed no longer
+              overwrites them on pod restart. Use git-owned appConfig.mcp_servers as the long-term
+              source of truth; seed lock protects runtime repairs until git catches up.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={agentGatewaySyncing}
+              onClick={() => setAgentGatewayRepairConfirmOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={agentGatewaySyncing}
+              onClick={() => void handleSyncAgentGateway(true)}
+            >
+              {agentGatewaySyncing ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Repairing...
+                </>
+              ) : (
+                "Repair and lock from seed"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <MCPToolTestDialog
         server={testingServer}
         open={Boolean(testingServer)}

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -141,12 +141,17 @@ describe("MCPServersTab AgentGateway repair", () => {
     await screen.findByText("Jira");
     fireEvent.click(screen.getByRole("button", { name: /Repair AgentGateway/i }));
 
+    expect(
+      await screen.findByRole("dialog", { name: /Repair AgentGateway MCP servers/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Repair and lock from seed/i }));
+
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/mcp-servers/agentgateway/sync",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({}),
+          body: JSON.stringify({ lock_from_seed: true }),
         }),
       );
     });
@@ -173,6 +178,20 @@ describe("MCPServersTab AgentGateway repair", () => {
 
     expect(screen.getByText("AgentGateway")).toBeInTheDocument();
     expect(screen.getByText(/Target: http:\/\/rag-server:9446\/mcp/i)).toBeInTheDocument();
+  });
+
+  it("shows a seed locked badge for MCP servers excluded from APP_CONFIG seed", async () => {
+    serverItems = [
+      {
+        ...agentGatewayRagServer,
+        seed_config_locked: true,
+        seed_config_locked_at: "2026-07-21T04:00:00.000Z",
+      },
+    ];
+    render(<MCPServersTab />);
+
+    await screen.findByText("RAG");
+    expect(screen.getByText("Seed locked")).toBeInTheDocument();
   });
 
   it("opens a test modal and invokes a saved MCP tool", async () => {

--- a/ui/src/lib/__tests__/seed-config-mcp-seed-lock.test.ts
+++ b/ui/src/lib/__tests__/seed-config-mcp-seed-lock.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ *
+ * seedMCPServers must skip documents marked seed_config_locked so Repair
+ * AgentGateway + explicit admin confirmation survives pod restarts.
+ */
+
+const mockCollection = {
+  findOne: jest.fn(),
+  replaceOne: jest.fn(),
+};
+
+jest.mock("@/lib/mongodb", () => ({
+  isMongoDBConfigured: true,
+  getCollection: jest.fn(async () => mockCollection),
+}));
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  reconcileConfigDrivenMcpServerRelationships: jest.fn(),
+}));
+
+import { seedMCPServers } from "../seed-config";
+
+describe("seedMCPServers — seed_config_locked guard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("skips MCP servers already marked seed_config_locked", async () => {
+    mockCollection.findOne.mockResolvedValue({
+      _id: "jira",
+      seed_config_locked: true,
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+
+    const count = await seedMCPServers([
+      {
+        id: "jira",
+        name: "Jira",
+        transport: "http",
+        endpoint: "http://agentgateway:4000/mcp/jira",
+        source: "agentgateway",
+      },
+    ]);
+
+    expect(count).toBe(0);
+    expect(mockCollection.replaceOne).not.toHaveBeenCalled();
+  });
+
+  it("upserts MCP servers that are not seed locked", async () => {
+    mockCollection.findOne.mockResolvedValue(null);
+    mockCollection.replaceOne.mockResolvedValue({ modifiedCount: 1 });
+
+    const count = await seedMCPServers([
+      {
+        id: "jira",
+        name: "Jira",
+        transport: "http",
+        endpoint: "http://agentgateway:4000/mcp/jira",
+        source: "agentgateway",
+      },
+    ]);
+
+    expect(count).toBe(1);
+    expect(mockCollection.replaceOne).toHaveBeenCalledWith(
+      { _id: "jira" },
+      expect.objectContaining({
+        _id: "jira",
+        endpoint: "http://agentgateway:4000/mcp/jira",
+      }),
+      { upsert: true },
+    );
+  });
+});

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -370,7 +370,7 @@ export async function adoptConfigImportedAgents(
   return { adopted, skipped };
 }
 
-async function seedMCPServers(
+export async function seedMCPServers(
   servers: Record<string, unknown>[],
 ): Promise<number> {
   if (servers.length === 0) return 0;
@@ -387,10 +387,18 @@ async function seedMCPServers(
       continue;
     }
 
+    // Preserve seed-locked rows managed via Repair AgentGateway (admin confirmed).
+    const existing = await collection.findOne({ _id: serverId });
+    if (existing?.seed_config_locked) {
+      console.log(
+        `[seed-config] Skipping seed-locked MCP server: ${serverId}`,
+      );
+      continue;
+    }
+
     const now = new Date().toISOString();
 
     // Preserve created_at if document already exists
-    const existing = await collection.findOne({ _id: serverId });
     const createdAt = existing?.created_at ?? now;
     const source: MCPServerConfig["source"] | undefined =
       serverData.source === "manual" ||

--- a/ui/src/types/dynamic-agent.ts
+++ b/ui/src/types/dynamic-agent.ts
@@ -50,6 +50,13 @@ export interface MCPServerConfig {
   credential_sources?: MCPCredentialSource[];
   enabled: boolean;
   config_driven?: boolean;  // Whether loaded from config.yaml (not editable)
+  /**
+   * When true, APP_CONFIG_PATH seed must not replace this MCP server document
+   * on startup (e.g. after an admin Repair AgentGateway with explicit lock).
+   */
+  seed_config_locked?: boolean;
+  seed_config_locked_at?: string;
+  seed_config_locked_by?: string;
   source?: 'manual' | 'config' | 'agentgateway';
   agentgateway_discovered?: boolean;
   agentgateway_endpoint?: string;

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.55.dev5"
+version = "0.5.55.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- Adds `seed_config_locked` fields on MCP server documents so `APP_CONFIG_PATH` seed skips them on pod restart.
- **Repair AgentGateway** now requires admin confirmation and sends `lock_from_seed: true`, marking every synced server as seed-locked in MongoDB.
- Shows a **Seed locked** badge in the MCP Servers table for excluded rows.

Git-owned `appConfig.mcp_servers` remains the long-term source of truth. Repair + lock is a one-time bootstrap path that survives restarts until git catches up (pairs with deployment-repo GitOps fixes).

## Motivation

On every `caipe-ui` pod start, `[seed-config]` upserts MCP servers from the Helm ConfigMap. UI **Repair AgentGateway** updates MongoDB at runtime but does not write git, so ArgoCD sync/restart overwrites repaired AgentGateway routes. This change lets admins explicitly opt repaired servers out of seed overwrites.

## Test plan

- [x] `seed-config-mcp-seed-lock.test.ts` — seed skips `seed_config_locked` docs
- [x] `agentgateway/__tests__/route.test.ts` — `lock_from_seed` sets lock fields + validation
- [x] `MCPServersTab.test.tsx` — confirmation dialog + lock payload + badge

```bash
cd ui && npm test -- --testPathPatterns="seed-config-mcp-seed-lock|agentgateway/__tests__/route|MCPServersTab.test"
```

## Related

- Deployment GitOps follow-up: https://github.com/cisco-eti/platform-apps-deployment/pull/840

Made with [Cursor](https://cursor.com)