### PR TITLE
fix(ui): load admin insights cards independently

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.56-dev.1"
+version = "0.5.56-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -3,7 +3,7 @@
  *
  * Covers:
  * - Loading state
- * - Error state with retry
+ * - Fatal auth errors and card-local stats errors
  * - Read-only badge and descriptions for non-admin users
  * - Admin actions visibility (role change, team CRUD) for admin users
  * - Admin actions hidden for read-only users
@@ -484,16 +484,15 @@ describe('Admin Dashboard Page', () => {
   });
 
   describe('Error state', () => {
-    it('shows error message and retry button on fetch failure', async () => {
+    it('keeps the page usable and shows card-local errors on stats fetch failure', async () => {
       // Must be on a tab with a loader (stats) so a fetch is actually triggered.
       currentSearchParams = new URLSearchParams('cat=insights&tab=stats');
       (global.fetch as jest.Mock) = jest.fn().mockRejectedValue(new Error('Network error'));
       render(<AdminPage />);
 
-      await waitFor(() => {
-        expect(screen.getByText(/network error/i)).toBeInTheDocument();
-      });
-      expect(screen.getByText('Retry')).toBeInTheDocument();
+      expect((await screen.findAllByText(/network error/i)).length).toBeGreaterThan(1);
+      expect(screen.getByRole('heading', { name: 'Admin' })).toBeInTheDocument();
+      expect(screen.queryByText('Retry')).not.toBeInTheDocument();
     });
 
     it('shows auth error on 401 response', async () => {
@@ -720,7 +719,8 @@ describe('Admin Dashboard Page', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Insights' }));
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(
-          expect.stringMatching(/\/api\/admin\/stats\?.*simulate_type=user.*simulate_id=kc-user/)
+          expect.stringMatching(/\/api\/admin\/stats\?.*simulate_type=user.*simulate_id=kc-user/),
+          expect.objectContaining({ signal: expect.any(AbortSignal) })
         );
       });
       expect(await screen.findByRole('tab', { name: 'Statistics' })).toBeInTheDocument();
@@ -1628,6 +1628,76 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getByText('Daily Active Users (DAU)')).toBeInTheDocument();
     });
 
+    it('updates cards independently and issues one request per section when a filter changes', async () => {
+      const baseFetch = setupFetchMock();
+      let resolveFeedback: ((response: unknown) => void) | undefined;
+      let deferFeedback = false;
+      const fetchMock = jest.fn((url: string) => {
+        const section = url.includes('/api/admin/stats?')
+          ? new URL(url, 'http://localhost').searchParams.get('section')
+          : null;
+        if (deferFeedback && section === 'feedback') {
+          return new Promise((resolve) => {
+            resolveFeedback = resolve;
+          });
+        }
+        return baseFetch(url);
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      render(<AdminPage />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('stats-card-top-agents')).toHaveAttribute('aria-busy', 'false');
+      });
+
+      const callsBeforeFilter = fetchMock.mock.calls.length;
+      deferFeedback = true;
+      fireEvent.change(screen.getByDisplayValue('All Sources'), { target: { value: 'web' } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('stats-card-feedback-summary')).toHaveAttribute('aria-busy', 'true');
+        expect(screen.getByTestId('stats-card-top-agents')).toHaveAttribute('aria-busy', 'false');
+      });
+      expect(screen.getByText('Top Agents by Usage')).toBeInTheDocument();
+
+      const refreshCalls = fetchMock.mock.calls
+        .slice(callsBeforeFilter)
+        .map(([url]) => new URL(url, 'http://localhost').searchParams.get('section'))
+        .filter(Boolean);
+      expect(refreshCalls).toHaveLength(9);
+      expect(new Set(refreshCalls).size).toBe(9);
+      expect(refreshCalls).not.toContain('filters');
+
+      resolveFeedback?.({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          success: true,
+          data: { feedback_summary: mockStatsResponse.data.feedback_summary },
+        }),
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('stats-card-feedback-summary')).toHaveAttribute('aria-busy', 'false');
+      });
+
+      const callsBeforeBotFilter = fetchMock.mock.calls.length;
+      fireEvent.click(screen.getByLabelText(/show bot users/i));
+      await waitFor(() => {
+        expect(fetchMock.mock.calls.length).toBe(callsBeforeBotFilter + 4);
+      });
+      const botFilterSections = fetchMock.mock.calls
+        .slice(callsBeforeBotFilter)
+        .map(([url]) => new URL(url, 'http://localhost').searchParams.get('section'));
+      expect(new Set(botFilterSections)).toEqual(new Set([
+        'top_users',
+        'top_agents',
+        'response_time',
+        'hourly_heatmap',
+      ]));
+    });
+
     it('renders user list with correct data', async () => {
       render(<AdminPage />);
 
@@ -1651,13 +1721,15 @@ describe('Admin Dashboard Page', () => {
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
-          expect.stringContaining('/api/admin/stats?from=')
+          expect.stringContaining('/api/admin/stats?from='),
+          expect.objectContaining({ signal: expect.any(AbortSignal) })
         );
       });
 
       // Initial fetch uses from/to date params instead of range=30d
       expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/api/admin/stats?from=')
+        expect.stringContaining('/api/admin/stats?from='),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });
 

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -10,6 +10,7 @@ RunStatsTable,
 TopCreatorsCard,
 VisibilityBreakdown,
 } from "@/components/admin/insights/SkillMetricsCards";
+import { AsyncStatsCard } from "@/components/admin/insights/AsyncStatsCard";
 import { CrawlConsoleDialog } from "@/components/admin/platform/CrawlConsoleDialog";
 import { CrawlConsoleHeaderPill } from "@/components/admin/platform/CrawlConsoleHeaderPill";
 import { HealthTab } from "@/components/admin/platform/HealthTab";
@@ -56,11 +57,13 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { SlidingSelectorIndicator } from "@/components/ui/sliding-selector";
 import { Tabs,TabsContent,TabsList,TabsTrigger } from "@/components/ui/tabs";
 import { useAdminRole } from "@/hooks/use-admin-role";
+import { useAdminStatsSections } from "@/hooks/use-admin-stats-sections";
 import { useAdminTabGates,type AdminTabGateSimulationTarget } from "@/hooks/useAdminTabGates";
 import { getConfig } from "@/lib/config";
 import { withAdminSimulationParams } from "@/lib/rbac/admin-simulation-query";
 import { cn } from "@/lib/utils";
 import type { SkillMetricsAdmin } from "@/types/agent-skill";
+import { ADMIN_STATS_SECTIONS,type AdminStats,type AdminStatsOwnerType,type AdminStatsSection } from "@/types/admin-stats";
 import type { Team as TeamType } from "@/types/teams";
 import { Activity,Archive,Bot,CheckCircle2,ChevronLeft,ChevronRight,Clock,Database,ExternalLink,Eye,FileText,Filter,Globe,Hash,KeyRound,Layers,Link2,ListChecks,Loader2,MessageSquare,RefreshCw,Search,Settings,Shield,ShieldCheck,ThumbsDown,ThumbsUp,Trash2,TrendingUp,Unlink,User,UserPlus,Users,UsersIcon,Wrench,X,Zap,type LucideIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
@@ -71,68 +74,17 @@ import { SlackIcon } from "@/components/ui/icons";
 
 // Owner classification for the Top Users leaderboards (server-computed in
 // /api/admin/stats). Drives the identity badge next to each name.
-type OwnerType = 'service_account' | 'slack_bot' | 'linked' | 'unlinked_slack';
+type OwnerType = AdminStatsOwnerType;
 
-interface AdminStats {
-  platform_summary?: {
-    satisfaction_rate: number;
-  };
-  overview: {
-    total_users: number;
-    total_conversations: number;
-    total_messages: number;
-    shared_conversations: number;
-    dau: number;
-    mau: number;
-    conversations_today: number;
-    messages_today: number;
-    avg_messages_per_conversation: number;
-  };
-  daily_activity: Array<{
-    date: string;
-    active_users: number;
-    conversations: number;
-    messages: number;
-  }>;
-  top_users: {
-    by_conversations: Array<{ _id: string; count: number; name?: string; owner_type?: OwnerType }>;
-    by_messages: Array<{ _id: string; count: number; name?: string; owner_type?: OwnerType }>;
-  };
-  top_agents: Array<{ _id: string; count: number }>;
-  feedback_summary: {
-    positive: number;
-    negative: number;
-    total: number;
-    satisfaction_rate?: number;
-    by_source?: Record<string, { positive: number; negative: number }>;
-    categories?: Array<{ category: string; count: number }>;
-    daily?: Array<{ date: string; positive: number; negative: number }>;
-  };
-  response_time: {
-    avg_ms: number;
-    min_ms: number;
-    max_ms: number;
-    sample_count: number;
-    samples?: Array<{ ts: string; latency_ms: number }>;
-  };
-  hourly_heatmap: Array<{ hour: number; count: number }>;
-  completed_workflows: {
-    total: number;
-    today: number;
-    failed: number;
-    completion_rate: number;
-    avg_steps_per_workflow: number;
-  };
-  slack?: {
-    channels: { total: number; qanda_enabled: number; alerts_enabled: number; ai_enabled: number };
-    total_interactions: number;
-    unique_users: number;
-    daily: Array<{ date: string; interactions: number; unique_users: number; escalated: number }>;
-    top_channels: Array<{ channel_name: string; interactions: number }>;
-  };
-  available_channels?: string[];
-  available_agents?: Array<{ id: string; name: string }>;
-}
+const FILTER_REFRESH_STATS_SECTIONS: readonly AdminStatsSection[] = ADMIN_STATS_SECTIONS.filter(
+  (section) => section !== 'filters',
+);
+const BOT_FILTER_STATS_SECTIONS: readonly AdminStatsSection[] = [
+  'top_users',
+  'top_agents',
+  'response_time',
+  'hourly_heatmap',
+];
 
 interface FeedbackEntry {
   message_id: string;
@@ -474,52 +426,60 @@ function formatBucketLabel(dateStr: string): string {
 }
 
 function OverviewStatsCards({
+  error,
+  loading,
   overview,
 }: {
-  overview: AdminStats['overview'] | null;
+  error?: string | null;
+  loading: boolean;
+  overview?: AdminStats['overview'];
 }) {
-  if (!overview) return null;
-
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Total Users</CardTitle>
-          <Users className="h-4 w-4 text-muted-foreground" />
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{overview.total_users}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            DAU: {overview.dau} | MAU: {overview.mau}
-          </p>
-        </CardContent>
-      </Card>
+      <AsyncStatsCard error={error} loading={loading} testId="stats-card-overview-users">
+        {overview ? <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Users</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{overview.total_users}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              DAU: {overview.dau} | MAU: {overview.mau}
+            </p>
+          </CardContent>
+        </Card> : undefined}
+      </AsyncStatsCard>
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Conversations</CardTitle>
-          <MessageSquare className="h-4 w-4 text-muted-foreground" />
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{overview.total_conversations}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            Today: +{overview.conversations_today}
-          </p>
-        </CardContent>
-      </Card>
+      <AsyncStatsCard error={error} loading={loading} testId="stats-card-overview-conversations">
+        {overview ? <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Conversations</CardTitle>
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{overview.total_conversations}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Today: +{overview.conversations_today}
+            </p>
+          </CardContent>
+        </Card> : undefined}
+      </AsyncStatsCard>
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Messages</CardTitle>
-          <Activity className="h-4 w-4 text-muted-foreground" />
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{overview.total_messages}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            Today: +{overview.messages_today}
-          </p>
-        </CardContent>
-      </Card>
+      <AsyncStatsCard error={error} loading={loading} testId="stats-card-overview-messages">
+        {overview ? <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Messages</CardTitle>
+            <Activity className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{overview.total_messages}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Today: +{overview.messages_today}
+            </p>
+          </CardContent>
+        </Card> : undefined}
+      </AsyncStatsCard>
     </div>
   );
 }
@@ -564,8 +524,6 @@ function AdminPage() {
     "selected account";
   const auditLogsEnabled = getConfig('auditLogsEnabled');
   const feedbackEnabled = getConfig('feedbackEnabled');
-  const [stats, setStats] = useState<AdminStats | null>(null);
-  const [globalOverview, setGlobalOverview] = useState<AdminStats['overview'] | null>(null);
   const [skillStats, setSkillStats] = useState<SkillMetricsAdmin | null>(null);
   // `teams` is the FULL team list, used only by the shared Stats/Feedback
   // team-filter dropdowns and the access-simulation team picker (which need
@@ -584,7 +542,6 @@ function AdminPage() {
   // Archived teams are hidden by default; this toggles the `include_archived`
   // query param so admins can reveal retired / orphaned-from-Okta teams.
   const [showArchivedTeams, setShowArchivedTeams] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedUserEmail, setSelectedUserEmail] = useState<string | null>(null);
   const [simulationType, setSimulationType] = useState<"user" | "team">(simulationTarget?.type ?? "user");
@@ -903,7 +860,6 @@ function AdminPage() {
     }
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
-  const [statsRefreshing, setStatsRefreshing] = useState(false);
   const [statsChannelFilter, setStatsChannelFilter] = useState<string[]>([]);
   const [statsChannels, setStatsChannels] = useState<string[]>([]);
   // Agent filter: selected agent NAMES (dropdown labels), mapped to ids for the
@@ -915,6 +871,72 @@ function AdminPage() {
   const [showBotUsers, setShowBotUsers] = useState(false);
   const rangeLabel = datePreset === "1h" ? "1 Hour" : datePreset === "12h" ? "12 Hours" : datePreset === "24h" ? "24 Hours" : datePreset === "7d" ? "7 Days" : datePreset === "90d" ? "90 Days" : datePreset === "custom" ? "Custom Range" : "30 Days";
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+
+  const expandedStatsUsers = useMemo(() => {
+    const emails = new Set<string>();
+    for (const selection of userFilter) {
+      if (selection.startsWith('team:')) {
+        const team = teams.find((candidate) => candidate.name === selection.slice(5));
+        for (const member of team?.members ?? []) emails.add(member.user_id);
+      } else {
+        emails.add(selection);
+      }
+    }
+    return [...emails];
+  }, [teams, userFilter]);
+
+  const getStatsSectionUrl = useCallback((section: AdminStatsSection): string => {
+    const params = new URLSearchParams({
+      from: dateRange.from,
+      section,
+      to: dateRange.to,
+    });
+    // Overview is intentionally global across source/user/agent filters, while
+    // still honoring the selected date range. This preserves the dashboard's
+    // platform-wide headline metrics without issuing a duplicate stats wave.
+    if (section !== 'overview') {
+      if (sourceFilter !== 'all') params.set('source', sourceFilter);
+      if (expandedStatsUsers.length > 0) params.set('user', expandedStatsUsers.join(','));
+      if (sourceFilter === 'slack' && statsChannelFilter.length > 0) {
+        params.set('channel', statsChannelFilter.join(','));
+      }
+      const agentIds = statsAgentFilter
+        .map((name) => statsAgents.find((agent) => agent.name === name)?.id)
+        .filter((id): id is string => Boolean(id));
+      if (agentIds.length > 0) params.set('agent', agentIds.join(','));
+      if (showBotUsers) params.set('include_bots', 'true');
+    }
+    return withAdminSimulationParams(`/api/admin/stats?${params.toString()}`, simulationTarget);
+  }, [
+    dateRange,
+    expandedStatsUsers,
+    showBotUsers,
+    simulationTarget,
+    sourceFilter,
+    statsAgentFilter,
+    statsAgents,
+    statsChannelFilter,
+  ]);
+
+  const {
+    data: stats,
+    loadSections: loadStatsSections,
+    refreshing: statsRefreshing,
+    reset: resetStatsSections,
+    statuses: statsSectionStatuses,
+  } = useAdminStatsSections({
+    getSectionUrl: getStatsSectionUrl,
+    onFatalError: setError,
+    scopeKey: simulationScopeKey,
+  });
+
+  useEffect(() => {
+    if (stats.available_channels) setStatsChannels(stats.available_channels);
+  }, [stats.available_channels]);
+
+  useEffect(() => {
+    if (stats.available_agents) setStatsAgents(stats.available_agents);
+  }, [stats.available_agents]);
 
   const visitedTabsRef = useRef<Set<string>>(new Set());
   const previousSimulationScopeKeyRef = useRef(simulationScopeKey);
@@ -928,10 +950,10 @@ function AdminPage() {
     if (previousSimulationScopeKeyRef.current !== simulationScopeKey) {
       previousSimulationScopeKeyRef.current = simulationScopeKey;
       visitedTabsRef.current.clear();
-      setStats(null);
-      setGlobalOverview(null);
+      resetStatsSections();
       setFeedbackData(null);
       setStatsChannels([]);
+      setStatsAgents([]);
       setFeedbackChannels([]);
       setFeedbackUsers([]);
       setTeams([]);
@@ -941,13 +963,11 @@ function AdminPage() {
       setGridLoaded(false);
       setSelectedUserId(null);
       setSelectedUserEmail(null);
-      setStatsRefreshing(false);
       setFeedbackLoading(false);
-      setLoading(false);
     }
     if (status !== "authenticated" && getConfig('ssoEnabled')) return;
     loadTabDataEvent(activeTab);
-  }, [activeTab, simulationScopeKey, status]);
+  }, [activeTab, resetStatsSections, simulationScopeKey, status]);
   const fetchTeamsFromDb = async (): Promise<Team[]> => {
     const response = await fetch(withAdminSimulationParams(`/api/admin/teams?fresh=${Date.now()}`, simulationTarget), {
       cache: 'no-store',
@@ -1035,148 +1055,48 @@ function AdminPage() {
     }
   };
 
-  // Expand team: prefixed selections to member emails
-  // See `filteredTeams` above for the canonical-team-membership refactor note —
-  // same defensive guard applies here.
-  const expandStatsUsers = (selected: string[]): string[] => {
-    const emails = new Set<string>();
-    for (const s of selected) {
-      if (s.startsWith('team:')) {
-        const team = teams.find((t) => t.name === s.slice(5));
-        if (team) (team.members ?? []).forEach((m) => emails.add(m.user_id));
-      } else {
-        emails.add(s);
-      }
-    }
-    return [...emails];
-  };
-
-  // Re-fetch stats when filters change (lightweight — only refetch stats endpoint)
-  const statsFilterRef = React.useRef({ range: dateRange, source: sourceFilter, users: userFilter, channels: statsChannelFilter, agents: statsAgentFilter, showBots: showBotUsers, teams });
-  // Map selected agent display names → their ids for the `agent` query param.
-  const agentIdsForNames = React.useCallback(
-    (names: string[]) => names
-      .map((n) => statsAgents.find((a) => a.name === n)?.id)
-      .filter((id): id is string => !!id),
-    [statsAgents],
-  );
-  const fetchStatsWithFilters = async (range?: DateRange, source?: 'all' | 'web' | 'slack', userEmails?: string[], channels?: string[], agents?: string[]) => {
-    if (status !== "authenticated" && getConfig('ssoEnabled')) return;
-    const requestScopeKey = simulationScopeKey;
-    setStatsRefreshing(true);
-    try {
-      const r = range ?? dateRange;
-      const s = source ?? sourceFilter;
-      const u = userEmails ?? expandStatsUsers(userFilter);
-      const ch = channels ?? statsChannelFilter;
-      const ag = agents ?? statsAgentFilter;
-      const params = new URLSearchParams({ from: r.from, to: r.to });
-      if (s !== 'all') params.set('source', s);
-      if (u.length > 0) params.set('user', u.join(','));
-      if (s === 'slack' && ch.length > 0) params.set('channel', ch.join(','));
-      const agentIds = agentIdsForNames(ag);
-      if (agentIds.length > 0) params.set('agent', agentIds.join(','));
-      if (showBotUsers) params.set('include_bots', 'true');
-      const hasNonRangeFilters = s !== 'all'
-        || u.length > 0
-        || agentIds.length > 0;
-      const overviewParams = new URLSearchParams({ from: r.from, to: r.to });
-      const [res, overviewRes] = await Promise.all([
-        fetch(withAdminSimulationParams(`/api/admin/stats?${params}`, simulationTarget)),
-        hasNonRangeFilters
-          ? fetch(withAdminSimulationParams(`/api/admin/stats?${overviewParams}`, simulationTarget))
-          : null,
-      ]);
-      if (res.ok) {
-        const [json, overviewJson] = await Promise.all([
-          res.json(),
-          overviewRes?.ok ? overviewRes.json() : Promise.resolve(null),
-        ]);
-        if (json.success && activeDataScopeKeyRef.current === requestScopeKey) {
-          setStats(json.data);
-          setGlobalOverview(
-            overviewJson?.success ? overviewJson.data.overview : json.data.overview,
-          );
-          if (json.data.available_channels) setStatsChannels(json.data.available_channels);
-          if (json.data.available_agents) setStatsAgents(json.data.available_agents);
-        }
-      }
-    } catch {
-      // keep existing stats on failure
-    } finally {
-      if (activeDataScopeKeyRef.current === requestScopeKey) {
-        setStatsRefreshing(false);
-      }
-    }
-  };
-  const fetchStatsWithFiltersEvent = useEffectEvent(fetchStatsWithFilters);
+  // Use a value-based signature so loading the team/filter option lists does not
+  // accidentally issue a second stats request. Only data that changes the query
+  // participates in the signature.
+  const statsFilterKey = useMemo(() => JSON.stringify({
+    agents: statsAgentFilter,
+    channels: statsChannelFilter,
+    from: dateRange.from,
+    source: sourceFilter,
+    to: dateRange.to,
+    users: expandedStatsUsers,
+  }), [
+    dateRange.from,
+    dateRange.to,
+    expandedStatsUsers,
+    sourceFilter,
+    statsAgentFilter,
+    statsChannelFilter,
+  ]);
+  const statsFilterRef = useRef(statsFilterKey);
   useEffect(() => {
-    const current = { range: dateRange, source: sourceFilter, users: userFilter, channels: statsChannelFilter, agents: statsAgentFilter, showBots: showBotUsers, teams };
-    if (statsFilterRef.current.range === current.range
-      && statsFilterRef.current.source === current.source
-      && statsFilterRef.current.users === current.users
-      && statsFilterRef.current.channels === current.channels
-      && statsFilterRef.current.agents === current.agents
-      && statsFilterRef.current.showBots === current.showBots
-      && statsFilterRef.current.teams === current.teams) return; // skip initial
-    statsFilterRef.current = current;
-    fetchStatsWithFiltersEvent();
-  }, [dateRange, sourceFilter, userFilter, statsChannelFilter, statsAgentFilter, showBotUsers, status, teams]);
+    if (statsFilterRef.current === statsFilterKey) return;
+    statsFilterRef.current = statsFilterKey;
+    if (!visitedTabsRef.current.has('_stats-loaded')) return;
+    if (status !== "authenticated" && getConfig('ssoEnabled')) return;
+    const handle = window.setTimeout(() => {
+      void loadStatsSections(FILTER_REFRESH_STATS_SECTIONS);
+    }, 150);
+    return () => window.clearTimeout(handle);
+  }, [loadStatsSections, statsFilterKey, status]);
+
+  const showBotUsersRef = useRef(showBotUsers);
+  useEffect(() => {
+    if (showBotUsersRef.current === showBotUsers) return;
+    showBotUsersRef.current = showBotUsers;
+    if (!visitedTabsRef.current.has('_stats-loaded')) return;
+    if (status !== "authenticated" && getConfig('ssoEnabled')) return;
+    void loadStatsSections(BOT_FILTER_STATS_SECTIONS);
+  }, [loadStatsSections, showBotUsers, status]);
 
   const loadStats = async () => {
-    const requestScopeKey = simulationScopeKey;
-    setLoading(true);
     setError(null);
-    try {
-      const hasStatsFilters = sourceFilter !== 'all' || userFilter.length > 0;
-      const p = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
-      const globalP = new URLSearchParams({ from: dateRange.from, to: dateRange.to });
-      if (sourceFilter !== 'all') p.set('source', sourceFilter);
-      if (userFilter.length > 0) p.set('user', userFilter.join(','));
-      if (showBotUsers) p.set('include_bots', 'true');
-      const [statsRes, globalStatsRes] = await Promise.all([
-        fetch(withAdminSimulationParams(`/api/admin/stats?${p}`, simulationTarget)),
-        hasStatsFilters
-          ? fetch(withAdminSimulationParams(`/api/admin/stats?${globalP}`, simulationTarget))
-          : null,
-      ]);
-
-      if (activeDataScopeKeyRef.current !== requestScopeKey) return;
-
-      if (statsRes.status === 401) {
-        setError('Not authenticated. Please sign in via SSO first.');
-        return;
-      }
-
-      const statsForbidden = statsRes.status === 403;
-      if (statsForbidden && !tabGateValues.settings) {
-        setError('Access denied. Try signing out and back in to refresh your session.');
-        return;
-      }
-
-      const [statsResponse, globalStatsResponse] = await Promise.all([
-        statsForbidden ? Promise.resolve({ success: false }) : statsRes.json(),
-        globalStatsRes ? globalStatsRes.json().catch(() => null) : null,
-      ]);
-
-      if (statsResponse.success) {
-        setStats(statsResponse.data);
-        if (statsResponse.data.available_channels) setStatsChannels(statsResponse.data.available_channels);
-        if (statsResponse.data.available_agents) setStatsAgents(statsResponse.data.available_agents);
-        const overviewData = globalStatsResponse?.success ? globalStatsResponse.data.overview : statsResponse.data.overview;
-        setGlobalOverview(overviewData);
-      } else if (!statsForbidden) {
-        throw new Error(statsResponse.error || 'Failed to load stats');
-      }
-    } catch (err) {
-      if (activeDataScopeKeyRef.current !== requestScopeKey) return;
-      console.error('[Admin] Failed to load stats:', err);
-      setError(getErrorMessage(err, "") || 'Failed to load stats');
-    } finally {
-      if (activeDataScopeKeyRef.current === requestScopeKey) {
-        setLoading(false);
-      }
-    }
+    await loadStatsSections();
   };
 
   const loadTeamsData = async () => {
@@ -1359,14 +1279,6 @@ function AdminPage() {
     setTeamDialogMode(mode);
     setTeamDetailsOpen(true);
   };
-
-  if (loading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <CAIPESpinner size="lg" message="Loading admin data..." />
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -2259,7 +2171,6 @@ function AdminPage() {
                         const src = e.target.value as 'all' | 'web' | 'slack';
                         setSourceFilter(src);
                         setStatsChannelFilter([]);
-                        fetchStatsWithFilters(undefined, src, undefined, []);
                         updateSharedFilterUrl({ source: src !== 'all' ? src : null });
                       }}
                       className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
@@ -2274,7 +2185,6 @@ function AdminPage() {
                         selected={statsChannelFilter}
                         onChange={(channels) => {
                           setStatsChannelFilter(channels);
-                          fetchStatsWithFilters(undefined, undefined, undefined, channels);
                         }}
                         placeholder="All Channels"
                         searchPlaceholder="Search channels..."
@@ -2288,7 +2198,6 @@ function AdminPage() {
                         selected={statsAgentFilter}
                         onChange={(agents) => {
                           setStatsAgentFilter(agents);
-                          fetchStatsWithFilters(undefined, undefined, undefined, undefined, agents);
                         }}
                         placeholder="All Agents"
                         searchPlaceholder="Search agents..."
@@ -2303,21 +2212,7 @@ function AdminPage() {
                       ]}
                       selected={userFilter}
                       onChange={(selected) => {
-                        const emails = new Set<string>();
-                        for (const s of selected) {
-                          if (s.startsWith('team:')) {
-                            const teamName = s.slice(5);
-                            const team = teams.find((t) => t.name === teamName);
-                            // Defensive read — see `filteredTeams` for the
-                            // canonical-team-membership refactor context.
-                            if (team) (team.members ?? []).forEach((m) => emails.add(m.user_id));
-                          } else {
-                            emails.add(s);
-                          }
-                        }
-                        const emailList = [...emails];
                         setUserFilter(selected);
-                        fetchStatsWithFilters(undefined, undefined, emailList);
                         updateSharedFilterUrl({ users: selected.length > 0 ? selected.join(',') : null });
                       }}
                       placeholder="All Users & Teams"
@@ -2331,7 +2226,6 @@ function AdminPage() {
                       onChange={(preset, range) => {
                         setDatePreset(preset);
                         setDateRange(range);
-                        fetchStatsWithFilters(range);
                         updateSharedFilterUrl({
                           dateRange: preset !== '30d' ? preset : null,
                           from: preset === 'custom' ? range.from : null,
@@ -2345,27 +2239,29 @@ function AdminPage() {
                     size="sm"
                     className="gap-1.5"
                     disabled={statsRefreshing}
-                    onClick={() => fetchStatsWithFilters()}
+                    onClick={() => void loadStatsSections()}
                   >
                     <RefreshCw className={cn("h-3.5 w-3.5", statsRefreshing && "animate-spin")} />
                     Refresh
                   </Button>
                 </div>
 
-                {stats && (
-                  <div className="relative space-y-4">
-                    {statsRefreshing && (
-                      <div className="absolute inset-0 bg-background/60 z-10 flex items-center justify-center rounded">
-                        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                      </div>
-                    )}
+                  <div className="space-y-4">
                     <OverviewStatsCards
-                      overview={globalOverview ?? stats.overview}
+                      error={statsSectionStatuses.overview.error}
+                      loading={statsSectionStatuses.overview.loading}
+                      overview={stats.overview}
                     />
 
                     {/* DAU and MAU Trend Charts */}
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                      <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.activity.error ?? statsSectionStatuses.overview.error}
+                        loading={statsSectionStatuses.activity.loading || statsSectionStatuses.overview.loading}
+                        minHeightClassName="min-h-96"
+                        testId="stats-card-daily-active-users"
+                      >
+                        {stats.daily_activity && stats.overview ? <Card>
                         <CardHeader>
                           <CardTitle>Daily Active Users (DAU)</CardTitle>
                           <CardDescription>Active users per day ({rangeLabel})</CardDescription>
@@ -2396,9 +2292,16 @@ function AdminPage() {
                             </div>
                           </div>
                         </CardContent>
-                      </Card>
+                        </Card> : undefined}
+                      </AsyncStatsCard>
 
-                      <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.activity.error ?? statsSectionStatuses.overview.error}
+                        loading={statsSectionStatuses.activity.loading || statsSectionStatuses.overview.loading}
+                        minHeightClassName="min-h-96"
+                        testId="stats-card-conversation-activity"
+                      >
+                        {stats.daily_activity && stats.overview ? <Card>
                         <CardHeader>
                           <CardTitle>Conversation Activity</CardTitle>
                           <CardDescription>New conversations created daily</CardDescription>
@@ -2429,11 +2332,18 @@ function AdminPage() {
                             </div>
                           </div>
                         </CardContent>
-                      </Card>
+                        </Card> : undefined}
+                      </AsyncStatsCard>
                     </div>
 
                     {/* Messages Activity Chart */}
-                    <Card>
+                    <AsyncStatsCard
+                      error={statsSectionStatuses.activity.error ?? statsSectionStatuses.overview.error}
+                      loading={statsSectionStatuses.activity.loading || statsSectionStatuses.overview.loading}
+                      minHeightClassName="min-h-80"
+                      testId="stats-card-message-activity"
+                    >
+                      {stats.daily_activity && stats.overview ? <Card>
                       <CardHeader>
                         <CardTitle>Message Activity ({rangeLabel})</CardTitle>
                         <CardDescription>Messages sent per day</CardDescription>
@@ -2470,7 +2380,8 @@ function AdminPage() {
                           </div>
                         </div>
                       </CardContent>
-                    </Card>
+                      </Card> : undefined}
+                    </AsyncStatsCard>
 
                     {/* Top Users */}
                     <div className="flex items-center justify-between">
@@ -2489,7 +2400,13 @@ function AdminPage() {
                       </label>
                     </div>
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                      <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.top_users.error}
+                        loading={statsSectionStatuses.top_users.loading}
+                        minHeightClassName="min-h-64"
+                        testId="stats-card-top-users-conversations"
+                      >
+                        {stats.top_users ? <Card>
                         <CardHeader>
                           <CardTitle>Top Users by Conversations</CardTitle>
                         </CardHeader>
@@ -2509,9 +2426,16 @@ function AdminPage() {
                             ))}
                           </div>
                         </CardContent>
-                      </Card>
+                        </Card> : undefined}
+                      </AsyncStatsCard>
 
-                      <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.top_users.error}
+                        loading={statsSectionStatuses.top_users.loading}
+                        minHeightClassName="min-h-64"
+                        testId="stats-card-top-users-messages"
+                      >
+                        {stats.top_users ? <Card>
                         <CardHeader>
                           <CardTitle>Top Users by Messages</CardTitle>
                         </CardHeader>
@@ -2531,12 +2455,19 @@ function AdminPage() {
                             ))}
                           </div>
                         </CardContent>
-                      </Card>
+                        </Card> : undefined}
+                      </AsyncStatsCard>
                     </div>
 
                     {/* Top Agents and Feedback */}
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                      <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.top_agents.error}
+                        loading={statsSectionStatuses.top_agents.loading}
+                        minHeightClassName="min-h-72"
+                        testId="stats-card-top-agents"
+                      >
+                        {stats.top_agents ? <Card>
                         <CardHeader>
                           <CardTitle className="flex items-center gap-2">
                             <Bot className="h-5 w-5" />
@@ -2571,9 +2502,16 @@ function AdminPage() {
                             })}
                           </div>
                         </CardContent>
-                      </Card>
+                        </Card> : undefined}
+                      </AsyncStatsCard>
 
-                      <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.feedback.error}
+                        loading={statsSectionStatuses.feedback.loading}
+                        minHeightClassName="min-h-72"
+                        testId="stats-card-feedback-summary"
+                      >
+                        {stats.feedback_summary ? <Card>
                         <CardHeader>
                           <CardTitle className="flex items-center gap-2">
                             <ThumbsUp className="h-5 w-5" />
@@ -2664,7 +2602,8 @@ function AdminPage() {
                           )}
 
                         </CardContent>
-                      </Card>
+                        </Card> : undefined}
+                      </AsyncStatsCard>
                     </div>
 
                     {/* Feedback Trend + Response Time — 50/50 split. Response Time
@@ -2672,8 +2611,16 @@ function AdminPage() {
                         it. It sits here rather than in the Web section so it
                         renders for Slack-only stacks too. */}
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                      {stats.feedback_summary?.daily && stats.feedback_summary.daily.length > 0 && (
-                        <Card>
+                      {(statsSectionStatuses.feedback.loading
+                        || statsSectionStatuses.feedback.error
+                        || (stats.feedback_summary?.daily?.length ?? 0) > 0) && (
+                        <AsyncStatsCard
+                          error={statsSectionStatuses.feedback.error}
+                          loading={statsSectionStatuses.feedback.loading}
+                          minHeightClassName="min-h-72"
+                          testId="stats-card-feedback-trend"
+                        >
+                          {stats.feedback_summary?.daily && stats.feedback_summary.daily.length > 0 ? <Card>
                           <CardHeader>
                             <CardTitle>Feedback Trend ({rangeLabel})</CardTitle>
                             <CardDescription>Daily positive vs negative feedback</CardDescription>
@@ -2688,13 +2635,19 @@ function AdminPage() {
                               color="rgb(34, 197, 94)"
                             />
                           </CardContent>
-                        </Card>
+                          </Card> : undefined}
+                        </AsyncStatsCard>
                       )}
 
                       {/* Always shown so filtering to an agent with no latency
                           samples renders an empty chart, not a missing card. */}
-                      {stats.response_time && (
-                        <Card>
+                      <AsyncStatsCard
+                        error={statsSectionStatuses.response_time.error}
+                        loading={statsSectionStatuses.response_time.loading}
+                        minHeightClassName="min-h-72"
+                        testId="stats-card-response-time"
+                      >
+                        {stats.response_time ? <Card>
                           <CardHeader>
                             <CardTitle className="flex items-center gap-2">
                               <Zap className="h-5 w-5" />
@@ -2727,13 +2680,18 @@ function AdminPage() {
                               );
                             })()}
                           </CardContent>
-                        </Card>
-                      )}
+                        </Card> : undefined}
+                      </AsyncStatsCard>
                     </div>
 
                     {/* Hourly Activity Heatmap */}
-                    {stats.hourly_heatmap && (
-                      <Card>
+                    <AsyncStatsCard
+                      error={statsSectionStatuses.hourly_heatmap.error}
+                      loading={statsSectionStatuses.hourly_heatmap.loading}
+                      minHeightClassName="min-h-72"
+                      testId="stats-card-hourly-activity"
+                    >
+                      {stats.hourly_heatmap ? <Card>
                         <CardHeader>
                           <CardTitle className="flex items-center gap-2">
                             <Clock className="h-5 w-5" />
@@ -2805,11 +2763,13 @@ function AdminPage() {
                             <span>11pm</span>
                           </div>
                         </CardContent>
-                      </Card>
-                    )}
+                      </Card> : undefined}
+                    </AsyncStatsCard>
 
                     {/* ─── Web Section ─── */}
-                    {stats.completed_workflows && (
+                    {(stats.completed_workflows
+                      || statsSectionStatuses.completed_workflows.loading
+                      || statsSectionStatuses.completed_workflows.error) && (
                       <>
                         <div className="flex items-center gap-2 pt-2">
                           <Globe className="h-5 w-5 text-muted-foreground" />
@@ -2819,8 +2779,13 @@ function AdminPage() {
 
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                           {/* Completed Workflows */}
-                          {stats.completed_workflows && (
-                            <Card>
+                          <AsyncStatsCard
+                            error={statsSectionStatuses.completed_workflows.error}
+                            loading={statsSectionStatuses.completed_workflows.loading}
+                            minHeightClassName="min-h-64"
+                            testId="stats-card-completed-workflows"
+                          >
+                            {stats.completed_workflows ? <Card>
                               <CardHeader>
                                 <CardTitle className="flex items-center gap-2">
                                   <CheckCircle2 className="h-5 w-5" />
@@ -2858,18 +2823,20 @@ function AdminPage() {
                                   </div>
                                 )}
                               </CardContent>
-                            </Card>
-                          )}
+                            </Card> : undefined}
+                          </AsyncStatsCard>
                         </div>
                       </>
                     )}
 
                     {/* ─── Slack Section ─── */}
-                    {stats.slack && (
-                      <SlackStatsSection slack={stats.slack} rangeLabel={rangeLabel} />
-                    )}
+                    <SlackStatsSection
+                      error={statsSectionStatuses.slack.error}
+                      loading={statsSectionStatuses.slack.loading}
+                      rangeLabel={rangeLabel}
+                      slack={stats.slack}
+                    />
                   </div>
-                )}
 
                 {/* ─── Skills Section ─── */}
                 {skillStats && (

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -1094,6 +1094,53 @@ describe('GET /api/admin/stats — Full Response Shape', () => {
 });
 
 // ============================================================================
+// Tests: independently loadable sections
+// ============================================================================
+
+describe('GET /api/admin/stats — Section Responses', () => {
+  beforeEach(resetMocks);
+
+  it('returns only the requested section and skips unrelated database queries', async () => {
+    const { feedbackCol } = setupAdminWithCollections();
+
+    const res = await GET(makeRequest('/api/admin/stats?section=overview'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveProperty('overview');
+    expect(body.data).not.toHaveProperty('daily_activity');
+    expect(body.data).not.toHaveProperty('feedback_summary');
+    expect(body.data).not.toHaveProperty('top_users');
+    expect(feedbackCol.aggregate).not.toHaveBeenCalled();
+    expect(mockGetAllAgents).not.toHaveBeenCalled();
+  });
+
+  it('isolates feedback queries and payload fields from the other cards', async () => {
+    const { feedbackCol } = setupAdminWithCollections();
+
+    const res = await GET(makeRequest('/api/admin/stats?section=feedback'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveProperty('feedback_summary');
+    expect(body.data).toHaveProperty('platform_summary');
+    expect(body.data).not.toHaveProperty('overview');
+    expect(body.data).not.toHaveProperty('response_time');
+    expect(feedbackCol.aggregate).toHaveBeenCalledTimes(4);
+  });
+
+  it('rejects unknown section names', async () => {
+    setupAdminWithCollections();
+
+    const res = await GET(makeRequest('/api/admin/stats?section=unknown'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('INVALID_STATS_SECTION');
+  });
+});
+
+// ============================================================================
 // Tests: parseRange — from/to support and sub-day presets
 // ============================================================================
 

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -17,10 +17,12 @@ createJsonResponseCacheStore,
 envTtlMs,
 withJsonResponseCache,
 } from '@/lib/server-response-cache';
-import type { Document } from 'mongodb';
+import { ADMIN_STATS_SECTIONS,type AdminStatsOwnerType,type AdminStatsSection } from '@/types/admin-stats';
+import type { Collection,Document } from 'mongodb';
 import { NextRequest,NextResponse } from 'next/server';
 
 const adminStatsCache = createJsonResponseCacheStore();
+let botOwnerIdsCache: { expiresAt: number; promise: Promise<string[]> } | null = null;
 
 interface SlackStats {
   channels: {
@@ -58,8 +60,16 @@ interface ChannelStatsDocument extends Document {
 
 type BucketUnit = 'minute' | 'hour' | 'day';
 
+function parseStatsSection(searchParams: URLSearchParams): AdminStatsSection | 'all' | null {
+  const section = searchParams.get('section');
+  if (!section) return 'all';
+  return (ADMIN_STATS_SECTIONS as readonly string[]).includes(section)
+    ? section as AdminStatsSection
+    : null;
+}
+
 /** Identity classification for a Top Users leaderboard owner (see classifyOwner). */
-type OwnerType = 'service_account' | 'slack_bot' | 'linked' | 'unlinked_slack';
+type OwnerType = AdminStatsOwnerType;
 
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
@@ -160,6 +170,33 @@ function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: nu
 // ("B0…"), the literal "unknown", the Slackbot sentinel, or platform service
 // accounts. We exclude those so the leaderboard is people-only.
 const BOT_OWNER_EXACT = ['unknown', 'USLACKBOT'];
+
+async function getBotOwnerIds(conversations: Collection<Document>): Promise<string[]> {
+  // Every independently loaded people/latency section needs the same global
+  // bot-owner lookup. Coalesce those concurrent requests and keep the result for
+  // the same short window as the stats response cache.
+  if (process.env.NODE_ENV !== 'test' && botOwnerIdsCache && botOwnerIdsCache.expiresAt > Date.now()) {
+    return botOwnerIdsCache.promise;
+  }
+
+  const promise = conversations.distinct('owner_id', {
+    'metadata.owner_is_bot': true,
+  }).then((ids) => ids.filter((id): id is string => typeof id === 'string' && id.length > 0));
+
+  if (process.env.NODE_ENV !== 'test') {
+    const cacheEntry = {
+      expiresAt: Date.now() + envTtlMs('ADMIN_STATS_CACHE_TTL_MS', 15_000),
+      promise,
+    };
+    botOwnerIdsCache = cacheEntry;
+    promise.catch(() => {
+      if (botOwnerIdsCache === cacheEntry) botOwnerIdsCache = null;
+    });
+  }
+
+  return promise;
+}
+
 /** Mongo match fragment (spread into a $match) that keeps only human owners. */
 const HUMAN_OWNER_MATCH: Record<string, unknown> = {
   $and: [
@@ -195,10 +232,17 @@ function andInto(target: Record<string, unknown>, clause: Record<string, unknown
 }
 
 // GET /api/admin/stats
+//
+// `section=<name>` returns one independently cacheable metric group so clients
+// can paint cards as their queries finish. Omitting `section` preserves the
+// original complete response for existing callers.
 export const GET = withErrorHandler(async (request: NextRequest) => {
   return withJsonResponseCache(request, adminStatsCache, () => getAdminStats(request), {
     ttlMs: envTtlMs('ADMIN_STATS_CACHE_TTL_MS', 15_000),
-    maxEntries: 512,
+    // A filtered dashboard now occupies one small entry per section instead of
+    // one large entry. Keep roughly the same number of complete dashboard views
+    // resident without forcing hot sections to evict each other immediately.
+    maxEntries: 2_048,
   });
 });
 
@@ -216,6 +260,20 @@ async function getAdminStats(request: NextRequest) {
 
   const { session } = await getAuthFromBearerOrSession(request);
   const { searchParams } = request.nextUrl;
+  const requestedSection = parseStatsSection(searchParams);
+  if (!requestedSection) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Invalid stats section. Expected one of: ${ADMIN_STATS_SECTIONS.join(', ')}`,
+        code: 'INVALID_STATS_SECTION',
+      },
+      { status: 400 },
+    );
+  }
+  const includesSection = (section: AdminStatsSection): boolean => (
+    requestedSection === 'all' || requestedSection === section
+  );
   const simulationScope = await resolveAuthorizedAdminSimulationScope(searchParams, session);
   const isFullAdmin = simulationScope
     ? await simulationSubjectCanManageAdminSurface(simulationScope, 'stats')
@@ -438,10 +496,14 @@ async function getAdminStats(request: NextRequest) {
     // Top Users section.
     const sectionConvMatch: Document = { ...convSourceFilter };
     const sectionMsgMatch: Document = { ...msgOwnerFilter };
-    if (!includeBots) {
-      const botOwnerIds = (await conversations.distinct('owner_id', {
-        'metadata.owner_is_bot': true,
-      })).filter((id): id is string => typeof id === 'string' && id.length > 0);
+    const needsHumanOwnerFilter = (
+      includesSection('top_users')
+      || includesSection('top_agents')
+      || includesSection('response_time')
+      || includesSection('hourly_heatmap')
+    );
+    if (!includeBots && needsHumanOwnerFilter) {
+      const botOwnerIds = await getBotOwnerIds(conversations);
       // Post-group $match for the leaderboards, which group on owner_id → _id.
       const humanOwnerMatch = botOwnerIds.length > 0
         ? { $and: [HUMAN_OWNER_MATCH, { _id: { $nin: botOwnerIds } }] }
@@ -474,30 +536,33 @@ async function getAdminStats(request: NextRequest) {
     //   - non-admin      → only the caller's own runs (owner_subject.id = sub).
     //   - admin + user=  → resolve the requested emails to Keycloak subs.
     //   - admin, no user → all runs.
-    let workflowRunFilter: Document | null = {};
-    if (sourceFilter === 'slack') {
-      workflowRunFilter = null; // web-only concept; skip the queries entirely
-    } else if (nonAdminScope) {
-      workflowRunFilter = nonAdminScope.sub
-        ? { 'owner_subject.type': 'user', 'owner_subject.id': nonAdminScope.sub }
-        : null;
-    } else if (userEmails.length > 0) {
-      const owners = await users
-        .find(
-          { email: { $in: userEmails } },
-          { projection: { keycloak_sub: 1, 'metadata.keycloak_sub': 1 } },
-        )
-        .toArray();
-      const subs = [
-        ...new Set(
-          owners
-            .map((u) => u.keycloak_sub || u.metadata?.keycloak_sub)
-            .filter((s): s is string => typeof s === 'string' && s.length > 0),
-        ),
-      ];
-      workflowRunFilter = subs.length > 0
-        ? { 'owner_subject.type': 'user', 'owner_subject.id': { $in: subs } }
-        : null; // requested users have no resolvable sub → match nothing
+    let workflowRunFilter: Document | null = null;
+    if (includesSection('completed_workflows')) {
+      workflowRunFilter = {};
+      if (sourceFilter === 'slack') {
+        workflowRunFilter = null; // web-only concept; skip the queries entirely
+      } else if (nonAdminScope) {
+        workflowRunFilter = nonAdminScope.sub
+          ? { 'owner_subject.type': 'user', 'owner_subject.id': nonAdminScope.sub }
+          : null;
+      } else if (userEmails.length > 0) {
+        const owners = await users
+          .find(
+            { email: { $in: userEmails } },
+            { projection: { keycloak_sub: 1, 'metadata.keycloak_sub': 1 } },
+          )
+          .toArray();
+        const subs = [
+          ...new Set(
+            owners
+              .map((u) => u.keycloak_sub || u.metadata?.keycloak_sub)
+              .filter((s): s is string => typeof s === 'string' && s.length > 0),
+          ),
+        ];
+        workflowRunFilter = subs.length > 0
+          ? { 'owner_subject.type': 'user', 'owner_subject.id': { $in: subs } }
+          : null; // requested users have no resolvable sub → match nothing
+      }
     }
 
     const now = new Date();
@@ -507,123 +572,137 @@ async function getAdminStats(request: NextRequest) {
     // ═══════════════════════════════════════════════════════════════
     // OVERVIEW STATS (parallel queries for speed)
     // ═══════════════════════════════════════════════════════════════
-    const [
-      totalUsers,
-      totalConversations,
-      totalMessages,
-      dau,
-      mau,
-      conversationsToday,
-      messagesToday,
-      sharedConversations,
-    ] = await Promise.all([
-      // Total users is range-aware like the conversation and message totals.
-      // Non-admins derive it from activity in conversations they can see;
-      // full admins use the existing last-login activity source.
-      nonAdminScope
-        ? conversations.aggregate([
-            { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
-            { $group: { _id: '$owner_id' } },
-            { $count: 'total' },
-          ]).toArray().then((r) => r[0]?.total || 0)
-        : users.countDocuments({ last_login: { $gte: rangeStart } }),
-      // Scoped to the selected date range (rangeStart), matching daily_activity
-      // and every other range-aware metric below — previously these were
-      // always lifetime totals regardless of the selected range.
-      conversations.countDocuments({ created_at: { $gte: rangeStart }, ...convSourceFilter }),
-      // msgOwnerFilter already carries 'metadata.source' when the caller
-      // explicitly filtered by source=web|slack; unfiltered, this counts
-      // every message regardless of metadata.source (including messages
-      // missing that field or tagged with other values, e.g. 'scheduler'),
-      // matching how totalConversations counts every conversation.
-      messages.countDocuments({ created_at: { $gte: rangeStart }, ...msgOwnerFilter }),
-      // DAU/MAU: derive from conversations when filters are applied, otherwise from users
-      hasFilters
-        ? conversations.aggregate([
-            { $match: { updated_at: { $gte: today }, ...convSourceFilter } },
-            { $group: { _id: '$owner_id' } },
-            { $count: 'total' },
-          ]).toArray().then((r) => r[0]?.total || 0)
-        : users.countDocuments({ last_login: { $gte: today } }),
-      hasFilters
-        ? conversations.aggregate([
-            { $match: { updated_at: { $gte: thisMonth }, ...convSourceFilter } },
-            { $group: { _id: '$owner_id' } },
-            { $count: 'total' },
-          ]).toArray().then((r) => r[0]?.total || 0)
-        : users.countDocuments({ last_login: { $gte: thisMonth } }),
-      conversations.countDocuments({ created_at: { $gte: today }, ...convSourceFilter }),
-      messages.countDocuments({ created_at: { $gte: today }, ...msgOwnerFilter }),
-      // `andInto` rather than spreading a literal `$or` — the non-admin scope
-      // can itself be an `$or`, which a spread would clobber (leaking shared
-      // conversation counts outside the caller's scope).
-      conversations.countDocuments(
-        (() => {
-          const sharedFilter: Record<string, unknown> = { ...convSourceFilter };
-          andInto(sharedFilter, {
-            $or: [
-              { 'sharing.shared_with.0': { $exists: true } },
-              { 'sharing.shared_with_teams.0': { $exists: true } },
-              { 'sharing.share_link_enabled': true },
-            ],
-          });
-          return sharedFilter;
-        })()
-      ),
-    ]);
+    let totalUsers = 0;
+    let totalConversations = 0;
+    let totalMessages = 0;
+    let dau = 0;
+    let mau = 0;
+    let conversationsToday = 0;
+    let messagesToday = 0;
+    let sharedConversations = 0;
+
+    if (includesSection('overview')) {
+      [
+        totalUsers,
+        totalConversations,
+        totalMessages,
+        dau,
+        mau,
+        conversationsToday,
+        messagesToday,
+        sharedConversations,
+      ] = await Promise.all([
+        // Total users is range-aware like the conversation and message totals.
+        // Non-admins derive it from activity in conversations they can see;
+        // full admins use the existing last-login activity source.
+        nonAdminScope
+          ? conversations.aggregate([
+              { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
+              { $group: { _id: '$owner_id' } },
+              { $count: 'total' },
+            ]).toArray().then((r) => r[0]?.total || 0)
+          : users.countDocuments({ last_login: { $gte: rangeStart } }),
+        // Scoped to the selected date range (rangeStart), matching daily_activity
+        // and every other range-aware metric below — previously these were
+        // always lifetime totals regardless of the selected range.
+        conversations.countDocuments({ created_at: { $gte: rangeStart }, ...convSourceFilter }),
+        // msgOwnerFilter already carries 'metadata.source' when the caller
+        // explicitly filtered by source=web|slack; unfiltered, this counts
+        // every message regardless of metadata.source (including messages
+        // missing that field or tagged with other values, e.g. 'scheduler'),
+        // matching how totalConversations counts every conversation.
+        messages.countDocuments({ created_at: { $gte: rangeStart }, ...msgOwnerFilter }),
+        // DAU/MAU: derive from conversations when filters are applied, otherwise from users
+        hasFilters
+          ? conversations.aggregate([
+              { $match: { updated_at: { $gte: today }, ...convSourceFilter } },
+              { $group: { _id: '$owner_id' } },
+              { $count: 'total' },
+            ]).toArray().then((r) => r[0]?.total || 0)
+          : users.countDocuments({ last_login: { $gte: today } }),
+        hasFilters
+          ? conversations.aggregate([
+              { $match: { updated_at: { $gte: thisMonth }, ...convSourceFilter } },
+              { $group: { _id: '$owner_id' } },
+              { $count: 'total' },
+            ]).toArray().then((r) => r[0]?.total || 0)
+          : users.countDocuments({ last_login: { $gte: thisMonth } }),
+        conversations.countDocuments({ created_at: { $gte: today }, ...convSourceFilter }),
+        messages.countDocuments({ created_at: { $gte: today }, ...msgOwnerFilter }),
+        // `andInto` rather than spreading a literal `$or` — the non-admin scope
+        // can itself be an `$or`, which a spread would clobber (leaking shared
+        // conversation counts outside the caller's scope).
+        conversations.countDocuments(
+          (() => {
+            const sharedFilter: Record<string, unknown> = { ...convSourceFilter };
+            andInto(sharedFilter, {
+              $or: [
+                { 'sharing.shared_with.0': { $exists: true } },
+                { 'sharing.shared_with_teams.0': { $exists: true } },
+                { 'sharing.share_link_enabled': true },
+              ],
+            });
+            return sharedFilter;
+          })()
+        ),
+      ]);
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // PARALLEL BATCH — all independent aggregations in one shot
     // ═══════════════════════════════════════════════════════════════
-    const feedbackColl = await getCollection('feedback'); // collection ref is instant; fetch inside the batch below
-
+    const includeFeedbackSection = includesSection('feedback');
+    const feedbackColl = includeFeedbackSection ? await getCollection('feedback') : null;
     const fbFilter: Document = { created_at: { $gte: rangeStart } };
-    if (sourceFilter === 'web') fbFilter.source = 'web';
-    else if (sourceFilter === 'slack') {
-      fbFilter.source = 'slack';
-      if (channelNames.length === 1) {
-        fbFilter.channel_name = channelNames[0];
-      } else if (channelNames.length > 1) {
-        fbFilter.channel_name = { $in: channelNames };
-      }
-    }
-    if (userEmails.length === 1) fbFilter.user_email = userEmails[0];
-    else if (userEmails.length > 1) fbFilter.user_email = { $in: userEmails };
 
-    // Non-admin: feedback is keyed by channel_name (slack) / user_email (web),
-    // so scope it directly rather than via the conversation-shaped scope filter.
-    // Owned agents add a third clause: feedback rows have no agent field, so we
-    // match by the conversation_ids routed to those agents (both surfaces).
-    if (nonAdminScope) {
-      const fbScope: Record<string, unknown>[] = [];
-      if (nonAdminChannelNames.length > 0) {
-        fbScope.push({
-          source: 'slack',
-          channel_name: nonAdminChannelNames.length === 1
-            ? nonAdminChannelNames[0]
-            : { $in: nonAdminChannelNames },
-        });
-      }
-      if (nonAdminScope.ownerEmail) fbScope.push({ user_email: nonAdminScope.ownerEmail });
-      if (nonAdminOwnedAgents.length > 0) {
-        const { ids: ownedConvIds } = await getOwnedAgentConversationIds(nonAdminOwnedAgents);
-        if (ownedConvIds.length > 0) {
-          fbScope.push({ conversation_id: { $in: ownedConvIds } });
+    if (includeFeedbackSection) {
+      if (sourceFilter === 'web') fbFilter.source = 'web';
+      else if (sourceFilter === 'slack') {
+        fbFilter.source = 'slack';
+        if (channelNames.length === 1) {
+          fbFilter.channel_name = channelNames[0];
+        } else if (channelNames.length > 1) {
+          fbFilter.channel_name = { $in: channelNames };
         }
       }
-      // Fail-closed: if the caller resolves to no feedback-bearing scope (e.g.
-      // owns agents that have produced no conversations, and has no channels or
-      // own email), match nothing rather than leaking unscoped feedback.
-      if (fbScope.length === 0) fbScope.push({ _id: null });
-      andInto(fbFilter, fbScope.length === 1 ? fbScope[0] : { $or: fbScope });
-    }
+      if (userEmails.length === 1) fbFilter.user_email = userEmails[0];
+      else if (userEmails.length > 1) fbFilter.user_email = { $in: userEmails };
 
-    // Agent-filter the feedback summary the same way: feedback carries no agent
-    // field, so match the conversation_ids routed to the selected agents. An
-    // empty result must match nothing (the filter was explicitly requested).
-    if (selectedAgents.length > 0) {
-      const { ids: selectedConvIds } = await getOwnedAgentConversationIds(selectedAgents);
-      andInto(fbFilter, { conversation_id: selectedConvIds.length > 0 ? { $in: selectedConvIds } : { $in: [null] } });
+      // Non-admin: feedback is keyed by channel_name (slack) / user_email (web),
+      // so scope it directly rather than via the conversation-shaped scope filter.
+      // Owned agents add a third clause: feedback rows have no agent field, so we
+      // match by the conversation_ids routed to those agents (both surfaces).
+      if (nonAdminScope) {
+        const fbScope: Record<string, unknown>[] = [];
+        if (nonAdminChannelNames.length > 0) {
+          fbScope.push({
+            source: 'slack',
+            channel_name: nonAdminChannelNames.length === 1
+              ? nonAdminChannelNames[0]
+              : { $in: nonAdminChannelNames },
+          });
+        }
+        if (nonAdminScope.ownerEmail) fbScope.push({ user_email: nonAdminScope.ownerEmail });
+        if (nonAdminOwnedAgents.length > 0) {
+          const { ids: ownedConvIds } = await getOwnedAgentConversationIds(nonAdminOwnedAgents);
+          if (ownedConvIds.length > 0) {
+            fbScope.push({ conversation_id: { $in: ownedConvIds } });
+          }
+        }
+        // Fail-closed: if the caller resolves to no feedback-bearing scope (e.g.
+        // owns agents that have produced no conversations, and has no channels or
+        // own email), match nothing rather than leaking unscoped feedback.
+        if (fbScope.length === 0) fbScope.push({ _id: null });
+        andInto(fbFilter, fbScope.length === 1 ? fbScope[0] : { $or: fbScope });
+      }
+
+      // Agent-filter the feedback summary the same way: feedback carries no agent
+      // field, so match the conversation_ids routed to the selected agents. An
+      // empty result must match nothing (the filter was explicitly requested).
+      if (selectedAgents.length > 0) {
+        const { ids: selectedConvIds } = await getOwnedAgentConversationIds(selectedAgents);
+        andInto(fbFilter, { conversation_id: selectedConvIds.length > 0 ? { $in: selectedConvIds } : { $in: [null] } });
+      }
     }
 
     const [
@@ -645,52 +724,62 @@ async function getAdminStats(request: NextRequest) {
       availableChannelsResult,
     ] = await Promise.all([
       // Daily active users
-      hasFilters
-        ? conversations.aggregate([
-            { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
-            { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$updated_at' } }, user: '$owner_id' } } },
-            { $group: { _id: '$_id.date', active_users: { $sum: 1 } } },
-          ]).toArray()
-        : users.aggregate([
-            { $match: { last_login: { $gte: rangeStart } } },
-            { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$last_login' } }, active_users: { $sum: 1 } } },
-          ]).toArray(),
+      includesSection('activity')
+        ? hasFilters
+          ? conversations.aggregate([
+              { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
+              { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$updated_at' } }, user: '$owner_id' } } },
+              { $group: { _id: '$_id.date', active_users: { $sum: 1 } } },
+            ]).toArray()
+          : users.aggregate([
+              { $match: { last_login: { $gte: rangeStart } } },
+              { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$last_login' } }, active_users: { $sum: 1 } } },
+            ]).toArray()
+        : Promise.resolve([]),
 
       // Daily conversations
-      conversations.aggregate([
-        { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
-        { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, conversations: { $sum: 1 } } },
-      ]).toArray(),
+      includesSection('activity')
+        ? conversations.aggregate([
+            { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
+            { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, conversations: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Daily messages — msgOwnerFilter already carries metadata.source
       // when source=web|slack was explicitly requested; unfiltered, this
       // counts every message regardless of metadata.source.
-      messages.aggregate([
-        { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-        { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, messages: { $sum: 1 } } },
-      ]).toArray(),
+      includesSection('activity')
+        ? messages.aggregate([
+            { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+            { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, messages: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Top users by conversations. Bots/service accounts are dropped via
       // HUMAN_OWNER_MATCH unless the caller passed include_bots=true.
-      conversations.aggregate([
-        { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
-        { $group: { _id: '$owner_id', count: { $sum: 1 } } },
-        ...topUserOwnerMatch,
-        { $sort: { count: -1 } },
-        { $limit: 10 },
-      ]).toArray(),
+      includesSection('top_users')
+        ? conversations.aggregate([
+            { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
+            { $group: { _id: '$owner_id', count: { $sum: 1 } } },
+            ...topUserOwnerMatch,
+            { $sort: { count: -1 } },
+            { $limit: 10 },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Top users by messages ($lookup for legacy owner_id). Same bot handling.
-      messages.aggregate([
-        { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
-        { $lookup: { from: 'conversations', localField: 'conversation_id', foreignField: '_id', as: '_conv' } },
-        { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
-        { $match: { _owner: { $ne: null } } },
-        { $group: { _id: '$_owner', count: { $sum: 1 } } },
-        ...topUserOwnerMatch,
-        { $sort: { count: -1 } },
-        { $limit: 10 },
-      ]).toArray(),
+      includesSection('top_users')
+        ? messages.aggregate([
+            { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+            { $lookup: { from: 'conversations', localField: 'conversation_id', foreignField: '_id', as: '_conv' } },
+            { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
+            { $match: { _owner: { $ne: null } } },
+            { $group: { _id: '$_owner', count: { $sum: 1 } } },
+            ...topUserOwnerMatch,
+            { $sort: { count: -1 } },
+            { $limit: 10 },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Top agents — dynamic-agent usage across BOTH surfaces, since each records
       // the routed agent in a different place:
@@ -702,81 +791,95 @@ async function getAdminStats(request: NextRequest) {
       // humanize both to a common display label, and merge by that label below.
       // Exclude only empty sentinels ('', null, 'unknown'); the "Default" agent
       // (id 'default') is a real configured dynamic_agent, so it counts.
-      Promise.all([
-        conversations.aggregate([
-          { $match: { created_at: { $gte: rangeStart }, 'metadata.thread_owner_agent_id': { $nin: [null, '', 'unknown'] }, ...sectionConvMatch } },
-          { $group: { _id: '$metadata.thread_owner_agent_id', count: { $sum: 1 } } },
-        ]).toArray(),
-        // Count DISTINCT conversations per agent via a two-stage $group
-        // (group by agent+conversation, then tally per agent). This avoids
-        // $project/$size — DocumentDB supports $group/$sum but not all
-        // aggregation expression operators — mirroring the pattern used
-        // elsewhere in this route.
-        //
-        // Slack messages also carry metadata.agent_name now, but Slack agent
-        // usage is counted from conversations.thread_owner_agent_id above — so
-        // the messages side must EXCLUDE Slack to avoid double-counting. When
-        // the caller explicitly filters source=slack there is no web side at
-        // all, so skip this aggregation entirely.
-        sourceFilter === 'slack'
-          ? Promise.resolve([] as { _id: string; count: number }[])
-          : messages.aggregate([
-              { $match: { role: 'assistant', 'metadata.source': { $ne: 'slack' }, 'metadata.agent_name': { $nin: [null, '', 'unknown'] }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
-              { $group: { _id: { agent: '$metadata.agent_name', conv: '$conversation_id' } } },
-              { $group: { _id: '$_id.agent', count: { $sum: 1 } } },
+      includesSection('top_agents')
+        ? Promise.all([
+            conversations.aggregate([
+              { $match: { created_at: { $gte: rangeStart }, 'metadata.thread_owner_agent_id': { $nin: [null, '', 'unknown'] }, ...sectionConvMatch } },
+              { $group: { _id: '$metadata.thread_owner_agent_id', count: { $sum: 1 } } },
             ]).toArray(),
-      ]).then(([slackAgents, webAgents]) => {
-        const byLabel = new Map<string, number>();
-        for (const row of [...slackAgents, ...webAgents] as Array<{ _id: string; count: number }>) {
-          const label = humanizeAgentName(String(row._id));
-          byLabel.set(label, (byLabel.get(label) ?? 0) + row.count);
-        }
-        return [...byLabel.entries()]
-          .map(([label, count]) => ({ _id: label, count }))
-          .sort((a, b) => b.count - a.count)
-          .slice(0, 10);
-      }),
+            // Count DISTINCT conversations per agent via a two-stage $group
+            // (group by agent+conversation, then tally per agent). This avoids
+            // $project/$size — DocumentDB supports $group/$sum but not all
+            // aggregation expression operators — mirroring the pattern used
+            // elsewhere in this route.
+            //
+            // Slack messages also carry metadata.agent_name now, but Slack agent
+            // usage is counted from conversations.thread_owner_agent_id above — so
+            // the messages side must EXCLUDE Slack to avoid double-counting. When
+            // the caller explicitly filters source=slack there is no web side at
+            // all, so skip this aggregation entirely.
+            sourceFilter === 'slack'
+              ? Promise.resolve([] as { _id: string; count: number }[])
+              : messages.aggregate([
+                  { $match: { role: 'assistant', 'metadata.source': { $ne: 'slack' }, 'metadata.agent_name': { $nin: [null, '', 'unknown'] }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+                  { $group: { _id: { agent: '$metadata.agent_name', conv: '$conversation_id' } } },
+                  { $group: { _id: '$_id.agent', count: { $sum: 1 } } },
+                ]).toArray(),
+          ]).then(([slackAgents, webAgents]) => {
+            const byLabel = new Map<string, number>();
+            for (const row of [...slackAgents, ...webAgents] as Array<{ _id: string; count: number }>) {
+              const label = humanizeAgentName(String(row._id));
+              byLabel.set(label, (byLabel.get(label) ?? 0) + row.count);
+            }
+            return [...byLabel.entries()]
+              .map(([label, count]) => ({ _id: label, count }))
+              .sort((a, b) => b.count - a.count)
+              .slice(0, 10);
+          })
+        : Promise.resolve([]),
 
       // Feedback: overall counts
-      feedbackColl.aggregate([
-        { $match: fbFilter },
-        { $group: { _id: '$rating', count: { $sum: 1 } } },
-      ]).toArray(),
+      includeFeedbackSection
+        ? feedbackColl!.aggregate([
+            { $match: fbFilter },
+            { $group: { _id: '$rating', count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Feedback: by source
-      feedbackColl.aggregate([
-        { $match: fbFilter },
-        { $group: { _id: { source: '$source', rating: '$rating' }, count: { $sum: 1 } } },
-      ]).toArray(),
+      includeFeedbackSection
+        ? feedbackColl!.aggregate([
+            { $match: fbFilter },
+            { $group: { _id: { source: '$source', rating: '$rating' }, count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Feedback: negative categories
-      feedbackColl.aggregate([
-        { $match: { ...fbFilter, rating: 'negative', value: { $nin: ['thumbs_down'] } } },
-        { $group: { _id: '$value', count: { $sum: 1 } } },
-        { $sort: { count: -1 } },
-      ]).toArray(),
+      includeFeedbackSection
+        ? feedbackColl!.aggregate([
+            { $match: { ...fbFilter, rating: 'negative', value: { $nin: ['thumbs_down'] } } },
+            { $group: { _id: '$value', count: { $sum: 1 } } },
+            { $sort: { count: -1 } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Feedback: daily trend
-      feedbackColl.aggregate([
-        { $match: fbFilter },
-        { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, rating: '$rating' }, count: { $sum: 1 } } },
-      ]).toArray(),
+      includeFeedbackSection
+        ? feedbackColl!.aggregate([
+            { $match: fbFilter },
+            { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, rating: '$rating' }, count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Response latency (overall)
-      messages.aggregate([
-        { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
-        { $group: { _id: null, avg_latency: { $avg: '$metadata.latency_ms' }, min_latency: { $min: '$metadata.latency_ms' }, max_latency: { $max: '$metadata.latency_ms' }, count: { $sum: 1 } } },
-      ]).toArray(),
+      includesSection('response_time')
+        ? messages.aggregate([
+            { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $group: { _id: null, avg_latency: { $avg: '$metadata.latency_ms' }, min_latency: { $min: '$metadata.latency_ms' }, max_latency: { $max: '$metadata.latency_ms' }, count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Latency trend, bucketed at the range's granularity (minute/hour/day)
       // so the x-axis scales with the selected window: per-minute for ≤2h,
       // per-hour for ≤1d, per-day beyond. Each bucket carries the MEAN latency
       // of its messages; the UI plots one point per bucket and draws the
       // average line client-side. Same filter as the overall latency stat.
-      messages.aggregate([
-        { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
-        { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, avg_latency: { $avg: '$metadata.latency_ms' } } },
-      ]).toArray(),
+      includesSection('response_time')
+        ? messages.aggregate([
+            { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, avg_latency: { $avg: '$metadata.latency_ms' } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Completed Workflows metric — real workflow-engine runs (workflow_runs
       // collection), NOT finished chats. A "workflow" is one document in
@@ -786,7 +889,7 @@ async function getAdminStats(request: NextRequest) {
       // runs only — the step count needed for the avg-steps card.
       // `workflowRunFilter` is null when this scope produces no runs (Slack-only
       // view, or a user filter that resolves to no subject), so the metric is 0.
-      workflowRunFilter
+      includesSection('completed_workflows') && workflowRunFilter
         ? workflowRuns.aggregate([
             { $match: { started_at: { $gte: rangeStart }, ...workflowRunFilter } },
             { $group: {
@@ -800,23 +903,27 @@ async function getAdminStats(request: NextRequest) {
         : Promise.resolve([]),
 
       // Completed workflows today — runs that reached `completed` today.
-      workflowRunFilter
+      includesSection('completed_workflows') && workflowRunFilter
         ? workflowRuns.countDocuments({ status: 'completed', completed_at: { $gte: today }, ...workflowRunFilter })
         : Promise.resolve(0),
 
       // Hourly heatmap — msgOwnerFilter already carries metadata.source
       // when source=web|slack was explicitly requested; unfiltered, this
       // counts every message regardless of metadata.source.
-      messages.aggregate([
-        { $match: { created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
-        { $addFields: { _ts: { $toDate: '$created_at' } } },
-        { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
-      ]).toArray(),
+      includesSection('hourly_heatmap')
+        ? messages.aggregate([
+            { $match: { created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $addFields: { _ts: { $toDate: '$created_at' } } },
+            { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
+          ]).toArray()
+        : Promise.resolve([]),
 
       // Available channel names (both schema variants). Non-admins get exactly
       // their readable channels (resolved after this batch) — a platform-wide
       // distinct would enumerate every channel name, so skip it for them.
-      nonAdminScope
+      !includesSection('filters')
+        ? Promise.resolve([[], []] as [string[], string[]])
+        : nonAdminScope
         ? Promise.resolve([[], []] as [string[], string[]])
         : Promise.all([
             conversations.distinct('slack_meta.channel_name', { source: 'slack', 'slack_meta.channel_name': { $ne: null } }),
@@ -1029,8 +1136,9 @@ async function getAdminStats(request: NextRequest) {
     const slackChannelScope = nonAdminScope ? nonAdminChannelNames : channelNames;
     const skipSlackBlock = !!nonAdminScope && nonAdminChannelNames.length === 0;
 
-    try {
-      const slackFilter: Document = { ...SLACK_CONV_MATCH, created_at: { $gte: rangeStart } };
+    if (includesSection('slack')) {
+      try {
+        const slackFilter: Document = { ...SLACK_CONV_MATCH, created_at: { $gte: rangeStart } };
       if (slackChannelScope.length > 0) {
         const names = slackChannelScope.length === 1 ? slackChannelScope[0] : { $in: slackChannelScope };
         // Override $or with $and to combine slack match + channel match
@@ -1051,10 +1159,10 @@ async function getAdminStats(request: NextRequest) {
           'metadata.thread_owner_agent_id': { $in: selectedAgents.map((a) => a.id) },
         });
       }
-      const slackHasData = skipSlackBlock ? 0 : await conversations.countDocuments(SLACK_CONV_MATCH, { limit: 1 });
+        const slackHasData = skipSlackBlock ? 0 : await conversations.countDocuments(SLACK_CONV_MATCH, { limit: 1 });
 
-      if (slackHasData > 0) {
-        const platformConfig = await getCollection<ChannelStatsDocument>('platform_config');
+        if (slackHasData > 0) {
+          const platformConfig = await getCollection<ChannelStatsDocument>('platform_config');
 
         // Helper: coalesce old slack_meta and new metadata fields
         const userId = { $ifNull: ['$metadata.user_id', '$slack_meta.user_id'] };
@@ -1187,7 +1295,7 @@ async function getAdminStats(request: NextRequest) {
           };
         });
 
-        slack = {
+          slack = {
           channels: configDoc
             ? { total: configDoc.total, qanda_enabled: configDoc.qanda_enabled, alerts_enabled: configDoc.alerts_enabled, ai_enabled: configDoc.ai_enabled }
             : { total: 0, qanda_enabled: 0, alerts_enabled: 0, ai_enabled: 0 },
@@ -1208,27 +1316,32 @@ async function getAdminStats(request: NextRequest) {
               interactions: c.interactions,
             };
           }),
-        };
+          };
+        }
+      } catch (err) {
+        // Slack data may not exist yet — silently skip
+        console.warn('Slack stats query failed:', err);
       }
-    } catch (err) {
-      // Slack data may not exist yet — silently skip
-      console.warn('Slack stats query failed:', err);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // PLATFORM SUMMARY — respects source/user filters
     // ═══════════════════════════════════════════════════════════════
     const [oldChannels, newChannels] = availableChannelsResult;
-    const availableChannels = nonAdminScope
-      ? [...new Set(nonAdminChannelNames)]
-      : [...new Set([...oldChannels, ...newChannels])];
+    const availableChannels = includesSection('filters')
+      ? nonAdminScope
+        ? [...new Set(nonAdminChannelNames)]
+        : [...new Set([...oldChannels, ...newChannels])]
+      : [];
 
     // Agent filter options: a non-admin sees only the agents they own; a full
     // admin sees every dynamic agent. Shape { id, name } so the UI can label by
     // name while filtering by the stable id.
-    const availableAgents = (nonAdminScope ? nonAdminOwnedAgents : await getAllAgents())
-      .map((a) => ({ id: a.id, name: a.name }))
-      .sort((a, b) => a.name.localeCompare(b.name));
+    const availableAgents = includesSection('filters')
+      ? (nonAdminScope ? nonAdminOwnedAgents : await getAllAgents())
+          .map((a) => ({ id: a.id, name: a.name }))
+          .sort((a, b) => a.name.localeCompare(b.name))
+      : [];
 
     const platformSummary = {
       satisfaction_rate: feedbackSummary.satisfaction_rate || 0,
@@ -1237,36 +1350,46 @@ async function getAdminStats(request: NextRequest) {
     return successResponse({
       range: searchParams.get('range') || '30d',
       days,
-      platform_summary: platformSummary,
-      overview: {
-        total_users: totalUsers,
-        total_conversations: totalConversations,
-        total_messages: totalMessages,
-        shared_conversations: sharedConversations,
-        dau,
-        mau,
-        conversations_today: conversationsToday,
-        messages_today: messagesToday,
-        avg_messages_per_conversation: avgMsgsPerConv,
-      },
-      daily_activity: dailyActivity,
-      top_users: {
-        by_conversations: topUsersByConversations,
-        by_messages: topUsersByMessages,
-      },
-      top_agents: topAgents,
-      feedback_summary: feedbackSummary,
-      response_time: responseTime,
-      hourly_heatmap: hourlyHeatmap,
-      completed_workflows: {
-        total: completedCount,
-        today: completedTodayCount,
-        failed: failedCount,
-        completion_rate: completionRate,
-        avg_steps_per_workflow: avgStepsCompleted,
-      },
+      ...(includesSection('overview') ? {
+        overview: {
+          total_users: totalUsers,
+          total_conversations: totalConversations,
+          total_messages: totalMessages,
+          shared_conversations: sharedConversations,
+          dau,
+          mau,
+          conversations_today: conversationsToday,
+          messages_today: messagesToday,
+          avg_messages_per_conversation: avgMsgsPerConv,
+        },
+      } : {}),
+      ...(includesSection('activity') ? { daily_activity: dailyActivity } : {}),
+      ...(includesSection('top_users') ? {
+        top_users: {
+          by_conversations: topUsersByConversations,
+          by_messages: topUsersByMessages,
+        },
+      } : {}),
+      ...(includesSection('top_agents') ? { top_agents: topAgents } : {}),
+      ...(includeFeedbackSection ? {
+        platform_summary: platformSummary,
+        feedback_summary: feedbackSummary,
+      } : {}),
+      ...(includesSection('response_time') ? { response_time: responseTime } : {}),
+      ...(includesSection('hourly_heatmap') ? { hourly_heatmap: hourlyHeatmap } : {}),
+      ...(includesSection('completed_workflows') ? {
+        completed_workflows: {
+          total: completedCount,
+          today: completedTodayCount,
+          failed: failedCount,
+          completion_rate: completionRate,
+          avg_steps_per_workflow: avgStepsCompleted,
+        },
+      } : {}),
       ...(slack ? { slack } : {}),
-      available_channels: availableChannels.sort(),
-      available_agents: availableAgents,
+      ...(includesSection('filters') ? {
+        available_channels: availableChannels.sort(),
+        available_agents: availableAgents,
+      } : {}),
     });
 }

--- a/ui/src/components/admin/insights/AsyncStatsCard.tsx
+++ b/ui/src/components/admin/insights/AsyncStatsCard.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Card,CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { AlertCircle,Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface AsyncStatsCardProps {
+  children?: ReactNode;
+  className?: string;
+  error?: string | null;
+  loading: boolean;
+  minHeightClassName?: string;
+  testId: string;
+}
+
+export function AsyncStatsCard({
+  children,
+  className,
+  error,
+  loading,
+  minHeightClassName = "min-h-40",
+  testId,
+}: AsyncStatsCardProps) {
+  return (
+    <div
+      aria-busy={loading}
+      className={cn("relative h-full", className)}
+      data-testid={testId}
+    >
+      {children ?? (
+        <Card className={cn("h-full", minHeightClassName)}>
+          <CardContent className="flex h-full min-h-[inherit] items-center justify-center p-6">
+            {!loading && error && (
+              <div className="flex max-w-sm items-center gap-2 text-center text-sm text-destructive" role="alert">
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {loading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-card/70 backdrop-blur-[1px]">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-label="Loading card" />
+        </div>
+      )}
+
+      {!loading && error && children && (
+        <div
+          className="absolute right-2 top-2 z-10 flex items-center gap-1 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive"
+          role="alert"
+          title={error}
+        >
+          <AlertCircle className="h-3.5 w-3.5" />
+          Refresh failed
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/admin/platform/SlackStatsSection.tsx
+++ b/ui/src/components/admin/platform/SlackStatsSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SimpleLineChart } from "@/components/admin/shared/SimpleLineChart";
+import { AsyncStatsCard } from "@/components/admin/insights/AsyncStatsCard";
 import {
 Card,
 CardContent,
@@ -8,40 +9,19 @@ CardDescription,
 CardHeader,
 CardTitle,
 } from "@/components/ui/card";
+import type { AdminSlackStats } from "@/types/admin-stats";
 import { Hash } from "lucide-react";
 
-interface SlackStats {
-  channels: {
-    total: number;
-    qanda_enabled: number;
-    alerts_enabled: number;
-    ai_enabled: number;
-  };
-  total_interactions: number;
-  unique_users: number;
-  configured_channels?: number;
-  configured_channels_daily?: Array<{
-    date: string;
-    total: number;
-  }>;
-  daily: Array<{
-    date: string;
-    interactions: number;
-    unique_users: number;
-    escalated: number;
-  }>;
-  top_channels: Array<{
-    channel_name: string;
-    interactions: number;
-  }>;
-}
-
 interface SlackStatsSectionProps {
-  slack: SlackStats;
+  error?: string | null;
+  loading?: boolean;
   rangeLabel: string;
+  slack?: AdminSlackStats;
 }
 
-export function SlackStatsSection({ slack, rangeLabel }: SlackStatsSectionProps) {
+export function SlackStatsSection({ error, loading = false, slack, rangeLabel }: SlackStatsSectionProps) {
+  if (!slack && !loading && !error) return null;
+
   return (
     <div className="space-y-4">
       {/* Section Header */}
@@ -52,8 +32,14 @@ export function SlackStatsSection({ slack, rangeLabel }: SlackStatsSectionProps)
       <div className="h-px bg-border" />
 
       {/* Configured Channels */}
-      {slack.configured_channels !== undefined && (
-        <Card>
+      {(slack?.configured_channels !== undefined || loading) && (
+        <AsyncStatsCard
+          error={error}
+          loading={loading}
+          minHeightClassName="min-h-72"
+          testId="stats-card-slack-configured-channels"
+        >
+          {slack?.configured_channels !== undefined ? <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Hash className="h-5 w-5" />
@@ -80,12 +66,19 @@ export function SlackStatsSection({ slack, rangeLabel }: SlackStatsSectionProps)
               </div>
             )}
           </CardContent>
-        </Card>
+          </Card> : undefined}
+        </AsyncStatsCard>
       )}
 
       {/* Daily Activity Chart */}
-      {slack.daily.length > 0 && (
-        <Card>
+      {((slack?.daily.length ?? 0) > 0 || loading) && (
+        <AsyncStatsCard
+          error={error}
+          loading={loading}
+          minHeightClassName="min-h-80"
+          testId="stats-card-slack-daily-activity"
+        >
+          {slack && slack.daily.length > 0 ? <Card>
           <CardHeader>
             <CardTitle>Daily Slack Activity ({rangeLabel})</CardTitle>
             <CardDescription>Thread interactions per day</CardDescription>
@@ -120,11 +113,18 @@ export function SlackStatsSection({ slack, rangeLabel }: SlackStatsSectionProps)
               </div>
             </div>
           </CardContent>
-        </Card>
+          </Card> : undefined}
+        </AsyncStatsCard>
       )}
 
       {/* Top Channels */}
-      <Card>
+      <AsyncStatsCard
+        error={error}
+        loading={loading}
+        minHeightClassName="min-h-56"
+        testId="stats-card-slack-top-channels"
+      >
+        {slack ? <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Hash className="h-5 w-5" />
@@ -161,7 +161,8 @@ export function SlackStatsSection({ slack, rangeLabel }: SlackStatsSectionProps)
             })}
           </div>
         </CardContent>
-      </Card>
+        </Card> : undefined}
+      </AsyncStatsCard>
     </div>
   );
 }

--- a/ui/src/hooks/use-admin-stats-sections.ts
+++ b/ui/src/hooks/use-admin-stats-sections.ts
@@ -1,0 +1,158 @@
+"use client";
+
+import { ADMIN_STATS_SECTIONS,type AdminStatsData,type AdminStatsSection } from "@/types/admin-stats";
+import { useCallback,useEffect,useMemo,useRef,useState } from "react";
+
+interface AdminStatsSectionStatus {
+  error: string | null;
+  loading: boolean;
+}
+
+type AdminStatsSectionStatuses = Record<AdminStatsSection, AdminStatsSectionStatus>;
+
+interface UseAdminStatsSectionsOptions {
+  getSectionUrl: (section: AdminStatsSection) => string;
+  onFatalError?: (message: string) => void;
+  scopeKey: string;
+}
+
+interface AdminStatsSectionError extends Error {
+  status?: number;
+}
+
+const createSectionStatuses = (): AdminStatsSectionStatuses => Object.fromEntries(
+  ADMIN_STATS_SECTIONS.map((section) => [section, { error: null, loading: false }]),
+) as AdminStatsSectionStatuses;
+
+function mergeSectionData(
+  current: AdminStatsData,
+  section: AdminStatsSection,
+  incoming: AdminStatsData,
+): AdminStatsData {
+  const next = { ...current, ...incoming };
+
+  // The Slack section is optional when no Slack data exists. A successful
+  // refresh with no key must clear stale data from the prior filter selection.
+  if (section === 'slack' && !Object.hasOwn(incoming, 'slack')) {
+    delete next.slack;
+  }
+
+  return next;
+}
+
+export function useAdminStatsSections({
+  getSectionUrl,
+  onFatalError,
+  scopeKey,
+}: UseAdminStatsSectionsOptions) {
+  const [data, setData] = useState<AdminStatsData>({});
+  const [statuses, setStatuses] = useState<AdminStatsSectionStatuses>(createSectionStatuses);
+  const abortControllersRef = useRef<Partial<Record<AdminStatsSection, AbortController>>>({});
+  const requestVersionsRef = useRef<Record<AdminStatsSection, number>>(
+    Object.fromEntries(ADMIN_STATS_SECTIONS.map((section) => [section, 0])) as Record<AdminStatsSection, number>,
+  );
+  const activeScopeKeyRef = useRef(scopeKey);
+  const getSectionUrlRef = useRef(getSectionUrl);
+  const onFatalErrorRef = useRef(onFatalError);
+
+  activeScopeKeyRef.current = scopeKey;
+  getSectionUrlRef.current = getSectionUrl;
+  onFatalErrorRef.current = onFatalError;
+
+  const loadSections = useCallback(async (
+    sections: readonly AdminStatsSection[] = ADMIN_STATS_SECTIONS,
+  ): Promise<void> => {
+    const requestScopeKey = activeScopeKeyRef.current;
+
+    setStatuses((current) => {
+      const next = { ...current };
+      for (const section of sections) {
+        next[section] = { error: null, loading: true };
+      }
+      return next;
+    });
+
+    await Promise.allSettled(sections.map(async (section) => {
+      abortControllersRef.current[section]?.abort();
+      const controller = new AbortController();
+      abortControllersRef.current[section] = controller;
+      const requestVersion = requestVersionsRef.current[section] + 1;
+      requestVersionsRef.current[section] = requestVersion;
+
+      try {
+        const response = await fetch(getSectionUrlRef.current(section), {
+          signal: controller.signal,
+        });
+        const body = await response.json().catch(() => null);
+
+        if (!response.ok || !body?.success) {
+          const message = response.status === 401
+            ? 'Not authenticated. Please sign in via SSO first.'
+            : response.status === 403
+              ? 'Access denied. Try signing out and back in to refresh your session.'
+              : body?.error || `Failed to load ${section.replaceAll('_', ' ')}`;
+          const error = new Error(message) as AdminStatsSectionError;
+          error.status = response.status;
+          throw error;
+        }
+
+        if (
+          activeScopeKeyRef.current !== requestScopeKey
+          || requestVersionsRef.current[section] !== requestVersion
+        ) return;
+
+        setData((current) => mergeSectionData(current, section, body.data ?? {}));
+        setStatuses((current) => ({
+          ...current,
+          [section]: { error: null, loading: false },
+        }));
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        if (
+          activeScopeKeyRef.current !== requestScopeKey
+          || requestVersionsRef.current[section] !== requestVersion
+        ) return;
+
+        const requestError = error as AdminStatsSectionError;
+        const message = requestError.message || `Failed to load ${section.replaceAll('_', ' ')}`;
+        setStatuses((current) => ({
+          ...current,
+          [section]: { error: message, loading: false },
+        }));
+
+        if (requestError.status === 401 || requestError.status === 403) {
+          onFatalErrorRef.current?.(message);
+        }
+      }
+    }));
+  }, []);
+
+  const reset = useCallback((): void => {
+    for (const section of ADMIN_STATS_SECTIONS) {
+      abortControllersRef.current[section]?.abort();
+      requestVersionsRef.current[section] += 1;
+    }
+    abortControllersRef.current = {};
+    setData({});
+    setStatuses(createSectionStatuses());
+  }, []);
+
+  useEffect(() => () => {
+    for (const controller of Object.values(abortControllersRef.current)) {
+      controller?.abort();
+    }
+  }, []);
+
+  const refreshing = useMemo(
+    () => Object.values(statuses).some(({ loading }) => loading),
+    [statuses],
+  );
+
+  return {
+    data,
+    loadSections,
+    refreshing,
+    reset,
+    statuses,
+  };
+}

--- a/ui/src/types/admin-stats.ts
+++ b/ui/src/types/admin-stats.ts
@@ -1,0 +1,109 @@
+export const ADMIN_STATS_SECTIONS = [
+  'overview',
+  'filters',
+  'activity',
+  'top_users',
+  'top_agents',
+  'feedback',
+  'response_time',
+  'hourly_heatmap',
+  'completed_workflows',
+  'slack',
+] as const;
+
+export type AdminStatsSection = typeof ADMIN_STATS_SECTIONS[number];
+
+export type AdminStatsOwnerType = 'service_account' | 'slack_bot' | 'linked' | 'unlinked_slack';
+
+export interface AdminSlackStats {
+  channels: {
+    total: number;
+    qanda_enabled: number;
+    alerts_enabled: number;
+    ai_enabled: number;
+  };
+  total_interactions: number;
+  unique_users: number;
+  configured_channels?: number;
+  configured_channels_daily?: Array<{
+    date: string;
+    total: number;
+  }>;
+  daily: Array<{
+    date: string;
+    interactions: number;
+    unique_users: number;
+    escalated: number;
+  }>;
+  top_channels: Array<{
+    channel_name: string;
+    interactions: number;
+  }>;
+}
+
+export interface AdminStats {
+  platform_summary: {
+    satisfaction_rate: number;
+  };
+  overview: {
+    total_users: number;
+    total_conversations: number;
+    total_messages: number;
+    shared_conversations: number;
+    dau: number;
+    mau: number;
+    conversations_today: number;
+    messages_today: number;
+    avg_messages_per_conversation: number;
+  };
+  daily_activity: Array<{
+    date: string;
+    active_users: number;
+    conversations: number;
+    messages: number;
+  }>;
+  top_users: {
+    by_conversations: Array<{
+      _id: string;
+      count: number;
+      name?: string;
+      owner_type?: AdminStatsOwnerType;
+    }>;
+    by_messages: Array<{
+      _id: string;
+      count: number;
+      name?: string;
+      owner_type?: AdminStatsOwnerType;
+    }>;
+  };
+  top_agents: Array<{ _id: string; count: number }>;
+  feedback_summary: {
+    positive: number;
+    negative: number;
+    total: number;
+    satisfaction_rate?: number;
+    by_source?: Record<string, { positive: number; negative: number }>;
+    categories?: Array<{ category: string; count: number }>;
+    daily?: Array<{ date: string; positive: number; negative: number }>;
+  };
+  response_time: {
+    avg_ms: number;
+    min_ms: number;
+    max_ms: number;
+    sample_count: number;
+    samples?: Array<{ ts: string; latency_ms: number }>;
+  };
+  hourly_heatmap: Array<{ hour: number; count: number }>;
+  completed_workflows: {
+    total: number;
+    today: number;
+    failed: number;
+    completion_rate: number;
+    avg_steps_per_workflow: number;
+  };
+  slack: AdminSlackStats;
+  available_channels: string[];
+  available_agents: Array<{ id: string; name: string }>;
+}
+
+export type AdminStatsData = Partial<AdminStats>;

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.56.dev1"
+version = "0.5.56.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

- Load Admin Insights stat sections concurrently so each card renders as soon as its data is ready, with card-local loading and error states.
- Add section-scoped responses to the stats API while preserving the existing all-sections response for backward compatibility.
- Centralize the section registry, fetch orchestration, and async card UI so adding future cards remains a small, consistent change.
- Debounce filter changes, cancel stale request waves, remove duplicate fetches, and refresh only bot-dependent sections when that filter changes.
- Keep the increased request count efficient with independently cached sections and a coalesced bot-owner lookup.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- [x] `npm run lint`
- [x] `npm test -- --runInBand` (529 suites, 6,662 tests)
- [x] Focused Admin Insights tests (2 suites, 135 tests)
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] `npm run build -- --webpack` compiles successfully, then Next.js route validation encounters the pre-existing invalid `__resetKeycloakHealthSummaryCacheForTests` export in `src/app/api/admin/keycloak/migration-health/summary/route.ts`.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable; none supplied)
- [ ] I have verified this change is not present in other open pull requests (check intentionally skipped)
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
