### PR TITLE
feat(ui): add admin filter deep links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.58-dev.2"
+version = "0.5.58-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -1284,23 +1284,6 @@ describe('Admin Dashboard Page', () => {
       });
     });
 
-    it('canonicalizes Authorization Insights deep links to the merged Metrics tab', async () => {
-      currentSearchParams = new URLSearchParams('cat=platform&tab=cas-insights');
-
-      render(<AdminPage />);
-
-      expect(await screen.findByText('Metrics & Health')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Metrics & Health' })).toHaveAttribute('aria-pressed', 'true');
-      expect(screen.getByRole('tab', { name: /^Metrics$/i })).toHaveAttribute(
-        'aria-selected',
-        'true',
-      );
-      expect(screen.queryByRole('tab', { name: /^Authorization Insights$/i })).not.toBeInTheDocument();
-      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=platform&tab=metrics', {
-        scroll: false,
-      });
-    });
-
     it('opens the requested Access Explorer sub-tab from the query string', async () => {
       currentSearchParams = new URLSearchParams('cat=security&tab=access-explorer');
 
@@ -1615,6 +1598,97 @@ describe('Admin Dashboard Page', () => {
 
       expect(await screen.findByText('Retired Team')).toBeInTheDocument();
       expect(screen.getByText('Archived')).toBeInTheDocument();
+    });
+  });
+
+  describe('Insights filter deep links', () => {
+    it('applies Statistics URL filters to the first card requests', async () => {
+      currentSearchParams = new URLSearchParams({
+        cat: 'insights',
+        tab: 'stats',
+        source: 'slack',
+        statsChannels: 'primary-channel',
+        statsAgents: 'agent-primary',
+        statsIncludeBots: 'true',
+        users: 'test-user@example.com',
+        dateRange: '7d',
+      });
+      const fetchMock = setupFetchMock();
+
+      render(<AdminPage />);
+      await screen.findByText('42');
+
+      const statsUrls = fetchMock.mock.calls
+        .map(([url]) => new URL(url, 'http://localhost'))
+        .filter((url) => url.pathname === '/api/admin/stats');
+      expect(statsUrls.length).toBeGreaterThan(0);
+      expect(statsUrls.every((url) => (
+        url.searchParams.get('source') === 'slack'
+        && url.searchParams.get('channel') === 'primary-channel'
+        && url.searchParams.get('agent') === 'agent-primary'
+        && url.searchParams.get('include_bots') === 'true'
+        && url.searchParams.get('user') === 'test-user@example.com'
+        && url.searchParams.get('range') === '7d'
+      ))).toBe(true);
+      expect(screen.getByLabelText(/show bot users/i)).toBeChecked();
+      expect(await screen.findByRole('button', { name: /Primary Agent/ })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByLabelText(/show bot users/i));
+      const updatedStatsUrl = new URL(replaceMock.mock.calls.at(-1)?.[0], 'http://localhost');
+      expect(updatedStatsUrl.searchParams.has('statsIncludeBots')).toBe(false);
+      expect(updatedStatsUrl.searchParams.get('statsChannels')).toBe('primary-channel');
+      expect(updatedStatsUrl.searchParams.get('statsAgents')).toBe('agent-primary');
+    });
+
+    it('applies Feedback URL filters to the initial request', async () => {
+      currentSearchParams = new URLSearchParams({
+        cat: 'insights',
+        tab: 'feedback',
+        source: 'slack',
+        channels: 'primary-channel',
+        rating: 'negative',
+        search: 'incorrect',
+        users: 'team:Platform Team,test-user@example.com',
+        dateRange: '7d',
+      });
+      const fetchMock = setupFetchMock({
+        feedback: {
+          ...mockFeedbackResponse,
+          data: {
+            ...mockFeedbackResponse.data,
+            channels: ['primary-channel'],
+            users: ['test-user@example.com'],
+          },
+        },
+      });
+
+      render(<AdminPage />);
+
+      await waitFor(() => {
+        expect(fetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/admin/feedback?'))).toBe(true);
+      });
+      const feedbackUrls = fetchMock.mock.calls
+        .map(([url]) => new URL(url, 'http://localhost'))
+        .filter((url) => url.pathname === '/api/admin/feedback');
+      expect(feedbackUrls).toHaveLength(1);
+      const feedbackUrl = feedbackUrls[0];
+      expect(feedbackUrl.searchParams.get('source')).toBe('slack');
+      expect(feedbackUrl.searchParams.get('channel')).toBe('primary-channel');
+      expect(feedbackUrl.searchParams.get('rating')).toBe('negative');
+      expect(feedbackUrl.searchParams.get('search')).toBe('incorrect');
+      expect(feedbackUrl.searchParams.get('team')).toBe('platform-team');
+      expect(feedbackUrl.searchParams.get('user')).toBe('test-user@example.com');
+      const from = Date.parse(feedbackUrl.searchParams.get('from') ?? '');
+      const to = Date.parse(feedbackUrl.searchParams.get('to') ?? '');
+      expect(to - from).toBeGreaterThanOrEqual(6.9 * 24 * 60 * 60 * 1000);
+      expect(to - from).toBeLessThanOrEqual(7.1 * 24 * 60 * 60 * 1000);
+      expect(screen.getByRole('button', { name: 'negative' })).toHaveClass('bg-primary');
+
+      fireEvent.click(screen.getByRole('button', { name: 'all' }));
+      const updatedFeedbackUrl = new URL(replaceMock.mock.calls.at(-1)?.[0], 'http://localhost');
+      expect(updatedFeedbackUrl.searchParams.has('rating')).toBe(false);
+      expect(updatedFeedbackUrl.searchParams.get('source')).toBe('slack');
+      expect(updatedFeedbackUrl.searchParams.get('channels')).toBe('primary-channel');
     });
   });
 

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -58,6 +58,7 @@ import { SlidingSelectorIndicator } from "@/components/ui/sliding-selector";
 import { Tabs,TabsContent,TabsList,TabsTrigger } from "@/components/ui/tabs";
 import { useAdminRole } from "@/hooks/use-admin-role";
 import { useAdminStatsSections } from "@/hooks/use-admin-stats-sections";
+import { useUrlFilterParams } from "@/hooks/use-url-filter-params";
 import { useAdminTabGates,type AdminTabGateSimulationTarget } from "@/hooks/useAdminTabGates";
 import { getConfig } from "@/lib/config";
 import { withAdminSimulationParams } from "@/lib/rbac/admin-simulation-query";
@@ -192,7 +193,6 @@ interface SimulationTeamOption {
 const VALID_TABS = ['users', 'teams', 'identity-sync', 'stats', 'skills', 'feedback', 'metrics', 'health', 'credentials', 'audit-logs', 'action-audit', 'access-explorer', 'rbac-self-check', 'keycloak', 'migrations', 'ai-review', 'settings', 'agents', 'release-notes', 'slack', 'webex', 'rag-access', 'service-accounts'] as const;
 const VALID_OPENFGA_SUBTABS = ['builder', 'explorer', 'graph', 'tuples', 'access', 'baseline', 'diagnostics'] as const;
 const MOVED_ADMIN_TAB_MAP = {
-  'cas-insights': 'metrics',
   insights: 'stats',
   openfga: 'access-explorer',
 } as const;
@@ -501,11 +501,27 @@ function simulationTargetFromParams(searchParams: { get(name: string): string | 
   };
 }
 
+function commaSeparatedFilter(value: string | null): string[] {
+  if (!value) return [];
+  return [...new Set(value.split(',').map((item) => item.trim()).filter(Boolean))];
+}
+
+function isValidDateRange(from: string | null, to: string | null): from is string {
+  return Boolean(
+    from &&
+    to &&
+    Number.isFinite(Date.parse(from)) &&
+    Number.isFinite(Date.parse(to)) &&
+    Date.parse(from) <= Date.parse(to)
+  );
+}
+
 function AdminPage() {
   const { status } = useSession();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const updateUrlFilters = useUrlFilterParams();
   const { isAdmin, loading: adminRoleLoading } = useAdminRole();
   const simulationTarget = useMemo(() => simulationTargetFromParams(searchParams), [searchParams]);
   const simulationScopeKey = simulationTarget
@@ -689,17 +705,14 @@ function AdminPage() {
       const firstVisible = cat.tabs.find((t) => tabGateValues[t.gateKey]);
       if (firstVisible) {
         setActiveTab(firstVisible.value);
-        const params = new URLSearchParams(searchParams.toString());
-        params.set('cat', catKey);
-        params.set('tab', firstVisible.value);
-        if (firstVisible.value !== 'access-explorer') {
-          params.delete('subtab');
-          params.delete('openfgaTab');
-        }
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+        updateUrlFilters({
+          cat: catKey,
+          tab: firstVisible.value,
+          ...(firstVisible.value === 'access-explorer' ? {} : { subtab: null, openfgaTab: null }),
+        });
       }
     },
-    [pathname, router, searchParams, tabGateValues]
+    [tabGateValues, updateUrlFilters]
   );
 
   useEffect(() => {
@@ -790,28 +803,32 @@ function AdminPage() {
   const [deletingTeam, setDeletingTeam] = useState<string | null>(null);
   const [teamPendingDelete, setTeamPendingDelete] = useState<Team | null>(null);
   // ── Shared filters (source, users, date range) across feedback + stats tabs ──
-  const initSource = searchParams.get('source') as 'all' | 'web' | 'slack' | null;
-  const initUsers = searchParams.get('users');
-  const initDatePreset = searchParams.get('dateRange') as DateRangePreset | null;
-  const initFrom = searchParams.get('from');
-  const initTo = searchParams.get('to');
+  const requestedSource = searchParams.get('source');
+  const sourceFromUrl: 'all' | 'web' | 'slack' =
+    requestedSource === 'web' || requestedSource === 'slack' ? requestedSource : 'all';
+  const usersFromUrl = commaSeparatedFilter(searchParams.get('users'));
+  const requestedDatePreset = searchParams.get('dateRange');
+  const requestedFrom = searchParams.get('from');
+  const requestedTo = searchParams.get('to');
+  const validDatePreset = requestedDatePreset &&
+    ['1h', '12h', '24h', '7d', '30d', '90d', 'custom'].includes(requestedDatePreset);
+  const datePresetFromUrl: DateRangePreset = validDatePreset &&
+    (requestedDatePreset !== 'custom' || isValidDateRange(requestedFrom, requestedTo))
+    ? requestedDatePreset as DateRangePreset
+    : '30d';
+  const dateRangeFromUrl: DateRange = datePresetFromUrl === 'custom'
+    ? { from: requestedFrom as string, to: requestedTo as string }
+    : presetToRange(datePresetFromUrl);
 
   const [sourceFilter, setSourceFilter] = useState<'all' | 'web' | 'slack'>(
-    initSource && ['all', 'web', 'slack'].includes(initSource) ? initSource : 'all'
+    sourceFromUrl
   );
-  const [userFilter, setUserFilter] = useState<string[]>(
-    initUsers ? initUsers.split(',').filter(Boolean) : []
-  );
-  const [datePreset, setDatePreset] = useState<DateRangePreset>(
-    initDatePreset && ['1h', '12h', '24h', '7d', '30d', '90d', 'custom'].includes(initDatePreset) ? initDatePreset : '30d'
-  );
-  const [dateRange, setDateRange] = useState<DateRange>(
-    initFrom ? { from: initFrom, to: initTo || new Date().toISOString() } : presetToRange(initDatePreset || '30d')
-  );
+  const [userFilter, setUserFilter] = useState<string[]>(usersFromUrl);
+  const [datePreset, setDatePreset] = useState<DateRangePreset>(datePresetFromUrl);
+  const [dateRange, setDateRange] = useState<DateRange>(dateRangeFromUrl);
 
   // Helper to sync shared filters to URL
   const updateSharedFilterUrl = (overrides: Record<string, string | null> = {}) => {
-    const params = new URLSearchParams(searchParams.toString());
     const shared: Record<string, string | null> = {
       source: sourceFilter !== 'all' ? sourceFilter : null,
       users: userFilter.length > 0 ? userFilter.join(',') : null,
@@ -820,55 +837,88 @@ function AdminPage() {
       to: datePreset === 'custom' ? dateRange.to : null,
       ...overrides,
     };
-    for (const [key, val] of Object.entries(shared)) {
-      if (val) { params.set(key, val); } else { params.delete(key); }
-    }
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    updateUrlFilters(shared);
   };
 
   // ── Feedback-only filters ──
-  const initRating = searchParams.get('rating') as 'all' | 'positive' | 'negative' | null;
-  const initChannels = searchParams.get('channels');
-  const initSearch = searchParams.get('search');
+  const requestedRating = searchParams.get('rating');
+  const feedbackRatingFromUrl: 'all' | 'positive' | 'negative' =
+    requestedRating === 'positive' || requestedRating === 'negative' ? requestedRating : 'all';
+  const feedbackChannelsFromUrl = commaSeparatedFilter(searchParams.get('channels'));
+  const feedbackSearchFromUrl = commaSeparatedFilter(searchParams.get('search'));
 
   const [feedbackData, setFeedbackData] = useState<FeedbackData | null>(null);
   const [feedbackFilter, setFeedbackFilter] = useState<'all' | 'positive' | 'negative'>(
-    initRating && ['all', 'positive', 'negative'].includes(initRating) ? initRating : 'all'
+    feedbackRatingFromUrl
   );
-  const [feedbackChannelFilter, setFeedbackChannelFilter] = useState<string[]>(
-    initChannels ? initChannels.split(',').filter(Boolean) : []
-  );
+  const [feedbackChannelFilter, setFeedbackChannelFilter] = useState<string[]>(feedbackChannelsFromUrl);
   const [feedbackChannels, setFeedbackChannels] = useState<string[]>([]);
-  const [feedbackSearchTags, setFeedbackSearchTags] = useState<string[]>(
-    initSearch ? initSearch.split(',').filter(Boolean) : []
-  );
+  const [feedbackSearchTags, setFeedbackSearchTags] = useState<string[]>(feedbackSearchFromUrl);
   const [feedbackUsers, setFeedbackUsers] = useState<string[]>([]);
   const [feedbackLoading, setFeedbackLoading] = useState(false);
 
   // Sync feedback-only filters to URL
   const updateFeedbackUrl = (overrides: Record<string, string | null>) => {
-    const params = new URLSearchParams(searchParams.toString());
     const defaults: Record<string, string | null> = {
       tab: activeTab,
       rating: feedbackFilter !== 'all' ? feedbackFilter : null,
       channels: feedbackChannelFilter.length > 0 ? feedbackChannelFilter.join(',') : null,
       search: feedbackSearchTags.length > 0 ? feedbackSearchTags.join(',') : null,
     };
-    const merged = { ...defaults, ...overrides };
-    for (const [key, val] of Object.entries(merged)) {
-      if (val) { params.set(key, val); } else { params.delete(key); }
-    }
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    updateUrlFilters({ ...defaults, ...overrides });
   };
-  const [statsChannelFilter, setStatsChannelFilter] = useState<string[]>([]);
+  const statsChannelsFromUrl = commaSeparatedFilter(searchParams.get('statsChannels'));
+  const statsAgentsFromUrl = commaSeparatedFilter(searchParams.get('statsAgents'));
+  const statsIncludeBotsFromUrl = searchParams.get('statsIncludeBots') === 'true';
+  const [statsChannelFilter, setStatsChannelFilter] = useState<string[]>(statsChannelsFromUrl);
   const [statsChannels, setStatsChannels] = useState<string[]>([]);
-  // Agent filter: selected agent NAMES (dropdown labels), mapped to ids for the
-  // query param via statsAgents. Options are scoped by the API to what the
-  // caller can see (owned agents for non-admins, all agents for admins).
-  const [statsAgentFilter, setStatsAgentFilter] = useState<string[]>([]);
+  // Store stable agent IDs in URL/state and map them to labels only for the
+  // dropdown. This lets the first deep-linked request apply the filter before
+  // the scoped agent option list has loaded.
+  const [statsAgentFilter, setStatsAgentFilter] = useState<string[]>(statsAgentsFromUrl);
   const [statsAgents, setStatsAgents] = useState<Array<{ id: string; name: string }>>([]);
   // Top-users leaderboard: hide bot/service identities by default; toggle to show.
-  const [showBotUsers, setShowBotUsers] = useState(false);
+  const [showBotUsers, setShowBotUsers] = useState(statsIncludeBotsFromUrl);
+  const insightsFilterUrlKey = [
+    searchParams.get('source'),
+    searchParams.get('users'),
+    searchParams.get('dateRange'),
+    searchParams.get('from'),
+    searchParams.get('to'),
+    searchParams.get('rating'),
+    searchParams.get('channels'),
+    searchParams.get('search'),
+    searchParams.get('statsChannels'),
+    searchParams.get('statsAgents'),
+    searchParams.get('statsIncludeBots'),
+  ].map((value) => value ?? '').join('\u0000');
+  const [previousInsightsFilterUrlKey, setPreviousInsightsFilterUrlKey] = useState(insightsFilterUrlKey);
+
+  if (insightsFilterUrlKey !== previousInsightsFilterUrlKey) {
+    setPreviousInsightsFilterUrlKey(insightsFilterUrlKey);
+    setSourceFilter(sourceFromUrl);
+    setUserFilter(usersFromUrl);
+    setDatePreset(datePresetFromUrl);
+    setDateRange(dateRangeFromUrl);
+    setFeedbackFilter(feedbackRatingFromUrl);
+    setFeedbackChannelFilter(feedbackChannelsFromUrl);
+    setFeedbackSearchTags(feedbackSearchFromUrl);
+    setStatsChannelFilter(statsChannelsFromUrl);
+    setStatsAgentFilter(statsAgentsFromUrl);
+    setShowBotUsers(statsIncludeBotsFromUrl);
+  }
+
+  const updateStatsFilterUrl = (overrides: Record<string, string | null> = {}) => {
+    updateUrlFilters({
+      statsChannels: statsChannelFilter.length > 0 ? statsChannelFilter.join(',') : null,
+      statsAgents: statsAgentFilter.length > 0 ? statsAgentFilter.join(',') : null,
+      statsIncludeBots: showBotUsers ? 'true' : null,
+      ...overrides,
+    });
+  };
+  const selectedStatsAgentNames = statsAgentFilter
+    .map((id) => statsAgents.find((agent) => agent.id === id)?.name)
+    .filter((name): name is string => Boolean(name));
   const rangeLabel = datePreset === "1h" ? "1 Hour" : datePreset === "12h" ? "12 Hours" : datePreset === "24h" ? "24 Hours" : datePreset === "7d" ? "7 Days" : datePreset === "90d" ? "90 Days" : datePreset === "custom" ? "Custom Range" : "30 Days";
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
 
@@ -909,10 +959,7 @@ function AdminPage() {
     if (sourceFilter === 'slack' && statsChannelFilter.length > 0) {
       params.set('channel', statsChannelFilter.join(','));
     }
-    const agentIds = statsAgentFilter
-      .map((name) => statsAgents.find((agent) => agent.name === name)?.id)
-      .filter((id): id is string => Boolean(id));
-    if (agentIds.length > 0) params.set('agent', agentIds.join(','));
+    if (statsAgentFilter.length > 0) params.set('agent', statsAgentFilter.join(','));
     if (showBotUsers) params.set('include_bots', 'true');
     return withAdminSimulationParams(`/api/admin/stats?${params.toString()}`, simulationTarget);
   }, [
@@ -923,7 +970,6 @@ function AdminPage() {
     simulationTarget,
     sourceFilter,
     statsAgentFilter,
-    statsAgents,
     statsChannelFilter,
   ]);
 
@@ -1138,11 +1184,14 @@ function AdminPage() {
     await loadStatsSections();
   };
 
-  const loadTeamsData = async () => {
+  const loadTeamsData = async (): Promise<Team[]> => {
     try {
-      setTeams(await fetchTeamsFromDb());
+      const loadedTeams = await fetchTeamsFromDb();
+      setTeams(loadedTeams);
+      return loadedTeams;
     } catch (err) {
       console.error('[Admin] Failed to load teams:', err);
+      return [];
     }
   };
 
@@ -1172,11 +1221,47 @@ function AdminPage() {
     return () => window.clearTimeout(handle);
   }, [loadSkillStats, skillStatsFilterKey, status]);
 
-  const loadFeedbackOnce = async () => {
-    if (!getConfig('feedbackEnabled')) return;
+  const getFeedbackUrl = (
+    rating = feedbackFilter,
+    page = 1,
+    source = sourceFilter,
+    channels = feedbackChannelFilter,
+    searchTags = feedbackSearchTags,
+    users = userFilter,
+    range = dateRange,
+    availableTeams = teams,
+  ): string => {
+    const params = new URLSearchParams({ page: String(page), limit: '50' });
+    if (rating !== 'all') params.set('rating', rating);
+    if (source !== 'all') params.set('source', source);
+    if (source === 'slack' && channels.length > 0) {
+      params.set('channel', channels.join(','));
+    }
+    if (searchTags.length > 0) params.set('search', searchTags.join(','));
+
+    const selectedUsers = new Set<string>();
+    const selectedTeams = new Set<string>();
+    for (const selection of users) {
+      if (selection.startsWith('team:')) {
+        const team = availableTeams.find((candidate) => candidate.name === selection.slice(5));
+        selectedTeams.add(team?.slug?.trim() || team?._id || selection.slice(5));
+      } else {
+        selectedUsers.add(selection);
+      }
+    }
+    if (selectedUsers.size > 0) params.set('user', [...selectedUsers].join(','));
+    if (selectedTeams.size > 0) params.set('team', [...selectedTeams].join(','));
+    if (range.from) params.set('from', range.from);
+    if (range.to) params.set('to', range.to);
+
+    return withAdminSimulationParams(`/api/admin/feedback?${params}`, simulationTarget);
+  };
+
+  const requestFeedback = async (url: string): Promise<void> => {
     const requestScopeKey = simulationScopeKey;
+    setFeedbackLoading(true);
     try {
-      const res = await fetch(withAdminSimulationParams('/api/admin/feedback', simulationTarget));
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json().catch(() => ({ success: false }));
         if (data.success && activeDataScopeKeyRef.current === requestScopeKey) {
@@ -1187,7 +1272,25 @@ function AdminPage() {
       }
     } catch (err) {
       console.error('[Admin] Failed to load feedback:', err);
+    } finally {
+      if (activeDataScopeKeyRef.current === requestScopeKey) {
+        setFeedbackLoading(false);
+      }
     }
+  };
+
+  const loadFeedbackOnce = async (availableTeams: Team[]): Promise<void> => {
+    if (!getConfig('feedbackEnabled')) return;
+    await requestFeedback(getFeedbackUrl(
+      feedbackFilter,
+      1,
+      sourceFilter,
+      feedbackChannelFilter,
+      feedbackSearchTags,
+      userFilter,
+      dateRange,
+      availableTeams,
+    ));
   };
 
   const loadTabData = async (tab: string) => {
@@ -1197,9 +1300,9 @@ function AdminPage() {
     // Teams data is shared across the Stats and Feedback filter dropdowns.
     // Use a data-level key (not the tab name) so it isn't confused with the
     // tab-visit guard that loadTabData adds before invoking the loader.
-    const loadTeamsIfNeeded = () => {
-      if (isSimulationActive) return Promise.resolve();
-      if (visitedTabsRef.current.has('_teams-loaded')) return Promise.resolve();
+    const loadTeamsIfNeeded = (): Promise<Team[]> => {
+      if (isSimulationActive) return Promise.resolve([]);
+      if (visitedTabsRef.current.has('_teams-loaded')) return Promise.resolve(teams);
       visitedTabsRef.current.add('_teams-loaded');
       return loadTeamsData();
     };
@@ -1222,7 +1325,10 @@ function AdminPage() {
       // alongside the rest of the stats data. The Skills tab keeps only the
       // Skill Hubs section, which self-loads.
       stats: async () => { await Promise.all([loadStatsIfNeeded(), loadTeamsIfNeeded(), loadSkillStats()]); },
-      feedback: async () => { await Promise.all([loadFeedbackOnce(), loadTeamsIfNeeded()]); },
+      feedback: async () => {
+        const availableTeams = await loadTeamsIfNeeded();
+        await loadFeedbackOnce(availableTeams);
+      },
     };
 
     const loader = loaders[tab];
@@ -1245,64 +1351,57 @@ function AdminPage() {
     searchTags?: string[],
     users?: string[],
     range?: DateRange,
-  ) => {
-    const requestScopeKey = simulationScopeKey;
-    setFeedbackLoading(true);
-    try {
-      const params = new URLSearchParams({ page: String(page), limit: '50' });
-      if (rating && rating !== 'all') params.set('rating', rating);
-      const src = source ?? sourceFilter;
-      if (src !== 'all') params.set('source', src);
-      const chs = channels ?? feedbackChannelFilter;
-      if (src === 'slack' && chs.length > 0) {
-        params.set('channel', chs.join(','));
-      }
-      const tags = searchTags ?? feedbackSearchTags;
-      if (tags.length > 0) params.set('search', tags.join(','));
-      const selections = users ?? userFilter;
-      const selectedUsers = new Set<string>();
-      const selectedTeams = new Set<string>();
-      for (const selection of selections) {
-        if (selection.startsWith('team:')) {
-          const team = teams.find((candidate) => candidate.name === selection.slice(5));
-          selectedTeams.add(team?.slug?.trim() || team?._id || selection.slice(5));
-        } else {
-          selectedUsers.add(selection);
-        }
-      }
-      if (selectedUsers.size > 0) params.set('user', [...selectedUsers].join(','));
-      if (selectedTeams.size > 0) params.set('team', [...selectedTeams].join(','));
-      const dr = range ?? dateRange;
-      if (dr.from) params.set('from', dr.from);
-      if (dr.to) params.set('to', dr.to);
-      const res = await fetch(withAdminSimulationParams(`/api/admin/feedback?${params}`, simulationTarget));
-      if (res.ok) {
-        const data = await res.json();
-        if (data.success && activeDataScopeKeyRef.current === requestScopeKey) {
-          setFeedbackData(data.data);
-          if (data.data.channels) setFeedbackChannels(data.data.channels);
-          if (data.data.users) setFeedbackUsers(data.data.users);
-        }
-      }
-    } catch (err) {
-      console.error('[Admin] Failed to load feedback:', err);
-    } finally {
-      if (activeDataScopeKeyRef.current === requestScopeKey) {
-        setFeedbackLoading(false);
-      }
-    }
+  ): Promise<void> => {
+    await requestFeedback(getFeedbackUrl(
+      rating ?? feedbackFilter,
+      page,
+      source ?? sourceFilter,
+      channels ?? feedbackChannelFilter,
+      searchTags ?? feedbackSearchTags,
+      users ?? userFilter,
+      range ?? dateRange,
+      teams,
+    ));
   };
+
+  const feedbackFilterKey = useMemo(() => JSON.stringify({
+    channels: feedbackChannelFilter,
+    from: dateRange.from,
+    rating: feedbackFilter,
+    search: feedbackSearchTags,
+    source: sourceFilter,
+    to: dateRange.to,
+    users: userFilter,
+  }), [
+    dateRange.from,
+    dateRange.to,
+    feedbackChannelFilter,
+    feedbackFilter,
+    feedbackSearchTags,
+    sourceFilter,
+    userFilter,
+  ]);
+  const feedbackFilterRef = useRef(feedbackFilterKey);
+  const loadFeedbackEvent = useEffectEvent(() => loadFeedback());
+  useEffect(() => {
+    if (feedbackFilterRef.current === feedbackFilterKey) return;
+    feedbackFilterRef.current = feedbackFilterKey;
+    if (!visitedTabsRef.current.has('feedback')) return;
+    if (status !== "authenticated" && getConfig('ssoEnabled')) return;
+    const handle = window.setTimeout(() => {
+      void loadFeedbackEvent();
+    }, 150);
+    return () => window.clearTimeout(handle);
+  }, [feedbackFilterKey, status]);
 
   const handleFeedbackFilterChange = (filter: 'all' | 'positive' | 'negative') => {
     setFeedbackFilter(filter);
-    loadFeedback(filter, 1);
     updateFeedbackUrl({ rating: filter !== 'all' ? filter : null });
   };
 
   const handleFeedbackSourceChange = (source: 'all' | 'web' | 'slack') => {
     setSourceFilter(source);
     setFeedbackChannelFilter([]);
-    loadFeedback(feedbackFilter, 1, source, [], undefined, undefined);
     updateSharedFilterUrl({ source: source !== 'all' ? source : null });
     updateFeedbackUrl({ channels: null });
   };
@@ -1416,14 +1515,11 @@ function AdminPage() {
               userSelectedAdminTabRef.current = true;
               setActiveTab(tab);
               setActiveCategory(categoryForTab(tab));
-              const params = new URLSearchParams(searchParams.toString());
-              params.set('cat', categoryForTab(tab));
-              params.set('tab', tab);
-              if (tab !== 'access-explorer') {
-                params.delete('subtab');
-                params.delete('openfgaTab');
-              }
-              router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+              updateUrlFilters({
+                cat: categoryForTab(tab),
+                tab,
+                ...(tab === 'access-explorer' ? {} : { subtab: null, openfgaTab: null }),
+              });
             }} className="space-y-4">
               {/* Category selector */}
               <div
@@ -1998,7 +2094,6 @@ function AdminPage() {
                           selected={feedbackChannelFilter}
                           onChange={(channels) => {
                             setFeedbackChannelFilter(channels);
-                            loadFeedback(feedbackFilter, 1, sourceFilter, channels);
                             updateFeedbackUrl({ channels: channels.length > 0 ? channels.join(',') : null });
                           }}
                           placeholder="All Channels"
@@ -2013,7 +2108,6 @@ function AdminPage() {
                       tags={feedbackSearchTags}
                       onChange={(tags) => {
                         setFeedbackSearchTags(tags);
-                        loadFeedback(feedbackFilter, 1, undefined, undefined, tags);
                         updateFeedbackUrl({ search: tags.length > 0 ? tags.join(',') : null });
                       }}
                       placeholder="Search reasons..."
@@ -2030,7 +2124,6 @@ function AdminPage() {
                           selected={userFilter}
                           onChange={(selected) => {
                             setUserFilter(selected);
-                            loadFeedback(feedbackFilter, 1, undefined, undefined, undefined, selected);
                             updateSharedFilterUrl({ users: selected.length > 0 ? selected.join(',') : null });
                           }}
                           placeholder="All Users & Teams"
@@ -2047,7 +2140,6 @@ function AdminPage() {
                     onChange={(preset, range) => {
                       setDatePreset(preset);
                       setDateRange(range);
-                      loadFeedback(feedbackFilter, 1, sourceFilter, feedbackChannelFilter.length > 0 ? feedbackChannelFilter : undefined, undefined, undefined, range);
                       updateSharedFilterUrl({
                         dateRange: preset !== '30d' ? preset : null,
                         from: preset === 'custom' ? range.from : null,
@@ -2224,6 +2316,7 @@ function AdminPage() {
                         setSourceFilter(src);
                         setStatsChannelFilter([]);
                         updateSharedFilterUrl({ source: src !== 'all' ? src : null });
+                        updateStatsFilterUrl({ statsChannels: null });
                       }}
                       className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                     >
@@ -2237,6 +2330,9 @@ function AdminPage() {
                         selected={statsChannelFilter}
                         onChange={(channels) => {
                           setStatsChannelFilter(channels);
+                          updateStatsFilterUrl({
+                            statsChannels: channels.length > 0 ? channels.join(',') : null,
+                          });
                         }}
                         placeholder="All Channels"
                         searchPlaceholder="Search channels..."
@@ -2247,9 +2343,15 @@ function AdminPage() {
                     {statsAgents.length > 0 && (
                       <MultiSelect
                         options={statsAgents.map((a) => a.name)}
-                        selected={statsAgentFilter}
+                        selected={selectedStatsAgentNames}
                         onChange={(agents) => {
-                          setStatsAgentFilter(agents);
+                          const agentIds = agents
+                            .map((name) => statsAgents.find((agent) => agent.name === name)?.id)
+                            .filter((id): id is string => Boolean(id));
+                          setStatsAgentFilter(agentIds);
+                          updateStatsFilterUrl({
+                            statsAgents: agentIds.length > 0 ? agentIds.join(',') : null,
+                          });
                         }}
                         placeholder="All Agents"
                         searchPlaceholder="Search agents..."
@@ -2446,7 +2548,11 @@ function AdminPage() {
                           type="checkbox"
                           className="h-4 w-4 rounded border-input accent-primary"
                           checked={showBotUsers}
-                          onChange={(event) => setShowBotUsers(event.target.checked)}
+                          onChange={(event) => {
+                            const checked = event.target.checked;
+                            setShowBotUsers(checked);
+                            updateStatsFilterUrl({ statsIncludeBots: checked ? 'true' : null });
+                          }}
                         />
                         Show bot users
                       </label>

--- a/ui/src/components/admin/platform/MetricsTab.tsx
+++ b/ui/src/components/admin/platform/MetricsTab.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useUrlFilterParams } from "@/hooks/use-url-filter-params";
+import { useSearchParams } from "next/navigation";
 import {
   type UseBatchPrometheusReturn,
   useBatchPrometheus,
@@ -56,6 +58,40 @@ function metricState(batch: UseBatchPrometheusReturn, id: string): MetricQuerySt
   };
 }
 
+const METRICS_RANGE_PRESETS: readonly DateRangePreset[] = [
+  "1h",
+  "12h",
+  "24h",
+  "7d",
+  "30d",
+  "90d",
+  "custom",
+];
+
+function metricsRangeFromParams(searchParams: { get(name: string): string | null }): {
+  customRange?: DateRange;
+  preset: DateRangePreset;
+} {
+  const rawPreset = searchParams.get("metricsRange");
+  const preset = rawPreset && (METRICS_RANGE_PRESETS as readonly string[]).includes(rawPreset)
+    ? rawPreset as DateRangePreset
+    : "24h";
+  if (preset !== "custom") return { preset };
+
+  const from = searchParams.get("metricsFrom");
+  const to = searchParams.get("metricsTo");
+  if (
+    !from ||
+    !to ||
+    !Number.isFinite(Date.parse(from)) ||
+    !Number.isFinite(Date.parse(to)) ||
+    Date.parse(from) > Date.parse(to)
+  ) {
+    return { preset: "24h" };
+  }
+  return { customRange: { from, to }, preset };
+}
+
 const percentFormat = (value: number): string => `${value.toFixed(2)}%`;
 const coresFormat = (value: number): string => `${value.toFixed(value < 0.1 ? 3 : 2)} cores`;
 const reliabilityTone = (value: number): "positive" | "warning" | "negative" => (
@@ -81,9 +117,21 @@ function modelLabel(metric: Record<string, string>): string {
 }
 
 export function MetricsTab() {
-  const [rangePreset, setRangePreset] = useState<DateRangePreset>("24h");
-  const [customRange, setCustomRange] = useState<DateRange | undefined>();
+  const searchParams = useSearchParams();
+  const updateUrlFilters = useUrlFilterParams();
+  const urlRange = metricsRangeFromParams(searchParams);
+  const urlRangeKey = `${urlRange.preset}\u0000${urlRange.customRange?.from ?? ""}\u0000${urlRange.customRange?.to ?? ""}`;
+  const [rangePreset, setRangePreset] = useState<DateRangePreset>(urlRange.preset);
+  const [customRange, setCustomRange] = useState<DateRange | undefined>(urlRange.customRange);
+  const [previousUrlRangeKey, setPreviousUrlRangeKey] = useState(urlRangeKey);
   const [snapshotAt, setSnapshotAt] = useState(() => Math.floor(Date.now() / 1000));
+
+  if (urlRangeKey !== previousUrlRangeKey) {
+    setPreviousUrlRangeKey(urlRangeKey);
+    setRangePreset(urlRange.preset);
+    setCustomRange(urlRange.customRange);
+  }
+
   const range = useMemo(
     () => resolveMetricsRange(rangePreset, customRange, snapshotAt),
     [customRange, rangePreset, snapshotAt],
@@ -173,6 +221,11 @@ export function MetricsTab() {
               setRangePreset(preset);
               setCustomRange(preset === "custom" ? selectedRange : undefined);
               setSnapshotAt(Math.floor(Date.now() / 1000));
+              updateUrlFilters({
+                metricsRange: preset === "24h" ? null : preset,
+                metricsFrom: preset === "custom" ? selectedRange.from : null,
+                metricsTo: preset === "custom" ? selectedRange.to : null,
+              });
             }}
           />
           <Button

--- a/ui/src/components/admin/platform/__tests__/MetricsTab.test.tsx
+++ b/ui/src/components/admin/platform/__tests__/MetricsTab.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent,render,screen } from "@testing-library/react";
+
+import { MetricsTab } from "../MetricsTab";
+
+const replaceMock = jest.fn();
+const mockUseBatchPrometheus = jest.fn();
+const mockUseAuthorizationMetrics = jest.fn();
+let currentSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/admin",
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+jest.mock("@/hooks/use-prometheus", () => ({
+  useBatchPrometheus: (...args: unknown[]) => mockUseBatchPrometheus(...args),
+}));
+
+jest.mock("@/hooks/use-authorization-metrics", () => ({
+  useAuthorizationMetrics: (...args: unknown[]) => mockUseAuthorizationMetrics(...args),
+}));
+
+jest.mock("../PrometheusCharts", () => ({
+  AgentHealthTable: () => null,
+  BarMetricChart: () => null,
+  DonutChart: () => null,
+  MetricStatCard: () => null,
+  TimeseriesChart: () => null,
+  TokenUsageChart: () => null,
+  smartBytesFormat: jest.fn(),
+  smartCountFormat: jest.fn(),
+  smartDurationFormat: jest.fn(),
+  smartRateFormat: jest.fn(),
+}));
+
+const batchState = {
+  configured: true,
+  error: null,
+  lastUpdatedAt: null,
+  loading: false,
+  queryErrors: {},
+  refetch: jest.fn().mockResolvedValue(undefined),
+  results: {},
+};
+
+const authorizationState = {
+  data: null,
+  error: null,
+  lastUpdatedAt: null,
+  loading: false,
+  refetch: jest.fn().mockResolvedValue(undefined),
+};
+
+describe("MetricsTab filter deep links", () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams();
+    replaceMock.mockReset();
+    mockUseBatchPrometheus.mockReset().mockReturnValue(batchState);
+    mockUseAuthorizationMetrics.mockReset().mockReturnValue(authorizationState);
+  });
+
+  it("restores a preset for operations and authorization metrics", () => {
+    currentSearchParams = new URLSearchParams("cat=platform&tab=metrics&metricsRange=7d");
+    render(<MetricsTab />);
+
+    expect(mockUseAuthorizationMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ seconds: 7 * 24 * 60 * 60 }),
+      { refreshInterval: 0 },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "24h" }));
+    expect(replaceMock).toHaveBeenLastCalledWith(
+      "/admin?cat=platform&tab=metrics",
+      { scroll: false },
+    );
+  });
+
+  it("restores custom endpoints and rewrites them for a relative range", () => {
+    currentSearchParams = new URLSearchParams({
+      cat: "platform",
+      tab: "metrics",
+      metricsRange: "custom",
+      metricsFrom: "2026-07-01T00:00:00.000Z",
+      metricsTo: "2026-07-02T12:00:00.000Z",
+    });
+    render(<MetricsTab />);
+
+    expect(mockUseAuthorizationMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        start: String(Date.parse("2026-07-01T00:00:00.000Z") / 1000),
+        end: String(Date.parse("2026-07-02T12:00:00.000Z") / 1000),
+      }),
+      { refreshInterval: 0 },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "1h" }));
+    expect(replaceMock).toHaveBeenLastCalledWith(
+      "/admin?cat=platform&tab=metrics&metricsRange=1h",
+      { scroll: false },
+    );
+  });
+});

--- a/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
+++ b/ui/src/components/admin/rebac/ConnectorAdminPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronRight,FileUp,HelpCircle,RefreshCw,RotateCw,Settings2 } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import React,{ useCallback,useEffect,useLayoutEffect,useMemo,useRef,useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -12,6 +13,7 @@ Dialog,DialogContent,DialogDescription,DialogFooter,DialogHeader,DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
+import { useUrlFilterParams } from "@/hooks/use-url-filter-params";
 import { withQueryParam } from "@/lib/rbac/admin-simulation-query";
 import { Tooltip,TooltipContent,TooltipTrigger } from "@/components/ui/tooltip";
 import { useSubtabParam } from "@/hooks/use-subtab-param";
@@ -587,14 +589,18 @@ function ConnectorLoadingState({ label }: { label: string }) {
 
 export function ConnectorAdminPanel({
   adapter,
+  configuredSearchParam,
   disabled = false,
   selfService = false,
 }: {
   adapter: ConnectorAdminAdapter;
+  configuredSearchParam?: string;
   disabled?: boolean;
   selfService?: boolean;
 }) {
   const { toast } = useToast();
+  const searchParams = useSearchParams();
+  const updateUrlFilters = useUrlFilterParams();
   const [items, setItems] = useState<ItemSummary[]>([]);
   const [selectedKey, setSelectedKey] = useState("");
   const [routes, setRoutes] = useState<ItemAgentRoute[]>([]);
@@ -658,7 +664,25 @@ export function ConnectorAdminPanel({
   const showTabBar = !selfService && !singlePanelView;
   const showSinglePanelSwitcher = !selfService && Boolean(singlePanelView);
   const hasAdvancedView = !selfService && (!singlePanelView || singlePanelView === "advanced");
-  const [configuredSearch, setConfiguredSearch] = useState("");
+  const configuredSearchFromUrl = configuredSearchParam
+    ? searchParams.get(configuredSearchParam) ?? ""
+    : "";
+  const [configuredSearch, setConfiguredSearch] = useState(configuredSearchFromUrl);
+  const [previousConfiguredSearchFromUrl, setPreviousConfiguredSearchFromUrl] = useState(
+    configuredSearchFromUrl,
+  );
+  if (configuredSearchFromUrl !== previousConfiguredSearchFromUrl) {
+    setPreviousConfiguredSearchFromUrl(configuredSearchFromUrl);
+    setConfiguredSearch(configuredSearchFromUrl);
+  }
+  const updateConfiguredSearch = useCallback((next: string) => {
+    setConfiguredSearch(next);
+    if (configuredSearchParam) {
+      updateUrlFilters({
+        [configuredSearchParam]: next.trim() ? next : null,
+      });
+    }
+  }, [configuredSearchParam, updateUrlFilters]);
   const [discoverySearch, setDiscoverySearch] = useState("");
   const switchPanelView = (next: PanelView) => {
     if (singlePanelView) setLocalSingleView(next);
@@ -1574,13 +1598,13 @@ export function ConnectorAdminPanel({
               <div className="flex w-full gap-2 sm:max-w-sm">
                 <Input
                   value={configuredSearch}
-                  onChange={(event) => setConfiguredSearch(event.target.value)}
+                  onChange={(event) => updateConfiguredSearch(event.target.value)}
                   placeholder={`Search ${adapter.itemPlural}`}
                   aria-label={`Search configured ${adapter.itemPlural}`}
                   className="h-8"
                 />
                 {configuredSearch && (
-                  <Button type="button" variant="ghost" size="sm" onClick={() => setConfiguredSearch("")}>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => updateConfiguredSearch("")}>
                     Clear
                   </Button>
                 )}

--- a/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
+++ b/ui/src/components/admin/rebac/SlackChannelRebacPanel.tsx
@@ -340,5 +340,12 @@ export function SlackChannelRebacPanel({
     }),
     [simulationTarget],
   );
-  return <ConnectorAdminPanel adapter={adapter} disabled={disabled} selfService={selfService} />;
+  return (
+    <ConnectorAdminPanel
+      adapter={adapter}
+      configuredSearchParam="slackChannelSearch"
+      disabled={disabled}
+      selfService={selfService}
+    />
+  );
 }

--- a/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/SlackChannelRebacPanel.test.tsx
@@ -1250,6 +1250,37 @@ it("opens the sub-tab named by the subtab URL param on load", async () => {
   ).toBeInTheDocument();
 });
 
+it("deep-links and updates the configured channel search", async () => {
+  currentSearchParams = new URLSearchParams(
+    "cat=integrations&tab=slack&subtab=channels&slackChannelSearch=incidents",
+  );
+  const { rerender } = render(<SlackChannelRebacPanel />);
+
+  const searchInput = await screen.findByRole("textbox", {
+    name: "Search configured channels",
+  });
+  expect(searchInput).toHaveValue("incidents");
+  expect(await screen.findByText("#incidents")).toBeInTheDocument();
+
+  fireEvent.change(searchInput, { target: { value: "platform-engineering" } });
+  expect(replaceMock).toHaveBeenLastCalledWith(
+    "/admin?cat=integrations&tab=slack&subtab=channels&slackChannelSearch=platform-engineering",
+    { scroll: false },
+  );
+
+  currentSearchParams = new URLSearchParams(
+    "cat=integrations&tab=slack&subtab=channels&slackChannelSearch=C123456789",
+  );
+  rerender(<SlackChannelRebacPanel />);
+  expect(searchInput).toHaveValue("C123456789");
+
+  fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+  expect(replaceMock).toHaveBeenLastCalledWith(
+    "/admin?cat=integrations&tab=slack&subtab=channels",
+    { scroll: false },
+  );
+});
+
 it("shows Slack bot runtime sync status and triggers reload/config sync", async () => {
   render(<SlackChannelRebacPanel />);
   await switchToTab("Advanced");

--- a/ui/src/components/admin/shared/DateRangeFilter.tsx
+++ b/ui/src/components/admin/shared/DateRangeFilter.tsx
@@ -66,13 +66,28 @@ function dateInputToLocalBoundary(value: string, endOfDay: boolean): Date {
 
 export function DateRangeFilter({ value, customRange, onChange }: DateRangeFilterProps) {
   const id = useId();
+  const customRangeFrom = customRange?.from;
+  const customRangeTo = customRange?.to;
+  const customRangeKey = `${customRangeFrom ?? "default"}|${customRangeTo ?? "default"}`;
   const [customOpen, setCustomOpen] = useState(false);
-  const [customFrom, setCustomFrom] = useState(
-    () => customRange ? toDateInputValue(customRange.from) : toDateInputValue(new Date(Date.now() - 30 * 86400000).toISOString())
-  );
-  const [customTo, setCustomTo] = useState(
-    () => customRange ? toDateInputValue(customRange.to) : toDateInputValue(new Date().toISOString())
-  );
+  const [customDraft, setCustomDraft] = useState(() => ({
+    rangeKey: customRangeKey,
+    from: customRangeFrom
+      ? toDateInputValue(customRangeFrom)
+      : toDateInputValue(new Date(Date.now() - 30 * 86400000).toISOString()),
+    to: customRangeTo
+      ? toDateInputValue(customRangeTo)
+      : toDateInputValue(new Date().toISOString()),
+  }));
+  const activeCustomDraft = customDraft.rangeKey === customRangeKey
+    ? customDraft
+    : {
+        rangeKey: customRangeKey,
+        from: customRangeFrom ? toDateInputValue(customRangeFrom) : customDraft.from,
+        to: customRangeTo ? toDateInputValue(customRangeTo) : customDraft.to,
+      };
+  const customFrom = activeCustomDraft.from;
+  const customTo = activeCustomDraft.to;
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -159,7 +174,10 @@ export function DateRangeFilter({ value, customRange, onChange }: DateRangeFilte
                   id={`${id}-from`}
                   type="date"
                   value={customFrom}
-                  onChange={(e) => setCustomFrom(e.target.value)}
+                  onChange={(e) => setCustomDraft({
+                    ...activeCustomDraft,
+                    from: e.target.value,
+                  })}
                   max={customTo}
                   className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                 />
@@ -171,7 +189,10 @@ export function DateRangeFilter({ value, customRange, onChange }: DateRangeFilte
                   id={`${id}-to`}
                   type="date"
                   value={customTo}
-                  onChange={(e) => setCustomTo(e.target.value)}
+                  onChange={(e) => setCustomDraft({
+                    ...activeCustomDraft,
+                    to: e.target.value,
+                  })}
                   min={customFrom}
                   max={toDateInputValue(new Date().toISOString())}
                   className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"

--- a/ui/src/components/admin/shared/__tests__/DateRangeFilter.test.tsx
+++ b/ui/src/components/admin/shared/__tests__/DateRangeFilter.test.tsx
@@ -42,4 +42,35 @@ describe("DateRangeFilter", () => {
     expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("adopts custom endpoints changed by URL navigation", () => {
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <DateRangeFilter
+        value="custom"
+        customRange={{
+          from: "2026-06-01T12:00:00.000Z",
+          to: "2026-06-03T12:00:00.000Z",
+        }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /2026-06-01/ }));
+    expect(screen.getByLabelText("From")).toHaveValue("2026-06-01");
+    expect(screen.getByLabelText("To")).toHaveValue("2026-06-03");
+
+    rerender(
+      <DateRangeFilter
+        value="custom"
+        customRange={{
+          from: "2026-07-05T12:00:00.000Z",
+          to: "2026-07-08T12:00:00.000Z",
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByLabelText("From")).toHaveValue("2026-07-05");
+    expect(screen.getByLabelText("To")).toHaveValue("2026-07-08");
+  });
 });

--- a/ui/src/hooks/use-url-filter-params.ts
+++ b/ui/src/hooks/use-url-filter-params.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { usePathname,useRouter,useSearchParams } from "next/navigation";
+import { useCallback,useEffect,useRef } from "react";
+
+export type UrlFilterParamUpdates = Record<string, string | null | undefined>;
+
+/**
+ * Replace selected URL search params without losing updates queued in the same
+ * render. Keeping the pending query in a ref matters when one interaction
+ * updates related filter groups before Next.js publishes new search params.
+ */
+export function useUrlFilterParams(): (updates: UrlFilterParamUpdates) => void {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const observedSearch = searchParams?.toString() ?? "";
+  const pendingSearchRef = useRef(observedSearch);
+
+  useEffect(() => {
+    pendingSearchRef.current = observedSearch;
+  }, [observedSearch]);
+
+  return useCallback((updates: UrlFilterParamUpdates) => {
+    const params = new URLSearchParams(pendingSearchRef.current);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === null || value === undefined) {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+    }
+
+    const nextSearch = params.toString();
+    pendingSearchRef.current = nextSearch;
+    router.replace(nextSearch ? `${pathname}?${nextSearch}` : pathname, { scroll: false });
+  }, [pathname, router]);
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.58.dev2"
+version = "0.5.58.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Adds shareable URL state for filters under **Admin → Insights**, **Admin → Metrics & Health**, and the configured Slack channels view, including the Metrics dashboard introduced in #2278.

- Restores filters before the first Statistics, Feedback, Metrics, or integrated Authorization request.
- Updates the URL without dropping sibling filters, including related updates from one interaction.
- Uses stable agent IDs in Statistics deep links.
- Makes configured Slack channel searches shareable for channel-owner handoff.
- Reconciles copied links and browser back/forward navigation with the visible controls.
- Omits default values to keep links compact.
- Accepts only current tab and filter names; no legacy aliases are retained.

| Admin page | Filter query parameters |
|---|---|
| Insights → Statistics | `source`, `users`, `dateRange`, `from`, `to`, `statsChannels`, `statsAgents`, `statsIncludeBots` |
| Insights → Feedback | `source`, `users`, `dateRange`, `from`, `to`, `rating`, `channels`, `search` |
| Integrations → Slack → Configured channels | `subtab=channels`, `slackChannelSearch` |
| Metrics & Health → Metrics (including Authorization) | `metricsRange`, `metricsFrom`, `metricsTo` |
| Metrics & Health → Health | No filter controls; `cat=platform&tab=health` remains directly linkable |

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this PR does not change charts.

## Testing

- `npm run lint`
- 174 focused Jest tests covering the Admin page, Slack and Webex connector panels, Metrics, integrated Authorization metrics, Prometheus charts, date-range navigation, and related metrics hooks
- `npm run build`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable) — no related issue was provided
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass — affected suites pass; the full repository test suite was not run
