### PR TITLE
fix(ci): build remaining 11 CI image workflows natively per-arch

### DIFF
--- a/.github/workflows/ci-agentgateway-config-bridge.yml
+++ b/.github/workflows/ci-agentgateway-config-bridge.yml
@@ -60,7 +60,6 @@ jobs:
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-agentgateway-config-bridge.yml
+++ b/.github/workflows/ci-agentgateway-config-bridge.yml
@@ -60,13 +60,28 @@ jobs:
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}agentgateway-config-bridge
@@ -101,28 +116,99 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: deploy/agentgateway
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}agentgateway-config-bridge
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -133,11 +219,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_PUSH_RESULT: ${{ needs.build-and-push.result }}
+          MERGE_RESULT: ${{ needs.merge-manifests.result }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
         run: |
           CONCLUSION="$BUILD_PUSH_RESULT"
           if [[ "$CONCLUSION" == "skipped" ]]; then CONCLUSION="success"; fi
+          MERGE_CONCLUSION="$MERGE_RESULT"
+          if [[ "$MERGE_CONCLUSION" == "skipped" ]]; then MERGE_CONCLUSION="success"; fi
+          if [[ "$MERGE_CONCLUSION" != "success" ]]; then CONCLUSION="failure"; fi
 
           gh api "/repos/${GH_REPOSITORY}/dispatches" --input - <<EOF
           {

--- a/.github/workflows/ci-audit-service.yml
+++ b/.github/workflows/ci-audit-service.yml
@@ -129,13 +129,28 @@ jobs:
             echo "image_prefix=$IMAGE_PREFIX"
           } >> "$GITHUB_OUTPUT"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}caipe-audit-service
@@ -170,22 +185,93 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}caipe-audit-service
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   retag-unchanged:
     runs-on: ubuntu-latest
@@ -270,6 +356,11 @@ jobs:
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: Build and Push fallback image
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -288,7 +379,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -299,13 +390,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_RESULT: ${{ needs.build-and-push.result }}
+          MERGE_RESULT: ${{ needs.merge-manifests.result }}
           RETAG_RESULT: ${{ needs.retag-unchanged.result }}
           REPOSITORY: ${{ github.repository }}
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-audit-service.yml
+++ b/.github/workflows/ci-audit-service.yml
@@ -129,7 +129,6 @@ jobs:
             echo "image_prefix=$IMAGE_PREFIX"
           } >> "$GITHUB_OUTPUT"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -122,13 +122,29 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     env:
       REGISTRY: ghcr.io
@@ -186,20 +202,18 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
           target: runner
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
           build-args: |
             CAIPE_URL=http://caipe-supervisor:8000
             BUILDKIT_INLINE_CACHE=1
@@ -208,6 +222,80 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}caipe-ui
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   retag-unchanged:
     runs-on: ubuntu-latest
@@ -347,6 +435,11 @@ jobs:
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: 🔨 Build and Push (fallback)
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -374,7 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -395,17 +488,20 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_PUSH_RESULT: ${{ needs.build-and-push.result }}
+          MERGE_RESULT: ${{ needs.merge-manifests.result }}
           RETAG_UNCHANGED_RESULT: ${{ needs.retag-unchanged.result }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
         run: |
           BUILD_RESULT="$BUILD_PUSH_RESULT"
+          MERGE_RESULT_VAL="$MERGE_RESULT"
           RETAG_RESULT="$RETAG_UNCHANGED_RESULT"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT_VAL" == "skipped" ]]; then MERGE_RESULT_VAL="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT_VAL" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -122,7 +122,6 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -130,13 +130,29 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     env:
       REGISTRY: ghcr.io
@@ -181,21 +197,93 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ai_platform_engineering/dynamic_agents
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}caipe-dynamic-agents
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   retag-unchanged:
     runs-on: ubuntu-latest
@@ -315,6 +403,11 @@ jobs:
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: 🔨 Build and Push (fallback)
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -335,7 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -356,19 +449,22 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_PUSH_RESULT: ${{ needs.build-and-push.result }}
+          MERGE_RESULT: ${{ needs.merge-manifests.result }}
           RETAG_UNCHANGED_RESULT: ${{ needs.retag-unchanged.result }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
         run: |
           # Determine overall conclusion
           BUILD_RESULT="$BUILD_PUSH_RESULT"
+          MERGE_RESULT_VAL="$MERGE_RESULT"
           RETAG_RESULT="$RETAG_UNCHANGED_RESULT"
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT_VAL" == "skipped" ]]; then MERGE_RESULT_VAL="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT_VAL" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -130,7 +130,6 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-keycloak-init.yml
+++ b/.github/workflows/ci-keycloak-init.yml
@@ -67,13 +67,28 @@ jobs:
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}keycloak-init
@@ -108,22 +123,93 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}keycloak-init
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   reconcile-test:
     # End-to-end functional test of init-idp.sh against a real Keycloak 26.3.
@@ -326,7 +412,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push, reconcile-test, strict-secrets-test, idp-hint-test]
+    needs: [determine-changes, build-and-push, merge-manifests, reconcile-test, strict-secrets-test, idp-hint-test]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -343,6 +429,9 @@ jobs:
         run: |
           CONCLUSION="${{ needs.build-and-push.result }}"
           if [[ "$CONCLUSION" == "skipped" ]]; then CONCLUSION="success"; fi
+          MERGE_CONCLUSION="${{ needs.merge-manifests.result }}"
+          if [[ "$MERGE_CONCLUSION" == "skipped" ]]; then MERGE_CONCLUSION="success"; fi
+          if [[ "$MERGE_CONCLUSION" != "success" ]]; then CONCLUSION="failure"; fi
 
           gh api /repos/${{ github.repository }}/dispatches --input - <<EOF
           {

--- a/.github/workflows/ci-keycloak-init.yml
+++ b/.github/workflows/ci-keycloak-init.yml
@@ -67,7 +67,6 @@ jobs:
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-mcp-servers.yml
+++ b/.github/workflows/ci-mcp-servers.yml
@@ -176,7 +176,6 @@ jobs:
             console.log(`Agents to retag: ${agentsToRetag.join(', ') || 'none'}`);
             console.log(`Image prefix: '${imagePrefix}'`);
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-mcp-servers.yml
+++ b/.github/workflows/ci-mcp-servers.yml
@@ -176,8 +176,13 @@ jobs:
             console.log(`Agents to retag: ${agentsToRetag.join(', ') || 'none'}`);
             console.log(`Image prefix: '${imagePrefix}'`);
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: [determine-agents, load-config]
     if: (needs.determine-agents.outputs.should_build == 'true' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'prebuild/')))
     permissions:
@@ -187,6 +192,14 @@ jobs:
     strategy:
       matrix:
         agent: ${{ fromJson(needs.determine-agents.outputs.agents_to_build) }}
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
       fail-fast: false
 
     env:
@@ -231,22 +244,101 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push MCP Docker image
+      - name: Build and push MCP image by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: build/agents/Dockerfile.mcp
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
           build-args: |
             AGENT_NAME=${{ matrix.agent }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.agent }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.agent }}-${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.agent }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest
+  # list, one matrix entry per MCP agent.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-agents, build-and-push]
+    if: |
+      needs.determine-agents.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        agent: ${{ fromJson(needs.determine-agents.outputs.agents_to_build) }}
+      fail-fast: false
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-agents.outputs.image_prefix }}mcp-${{ matrix.agent }}
+
+    steps:
+      - name: 🔒 harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-${{ matrix.agent }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-agents.outputs.tag_version }},enable=${{ needs.determine-agents.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   # Retag unchanged agents from previous version when tag_version is provided
   # If source image doesn't exist (still building), falls back to full build
@@ -370,6 +462,11 @@ jobs:
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: 🔨 Build and Push (fallback)
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -390,7 +487,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-agents, build-and-push, retag-unchanged]
+    needs: [determine-agents, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-agents.outputs.tag_version != '' &&
@@ -414,13 +511,15 @@ jobs:
         run: |
           # Determine overall conclusion
           BUILD_RESULT="${{ needs.build-and-push.result }}"
+          MERGE_RESULT="${{ needs.merge-manifests.result }}"
           RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-openfga-authz-bridge.yml
+++ b/.github/workflows/ci-openfga-authz-bridge.yml
@@ -59,13 +59,28 @@ jobs:
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}openfga-authz-bridge
@@ -100,28 +115,99 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: deploy/openfga/bridge
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}openfga-authz-bridge
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -135,6 +221,9 @@ jobs:
         run: |
           CONCLUSION="${{ needs.build-and-push.result }}"
           if [[ "$CONCLUSION" == "skipped" ]]; then CONCLUSION="success"; fi
+          MERGE_CONCLUSION="${{ needs.merge-manifests.result }}"
+          if [[ "$MERGE_CONCLUSION" == "skipped" ]]; then MERGE_CONCLUSION="success"; fi
+          if [[ "$MERGE_CONCLUSION" != "success" ]]; then CONCLUSION="failure"; fi
 
           gh api /repos/${{ github.repository }}/dispatches --input - <<EOF
           {

--- a/.github/workflows/ci-openfga-authz-bridge.yml
+++ b/.github/workflows/ci-openfga-authz-bridge.yml
@@ -59,7 +59,6 @@ jobs:
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "image_prefix=$IMAGE_PREFIX" >> "$GITHUB_OUTPUT"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-scheduler.yml
+++ b/.github/workflows/ci-scheduler.yml
@@ -114,7 +114,6 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX"              >> $GITHUB_OUTPUT
           echo "Outputs: scheduler=$BUILD_SCHED, cron_runner=$BUILD_RUNNER, prefix=$IMAGE_PREFIX"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-scheduler.yml
+++ b/.github/workflows/ci-scheduler.yml
@@ -114,8 +114,13 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX"              >> $GITHUB_OUTPUT
           echo "Outputs: scheduler=$BUILD_SCHED, cron_runner=$BUILD_RUNNER, prefix=$IMAGE_PREFIX"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     permissions:
       contents: read
@@ -129,11 +134,33 @@ jobs:
             context: .
             dockerfile: build/Dockerfile.scheduler
             should_build: ${{ needs.determine-changes.outputs.should_build_scheduler }}
+            platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - name: scheduler
+            image: caipe-scheduler
+            context: .
+            dockerfile: build/Dockerfile.scheduler
+            should_build: ${{ needs.determine-changes.outputs.should_build_scheduler }}
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
           - name: cron-runner
             image: caipe-cron-runner
             context: .
             dockerfile: build/Dockerfile.cron-runner
             should_build: ${{ needs.determine-changes.outputs.should_build_cron_runner }}
+            platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - name: cron-runner
+            image: caipe-cron-runner
+            context: .
+            dockerfile: build/Dockerfile.cron-runner
+            should_build: ${{ needs.determine-changes.outputs.should_build_cron_runner }}
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}${{ matrix.image }}
@@ -141,7 +168,7 @@ jobs:
     steps:
       - name: Skip if not building this image
         if: matrix.should_build != 'true'
-        run: echo "Nothing to build for ${{ matrix.name }}; exiting."
+        run: echo "Nothing to build for ${{ matrix.name }} (${{ matrix.arch }}); exiting."
 
       - name: Harden runner
         if: matrix.should_build == 'true'
@@ -177,22 +204,112 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
+      - name: Build and push by digest
         if: matrix.should_build == 'true'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Docker image
-        if: matrix.should_build == 'true'
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          # Push only on tag or manual dispatch; PR builds validate without publishing.
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.name }}
+          # Push only on tag or manual dispatch; PR builds validate without publishing.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.name }}-${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: matrix.should_build == 'true' && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: matrix.should_build == 'true' && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.name }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest
+  # list, one matrix entry per image (scheduler, cron-runner).
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: scheduler
+            image: caipe-scheduler
+            should_build: ${{ needs.determine-changes.outputs.should_build_scheduler }}
+          - name: cron-runner
+            image: caipe-cron-runner
+            should_build: ${{ needs.determine-changes.outputs.should_build_cron_runner }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}${{ matrix.image }}
+    steps:
+      - name: Skip if not building this image
+        if: matrix.should_build != 'true'
+        run: echo "Nothing to merge for ${{ matrix.name }}; exiting."
+
+      - name: Harden runner
+        if: matrix.should_build == 'true'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        if: matrix.should_build == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-${{ matrix.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        if: matrix.should_build == 'true'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        if: matrix.should_build == 'true'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        if: matrix.should_build == 'true'
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        if: matrix.should_build == 'true'
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        if: matrix.should_build == 'true'
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -164,7 +164,6 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -164,13 +164,29 @@ jobs:
           echo "image_prefix=$IMAGE_PREFIX" >> $GITHUB_OUTPUT
           echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG, prefix=$IMAGE_PREFIX"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     env:
       REGISTRY: ghcr.io
@@ -236,19 +252,17 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.arch }}
           build-args: |
             SKILL_SCANNER_VERSION=${{ needs.determine-changes.outputs.scanner_version }}
             BUILDKIT_INLINE_CACHE=1
@@ -257,6 +271,80 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}skill-scanner
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   retag-unchanged:
     runs-on: ubuntu-latest
@@ -394,6 +482,11 @@ jobs:
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: 🔨 Build and Push (fallback)
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -422,7 +515,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -445,12 +538,14 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           BUILD_RESULT="${{ needs.build-and-push.result }}"
+          MERGE_RESULT="${{ needs.merge-manifests.result }}"
           RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -160,7 +160,6 @@ jobs:
           cd ../../..
           uv run --project ai_platform_engineering/integrations/slack_bot pytest ai_platform_engineering/integrations/slack_bot/tests/ -v -m "not integration"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -160,13 +160,29 @@ jobs:
           cd ../../..
           uv run --project ai_platform_engineering/integrations/slack_bot pytest ai_platform_engineering/integrations/slack_bot/tests/ -v -m "not integration"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     env:
       REGISTRY: ghcr.io
@@ -211,19 +227,91 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}caipe-slack-bot
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   retag-unchanged:
     runs-on: ubuntu-latest
@@ -339,6 +427,11 @@ jobs:
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: 🔨 Build and Push (fallback)
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -357,7 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -380,12 +473,14 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           BUILD_RESULT="${{ needs.build-and-push.result }}"
+          MERGE_RESULT="${{ needs.merge-manifests.result }}"
           RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-webex-bot.yml
+++ b/.github/workflows/ci-webex-bot.yml
@@ -151,13 +151,29 @@ jobs:
           cd ../../..
           uv run --project ai_platform_engineering/integrations/webex_bot pytest ai_platform_engineering/integrations/webex_bot/tests/ -v -m "not integration"
 
+  # assisted-by claude code claude-sonnet-4-6
+  # Build natively per-platform (no QEMU) and push by digest only;
+  # merge-manifests combines the per-arch digests into the final tagged
+  # multi-arch manifest list. See ci-rag.yml for the incident this pattern
+  # was introduced to fix (QEMU-emulated arm64 timing out/OOMing).
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: determine-changes
     if: needs.determine-changes.outputs.should_build == 'true'
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     env:
       REGISTRY: ghcr.io
@@ -192,19 +208,91 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into a single tagged multi-arch manifest list.
+  merge-manifests:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build-and-push]
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ needs.determine-changes.outputs.image_prefix }}caipe-webex-bot
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.') && !contains(github.ref_name, '-hotfix.') && !contains(github.ref_name, '-chart.')) }}
+            type=raw,value=${{ needs.determine-changes.outputs.tag_version }},enable=${{ needs.determine-changes.outputs.tag_version != '' }}
+            type=ref,event=tag,prefix=
+            type=sha,format=short,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   retag-unchanged:
     runs-on: ubuntu-latest
@@ -309,6 +397,11 @@ jobs:
       - name: Set up QEMU
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      # Known gap: this fallback still cross-builds arm64 under QEMU rather
+      # than a native runner (unlike build-and-push above). It only runs when
+      # the source image for retagging is missing — rare — so it hasn't been
+      # split per-platform. Apply the same native-runner + digest-merge
+      # treatment here if this path ever times out/OOMs.
       - name: 🔨 Build and Push (fallback)
         if: steps.retag-or-build.outputs.needs_build == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -326,7 +419,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -339,12 +432,14 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           BUILD_RESULT="${{ needs.build-and-push.result }}"
+          MERGE_RESULT="${{ needs.merge-manifests.result }}"
           RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
+          if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
           if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-webex-bot.yml
+++ b/.github/workflows/ci-webex-bot.yml
@@ -151,7 +151,6 @@ jobs:
           cd ../../..
           uv run --project ai_platform_engineering/integrations/webex_bot pytest ai_platform_engineering/integrations/webex_bot/tests/ -v -m "not integration"
 
-  # assisted-by claude code claude-sonnet-4-6
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
   # multi-arch manifest list. See ci-rag.yml for the incident this pattern


### PR DESCRIPTION
# Description

Follow-up to #2272 (ci-rag.yml). That PR converted the RAG image builds from
QEMU-emulated arm64 to native `ubuntu-24.04-arm` runners after
`ingestors/default` started timing out / OOMing the runner. This PR applies
the same pattern to every **other** image-building CI workflow that still
cross-builds arm64 via QEMU:

| Workflow | Shape | retag-unchanged? |
|---|---|---|
| `ci-agentgateway-config-bridge.yml` | single image | no |
| `ci-openfga-authz-bridge.yml` | single image | no |
| `ci-keycloak-init.yml` | single image (+3 unrelated local-test jobs, untouched) | no |
| `ci-audit-service.yml` | single image | yes |
| `ci-dynamic-agents.yml` | single image | yes |
| `ci-caipe-ui.yml` | single image (`target: runner`, extra build-args) | yes |
| `ci-slack-bot.yml` | single image | yes |
| `ci-webex-bot.yml` | single image | yes |
| `ci-skill-scanner.yml` | single image (extra build-args) | yes |
| `ci-scheduler.yml` | matrix: scheduler + cron-runner | no |
| `ci-mcp-servers.yml` | matrix: per MCP agent | yes |

**Important distinction from #2272**: none of these 11 images share
`ingestors/default`'s specific failure mode — I confirmed
`Dockerfile.ingestors` is the *only* Dockerfile in the repo that installs
Chromium/Playwright, and all 11 of these workflows' most recent runs are
green. So this PR is a **CI reliability/cost improvement**, not a bug fix:
native arm64 runners are faster than QEMU emulation for every build here,
and it closes off the same failure mode before any of these images grow
heavy enough to hit it.

## What changed in each `build-and-push` job

- Added a `platform` matrix dimension: `linux/amd64` on `ubuntu-latest`,
  `linux/arm64` on `ubuntu-24.04-arm` (free for this public repo, GA since
  Jan 2025 — no QEMU, no `docker/setup-qemu-action` step).
- Each per-platform build now pushes **by digest only**
  (`push-by-digest=true`) instead of pushing tags directly.
- A new **`merge-manifests`** job (matrixed by image where the source job
  was matrixed, e.g. `ci-scheduler.yml`, `ci-mcp-servers.yml`) downloads the
  per-arch digest artifacts and runs `docker buildx imagetools create` to
  publish the final tagged multi-arch manifest list — the standard Docker
  [multi-platform CI pattern](https://docs.docker.com/build/ci/github-actions/multi-platform/).
- Each `notify-release` job now also waits on `merge-manifests` before
  reporting success/failure to the release-finalize dispatch.
- Cache scopes (`type=gha,scope=...`) now include the arch, since amd64 and
  arm64 now build in separate jobs/runners and would otherwise race on the
  same GHA cache key.

**Known gap, documented inline in every file**: each workflow's
`retag-unchanged` fallback build (only exercised when the source image for
a retag is missing — rare in practice) is left on QEMU, matching the same
call made in #2272 for `ci-rag.yml`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — all 11 files parse
      and produce the expected job graph (confirmed job list per file).
- [x] Confirmed no stray QEMU steps remain in any `build-and-push` job —
      `setup-qemu-action` only appears in the (intentionally untouched)
      `retag-unchanged` fallback builds, and in `ci-scheduler.yml`/the 3
      no-retag files, 0 QEMU references remain at all.
- [ ] Because this PR only touches workflow files, none of these
      `ci-*.yml` workflows auto-trigger on this PR (each is path-filtered to
      its own component's source). Recommend a maintainer runs
      `workflow_dispatch` (with `force_build`/`build_all: true` where
      applicable) on this branch for at least one single-image workflow and
      one matrixed workflow (e.g. `ci-audit-service.yml` and
      `ci-mcp-servers.yml`) to validate the digest-push → merge-manifests
      path end-to-end before merging.
- [ ] Confirm a produced manifest list is truly multi-arch, e.g.:
      `docker buildx imagetools inspect ghcr.io/cnoe-io/caipe-audit-service:<tag>`

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable) — follow-up to #2272
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (inline workflow comments)
- [ ] All code style checks pass (workflow-only change; no lint/test suite applies)
- [ ] New code contribution is covered by automated tests (GitHub Actions workflows aren't unit-testable; verified via YAML parse + manual `workflow_dispatch` run recommended above)
- [ ] All new and existing tests pass
