### PR TITLE
feat(ui): link feedback trends to daily feedback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.60-dev.1"
+version = "0.5.60-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -13,7 +13,7 @@
 // assisted-by Codex Codex-sonnet-4-6
 
 import React from 'react';
-import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 
 // assisted-by Codex Codex-sonnet-4-6
 
@@ -1759,6 +1759,24 @@ describe('Admin Dashboard Page', () => {
       expect(screen.getByText('Messages')).toBeInTheDocument();
       expect(screen.getByText('Daily Active Users (DAU)')).toBeInTheDocument();
       expect(screen.queryByText('NaN')).not.toBeInTheDocument();
+    });
+
+    it('does not refresh the default 30-day stats after entering Statistics', async () => {
+      const fetchMock = setupFetchMock();
+      render(<AdminPage />);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('42');
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 200));
+      });
+
+      const statsUrls = fetchMock.mock.calls
+        .map(([url]) => new URL(url, 'http://localhost'))
+        .filter((url) => url.pathname === '/api/admin/stats');
+      expect(statsUrls).toHaveLength(10);
+      expect(new Set(statsUrls.map((url) => url.searchParams.get('section'))).size).toBe(10);
+      expect(statsUrls.every((url) => url.searchParams.get('range') === '30d')).toBe(true);
     });
 
     it('passes positive and negative daily feedback as separate chart series', async () => {

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -22,6 +22,7 @@ import { render, screen, waitFor, within, fireEvent } from '@testing-library/rea
 // ============================================================================
 
 let mockIsAdmin = false;
+const pushMock = jest.fn();
 const replaceMock = jest.fn();
 let currentSearchParams = new URLSearchParams();
 jest.mock('@/hooks/use-admin-role', () => ({
@@ -35,7 +36,7 @@ jest.mock('next-auth/react', () => ({
 
 jest.mock('next/navigation', () => ({
   useSearchParams: () => currentSearchParams,
-  useRouter: () => ({ push: jest.fn(), replace: replaceMock, back: jest.fn(), refresh: jest.fn() }),
+  useRouter: () => ({ push: pushMock, replace: replaceMock, back: jest.fn(), refresh: jest.fn() }),
   usePathname: () => '/admin',
 }));
 
@@ -1300,9 +1301,10 @@ describe('Admin Dashboard Page', () => {
         'true'
       );
       expect(screen.queryByRole('tab', { name: /^Insights$/i })).not.toBeInTheDocument();
-      expect(replaceMock).toHaveBeenCalledWith('/admin?cat=insights&tab=stats', {
-        scroll: false,
-      });
+      expect(replaceMock).toHaveBeenCalledWith(
+        '/admin?cat=insights&tab=stats&dateRange=30d',
+        { scroll: false },
+      );
     });
 
     it('opens the requested Access Explorer sub-tab from the query string', async () => {
@@ -1623,6 +1625,20 @@ describe('Admin Dashboard Page', () => {
   });
 
   describe('Insights filter deep links', () => {
+    it('makes the default Statistics range explicit in the URL', async () => {
+      currentSearchParams = new URLSearchParams('cat=insights&tab=stats');
+      setupFetchMock();
+
+      render(<AdminPage />);
+
+      await waitFor(() => {
+        expect(replaceMock).toHaveBeenCalledWith(
+          '/admin?cat=insights&tab=stats&dateRange=30d',
+          { scroll: false },
+        );
+      });
+    });
+
     it('applies Statistics URL filters to the first card requests', async () => {
       currentSearchParams = new URLSearchParams({
         cat: 'insights',
@@ -1770,14 +1786,14 @@ describe('Admin Dashboard Page', () => {
       expect(chart).not.toHaveTextContent('"value":11');
     });
 
-    it('opens Feedback with the clicked trend date while preserving shared filters', async () => {
+    it('pushes Feedback onto browser history with the clicked trend date', async () => {
       currentSearchParams = new URLSearchParams({
         cat: 'insights',
         tab: 'stats',
         source: 'slack',
         users: 'test-user@example.com',
         statsAgents: 'agent-primary',
-        dateRange: '7d',
+        dateRange: '30d',
       });
       setupFetchMock({
         stats: {
@@ -1798,7 +1814,7 @@ describe('Admin Dashboard Page', () => {
 
       fireEvent.click(await screen.findByRole('button', { name: 'View feedback for Jul 20' }));
 
-      const targetUrl = new URL(replaceMock.mock.calls.at(-1)?.[0], 'http://localhost');
+      const targetUrl = new URL(pushMock.mock.calls.at(-1)?.[0], 'http://localhost');
       expect(targetUrl.pathname).toBe('/admin');
       expect(targetUrl.searchParams.get('cat')).toBe('insights');
       expect(targetUrl.searchParams.get('tab')).toBe('feedback');
@@ -1812,6 +1828,37 @@ describe('Admin Dashboard Page', () => {
       expect(targetUrl.searchParams.get('source')).toBe('slack');
       expect(targetUrl.searchParams.get('users')).toBe('test-user@example.com');
       expect(targetUrl.searchParams.get('statsAgents')).toBe('agent-primary');
+      expect(replaceMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('tab=feedback'),
+        { scroll: false },
+      );
+    });
+
+    it('resets a custom Feedback date when manually returning to Statistics', async () => {
+      currentSearchParams = new URLSearchParams({
+        cat: 'insights',
+        tab: 'feedback',
+        source: 'slack',
+        dateRange: 'custom',
+        from: new Date(2026, 6, 20, 0, 0, 0, 0).toISOString(),
+        to: new Date(2026, 6, 20, 23, 59, 59, 999).toISOString(),
+      });
+      setupFetchMock();
+
+      render(<AdminPage />);
+
+      fireEvent.mouseDown(
+        await screen.findByRole('tab', { name: 'Statistics' }),
+        { button: 0, ctrlKey: false },
+      );
+
+      const targetUrl = new URL(replaceMock.mock.calls.at(-1)?.[0], 'http://localhost');
+      expect(targetUrl.searchParams.get('cat')).toBe('insights');
+      expect(targetUrl.searchParams.get('tab')).toBe('stats');
+      expect(targetUrl.searchParams.get('dateRange')).toBe('30d');
+      expect(targetUrl.searchParams.has('from')).toBe(false);
+      expect(targetUrl.searchParams.has('to')).toBe(false);
+      expect(targetUrl.searchParams.get('source')).toBe('slack');
     });
 
     it('updates cards independently and issues one request per section when a filter changes', async () => {

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -72,9 +72,28 @@ jest.mock('@/components/admin/shared/SimpleLineChart', () => ({
 jest.mock('@/components/admin/shared/FeedbackTrendChart', () => ({
   FeedbackTrendChart: ({
     data,
+    onPointClick,
   }: {
-    data: Array<{ label: string; positive: number; negative: number }>;
-  }) => <div data-testid="feedback-trend-chart">{JSON.stringify(data)}</div>,
+    data: Array<{ date: string; label: string; positive: number; negative: number }>;
+    onPointClick?: (point: {
+      date: string;
+      label: string;
+      positive: number;
+      negative: number;
+    }) => void;
+  }) => (
+    <div data-testid="feedback-trend-chart">
+      {JSON.stringify(data)}
+      {data.map((point) => (
+        <button
+          aria-label={`View feedback for ${point.label}`}
+          key={point.date}
+          onClick={() => onPointClick?.(point)}
+          type="button"
+        />
+      ))}
+    </div>
+  ),
 }));
 
 jest.mock('@/components/admin/platform/MetricsTab', () => ({
@@ -1749,6 +1768,50 @@ describe('Admin Dashboard Page', () => {
       expect(chart).toHaveTextContent('"positive":8');
       expect(chart).toHaveTextContent('"negative":3');
       expect(chart).not.toHaveTextContent('"value":11');
+    });
+
+    it('opens Feedback with the clicked trend date while preserving shared filters', async () => {
+      currentSearchParams = new URLSearchParams({
+        cat: 'insights',
+        tab: 'stats',
+        source: 'slack',
+        users: 'test-user@example.com',
+        statsAgents: 'agent-primary',
+        dateRange: '7d',
+      });
+      setupFetchMock({
+        stats: {
+          ...mockStatsResponse,
+          data: {
+            ...mockStatsResponse.data,
+            feedback_summary: {
+              positive: 8,
+              negative: 3,
+              total: 11,
+              daily: [{ date: '2026-07-20', positive: 8, negative: 3 }],
+            },
+          },
+        },
+      });
+
+      render(<AdminPage />);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'View feedback for Jul 20' }));
+
+      const targetUrl = new URL(replaceMock.mock.calls.at(-1)?.[0], 'http://localhost');
+      expect(targetUrl.pathname).toBe('/admin');
+      expect(targetUrl.searchParams.get('cat')).toBe('insights');
+      expect(targetUrl.searchParams.get('tab')).toBe('feedback');
+      expect(targetUrl.searchParams.get('dateRange')).toBe('custom');
+      expect(targetUrl.searchParams.get('from')).toBe(
+        new Date(2026, 6, 20, 0, 0, 0, 0).toISOString(),
+      );
+      expect(targetUrl.searchParams.get('to')).toBe(
+        new Date(2026, 6, 20, 23, 59, 59, 999).toISOString(),
+      );
+      expect(targetUrl.searchParams.get('source')).toBe('slack');
+      expect(targetUrl.searchParams.get('users')).toBe('test-user@example.com');
+      expect(targetUrl.searchParams.get('statsAgents')).toBe('agent-primary');
     });
 
     it('updates cards independently and issues one request per section when a filter changes', async () => {

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -701,10 +701,21 @@ function AdminPage() {
     if (activeCategory !== nextCategory) setActiveCategory(nextCategory);
     if (activeTab !== nextTab) setActiveTab(nextTab);
 
-    if (requestedCategory !== nextCategory || requestedTab !== nextTab) {
+    const shouldSetDefaultStatsRange =
+      nextTab === 'stats' && searchParams.get('dateRange') === null;
+    if (
+      requestedCategory !== nextCategory
+      || requestedTab !== nextTab
+      || shouldSetDefaultStatsRange
+    ) {
       const params = new URLSearchParams(searchParams.toString());
       params.set('cat', nextCategory);
       params.set('tab', nextTab);
+      if (shouldSetDefaultStatsRange) {
+        params.set('dateRange', '30d');
+        params.delete('from');
+        params.delete('to');
+      }
       if (nextTab !== 'access-explorer') {
         params.delete('subtab');
         params.delete('openfgaTab');
@@ -723,25 +734,6 @@ function AdminPage() {
     tabGateValues,
     visibleCategories,
   ]);
-
-  const handleCategoryChange = useCallback(
-    (catKey: CategoryKey) => {
-      userSelectedAdminTabRef.current = true;
-      setActiveCategory(catKey);
-      const cat = CATEGORIES.find((c) => c.key === catKey);
-      if (!cat) return;
-      const firstVisible = cat.tabs.find((t) => tabGateValues[t.gateKey]);
-      if (firstVisible) {
-        setActiveTab(firstVisible.value);
-        updateUrlFilters({
-          cat: catKey,
-          tab: firstVisible.value,
-          ...(firstVisible.value === 'access-explorer' ? {} : { subtab: null, openfgaTab: null }),
-        });
-      }
-    },
-    [tabGateValues, updateUrlFilters]
-  );
 
   useEffect(() => {
     setSimulationType(simulationTarget?.type ?? "user");
@@ -864,23 +856,50 @@ function AdminPage() {
     setActiveTab('feedback');
     setDatePreset('custom');
     setDateRange(range);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('cat', 'insights');
+    params.set('tab', 'feedback');
+    params.set('dateRange', 'custom');
+    params.set('from', range.from);
+    params.set('to', range.to);
+    params.delete('subtab');
+    params.delete('openfgaTab');
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [pathname, router, searchParams]);
+
+  const selectAdminTab = useCallback((tab: string) => {
+    userSelectedAdminTabRef.current = true;
+    setActiveTab(tab);
+    setActiveCategory(categoryForTab(tab));
+
+    const resetStatsRange = tab === 'stats';
+    if (resetStatsRange) {
+      setDatePreset('30d');
+      setDateRange(presetToRange('30d'));
+    }
     updateUrlFilters({
-      cat: 'insights',
-      tab: 'feedback',
-      dateRange: 'custom',
-      from: range.from,
-      to: range.to,
-      subtab: null,
-      openfgaTab: null,
+      cat: categoryForTab(tab),
+      tab,
+      ...(resetStatsRange ? { dateRange: '30d', from: null, to: null } : {}),
+      ...(tab === 'access-explorer' ? {} : { subtab: null, openfgaTab: null }),
     });
   }, [updateUrlFilters]);
+
+  const handleCategoryChange = useCallback(
+    (catKey: CategoryKey) => {
+      const cat = CATEGORIES.find((candidate) => candidate.key === catKey);
+      const firstVisible = cat?.tabs.find((tab) => tabGateValues[tab.gateKey]);
+      if (firstVisible) selectAdminTab(firstVisible.value);
+    },
+    [selectAdminTab, tabGateValues],
+  );
 
   // Helper to sync shared filters to URL
   const updateSharedFilterUrl = (overrides: Record<string, string | null> = {}) => {
     const shared: Record<string, string | null> = {
       source: sourceFilter !== 'all' ? sourceFilter : null,
       users: userFilter.length > 0 ? userFilter.join(',') : null,
-      dateRange: datePreset !== '30d' ? datePreset : null,
+      dateRange: datePreset,
       from: datePreset === 'custom' ? dateRange.from : null,
       to: datePreset === 'custom' ? dateRange.to : null,
       ...overrides,
@@ -1559,16 +1578,11 @@ function AdminPage() {
             </div>
 
             {/* Tabbed Content */}
-            <Tabs value={activeTab} onValueChange={(tab) => {
-              userSelectedAdminTabRef.current = true;
-              setActiveTab(tab);
-              setActiveCategory(categoryForTab(tab));
-              updateUrlFilters({
-                cat: categoryForTab(tab),
-                tab,
-                ...(tab === 'access-explorer' ? {} : { subtab: null, openfgaTab: null }),
-              });
-            }} className="space-y-4">
+            <Tabs
+              className="space-y-4"
+              onValueChange={selectAdminTab}
+              value={activeTab}
+            >
               {/* Category selector */}
               <div
                 aria-label="Admin sections"
@@ -2198,7 +2212,7 @@ function AdminPage() {
                       setDatePreset(preset);
                       setDateRange(range);
                       updateSharedFilterUrl({
-                        dateRange: preset !== '30d' ? preset : null,
+                        dateRange: preset,
                         from: preset === 'custom' ? range.from : null,
                         to: preset === 'custom' ? range.to : null,
                       });
@@ -2438,7 +2452,7 @@ function AdminPage() {
                         setDatePreset(preset);
                         setDateRange(range);
                         updateSharedFilterUrl({
-                          dateRange: preset !== '30d' ? preset : null,
+                          dateRange: preset,
                           from: preset === 'custom' ? range.from : null,
                           to: preset === 'custom' ? range.to : null,
                         });

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -31,7 +31,7 @@ import { PlatformSettingsTab } from "@/components/admin/settings/PlatformSetting
 import { ReleaseNotesSettingsTab } from "@/components/admin/settings/ReleaseNotesSettingsTab";
 import { ReviewConfigsTab } from "@/components/admin/settings/ReviewConfigsTab";
 import { DateRangeFilter,presetToRange,type DateRange,type DateRangePreset } from "@/components/admin/shared/DateRangeFilter";
-import { FeedbackTrendChart } from "@/components/admin/shared/FeedbackTrendChart";
+import { FeedbackTrendChart,type FeedbackTrendPoint } from "@/components/admin/shared/FeedbackTrendChart";
 import { SimpleLineChart } from "@/components/admin/shared/SimpleLineChart";
 import { CreateTeamDialog } from "@/components/admin/teams/CreateTeamDialog";
 import { IdentitySyncPanel } from "@/components/admin/teams/IdentitySyncPanel";
@@ -417,6 +417,28 @@ function movedAdminTab(tab: string | null): typeof VALID_TABS[number] | null {
   return (MOVED_ADMIN_TAB_MAP as Record<string, typeof VALID_TABS[number]>)[tab] ?? null;
 }
 
+function localDateFromBucketKey(dateKey: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:T|$)/.exec(dateKey);
+  if (!match) return null;
+  const [, yearValue, monthValue, dayValue] = match;
+  const year = Number(yearValue);
+  const month = Number(monthValue) - 1;
+  const day = Number(dayValue);
+  const date = new Date(year, month, day);
+  return date.getFullYear() === year && date.getMonth() === month && date.getDate() === day
+    ? date
+    : null;
+}
+
+function feedbackDateRangeForBucket(dateKey: string): DateRange | null {
+  const from = localDateFromBucketKey(dateKey);
+  if (!from) return null;
+  from.setHours(0, 0, 0, 0);
+  const to = new Date(from);
+  to.setHours(23, 59, 59, 999);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
 // Bucket keys carry a time component ("2026-07-10T14:30") for hour/minute
 // buckets and are date-only ("2026-07-10") for day buckets — use that to
 // decide whether to label chart points by time-of-day or by calendar date.
@@ -424,7 +446,10 @@ function formatBucketLabel(dateStr: string): string {
   if (dateStr.includes('T')) {
     return new Date(dateStr).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
   }
-  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return localDateFromBucketKey(dateStr)?.toLocaleDateString(
+    'en-US',
+    { month: 'short', day: 'numeric' },
+  ) ?? dateStr;
 }
 
 function OverviewStatsCards({
@@ -829,6 +854,26 @@ function AdminPage() {
   const [userFilter, setUserFilter] = useState<string[]>(usersFromUrl);
   const [datePreset, setDatePreset] = useState<DateRangePreset>(datePresetFromUrl);
   const [dateRange, setDateRange] = useState<DateRange>(dateRangeFromUrl);
+
+  const openFeedbackForTrendPoint = useCallback((point: FeedbackTrendPoint) => {
+    const range = feedbackDateRangeForBucket(point.date);
+    if (!range) return;
+
+    userSelectedAdminTabRef.current = true;
+    setActiveCategory('insights');
+    setActiveTab('feedback');
+    setDatePreset('custom');
+    setDateRange(range);
+    updateUrlFilters({
+      cat: 'insights',
+      tab: 'feedback',
+      dateRange: 'custom',
+      from: range.from,
+      to: range.to,
+      subtab: null,
+      openfgaTab: null,
+    });
+  }, [updateUrlFilters]);
 
   // Helper to sync shared filters to URL
   const updateSharedFilterUrl = (overrides: Record<string, string | null> = {}) => {
@@ -2798,11 +2843,15 @@ function AdminPage() {
                           <CardContent>
                             <FeedbackTrendChart
                               data={stats.feedback_summary.daily.map((day) => ({
+                                date: day.date,
                                 label: formatBucketLabel(day.date),
                                 positive: day.positive,
                                 negative: day.negative,
                               }))}
                               height={180}
+                              onPointClick={tabGateValues.feedback
+                                ? openFeedbackForTrendPoint
+                                : undefined}
                             />
                           </CardContent>
                           </Card> : undefined}

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1201,10 +1201,10 @@ function AdminPage() {
   const statsFilterKey = useMemo(() => JSON.stringify({
     agents: statsAgentFilter,
     channels: statsChannelFilter,
-    from: dateRange.from,
+    from: datePreset === 'custom' ? dateRange.from : null,
     range: datePreset,
     source: sourceFilter,
-    to: dateRange.to,
+    to: datePreset === 'custom' ? dateRange.to : null,
     teams: selectedStatsFilters.teamSlugs,
     users: selectedStatsFilters.userEmails,
   }), [
@@ -1217,10 +1217,10 @@ function AdminPage() {
     statsChannelFilter,
   ]);
   const skillStatsFilterKey = useMemo(() => JSON.stringify({
-    from: dateRange.from,
+    from: datePreset === 'custom' ? dateRange.from : null,
     range: datePreset,
     source: sourceFilter,
-    to: dateRange.to,
+    to: datePreset === 'custom' ? dateRange.to : null,
     teams: selectedStatsFilters.teamSlugs,
     users: selectedStatsFilters.userEmails,
   }), [datePreset, dateRange.from, dateRange.to, selectedStatsFilters, sourceFilter]);

--- a/ui/src/components/admin/shared/FeedbackTrendChart.tsx
+++ b/ui/src/components/admin/shared/FeedbackTrendChart.tsx
@@ -14,6 +14,7 @@ const POSITIVE_COLOR = "rgb(34, 197, 94)";
 const NEGATIVE_COLOR = "rgb(239, 68, 68)";
 
 export interface FeedbackTrendPoint {
+  date: string;
   label: string;
   positive: number;
   negative: number;
@@ -22,10 +23,12 @@ export interface FeedbackTrendPoint {
 interface FeedbackTrendChartProps {
   data: FeedbackTrendPoint[];
   height?: number;
+  onPointClick?: (point: FeedbackTrendPoint) => void;
 }
 
 interface FeedbackTrendTooltipProps {
   active?: boolean;
+  interactive?: boolean;
   label?: string;
   point?: FeedbackTrendPoint;
 }
@@ -69,6 +72,7 @@ function netColorClass(net: number): string {
 
 export function FeedbackTrendTooltip({
   active,
+  interactive,
   label,
   point,
 }: FeedbackTrendTooltipProps) {
@@ -128,11 +132,20 @@ export function FeedbackTrendTooltip({
           </span>
         </div>
       </div>
+      {interactive && (
+        <p className="mt-2 border-t border-border pt-2 text-muted-foreground">
+          Click to view feedback for this date
+        </p>
+      )}
     </div>
   );
 }
 
-export function FeedbackTrendChart({ data, height = 180 }: FeedbackTrendChartProps) {
+export function FeedbackTrendChart({
+  data,
+  height = 180,
+  onPointClick,
+}: FeedbackTrendChartProps) {
   if (data.length === 0) {
     return (
       <div className="flex h-48 items-center justify-center text-muted-foreground">
@@ -192,12 +205,21 @@ export function FeedbackTrendChart({ data, height = 180 }: FeedbackTrendChartPro
         </span>
       </div>
 
-      <div style={{ height }}>
+      <div
+        className={onPointClick ? "cursor-pointer" : undefined}
+        style={{ height }}
+        title={onPointClick ? "Click a point to view feedback for that date" : undefined}
+      >
         <ResponsiveContainer height="100%" minWidth={0} width="100%">
           <LineChart
             accessibilityLayer
             data={data}
             margin={{ top: 8, right: 12, bottom: 0, left: -8 }}
+            onClick={onPointClick ? ({ activeTooltipIndex }) => {
+              if (activeTooltipIndex === undefined) return;
+              const point = data[Number(activeTooltipIndex)];
+              if (point) onPointClick(point);
+            } : undefined}
           >
             <CartesianGrid
               stroke="hsl(var(--border))"
@@ -224,6 +246,7 @@ export function FeedbackTrendChart({ data, height = 180 }: FeedbackTrendChartPro
               content={({ active, label, payload }) => (
                 <FeedbackTrendTooltip
                   active={active}
+                  interactive={Boolean(onPointClick)}
                   label={typeof label === "string" ? label : undefined}
                   point={payload?.[0]?.payload as FeedbackTrendPoint | undefined}
                 />

--- a/ui/src/components/admin/shared/__tests__/FeedbackTrendChart.test.tsx
+++ b/ui/src/components/admin/shared/__tests__/FeedbackTrendChart.test.tsx
@@ -1,12 +1,25 @@
 import type { ReactNode } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 
 jest.mock("recharts", () => ({
   CartesianGrid: () => null,
   Line: ({ dataKey }: { dataKey: string }) => (
     <div data-series={dataKey} data-testid="feedback-series" />
   ),
-  LineChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  LineChart: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: (state: { activeTooltipIndex?: number }) => void;
+  }) => (
+    <div
+      data-testid="feedback-chart-surface"
+      onClick={() => onClick?.({ activeTooltipIndex: 1 })}
+    >
+      {children}
+    </div>
+  ),
   ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Tooltip: () => null,
   XAxis: () => null,
@@ -20,8 +33,8 @@ import {
 
 describe("FeedbackTrendChart", () => {
   const data = [
-    { label: "Jul 20", positive: 8, negative: 3 },
-    { label: "Jul 21", positive: 4, negative: 2 },
+    { date: "2026-07-20", label: "Jul 20", positive: 8, negative: 3 },
+    { date: "2026-07-21", label: "Jul 21", positive: 4, negative: 2 },
   ];
 
   it("summarizes both series and their net difference", () => {
@@ -41,8 +54,9 @@ describe("FeedbackTrendChart", () => {
     render(
       <FeedbackTrendTooltip
         active
+        interactive
         label="Jul 20"
-        point={{ label: "Jul 20", positive: 8, negative: 3 }}
+        point={{ date: "2026-07-20", label: "Jul 20", positive: 8, negative: 3 }}
       />,
     );
 
@@ -53,6 +67,7 @@ describe("FeedbackTrendChart", () => {
     expect(within(tooltip).getByText("11")).toBeInTheDocument();
     expect(within(tooltip).getByText("+5")).toBeInTheDocument();
     expect(within(tooltip).getByText("73%")).toBeInTheDocument();
+    expect(within(tooltip).getByText("Click to view feedback for this date")).toBeInTheDocument();
   });
 
   it("uses a neutral rate when a day has no feedback", () => {
@@ -60,7 +75,7 @@ describe("FeedbackTrendChart", () => {
       <FeedbackTrendTooltip
         active
         label="Jul 22"
-        point={{ label: "Jul 22", positive: 0, negative: 0 }}
+        point={{ date: "2026-07-22", label: "Jul 22", positive: 0, negative: 0 }}
       />,
     );
 
@@ -72,5 +87,17 @@ describe("FeedbackTrendChart", () => {
     render(<FeedbackTrendChart data={[]} />);
 
     expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+
+  it("opens the selected feedback date when the chart is clicked", () => {
+    const onPointClick = jest.fn();
+    render(<FeedbackTrendChart data={data} onPointClick={onPointClick} />);
+
+    fireEvent.click(screen.getByTestId("feedback-chart-surface"));
+
+    expect(onPointClick).toHaveBeenCalledWith(data[1]);
+    expect(screen.getByTitle("Click a point to view feedback for that date")).toHaveClass(
+      "cursor-pointer",
+    );
   });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.60.dev1"
+version = "0.5.60.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Make the Admin → Insights feedback trend chart a drill-down into the Feedback tab.

- Clicking a chart point opens Admin → Insights → Feedback.
- The clicked calendar date becomes a one-day custom feedback range.
- The drill-down pushes a browser-history entry so Back returns to Statistics.
- Statistics deep-links its default `dateRange=30d` and clears custom date endpoints when selected.
- Entering the default 30-day Statistics view does not trigger a redundant stats refresh.
- Existing source, user, simulation, and stats filter query parameters remain intact.
- The tooltip and pointer cursor advertise the interaction.
- Date-only chart labels use local calendar dates so the displayed date matches the feedback filter.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `npm test -- --runInBand --runTestsByPath src/components/admin/shared/__tests__/FeedbackTrendChart.test.tsx src/app/(app)/admin/__tests__/admin-page.test.tsx` (84 tests)
- `npm test -- --coverage --coverageReporters=text --coverageReporters=json-summary --forceExit` (535 suites, 6,717 tests)
- `npm run lint`
- `npm run build`