### PR TITLE
docs(releases): add release blog posts and changelog entries for 0.5.56, 0.5.57, 0.5.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ## 0.5.57 (2026-07-22)
 
+### Fix
+
+- **insights**: apply filters consistently across cards (#2270)
+- **insights**: count only assistant messages (#2267)
+- **ui**: load admin insights cards independently (#2260)
+- **insights**: refresh stats and restore user activity (#2259)
+
 ## 0.5.56-dev.4 (2026-07-22)
 
 ### Fix
@@ -33,6 +40,27 @@
 - **insights**: refresh stats and restore user activity (#2259)
 
 ## 0.5.56 (2026-07-21)
+
+### Feat
+
+- **ui**: mint signed agent context for MCP tool callers
+- **ui**: scope admin insights by owned agents and add agent filter (#2209)
+- **auth**: OIDC_GROUP_INCLUDELIST and OIDC_GROUP_EXCLUDELIST for AD group sync filtering (#2237)
+- **ci**: link failed CIs and initiated gh user in the release draft to take action
+
+### Fix
+
+- **insights**: remove self-resolution and est. hours saved stats (#2256)
+- **ci**: scope GitHub App token permissions in prebuild artifact comment workflow (#2250)
+- **openfga-bridge**: shorten local context TTL to 8h, fix audit obj, add prebuild image flow
+- **ui**: stop revoking agent-context grants before caller can use them
+- **e2e**: drive the MCP tool picker as a combobox, not a <select>
+- **service-accounts**: let org admins manage service accounts outside their own team
+- **service-accounts**: org admins see all SAs; add search + pagination
+
+### Refactor
+
+- **mcp**: restyle MCP lab tool picker as a searchable combobox
 
 ## 0.5.55-dev.6 (2026-07-21)
 

--- a/docs/releases/2026-07-21-release-0-5-56.md
+++ b/docs/releases/2026-07-21-release-0-5-56.md
@@ -1,0 +1,113 @@
+---
+slug: release-0.5.56
+title: "Release 0.5.56 — Insights RBAC Scoping and AD Group Sync Filtering"
+date: 2026-07-21
+authors: [sriaradhyula, suwhang-cisco, cisco-erilutz]
+tags: [release]
+---
+
+> Released: 2026-07-21
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.56`
+> Previous release: 0.5.55
+
+## Highlights
+
+0.5.56 tightens who can see what in Admin Insights: non-admins now only see data for resources they own, with a new agent filter to narrow further. Operators syncing Active Directory / OIDC groups into CAIPE teams can now include or exclude specific groups by regex instead of syncing every group a user belongs to. The MCP tool picker in the admin lab is now a searchable combobox instead of a plain dropdown, and two unreliable Insights stats (self-resolution, estimated hours saved) have been removed.
+
+<!-- truncate -->
+
+## What's New
+
+### Admin Insights: owner-scoped visibility and agent filter
+
+- Non-admin users now see Insights data only for resources they own — their readable Slack channels, their own web conversations, and agents they manage. Admins continue to see everything.
+- A new agent filter dropdown lets any user narrow Insights down to a specific agent; non-admins only see agents they own in the list.
+- Web chats now show up in the Top Agents leaderboard alongside Slack activity.
+
+([#2209](https://github.com/cnoe-io/ai-platform-engineering/pull/2209))
+
+### AD / OIDC group sync filtering
+
+Two new environment variables control which Active Directory groups get synced into CAIPE teams from the OIDC `member_of` claim:
+
+- `OIDC_GROUP_INCLUDELIST` — comma-separated regex patterns; only matching groups are synced. Unset means all groups are included (no change from prior behavior).
+- `OIDC_GROUP_EXCLUDELIST` — comma-separated regex patterns; matching groups are dropped, and any existing team membership from an excluded group is actively removed on the user's next login.
+
+Both lists can be combined — includelist is applied first, then excludelist.
+
+([#2237](https://github.com/cnoe-io/ai-platform-engineering/pull/2237))
+
+### Service accounts: full org-admin visibility
+
+Org admins can now see, search, and page through **all** service accounts in the platform, not just ones belonging to their own team.
+
+### Searchable MCP tool picker
+
+The MCP tool picker in the admin lab is now a searchable combobox instead of a plain `<select>`, making it usable when a tool list is long.
+
+## Bug Fixes
+
+- **insights**: removed the "self-resolution" and "estimated hours saved" stats — both were unreliable heuristics (guessing whether a thread was resolved by a human reply, then multiplying that guess by arbitrary time constants) presented as facts on the dashboard. ([#2256](https://github.com/cnoe-io/ai-platform-engineering/pull/2256))
+- **agent context**: fixed a timing issue where a signed agent-context grant for an MCP tool caller could be revoked before the caller had a chance to use it.
+
+## Security
+
+- Shortened the local-context grant TTL used by the OpenFGA authorization bridge to 8 hours and corrected the audit object recorded for these grants.
+- Scoped down the GitHub App token used by the prebuild artifact-comment CI workflow to only the permissions the reconciler script actually needs (flagged by static analysis as over-broad). ([#2250](https://github.com/cnoe-io/ai-platform-engineering/pull/2250))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.55.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.55 → 0.5.56
+
+### Overview
+
+Drop-in upgrade — no `values.yaml` edits required. The Helm chart's default values are unchanged between 0.5.55 and 0.5.56.
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.55 and 0.5.56. Drop-in upgrade.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.56 \
+  -f your-values.yaml
+```
+
+#### 2. Optional: configure AD group sync filtering
+
+If you want to limit which AD/OIDC groups sync into CAIPE teams, set one or both new env vars on the UI deployment:
+
+```yaml
+env:
+  OIDC_GROUP_INCLUDELIST: "^caipe-.*,^platform-.*"
+  OIDC_GROUP_EXCLUDELIST: "^contractors-.*"
+```
+
+Leaving both unset preserves existing behavior — no action required to upgrade safely.
+
+#### 3. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+### Personal Impact Analysis
+
+No `values.yaml` changes are required. If you rely on the Insights "self-resolution" or "estimated hours saved" cards, note that they are removed in this release and will no longer appear on the Admin Insights dashboard.
+
+### Full Values Diff
+
+No diff — `values.yaml` is identical between 0.5.55 and 0.5.56.

--- a/docs/releases/2026-07-22-release-0-5-57.md
+++ b/docs/releases/2026-07-22-release-0-5-57.md
@@ -1,0 +1,78 @@
+---
+slug: release-0.5.57
+title: "Release 0.5.57 — Admin Insights Reliability Fixes"
+date: 2026-07-22
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-22
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.57`
+> Previous release: 0.5.56
+
+## Highlights
+
+0.5.57 is a focused reliability pass on the Admin Insights dashboard introduced in recent releases: stats now load independently per card, filters apply consistently everywhere, message counts no longer double-count each conversation turn, and the user activity drawer works again.
+
+<!-- truncate -->
+
+## What's New
+
+### Insights cards load independently
+
+Each Admin Insights stat card now fetches and renders as soon as its own data is ready, instead of the whole dashboard waiting on the slowest section. Filter changes are debounced, stale requests are cancelled, and only bot-dependent sections refetch when the bot filter changes.
+
+([#2260](https://github.com/cnoe-io/ai-platform-engineering/pull/2260))
+
+## Bug Fixes
+
+- **insights**: message totals were counting both the human prompt and the AI response as two messages per exchange; now only assistant-authored messages count toward totals, consistently across overview, daily activity, top-user rankings, agent usage, response-time, and hourly activity metrics. ([#2267](https://github.com/cnoe-io/ai-platform-engineering/pull/2267))
+- **insights**: date, source, user/team, agent, channel, and bot filters now apply consistently across every Insights card and chart — previously some cards ignored certain filters. ([#2270](https://github.com/cnoe-io/ai-platform-engineering/pull/2270))
+- **insights**: restored the user activity drawer (it was calling a Keycloak endpoint that no longer matched its expected contract) and made Total Users, Conversations, and Messages counts respect the selected date range. Fixed a crash when opening 90-day activity links for legacy, ownerless leaderboard rows. ([#2259](https://github.com/cnoe-io/ai-platform-engineering/pull/2259))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.56.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.56 → 0.5.57
+
+### Overview
+
+Drop-in upgrade — no `values.yaml` edits required. This release only changes Admin Insights behavior; no Helm values changed.
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.56 and 0.5.57. Drop-in upgrade.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.57 \
+  -f your-values.yaml
+```
+
+#### 2. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If your team relies on Admin Insights message totals for reporting, expect totals to roughly halve after this upgrade — that's the double-counting fix, not a data loss.
+
+### Personal Impact Analysis
+
+No `values.yaml` changes required. No action needed beyond the chart bump.
+
+### Full Values Diff
+
+No diff — `values.yaml` is identical between 0.5.56 and 0.5.57.

--- a/docs/releases/2026-07-22-release-0-5-58.md
+++ b/docs/releases/2026-07-22-release-0-5-58.md
@@ -1,0 +1,92 @@
+---
+slug: release-0.5.58
+title: "Release 0.5.58 — CI Build Reliability (Native Per-Arch Images)"
+date: 2026-07-22
+authors: [sriaradhyula, suwhang-cisco]
+tags: [release]
+---
+
+> Released: 2026-07-22
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.58`
+> Previous release: 0.5.57
+
+## Highlights
+
+0.5.58 is an internal CI reliability release with no application-facing changes: container image builds for `arm64` now run on native ARM runners instead of QEMU emulation, fixing intermittent build timeouts and out-of-memory failures that were affecting release tagging.
+
+**Known issue:** the `mcp-webex` container image failed to publish under this exact `0.5.58` tag due to a CI bug (see Known Issues below). If you use the Webex MCP server, pin `mcp-webex` to `0.5.57` or `latest` instead of `0.5.58` until you upgrade to a later release.
+
+<!-- truncate -->
+
+## What's New
+
+### Native per-arch image builds
+
+RAG images and the remaining 11 image-building CI workflows (agentgateway config bridge, OpenFGA authz bridge, Keycloak init, audit service, CAIPE UI, dynamic agents, MCP servers, scheduler, skill scanner, Slack bot, Webex bot) now build their `arm64` variant on native `ubuntu-24.04-arm` runners instead of cross-building via QEMU emulation. QEMU emulation had started timing out or exhausting runner memory on heavier images (e.g. `ingestors/default` installing Chromium), causing release-tagging CI runs to fail. ([#2272](https://github.com/cnoe-io/ai-platform-engineering/pull/2272), [#2274](https://github.com/cnoe-io/ai-platform-engineering/pull/2274))
+
+## Bug Fixes
+
+- **workflow**: corrected the release workflow's global status check so it accurately reflects whether all required jobs passed.
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.57.
+
+## Known Issues
+
+**`mcp-webex` image missing for the `0.5.58` tag.** The `[CI][MCP] MCP Servers Docker Build and Push` workflow failed on this release's tag push: the manifest-merge step for `mcp-webex` errored with a digest "not found", caused by a digest-artifact naming collision across the 11 parallel MCP server image builds. Every other MCP server image (and every other service image in this release) published successfully — only `mcp-webex:0.5.58` is affected.
+
+- The underlying bug was fixed in [#2277](https://github.com/cnoe-io/ai-platform-engineering/pull/2277) (`fix(ci): disambiguate digest artifact patterns to prevent name-prefix collisions`), but that fix landed in the `0.5.58-dev.2`/`0.5.58-dev.3` prereleases — after the `0.5.58` tag was already cut. It was never backported to republish the numbered `0.5.58` tag itself.
+- `ghcr.io/cnoe-io/mcp-webex:0.5.58` does not exist. `ghcr.io/cnoe-io/mcp-webex:latest` is unaffected and currently points past this issue.
+- **If your `values.yaml` pins `mcp-webex` to `0.5.58` explicitly**, the image pull will fail. Pin it to `0.5.57` or `latest` instead, or wait for the next numbered release, which will include the fix.
+
+---
+
+## Upgrade Guide: 0.5.57 → 0.5.58
+
+### Overview
+
+Drop-in upgrade for every component except `mcp-webex` — no `values.yaml` edits required. This release is CI-tooling-only; no application code changed.
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.57 and 0.5.58. Drop-in upgrade.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.58 \
+  -f your-values.yaml
+```
+
+#### 2. If you use the Webex MCP server
+
+Do not pin `mcp-webex` to `0.5.58` — that tag does not exist on `ghcr.io`. Keep it on `0.5.57` or `latest`:
+
+```yaml
+mcpWebex:
+  image:
+    tag: "0.5.57"  # or "latest" — do not use "0.5.58"
+```
+
+All other component images are unaffected and safe to bump to `0.5.58`.
+
+#### 3. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+Check that any pod using the `mcp-webex` image actually pulled and started — an `ImagePullBackOff` there is the symptom of this known issue.
+
+### Personal Impact Analysis
+
+No `values.yaml` changes required, aside from avoiding an explicit `mcp-webex:0.5.58` pin as described above.
+
+### Full Values Diff
+
+No diff — `values.yaml` is identical between 0.5.57 and 0.5.58.


### PR DESCRIPTION
## Description

Adds the missing release blog posts for 0.5.56, 0.5.57, and 0.5.58, and fills in the previously-empty stable entries in CHANGELOG.md, continuing the pattern from #2251.

**Blog posts added** (`docs/releases/`):
- **0.5.56** — Admin Insights owner-scoped RBAC + agent filter, OIDC_GROUP_INCLUDELIST/EXCLUDELIST for AD group sync filtering, org-admin service account visibility, searchable MCP tool picker, removal of the self-resolution / est. hours saved stats
- **0.5.57** — Admin Insights reliability pass: independent per-card loading, message double-counting fix, consistent filters across cards, restored user activity drawer
- **0.5.58** — CI-only release: native per-arch (arm64) image builds to replace flaky QEMU emulation. Calls out a known issue in Known Issues / Upgrade Guide: the `mcp-webex` image failed to publish under the `0.5.58` tag itself (digest-artifact collision in the manifest-merge step, fixed in #2277 but only for the `0.5.58-dev.2`/`dev.3` prereleases — the numbered `0.5.58` tag was never republished)

**CHANGELOG.md**:
- Populated `## 0.5.56` and `## 0.5.57` stable entries with aggregated feat/fix content rolled up from their dev prereleases (previously empty)
- `## 0.5.58` already had its Fix entries populated; left unchanged

All three releases have an identical Helm `values.yaml` — confirmed via `helm show values` diff across 0.5.55 to 0.5.58 — so each upgrade guide documents a drop-in upgrade.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable — documentation only.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
