### PR TITLE
fix(ci): stop hard-failing CI for fork PRs from outside contributors

### DIFF
--- a/.github/workflows/pr-version-bump.yml
+++ b/.github/workflows/pr-version-bump.yml
@@ -35,6 +35,26 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+
+            // This job commits the version bump directly onto the PR's own
+            // branch, which needs the CI_BUILD_APP_ID/PRIVATE_KEY secrets to
+            // mint a push-capable token. Fork-triggered pull_request runs
+            // never receive repo secrets (GitHub security boundary) and the
+            // default GITHUB_TOKEN is forced read-only for them too, so
+            // there is no token here that could push to someone else's fork
+            // anyway. Skip cleanly instead of failing every external
+            // contributor's PR — auto-tag.yml re-derives the correct version
+            // from the commit history on push to main, independent of
+            // whatever is checked into the PR branch.
+            const repoFullName = `${context.repo.owner}/${context.repo.repo}`;
+            const isFork = pr.head.repo?.full_name !== repoFullName;
+            if (isFork) {
+              core.setOutput('should_run', 'false');
+              core.setOutput('reason', `fork PR from ${pr.head.repo?.full_name ?? 'unknown'} — version bump is applied after merge, not on contributor branches`);
+              core.notice(`should_run=false: fork PR (${pr.head.repo?.full_name}) — skipping version-bump auto-commit; auto-tag.yml finalizes the version on push to main.`);
+              return;
+            }
+
             const supportedBase = pr.base.ref === 'main' || pr.base.ref.startsWith('release/');
             if (!supportedBase) {
               core.setOutput('should_run', 'false');

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -64,8 +64,12 @@ jobs:
       # the scan itself so contributors get results in the job log.
       - name: 🔍 Determine fork status
         id: fork-check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" && "$HEAD_REPO" != "$BASE_REPO" ]]; then
             echo "is_fork=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_fork=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -55,8 +55,25 @@ jobs:
         with:
           egress-policy: audit
 
+      # Fork-triggered pull_request runs never receive repo secrets (GitHub
+      # security boundary), so CI_SECURITY_APP_ID/PRIVATE_KEY resolve empty
+      # there and create-github-app-token hard-fails. The default GITHUB_TOKEN
+      # is also forced read-only for fork PRs regardless of declared
+      # permissions, so security-events: write is unavailable either way.
+      # Detect that case and skip the app-token + SARIF upload, but still run
+      # the scan itself so contributors get results in the job log.
+      - name: 🔍 Determine fork status
+        id: fork-check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🔑 Generate GitHub App token
         id: app-token
+        if: steps.fork-check.outputs.is_fork != 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.CI_SECURITY_APP_ID }}
@@ -80,7 +97,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-        if: ${{ always() && steps.scan.outputs.sarif != '' }}
+        if: ${{ always() && steps.scan.outputs.sarif != '' && steps.fork-check.outputs.is_fork != 'true' }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
           # Keep this stable as "grype": GitHub Code Scanning correlates SARIF
@@ -95,6 +112,11 @@ jobs:
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: ℹ️ Note SARIF upload skipped for fork PR
+        if: ${{ always() && steps.fork-check.outputs.is_fork == 'true' }}
+        run: |
+          echo "::notice::This PR is from a fork, so results can't be uploaded to GitHub Code Scanning (that needs security-events: write, unavailable to fork-triggered pull_request runs). The Grype scan above still ran — see its output for findings. A maintainer can re-run this workflow after merge to get code-scanning annotations."
 
   scan-containers:
     name: Container scan (${{ matrix.image }})


### PR DESCRIPTION
# Description

Fixes CI for pull requests from outside/fork contributors — reported on
#2255 (`rayl15/ai-platform-engineering`, a genuine fork PR).

## Root cause

GitHub Actions never exposes repository secrets to `pull_request` runs
triggered from a fork, and forces the default `GITHUB_TOKEN` to be
read-only there too — regardless of what the workflow's `permissions:`
block declares. This is a hard platform security boundary, not a repo
setting.

Two workflows unconditionally minted a GitHub App token from repo secrets
on every `pull_request` run:

- **`pr-version-bump.yml`** → `Bump version files on PR`, using
  `secrets.CI_BUILD_APP_ID` / `CI_BUILD_APP_PRIVATE_KEY` to get a
  push-capable token for committing the version bump onto the PR's own
  branch.
- **`security-scan.yml`** → `Filesystem scan`, using
  `secrets.CI_SECURITY_APP_ID` / `CI_SECURITY_APP_PRIVATE_KEY` to get a
  `security-events: write` token for uploading Grype's SARIF output to
  GitHub Code Scanning.

For a fork PR, both secrets resolve to empty strings, so
`actions/create-github-app-token` fails immediately with
`The 'client-id' ... must be a non-empty string`, and the check goes red
— **unconditionally, for every external contributor, regardless of what
their PR actually changes.**

## Fix

- **`pr-version-bump.yml`**: detect fork PRs in the `eligibility` job
  (`pr.head.repo.full_name !== owner/repo`) and set `should_run=false`
  with a clear reason. This causes the whole `version-bump` job to be
  skipped (shows as a neutral "skipped" check, not a failure). Committing
  directly onto a fork's branch isn't possible regardless of token
  (pushing to someone else's fork needs their explicit cooperation), and
  it isn't needed either: `auto-tag.yml` re-derives the correct next
  version from commit history on push to `main`, independent of whatever
  version string happens to be sitting in the PR branch.

- **`security-scan.yml`**: detect fork PRs with a small inline step
  before the app-token step, and skip *only* the app-token generation +
  `Upload SARIF to GitHub Code Scanning` step for forks (both need
  `security-events: write`, unavailable to fork-triggered runs either
  way). The Grype scan itself still runs unconditionally — its output is
  visible in the job log for every contributor. Added a `::notice::`
  explaining why code-scanning annotations aren't present for a fork PR
  (a maintainer can re-run the workflow post-merge to get them).

`scan-containers` in `security-scan.yml` is untouched — it only runs on
`workflow_dispatch`, never on `pull_request`, so it was never affected.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — both files parse.
- [ ] Recommend re-running (or asking `rayl15` to push a new commit to)
      #2255 to confirm `Bump version files on PR` and `Filesystem scan`
      now show as skipped/passing instead of failing, and that the Grype
      scan still logs its findings.
- [ ] Confirm a same-repo (non-fork) PR still gets the version bump
      auto-committed and the SARIF upload as before — this change only
      adds a new early-exit path for forks, the non-fork path is
      untouched.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable) — fixes the CI failure reported on #2255
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (inline workflow comments)
- [ ] All code style checks pass (workflow-only change; no lint/test suite applies)
- [ ] New code contribution is covered by automated tests (GitHub Actions workflows aren't unit-testable; verified via YAML parse + will validate against #2255 directly)
- [ ] All new and existing tests pass
