### PR TITLE
fix(ui): compare positive and negative feedback trends

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.56 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.58 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.56 -f your-values.yaml'}
+                  {'    --version 0.5.58 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.56 -f your-values.yaml'}
+              {'    --version 0.5.58 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.58"
+version = "0.5.58-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -69,6 +69,14 @@ jest.mock('@/components/admin/shared/SimpleLineChart', () => ({
   SimpleLineChart: () => <div data-testid="line-chart" />,
 }));
 
+jest.mock('@/components/admin/shared/FeedbackTrendChart', () => ({
+  FeedbackTrendChart: ({
+    data,
+  }: {
+    data: Array<{ label: string; positive: number; negative: number }>;
+  }) => <div data-testid="feedback-trend-chart">{JSON.stringify(data)}</div>,
+}));
+
 jest.mock('@/components/admin/platform/MetricsTab', () => ({
   MetricsTab: () => <div data-testid="metrics-tab">MetricsTab</div>,
 }));
@@ -1623,6 +1631,31 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getByText('Messages')).toBeInTheDocument();
       expect(screen.getByText('Daily Active Users (DAU)')).toBeInTheDocument();
       expect(screen.queryByText('NaN')).not.toBeInTheDocument();
+    });
+
+    it('passes positive and negative daily feedback as separate chart series', async () => {
+      setupFetchMock({
+        stats: {
+          ...mockStatsResponse,
+          data: {
+            ...mockStatsResponse.data,
+            feedback_summary: {
+              positive: 8,
+              negative: 3,
+              total: 11,
+              daily: [{ date: '2026-07-20', positive: 8, negative: 3 }],
+            },
+          },
+        },
+      });
+      render(<AdminPage />);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+
+      const chart = await screen.findByTestId('feedback-trend-chart');
+      expect(chart).toHaveTextContent('"positive":8');
+      expect(chart).toHaveTextContent('"negative":3');
+      expect(chart).not.toHaveTextContent('"value":11');
     });
 
     it('updates cards independently and issues one request per section when a filter changes', async () => {

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -31,6 +31,7 @@ import { PlatformSettingsTab } from "@/components/admin/settings/PlatformSetting
 import { ReleaseNotesSettingsTab } from "@/components/admin/settings/ReleaseNotesSettingsTab";
 import { ReviewConfigsTab } from "@/components/admin/settings/ReviewConfigsTab";
 import { DateRangeFilter,presetToRange,type DateRange,type DateRangePreset } from "@/components/admin/shared/DateRangeFilter";
+import { FeedbackTrendChart } from "@/components/admin/shared/FeedbackTrendChart";
 import { SimpleLineChart } from "@/components/admin/shared/SimpleLineChart";
 import { CreateTeamDialog } from "@/components/admin/teams/CreateTeamDialog";
 import { IdentitySyncPanel } from "@/components/admin/teams/IdentitySyncPanel";
@@ -2678,13 +2679,13 @@ function AdminPage() {
                             <CardDescription>Daily positive vs negative feedback</CardDescription>
                           </CardHeader>
                           <CardContent>
-                            <SimpleLineChart
+                            <FeedbackTrendChart
                               data={stats.feedback_summary.daily.map((day) => ({
                                 label: formatBucketLabel(day.date),
-                                value: day.positive + day.negative,
+                                positive: day.positive,
+                                negative: day.negative,
                               }))}
                               height={180}
-                              color="rgb(34, 197, 94)"
                             />
                           </CardContent>
                           </Card> : undefined}

--- a/ui/src/components/admin/shared/FeedbackTrendChart.tsx
+++ b/ui/src/components/admin/shared/FeedbackTrendChart.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const POSITIVE_COLOR = "rgb(34, 197, 94)";
+const NEGATIVE_COLOR = "rgb(239, 68, 68)";
+
+export interface FeedbackTrendPoint {
+  label: string;
+  positive: number;
+  negative: number;
+}
+
+interface FeedbackTrendChartProps {
+  data: FeedbackTrendPoint[];
+  height?: number;
+}
+
+interface FeedbackTrendTooltipProps {
+  active?: boolean;
+  label?: string;
+  point?: FeedbackTrendPoint;
+}
+
+interface FeedbackTrendSummary {
+  positive: number;
+  negative: number;
+  total: number;
+  net: number;
+  positiveRate: number | null;
+}
+
+function summarizeFeedback(data: FeedbackTrendPoint[]): FeedbackTrendSummary {
+  const { positive, negative } = data.reduce(
+    (summary, point) => ({
+      positive: summary.positive + point.positive,
+      negative: summary.negative + point.negative,
+    }),
+    { positive: 0, negative: 0 },
+  );
+  const total = positive + negative;
+
+  return {
+    positive,
+    negative,
+    total,
+    net: positive - negative,
+    positiveRate: total > 0 ? Math.round((positive / total) * 100) : null,
+  };
+}
+
+function formatNet(net: number): string {
+  return `${net > 0 ? "+" : ""}${net.toLocaleString()}`;
+}
+
+function netColorClass(net: number): string {
+  if (net > 0) return "text-green-500";
+  if (net < 0) return "text-red-500";
+  return "text-muted-foreground";
+}
+
+export function FeedbackTrendTooltip({
+  active,
+  label,
+  point,
+}: FeedbackTrendTooltipProps) {
+  if (!active || !point) return null;
+
+  const summary = summarizeFeedback([point]);
+
+  return (
+    <div
+      className="min-w-48 rounded-lg border border-border bg-popover p-3 text-xs text-popover-foreground shadow-md"
+      role="tooltip"
+    >
+      <p className="mb-2 font-semibold">{label ?? point.label}</p>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-6">
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <span
+              aria-hidden="true"
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: POSITIVE_COLOR }}
+            />
+            Positive
+          </span>
+          <span className="font-semibold tabular-nums text-green-500">
+            {point.positive.toLocaleString()}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-6">
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <span
+              aria-hidden="true"
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: NEGATIVE_COLOR }}
+            />
+            Negative
+          </span>
+          <span className="font-semibold tabular-nums text-red-500">
+            {point.negative.toLocaleString()}
+          </span>
+        </div>
+      </div>
+      <div className="mt-2 space-y-1.5 border-t border-border pt-2">
+        <div className="flex items-center justify-between gap-6">
+          <span className="text-muted-foreground">Total</span>
+          <span className="font-semibold tabular-nums">{summary.total.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-6">
+          <span className="text-muted-foreground">Net</span>
+          <span className={`font-semibold tabular-nums ${netColorClass(summary.net)}`}>
+            {formatNet(summary.net)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-6">
+          <span className="text-muted-foreground">Positive rate</span>
+          <span className="font-semibold tabular-nums">
+            {summary.positiveRate === null ? "—" : `${summary.positiveRate}%`}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FeedbackTrendChart({ data, height = 180 }: FeedbackTrendChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-muted-foreground">
+        No data available
+      </div>
+    );
+  }
+
+  const summary = summarizeFeedback(data);
+
+  return (
+    <div
+      aria-label="Positive versus negative feedback by day"
+      className="w-full"
+      role="region"
+    >
+      <div
+        aria-label="Feedback totals for the selected range"
+        className="mb-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs"
+      >
+        <span className="flex items-center gap-2 text-muted-foreground">
+          <span
+            aria-hidden="true"
+            className="w-5 border-t-2"
+            style={{ borderColor: POSITIVE_COLOR }}
+          />
+          Positive
+          <strong
+            className="font-semibold tabular-nums text-foreground"
+            data-testid="feedback-positive-total"
+          >
+            {summary.positive.toLocaleString()}
+          </strong>
+        </span>
+        <span className="flex items-center gap-2 text-muted-foreground">
+          <span
+            aria-hidden="true"
+            className="w-5 border-t-2 border-dashed"
+            style={{ borderColor: NEGATIVE_COLOR }}
+          />
+          Negative
+          <strong
+            className="font-semibold tabular-nums text-foreground"
+            data-testid="feedback-negative-total"
+          >
+            {summary.negative.toLocaleString()}
+          </strong>
+        </span>
+        <span className="ml-auto text-muted-foreground">
+          Net{" "}
+          <strong
+            className={`font-semibold tabular-nums ${netColorClass(summary.net)}`}
+            data-testid="feedback-net-total"
+          >
+            {formatNet(summary.net)}
+          </strong>
+        </span>
+      </div>
+
+      <div style={{ height }}>
+        <ResponsiveContainer height="100%" minWidth={0} width="100%">
+          <LineChart
+            accessibilityLayer
+            data={data}
+            margin={{ top: 8, right: 12, bottom: 0, left: -8 }}
+          >
+            <CartesianGrid
+              stroke="hsl(var(--border))"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              axisLine={false}
+              dataKey="label"
+              interval="preserveStartEnd"
+              minTickGap={36}
+              tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 11 }}
+              tickLine={false}
+            />
+            <YAxis
+              allowDecimals={false}
+              axisLine={false}
+              domain={[0, (dataMax: number) => Math.max(1, dataMax)]}
+              tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 11 }}
+              tickLine={false}
+              width={38}
+            />
+            <Tooltip
+              content={({ active, label, payload }) => (
+                <FeedbackTrendTooltip
+                  active={active}
+                  label={typeof label === "string" ? label : undefined}
+                  point={payload?.[0]?.payload as FeedbackTrendPoint | undefined}
+                />
+              )}
+              cursor={{ stroke: "hsl(var(--muted-foreground))", strokeDasharray: "4 4" }}
+              isAnimationActive={false}
+            />
+            <Line
+              activeDot={{ r: 5, strokeWidth: 2 }}
+              dataKey="positive"
+              dot={{ fill: POSITIVE_COLOR, r: 3, strokeWidth: 0 }}
+              isAnimationActive={false}
+              name="Positive"
+              stroke={POSITIVE_COLOR}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+              type="linear"
+            />
+            <Line
+              activeDot={{ r: 5, strokeWidth: 2 }}
+              dataKey="negative"
+              dot={{ fill: NEGATIVE_COLOR, r: 3, strokeWidth: 0 }}
+              isAnimationActive={false}
+              name="Negative"
+              stroke={NEGATIVE_COLOR}
+              strokeDasharray="5 4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+              type="linear"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/admin/shared/__tests__/FeedbackTrendChart.test.tsx
+++ b/ui/src/components/admin/shared/__tests__/FeedbackTrendChart.test.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import { render, screen, within } from "@testing-library/react";
+
+jest.mock("recharts", () => ({
+  CartesianGrid: () => null,
+  Line: ({ dataKey }: { dataKey: string }) => (
+    <div data-series={dataKey} data-testid="feedback-series" />
+  ),
+  LineChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+import {
+  FeedbackTrendChart,
+  FeedbackTrendTooltip,
+} from "../FeedbackTrendChart";
+
+describe("FeedbackTrendChart", () => {
+  const data = [
+    { label: "Jul 20", positive: 8, negative: 3 },
+    { label: "Jul 21", positive: 4, negative: 2 },
+  ];
+
+  it("summarizes both series and their net difference", () => {
+    render(<FeedbackTrendChart data={data} />);
+
+    expect(screen.getByTestId("feedback-positive-total")).toHaveTextContent("12");
+    expect(screen.getByTestId("feedback-negative-total")).toHaveTextContent("5");
+    expect(screen.getByTestId("feedback-net-total")).toHaveTextContent("+7");
+    expect(screen.getByLabelText("Positive versus negative feedback by day")).toBeInTheDocument();
+    expect(screen.getAllByTestId("feedback-series").map((series) => series.dataset.series)).toEqual([
+      "positive",
+      "negative",
+    ]);
+  });
+
+  it("shows a useful per-day comparison in the tooltip", () => {
+    render(
+      <FeedbackTrendTooltip
+        active
+        label="Jul 20"
+        point={{ label: "Jul 20", positive: 8, negative: 3 }}
+      />,
+    );
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(within(tooltip).getByText("Jul 20")).toBeInTheDocument();
+    expect(within(tooltip).getByText("8")).toBeInTheDocument();
+    expect(within(tooltip).getByText("3")).toBeInTheDocument();
+    expect(within(tooltip).getByText("11")).toBeInTheDocument();
+    expect(within(tooltip).getByText("+5")).toBeInTheDocument();
+    expect(within(tooltip).getByText("73%")).toBeInTheDocument();
+  });
+
+  it("uses a neutral rate when a day has no feedback", () => {
+    render(
+      <FeedbackTrendTooltip
+        active
+        label="Jul 22"
+        point={{ label: "Jul 22", positive: 0, negative: 0 }}
+      />,
+    );
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getAllByText("0")).toHaveLength(4);
+  });
+
+  it("handles an empty series", () => {
+    render(<FeedbackTrendChart data={[]} />);
+
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.58"
+version = "0.5.58.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Makes the admin Feedback Trend card match its positive-vs-negative description.

- Plots daily positive and negative feedback as separate series.
- Uses a solid green line and a dashed red line so the comparison does not rely on color alone.
- Adds selected-range positive, negative, and net totals; net is positive minus negative.
- Expands the hover details with daily positive, negative, total, net, and positive-rate values.
- Keeps the existing admin stats API contract unchanged.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this is a UI-only chart fix.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (not applicable; no related issue)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in this description and the user-facing labels
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] Relevant new and existing tests pass

## Testing

- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`
- `npm test -- --runInBand --runTestsByPath src/components/admin/shared/__tests__/FeedbackTrendChart.test.tsx src/app/(app)/admin/__tests__/admin-page.test.tsx` (77 tests)
- `npm run build`
