### PR TITLE
fix(insights): apply filters consistently across cards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.56-dev.3"
+version = "0.5.56-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -230,6 +230,8 @@ const mockStatsResponse = {
       completion_rate: 0,
       avg_messages_per_workflow: 0,
     },
+    available_channels: ['primary-channel'],
+    available_agents: [{ id: 'agent-primary', name: 'Primary Agent' }],
   },
 };
 
@@ -1626,6 +1628,7 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getByText('Conversations')).toBeInTheDocument();
       expect(screen.getByText('Messages')).toBeInTheDocument();
       expect(screen.getByText('Daily Active Users (DAU)')).toBeInTheDocument();
+      expect(screen.queryByText('NaN')).not.toBeInTheDocument();
     });
 
     it('updates cards independently and issues one request per section when a filter changes', async () => {
@@ -1669,6 +1672,19 @@ describe('Admin Dashboard Page', () => {
       expect(refreshCalls).toHaveLength(9);
       expect(new Set(refreshCalls).size).toBe(9);
       expect(refreshCalls).not.toContain('filters');
+      const refreshUrls = fetchMock.mock.calls
+        .slice(callsBeforeFilter)
+        .map(([url]) => new URL(url, 'http://localhost'))
+        .filter((url) => url.pathname === '/api/admin/stats');
+      expect(refreshUrls).toHaveLength(9);
+      expect(refreshUrls.every((url) => url.searchParams.get('source') === 'web')).toBe(true);
+      await waitFor(() => {
+        expect(fetchMock.mock.calls.slice(callsBeforeFilter).some(([url]) => {
+          const parsed = new URL(url, 'http://localhost');
+          return parsed.pathname === '/api/admin/stats/skills'
+            && parsed.searchParams.get('source') === 'web';
+        })).toBe(true);
+      });
 
       resolveFeedback?.({
         ok: true,
@@ -1698,6 +1714,112 @@ describe('Admin Dashboard Page', () => {
       ]));
     });
 
+    it('applies an agent selection to every card, including overview', async () => {
+      const filteredStats = {
+        ...mockStatsResponse,
+        data: {
+          ...mockStatsResponse.data,
+          overview: {
+            ...mockStatsResponse.data.overview,
+            total_users: 7,
+            total_conversations: 8,
+            total_messages: 9,
+          },
+        },
+      };
+      const fetchMock = setupFetchMock({
+        stats: (url: string) => new URL(url, 'http://localhost').searchParams.has('agent')
+          ? filteredStats
+          : mockStatsResponse,
+      });
+
+      render(<AdminPage />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('42');
+
+      const callsBeforeFilter = fetchMock.mock.calls.length;
+      fireEvent.click(await screen.findByRole('button', { name: 'All Agents' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Primary Agent' }));
+
+      await waitFor(() => {
+        const usersCard = screen.getByText('Total Users').closest('.rounded-lg');
+        expect(within(usersCard as HTMLElement).getByText('7')).toBeInTheDocument();
+      });
+
+      const refreshUrls = fetchMock.mock.calls
+        .slice(callsBeforeFilter)
+        .map(([url]) => new URL(url, 'http://localhost'))
+        .filter((url) => url.pathname === '/api/admin/stats');
+      expect(refreshUrls).toHaveLength(9);
+      expect(refreshUrls.every((url) => url.searchParams.get('agent') === 'agent-primary')).toBe(true);
+      expect(refreshUrls.find((url) => url.searchParams.get('section') === 'overview'))
+        .toBeDefined();
+    });
+
+    it('applies a Slack channel selection to every card request', async () => {
+      const fetchMock = setupFetchMock();
+      render(<AdminPage />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('42');
+
+      fireEvent.change(screen.getByDisplayValue('All Sources'), { target: { value: 'slack' } });
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'All Channels' })).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        const sourceRefreshes = fetchMock.mock.calls.filter(([url]) => {
+          const parsed = new URL(url, 'http://localhost');
+          return parsed.pathname === '/api/admin/stats' && parsed.searchParams.get('source') === 'slack';
+        });
+        expect(sourceRefreshes.length).toBeGreaterThanOrEqual(9);
+      });
+
+      const callsBeforeChannel = fetchMock.mock.calls.length;
+      fireEvent.click(screen.getByRole('button', { name: 'All Channels' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'primary-channel' }));
+
+      await waitFor(() => {
+        const channelRefreshes = fetchMock.mock.calls
+          .slice(callsBeforeChannel)
+          .map(([url]) => new URL(url, 'http://localhost'))
+          .filter((url) => url.pathname === '/api/admin/stats');
+        expect(channelRefreshes).toHaveLength(9);
+        expect(channelRefreshes.every((url) => (
+          url.searchParams.get('source') === 'slack'
+          && url.searchParams.get('channel') === 'primary-channel'
+        ))).toBe(true);
+      });
+    });
+
+    it('expands a team selection and applies its users to every card request', async () => {
+      const fetchMock = setupFetchMock();
+      render(<AdminPage />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('42');
+
+      fireEvent.click(screen.getByRole('button', { name: 'All Users & Teams' }));
+      const callsBeforeTeam = fetchMock.mock.calls.length;
+      fireEvent.click(await screen.findByRole('button', { name: 'team:Platform Team' }));
+
+      await waitFor(() => {
+        const teamRefreshes = fetchMock.mock.calls
+          .slice(callsBeforeTeam)
+          .map(([url]) => new URL(url, 'http://localhost'))
+          .filter((url) => url.pathname === '/api/admin/stats');
+        expect(teamRefreshes).toHaveLength(9);
+        expect(teamRefreshes.every((url) => (
+          url.searchParams.get('user') === 'admin@example.com,user@example.com'
+        ))).toBe(true);
+      });
+      await waitFor(() => {
+        expect(fetchMock.mock.calls.slice(callsBeforeTeam).some(([url]) => {
+          const parsed = new URL(url, 'http://localhost');
+          return parsed.pathname === '/api/admin/stats/skills'
+            && parsed.searchParams.get('user') === 'admin@example.com,user@example.com';
+        })).toBe(true);
+      });
+    });
+
     it('renders user list with correct data', async () => {
       render(<AdminPage />);
 
@@ -1710,7 +1832,7 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getByText('Regular User')).toBeInTheDocument();
     });
 
-    it('fetches stats with date range params', async () => {
+    it('fetches stats with a relative date preset', async () => {
       const fetchMock = setupFetchMock();
 
       render(<AdminPage />);
@@ -1721,14 +1843,14 @@ describe('Admin Dashboard Page', () => {
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
-          expect.stringContaining('/api/admin/stats?from='),
+          expect.stringMatching(/\/api\/admin\/stats\?.*range=30d/),
           expect.objectContaining({ signal: expect.any(AbortSignal) })
         );
       });
 
-      // Initial fetch uses from/to date params instead of range=30d
+      // Presets stay relative, so a manual refresh advances the range endpoint.
       expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/api/admin/stats?from='),
+        expect.stringMatching(/\/api\/admin\/stats\?.*range=30d/),
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
     });
@@ -1749,11 +1871,17 @@ describe('Admin Dashboard Page', () => {
       setupFetchMock({
         stats: (url: string) => {
           const requestUrl = new URL(url, 'http://localhost:3000');
-          const from = new Date(requestUrl.searchParams.get('from') || 0);
-          const to = new Date(requestUrl.searchParams.get('to') || 0);
-          return to.getTime() - from.getTime() <= 2 * 60 * 60 * 1000
-            ? shortRangeStats
-            : mockStatsResponse;
+          if (requestUrl.searchParams.get('range') === '1h') return shortRangeStats;
+          const fromParam = requestUrl.searchParams.get('from');
+          const toParam = requestUrl.searchParams.get('to');
+          if (fromParam && toParam) {
+            const from = new Date(fromParam);
+            const to = new Date(toParam);
+            if (to.getTime() - from.getTime() <= 2 * 60 * 60 * 1000) {
+              return shortRangeStats;
+            }
+          }
+          return mockStatsResponse;
         },
       });
 
@@ -1770,6 +1898,13 @@ describe('Admin Dashboard Page', () => {
         expect(within(usersCard as HTMLElement).getByText('2')).toBeInTheDocument();
         expect(within(conversationsCard as HTMLElement).getByText('3')).toBeInTheDocument();
         expect(within(messagesCard as HTMLElement).getByText('4')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect((global.fetch as jest.Mock).mock.calls.some(([url]) => {
+          const parsed = new URL(url, 'http://localhost');
+          return parsed.pathname === '/api/admin/stats/skills'
+            && parsed.searchParams.get('range') === '1h';
+        })).toBe(true);
       });
     });
   });

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -271,19 +271,13 @@ const mockTeamsResponse = {
       {
         _id: 'team-1',
         name: 'Platform Team',
+        slug: 'platform-team',
         description: 'The platform engineering team',
         owner_id: 'admin@example.com',
         created_at: new Date().toISOString(),
-        // Commit 4/8 + 5/8 of the canonical-team-membership refactor:
-        // `member_count` is the new server-aggregated truth from
-        // `team_membership_sources`. We still emit a legacy `members[]`
-        // so older defensive readers (search/filter UX) keep working
-        // through the dual-write window.
+        // Production list responses expose the canonical count and intentionally
+        // omit the retired embedded members[]. Team filters must use the slug.
         member_count: 2,
-        members: [
-          { user_id: 'admin@example.com', role: 'owner', added_at: new Date().toISOString() },
-          { user_id: 'user@example.com', role: 'member', added_at: new Date().toISOString() },
-        ],
       },
     ],
   },
@@ -1791,7 +1785,7 @@ describe('Admin Dashboard Page', () => {
       });
     });
 
-    it('expands a team selection and applies its users to every card request', async () => {
+    it('refreshes every card with the canonical team slug when members are not embedded', async () => {
       const fetchMock = setupFetchMock();
       render(<AdminPage />);
       fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
@@ -1808,14 +1802,16 @@ describe('Admin Dashboard Page', () => {
           .filter((url) => url.pathname === '/api/admin/stats');
         expect(teamRefreshes).toHaveLength(9);
         expect(teamRefreshes.every((url) => (
-          url.searchParams.get('user') === 'admin@example.com,user@example.com'
+          url.searchParams.get('team') === 'platform-team'
+          && url.searchParams.has('user') === false
         ))).toBe(true);
       });
       await waitFor(() => {
         expect(fetchMock.mock.calls.slice(callsBeforeTeam).some(([url]) => {
           const parsed = new URL(url, 'http://localhost');
           return parsed.pathname === '/api/admin/stats/skills'
-            && parsed.searchParams.get('user') === 'admin@example.com,user@example.com';
+            && parsed.searchParams.get('team') === 'platform-team'
+            && parsed.searchParams.has('user') === false;
         })).toBe(true);
       });
     });

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -872,17 +872,21 @@ function AdminPage() {
   const rangeLabel = datePreset === "1h" ? "1 Hour" : datePreset === "12h" ? "12 Hours" : datePreset === "24h" ? "24 Hours" : datePreset === "7d" ? "7 Days" : datePreset === "90d" ? "90 Days" : datePreset === "custom" ? "Custom Range" : "30 Days";
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
 
-  const expandedStatsUsers = useMemo(() => {
-    const emails = new Set<string>();
+  const selectedStatsFilters = useMemo(() => {
+    const userEmails = new Set<string>();
+    const teamSlugs = new Set<string>();
     for (const selection of userFilter) {
       if (selection.startsWith('team:')) {
         const team = teams.find((candidate) => candidate.name === selection.slice(5));
-        for (const member of team?.members ?? []) emails.add(member.user_id);
+        // Team rosters are canonical in team_membership_sources and are no
+        // longer embedded in list responses. Send the stable slug so the API
+        // can resolve members server-side while preserving its RBAC scope.
+        teamSlugs.add(team?.slug?.trim() || team?._id || selection.slice(5));
       } else {
-        emails.add(selection);
+        userEmails.add(selection);
       }
     }
-    return [...emails];
+    return { teamSlugs: [...teamSlugs], userEmails: [...userEmails] };
   }, [teams, userFilter]);
 
   const getStatsSectionUrl = useCallback((section: AdminStatsSection): string => {
@@ -896,7 +900,12 @@ function AdminPage() {
       params.set('range', datePreset);
     }
     if (sourceFilter !== 'all') params.set('source', sourceFilter);
-    if (expandedStatsUsers.length > 0) params.set('user', expandedStatsUsers.join(','));
+    if (selectedStatsFilters.userEmails.length > 0) {
+      params.set('user', selectedStatsFilters.userEmails.join(','));
+    }
+    if (selectedStatsFilters.teamSlugs.length > 0) {
+      params.set('team', selectedStatsFilters.teamSlugs.join(','));
+    }
     if (sourceFilter === 'slack' && statsChannelFilter.length > 0) {
       params.set('channel', statsChannelFilter.join(','));
     }
@@ -909,7 +918,7 @@ function AdminPage() {
   }, [
     dateRange,
     datePreset,
-    expandedStatsUsers,
+    selectedStatsFilters,
     showBotUsers,
     simulationTarget,
     sourceFilter,
@@ -927,9 +936,14 @@ function AdminPage() {
       params.set('range', datePreset);
     }
     if (sourceFilter !== 'all') params.set('source', sourceFilter);
-    if (expandedStatsUsers.length > 0) params.set('user', expandedStatsUsers.join(','));
+    if (selectedStatsFilters.userEmails.length > 0) {
+      params.set('user', selectedStatsFilters.userEmails.join(','));
+    }
+    if (selectedStatsFilters.teamSlugs.length > 0) {
+      params.set('team', selectedStatsFilters.teamSlugs.join(','));
+    }
     return withAdminSimulationParams(`/api/admin/stats/skills?${params.toString()}`, simulationTarget);
-  }, [datePreset, dateRange, expandedStatsUsers, simulationTarget, sourceFilter]);
+  }, [datePreset, dateRange, selectedStatsFilters, simulationTarget, sourceFilter]);
 
   const {
     data: stats,
@@ -1078,12 +1092,13 @@ function AdminPage() {
     range: datePreset,
     source: sourceFilter,
     to: dateRange.to,
-    users: expandedStatsUsers,
+    teams: selectedStatsFilters.teamSlugs,
+    users: selectedStatsFilters.userEmails,
   }), [
     dateRange.from,
     dateRange.to,
     datePreset,
-    expandedStatsUsers,
+    selectedStatsFilters,
     sourceFilter,
     statsAgentFilter,
     statsChannelFilter,
@@ -1093,8 +1108,9 @@ function AdminPage() {
     range: datePreset,
     source: sourceFilter,
     to: dateRange.to,
-    users: expandedStatsUsers,
-  }), [datePreset, dateRange.from, dateRange.to, expandedStatsUsers, sourceFilter]);
+    teams: selectedStatsFilters.teamSlugs,
+    users: selectedStatsFilters.userEmails,
+  }), [datePreset, dateRange.from, dateRange.to, selectedStatsFilters, sourceFilter]);
   const skillStatsFilterRef = useRef(skillStatsFilterKey);
   const statsFilterRef = useRef(statsFilterKey);
   useEffect(() => {
@@ -1243,8 +1259,19 @@ function AdminPage() {
       }
       const tags = searchTags ?? feedbackSearchTags;
       if (tags.length > 0) params.set('search', tags.join(','));
-      const usrs = users ?? userFilter;
-      if (usrs.length > 0) params.set('user', usrs.join(','));
+      const selections = users ?? userFilter;
+      const selectedUsers = new Set<string>();
+      const selectedTeams = new Set<string>();
+      for (const selection of selections) {
+        if (selection.startsWith('team:')) {
+          const team = teams.find((candidate) => candidate.name === selection.slice(5));
+          selectedTeams.add(team?.slug?.trim() || team?._id || selection.slice(5));
+        } else {
+          selectedUsers.add(selection);
+        }
+      }
+      if (selectedUsers.size > 0) params.set('user', [...selectedUsers].join(','));
+      if (selectedTeams.size > 0) params.set('team', [...selectedTeams].join(','));
       const dr = range ?? dateRange;
       if (dr.from) params.set('from', dr.from);
       if (dr.to) params.set('to', dr.to);
@@ -2003,19 +2030,7 @@ function AdminPage() {
                           selected={userFilter}
                           onChange={(selected) => {
                             setUserFilter(selected);
-                            const emails = new Set<string>();
-                            for (const s of selected) {
-                              if (s.startsWith('team:')) {
-                                const team = teams.find((t) => t.name === s.slice(5));
-                                // Defensive read — see `filteredTeams` for the
-                                // canonical-team-membership refactor context.
-                                if (team) (team.members ?? []).forEach((m) => emails.add(m.user_id));
-                              } else {
-                                emails.add(s);
-                              }
-                            }
-                            const emailList = [...emails];
-                            loadFeedback(feedbackFilter, 1, undefined, undefined, undefined, emailList);
+                            loadFeedback(feedbackFilter, 1, undefined, undefined, undefined, selected);
                             updateSharedFilterUrl({ users: selected.length > 0 ? selected.join(',') : null });
                           }}
                           placeholder="All Users & Teams"

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -886,29 +886,29 @@ function AdminPage() {
   }, [teams, userFilter]);
 
   const getStatsSectionUrl = useCallback((section: AdminStatsSection): string => {
-    const params = new URLSearchParams({
-      from: dateRange.from,
-      section,
-      to: dateRange.to,
-    });
-    // Overview is intentionally global across source/user/agent filters, while
-    // still honoring the selected date range. This preserves the dashboard's
-    // platform-wide headline metrics without issuing a duplicate stats wave.
-    if (section !== 'overview') {
-      if (sourceFilter !== 'all') params.set('source', sourceFilter);
-      if (expandedStatsUsers.length > 0) params.set('user', expandedStatsUsers.join(','));
-      if (sourceFilter === 'slack' && statsChannelFilter.length > 0) {
-        params.set('channel', statsChannelFilter.join(','));
-      }
-      const agentIds = statsAgentFilter
-        .map((name) => statsAgents.find((agent) => agent.name === name)?.id)
-        .filter((id): id is string => Boolean(id));
-      if (agentIds.length > 0) params.set('agent', agentIds.join(','));
-      if (showBotUsers) params.set('include_bots', 'true');
+    const params = new URLSearchParams({ section });
+    if (datePreset === 'custom') {
+      params.set('from', dateRange.from);
+      params.set('to', dateRange.to);
+    } else {
+      // Relative presets stay relative when the dashboard is manually refreshed;
+      // custom ranges remain fixed to their explicit endpoints.
+      params.set('range', datePreset);
     }
+    if (sourceFilter !== 'all') params.set('source', sourceFilter);
+    if (expandedStatsUsers.length > 0) params.set('user', expandedStatsUsers.join(','));
+    if (sourceFilter === 'slack' && statsChannelFilter.length > 0) {
+      params.set('channel', statsChannelFilter.join(','));
+    }
+    const agentIds = statsAgentFilter
+      .map((name) => statsAgents.find((agent) => agent.name === name)?.id)
+      .filter((id): id is string => Boolean(id));
+    if (agentIds.length > 0) params.set('agent', agentIds.join(','));
+    if (showBotUsers) params.set('include_bots', 'true');
     return withAdminSimulationParams(`/api/admin/stats?${params.toString()}`, simulationTarget);
   }, [
     dateRange,
+    datePreset,
     expandedStatsUsers,
     showBotUsers,
     simulationTarget,
@@ -917,6 +917,19 @@ function AdminPage() {
     statsAgents,
     statsChannelFilter,
   ]);
+
+  const getSkillStatsUrl = useCallback((): string => {
+    const params = new URLSearchParams();
+    if (datePreset === 'custom') {
+      params.set('from', dateRange.from);
+      params.set('to', dateRange.to);
+    } else {
+      params.set('range', datePreset);
+    }
+    if (sourceFilter !== 'all') params.set('source', sourceFilter);
+    if (expandedStatsUsers.length > 0) params.set('user', expandedStatsUsers.join(','));
+    return withAdminSimulationParams(`/api/admin/stats/skills?${params.toString()}`, simulationTarget);
+  }, [datePreset, dateRange, expandedStatsUsers, simulationTarget, sourceFilter]);
 
   const {
     data: stats,
@@ -1062,17 +1075,27 @@ function AdminPage() {
     agents: statsAgentFilter,
     channels: statsChannelFilter,
     from: dateRange.from,
+    range: datePreset,
     source: sourceFilter,
     to: dateRange.to,
     users: expandedStatsUsers,
   }), [
     dateRange.from,
     dateRange.to,
+    datePreset,
     expandedStatsUsers,
     sourceFilter,
     statsAgentFilter,
     statsChannelFilter,
   ]);
+  const skillStatsFilterKey = useMemo(() => JSON.stringify({
+    from: dateRange.from,
+    range: datePreset,
+    source: sourceFilter,
+    to: dateRange.to,
+    users: expandedStatsUsers,
+  }), [datePreset, dateRange.from, dateRange.to, expandedStatsUsers, sourceFilter]);
+  const skillStatsFilterRef = useRef(skillStatsFilterKey);
   const statsFilterRef = useRef(statsFilterKey);
   useEffect(() => {
     if (statsFilterRef.current === statsFilterKey) return;
@@ -1107,17 +1130,31 @@ function AdminPage() {
     }
   };
 
-  const loadSkillStats = async () => {
+  const loadSkillStats = useCallback(async (): Promise<void> => {
+    const requestScopeKey = simulationScopeKey;
     try {
-      const res = await fetch('/api/admin/stats/skills');
+      const res = await fetch(getSkillStatsUrl());
       if (res.ok) {
         const data = await res.json().catch(() => ({ success: false }));
-        if (data.success) setSkillStats(data.data);
+        if (data.success && activeDataScopeKeyRef.current === requestScopeKey) {
+          setSkillStats(data.data);
+        }
       }
     } catch (err) {
       console.error('[Admin] Failed to load skill stats:', err);
     }
-  };
+  }, [getSkillStatsUrl, simulationScopeKey]);
+
+  useEffect(() => {
+    if (skillStatsFilterRef.current === skillStatsFilterKey) return;
+    skillStatsFilterRef.current = skillStatsFilterKey;
+    if (!visitedTabsRef.current.has('_stats-loaded')) return;
+    if (status !== "authenticated" && getConfig('ssoEnabled')) return;
+    const handle = window.setTimeout(() => {
+      void loadSkillStats();
+    }, 150);
+    return () => window.clearTimeout(handle);
+  }, [loadSkillStats, skillStatsFilterKey, status]);
 
   const loadFeedbackOnce = async () => {
     if (!getConfig('feedbackEnabled')) return;
@@ -2239,7 +2276,7 @@ function AdminPage() {
                     size="sm"
                     className="gap-1.5"
                     disabled={statsRefreshing}
-                    onClick={() => void loadStatsSections()}
+                    onClick={() => void Promise.all([loadStatsSections(), loadSkillStats()])}
                   >
                     <RefreshCw className={cn("h-3.5 w-3.5", statsRefreshing && "animate-spin")} />
                     Refresh
@@ -2286,7 +2323,7 @@ function AdminPage() {
                             </div>
                             <div>
                               <p className="text-2xl font-bold text-green-500">
-                                {Math.round((stats.daily_activity.reduce((sum, d) => sum + d.active_users, 0) / stats.daily_activity.length))}
+                                {Math.round(stats.daily_activity.reduce((sum, d) => sum + d.active_users, 0) / Math.max(stats.daily_activity.length, 1))}
                               </p>
                               <p className="text-xs text-muted-foreground">Avg/Day</p>
                             </div>
@@ -2326,7 +2363,7 @@ function AdminPage() {
                             </div>
                             <div>
                               <p className="text-2xl font-bold text-purple-500">
-                                {Math.round((stats.daily_activity.reduce((sum, d) => sum + d.conversations, 0) / stats.daily_activity.length))}
+                                {Math.round(stats.daily_activity.reduce((sum, d) => sum + d.conversations, 0) / Math.max(stats.daily_activity.length, 1))}
                               </p>
                               <p className="text-xs text-muted-foreground">Avg/Day</p>
                             </div>
@@ -2368,13 +2405,13 @@ function AdminPage() {
                           </div>
                           <div>
                             <p className="text-2xl font-bold text-orange-500">
-                              {Math.round((stats.daily_activity.reduce((sum, d) => sum + d.messages, 0) / stats.daily_activity.length))}
+                              {Math.round(stats.daily_activity.reduce((sum, d) => sum + d.messages, 0) / Math.max(stats.daily_activity.length, 1))}
                             </p>
                             <p className="text-xs text-muted-foreground">Avg/Day</p>
                           </div>
                           <div>
                             <p className="text-2xl font-bold text-blue-500">
-                              {(stats.overview.total_messages / stats.overview.total_conversations).toFixed(1)}
+                              {stats.overview.avg_messages_per_conversation.toFixed(1)}
                             </p>
                             <p className="text-xs text-muted-foreground">Msgs/Chat</p>
                           </div>
@@ -2844,7 +2881,7 @@ function AdminPage() {
                     <div>
                       <h3 className="text-lg font-semibold">Skills</h3>
                       <p className="text-sm text-muted-foreground">
-                        Skill creation and usage across the platform
+                        Date and user filters apply to creation and runs; source applies to runs. Legacy skill runs have no agent or channel attribution.
                       </p>
                     </div>
 
@@ -2852,19 +2889,19 @@ function AdminPage() {
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                       <Card>
                         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                          <CardTitle className="text-sm font-medium">Total Skills</CardTitle>
+                          <CardTitle className="text-sm font-medium">Skills Created</CardTitle>
                           <Layers className="h-4 w-4 text-muted-foreground" />
                         </CardHeader>
                         <CardContent>
                           <div className="text-2xl font-bold">{skillStats.total_skills}</div>
                           <p className="text-xs text-muted-foreground mt-1">
-                            {skillStats.system_skills} system, {skillStats.user_skills} user-created
+                            {rangeLabel} · {skillStats.system_skills} system, {skillStats.user_skills} user-created
                           </p>
                         </CardContent>
                       </Card>
                       <Card>
                         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                          <CardTitle className="text-sm font-medium">User Skills</CardTitle>
+                          <CardTitle className="text-sm font-medium">User Skills Created</CardTitle>
                           <Users className="h-4 w-4 text-muted-foreground" />
                         </CardHeader>
                         <CardContent>
@@ -2930,7 +2967,7 @@ function AdminPage() {
                     {skillStats.daily_created.length > 0 && (
                       <Card>
                         <CardHeader>
-                          <CardTitle>Skills Created (Last 30 Days)</CardTitle>
+                          <CardTitle>Skills Created ({rangeLabel})</CardTitle>
                           <CardDescription>New user-created skills per day</CardDescription>
                         </CardHeader>
                         <CardContent>

--- a/ui/src/app/api/__tests__/admin-feedback.test.ts
+++ b/ui/src/app/api/__tests__/admin-feedback.test.ts
@@ -62,6 +62,11 @@ jest.mock('@/lib/rbac/user-insights-scope', () => ({
   getOwnedAgentConversationIds: (...args: unknown[]) => mockGetOwnedAgentConversationIds(...args),
 }));
 
+const mockLoadTeamMembersForSlugs = jest.fn();
+jest.mock('@/lib/rbac/team-membership-store', () => ({
+  loadTeamMembersForSlugs: (...args: unknown[]) => mockLoadTeamMembersForSlugs(...args),
+}));
+
 const mockCheckOpenFgaTuple = jest.fn();
 jest.mock('@/lib/rbac/openfga', () => ({
   checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
@@ -237,6 +242,8 @@ describe('GET /api/admin/feedback', () => {
     mockGetOwnedAgents.mockResolvedValue([]);
     mockGetOwnedAgentConversationIds.mockReset();
     mockGetOwnedAgentConversationIds.mockResolvedValue({ ids: [], capped: false });
+    mockLoadTeamMembersForSlugs.mockReset();
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map());
     mockIsMongoDBConfigured = true;
     mockFeedbackEnabled = true;
   });
@@ -510,6 +517,34 @@ describe('GET /api/admin/feedback', () => {
     await GET(makeRequest('/api/admin/feedback?user=alice@co.com'));
     const filter = feedbackCol.find.mock.calls[0][0];
     expect(filter.user_email).toBe('alice@co.com');
+  });
+
+  it('resolves a team filter from canonical membership records', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([
+      ['platform-team', [
+        { user_email: 'alice@example.com' },
+        { user_email: 'bob@example.com' },
+      ]],
+    ]));
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    await GET(makeRequest('/api/admin/feedback?team=platform-team'));
+
+    expect(mockLoadTeamMembersForSlugs).toHaveBeenCalledWith(['platform-team']);
+    expect(feedbackCol.find.mock.calls[0][0].user_email).toEqual({
+      $in: ['alice@example.com', 'bob@example.com'],
+    });
+  });
+
+  it('fails closed when a selected team has no canonical members', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([['empty-team', []]]));
+    const feedbackCol = setupFeedbackCollection([], 0);
+
+    await GET(makeRequest('/api/admin/feedback?team=empty-team'));
+
+    expect(feedbackCol.find.mock.calls[0][0].user_email).toEqual({ $in: [] });
   });
 
   it('filters by search terms as regex OR on comment and value', async () => {

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -83,6 +83,11 @@ jest.mock('@/lib/rbac/user-insights-scope', () => ({
   getAgentsByIds: (...args: unknown[]) => mockGetAgentsByIds(...(args as [string[]])),
 }));
 
+const mockLoadTeamMembersForSlugs = jest.fn();
+jest.mock('@/lib/rbac/team-membership-store', () => ({
+  loadTeamMembersForSlugs: (...args: unknown[]) => mockLoadTeamMembersForSlugs(...args),
+}));
+
 const mockCheckPermission = jest.requireMock<{ checkPermission: jest.Mock }>(
   '@/lib/rbac/keycloak-authz'
 ).checkPermission;
@@ -203,6 +208,8 @@ function resetMocks() {
   mockGetAllAgents.mockResolvedValue([]);
   mockGetAgentsByIds.mockReset();
   mockGetAgentsByIds.mockResolvedValue([]);
+  mockLoadTeamMembersForSlugs.mockReset();
+  mockLoadTeamMembersForSlugs.mockResolvedValue(new Map());
   Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
 }
 
@@ -1302,6 +1309,44 @@ describe('GET /api/admin/stats — Source & User Filters', () => {
     expect(hasUserFilter).toBe(true);
   });
 
+  it('resolves canonical team members and applies them to conversation and message queries', async () => {
+    const { convCol, msgCol } = setupAdminWithCollections();
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([
+      ['platform-team', [
+        { user_email: 'alice@example.com' },
+        { user_email: 'bob@example.com' },
+      ]],
+    ]));
+
+    await GET(makeRequest('/api/admin/stats?section=overview&team=platform-team'));
+
+    expect(mockLoadTeamMembersForSlugs).toHaveBeenCalledWith(['platform-team']);
+    const conversationFilters = convCol.countDocuments.mock.calls.map((call: unknown[]) => (
+      JSON.stringify(call[0] ?? {})
+    ));
+    expect(conversationFilters.some((filter: string) => (
+      filter.includes('alice@example.com') && filter.includes('bob@example.com')
+    ))).toBe(true);
+    const messageFilters = msgCol.countDocuments.mock.calls.map((call: unknown[]) => (
+      JSON.stringify(call[0] ?? {})
+    ));
+    expect(messageFilters.some((filter: string) => (
+      filter.includes('alice@example.com') && filter.includes('bob@example.com')
+    ))).toBe(true);
+  });
+
+  it('fails closed when a selected team has no canonical members', async () => {
+    const { convCol } = setupAdminWithCollections();
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([['empty-team', []]]));
+
+    await GET(makeRequest('/api/admin/stats?section=overview&team=empty-team'));
+
+    const conversationFilters = convCol.countDocuments.mock.calls.map((call: unknown[]) => call[0] ?? {});
+    expect(conversationFilters.some((filter: { owner_id?: { $in?: unknown[] } }) => (
+      Array.isArray(filter.owner_id?.$in) && filter.owner_id.$in.length === 0
+    ))).toBe(true);
+  });
+
   it('applies a Slack channel filter to conversation and message metrics', async () => {
     const { convCol, msgCol } = setupAdminWithCollections();
 
@@ -1355,6 +1400,26 @@ describe('GET /api/admin/stats — Source & User Filters', () => {
 
 describe('GET /api/admin/stats — non-admin scoping', () => {
   beforeEach(resetMocks);
+
+  it('intersects a selected team with the existing non-admin visibility scope', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue(['primary-channel']);
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([
+      ['platform-team', [{ user_email: 'teammate@example.com' }]],
+    ]));
+    const { convCol } = setupNonAdminCollections();
+
+    await GET(makeRequest('/api/admin/stats?section=overview&team=platform-team'));
+
+    const filters = convCol.countDocuments.mock.calls.map((call: unknown[]) => (
+      JSON.stringify(call[0] ?? {})
+    ));
+    expect(filters.some((filter: string) => (
+      filter.includes('teammate@example.com')
+      && filter.includes('user@example.com')
+      && filter.includes('primary-channel')
+    ))).toBe(true);
+  });
 
   it('non-admin with readable channels: convSourceFilter ANDs in the channel scope', async () => {
     mockGetServerSession.mockResolvedValue(userSession());

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -404,7 +404,7 @@ describe('GET /api/admin/stats — Overview', () => {
       })
     );
     expect(usersCol.countDocuments).toHaveBeenNthCalledWith(1, {
-      last_login: { $gte: expect.any(Date) },
+      last_login: { $gte: expect.any(Date), $lte: expect.any(Date) },
     });
   });
 
@@ -1182,7 +1182,7 @@ describe('GET /api/admin/stats — Custom Date Range (from/to)', () => {
   beforeEach(resetMocks);
 
   it('uses from/to ISO dates to compute the range instead of preset', async () => {
-    setupAdminWithCollections();
+    const { convCol, msgCol } = setupAdminWithCollections();
 
     // 10-day custom range
     const from = '2026-03-01T00:00:00.000Z';
@@ -1194,10 +1194,23 @@ describe('GET /api/admin/stats — Custom Date Range (from/to)', () => {
     // daily_activity length should be 10 days
     expect(body.data.daily_activity).toHaveLength(10);
     expect(body.data.days).toBe(10);
+
+    const expectedEnd = new Date(to);
+    const conversationMatch = convCol.aggregate.mock.calls
+      .flatMap((call: unknown[]) => call[0])
+      .find((stage: Record<string, unknown>) => stage.$match?.created_at);
+    expect(conversationMatch.$match.created_at.$lte).toEqual(expectedEnd);
+    const messageMatch = msgCol.aggregate.mock.calls
+      .flatMap((call: unknown[]) => call[0])
+      .find((stage: Record<string, unknown>) => stage.$match?.created_at);
+    expect(messageMatch.$match.created_at.$lte).toEqual(expectedEnd);
+    expect(new Date(body.data.daily_activity.at(-1).date).getTime())
+      .toBeLessThanOrEqual(expectedEnd.getTime());
   });
 
   it('supports sub-day presets like 1h and 12h (bucketed by 5-minute intervals)', async () => {
-    setupAdminWithCollections();
+    const { usersCol, convCol, msgCol } = setupAdminWithCollections();
+    const requestStartedAt = Date.now();
 
     const req = makeRequest('/api/admin/stats?range=1h');
     const res = await GET(req);
@@ -1206,6 +1219,23 @@ describe('GET /api/admin/stats — Custom Date Range (from/to)', () => {
     // 1h range buckets by 5-minute steps so the chart isn't a single point.
     expect(body.data.daily_activity).toHaveLength(12);
     expect(body.data.days).toBe(1);
+
+    // Calendar cards (DAU/MAU and "Today") must also honor the shorter
+    // selected window instead of silently counting everything since midnight.
+    const earliestAllowed = requestStartedAt - (60 * 60 * 1000) - 1_000;
+    const lowerBounds = [
+      ...usersCol.countDocuments.mock.calls.map((call: unknown[]) => (
+        (call[0] as { last_login?: { $gte?: Date } })?.last_login?.$gte
+      )),
+      ...convCol.countDocuments.mock.calls.map((call: unknown[]) => (
+        (call[0] as { created_at?: { $gte?: Date } })?.created_at?.$gte
+      )),
+      ...msgCol.countDocuments.mock.calls.map((call: unknown[]) => (
+        (call[0] as { created_at?: { $gte?: Date } })?.created_at?.$gte
+      )),
+    ].filter((date): date is Date => date instanceof Date);
+    expect(lowerBounds.length).toBeGreaterThan(0);
+    expect(lowerBounds.every((date) => date.getTime() >= earliestAllowed)).toBe(true);
   });
 });
 
@@ -1270,6 +1300,52 @@ describe('GET /api/admin/stats — Source & User Filters', () => {
       (call: unknown[]) => call[0]?.owner_id?.$in?.includes('alice@co.com')
     );
     expect(hasUserFilter).toBe(true);
+  });
+
+  it('applies a Slack channel filter to conversation and message metrics', async () => {
+    const { convCol, msgCol } = setupAdminWithCollections();
+
+    await GET(makeRequest('/api/admin/stats?section=overview&source=slack&channel=primary-channel'));
+
+    const conversationFilters = convCol.countDocuments.mock.calls.map((call: unknown[]) => (
+      JSON.stringify(call[0] ?? {})
+    ));
+    expect(conversationFilters.some((filter: string) => filter.includes('primary-channel'))).toBe(true);
+
+    const messageFilters = msgCol.countDocuments.mock.calls.map((call: unknown[]) => (
+      JSON.stringify(call[0] ?? {})
+    ));
+    expect(messageFilters.length).toBeGreaterThan(0);
+    expect(messageFilters.every((filter: string) => filter.includes('primary-channel'))).toBe(true);
+  });
+
+  it('omits the Slack-only section when source=web', async () => {
+    const { convCol } = setupAdminWithCollections();
+
+    const res = await GET(makeRequest('/api/admin/stats?section=slack&source=web'));
+    const body = await res.json();
+
+    expect(body.data).not.toHaveProperty('slack');
+    const probeCalls = convCol.countDocuments.mock.calls.filter(
+      (call: unknown[]) => call[1]?.limit === 1,
+    );
+    expect(probeCalls).toHaveLength(0);
+  });
+
+  it('applies a user filter to Slack interaction cards and omits userless configuration data', async () => {
+    const { convCol } = setupAdminWithCollections();
+    convCol.countDocuments.mockResolvedValue(1);
+
+    const res = await GET(makeRequest('/api/admin/stats?section=slack&user=person@example.com'));
+    const body = await res.json();
+
+    const slackPipelines = convCol.aggregate.mock.calls.map((call: unknown[]) => call[0]);
+    expect(slackPipelines.length).toBeGreaterThan(0);
+    expect(slackPipelines.every((pipeline: unknown) => (
+      JSON.stringify(pipeline).includes('person@example.com')
+    ))).toBe(true);
+    expect(body.data.slack).not.toHaveProperty('configured_channels');
+    expect(body.data.slack).not.toHaveProperty('configured_channels_daily');
   });
 });
 
@@ -1578,6 +1654,20 @@ describe('GET /api/admin/stats — non-admin scoping', () => {
     // getAgentsByIds is the admin-only resolver; a non-admin never calls it.
     expect(mockGetAgentsByIds).not.toHaveBeenCalled();
   });
+
+  it('non-admin: an unowned agent filter also fails closed for feedback', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockGetReadableSlackChannelNames.mockResolvedValue([]);
+    mockGetOwnedAgents.mockResolvedValue([{ id: 'agent-owned', name: 'Owned Agent' }]);
+    const { feedbackCol } = setupNonAdminCollections();
+
+    await GET(makeRequest('/api/admin/stats?section=feedback&agent=agent-unowned'));
+
+    expect(mockGetOwnedAgentConversationIds).toHaveBeenCalledWith([]);
+    const feedbackQueries = JSON.stringify(feedbackCol.aggregate.mock.calls);
+    expect(feedbackQueries).toContain('conversation_id');
+    expect(feedbackQueries).toContain('[null]');
+  });
 });
 
 describe('GET /api/admin/stats — agent filter (admin)', () => {
@@ -1609,6 +1699,38 @@ describe('GET /api/admin/stats — agent filter (admin)', () => {
       JSON.stringify(call[0] ?? {}).includes('X Agent')
     );
     expect(msgHasAgent).toBe(true);
+  });
+
+  it('admin: agent-filtered overview derives users from matching conversations', async () => {
+    mockGetAgentsByIds.mockResolvedValue([{ id: 'agent-primary', name: 'Primary Agent' }]);
+    const { usersCol, convCol, msgCol } = setupAdminWithCollections();
+
+    await GET(makeRequest('/api/admin/stats?section=overview&agent=agent-primary'));
+
+    expect(usersCol.countDocuments).not.toHaveBeenCalled();
+    const conversationQueries = JSON.stringify([
+      ...convCol.countDocuments.mock.calls,
+      ...convCol.aggregate.mock.calls,
+    ]);
+    expect(conversationQueries).toContain('participants');
+    expect(conversationQueries).toContain('agent-primary');
+    const messageQueries = JSON.stringify(msgCol.countDocuments.mock.calls);
+    expect(messageQueries).toContain('Primary Agent');
+  });
+
+  it('admin: agent filter scopes completed workflows by step agent id', async () => {
+    mockGetAgentsByIds.mockResolvedValue([{ id: 'agent-primary', name: 'Primary Agent' }]);
+    setupAdminWithCollections();
+
+    await GET(makeRequest('/api/admin/stats?section=completed_workflows&agent=agent-primary'));
+
+    const workflowCol = mockCollections.workflow_runs as ReturnType<typeof createMockCollection>;
+    const workflowQueries = JSON.stringify([
+      ...workflowCol.aggregate.mock.calls,
+      ...workflowCol.countDocuments.mock.calls,
+    ]);
+    expect(workflowQueries).toContain('steps.agent_id');
+    expect(workflowQueries).toContain('agent-primary');
   });
 
   it('admin: agent filter also scopes the Slack block by thread_owner_agent_id', async () => {
@@ -1694,5 +1816,29 @@ describe('GET /api/admin/stats — Configured Channels', () => {
     for (let i = 1; i < daily.length; i++) {
       expect(daily[i].total).toBeGreaterThanOrEqual(daily[i - 1].total);
     }
+  });
+
+  it('filters configured channels by selected agent routes', async () => {
+    mockGetAgentsByIds.mockResolvedValue([{ id: 'agent-primary', name: 'Primary Agent' }]);
+    const { convCol } = setupAdminWithCollections();
+    convCol.countDocuments.mockResolvedValue(1);
+    stubChannelMappings([
+      { slack_channel_id: 'C1', channel_name: 'primary', active: true },
+      { slack_channel_id: 'C2', channel_name: 'secondary', active: true },
+    ]);
+    const routeCol = createMockCollection();
+    routeCol.find = jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([{ channel_id: 'C2' }]),
+    });
+    mockCollections.slack_channel_agent_routes = routeCol;
+
+    const res = await GET(makeRequest('/api/admin/stats?section=slack&agent=agent-primary'));
+    const body = await res.json();
+
+    expect(body.data.slack.configured_channels).toBe(1);
+    expect(routeCol.find).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: { $in: ['agent-primary'] } }),
+      expect.any(Object),
+    );
   });
 });

--- a/ui/src/app/api/admin/feedback/route.ts
+++ b/ui/src/app/api/admin/feedback/route.ts
@@ -15,6 +15,7 @@ import {
 resolveAuthorizedAdminSimulationScope,
 simulationSubjectCanManageAdminSurface,
 } from '@/lib/rbac/admin-simulation-server';
+import { resolveInsightsUserFilter } from '@/lib/rbac/insights-user-filter';
 import { getOwnedAgentConversationIds, getOwnedAgents, getReadableSlackChannelNames } from '@/lib/rbac/user-insights-scope';
 import type { Conversation } from '@/types/mongodb';
 import type { Document,ObjectId } from 'mongodb';
@@ -100,6 +101,11 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const source = searchParams.get('source'); // 'web' | 'slack' | null (all)
     const channel = searchParams.get('channel'); // comma-separated channel names | null (all)
     const userFilter = searchParams.get('user'); // comma-separated user emails | null (all)
+    const teamFilter = searchParams.get('team'); // comma-separated team slugs | null (all)
+    const { active: hasUserFilter, emails: userEmails } = await resolveInsightsUserFilter(
+      userFilter,
+      teamFilter,
+    );
     const search = searchParams.get('search'); // comma-separated search terms OR'd as regex on comment/value
     const from = searchParams.get('from'); // ISO date string for start of range
     const to = searchParams.get('to'); // ISO date string for end of range
@@ -126,13 +132,8 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         }
       }
     }
-    if (userFilter) {
-      const users = userFilter.split(',').map((u) => u.trim()).filter(Boolean);
-      if (users.length === 1) {
-        filter.user_email = users[0];
-      } else if (users.length > 1) {
-        filter.user_email = { $in: users };
-      }
+    if (hasUserFilter) {
+      filter.user_email = userEmails.length === 1 ? userEmails[0] : { $in: userEmails };
     }
     if (search) {
       const terms = search.split(',').map((t) => t.trim()).filter(Boolean);

--- a/ui/src/app/api/admin/stats/__tests__/stats-rbac-routes.test.ts
+++ b/ui/src/app/api/admin/stats/__tests__/stats-rbac-routes.test.ts
@@ -39,6 +39,11 @@ jest.mock("@/lib/rbac/audit", () => ({
   logAuthzDecision: jest.fn(),
 }));
 
+const mockLoadTeamMembersForSlugs = jest.fn();
+jest.mock("@/lib/rbac/team-membership-store", () => ({
+  loadTeamMembersForSlugs: (...args: unknown[]) => mockLoadTeamMembersForSlugs(...args),
+}));
+
 jest.mock("@/lib/mongodb", () => ({
   getCollection: (...args: unknown[]) => mockGetCollection(...args),
   connectToDatabase: (...args: unknown[]) => mockConnectToDatabase(...args),
@@ -62,6 +67,7 @@ async function expectStatsDenied(response: Response): Promise<void> {
 beforeEach(() => {
   jest.clearAllMocks();
   mockCheckPermission.mockResolvedValue({ allowed: false, reason: "DENY_NO_CAPABILITY" });
+  mockLoadTeamMembersForSlugs.mockResolvedValue(new Map());
 });
 
 describe("admin stats RBAC routes", () => {
@@ -108,6 +114,40 @@ describe("admin stats RBAC routes", () => {
         started_at: { $gte: new Date(from), $lte: new Date(to) },
         owner_id: "person@example.com",
         _id: null,
+      });
+    }
+  });
+
+  it("resolves a selected team from the canonical roster for skill metrics", async () => {
+    mockCheckPermission.mockResolvedValue({ allowed: true, reason: "ALLOW" });
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([
+      ["platform-team", [
+        { user_email: "alice@example.com" },
+        { user_email: "bob@example.com" },
+      ]],
+    ]));
+    const configs = {
+      find: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+      aggregate: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+    };
+    const runs = {
+      aggregate: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+    };
+    mockGetCollection.mockImplementation((name: string) => (
+      name === "agent_skills" ? Promise.resolve(configs) : Promise.resolve(runs)
+    ));
+    const { GET } = await import("../skills/route");
+
+    const response = await GET(request("/api/admin/stats/skills?team=platform-team"));
+
+    expect(response.status).toBe(200);
+    expect(mockLoadTeamMembersForSlugs).toHaveBeenCalledWith(["platform-team"]);
+    expect(configs.find).toHaveBeenCalledWith(expect.objectContaining({
+      owner_id: { $in: ["alice@example.com", "bob@example.com"] },
+    }));
+    for (const [pipeline] of runs.aggregate.mock.calls) {
+      expect(pipeline[0].$match.owner_id).toEqual({
+        $in: ["alice@example.com", "bob@example.com"],
       });
     }
   });

--- a/ui/src/app/api/admin/stats/__tests__/stats-rbac-routes.test.ts
+++ b/ui/src/app/api/admin/stats/__tests__/stats-rbac-routes.test.ts
@@ -73,4 +73,42 @@ describe("admin stats RBAC routes", () => {
     await expectStatsDenied(response);
     expect(mockGetCollection).not.toHaveBeenCalled();
   });
+
+  it("applies date, user, and web-only source filters to skill metrics", async () => {
+    mockCheckPermission.mockResolvedValue({ allowed: true, reason: "ALLOW" });
+    const configs = {
+      find: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+      aggregate: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+    };
+    const runs = {
+      aggregate: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+    };
+    mockGetCollection.mockImplementation((name: string) => (
+      name === "agent_skills" ? Promise.resolve(configs) : Promise.resolve(runs)
+    ));
+    const { GET } = await import("../skills/route");
+    const from = "2026-06-01T00:00:00.000Z";
+    const to = "2026-06-30T23:59:59.999Z";
+
+    const response = await GET(request(
+      `/api/admin/stats/skills?from=${from}&to=${to}&source=slack&user=person@example.com`,
+    ));
+
+    expect(response.status).toBe(200);
+    expect(configs.find).toHaveBeenCalledWith({
+      created_at: { $gte: new Date(from), $lte: new Date(to) },
+      owner_id: "person@example.com",
+    });
+    expect(configs.aggregate.mock.calls[0][0][0].$match).toEqual(expect.objectContaining({
+      created_at: { $gte: new Date(from), $lte: new Date(to) },
+      owner_id: "person@example.com",
+    }));
+    for (const [pipeline] of runs.aggregate.mock.calls) {
+      expect(pipeline[0].$match).toEqual({
+        started_at: { $gte: new Date(from), $lte: new Date(to) },
+        owner_id: "person@example.com",
+        _id: null,
+      });
+    }
+  });
 });

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -121,17 +121,24 @@ function generateBucketKeys(now: Date, count: number, unit: BucketUnit): string[
 }
 
 /**
- * Parse range params into { rangeStart, days, bucketUnit, bucketCount }. Supports preset
- * strings and explicit from/to ISO dates. Short ranges bucket at finer granularity (minute
- * for ≤2h, hour for ≤1d) rather than clamping to day-granularity, so 1h/12h/24h charts show
- * more than one data point.
+ * Parse range params into bounded endpoints plus chart bucket metadata. Supports
+ * preset strings and explicit from/to ISO dates. Short ranges bucket at finer
+ * granularity (minute for ≤2h, hour for ≤1d) rather than clamping to
+ * day-granularity, so 1h/12h/24h charts show more than one data point.
  */
-function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: number; bucketUnit: BucketUnit; bucketCount: number } {
+function parseRange(searchParams: URLSearchParams): {
+  rangeStart: Date;
+  rangeEnd: Date;
+  days: number;
+  bucketUnit: BucketUnit;
+  bucketCount: number;
+} {
   const now = new Date();
   const fromParam = searchParams.get('from');
   const toParam = searchParams.get('to');
 
   let rangeStart: Date;
+  let rangeEnd = now;
   let ms: number;
 
   if (fromParam) {
@@ -139,6 +146,7 @@ function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: nu
     const to = toParam ? new Date(toParam) : now;
     ms = to.getTime() - from.getTime();
     rangeStart = from;
+    rangeEnd = to;
   } else {
     const range = searchParams.get('range');
     switch (range) {
@@ -160,7 +168,7 @@ function parseRange(searchParams: URLSearchParams): { rangeStart: Date; days: nu
     bucketUnit === 'minute' ? Math.max(1, Math.round(ms / (MINUTE_BUCKET_STEP_MIN * MINUTE_MS))) :
     bucketUnit === 'hour' ? Math.max(1, Math.round(ms / HOUR_MS)) :
     days;
-  return { rangeStart, days, bucketUnit, bucketCount };
+  return { rangeStart, rangeEnd, days, bucketUnit, bucketCount };
 }
 
 // ── Human vs. bot identity ──────────────────────────────────────────────────
@@ -309,7 +317,8 @@ async function getAdminStats(request: NextRequest) {
     nonAdminScope = { channelNames, ownerEmail: email, ownedAgents, sub };
   }
 
-    const { rangeStart, days, bucketUnit, bucketCount } = parseRange(searchParams);
+    const { rangeStart, rangeEnd, days, bucketUnit, bucketCount } = parseRange(searchParams);
+    const rangeDateMatch = { $gte: rangeStart, $lte: rangeEnd };
 
     // Optional filters
     const sourceFilter = searchParams.get('source'); // 'web' | 'slack' | null (all)
@@ -340,7 +349,11 @@ async function getAdminStats(request: NextRequest) {
     // A non-admin view is always "filtered" — DAU/MAU and daily-user activity
     // must derive from the scoped conversations, never from the platform-wide
     // users collection (which would leak global active-user counts).
-    const hasFilters = !!sourceFilter || userEmails.length > 0 || !!nonAdminScope;
+    const hasFilters = !!sourceFilter
+      || userEmails.length > 0
+      || channelNames.length > 0
+      || agentIds.length > 0
+      || !!nonAdminScope;
     const convSourceFilter: Document = {};
     const msgOwnerFilter: Document = {};
     if (sourceFilter === 'web') {
@@ -359,6 +372,10 @@ async function getAdminStats(request: NextRequest) {
         ]};
         delete convSourceFilter.$or;
         convSourceFilter.$and = [SLACK_CONV_MATCH, channelMatch];
+        // Current Slack messages carry channel_name directly. Applying the
+        // same selection here keeps message totals, latency, leaderboards, and
+        // the hourly heatmap aligned with conversation-based cards.
+        msgOwnerFilter['metadata.channel_name'] = names;
       }
     }
     if (userEmails.length === 1) {
@@ -372,23 +389,19 @@ async function getAdminStats(request: NextRequest) {
     // Non-admin scope, reused by every query below so the whole payload stays
     // within the caller's visibility:
     //   - `convSourceFilter` / `msgOwnerFilter` get an $or of the caller's
-    //     readable Slack channels, their own web conversations, AND their owned
-    //     agents (keyed per-collection: conv → thread_owner_agent_id (id),
-    //     msg → agent_name (display name)).
+    //     readable Slack channels, their own conversations, AND their owned
+    //     agents (using each collection's canonical fields).
     //   - `nonAdminChannelNames` bounds Slack-channel-keyed queries (feedback,
-    //     the Slack block, available_channels). Slack docs in the `messages`
-    //     collection carry no channel_name, so Slack message counts can only
-    //     be bounded by owner_id / agent via the shared scope filter.
+    //     the Slack block, available_channels).
     const nonAdminChannelNames = nonAdminScope?.channelNames ?? [];
     const nonAdminOwnedAgents = nonAdminScope?.ownedAgents ?? [];
     if (nonAdminScope) {
       const { channelNames: scopeChannelNames, ownerEmail, ownedAgents } = nonAdminScope;
-      // Base clauses apply to both collections: readable Slack channels (only
-      // ever match conversation-shaped docs) + the caller's own web content.
-      const baseScopeClauses: Record<string, unknown>[] = [];
+      const convScopeClauses: Record<string, unknown>[] = [];
+      const msgScopeClauses: Record<string, unknown>[] = [];
       if (scopeChannelNames.length > 0) {
         const names = scopeChannelNames.length === 1 ? scopeChannelNames[0] : { $in: scopeChannelNames };
-        baseScopeClauses.push({
+        convScopeClauses.push({
           $and: [
             { $or: [{ source: 'slack' }, { client_type: 'slack' }] },
             { $or: [
@@ -397,18 +410,34 @@ async function getAdminStats(request: NextRequest) {
             ]},
           ],
         });
+        msgScopeClauses.push({
+          'metadata.source': 'slack',
+          'metadata.channel_name': names,
+        });
       }
-      if (ownerEmail) baseScopeClauses.push({ owner_id: ownerEmail });
+      if (ownerEmail) {
+        convScopeClauses.push({ owner_id: ownerEmail });
+        msgScopeClauses.push({ owner_id: ownerEmail });
+      }
 
-      // Owned-agent axis is keyed differently per collection: conversations
-      // record the agent id (Slack), messages record the display name (web).
+      // Owned-agent scope supports both Slack's metadata and the participant /
+      // top-level fields used by web and scheduled conversations.
       const ownedAgentIds = ownedAgents.map((a) => a.id);
       const ownedAgentNames = ownedAgents.map((a) => a.name);
-      const convScopeClauses = [...baseScopeClauses];
-      const msgScopeClauses = [...baseScopeClauses];
       if (ownedAgentIds.length > 0) {
-        convScopeClauses.push({ 'metadata.thread_owner_agent_id': { $in: ownedAgentIds } });
-        msgScopeClauses.push({ 'metadata.agent_name': { $in: ownedAgentNames } });
+        convScopeClauses.push({
+          $or: [
+            { 'metadata.thread_owner_agent_id': { $in: ownedAgentIds } },
+            { participants: { $elemMatch: { type: 'agent', id: { $in: ownedAgentIds } } } },
+            { agent_id: { $in: ownedAgentIds } },
+          ],
+        });
+        msgScopeClauses.push({
+          $or: [
+            { 'metadata.agent_name': { $in: ownedAgentNames } },
+            { 'metadata.agent_id': { $in: ownedAgentIds } },
+          ],
+        });
       }
 
       if (convScopeClauses.length === 0 && msgScopeClauses.length === 0) {
@@ -477,8 +506,22 @@ async function getAdminStats(request: NextRequest) {
       const selNames = selectedAgents.map((a) => a.name);
       // A requested-but-unresolvable agent set must match nothing, not fall
       // through to the unfiltered payload.
-      andInto(convSourceFilter, { 'metadata.thread_owner_agent_id': { $in: selIds } });
-      andInto(msgOwnerFilter, { 'metadata.agent_name': { $in: selNames } });
+      andInto(convSourceFilter, {
+        $or: [
+          // Slack routes are persisted on the conversation metadata.
+          { 'metadata.thread_owner_agent_id': { $in: selIds } },
+          // Web conversations persist the selected agent as a participant.
+          { participants: { $elemMatch: { type: 'agent', id: { $in: selIds } } } },
+          // Scheduled/API-created conversations may also carry a top-level id.
+          { agent_id: { $in: selIds } },
+        ],
+      });
+      andInto(msgOwnerFilter, {
+        $or: [
+          { 'metadata.agent_name': { $in: selNames } },
+          { 'metadata.agent_id': { $in: selIds } },
+        ],
+      });
     }
 
     const users = await getCollection('users');
@@ -566,11 +609,23 @@ async function getAdminStats(request: NextRequest) {
           ? { 'owner_subject.type': 'user', 'owner_subject.id': { $in: subs } }
           : null; // requested users have no resolvable sub → match nothing
       }
+      if (workflowRunFilter && agentIds.length > 0) {
+        // A workflow is attributable to every agent used by one of its steps.
+        // Keep an explicitly requested but unresolved set fail-closed via $in: [].
+        andInto(workflowRunFilter, {
+          'steps.agent_id': { $in: selectedAgents.map((agent) => agent.id) },
+        });
+      }
     }
 
     const now = new Date();
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const thisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    // "Today" and active-user cards retain their calendar semantics, but a
+    // shorter selected window must still narrow them. For example, the 1h
+    // preset must not quietly show all activity since midnight.
+    const todayRangeStart = new Date(Math.max(today.getTime(), rangeStart.getTime()));
+    const monthRangeStart = new Date(Math.max(thisMonth.getTime(), rangeStart.getTime()));
 
     // ═══════════════════════════════════════════════════════════════
     // OVERVIEW STATS (parallel queries for speed)
@@ -596,46 +651,51 @@ async function getAdminStats(request: NextRequest) {
         sharedConversations,
       ] = await Promise.all([
         // Total users is range-aware like the conversation and message totals.
-        // Non-admins derive it from activity in conversations they can see;
-        // full admins use the existing last-login activity source.
-        nonAdminScope
+        // Any dimension filter must derive it from matching conversations;
+        // otherwise agent/source/channel selections would leave this card at
+        // the platform-wide users count. Unfiltered admins retain the existing
+        // last-login activity source.
+        nonAdminScope || hasFilters
           ? conversations.aggregate([
-              { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
+              { $match: { updated_at: rangeDateMatch, ...convSourceFilter } },
               { $group: { _id: '$owner_id' } },
               { $count: 'total' },
             ]).toArray().then((r) => r[0]?.total || 0)
-          : users.countDocuments({ last_login: { $gte: rangeStart } }),
+          : users.countDocuments({ last_login: rangeDateMatch }),
         // Scoped to the selected date range (rangeStart), matching daily_activity
         // and every other range-aware metric below — previously these were
         // always lifetime totals regardless of the selected range.
-        conversations.countDocuments({ created_at: { $gte: rangeStart }, ...convSourceFilter }),
+        conversations.countDocuments({ created_at: rangeDateMatch, ...convSourceFilter }),
         // Count only assistant rows (messages sent by the AI platform).
         // msgOwnerFilter also carries metadata.source when explicitly filtered;
         // without a source filter, assistant rows from every source are counted.
-        messages.countDocuments({ created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter }),
+        messages.countDocuments({ created_at: rangeDateMatch, ...AI_MESSAGE_MATCH, ...msgOwnerFilter }),
         // DAU/MAU: derive from conversations when filters are applied, otherwise from users
         hasFilters
           ? conversations.aggregate([
-              { $match: { updated_at: { $gte: today }, ...convSourceFilter } },
+              { $match: { updated_at: { $gte: todayRangeStart, $lte: rangeEnd }, ...convSourceFilter } },
               { $group: { _id: '$owner_id' } },
               { $count: 'total' },
             ]).toArray().then((r) => r[0]?.total || 0)
-          : users.countDocuments({ last_login: { $gte: today } }),
+          : users.countDocuments({ last_login: { $gte: todayRangeStart, $lte: rangeEnd } }),
         hasFilters
           ? conversations.aggregate([
-              { $match: { updated_at: { $gte: thisMonth }, ...convSourceFilter } },
+              { $match: { updated_at: { $gte: monthRangeStart, $lte: rangeEnd }, ...convSourceFilter } },
               { $group: { _id: '$owner_id' } },
               { $count: 'total' },
             ]).toArray().then((r) => r[0]?.total || 0)
-          : users.countDocuments({ last_login: { $gte: thisMonth } }),
-        conversations.countDocuments({ created_at: { $gte: today }, ...convSourceFilter }),
-        messages.countDocuments({ created_at: { $gte: today }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter }),
+          : users.countDocuments({ last_login: { $gte: monthRangeStart, $lte: rangeEnd } }),
+        conversations.countDocuments({ created_at: { $gte: todayRangeStart, $lte: rangeEnd }, ...convSourceFilter }),
+        messages.countDocuments({ created_at: { $gte: todayRangeStart, $lte: rangeEnd }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter }),
         // `andInto` rather than spreading a literal `$or` — the non-admin scope
         // can itself be an `$or`, which a spread would clobber (leaking shared
         // conversation counts outside the caller's scope).
         conversations.countDocuments(
           (() => {
-            const sharedFilter: Record<string, unknown> = { ...convSourceFilter };
+            const sharedFilter: Record<string, unknown> = {
+              created_at: rangeDateMatch,
+              ...convSourceFilter,
+            };
             andInto(sharedFilter, {
               $or: [
                 { 'sharing.shared_with.0': { $exists: true } },
@@ -654,7 +714,7 @@ async function getAdminStats(request: NextRequest) {
     // ═══════════════════════════════════════════════════════════════
     const includeFeedbackSection = includesSection('feedback');
     const feedbackColl = includeFeedbackSection ? await getCollection('feedback') : null;
-    const fbFilter: Document = { created_at: { $gte: rangeStart } };
+    const fbFilter: Document = { created_at: rangeDateMatch };
 
     if (includeFeedbackSection) {
       if (sourceFilter === 'web') fbFilter.source = 'web';
@@ -700,7 +760,7 @@ async function getAdminStats(request: NextRequest) {
       // Agent-filter the feedback summary the same way: feedback carries no agent
       // field, so match the conversation_ids routed to the selected agents. An
       // empty result must match nothing (the filter was explicitly requested).
-      if (selectedAgents.length > 0) {
+      if (agentIds.length > 0) {
         const { ids: selectedConvIds } = await getOwnedAgentConversationIds(selectedAgents);
         andInto(fbFilter, { conversation_id: selectedConvIds.length > 0 ? { $in: selectedConvIds } : { $in: [null] } });
       }
@@ -728,12 +788,12 @@ async function getAdminStats(request: NextRequest) {
       includesSection('activity')
         ? hasFilters
           ? conversations.aggregate([
-              { $match: { updated_at: { $gte: rangeStart }, ...convSourceFilter } },
+              { $match: { updated_at: rangeDateMatch, ...convSourceFilter } },
               { $group: { _id: { date: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$updated_at' } }, user: '$owner_id' } } },
               { $group: { _id: '$_id.date', active_users: { $sum: 1 } } },
             ]).toArray()
           : users.aggregate([
-              { $match: { last_login: { $gte: rangeStart } } },
+              { $match: { last_login: rangeDateMatch } },
               { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$last_login' } }, active_users: { $sum: 1 } } },
             ]).toArray()
         : Promise.resolve([]),
@@ -741,7 +801,7 @@ async function getAdminStats(request: NextRequest) {
       // Daily conversations
       includesSection('activity')
         ? conversations.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
+            { $match: { created_at: rangeDateMatch, ...convSourceFilter } },
             { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, conversations: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -750,7 +810,7 @@ async function getAdminStats(request: NextRequest) {
       // the assistant-role invariant in AI_MESSAGE_MATCH.
       includesSection('activity')
         ? messages.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
+            { $match: { created_at: rangeDateMatch, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
             { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, messages: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -759,7 +819,7 @@ async function getAdminStats(request: NextRequest) {
       // HUMAN_OWNER_MATCH unless the caller passed include_bots=true.
       includesSection('top_users')
         ? conversations.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...convSourceFilter } },
+            { $match: { created_at: rangeDateMatch, ...convSourceFilter } },
             { $group: { _id: '$owner_id', count: { $sum: 1 } } },
             ...topUserOwnerMatch,
             { $sort: { count: -1 } },
@@ -770,7 +830,7 @@ async function getAdminStats(request: NextRequest) {
       // Top users by AI messages ($lookup for legacy owner_id). Same bot handling.
       includesSection('top_users')
         ? messages.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
+            { $match: { created_at: rangeDateMatch, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
             { $lookup: { from: 'conversations', localField: 'conversation_id', foreignField: '_id', as: '_conv' } },
             { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
             { $match: { _owner: { $ne: null } } },
@@ -794,7 +854,7 @@ async function getAdminStats(request: NextRequest) {
       includesSection('top_agents')
         ? Promise.all([
             conversations.aggregate([
-              { $match: { created_at: { $gte: rangeStart }, 'metadata.thread_owner_agent_id': { $nin: [null, '', 'unknown'] }, ...sectionConvMatch } },
+              { $match: { created_at: rangeDateMatch, 'metadata.thread_owner_agent_id': { $nin: [null, '', 'unknown'] }, ...sectionConvMatch } },
               { $group: { _id: '$metadata.thread_owner_agent_id', count: { $sum: 1 } } },
             ]).toArray(),
             // Count DISTINCT conversations per agent via a two-stage $group
@@ -811,7 +871,7 @@ async function getAdminStats(request: NextRequest) {
             sourceFilter === 'slack'
               ? Promise.resolve([] as { _id: string; count: number }[])
               : messages.aggregate([
-                  { $match: { ...AI_MESSAGE_MATCH, 'metadata.source': { $ne: 'slack' }, 'metadata.agent_name': { $nin: [null, '', 'unknown'] }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+                  { $match: { ...AI_MESSAGE_MATCH, 'metadata.source': { $ne: 'slack' }, 'metadata.agent_name': { $nin: [null, '', 'unknown'] }, created_at: rangeDateMatch, ...sectionMsgMatch } },
                   { $group: { _id: { agent: '$metadata.agent_name', conv: '$conversation_id' } } },
                   { $group: { _id: '$_id.agent', count: { $sum: 1 } } },
                 ]).toArray(),
@@ -864,7 +924,7 @@ async function getAdminStats(request: NextRequest) {
       // Response latency (overall)
       includesSection('response_time')
         ? messages.aggregate([
-            { $match: { ...AI_MESSAGE_MATCH, 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $match: { ...AI_MESSAGE_MATCH, 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: rangeDateMatch, ...sectionMsgMatch } },
             { $group: { _id: null, avg_latency: { $avg: '$metadata.latency_ms' }, min_latency: { $min: '$metadata.latency_ms' }, max_latency: { $max: '$metadata.latency_ms' }, count: { $sum: 1 } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -876,7 +936,7 @@ async function getAdminStats(request: NextRequest) {
       // average line client-side. Same filter as the overall latency stat.
       includesSection('response_time')
         ? messages.aggregate([
-            { $match: { ...AI_MESSAGE_MATCH, 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: { $gte: rangeStart }, ...sectionMsgMatch } },
+            { $match: { ...AI_MESSAGE_MATCH, 'metadata.latency_ms': { $exists: true, $gt: 0 }, created_at: rangeDateMatch, ...sectionMsgMatch } },
             { $group: { _id: { $dateToString: { format: BUCKET_DATE_FORMAT[bucketUnit], date: '$created_at' } }, avg_latency: { $avg: '$metadata.latency_ms' } } },
           ]).toArray()
         : Promise.resolve([]),
@@ -891,7 +951,7 @@ async function getAdminStats(request: NextRequest) {
       // view, or a user filter that resolves to no subject), so the metric is 0.
       includesSection('completed_workflows') && workflowRunFilter
         ? workflowRuns.aggregate([
-            { $match: { started_at: { $gte: rangeStart }, ...workflowRunFilter } },
+            { $match: { started_at: rangeDateMatch, ...workflowRunFilter } },
             { $group: {
               _id: null,
               total_runs: { $sum: 1 },
@@ -904,13 +964,13 @@ async function getAdminStats(request: NextRequest) {
 
       // Completed workflows today — runs that reached `completed` today.
       includesSection('completed_workflows') && workflowRunFilter
-        ? workflowRuns.countDocuments({ status: 'completed', completed_at: { $gte: today }, ...workflowRunFilter })
+        ? workflowRuns.countDocuments({ status: 'completed', completed_at: { $gte: todayRangeStart, $lte: rangeEnd }, ...workflowRunFilter })
         : Promise.resolve(0),
 
       // Hourly AI-message heatmap, combined with the section's owner filters.
       includesSection('hourly_heatmap')
         ? messages.aggregate([
-            { $match: { created_at: { $gte: rangeStart }, ...AI_MESSAGE_MATCH, ...sectionMsgMatch } },
+            { $match: { created_at: rangeDateMatch, ...AI_MESSAGE_MATCH, ...sectionMsgMatch } },
             { $addFields: { _ts: { $toDate: '$created_at' } } },
             { $group: { _id: { $hour: '$_ts' }, count: { $sum: 1 } } },
           ]).toArray()
@@ -936,7 +996,7 @@ async function getAdminStats(request: NextRequest) {
     const userMap = new Map(dailyUserActivity.map((d) => [d._id, d.active_users]));
     const convMap = new Map(dailyConvActivity.map((d) => [d._id, d.conversations]));
 
-    const dailyActivity = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => ({
+    const dailyActivity = generateBucketKeys(rangeEnd, bucketCount, bucketUnit).map((dateKey) => ({
       date: dateKey,
       active_users: userMap.get(dateKey) || 0,
       conversations: convMap.get(dateKey) || 0,
@@ -1052,7 +1112,7 @@ async function getAdminStats(request: NextRequest) {
       if (!dailyFbMap.has(date)) dailyFbMap.set(date, { positive: 0, negative: 0 });
       dailyFbMap.get(date)![row._id.rating as 'positive' | 'negative'] = row.count;
     }
-    const dailyFeedback = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => {
+    const dailyFeedback = generateBucketKeys(rangeEnd, bucketCount, bucketUnit).map((dateKey) => {
       const entry = dailyFbMap.get(dateKey);
       return {
         date: dateKey,
@@ -1085,7 +1145,7 @@ async function getAdminStats(request: NextRequest) {
     const latencyByBucket = new Map<string, number>(
       latencyDaily.map((s) => [String(s._id), Math.round(s.avg_latency)]),
     );
-    const latencySamples = generateBucketKeys(now, bucketCount, bucketUnit)
+    const latencySamples = generateBucketKeys(rangeEnd, bucketCount, bucketUnit)
       .filter((key) => latencyByBucket.has(key))
       .map((key) => ({ ts: key, latency_ms: latencyByBucket.get(key)! }));
 
@@ -1126,68 +1186,77 @@ async function getAdminStats(request: NextRequest) {
     // SLACK STATS (from conversations with source:"slack" or client_type:"slack")
     // ═══════════════════════════════════════════════════════════════
     let slack: SlackStats | undefined;
-
-    // Slack block channel scope: admins use the `channel` query param; a
-    // non-admin is hard-bounded to their readable channels (their web
-    // conversations don't appear in this Slack-only section). A non-admin with
-    // no readable channels sees no Slack block at all.
-    const slackChannelScope = nonAdminScope ? nonAdminChannelNames : channelNames;
     const skipSlackBlock = !!nonAdminScope && nonAdminChannelNames.length === 0;
 
-    if (includesSection('slack')) {
+    if (includesSection('slack') && sourceFilter !== 'web' && !skipSlackBlock) {
       try {
-        const slackFilter: Document = { ...SLACK_CONV_MATCH, created_at: { $gte: rangeStart } };
-      if (slackChannelScope.length > 0) {
-        const names = slackChannelScope.length === 1 ? slackChannelScope[0] : { $in: slackChannelScope };
-        // Override $or with $and to combine slack match + channel match
-        delete slackFilter.$or;
-        slackFilter.$and = [
-          SLACK_CONV_MATCH,
-          { created_at: { $gte: rangeStart } },
-          { $or: [{ 'slack_meta.channel_name': names }, { 'metadata.channel_name': names }] },
-        ];
-        delete slackFilter.created_at;
-      }
-      // Agent filter applies to the Slack block too: Slack conversations carry
-      // the routed agent on metadata.thread_owner_agent_id, so scope by the
-      // selected agent ids to keep this section consistent with the rest of the
-      // page (Overview, Top Users, Top Agents, etc.).
-      if (selectedAgents.length > 0) {
-        andInto(slackFilter, {
-          'metadata.thread_owner_agent_id': { $in: selectedAgents.map((a) => a.id) },
-        });
-      }
-        const slackHasData = skipSlackBlock ? 0 : await conversations.countDocuments(SLACK_CONV_MATCH, { limit: 1 });
+        // Start with the same conversation filter used by every other card, then
+        // constrain it to Slack. This carries source, channel, user, agent, and
+        // non-admin scope into all Slack interaction cards without maintaining a
+        // second, subtly different filter implementation.
+        const slackFilter: Document = { ...SLACK_CONV_MATCH, created_at: rangeDateMatch };
+        if (Object.keys(convSourceFilter).length > 0) {
+          andInto(slackFilter, convSourceFilter);
+        }
+        if (nonAdminScope) {
+          const readableNames = nonAdminChannelNames.length === 1
+            ? nonAdminChannelNames[0]
+            : { $in: nonAdminChannelNames };
+          andInto(slackFilter, {
+            $or: [
+              { 'slack_meta.channel_name': readableNames },
+              { 'metadata.channel_name': readableNames },
+            ],
+          });
+        }
+        const slackHasData = await conversations.countDocuments(SLACK_CONV_MATCH, { limit: 1 });
 
         if (slackHasData > 0) {
           const platformConfig = await getCollection<ChannelStatsDocument>('platform_config');
 
-        // Helper: coalesce old slack_meta and new metadata fields
-        const userId = { $ifNull: ['$metadata.user_id', '$slack_meta.user_id'] };
-        const escalated = { $ifNull: ['$metadata.escalated', '$slack_meta.escalated'] };
-        const channelName = { $ifNull: ['$metadata.channel_name', '$slack_meta.channel_name'] };
-        const channelId = { $ifNull: ['$metadata.channel_id', '$slack_meta.channel_id'] };
+          // Helper: coalesce old slack_meta and new metadata fields.
+          const userId = { $ifNull: ['$metadata.user_id', '$slack_meta.user_id'] };
+          const escalated = { $ifNull: ['$metadata.escalated', '$slack_meta.escalated'] };
+          const channelName = { $ifNull: ['$metadata.channel_name', '$slack_meta.channel_name'] };
+          const channelId = { $ifNull: ['$metadata.channel_id', '$slack_meta.channel_id'] };
 
-        const channelMappingColl = await getCollection<{
-          slack_channel_id?: string;
-          channel_name?: string;
-          created_at?: string | Date;
-          active?: boolean;
-        }>('channel_team_mappings');
+          const channelMappingColl = await getCollection<{
+            slack_channel_id?: string;
+            channel_name?: string;
+            created_at?: string | Date;
+            active?: boolean;
+          }>('channel_team_mappings');
+          const requestedReadableChannels = nonAdminScope
+            ? (channelNames.length > 0
+                ? nonAdminChannelNames.filter((name) => channelNames.includes(name))
+                : nonAdminChannelNames)
+            : channelNames;
+          const mappingFilter: Document = { slack_channel_id: { $ne: null } };
+          if (requestedReadableChannels.length > 0) {
+            mappingFilter.channel_name = { $in: requestedReadableChannels };
+          } else if (nonAdminScope) {
+            // Configuration is channel-scoped and cannot be attributed through
+            // the owned-agent/user axes without revealing unreadable channels.
+            mappingFilter._id = null;
+          }
 
-        const [configDoc, slackTotal, slackUniqueUsers, slackDailyAgg, slackTopChannels, channelMappings] =
-          await Promise.all([
-            // Channel config
+          const selectedAgentIds = selectedAgents.map((agent) => agent.id);
+          const [
+            configDoc,
+            slackTotal,
+            slackUniqueUsers,
+            slackDailyAgg,
+            slackTopChannels,
+            channelMappings,
+            selectedAgentRoutes,
+          ] = await Promise.all([
             platformConfig.findOne({ _id: 'channel_stats' }),
-            // Total interactions (threads) in range
             conversations.countDocuments(slackFilter),
-            // Unique Slack users
             conversations.aggregate([
               { $match: slackFilter },
               { $group: { _id: userId } },
               { $count: 'total' },
             ]).toArray(),
-            // Daily breakdown
             conversations.aggregate([
               { $match: slackFilter },
               {
@@ -1200,9 +1269,6 @@ async function getAdminStats(request: NextRequest) {
               },
               { $sort: { _id: 1 } },
             ]).toArray(),
-            // Top channels — group by channel_id (stable) and carry a candidate
-            // name; the id→name mapping is resolved after the batch so raw ids
-            // like "CFW7VL1GX" don't leak into the UI.
             conversations.aggregate([
               { $match: slackFilter },
               { $addFields: { _channelId: channelId, _channelName: channelName } },
@@ -1210,8 +1276,6 @@ async function getAdminStats(request: NextRequest) {
               {
                 $group: {
                   _id: '$_channelId',
-                  // A channel's own metadata.channel_name is the best in-band
-                  // name; keep the first non-null we see.
                   name: { $first: '$_channelName' },
                   interactions: { $sum: 1 },
                 },
@@ -1219,101 +1283,105 @@ async function getAdminStats(request: NextRequest) {
               { $sort: { interactions: -1 } },
               { $limit: 10 },
             ]).toArray(),
-            // Channel id → human name (authoritative source; covers ids whose
-            // conversation metadata only carries the raw id). Also carries
-            // created_at + active for the "configured channels" stat/timeline.
-            // Non-admins only ever see their readable channels here.
             channelMappingColl.find(
-              {
-                slack_channel_id: { $ne: null },
-                ...(nonAdminScope && nonAdminChannelNames.length > 0
-                  ? { channel_name: { $in: nonAdminChannelNames } }
-                  : {}),
-              },
+              mappingFilter,
               { projection: { slack_channel_id: 1, channel_name: 1, created_at: 1, active: 1 } },
             ).toArray(),
+            agentIds.length > 0
+              ? getCollection<{ channel_id?: string }>('slack_channel_agent_routes')
+                  .then((routes) => routes.find(
+                    {
+                      agent_id: { $in: selectedAgentIds },
+                      enabled: { $ne: false },
+                      status: 'active',
+                    },
+                    { projection: { channel_id: 1 } },
+                  ).toArray())
+              : Promise.resolve([]),
           ]);
 
-        // Normalize a channel name: strip a leading '#', fall back to null when
-        // the "name" is really just the raw id (e.g. name === channel_id).
-        const normalizeChannelName = (name: unknown, id: string): string | null => {
-          if (typeof name !== 'string' || !name.trim() || name === id) return null;
-          return name.replace(/^#/, '').trim();
-        };
-        const channelNameById = new Map<string, string>();
-        for (const m of channelMappings) {
-          const clean = normalizeChannelName(m.channel_name, m.slack_channel_id);
-          if (m.slack_channel_id && clean) channelNameById.set(m.slack_channel_id, clean);
-        }
-
-        // ── Configured channels: count + cumulative timeline ───────────
-        // How many Slack channels are wired to a team (active mappings), and
-        // how that total grew over the selected range. Distinct by channel id
-        // so a re-mapped channel isn't double-counted. Timeline is cumulative:
-        // each bucket is the running total of channels configured on/before it,
-        // seeded with those configured before the range start.
-        const activeMappings = channelMappings.filter((m) => m.active !== false && m.slack_channel_id);
-        const configuredChannelsTotal = new Set(activeMappings.map((m) => m.slack_channel_id)).size;
-
-        const configuredBeforeRange = new Set<string>();
-        const configuredByBucket = new Map<string, Set<string>>();
-        for (const m of activeMappings) {
-          const created = m.created_at ? new Date(m.created_at) : null;
-          if (!created || Number.isNaN(created.getTime()) || created < rangeStart) {
-            // No timestamp (legacy) or configured before the window → part of
-            // the starting baseline rather than growth inside the range.
-            configuredBeforeRange.add(m.slack_channel_id);
-            continue;
-          }
-          const key = bucketDateKey(floorToBucket(created, bucketUnit), bucketUnit);
-          if (!configuredByBucket.has(key)) configuredByBucket.set(key, new Set());
-          configuredByBucket.get(key)!.add(m.slack_channel_id);
-        }
-        let runningConfigured = configuredBeforeRange.size;
-        const configuredChannelsDaily = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => {
-          runningConfigured += configuredByBucket.get(dateKey)?.size ?? 0;
-          return { date: dateKey, total: runningConfigured };
-        });
-
-        // Build daily array with gaps filled
-        const slackDailyMap = new Map(
-          slackDailyAgg.map((d) => [d._id, {
-            interactions: d.interactions,
-            unique_users: d.unique_users?.length || 0,
-            escalated: d.escalated,
-          }])
-        );
-        const slackDaily = generateBucketKeys(now, bucketCount, bucketUnit).map((dateKey) => {
-          const entry = slackDailyMap.get(dateKey);
-          return {
-            date: dateKey,
-            interactions: entry?.interactions || 0,
-            unique_users: entry?.unique_users || 0,
-            escalated: entry?.escalated || 0,
+          // Normalize a channel name: strip a leading '#', fall back to null
+          // when the "name" is really just the raw id.
+          const normalizeChannelName = (name: unknown, id: string): string | null => {
+            if (typeof name !== 'string' || !name.trim() || name === id) return null;
+            return name.replace(/^#/, '').trim();
           };
-        });
+          const channelNameById = new Map<string, string>();
+          for (const mapping of channelMappings) {
+            const clean = normalizeChannelName(mapping.channel_name, mapping.slack_channel_id);
+            if (mapping.slack_channel_id && clean) {
+              channelNameById.set(mapping.slack_channel_id, clean);
+            }
+          }
+
+          // Configured Channels is configuration data, not user activity. It is
+          // omitted for a user filter; channel, agent, and date filters do apply.
+          const selectedAgentChannelIds = new Set(
+            selectedAgentRoutes.flatMap((route) => route.channel_id ? [route.channel_id] : []),
+          );
+          const activeMappings = channelMappings.filter((mapping) => {
+            if (mapping.active === false || !mapping.slack_channel_id) return false;
+            if (agentIds.length > 0 && !selectedAgentChannelIds.has(mapping.slack_channel_id)) return false;
+            const created = mapping.created_at ? new Date(mapping.created_at) : null;
+            return !created || Number.isNaN(created.getTime()) || created <= rangeEnd;
+          });
+          const configuredChannelsTotal = new Set(
+            activeMappings.map((mapping) => mapping.slack_channel_id),
+          ).size;
+
+          const configuredBeforeRange = new Set<string>();
+          const configuredByBucket = new Map<string, Set<string>>();
+          for (const mapping of activeMappings) {
+            const created = mapping.created_at ? new Date(mapping.created_at) : null;
+            if (!created || Number.isNaN(created.getTime()) || created < rangeStart) {
+              configuredBeforeRange.add(mapping.slack_channel_id);
+              continue;
+            }
+            const key = bucketDateKey(floorToBucket(created, bucketUnit), bucketUnit);
+            if (!configuredByBucket.has(key)) configuredByBucket.set(key, new Set());
+            configuredByBucket.get(key)!.add(mapping.slack_channel_id);
+          }
+          let runningConfigured = configuredBeforeRange.size;
+          const configuredChannelsDaily = generateBucketKeys(rangeEnd, bucketCount, bucketUnit).map((dateKey) => {
+            runningConfigured += configuredByBucket.get(dateKey)?.size ?? 0;
+            return { date: dateKey, total: runningConfigured };
+          });
+
+          const slackDailyMap = new Map(
+            slackDailyAgg.map((day) => [day._id, {
+              interactions: day.interactions,
+              unique_users: day.unique_users?.length || 0,
+              escalated: day.escalated,
+            }]),
+          );
+          const slackDaily = generateBucketKeys(rangeEnd, bucketCount, bucketUnit).map((dateKey) => {
+            const entry = slackDailyMap.get(dateKey);
+            return {
+              date: dateKey,
+              interactions: entry?.interactions || 0,
+              unique_users: entry?.unique_users || 0,
+              escalated: entry?.escalated || 0,
+            };
+          });
 
           slack = {
-          channels: configDoc
-            ? { total: configDoc.total, qanda_enabled: configDoc.qanda_enabled, alerts_enabled: configDoc.alerts_enabled, ai_enabled: configDoc.ai_enabled }
-            : { total: 0, qanda_enabled: 0, alerts_enabled: 0, ai_enabled: 0 },
-          configured_channels: configuredChannelsTotal,
-          configured_channels_daily: configuredChannelsDaily,
-          total_interactions: slackTotal,
-          unique_users: slackUniqueUsers[0]?.total || 0,
-          daily: slackDaily,
-          // Resolve each channel id to a human name: prefer the authoritative
-          // channel_team_mappings entry, then the conversation's own
-          // metadata.channel_name, and only fall back to the raw id if neither
-          // is available.
-          top_channels: slackTopChannels.map((c) => {
-            const id: string = c._id;
-            const resolvedName = channelNameById.get(id) || normalizeChannelName(c.name, id) || id;
-            return {
-              channel_name: resolvedName,
-              interactions: c.interactions,
-            };
-          }),
+            channels: configDoc
+              ? { total: configDoc.total, qanda_enabled: configDoc.qanda_enabled, alerts_enabled: configDoc.alerts_enabled, ai_enabled: configDoc.ai_enabled }
+              : { total: 0, qanda_enabled: 0, alerts_enabled: 0, ai_enabled: 0 },
+            ...(userEmails.length === 0 ? {
+              configured_channels: configuredChannelsTotal,
+              configured_channels_daily: configuredChannelsDaily,
+            } : {}),
+            total_interactions: slackTotal,
+            unique_users: slackUniqueUsers[0]?.total || 0,
+            daily: slackDaily,
+            top_channels: slackTopChannels.map((channel) => {
+              const id: string = channel._id;
+              return {
+                channel_name: channelNameById.get(id) || normalizeChannelName(channel.name, id) || id,
+                interactions: channel.interactions,
+              };
+            }),
           };
         }
       } catch (err) {

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -10,6 +10,7 @@ import {
 resolveAuthorizedAdminSimulationScope,
 simulationSubjectCanManageAdminSurface,
 } from '@/lib/rbac/admin-simulation-server';
+import { resolveInsightsUserFilter } from '@/lib/rbac/insights-user-filter';
 import { requireAdminSurfaceManage } from '@/lib/rbac/require-openfga';
 import { getAgentsByIds, getAllAgents, getOwnedAgentConversationIds, getOwnedAgents, getReadableSlackChannelNames, type OwnedAgent } from '@/lib/rbac/user-insights-scope';
 import {
@@ -323,7 +324,11 @@ async function getAdminStats(request: NextRequest) {
     // Optional filters
     const sourceFilter = searchParams.get('source'); // 'web' | 'slack' | null (all)
     const userFilter = searchParams.get('user'); // comma-separated emails | null (all)
-    const userEmails = userFilter ? userFilter.split(',').map((u) => u.trim()).filter(Boolean) : [];
+    const teamFilter = searchParams.get('team'); // comma-separated team slugs | null (all)
+    const { active: hasUserFilter, emails: userEmails } = await resolveInsightsUserFilter(
+      userFilter,
+      teamFilter,
+    );
     const channelFilter = searchParams.get('channel'); // comma-separated channel names (slack only)
     const channelNames = channelFilter ? channelFilter.split(',').map((c) => c.trim()).filter(Boolean) : [];
     const agentFilter = searchParams.get('agent'); // comma-separated agent ids (dynamic agents)
@@ -350,7 +355,7 @@ async function getAdminStats(request: NextRequest) {
     // must derive from the scoped conversations, never from the platform-wide
     // users collection (which would leak global active-user counts).
     const hasFilters = !!sourceFilter
-      || userEmails.length > 0
+      || hasUserFilter
       || channelNames.length > 0
       || agentIds.length > 0
       || !!nonAdminScope;
@@ -378,12 +383,10 @@ async function getAdminStats(request: NextRequest) {
         msgOwnerFilter['metadata.channel_name'] = names;
       }
     }
-    if (userEmails.length === 1) {
-      convSourceFilter.owner_id = userEmails[0];
-      msgOwnerFilter.owner_id = userEmails[0];
-    } else if (userEmails.length > 1) {
-      convSourceFilter.owner_id = { $in: userEmails };
-      msgOwnerFilter.owner_id = { $in: userEmails };
+    if (hasUserFilter) {
+      const owners = userEmails.length === 1 ? userEmails[0] : { $in: userEmails };
+      convSourceFilter.owner_id = owners;
+      msgOwnerFilter.owner_id = owners;
     }
 
     // Non-admin scope, reused by every query below so the whole payload stays
@@ -588,16 +591,21 @@ async function getAdminStats(request: NextRequest) {
       if (sourceFilter === 'slack') {
         workflowRunFilter = null; // web-only concept; skip the queries entirely
       } else if (nonAdminScope) {
-        workflowRunFilter = nonAdminScope.sub
+        const includesCaller = !hasUserFilter || userEmails.some(
+          (email) => email.toLowerCase() === nonAdminScope.ownerEmail.toLowerCase(),
+        );
+        workflowRunFilter = includesCaller && nonAdminScope.sub
           ? { 'owner_subject.type': 'user', 'owner_subject.id': nonAdminScope.sub }
           : null;
-      } else if (userEmails.length > 0) {
-        const owners = await users
-          .find(
-            { email: { $in: userEmails } },
-            { projection: { keycloak_sub: 1, 'metadata.keycloak_sub': 1 } },
-          )
-          .toArray();
+      } else if (hasUserFilter) {
+        const owners = userEmails.length > 0
+          ? await users
+              .find(
+                { email: { $in: userEmails } },
+                { projection: { keycloak_sub: 1, 'metadata.keycloak_sub': 1 } },
+              )
+              .toArray()
+          : [];
         const subs = [
           ...new Set(
             owners
@@ -726,8 +734,9 @@ async function getAdminStats(request: NextRequest) {
           fbFilter.channel_name = { $in: channelNames };
         }
       }
-      if (userEmails.length === 1) fbFilter.user_email = userEmails[0];
-      else if (userEmails.length > 1) fbFilter.user_email = { $in: userEmails };
+      if (hasUserFilter) {
+        fbFilter.user_email = userEmails.length === 1 ? userEmails[0] : { $in: userEmails };
+      }
 
       // Non-admin: feedback is keyed by channel_name (slack) / user_email (web),
       // so scope it directly rather than via the conversation-shaped scope filter.
@@ -1368,7 +1377,7 @@ async function getAdminStats(request: NextRequest) {
             channels: configDoc
               ? { total: configDoc.total, qanda_enabled: configDoc.qanda_enabled, alerts_enabled: configDoc.alerts_enabled, ai_enabled: configDoc.ai_enabled }
               : { total: 0, qanda_enabled: 0, alerts_enabled: 0, ai_enabled: 0 },
-            ...(userEmails.length === 0 ? {
+            ...(!hasUserFilter ? {
               configured_channels: configuredChannelsTotal,
               configured_channels_daily: configuredChannelsDaily,
             } : {}),

--- a/ui/src/app/api/admin/stats/skills/route.ts
+++ b/ui/src/app/api/admin/stats/skills/route.ts
@@ -9,7 +9,37 @@ withErrorHandler,
 import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
 import type { AgentSkill } from '@/types/agent-skill';
 import type { WorkflowRun } from '@/types/workflow-run';
+import type { Document } from 'mongodb';
 import { NextRequest,NextResponse } from 'next/server';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function parseRangeBounds(searchParams: URLSearchParams): { rangeStart: Date; rangeEnd: Date } {
+  const now = new Date();
+  const fromParam = searchParams.get('from');
+  const toParam = searchParams.get('to');
+  if (fromParam) {
+    return {
+      rangeStart: new Date(fromParam),
+      rangeEnd: toParam ? new Date(toParam) : now,
+    };
+  }
+
+  const rangeMs = (() => {
+    switch (searchParams.get('range')) {
+      case '1h': return HOUR_MS;
+      case '12h': return 12 * HOUR_MS;
+      case '24h':
+      case '1d': return DAY_MS;
+      case '7d': return 7 * DAY_MS;
+      case '90d': return 90 * DAY_MS;
+      case '30d':
+      default: return 30 * DAY_MS;
+    }
+  })();
+  return { rangeStart: new Date(now.getTime() - rangeMs), rangeEnd: now };
+}
 
 export const GET = withErrorHandler(async (request: NextRequest) => {
   if (!isMongoDBConfigured) {
@@ -28,11 +58,31 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
 
     const configs = await getCollection<AgentSkill>('agent_skills');
     const runs = await getCollection<WorkflowRun>('workflow_runs');
+    const { searchParams } = request.nextUrl;
+    const { rangeStart, rangeEnd } = parseRangeBounds(searchParams);
+    const dateMatch = { $gte: rangeStart, $lte: rangeEnd };
+    const sourceFilter = searchParams.get('source');
+    const userEmails = (searchParams.get('user') ?? '')
+      .split(',')
+      .map((email) => email.trim())
+      .filter(Boolean);
 
-    const now = new Date();
-    const last30Days = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    // Skill inventory is attributable by creator and creation time. It has no
+    // source, Slack-channel, or dynamic-agent axis, so those filters do not
+    // apply to the catalog cards.
+    const configFilter: Document = { created_at: dateMatch };
+    if (userEmails.length === 1) configFilter.owner_id = userEmails[0];
+    else if (userEmails.length > 1) configFilter.owner_id = { $in: userEmails };
 
-    const allConfigs = await configs.find({}).toArray();
+    // Legacy skill-run records are web-only and carry owner email + timestamps,
+    // but no dynamic-agent/channel attribution. A Slack selection therefore
+    // correctly yields zero run metrics while leaving catalog creation metrics.
+    const runFilter: Document = { started_at: dateMatch };
+    if (userEmails.length === 1) runFilter.owner_id = userEmails[0];
+    else if (userEmails.length > 1) runFilter.owner_id = { $in: userEmails };
+    if (sourceFilter === 'slack') runFilter._id = null;
+
+    const allConfigs = await configs.find(configFilter).toArray();
 
     const systemSkills = allConfigs.filter((c) => c.is_system).length;
     const userConfigs = allConfigs.filter((c) => !c.is_system);
@@ -59,13 +109,13 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
       .sort((a, b) => b.count - a.count)
       .slice(0, 15);
 
-    // Daily creation timeline (last 30 days, user-created only)
+    // Creation timeline for the selected range (user-created only).
     const dailyCreatedAgg = await configs
       .aggregate([
         {
           $match: {
+            ...configFilter,
             is_system: { $ne: true },
-            created_at: { $gte: last30Days },
           },
         },
         {
@@ -88,6 +138,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // Overall run stats
     const overallRunAgg = await runs
       .aggregate([
+        { $match: runFilter },
         {
           $group: {
             _id: null,
@@ -129,6 +180,7 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // Top skills by run count
     const topSkillsAgg = await runs
       .aggregate([
+        { $match: runFilter },
         {
           $group: {
             _id: '$workflow_id',

--- a/ui/src/app/api/admin/stats/skills/route.ts
+++ b/ui/src/app/api/admin/stats/skills/route.ts
@@ -7,6 +7,7 @@ successResponse,
 withErrorHandler,
 } from '@/lib/api-middleware';
 import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
+import { resolveInsightsUserFilter } from '@/lib/rbac/insights-user-filter';
 import type { AgentSkill } from '@/types/agent-skill';
 import type { WorkflowRun } from '@/types/workflow-run';
 import type { Document } from 'mongodb';
@@ -62,24 +63,26 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const { rangeStart, rangeEnd } = parseRangeBounds(searchParams);
     const dateMatch = { $gte: rangeStart, $lte: rangeEnd };
     const sourceFilter = searchParams.get('source');
-    const userEmails = (searchParams.get('user') ?? '')
-      .split(',')
-      .map((email) => email.trim())
-      .filter(Boolean);
+    const { active: hasUserFilter, emails: userEmails } = await resolveInsightsUserFilter(
+      searchParams.get('user'),
+      searchParams.get('team'),
+    );
 
     // Skill inventory is attributable by creator and creation time. It has no
     // source, Slack-channel, or dynamic-agent axis, so those filters do not
     // apply to the catalog cards.
     const configFilter: Document = { created_at: dateMatch };
-    if (userEmails.length === 1) configFilter.owner_id = userEmails[0];
-    else if (userEmails.length > 1) configFilter.owner_id = { $in: userEmails };
+    if (hasUserFilter) {
+      configFilter.owner_id = userEmails.length === 1 ? userEmails[0] : { $in: userEmails };
+    }
 
     // Legacy skill-run records are web-only and carry owner email + timestamps,
     // but no dynamic-agent/channel attribution. A Slack selection therefore
     // correctly yields zero run metrics while leaving catalog creation metrics.
     const runFilter: Document = { started_at: dateMatch };
-    if (userEmails.length === 1) runFilter.owner_id = userEmails[0];
-    else if (userEmails.length > 1) runFilter.owner_id = { $in: userEmails };
+    if (hasUserFilter) {
+      runFilter.owner_id = userEmails.length === 1 ? userEmails[0] : { $in: userEmails };
+    }
     if (sourceFilter === 'slack') runFilter._id = null;
 
     const allConfigs = await configs.find(configFilter).toArray();

--- a/ui/src/lib/rbac/insights-user-filter.ts
+++ b/ui/src/lib/rbac/insights-user-filter.ts
@@ -1,0 +1,54 @@
+import { loadTeamMembersForSlugs } from './team-membership-store';
+
+export interface InsightsUserFilter {
+  active: boolean;
+  emails: string[];
+  teamSlugs: string[];
+}
+
+function parseFilterValues(value: string | null): string[] {
+  return [...new Set(
+    (value ?? '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  )];
+}
+
+/**
+ * Resolve the user/team filter into the owner emails stored on Insights data.
+ *
+ * This is a query filter, not an authorization decision. Callers must apply the
+ * returned emails in addition to their existing server-side visibility scope.
+ * `active` stays true when a selected team has no resolvable members so callers
+ * can fail closed with `$in: []` instead of accidentally returning all users.
+ */
+export async function resolveInsightsUserFilter(
+  userFilter: string | null,
+  teamFilter: string | null,
+): Promise<InsightsUserFilter> {
+  const directUsers = parseFilterValues(userFilter);
+  const teamSlugs = parseFilterValues(teamFilter);
+  const emails = new Map<string, string>();
+
+  const addEmail = (value: string | undefined): void => {
+    const email = value?.trim();
+    if (!email) return;
+    const normalized = email.toLowerCase();
+    if (!emails.has(normalized)) emails.set(normalized, email);
+  };
+
+  directUsers.forEach(addEmail);
+  if (teamSlugs.length > 0) {
+    const membersByTeam = await loadTeamMembersForSlugs(teamSlugs);
+    for (const members of membersByTeam.values()) {
+      for (const member of members) addEmail(member.user_email);
+    }
+  }
+
+  return {
+    active: directUsers.length > 0 || teamSlugs.length > 0,
+    emails: [...emails.values()],
+    teamSlugs,
+  };
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.56.dev3"
+version = "0.5.56.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fixes inconsistent filtering across the Admin > Insights dashboard.

- Applies date, source, user/team, agent, channel, and bot filters to every applicable usage card and chart.
- Propagates agent filters through conversations, messages, feedback, workflows, and Slack routing data.
- Applies source and user/date filters to skills metrics, while documenting that legacy skill records do not contain agent or channel attribution.
- Keeps non-admin queries scoped to owned agents and fails closed when agent resolution returns no matches.
- Prevents stale Slack metrics when the Web source is selected and avoids invalid average values for empty results.
- Adds regression coverage for the frontend requests and backend aggregation pipelines.

No related issue.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this PR does not change Helm charts.

## Testing

- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` (531 suites, 6,685 tests passed)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
