### PR TITLE
fix(insights): refresh stats and restore user activity

### DIFF
--- a/docs/docs/api/admin-user-management.md
+++ b/docs/docs/api/admin-user-management.md
@@ -783,6 +783,29 @@ Replaces `keycloak_roles` on the team.
 
 ---
 
+## User Activity
+
+### GET `/api/admin/users/activity/{identity}`
+
+**Auth:** Organization audit access.
+
+Returns the MongoDB-backed activity used by the admin Insights user drawer.
+`identity` may be a user email or an integration user ID. Linked email and
+integration identities are combined so the response includes activity from
+both surfaces.
+
+The response contains:
+
+- Profile metadata from the `users` collection.
+- Conversation and feedback totals.
+- The 20 most recent conversations.
+- The 10 most recent feedback entries.
+
+This endpoint is separate from `GET /api/admin/users/{id}`, which accepts a
+Keycloak subject ID and returns identity-management data.
+
+---
+
 ## Platform Statistics
 
 ### GET `/api/admin/stats`

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.55 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.56 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.55 -f your-values.yaml'}
+                  {'    --version 0.5.56 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.55 -f your-values.yaml'}
+              {'    --version 0.5.56 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.56"
+version = "0.5.56-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -348,17 +348,20 @@ function setupFetchMock(overrides: {
       });
     }
     if (url.includes('/api/admin/stats') && !url.includes('skills')) {
+      const statsResponse = typeof overrides.stats === 'function'
+        ? overrides.stats(url)
+        : overrides.stats;
       if (overrides.statsStatus) {
         return Promise.resolve({
           ok: overrides.statsStatus >= 200 && overrides.statsStatus < 300,
           status: overrides.statsStatus,
-          json: () => Promise.resolve(overrides.stats || { success: false, error: 'Forbidden' }),
+          json: () => Promise.resolve(statsResponse || { success: false, error: 'Forbidden' }),
         });
       }
       return Promise.resolve({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(overrides.stats || mockStatsResponse),
+        json: () => Promise.resolve(statsResponse || mockStatsResponse),
       });
     }
     if (url.includes('/api/admin/users')) {
@@ -1656,6 +1659,46 @@ describe('Admin Dashboard Page', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         expect.stringContaining('/api/admin/stats?from=')
       );
+    });
+
+    it('updates all overview cards when the date range changes', async () => {
+      const shortRangeStats = {
+        ...mockStatsResponse,
+        data: {
+          ...mockStatsResponse.data,
+          overview: {
+            ...mockStatsResponse.data.overview,
+            total_users: 2,
+            total_conversations: 3,
+            total_messages: 4,
+          },
+        },
+      };
+      setupFetchMock({
+        stats: (url: string) => {
+          const requestUrl = new URL(url, 'http://localhost:3000');
+          const from = new Date(requestUrl.searchParams.get('from') || 0);
+          const to = new Date(requestUrl.searchParams.get('to') || 0);
+          return to.getTime() - from.getTime() <= 2 * 60 * 60 * 1000
+            ? shortRangeStats
+            : mockStatsResponse;
+        },
+      });
+
+      render(<AdminPage />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('42');
+
+      fireEvent.click(screen.getByRole('button', { name: '1h' }));
+
+      await waitFor(() => {
+        const usersCard = screen.getByText('Total Users').closest('.rounded-lg');
+        const conversationsCard = screen.getByText('Conversations').closest('.rounded-lg');
+        const messagesCard = screen.getByText('Messages').closest('.rounded-lg');
+        expect(within(usersCard as HTMLElement).getByText('2')).toBeInTheDocument();
+        expect(within(conversationsCard as HTMLElement).getByText('3')).toBeInTheDocument();
+        expect(within(messagesCard as HTMLElement).getByText('4')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1077,11 +1077,26 @@ function AdminPage() {
       const agentIds = agentIdsForNames(ag);
       if (agentIds.length > 0) params.set('agent', agentIds.join(','));
       if (showBotUsers) params.set('include_bots', 'true');
-      const res = await fetch(withAdminSimulationParams(`/api/admin/stats?${params}`, simulationTarget));
+      const hasNonRangeFilters = s !== 'all'
+        || u.length > 0
+        || agentIds.length > 0;
+      const overviewParams = new URLSearchParams({ from: r.from, to: r.to });
+      const [res, overviewRes] = await Promise.all([
+        fetch(withAdminSimulationParams(`/api/admin/stats?${params}`, simulationTarget)),
+        hasNonRangeFilters
+          ? fetch(withAdminSimulationParams(`/api/admin/stats?${overviewParams}`, simulationTarget))
+          : null,
+      ]);
       if (res.ok) {
-        const json = await res.json();
+        const [json, overviewJson] = await Promise.all([
+          res.json(),
+          overviewRes?.ok ? overviewRes.json() : Promise.resolve(null),
+        ]);
         if (json.success && activeDataScopeKeyRef.current === requestScopeKey) {
           setStats(json.data);
+          setGlobalOverview(
+            overviewJson?.success ? overviewJson.data.overview : json.data.overview,
+          );
           if (json.data.available_channels) setStatsChannels(json.data.available_channels);
           if (json.data.available_agents) setStatsAgents(json.data.available_agents);
         }
@@ -1115,13 +1130,14 @@ function AdminPage() {
     try {
       const hasStatsFilters = sourceFilter !== 'all' || userFilter.length > 0;
       const p = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
+      const globalP = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
       if (sourceFilter !== 'all') p.set('source', sourceFilter);
       if (userFilter.length > 0) p.set('user', userFilter.join(','));
       if (showBotUsers) p.set('include_bots', 'true');
       const [statsRes, globalStatsRes] = await Promise.all([
         fetch(withAdminSimulationParams(`/api/admin/stats?${p}`, simulationTarget)),
         hasStatsFilters
-          ? fetch(withAdminSimulationParams('/api/admin/stats', simulationTarget))
+          ? fetch(withAdminSimulationParams(`/api/admin/stats?${globalP}`, simulationTarget))
           : null,
       ]);
 

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -404,6 +404,9 @@ describe('GET /api/admin/stats — Overview', () => {
         shared_conversations: 2,
       })
     );
+    expect(usersCol.countDocuments).toHaveBeenNthCalledWith(1, {
+      last_login: { $gte: expect.any(Date) },
+    });
   });
 
   it('computes avg_messages_per_conversation correctly', async () => {
@@ -520,6 +523,27 @@ describe('GET /api/admin/stats — Top Users', () => {
     expect(body.data.top_users).toHaveProperty('by_messages');
     expect(Array.isArray(body.data.top_users.by_conversations)).toBe(true);
     expect(Array.isArray(body.data.top_users.by_messages)).toBe(true);
+  });
+
+  it('ignores legacy ownerless rows in a 90-day leaderboard', async () => {
+    const { convCol } = setupAdminWithCollections();
+    convCol.aggregate.mockImplementation((pipeline: Record<string, unknown>[]) => ({
+      toArray: async () =>
+        pipeline.some((stage) => stage.$group?._id === '$owner_id')
+          ? [
+              { _id: null, count: 4 },
+              { _id: 'test-user@example.com', count: 2 },
+            ]
+          : [],
+    }));
+
+    const response = await GET(makeRequest('/api/admin/stats?range=90d'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.top_users.by_conversations).toEqual([
+      expect.objectContaining({ _id: 'test-user@example.com', count: 2 }),
+    ]);
   });
 
   it('labels a bot/app owner with its persisted owner_display_name', async () => {
@@ -1591,4 +1615,3 @@ describe('GET /api/admin/stats — Configured Channels', () => {
     }
   });
 });
-

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -517,15 +517,16 @@ async function getAdminStats(request: NextRequest) {
       messagesToday,
       sharedConversations,
     ] = await Promise.all([
-      // Non-admins must not see platform-wide headcount — derive their
-      // total_users from distinct owners of the conversations they can see.
+      // Total users is range-aware like the conversation and message totals.
+      // Non-admins derive it from activity in conversations they can see;
+      // full admins use the existing last-login activity source.
       nonAdminScope
         ? conversations.aggregate([
-            { $match: { ...convSourceFilter } },
+            { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
             { $group: { _id: '$owner_id' } },
             { $count: 'total' },
           ]).toArray().then((r) => r[0]?.total || 0)
-        : users.countDocuments({}),
+        : users.countDocuments({ last_login: { $gte: rangeStart } }),
       // Scoped to the selected date range (rangeStart), matching daily_activity
       // and every other range-aware metric below — previously these were
       // always lifetime totals regardless of the selected range.
@@ -841,7 +842,7 @@ async function getAdminStats(request: NextRequest) {
     const topOwnerIds = [...new Set([
       ...rawTopByConvs.map((u) => u._id),
       ...rawTopByMsgs.map((u) => u._id),
-    ])].filter(Boolean);
+    ].filter((id): id is string => typeof id === 'string' && id.trim().length > 0))];
 
     const userDocs = topOwnerIds.length > 0
       ? await users.find(
@@ -902,13 +903,19 @@ async function getAdminStats(request: NextRequest) {
       return 'unlinked_slack';
     };
 
+    // Legacy activity can have a missing owner_id. Wider windows (notably 90d)
+    // are more likely to include those rows, so discard them before calling
+    // string-only identity helpers such as classifyOwner().
     const enrichTopUsers = (raw: typeof rawTopByConvs) =>
-      raw.map((u) => ({
-        _id: u._id,
-        count: u.count,
-        name: nameByOwner.get(u._id) || u._id,
-        owner_type: classifyOwner(u._id),
-      }));
+      raw.flatMap((u) => {
+        if (typeof u._id !== 'string' || !u._id.trim()) return [];
+        return [{
+          _id: u._id,
+          count: u.count,
+          name: nameByOwner.get(u._id) || u._id,
+          owner_type: classifyOwner(u._id),
+        }];
+      });
 
     const topUsersByConversations = enrichTopUsers(rawTopByConvs);
     const topUsersByMessages = enrichTopUsers(rawTopByMsgs);

--- a/ui/src/app/api/admin/users/activity/[identity]/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/users/activity/[identity]/__tests__/route.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuth = jest.fn();
+const mockRequireRbacPermission = jest.fn();
+const mockResolveSimulationScope = jest.fn();
+const mockSimulationCanManage = jest.fn();
+const mockFindUser = jest.fn();
+const mockFindConversations = jest.fn();
+const mockCountConversations = jest.fn();
+const mockAggregateFeedback = jest.fn();
+const mockFindFeedback = jest.fn();
+const mockGetRealmUserById = jest.fn();
+
+let mongoConfigured = true;
+
+jest.mock("@/lib/api-middleware", () => {
+  const actual = jest.requireActual("@/lib/api-middleware");
+  return {
+    ...actual,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuth(...args),
+    requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
+  };
+});
+
+jest.mock("@/lib/rbac/admin-simulation-server", () => ({
+  resolveAuthorizedAdminSimulationScope: (...args: unknown[]) =>
+    mockResolveSimulationScope(...args),
+  simulationSubjectCanManageAdminSurface: (...args: unknown[]) =>
+    mockSimulationCanManage(...args),
+}));
+
+jest.mock("@/lib/rbac/keycloak-admin", () => ({
+  getRealmUserById: (...args: unknown[]) => mockGetRealmUserById(...args),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  get isMongoDBConfigured() {
+    return mongoConfigured;
+  },
+  getCollection: async (name: string) => {
+    if (name === "users") {
+      return { findOne: (...args: unknown[]) => mockFindUser(...args) };
+    }
+    if (name === "conversations") {
+      return {
+        find: (...args: unknown[]) => {
+          mockFindConversations(...args);
+          return {
+            sort: () => ({
+              limit: () => ({ toArray: () => mockFindConversations() }),
+            }),
+          };
+        },
+        countDocuments: (...args: unknown[]) => mockCountConversations(...args),
+      };
+    }
+    if (name === "feedback") {
+      return {
+        aggregate: (...args: unknown[]) => {
+          mockAggregateFeedback(...args);
+          return { toArray: () => mockAggregateFeedback() };
+        },
+        find: (...args: unknown[]) => {
+          mockFindFeedback(...args);
+          return {
+            sort: () => ({
+              limit: () => ({ toArray: () => mockFindFeedback() }),
+            }),
+          };
+        },
+      };
+    }
+    throw new Error(`Unexpected collection: ${name}`);
+  },
+}));
+
+function request(identity: string, query = "") {
+  return {
+    request: new NextRequest(
+      new URL(
+        `/api/admin/users/activity/${encodeURIComponent(identity)}${query}`,
+        "http://localhost:3000",
+      ),
+    ),
+    context: { params: Promise.resolve({ identity }) },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mongoConfigured = true;
+  mockGetAuth.mockResolvedValue({ session: { sub: "admin-sub" } });
+  mockRequireRbacPermission.mockResolvedValue(undefined);
+  mockResolveSimulationScope.mockResolvedValue(null);
+  mockSimulationCanManage.mockResolvedValue(true);
+  mockFindUser.mockResolvedValue({
+    email: "test-user@example.com",
+    name: "Test User",
+    slack_user_id: "U123TEST",
+    source: "web",
+    avatar_url: null,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    last_login: new Date("2026-07-20T00:00:00.000Z"),
+    metadata: { role: "user" },
+  });
+  mockFindConversations
+    .mockResolvedValueOnce(undefined)
+    .mockResolvedValueOnce([
+      {
+        _id: "conversation-1",
+        title: "Example conversation",
+        client_type: "slack",
+        metadata: { channel_id: "C123TEST", channel_name: "example-channel" },
+        created_at: new Date("2026-07-20T10:00:00.000Z"),
+        updated_at: new Date("2026-07-20T11:00:00.000Z"),
+      },
+    ]);
+  mockCountConversations.mockResolvedValue(3);
+  mockAggregateFeedback
+    .mockResolvedValueOnce(undefined)
+    .mockResolvedValueOnce([{ total: 2, positive: 1, negative: 1 }]);
+  mockFindFeedback
+    .mockResolvedValueOnce(undefined)
+    .mockResolvedValueOnce([
+      {
+        source: "web",
+        rating: "positive",
+        value: "thumbs_up",
+        conversation_id: "conversation-1",
+        created_at: new Date("2026-07-20T11:05:00.000Z"),
+      },
+    ]);
+});
+
+describe("GET /api/admin/users/activity/[identity]", () => {
+  it("loads activity by analytics identity without treating the email as a Keycloak id", async () => {
+    const { GET } = await import("../route");
+    const { request: req,context } = request("test-user@example.com");
+
+    const response = await GET(req, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockRequireRbacPermission).toHaveBeenCalledWith(
+      { sub: "admin-sub" },
+      "admin_ui",
+      "view",
+    );
+    expect(mockGetRealmUserById).not.toHaveBeenCalled();
+    expect(mockCountConversations).toHaveBeenCalledWith({
+      owner_id: {
+        $in: expect.arrayContaining(["test-user@example.com", "U123TEST"]),
+      },
+    });
+    expect(body.data).toMatchObject({
+      profile: {
+        email: "test-user@example.com",
+        name: "Test User",
+        slack_user_id: "U123TEST",
+      },
+      stats: {
+        total_conversations: 3,
+        feedback_given: 2,
+        feedback_positive: 1,
+        feedback_negative: 1,
+      },
+      recent_conversations: [
+        {
+          id: "conversation-1",
+          source: "slack",
+          channel_id: "C123TEST",
+          channel_name: "example-channel",
+        },
+      ],
+    });
+  });
+
+  it("does not let a scoped preview subject widen itself to another user's activity", async () => {
+    mockResolveSimulationScope.mockResolvedValue({
+      openfgaUser: "user:preview-sub",
+      ownerEmail: "preview@example.com",
+      subjectType: "user",
+      subjectId: "preview-sub",
+    });
+    mockSimulationCanManage.mockResolvedValue(false);
+    const { GET } = await import("../route");
+    const { request: req,context } = request(
+      "test-user@example.com",
+      "?simulate_type=user&simulate_id=preview-sub",
+    );
+
+    const response = await GET(req, context);
+
+    expect(response.status).toBe(403);
+    expect(mockFindUser).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/admin/users/activity/[identity]/route.ts
+++ b/ui/src/app/api/admin/users/activity/[identity]/route.ts
@@ -1,0 +1,277 @@
+// GET /api/admin/users/activity/[identity] - Get a user's Mongo-backed activity
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  requireRbacPermission,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
+import {
+  resolveAuthorizedAdminSimulationScope,
+  simulationSubjectCanManageAdminSurface,
+} from "@/lib/rbac/admin-simulation-server";
+import type { User } from "@/types/mongodb";
+import type { Document,Filter } from "mongodb";
+import { type NextRequest,NextResponse } from "next/server";
+
+interface ActivityUser extends User {
+  slack_user_id?: string;
+  source?: string;
+}
+
+interface ActivityConversation extends Document {
+  _id?: unknown;
+  channel_id?: string;
+  channel_name?: string;
+  client_type?: string;
+  created_at?: Date | string;
+  metadata?: {
+    channel_id?: string;
+    channel_name?: string;
+    owner_display_name?: string;
+  };
+  slack_meta?: {
+    channel_id?: string;
+    channel_name?: string;
+  };
+  source?: string;
+  title?: string;
+  updated_at?: Date | string;
+}
+
+interface ActivityFeedback extends Document {
+  channel_name?: string;
+  comment?: string;
+  conversation_id?: string;
+  created_at?: Date | string;
+  rating?: string;
+  slack_permalink?: string;
+  source?: string;
+  value?: string;
+}
+
+function dateString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" ? value : "";
+}
+
+function conversationSource(conversation: ActivityConversation): string {
+  return conversation.source === "slack" || conversation.client_type === "slack"
+    ? "slack"
+    : "web";
+}
+
+export const GET = withErrorHandler(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ identity: string }> }
+  ) => {
+    if (!isMongoDBConfigured) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "MongoDB not configured - admin features require MongoDB",
+          code: "MONGODB_NOT_CONFIGURED",
+        },
+        { status: 503 }
+      );
+    }
+
+    const { session } = await getAuthFromBearerOrSession(request);
+    const simulationScope = await resolveAuthorizedAdminSimulationScope(
+      request.nextUrl.searchParams,
+      session,
+    );
+    if (simulationScope) {
+      const canReadAllStats = await simulationSubjectCanManageAdminSurface(
+        simulationScope,
+        "stats",
+      );
+      if (!canReadAllStats) {
+        throw new ApiError(
+          "The selected preview subject cannot view another user's activity.",
+          403,
+          "admin_surface:stats#can_manage",
+          "pdp_denied",
+          "contact_admin",
+        );
+      }
+    } else {
+      // Match the authorization level of the original admin activity drawer:
+      // detailed conversation titles and feedback are organization-audit data.
+      await requireRbacPermission(session, "admin_ui", "view");
+    }
+
+    const { identity: rawIdentity } = await context.params;
+    const identity = rawIdentity.trim();
+    if (!identity) {
+      throw new ApiError("User identity is required", 400, "INVALID_USER_IDENTITY");
+    }
+
+    const normalizedIdentity = identity.includes("@")
+      ? identity.toLowerCase()
+      : identity;
+    const users = await getCollection<ActivityUser>("users");
+    const conversations = await getCollection<ActivityConversation>("conversations");
+    const feedback = await getCollection<ActivityFeedback>("feedback");
+
+    const userLookup: Filter<ActivityUser> = {
+      $or: [
+        { email: identity },
+        { email: normalizedIdentity },
+        { slack_user_id: identity },
+      ],
+    };
+    const user = await users.findOne(userLookup);
+
+    // A linked person can own web activity by email and Slack activity by the
+    // linked Slack id. Query every known identifier so the drawer is complete.
+    const ownerIds = new Set<string>();
+    const addOwnerId = (value: unknown) => {
+      if (typeof value !== "string" || !value.trim()) return;
+      const trimmed = value.trim();
+      ownerIds.add(trimmed);
+      if (trimmed.includes("@")) ownerIds.add(trimmed.toLowerCase());
+    };
+    addOwnerId(identity);
+    addOwnerId(user?.email);
+    addOwnerId(user?.slack_user_id);
+    const identities = [...ownerIds];
+    const conversationFilter = {
+      owner_id: identities.length === 1 ? identities[0] : { $in: identities },
+    };
+    const feedbackFilter = {
+      $or: [
+        { user_email: { $in: identities } },
+        { user_id: { $in: identities } },
+      ],
+    };
+
+    const [recentConversations,totalConversations,feedbackStats,recentFeedback] =
+      await Promise.all([
+        conversations
+          .find(conversationFilter, {
+            projection: {
+              _id: 1,
+              channel_id: 1,
+              channel_name: 1,
+              client_type: 1,
+              created_at: 1,
+              "metadata.channel_id": 1,
+              "metadata.channel_name": 1,
+              "metadata.owner_display_name": 1,
+              slack_meta: 1,
+              source: 1,
+              title: 1,
+              updated_at: 1,
+            },
+          })
+          .sort({ updated_at: -1 })
+          .limit(20)
+          .toArray(),
+        conversations.countDocuments(conversationFilter),
+        feedback
+          .aggregate([
+            { $match: feedbackFilter },
+            {
+              $group: {
+                _id: null,
+                total: { $sum: 1 },
+                positive: {
+                  $sum: { $cond: [{ $eq: ["$rating", "positive"] }, 1, 0] },
+                },
+                negative: {
+                  $sum: { $cond: [{ $eq: ["$rating", "negative"] }, 1, 0] },
+                },
+              },
+            },
+          ])
+          .toArray(),
+        feedback
+          .find(feedbackFilter, {
+            projection: {
+              _id: 0,
+              channel_name: 1,
+              comment: 1,
+              conversation_id: 1,
+              created_at: 1,
+              rating: 1,
+              slack_permalink: 1,
+              source: 1,
+              value: 1,
+            },
+          })
+          .sort({ created_at: -1 })
+          .limit(10)
+          .toArray(),
+      ]);
+
+    const feedbackSummary = feedbackStats[0] ?? {
+      total: 0,
+      positive: 0,
+      negative: 0,
+    };
+    if (!user && totalConversations === 0 && feedbackSummary.total === 0) {
+      throw new ApiError("User not found", 404, "USER_NOT_FOUND");
+    }
+
+    const firstConversation = recentConversations[0];
+    const inferredSource = firstConversation
+      ? conversationSource(firstConversation)
+      : /^[UW][A-Z0-9]+$/.test(identity)
+        ? "slack"
+        : "web";
+
+    return successResponse({
+      profile: {
+        email: user?.email ?? (identity.includes("@") ? normalizedIdentity : ""),
+        name:
+          user?.name ||
+          firstConversation?.metadata?.owner_display_name ||
+          identity,
+        avatar_url: user?.avatar_url ?? null,
+        role: user?.metadata?.role ?? "user",
+        source: user?.source ?? inferredSource,
+        slack_user_id:
+          user?.slack_user_id ?? (/^[UW][A-Z0-9]+$/.test(identity) ? identity : null),
+        created_at: dateString(user?.created_at),
+        last_login: dateString(user?.last_login),
+      },
+      stats: {
+        total_conversations: totalConversations,
+        feedback_given: Number(feedbackSummary.total ?? 0),
+        feedback_positive: Number(feedbackSummary.positive ?? 0),
+        feedback_negative: Number(feedbackSummary.negative ?? 0),
+      },
+      recent_conversations: recentConversations.map((conversation) => ({
+        id: String(conversation._id ?? ""),
+        title: conversation.title || "Untitled",
+        source: conversationSource(conversation),
+        channel_id:
+          conversation.channel_id ??
+          conversation.metadata?.channel_id ??
+          conversation.slack_meta?.channel_id ??
+          null,
+        channel_name:
+          conversation.channel_name ??
+          conversation.metadata?.channel_name ??
+          conversation.slack_meta?.channel_name ??
+          null,
+        created_at: dateString(conversation.created_at),
+        updated_at: dateString(conversation.updated_at),
+      })),
+      recent_feedback: recentFeedback.map((entry) => ({
+        source: entry.source || "web",
+        rating: entry.rating || "",
+        value: entry.value || "",
+        comment: entry.comment ?? null,
+        channel_name: entry.channel_name ?? null,
+        conversation_id: entry.conversation_id ?? null,
+        slack_permalink: entry.slack_permalink ?? null,
+        created_at: dateString(entry.created_at),
+      })),
+    });
+  }
+);

--- a/ui/src/components/admin/teams/UserDetailPanel.tsx
+++ b/ui/src/components/admin/teams/UserDetailPanel.tsx
@@ -122,7 +122,7 @@ export function UserDetailPanel({
     setError(null);
     setActiveTab("overview");
     fetch(withAdminSimulationParams(
-      `/api/admin/users/${encodeURIComponent(email)}`,
+      `/api/admin/users/activity/${encodeURIComponent(email)}`,
       simulationTarget,
     ))
       .then((res) => res.json())

--- a/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
+++ b/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
@@ -1,0 +1,50 @@
+import { render,screen,waitFor } from "@testing-library/react";
+
+import { UserDetailPanel } from "../UserDetailPanel";
+
+describe("UserDetailPanel", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          profile: {
+            email: "test-user@example.com",
+            name: "Test User",
+            avatar_url: null,
+            role: "user",
+            source: "web",
+            slack_user_id: null,
+            created_at: "2026-01-01T00:00:00.000Z",
+            last_login: "2026-07-20T00:00:00.000Z",
+          },
+          stats: {
+            total_conversations: 1,
+            feedback_given: 0,
+            feedback_positive: 0,
+            feedback_negative: 0,
+          },
+          recent_conversations: [],
+          recent_feedback: [],
+        },
+      }),
+    }) as jest.Mock;
+  });
+
+  it("uses the Mongo activity endpoint instead of the Keycloak id endpoint", async () => {
+    render(
+      <UserDetailPanel
+        email="test-user@example.com"
+        onClose={jest.fn()}
+      />,
+    );
+
+    await screen.findByText("Test User");
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/admin/users/activity/test-user%40example.com",
+      );
+    });
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.56"
+version = "0.5.56.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fixes three Admin → Insights regressions:

- Restores the user activity drawer through a Mongo-backed activity endpoint instead of sending an email to the Keycloak subject-ID endpoint.
- Refreshes Total Users, Conversations, and Messages when the date range changes; Total Users is now range-aware.
- Ignores legacy ownerless leaderboard rows so 90-day deep links no longer crash on `.startsWith()`.

The existing `/api/admin/users/{id}` contract remains Keycloak ID-based. The separate activity route is needed because the drawer reads MongoDB conversations and feedback and must support identities, such as Slack-only users, that do not have a Keycloak subject.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Validation

- `npm run lint` — passed
- `npm test -- --runInBand` — passed (531 suites, 6,663 tests)
- `./node_modules/.bin/tsc --noEmit` — passed
- `npm run build -- --webpack` — webpack compilation passed; Next.js route type validation remains blocked by the pre-existing invalid `__resetKeycloakHealthSummaryCacheForTests` export in unchanged `src/app/api/admin/keycloak/migration-health/summary/route.ts`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
