### PR TITLE
fix(insights): count only assistant messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.56-dev.2"
+version = "0.5.56-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -11,8 +11,8 @@
  * - Authentication: 401 when unauthenticated
  * - Authorization: 403 when non-admin (OIDC + MongoDB fallback)
  * - MongoDB guard: 503 when MongoDB is not configured
- * - Overview stats: total users, conversations, messages, DAU, MAU, shared,
- *   avg messages per conversation
+ * - Overview stats: total users, conversations, assistant messages, DAU, MAU,
+ *   shared, avg assistant messages per conversation
  * - Daily activity: optimized 30-day aggregation (3 pipelines vs 90 queries)
  * - Top users by conversations: direct owner_id group
  * - Top users by messages: $lookup fallback for legacy messages without owner_id
@@ -369,9 +369,8 @@ describe('GET /api/admin/stats — Overview', () => {
     // Promise.all order (no filters):
     // users: totalUsers, dau, mau
     // conversations: totalConversations, conversationsToday, sharedConversations
-    // messages: totalMessages, messagesToday — a single unfiltered count each,
-    // covering every metadata.source (not just 'web'/'slack'), so message
-    // counts stay in sync with conversation counts.
+    // messages: totalMessages, messagesToday — assistant rows across every
+    // metadata.source (not just 'web'/'slack').
     usersCol.countDocuments
       .mockResolvedValueOnce(15)   // totalUsers
       .mockResolvedValueOnce(3)    // dau
@@ -407,6 +406,41 @@ describe('GET /api/admin/stats — Overview', () => {
     expect(usersCol.countDocuments).toHaveBeenNthCalledWith(1, {
       last_login: { $gte: expect.any(Date) },
     });
+  });
+
+  it('excludes human messages from overview and activity metrics', async () => {
+    const { msgCol } = setupAdminWithCollections();
+
+    await GET(makeRequest('/api/admin/stats'));
+
+    // Overview total + today must both count only AI-platform output.
+    expect(msgCol.countDocuments).toHaveBeenCalledTimes(2);
+    for (const [filter] of msgCol.countDocuments.mock.calls) {
+      expect(filter).toEqual(expect.objectContaining({ role: 'assistant' }));
+    }
+
+    // The daily activity and top-users aggregations share the same invariant.
+    type PipelineStage = {
+      $group?: Record<string, unknown>;
+      $lookup?: { from?: string };
+      $match?: Record<string, unknown>;
+    };
+    const pipelines = msgCol.aggregate.mock.calls.map(
+      (call: unknown[]) => call[0] as PipelineStage[]
+    );
+    const dailyPipeline = pipelines.find((pipeline) =>
+      pipeline.some((stage) => stage.$group?.messages)
+    );
+    const topUsersPipeline = pipelines.find((pipeline) =>
+      pipeline.some((stage) => stage.$lookup?.from === 'conversations')
+    );
+
+    expect(dailyPipeline?.[0].$match).toEqual(
+      expect.objectContaining({ role: 'assistant' })
+    );
+    expect(topUsersPipeline?.[0].$match).toEqual(
+      expect.objectContaining({ role: 'assistant' })
+    );
   });
 
   it('computes avg_messages_per_conversation correctly', async () => {

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -331,8 +331,11 @@ async function getAdminStats(request: NextRequest) {
     let topUserOwnerMatch: Record<string, unknown>[] = [];
 
     // Build reusable filter fragments for conversations and messages.
+    // Message analytics measure platform output, so human and system rows stay
+    // available for chat history/audit without inflating Insights metrics.
     // Support both legacy (source/slack_meta) and new (client_type/metadata) schemas.
     const SLACK_CONV_MATCH = { $or: [{ source: 'slack' }, { client_type: 'slack' }] };
+    const AI_MESSAGE_MATCH: Document = { role: 'assistant' };
 
     // A non-admin view is always "filtered" — DAU/MAU and daily-user activity
     // must derive from the scoped conversations, never from the platform-wide
@@ -606,12 +609,10 @@ async function getAdminStats(request: NextRequest) {
         // and every other range-aware metric below — previously these were
         // always lifetime totals regardless of the selected range.
         conversations.countDocuments({ created_at: { $gte: rangeStart }, ...convSourceFilter }),
-        // msgOwnerFilter already carries 'metadata.source' when the caller
-        // explicitly filtered by source=web|slack; unfiltered, this counts
-        // every message regardless of metadata.source (including messages
-        // missing that field or tagged with other values, e.g. 'scheduler'),
-        // matching how totalConversations counts every conversation.
-        messages.countDocuments({ created_at: { $gte: rangeStart }, ...msgOwnerFilter }),
+        // Count only assistant rows (messages sent by the AI platform).
+        // msgOwnerFilter also carries metadata.source when explicitly filtered;
+        // without a source filter, assistant rows from every source are counted.
+        messages.countDocuments({ created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter }),
         // DAU/MAU: derive from conversations when filters are applied, otherwise from users
         hasFilters
           ? conversations.aggregate([
@@ -628,7 +629,7 @@ async function getAdminStats(request: NextRequest) {
             ]).toArray().then((r) => r[0]?.total || 0)
           : users.countDocuments({ last_login: { $gte: thisMonth } }),
         conversations.countDocuments({ created_at: { $gte: today }, ...convSourceFilter }),
-        messages.countDocuments({ created_at: { $gte: today }, ...msgOwnerFilter }),
+        messages.countDocuments({ created_at: { $gte: today }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter }),
         // `andInto` rather than spreading a literal `$or` — the non-admin scope
         // can itself be an `$or`, which a spread would clobber (leaking shared
         // conversation counts outside the caller's scope).
@@ -745,12 +746,11 @@ async function getAdminStats(request: NextRequest) {
           ]).toArray()
         : Promise.resolve([]),
 
-      // Daily messages — msgOwnerFilter already carries metadata.source
-      // when source=web|slack was explicitly requested; unfiltered, this
-      // counts every message regardless of metadata.source.
+      // Daily AI messages. Human prompts remain persisted but are excluded by
+      // the assistant-role invariant in AI_MESSAGE_MATCH.
       includesSection('activity')
         ? messages.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+            { $match: { created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
             { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, messages: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -767,10 +767,10 @@ async function getAdminStats(request: NextRequest) {
           ]).toArray()
         : Promise.resolve([]),
 
-      // Top users by messages ($lookup for legacy owner_id). Same bot handling.
+      // Top users by AI messages ($lookup for legacy owner_id). Same bot handling.
       includesSection('top_users')
         ? messages.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...msgOwnerFilter } },
+            { $match: { created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
             { $lookup: { from: 'conversations', localField: 'conversation_id', foreignField: '_id', as: '_conv' } },
             { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
             { $match: { _owner: { $ne: null } } },
@@ -811,7 +811,7 @@ async function getAdminStats(request: NextRequest) {
             sourceFilter === 'slack'
               ? Promise.resolve([] as { _id: string; count: number }[])
               : messages.aggregate([
-                  { $match: { role: 'assistant', 'metadata.source': { $ne: 'slack' }, 'metadata.agent_name': { $nin: [null, '', 'unknown'] }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+                  { $match: { ...AI_MESSAGE_MATCH, 'metadata.source': { $ne: 'slack' }, 'metadata.agent_name': { $nin: [null, '', 'unknown'] }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
                   { $group: { _id: { agent: '$metadata.agent_name', conv: '$conversation_id' } } },
                   { $group: { _id: '$_id.agent', count: { $sum: 1 } } },
                 ]).toArray(),
@@ -864,7 +864,7 @@ async function getAdminStats(request: NextRequest) {
       // Response latency (overall)
       includesSection('response_time')
         ? messages.aggregate([
-            { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $match: { ...AI_MESSAGE_MATCH, 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
             { $group: { _id: null, avg_latency: { $avg: '$metadata.latency_ms' }, min_latency: { $min: '$metadata.latency_ms' }, max_latency: { $max: '$metadata.latency_ms' }, count: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -876,7 +876,7 @@ async function getAdminStats(request: NextRequest) {
       // average line client-side. Same filter as the overall latency stat.
       includesSection('response_time')
         ? messages.aggregate([
-            { $match: { role: 'assistant', 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $match: { ...AI_MESSAGE_MATCH, 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
             { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, avg_latency: { $avg: '$metadata.latency_ms' } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -907,12 +907,10 @@ async function getAdminStats(request: NextRequest) {
         ? workflowRuns.countDocuments({ status: 'completed', completed_at: { $gte: today }, ...workflowRunFilter })
         : Promise.resolve(0),
 
-      // Hourly heatmap — msgOwnerFilter already carries metadata.source
-      // when source=web|slack was explicitly requested; unfiltered, this
-      // counts every message regardless of metadata.source.
+      // Hourly AI-message heatmap, combined with the section's owner filters.
       includesSection('hourly_heatmap')
         ? messages.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $match: { created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...sectionMsgMatch } },
             { $addFields: { _ts: { $toDate: '$created_at' } } },
             { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
           ]).toArray()

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.56.dev2"
+version = "0.5.56.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

A successful Slack turn persists two message rows: the human prompt and the AI-platform response. Admin Insights queried the `messages` collection without a role predicate, so one exchange increased the message total by two.

This change:

- counts only `role: assistant` rows in Admin Insights message metrics
- applies the same rule to web, Slack, and other message sources
- keeps human and system rows persisted for conversation history and audit use
- keeps overview, daily activity, top-user rankings, agent usage, response-time metrics, and hourly activity on the same definition
- adds regression coverage for overview and aggregation queries

## Testing

- `npm test -- --runInBand src/app/api/__tests__/admin-stats.test.ts` — 69 passed
- `npm run lint`
- `npm run build`

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass (affected Admin Stats suite: 69/69)
