### PR TITLE
fix(ci): disambiguate digest artifact patterns to prevent name-prefix collisions

### DIFF
--- a/.github/workflows/ci-mcp-servers.yml
+++ b/.github/workflows/ci-mcp-servers.yml
@@ -268,7 +268,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: digests-${{ matrix.agent }}-${{ matrix.arch }}
+          name: digests-${{ matrix.agent }}--${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -276,6 +276,7 @@ jobs:
   # Combine the per-arch digests into a single tagged multi-arch manifest
   # list, one matrix entry per MCP agent.
   merge-manifests:
+    name: Merge manifest
     runs-on: ubuntu-latest
     needs: [determine-agents, build-and-push]
     if: |
@@ -303,7 +304,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: digests-${{ matrix.agent }}-*
+          pattern: digests-${{ matrix.agent }}--*
           path: /tmp/digests
           merge-multiple: true
 

--- a/.github/workflows/ci-rag.yml
+++ b/.github/workflows/ci-rag.yml
@@ -332,7 +332,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: digests-${{ matrix.component }}-${{ matrix.variant }}-${{ matrix.arch }}
+          name: digests-${{ matrix.component }}-${{ matrix.variant }}--${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -342,6 +342,7 @@ jobs:
   # unlike build-and-push, this is not split per-platform since it only
   # manipulates registry metadata (no image content is built here).
   merge-manifests:
+    name: Merge manifest
     runs-on: ubuntu-latest
     needs: [determine-changes, build-and-push]
     if: |
@@ -368,7 +369,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: digests-${{ matrix.component }}-${{ matrix.variant }}-*
+          pattern: digests-${{ matrix.component }}-${{ matrix.variant }}--*
           path: /tmp/digests
           merge-multiple: true
 

--- a/.github/workflows/ci-scheduler.yml
+++ b/.github/workflows/ci-scheduler.yml
@@ -230,7 +230,7 @@ jobs:
         if: matrix.should_build == 'true' && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: digests-${{ matrix.name }}-${{ matrix.arch }}
+          name: digests-${{ matrix.name }}--${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -238,6 +238,7 @@ jobs:
   # Combine the per-arch digests into a single tagged multi-arch manifest
   # list, one matrix entry per image (scheduler, cron-runner).
   merge-manifests:
+    name: Merge manifest
     runs-on: ubuntu-latest
     needs: [determine-changes, build-and-push]
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
@@ -272,7 +273,7 @@ jobs:
         if: matrix.should_build == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: digests-${{ matrix.name }}-*
+          pattern: digests-${{ matrix.name }}--*
           path: /tmp/digests
           merge-multiple: true
 


### PR DESCRIPTION
# Description

Fixes the CI build failure flagged on the draft `0.5.58` release:
https://github.com/cnoe-io/ai-platform-engineering/releases/tag/untagged-e05e2f5d9fe875c2dc3c
(run [29940392120](https://github.com/cnoe-io/ai-platform-engineering/actions/runs/29940392120), job `merge-manifests (webex)`).

## Root cause

`merge-manifests`'s digest download used `pattern: digests-${{ matrix.agent }}-*`.
For `agent=webex` that pattern is `digests-webex-*`, which also glob-matches
`digests-webex-meetings-amd64` / `-arm64` — "webex" is a literal string
prefix of "webex-meetings". The webex merge job downloaded four digest
files instead of two, including two that were actually pushed under
`ghcr.io/cnoe-io/mcp-webex-meetings`, and `docker buildx imagetools create`
failed trying to reference one of those digests under `mcp-webex`:

```
ERROR: ghcr.io/cnoe-io/mcp-webex@sha256:09f91f3f...: not found
```

All 28 native per-arch `build-and-push` jobs in that run succeeded (real
end-to-end confirmation the native-arm64 conversion from #2274 works) — only
this one merge step, and only for the one agent name that happens to be a
prefix of another, was affected.

## Fix

Insert a `--` (double-dash) separator between the matrix key(s) and the arch
suffix in both the upload name and the download pattern, in every workflow
that matrixes over a dynamic name list:

- `ci-mcp-servers.yml` (`matrix.agent`) — the one that actually broke
- `ci-rag.yml` (`matrix.component`-`matrix.variant`) — same class of risk, no
  current collision, fixed defensively
- `ci-scheduler.yml` (`matrix.name`) — same, no current collision, fixed
  defensively

e.g. `digests-webex-amd64` / `digests-webex-meetings-amd64` (ambiguous)
becomes `digests-webex--amd64` / `digests-webex-meetings--amd64`
(unambiguous — no agent name can produce that literal `--` unless it's
followed by nothing else).

Also gave the three matrixed `merge-manifests` jobs an explicit
`name: Merge manifest` so the Actions UI reads "Merge manifest (webex)"
rather than the bare job-id auto-suffix "merge-manifests (webex)".

## Test plan

- [x] Confirmed via `.github/agents.json` that `webex` / `webex-meetings` is
      the only current prefix collision among MCP agents (script checked
      every pair).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — all three files parse.
- [ ] Recommend a maintainer re-runs (or triggers a new `workflow_dispatch`
      for) `ci-mcp-servers.yml` targeting `webex` and `webex-meetings`
      specifically to confirm both manifests now merge correctly and don't
      cross-contaminate.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable) — fixes CI failure on draft release 0.5.58
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (inline workflow comments)
- [ ] All code style checks pass (workflow-only change; no lint/test suite applies)
- [ ] New code contribution is covered by automated tests (GitHub Actions workflows aren't unit-testable; verified via YAML parse + agent-list collision check above)
- [ ] All new and existing tests pass
