### PR TITLE
fix(workflow): do global check correctly

### DIFF
--- a/ui/src/app/api/workflow-configs/check-agent-access/__tests__/route.test.ts
+++ b/ui/src/app/api/workflow-configs/check-agent-access/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockCheckOpenFgaTuple = jest.fn();
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => ({
+  withAuth: async (
+    _request: NextRequest,
+    handler: () => Promise<Response>,
+  ): Promise<Response> => handler(),
+}));
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+import { POST } from "../route";
+
+interface CheckTuple {
+  user: string;
+  relation: string;
+  object: string;
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/workflow-configs/check-agent-access", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      visibility: "team",
+      shared_with_teams: ["example-team"],
+      steps: [{ type: "step", agent_id: "example-agent" }],
+    }),
+  });
+}
+
+describe("POST /api/workflow-configs/check-agent-access", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCollection.mockResolvedValue({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          { _id: "example-agent", name: "Example agent" },
+        ]),
+      }),
+    });
+  });
+
+  it("does not report a team gap when the agent has global access", async () => {
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: CheckTuple) => ({
+      allowed: tuple.user === "user:*",
+    }));
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ gaps: [] });
+    expect(mockCheckOpenFgaTuple).toHaveBeenCalledWith({
+      user: "user:*",
+      relation: "user",
+      object: "agent:example-agent",
+    });
+    expect(mockCheckOpenFgaTuple).not.toHaveBeenCalledWith({
+      user: "team:example-team#member",
+      relation: "user",
+      object: "agent:example-agent",
+    });
+  });
+
+  it("falls back to the explicit team grant when the agent is not global", async () => {
+    mockCheckOpenFgaTuple.mockImplementation(async (tuple: CheckTuple) => ({
+      allowed: tuple.user === "team:example-team#member",
+    }));
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ gaps: [] });
+    expect(mockCheckOpenFgaTuple).toHaveBeenNthCalledWith(1, {
+      user: "user:*",
+      relation: "user",
+      object: "agent:example-agent",
+    });
+    expect(mockCheckOpenFgaTuple).toHaveBeenNthCalledWith(2, {
+      user: "team:example-team#member",
+      relation: "user",
+      object: "agent:example-agent",
+    });
+  });
+});

--- a/ui/src/app/api/workflow-configs/check-agent-access/route.ts
+++ b/ui/src/app/api/workflow-configs/check-agent-access/route.ts
@@ -54,8 +54,20 @@ async function resolveAgentNames(agentIds: string[]): Promise<Map<string, string
   return names;
 }
 
-// Check whether team:{slug}#member has the `user` relation on agent:{agentId}.
+// A global agent's `user:*` grant covers every team's users. Otherwise, check
+// whether team:{slug}#member has an explicit `user` relation on the agent.
 async function teamHasAgentAccess(teamSlug: string, agentId: string): Promise<boolean> {
+  try {
+    const globalResult = await checkOpenFgaTuple({
+      user: "user:*",
+      relation: "user",
+      object: `agent:${agentId}`,
+    });
+    if (globalResult.allowed) return true;
+  } catch {
+    // A failed global check does not rule out an explicit team grant.
+  }
+
   try {
     const result = await checkOpenFgaTuple({
       user: `team:${teamSlug}#member`,


### PR DESCRIPTION
# Description

Team-visible workflows incorrectly reported global step agents as inaccessible because validation only checked explicit team grants and ignored the global user:* grant.
The fix checks global agent access first and treats it as accessible to every team, falling back to the explicit team grant check when needed. Regression tests cover both paths.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
