### PR TITLE
fix(insights): scope user drawer and paginate top users

### DIFF
--- a/ai_platform_engineering/integrations/slack_bot/tests/test_escalation_victorops_conversation.py
+++ b/ai_platform_engineering/integrations/slack_bot/tests/test_escalation_victorops_conversation.py
@@ -56,6 +56,10 @@ def test_ping_victorops_oncall_registers_conversation_before_streaming():
 
     sse_client.create_conversation.assert_called_once()
     assert sse_client.create_conversation.call_args.kwargs["agent_id"] == "victorops-oncall"
+    assert sse_client.create_conversation.call_args.kwargs["metadata"] == {
+        "channel_id": "C123",
+        "thread_ts": "1.1",
+    }
 
     # stream_chat must use the conversation_id create_conversation returned,
     # not an ad hoc, unregistered id.

--- a/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
+++ b/ai_platform_engineering/integrations/slack_bot/utils/escalation.py
@@ -96,11 +96,15 @@ def _ping_victorops_oncall(
 
     # Register a fresh conversation (no idempotency_key) so the on-call lookup
     # does not inherit the channel thread history, which can be very large and
-    # cause incorrect results, and so stream_chat has a conversation_id the
-    # server actually knows about.
+    # cause incorrect results. Retain the originating thread only as metadata
+    # so authorized Insights viewers can navigate back to Slack.
     conv_result = sse_client.create_conversation(
       title="VictorOps on-call lookup",
       agent_id=agent_id,
+      metadata={
+        "channel_id": channel_id,
+        "thread_ts": thread_ts,
+      },
     )
     conversation_id = conv_result["conversation_id"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.60-dev.2"
+version = "0.5.60-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -1879,6 +1879,87 @@ describe('Admin Dashboard Page', () => {
       expect(targetUrl.searchParams.get('source')).toBe('slack');
     });
 
+    it('loads a requested Top Users page without changing the other leaderboard page', async () => {
+      const fetchMock = setupFetchMock({
+        stats: (url: string) => {
+          const requestUrl = new URL(url, 'http://localhost');
+          if (requestUrl.searchParams.get('section') !== 'top_users') {
+            // Section requests return only their own payload in production.
+            // Keeping unrelated responses empty prevents a later request from
+            // replacing the Top Users page under test with fixture defaults.
+            return { success: true, data: {} };
+          }
+          const conversationsPage = Number(
+            requestUrl.searchParams.get('top_conversations_page') ?? '1',
+          );
+          const messagesPage = Number(
+            requestUrl.searchParams.get('top_messages_page') ?? '1',
+          );
+          return {
+            success: true,
+            data: {
+              top_users: {
+                by_conversations: [{
+                  _id: conversationsPage === 2
+                    ? 'test-user-11@example.com'
+                    : 'test-user-01@example.com',
+                  name: conversationsPage === 2 ? 'Test User 11' : 'Test User 01',
+                  count: 20,
+                  owner_type: 'linked',
+                }],
+                by_messages: [{
+                  _id: messagesPage === 2
+                    ? 'test-message-user-11@example.com'
+                    : 'test-message-user-01@example.com',
+                  name: messagesPage === 2 ? 'Test Message User 11' : 'Test Message User 01',
+                  count: 40,
+                  owner_type: 'linked',
+                }],
+                pagination: {
+                  by_conversations: {
+                    page: conversationsPage,
+                    limit: 10,
+                    total: 21,
+                    total_pages: 3,
+                  },
+                  by_messages: {
+                    page: messagesPage,
+                    limit: 10,
+                    total: 21,
+                    total_pages: 3,
+                  },
+                },
+              },
+            },
+          };
+        },
+      });
+      render(<AdminPage />);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('Test User 01');
+
+      const pageInput = screen.getByRole('spinbutton', {
+        name: 'Go to top users by conversations page',
+      });
+      fireEvent.change(pageInput, { target: { value: '2' } });
+      fireEvent.submit(pageInput.closest('form') as HTMLFormElement);
+
+      expect(await screen.findByText('Test User 11')).toBeInTheDocument();
+      expect(screen.getByText('#11')).toBeInTheDocument();
+      expect(screen.getByText('Test Message User 01')).toBeInTheDocument();
+
+      const lastTopUsersRequest = fetchMock.mock.calls
+        .map(([url]) => new URL(url, 'http://localhost'))
+        .filter((url) => (
+          url.pathname === '/api/admin/stats'
+          && url.searchParams.get('section') === 'top_users'
+        ))
+        .at(-1);
+      expect(lastTopUsersRequest?.searchParams.get('top_conversations_page')).toBe('2');
+      expect(lastTopUsersRequest?.searchParams.get('top_messages_page')).toBe('1');
+    });
+
     it('updates cards independently and issues one request per section when a filter changes', async () => {
       const baseFetch = setupFetchMock();
       let resolveFeedback: ((response: unknown) => void) | undefined;

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -1960,6 +1960,99 @@ describe('Admin Dashboard Page', () => {
       expect(lastTopUsersRequest?.searchParams.get('top_messages_page')).toBe('1');
     });
 
+    it('shows pagination loading only on the requested Top Users card', async () => {
+      const topUsersResponse = (url: string) => {
+        const requestUrl = new URL(url, 'http://localhost');
+        if (requestUrl.searchParams.get('section') !== 'top_users') {
+          return { success: true, data: {} };
+        }
+        const conversationsPage = Number(
+          requestUrl.searchParams.get('top_conversations_page') ?? '1',
+        );
+        return {
+          success: true,
+          data: {
+            top_users: {
+              by_conversations: [{
+                _id: conversationsPage === 2
+                  ? 'test-user-11@example.com'
+                  : 'test-user-01@example.com',
+                name: conversationsPage === 2 ? 'Test User 11' : 'Test User 01',
+                count: 20,
+                owner_type: 'linked',
+              }],
+              by_messages: [{
+                _id: 'test-message-user-01@example.com',
+                name: 'Test Message User 01',
+                count: 40,
+                owner_type: 'linked',
+              }],
+              pagination: {
+                by_conversations: {
+                  page: conversationsPage,
+                  limit: 10,
+                  total: 21,
+                  total_pages: 3,
+                },
+                by_messages: {
+                  page: 1,
+                  limit: 10,
+                  total: 21,
+                  total_pages: 3,
+                },
+              },
+            },
+          },
+        };
+      };
+      const baseFetch = setupFetchMock({ stats: topUsersResponse });
+      let deferNextTopUsersRequest = false;
+      let resolveTopUsersRequest: (() => void) | undefined;
+      const fetchMock = jest.fn((url: string) => {
+        const requestUrl = new URL(url, 'http://localhost');
+        if (
+          deferNextTopUsersRequest
+          && requestUrl.pathname === '/api/admin/stats'
+          && requestUrl.searchParams.get('section') === 'top_users'
+        ) {
+          deferNextTopUsersRequest = false;
+          return new Promise((resolve) => {
+            resolveTopUsersRequest = () => resolve({
+              ok: true,
+              status: 200,
+              json: () => Promise.resolve(topUsersResponse(url)),
+            });
+          });
+        }
+        return baseFetch(url);
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      render(<AdminPage />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Insights' }));
+      await screen.findByText('Test User 01');
+
+      deferNextTopUsersRequest = true;
+      fireEvent.click(screen.getByRole('button', {
+        name: 'Next top users by conversations page',
+      }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('stats-card-top-users-conversations'),
+        ).toHaveAttribute('aria-busy', 'true');
+        expect(
+          screen.getByTestId('stats-card-top-users-messages'),
+        ).toHaveAttribute('aria-busy', 'false');
+      });
+      expect(screen.getByText('Test Message User 01')).toBeInTheDocument();
+
+      await act(async () => {
+        resolveTopUsersRequest?.();
+      });
+      expect(await screen.findByText('Test User 11')).toBeInTheDocument();
+    });
+
     it('updates cards independently and issues one request per section when a filter changes', async () => {
       const baseFetch = setupFetchMock();
       let resolveFeedback: ((response: unknown) => void) | undefined;

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -30,6 +30,7 @@ import { MCPCatalogSettingsCard } from "@/components/admin/settings/MCPCatalogSe
 import { PlatformSettingsTab } from "@/components/admin/settings/PlatformSettingsTab";
 import { ReleaseNotesSettingsTab } from "@/components/admin/settings/ReleaseNotesSettingsTab";
 import { ReviewConfigsTab } from "@/components/admin/settings/ReviewConfigsTab";
+import { CardPagination } from "@/components/admin/shared/CardPagination";
 import { DateRangeFilter,presetToRange,type DateRange,type DateRangePreset } from "@/components/admin/shared/DateRangeFilter";
 import { FeedbackTrendChart,type FeedbackTrendPoint } from "@/components/admin/shared/FeedbackTrendChart";
 import { SimpleLineChart } from "@/components/admin/shared/SimpleLineChart";
@@ -946,6 +947,16 @@ function AdminPage() {
   const [statsAgents, setStatsAgents] = useState<Array<{ id: string; name: string }>>([]);
   // Top-users leaderboard: hide bot/service identities by default; toggle to show.
   const [showBotUsers, setShowBotUsers] = useState(statsIncludeBotsFromUrl);
+  const [topConversationsPage, setTopConversationsPage] = useState(1);
+  const [topMessagesPage, setTopMessagesPage] = useState(1);
+  const topConversationsPageRef = useRef(1);
+  const topMessagesPageRef = useRef(1);
+  const resetTopUserPages = useCallback(() => {
+    topConversationsPageRef.current = 1;
+    topMessagesPageRef.current = 1;
+    setTopConversationsPage(1);
+    setTopMessagesPage(1);
+  }, []);
   const insightsFilterUrlKey = [
     searchParams.get('source'),
     searchParams.get('users'),
@@ -1028,6 +1039,10 @@ function AdminPage() {
     }
     if (statsAgentFilter.length > 0) params.set('agent', statsAgentFilter.join(','));
     if (showBotUsers) params.set('include_bots', 'true');
+    if (section === 'top_users') {
+      params.set('top_conversations_page', String(topConversationsPageRef.current));
+      params.set('top_messages_page', String(topMessagesPageRef.current));
+    }
     return withAdminSimulationParams(`/api/admin/stats?${params.toString()}`, simulationTarget);
   }, [
     dateRange,
@@ -1104,10 +1119,11 @@ function AdminPage() {
       setSelectedUserId(null);
       setSelectedUserEmail(null);
       setFeedbackLoading(false);
+      resetTopUserPages();
     }
     if (status !== "authenticated" && getConfig('ssoEnabled')) return;
     loadTabDataEvent(activeTab);
-  }, [activeTab, resetStatsSections, simulationScopeKey, status]);
+  }, [activeTab, resetStatsSections, resetTopUserPages, simulationScopeKey, status]);
   const fetchTeamsFromDb = async (): Promise<Team[]> => {
     const response = await fetch(withAdminSimulationParams(`/api/admin/teams?fresh=${Date.now()}`, simulationTarget), {
       cache: 'no-store',
@@ -1232,10 +1248,11 @@ function AdminPage() {
     if (!visitedTabsRef.current.has('_stats-loaded')) return;
     if (status !== "authenticated" && getConfig('ssoEnabled')) return;
     const handle = window.setTimeout(() => {
+      resetTopUserPages();
       void loadStatsSections(FILTER_REFRESH_STATS_SECTIONS);
     }, 150);
     return () => window.clearTimeout(handle);
-  }, [loadStatsSections, statsFilterKey, status]);
+  }, [loadStatsSections, resetTopUserPages, statsFilterKey, status]);
 
   const showBotUsersRef = useRef(showBotUsers);
   useEffect(() => {
@@ -1243,8 +1260,23 @@ function AdminPage() {
     showBotUsersRef.current = showBotUsers;
     if (!visitedTabsRef.current.has('_stats-loaded')) return;
     if (status !== "authenticated" && getConfig('ssoEnabled')) return;
+    resetTopUserPages();
     void loadStatsSections(BOT_FILTER_STATS_SECTIONS);
-  }, [loadStatsSections, showBotUsers, status]);
+  }, [loadStatsSections, resetTopUserPages, showBotUsers, status]);
+
+  const loadTopUsersPage = (
+    leaderboard: 'conversations' | 'messages',
+    page: number,
+  ) => {
+    if (leaderboard === 'conversations') {
+      topConversationsPageRef.current = page;
+      setTopConversationsPage(page);
+    } else {
+      topMessagesPageRef.current = page;
+      setTopMessagesPage(page);
+    }
+    void loadStatsSections(['top_users']);
+  };
 
   const loadStats = async () => {
     setError(null);
@@ -2646,7 +2678,10 @@ function AdminPage() {
                             ) : stats.top_users.by_conversations.map((u, i) => (
                               <div key={u._id} className="flex items-center justify-between">
                                 <div className="flex items-center gap-2 min-w-0">
-                                  <div className="w-6 text-sm text-muted-foreground shrink-0">#{i + 1}</div>
+                                  <div className="w-8 text-sm text-muted-foreground shrink-0">
+                                    #{((stats.top_users.pagination?.by_conversations.page ?? topConversationsPage) - 1)
+                                      * (stats.top_users.pagination?.by_conversations.limit ?? 10) + i + 1}
+                                  </div>
                                   <OwnerTypeBadge ownerType={u.owner_type} />
                                   <div className="text-sm truncate max-w-[200px] text-primary hover:underline cursor-pointer" onClick={() => setSelectedUserEmail(u._id)} title={u._id}>{u.name || u._id}</div>
                                 </div>
@@ -2654,6 +2689,17 @@ function AdminPage() {
                               </div>
                             ))}
                           </div>
+                          {stats.top_users.pagination?.by_conversations && (
+                            <CardPagination
+                              label="top users by conversations"
+                              disabled={statsSectionStatuses.top_users.loading}
+                              page={stats.top_users.pagination.by_conversations.page}
+                              pageSize={stats.top_users.pagination.by_conversations.limit}
+                              total={stats.top_users.pagination.by_conversations.total}
+                              className="border-t border-border pt-3"
+                              onPageChange={(page) => loadTopUsersPage('conversations', page)}
+                            />
+                          )}
                         </CardContent>
                         </Card> : undefined}
                       </AsyncStatsCard>
@@ -2675,7 +2721,10 @@ function AdminPage() {
                             ) : stats.top_users.by_messages.map((u, i) => (
                               <div key={u._id} className="flex items-center justify-between">
                                 <div className="flex items-center gap-2 min-w-0">
-                                  <div className="w-6 text-sm text-muted-foreground shrink-0">#{i + 1}</div>
+                                  <div className="w-8 text-sm text-muted-foreground shrink-0">
+                                    #{((stats.top_users.pagination?.by_messages.page ?? topMessagesPage) - 1)
+                                      * (stats.top_users.pagination?.by_messages.limit ?? 10) + i + 1}
+                                  </div>
                                   <OwnerTypeBadge ownerType={u.owner_type} />
                                   <div className="text-sm truncate max-w-[200px] text-primary hover:underline cursor-pointer" onClick={() => setSelectedUserEmail(u._id)} title={u._id}>{u.name || u._id}</div>
                                 </div>
@@ -2683,6 +2732,17 @@ function AdminPage() {
                               </div>
                             ))}
                           </div>
+                          {stats.top_users.pagination?.by_messages && (
+                            <CardPagination
+                              label="top users by messages"
+                              disabled={statsSectionStatuses.top_users.loading}
+                              page={stats.top_users.pagination.by_messages.page}
+                              pageSize={stats.top_users.pagination.by_messages.limit}
+                              total={stats.top_users.pagination.by_messages.total}
+                              className="border-t border-border pt-3"
+                              onPageChange={(page) => loadTopUsersPage('messages', page)}
+                            />
+                          )}
                         </CardContent>
                         </Card> : undefined}
                       </AsyncStatsCard>

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -949,13 +949,19 @@ function AdminPage() {
   const [showBotUsers, setShowBotUsers] = useState(statsIncludeBotsFromUrl);
   const [topConversationsPage, setTopConversationsPage] = useState(1);
   const [topMessagesPage, setTopMessagesPage] = useState(1);
+  const [loadingTopUsersLeaderboard, setLoadingTopUsersLeaderboard] = useState<
+    'conversations' | 'messages' | null
+  >(null);
   const topConversationsPageRef = useRef(1);
   const topMessagesPageRef = useRef(1);
+  const topUsersPageRequestVersionRef = useRef(0);
   const resetTopUserPages = useCallback(() => {
+    topUsersPageRequestVersionRef.current += 1;
     topConversationsPageRef.current = 1;
     topMessagesPageRef.current = 1;
     setTopConversationsPage(1);
     setTopMessagesPage(1);
+    setLoadingTopUsersLeaderboard(null);
   }, []);
   const insightsFilterUrlKey = [
     searchParams.get('source'),
@@ -1264,10 +1270,13 @@ function AdminPage() {
     void loadStatsSections(BOT_FILTER_STATS_SECTIONS);
   }, [loadStatsSections, resetTopUserPages, showBotUsers, status]);
 
-  const loadTopUsersPage = (
+  const loadTopUsersPage = async (
     leaderboard: 'conversations' | 'messages',
     page: number,
-  ) => {
+  ): Promise<void> => {
+    const requestVersion = topUsersPageRequestVersionRef.current + 1;
+    topUsersPageRequestVersionRef.current = requestVersion;
+    setLoadingTopUsersLeaderboard(leaderboard);
     if (leaderboard === 'conversations') {
       topConversationsPageRef.current = page;
       setTopConversationsPage(page);
@@ -1275,8 +1284,21 @@ function AdminPage() {
       topMessagesPageRef.current = page;
       setTopMessagesPage(page);
     }
-    void loadStatsSections(['top_users']);
+    try {
+      await loadStatsSections(['top_users']);
+    } finally {
+      if (topUsersPageRequestVersionRef.current === requestVersion) {
+        setLoadingTopUsersLeaderboard(null);
+      }
+    }
   };
+
+  const topConversationsLoading = loadingTopUsersLeaderboard === null
+    ? statsSectionStatuses.top_users.loading
+    : loadingTopUsersLeaderboard === 'conversations';
+  const topMessagesLoading = loadingTopUsersLeaderboard === null
+    ? statsSectionStatuses.top_users.loading
+    : loadingTopUsersLeaderboard === 'messages';
 
   const loadStats = async () => {
     setError(null);
@@ -2663,7 +2685,7 @@ function AdminPage() {
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                       <AsyncStatsCard
                         error={statsSectionStatuses.top_users.error}
-                        loading={statsSectionStatuses.top_users.loading}
+                        loading={topConversationsLoading}
                         minHeightClassName="min-h-64"
                         testId="stats-card-top-users-conversations"
                       >
@@ -2692,12 +2714,12 @@ function AdminPage() {
                           {stats.top_users.pagination?.by_conversations && (
                             <CardPagination
                               label="top users by conversations"
-                              disabled={statsSectionStatuses.top_users.loading}
+                              disabled={topConversationsLoading}
                               page={stats.top_users.pagination.by_conversations.page}
                               pageSize={stats.top_users.pagination.by_conversations.limit}
                               total={stats.top_users.pagination.by_conversations.total}
                               className="border-t border-border pt-3"
-                              onPageChange={(page) => loadTopUsersPage('conversations', page)}
+                              onPageChange={(page) => void loadTopUsersPage('conversations', page)}
                             />
                           )}
                         </CardContent>
@@ -2706,7 +2728,7 @@ function AdminPage() {
 
                       <AsyncStatsCard
                         error={statsSectionStatuses.top_users.error}
-                        loading={statsSectionStatuses.top_users.loading}
+                        loading={topMessagesLoading}
                         minHeightClassName="min-h-64"
                         testId="stats-card-top-users-messages"
                       >
@@ -2735,12 +2757,12 @@ function AdminPage() {
                           {stats.top_users.pagination?.by_messages && (
                             <CardPagination
                               label="top users by messages"
-                              disabled={statsSectionStatuses.top_users.loading}
+                              disabled={topMessagesLoading}
                               page={stats.top_users.pagination.by_messages.page}
                               pageSize={stats.top_users.pagination.by_messages.limit}
                               total={stats.top_users.pagination.by_messages.total}
                               className="border-t border-border pt-3"
-                              onPageChange={(page) => loadTopUsersPage('messages', page)}
+                              onPageChange={(page) => void loadTopUsersPage('messages', page)}
                             />
                           )}
                         </CardContent>

--- a/ui/src/app/api/__tests__/admin-stats.test.ts
+++ b/ui/src/app/api/__tests__/admin-stats.test.ts
@@ -566,6 +566,71 @@ describe('GET /api/admin/stats — Top Users', () => {
     expect(Array.isArray(body.data.top_users.by_messages)).toBe(true);
   });
 
+  it('paginates each leaderboard independently in stable groups of 10', async () => {
+    const { convCol, msgCol } = setupAdminWithCollections();
+
+    convCol.aggregate.mockImplementation((pipeline: Record<string, unknown>[]) => ({
+      toArray: async () => {
+        if (!pipeline.some((stage) => stage.$group?._id === '$owner_id')) return [];
+        if (pipeline.some((stage) => stage.$count === 'total')) {
+          return [{ total: 23 }];
+        }
+        return [{ _id: 'conversation-user@example.com', count: 12 }];
+      },
+    }));
+    msgCol.aggregate.mockImplementation((pipeline: Record<string, unknown>[]) => ({
+      toArray: async () => {
+        if (!pipeline.some((stage) => stage.$group?._id === '$_owner')) return [];
+        if (pipeline.some((stage) => stage.$count === 'total')) {
+          return [{ total: 31 }];
+        }
+        return [{ _id: 'message-user@example.com', count: 20 }];
+      },
+    }));
+
+    const response = await GET(makeRequest(
+      '/api/admin/stats?section=top_users&include_bots=true&top_conversations_page=2&top_messages_page=3',
+    ));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.top_users.pagination).toEqual({
+      by_conversations: {
+        page: 2,
+        limit: 10,
+        total: 23,
+        total_pages: 3,
+      },
+      by_messages: {
+        page: 3,
+        limit: 10,
+        total: 31,
+        total_pages: 4,
+      },
+    });
+
+    const conversationPagePipeline = convCol.aggregate.mock.calls
+      .map((call: unknown[]) => call[0] as Record<string, unknown>[])
+      .find((pipeline) => pipeline.some((stage) => stage.$limit === 10));
+    expect(conversationPagePipeline).toEqual(expect.arrayContaining([
+      { $sort: { count: -1, _id: 1 } },
+      { $skip: 10 },
+      { $limit: 10 },
+    ]));
+
+    const messagePagePipeline = msgCol.aggregate.mock.calls
+      .map((call: unknown[]) => call[0] as Record<string, unknown>[])
+      .find((pipeline) =>
+        pipeline.some((stage) => stage.$group?._id === '$_owner') &&
+        pipeline.some((stage) => stage.$limit === 10)
+      );
+    expect(messagePagePipeline).toEqual(expect.arrayContaining([
+      { $sort: { count: -1, _id: 1 } },
+      { $skip: 20 },
+      { $limit: 10 },
+    ]));
+  });
+
   it('ignores legacy ownerless rows in a 90-day leaderboard', async () => {
     const { convCol } = setupAdminWithCollections();
     convCol.aggregate.mockImplementation((pipeline: Record<string, unknown>[]) => ({

--- a/ui/src/app/api/admin/stats/route.ts
+++ b/ui/src/app/api/admin/stats/route.ts
@@ -24,6 +24,10 @@ import { NextRequest,NextResponse } from 'next/server';
 
 const adminStatsCache = createJsonResponseCacheStore();
 let botOwnerIdsCache: { expiresAt: number; promise: Promise<string[]> } | null = null;
+const TOP_USERS_PAGE_SIZE = 10;
+const VALID_TOP_USER_OWNER_STAGE = {
+  $match: { _id: { $nin: [null, ''] } },
+};
 
 interface SlackStats {
   channels: {
@@ -67,6 +71,11 @@ function parseStatsSection(searchParams: URLSearchParams): AdminStatsSection | '
   return (ADMIN_STATS_SECTIONS as readonly string[]).includes(section)
     ? section as AdminStatsSection
     : null;
+}
+
+function parsePositivePage(searchParams: URLSearchParams, key: string): number {
+  const parsed = Number.parseInt(searchParams.get(key) ?? '1', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
 }
 
 /** Identity classification for a Top Users leaderboard owner (see classifyOwner). */
@@ -337,6 +346,8 @@ async function getAdminStats(request: NextRequest) {
     // posters, MR bots, service accounts). `include_bots=true` shows them —
     // surfaced as a "Show Bot Users" toggle in the UI.
     const includeBots = searchParams.get('include_bots') === 'true';
+    const topConversationsPage = parsePositivePage(searchParams, 'top_conversations_page');
+    const topMessagesPage = parsePositivePage(searchParams, 'top_messages_page');
     // Populated after the collections are available (below): a no-op $match
     // spread when bots are included, else a $match that drops bot/service
     // identities — both those detectable by ID pattern (HUMAN_OWNER_MATCH) and
@@ -460,7 +471,24 @@ async function getAdminStats(request: NextRequest) {
             avg_messages_per_conversation: 0,
           },
           daily_activity: [],
-          top_users: { by_conversations: [], by_messages: [] },
+          top_users: {
+            by_conversations: [],
+            by_messages: [],
+            pagination: {
+              by_conversations: {
+                page: topConversationsPage,
+                limit: TOP_USERS_PAGE_SIZE,
+                total: 0,
+                total_pages: 0,
+              },
+              by_messages: {
+                page: topMessagesPage,
+                limit: TOP_USERS_PAGE_SIZE,
+                total: 0,
+                total_pages: 0,
+              },
+            },
+          },
           top_agents: [],
           feedback_summary: {
             positive: 0,
@@ -781,6 +809,8 @@ async function getAdminStats(request: NextRequest) {
       dailyMsgActivity,
       rawTopByConvs,
       rawTopByMsgs,
+      rawTopByConvsTotal,
+      rawTopByMsgsTotal,
       topAgents,
       fbOverall,
       fbBySource,
@@ -830,9 +860,11 @@ async function getAdminStats(request: NextRequest) {
         ? conversations.aggregate([
             { $match: { created_at: rangeDateMatch, ...convSourceFilter } },
             { $group: { _id: '$owner_id', count: { $sum: 1 } } },
+            VALID_TOP_USER_OWNER_STAGE,
             ...topUserOwnerMatch,
-            { $sort: { count: -1 } },
-            { $limit: 10 },
+            { $sort: { count: -1, _id: 1 } },
+            { $skip: (topConversationsPage - 1) * TOP_USERS_PAGE_SIZE },
+            { $limit: TOP_USERS_PAGE_SIZE },
           ]).toArray()
         : Promise.resolve([]),
 
@@ -844,9 +876,37 @@ async function getAdminStats(request: NextRequest) {
             { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
             { $match: { _owner: { $ne: null } } },
             { $group: { _id: '$_owner', count: { $sum: 1 } } },
+            VALID_TOP_USER_OWNER_STAGE,
             ...topUserOwnerMatch,
-            { $sort: { count: -1 } },
-            { $limit: 10 },
+            { $sort: { count: -1, _id: 1 } },
+            { $skip: (topMessagesPage - 1) * TOP_USERS_PAGE_SIZE },
+            { $limit: TOP_USERS_PAGE_SIZE },
+          ]).toArray()
+        : Promise.resolve([]),
+
+      // Separate count pipelines keep pagination compatible with DocumentDB,
+      // which does not support the $facet approach commonly used to return
+      // rows and totals in one aggregation.
+      includesSection('top_users')
+        ? conversations.aggregate([
+            { $match: { created_at: rangeDateMatch, ...convSourceFilter } },
+            { $group: { _id: '$owner_id' } },
+            VALID_TOP_USER_OWNER_STAGE,
+            ...topUserOwnerMatch,
+            { $count: 'total' },
+          ]).toArray()
+        : Promise.resolve([]),
+
+      includesSection('top_users')
+        ? messages.aggregate([
+            { $match: { created_at: rangeDateMatch, ...AI_MESSAGE_MATCH, ...msgOwnerFilter } },
+            { $lookup: { from: 'conversations', localField: 'conversation_id', foreignField: '_id', as: '_conv' } },
+            { $addFields: { _owner: { $ifNull: ['$owner_id', { $arrayElemAt: ['$_conv.owner_id', 0] }] } } },
+            { $match: { _owner: { $ne: null } } },
+            { $group: { _id: '$_owner' } },
+            VALID_TOP_USER_OWNER_STAGE,
+            ...topUserOwnerMatch,
+            { $count: 'total' },
           ]).toArray()
         : Promise.resolve([]),
 
@@ -1093,6 +1153,8 @@ async function getAdminStats(request: NextRequest) {
 
     const topUsersByConversations = enrichTopUsers(rawTopByConvs);
     const topUsersByMessages = enrichTopUsers(rawTopByMsgs);
+    const topUsersByConversationsTotal = Number(rawTopByConvsTotal[0]?.total ?? 0);
+    const topUsersByMessagesTotal = Number(rawTopByMsgsTotal[0]?.total ?? 0);
 
     // ── Post-process feedback ───────────────────────────────────────
     const fbMap = new Map(fbOverall.map((f) => [f._id, f.count]));
@@ -1443,6 +1505,20 @@ async function getAdminStats(request: NextRequest) {
         top_users: {
           by_conversations: topUsersByConversations,
           by_messages: topUsersByMessages,
+          pagination: {
+            by_conversations: {
+              page: topConversationsPage,
+              limit: TOP_USERS_PAGE_SIZE,
+              total: topUsersByConversationsTotal,
+              total_pages: Math.ceil(topUsersByConversationsTotal / TOP_USERS_PAGE_SIZE),
+            },
+            by_messages: {
+              page: topMessagesPage,
+              limit: TOP_USERS_PAGE_SIZE,
+              total: topUsersByMessagesTotal,
+              total_pages: Math.ceil(topUsersByMessagesTotal / TOP_USERS_PAGE_SIZE),
+            },
+          },
         },
       } : {}),
       ...(includesSection('top_agents') ? { top_agents: topAgents } : {}),

--- a/ui/src/app/api/admin/users/activity/[identity]/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/users/activity/[identity]/__tests__/route.test.ts
@@ -12,7 +12,9 @@ const mockHasOrganizationAdmin = jest.fn();
 const mockResolveSimulationScope = jest.fn();
 const mockSimulationCanManage = jest.fn();
 const mockSimulationCanAudit = jest.fn();
-const mockGetReadableSlackChannelNames = jest.fn();
+const mockGetDirectSharingAccessConversationIds = jest.fn();
+const mockGetReadableMessagingConversationScope = jest.fn();
+const mockGetReadableConversationIds = jest.fn();
 const mockGetOwnedAgents = jest.fn();
 const mockGetOwnedAgentConversationIds = jest.fn();
 const mockGetInsightsActorTeamSlugs = jest.fn();
@@ -45,6 +47,11 @@ jest.mock("@/lib/rbac/admin-simulation-server", () => ({
     mockSimulationCanAudit(...args),
 }));
 
+jest.mock("@/lib/rbac/conversation-implicit-authz", () => ({
+  getDirectSharingAccessConversationIds: (...args: unknown[]) =>
+    mockGetDirectSharingAccessConversationIds(...args),
+}));
+
 jest.mock("@/lib/rbac/platform-admin", () => ({
   hasOrganizationAdmin: (...args: unknown[]) =>
     mockHasOrganizationAdmin(...args),
@@ -58,8 +65,10 @@ jest.mock("@/lib/rbac/require-openfga", () => ({
 }));
 
 jest.mock("@/lib/rbac/user-insights-scope", () => ({
-  getReadableSlackChannelNames: (...args: unknown[]) =>
-    mockGetReadableSlackChannelNames(...args),
+  getReadableMessagingConversationScope: (...args: unknown[]) =>
+    mockGetReadableMessagingConversationScope(...args),
+  getReadableConversationIds: (...args: unknown[]) =>
+    mockGetReadableConversationIds(...args),
   getOwnedAgents: (...args: unknown[]) => mockGetOwnedAgents(...args),
   getOwnedAgentConversationIds: (...args: unknown[]) =>
     mockGetOwnedAgentConversationIds(...args),
@@ -153,7 +162,12 @@ beforeEach(() => {
   mockResolveSimulationScope.mockResolvedValue(null);
   mockSimulationCanManage.mockResolvedValue(true);
   mockSimulationCanAudit.mockResolvedValue(true);
-  mockGetReadableSlackChannelNames.mockResolvedValue([]);
+  mockGetDirectSharingAccessConversationIds.mockResolvedValue([]);
+  mockGetReadableMessagingConversationScope.mockResolvedValue({
+    slackChannelIds: [],
+    webexSpaceIds: [],
+  });
+  mockGetReadableConversationIds.mockResolvedValue([]);
   mockGetOwnedAgents.mockResolvedValue([]);
   mockGetOwnedAgentConversationIds.mockResolvedValue({ ids: [], capped: false });
   mockGetInsightsActorTeamSlugs.mockResolvedValue([]);
@@ -170,6 +184,7 @@ beforeEach(() => {
     metadata: { role: "user" },
   });
   mockFindConversations
+    .mockReset()
     .mockResolvedValueOnce(undefined)
     .mockResolvedValueOnce([
       {
@@ -187,11 +202,13 @@ beforeEach(() => {
         updated_at: new Date("2026-07-20T11:00:00.000Z"),
       },
     ]);
-  mockCountConversations.mockResolvedValue(3);
+  mockCountConversations.mockReset().mockResolvedValue(3);
   mockAggregateFeedback
+    .mockReset()
     .mockResolvedValueOnce(undefined)
     .mockResolvedValueOnce([{ total: 2, positive: 1, negative: 1 }]);
   mockFindFeedback
+    .mockReset()
     .mockResolvedValueOnce(undefined)
     .mockResolvedValueOnce([
       {
@@ -259,6 +276,7 @@ describe("GET /api/admin/users/activity/[identity]", () => {
       },
       stats: {
         total_conversations: 3,
+        visible_conversations: 3,
         feedback_given: 2,
         feedback_positive: 1,
         feedback_negative: 1,
@@ -307,7 +325,7 @@ describe("GET /api/admin/users/activity/[identity]", () => {
     });
   });
 
-  it("lets a scoped teammate view scoped overview/feedback but never conversation rows", async () => {
+  it("shows a scoped teammate only readable Slack-channel conversations", async () => {
     mockGetAuth.mockResolvedValue({
       session: {
         sub: "member-sub",
@@ -316,7 +334,10 @@ describe("GET /api/admin/users/activity/[identity]", () => {
     });
     mockRequireAdminSurfaceManage.mockRejectedValue(new Error("not manager"));
     mockHasOrganizationAdmin.mockResolvedValue(false);
-    mockGetReadableSlackChannelNames.mockResolvedValue(["example-channel"]);
+    mockGetReadableMessagingConversationScope.mockResolvedValue({
+      slackChannelIds: ["C123TEST"],
+      webexSpaceIds: [],
+    });
     mockGetOwnedAgents.mockResolvedValue([
       { id: "agent-owned", name: "Owned Agent" },
     ]);
@@ -324,6 +345,10 @@ describe("GET /api/admin/users/activity/[identity]", () => {
       ids: ["conversation-1"],
       capped: false,
     });
+    mockCountConversations
+      .mockReset()
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(1);
     mockGetInsightsActorTeamSlugs.mockResolvedValue(["primary"]);
     mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([
       ["primary", [{
@@ -335,6 +360,40 @@ describe("GET /api/admin/users/activity/[identity]", () => {
         provider_ids: [],
       }]],
     ]));
+    mockFindFeedback
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([
+        {
+          source: "slack",
+          rating: "positive",
+          value: "thumbs_up",
+          channel_id: "C123TEST",
+          channel_name: "example-channel",
+          conversation_id: "conversation-1",
+          slack_permalink:
+            "https://example.slack.com/archives/C123TEST/p1775100000123456",
+          created_at: new Date("2026-07-20T11:05:00.000Z"),
+        },
+        {
+          source: "web",
+          rating: "positive",
+          value: "thumbs_up",
+          conversation_id: "conversation-private",
+          created_at: new Date("2026-07-20T11:06:00.000Z"),
+        },
+        {
+          source: "slack",
+          rating: "positive",
+          value: "thumbs_up",
+          channel_id: "COTHER",
+          channel_name: "example-channel",
+          conversation_id: "conversation-other-channel",
+          slack_permalink:
+            "https://example.slack.com/archives/COTHER/p1775100000123456",
+          created_at: new Date("2026-07-20T11:07:00.000Z"),
+        },
+      ]);
 
     const { GET } = await import("../route");
     const { request: req,context } = request("test-user@example.com");
@@ -349,16 +408,95 @@ describe("GET /api/admin/users/activity/[identity]", () => {
       },
       "stats",
     );
-    expect(body.data.can_view_conversations).toBe(false);
-    expect(body.data.recent_conversations).toEqual([]);
+    expect(body.data.can_view_conversations).toBe(true);
+    expect(body.data.stats.visible_conversations).toBe(1);
+    expect(body.data.recent_conversations).toEqual([
+      expect.objectContaining({
+        id: "conversation-1",
+        source: "slack",
+        channel_name: "example-channel",
+      }),
+    ]);
     expect(body.data.recent_feedback).toEqual([
       expect.objectContaining({
+        conversation_id: null,
+        slack_permalink:
+          "https://example.slack.com/archives/C123TEST/p1775100000123456",
+      }),
+      expect.objectContaining({
+        source: "web",
+        conversation_id: null,
+        slack_permalink: null,
+      }),
+      expect.objectContaining({
+        source: "slack",
         conversation_id: null,
         slack_permalink: null,
       }),
     ]);
-    // The server does not even fetch conversation titles for scoped viewers.
-    expect(mockFindConversations).not.toHaveBeenCalled();
+    expect(mockAggregateFeedback.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining([
+        {
+          $match: expect.objectContaining({
+            $and: expect.arrayContaining([
+              expect.objectContaining({
+                $or: expect.arrayContaining([
+                  {
+                    source: "slack",
+                    channel_id: "C123TEST",
+                  },
+                ]),
+              }),
+            ]),
+          }),
+        },
+      ]),
+    );
+    // Slack titles are fetched only through a channel-id clause. The explicit
+    // source and DM exclusions prevent owned agents and same-named channels
+    // from widening the conversation list.
+    expect(mockFindConversations.mock.calls[0]?.[0]).toEqual({
+      $and: [
+        {
+          owner_id: {
+            $in: expect.arrayContaining([
+              "test-user@example.com",
+              "U123TEST",
+            ]),
+          },
+        },
+        {
+          $or: expect.arrayContaining([
+            {
+              $and: [
+                { $or: [{ source: "slack" }, { client_type: "slack" }] },
+                { channel_type: { $ne: "dm" } },
+                { "metadata.channel_type": { $ne: "dm" } },
+                {
+                  $or: [
+                    { channel_id: "C123TEST" },
+                    { "metadata.channel_id": "C123TEST" },
+                    { "slack_meta.channel_id": "C123TEST" },
+                  ],
+                },
+              ],
+            },
+            {
+              $and: [
+                { client_type: { $nin: ["slack", "webex"] } },
+                { source: { $nin: ["slack", "webex"] } },
+                {
+                  $or: expect.arrayContaining([
+                    { owner_id: "member@example.com" },
+                    { "sharing.shared_with": "member@example.com" },
+                  ]),
+                },
+              ],
+            },
+          ]),
+        },
+      ],
+    });
     expect(mockCountConversations).toHaveBeenCalledWith({
       $and: [
         {
@@ -381,6 +519,200 @@ describe("GET /api/admin/users/activity/[identity]", () => {
     });
   });
 
+  it("does not let full Insights management bypass channel-level conversation RBAC", async () => {
+    mockHasOrganizationAdmin.mockResolvedValue(false);
+    mockGetReadableMessagingConversationScope.mockResolvedValue({
+      slackChannelIds: ["C123TEST"],
+      webexSpaceIds: [],
+    });
+    mockCountConversations
+      .mockReset()
+      .mockResolvedValueOnce(8)
+      .mockResolvedValueOnce(1);
+
+    const { GET } = await import("../route");
+    const { request: req,context } = request("test-user@example.com");
+    const response = await GET(req, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.stats).toMatchObject({
+      total_conversations: 8,
+      visible_conversations: 1,
+    });
+    expect(mockFindConversations.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        $and: expect.arrayContaining([
+          expect.objectContaining({
+            $or: expect.arrayContaining([
+              expect.objectContaining({
+                $and: expect.arrayContaining([
+                  { "metadata.channel_type": { $ne: "dm" } },
+                ]),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    );
+    // Full Insights aggregate access does not grant access to personal web
+    // conversation ids when organization audit access is absent.
+    expect(body.data.recent_feedback[0]).toMatchObject({
+      source: "web",
+      conversation_id: null,
+      slack_permalink: null,
+    });
+  });
+
+  it("shows conversations from mapped Webex spaces but not unmapped direct spaces", async () => {
+    mockGetAuth.mockResolvedValue({
+      session: {
+        sub: "member-sub",
+        user: { email: "member@example.com" },
+      },
+    });
+    mockRequireAdminSurfaceManage.mockRejectedValue(new Error("not manager"));
+    mockHasOrganizationAdmin.mockResolvedValue(false);
+    mockGetReadableMessagingConversationScope.mockResolvedValue({
+      slackChannelIds: [],
+      webexSpaceIds: ["space-shared"],
+    });
+    mockCountConversations
+      .mockReset()
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1);
+    mockFindConversations
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([
+        {
+          _id: "conversation-webex",
+          title: "Example Webex thread",
+          client_type: "webex",
+          metadata: {
+            webex_space_id: "space-shared",
+            webex_message_id: "message-1",
+          },
+          created_at: new Date("2026-07-20T10:00:00.000Z"),
+          updated_at: new Date("2026-07-20T11:00:00.000Z"),
+        },
+      ]);
+    const { GET } = await import("../route");
+    const { request: req,context } = request("test-user@example.com");
+    const response = await GET(req, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockFindConversations.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        $and: expect.arrayContaining([
+          expect.objectContaining({
+            $or: expect.arrayContaining([
+              {
+                $and: [
+                  { $or: [{ source: "webex" }, { client_type: "webex" }] },
+                  { "metadata.webex_space_id": "space-shared" },
+                ],
+              },
+            ]),
+          }),
+        ]),
+      }),
+    );
+    expect(body.data.recent_conversations).toEqual([
+      expect.objectContaining({
+        id: "conversation-webex",
+        source: "webex",
+        channel_id: "space-shared",
+        webex_permalink: "webexteams://im?space=space-shared",
+      }),
+    ]);
+  });
+
+  it("shows web conversations shared through existing conversation RBAC", async () => {
+    mockGetAuth.mockResolvedValue({
+      session: {
+        sub: "member-sub",
+        user: { email: "member@example.com" },
+      },
+    });
+    mockRequireAdminSurfaceManage.mockRejectedValue(new Error("not manager"));
+    mockHasOrganizationAdmin.mockResolvedValue(false);
+    mockGetDirectSharingAccessConversationIds.mockResolvedValue([
+      "conversation-shared",
+    ]);
+    mockCountConversations
+      .mockReset()
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1);
+    mockFindConversations
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([
+        {
+          _id: "conversation-shared",
+          title: "Shared web conversation",
+          client_type: "webui",
+          created_at: new Date("2026-07-20T10:00:00.000Z"),
+          updated_at: new Date("2026-07-20T11:00:00.000Z"),
+        },
+      ]);
+    mockFindFeedback
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([
+        {
+          source: "web",
+          rating: "positive",
+          value: "thumbs_up",
+          conversation_id: "conversation-shared",
+          created_at: new Date("2026-07-20T11:05:00.000Z"),
+        },
+      ]);
+
+    const { GET } = await import("../route");
+    const { request: req,context } = request("test-user@example.com");
+    const response = await GET(req, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetDirectSharingAccessConversationIds).toHaveBeenCalledWith(
+      "member@example.com",
+      expect.any(Function),
+    );
+    expect(mockFindConversations.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        $and: expect.arrayContaining([
+          expect.objectContaining({
+            $or: expect.arrayContaining([
+              expect.objectContaining({
+                $and: expect.arrayContaining([
+                  expect.objectContaining({
+                    $or: expect.arrayContaining([
+                      { _id: { $in: ["conversation-shared"] } },
+                    ]),
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    );
+    expect(body.data.recent_conversations).toEqual([
+      expect.objectContaining({
+        id: "conversation-shared",
+        source: "web",
+      }),
+    ]);
+    expect(body.data.recent_feedback).toEqual([
+      expect.objectContaining({
+        source: "web",
+        conversation_id: "conversation-shared",
+      }),
+    ]);
+  });
+
   it("does not let a scoped preview subject widen itself to another user's activity", async () => {
     mockResolveSimulationScope.mockResolvedValue({
       openfgaUser: "user:preview-sub",
@@ -399,6 +731,10 @@ describe("GET /api/admin/users/activity/[identity]", () => {
       .mockReset()
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce([]);
+    mockFindConversations
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
     const { GET } = await import("../route");
     const { request: req,context } = request(
       "test-user@example.com",
@@ -409,6 +745,25 @@ describe("GET /api/admin/users/activity/[identity]", () => {
 
     expect(response.status).toBe(403);
     expect(mockRequireBaselineAdminSurfaceRead).not.toHaveBeenCalled();
-    expect(mockFindConversations).not.toHaveBeenCalled();
+    expect(mockFindConversations.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        $and: expect.arrayContaining([
+          expect.objectContaining({
+            $or: expect.arrayContaining([
+              expect.objectContaining({
+                $and: expect.arrayContaining([
+                  expect.objectContaining({
+                    $or: expect.arrayContaining([
+                      { owner_id: "preview@example.com" },
+                      { "sharing.shared_with": "preview@example.com" },
+                    ]),
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    );
   });
 });

--- a/ui/src/app/api/admin/users/activity/[identity]/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/users/activity/[identity]/__tests__/route.test.ts
@@ -3,17 +3,28 @@
  */
 
 import { NextRequest } from "next/server";
+import { ApiError } from "@/lib/api-error";
 
 const mockGetAuth = jest.fn();
-const mockRequireRbacPermission = jest.fn();
+const mockRequireAdminSurfaceManage = jest.fn();
+const mockRequireBaselineAdminSurfaceRead = jest.fn();
+const mockHasOrganizationAdmin = jest.fn();
 const mockResolveSimulationScope = jest.fn();
 const mockSimulationCanManage = jest.fn();
+const mockSimulationCanAudit = jest.fn();
+const mockGetReadableSlackChannelNames = jest.fn();
+const mockGetOwnedAgents = jest.fn();
+const mockGetOwnedAgentConversationIds = jest.fn();
+const mockGetInsightsActorTeamSlugs = jest.fn();
+const mockLoadTeamMembersForSlugs = jest.fn();
 const mockFindUser = jest.fn();
 const mockFindConversations = jest.fn();
 const mockCountConversations = jest.fn();
 const mockAggregateFeedback = jest.fn();
 const mockFindFeedback = jest.fn();
+const mockAggregateMessages = jest.fn();
 const mockGetRealmUserById = jest.fn();
+let messageRows: Record<string, unknown>[] = [];
 
 let mongoConfigured = true;
 
@@ -22,7 +33,6 @@ jest.mock("@/lib/api-middleware", () => {
   return {
     ...actual,
     getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuth(...args),
-    requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
   };
 });
 
@@ -31,6 +41,35 @@ jest.mock("@/lib/rbac/admin-simulation-server", () => ({
     mockResolveSimulationScope(...args),
   simulationSubjectCanManageAdminSurface: (...args: unknown[]) =>
     mockSimulationCanManage(...args),
+  simulationSubjectCanAuditOrganization: (...args: unknown[]) =>
+    mockSimulationCanAudit(...args),
+}));
+
+jest.mock("@/lib/rbac/platform-admin", () => ({
+  hasOrganizationAdmin: (...args: unknown[]) =>
+    mockHasOrganizationAdmin(...args),
+}));
+
+jest.mock("@/lib/rbac/require-openfga", () => ({
+  requireAdminSurfaceManage: (...args: unknown[]) =>
+    mockRequireAdminSurfaceManage(...args),
+  requireBaselineAdminSurfaceRead: (...args: unknown[]) =>
+    mockRequireBaselineAdminSurfaceRead(...args),
+}));
+
+jest.mock("@/lib/rbac/user-insights-scope", () => ({
+  getReadableSlackChannelNames: (...args: unknown[]) =>
+    mockGetReadableSlackChannelNames(...args),
+  getOwnedAgents: (...args: unknown[]) => mockGetOwnedAgents(...args),
+  getOwnedAgentConversationIds: (...args: unknown[]) =>
+    mockGetOwnedAgentConversationIds(...args),
+  getInsightsActorTeamSlugs: (...args: unknown[]) =>
+    mockGetInsightsActorTeamSlugs(...args),
+}));
+
+jest.mock("@/lib/rbac/team-membership-store", () => ({
+  loadTeamMembersForSlugs: (...args: unknown[]) =>
+    mockLoadTeamMembersForSlugs(...args),
 }));
 
 jest.mock("@/lib/rbac/keycloak-admin", () => ({
@@ -74,6 +113,14 @@ jest.mock("@/lib/mongodb", () => ({
         },
       };
     }
+    if (name === "messages") {
+      return {
+        aggregate: (...args: unknown[]) => {
+          mockAggregateMessages(...args);
+          return { toArray: async () => messageRows };
+        },
+      };
+    }
     throw new Error(`Unexpected collection: ${name}`);
   },
 }));
@@ -93,13 +140,28 @@ function request(identity: string, query = "") {
 beforeEach(() => {
   jest.clearAllMocks();
   mongoConfigured = true;
-  mockGetAuth.mockResolvedValue({ session: { sub: "admin-sub" } });
-  mockRequireRbacPermission.mockResolvedValue(undefined);
+  messageRows = [];
+  mockGetAuth.mockResolvedValue({
+    session: {
+      sub: "admin-sub",
+      user: { email: "admin@example.com" },
+    },
+  });
+  mockRequireAdminSurfaceManage.mockResolvedValue(undefined);
+  mockRequireBaselineAdminSurfaceRead.mockResolvedValue(undefined);
+  mockHasOrganizationAdmin.mockResolvedValue(true);
   mockResolveSimulationScope.mockResolvedValue(null);
   mockSimulationCanManage.mockResolvedValue(true);
+  mockSimulationCanAudit.mockResolvedValue(true);
+  mockGetReadableSlackChannelNames.mockResolvedValue([]);
+  mockGetOwnedAgents.mockResolvedValue([]);
+  mockGetOwnedAgentConversationIds.mockResolvedValue({ ids: [], capped: false });
+  mockGetInsightsActorTeamSlugs.mockResolvedValue([]);
+  mockLoadTeamMembersForSlugs.mockResolvedValue(new Map());
   mockFindUser.mockResolvedValue({
     email: "test-user@example.com",
     name: "Test User",
+    keycloak_sub: "target-sub",
     slack_user_id: "U123TEST",
     source: "web",
     avatar_url: null,
@@ -114,7 +176,13 @@ beforeEach(() => {
         _id: "conversation-1",
         title: "Example conversation",
         client_type: "slack",
-        metadata: { channel_id: "C123TEST", channel_name: "example-channel" },
+        idempotency_key: "1775100000.123456",
+        metadata: {
+          channel_id: "C123TEST",
+          channel_name: "example-channel",
+          thread_ts: "1775100000.123456",
+          workspace_url: "https://example.slack.com",
+        },
         created_at: new Date("2026-07-20T10:00:00.000Z"),
         updated_at: new Date("2026-07-20T11:00:00.000Z"),
       },
@@ -137,6 +205,31 @@ beforeEach(() => {
 });
 
 describe("GET /api/admin/users/activity/[identity]", () => {
+  it("rejects callers who cannot read the Insights surface", async () => {
+    mockRequireAdminSurfaceManage.mockRejectedValue(new Error("not manager"));
+    mockHasOrganizationAdmin.mockResolvedValue(false);
+    mockRequireBaselineAdminSurfaceRead.mockRejectedValue(
+      new ApiError(
+        "You do not have permission to view this read-only dashboard surface.",
+        403,
+      ),
+    );
+    const { GET } = await import("../route");
+    const { request: req,context } = request("test-user@example.com");
+
+    const response = await GET(req, context);
+
+    expect(response.status).toBe(403);
+    expect(mockRequireBaselineAdminSurfaceRead).toHaveBeenCalledWith(
+      {
+        sub: "admin-sub",
+        user: { email: "admin@example.com" },
+      },
+      "stats",
+    );
+    expect(mockFindUser).not.toHaveBeenCalled();
+  });
+
   it("loads activity by analytics identity without treating the email as a Keycloak id", async () => {
     const { GET } = await import("../route");
     const { request: req,context } = request("test-user@example.com");
@@ -145,10 +238,12 @@ describe("GET /api/admin/users/activity/[identity]", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockRequireRbacPermission).toHaveBeenCalledWith(
-      { sub: "admin-sub" },
-      "admin_ui",
-      "view",
+    expect(mockRequireAdminSurfaceManage).toHaveBeenCalledWith(
+      {
+        sub: "admin-sub",
+        user: { email: "admin@example.com" },
+      },
+      "stats",
     );
     expect(mockGetRealmUserById).not.toHaveBeenCalled();
     expect(mockCountConversations).toHaveBeenCalledWith({
@@ -174,6 +269,113 @@ describe("GET /api/admin/users/activity/[identity]", () => {
           source: "slack",
           channel_id: "C123TEST",
           channel_name: "example-channel",
+          slack_permalink:
+            "https://example.slack.com/archives/C123TEST/p1775100000123456",
+        },
+      ],
+      can_view_conversations: true,
+    });
+  });
+
+  it("opens an admin drawer for an identity represented only by message analytics", async () => {
+    mockFindUser.mockResolvedValue(null);
+    mockFindConversations
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
+    mockCountConversations.mockResolvedValue(0);
+    mockAggregateFeedback
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
+    mockFindFeedback
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
+    messageRows = [{ _id: "message-1" }];
+
+    const { GET } = await import("../route");
+    const { request: req,context } = request("message-user@example.com");
+    const response = await GET(req, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockAggregateMessages).toHaveBeenCalled();
+    expect(body.data.profile).toMatchObject({
+      email: "message-user@example.com",
+      name: "message-user@example.com",
+    });
+  });
+
+  it("lets a scoped teammate view scoped overview/feedback but never conversation rows", async () => {
+    mockGetAuth.mockResolvedValue({
+      session: {
+        sub: "member-sub",
+        user: { email: "member@example.com" },
+      },
+    });
+    mockRequireAdminSurfaceManage.mockRejectedValue(new Error("not manager"));
+    mockHasOrganizationAdmin.mockResolvedValue(false);
+    mockGetReadableSlackChannelNames.mockResolvedValue(["example-channel"]);
+    mockGetOwnedAgents.mockResolvedValue([
+      { id: "agent-owned", name: "Owned Agent" },
+    ]);
+    mockGetOwnedAgentConversationIds.mockResolvedValue({
+      ids: ["conversation-1"],
+      capped: false,
+    });
+    mockGetInsightsActorTeamSlugs.mockResolvedValue(["primary"]);
+    mockLoadTeamMembersForSlugs.mockResolvedValue(new Map([
+      ["primary", [{
+        identity_key: "target-sub",
+        user_subject: "target-sub",
+        user_email: "test-user@example.com",
+        role: "member",
+        source_types: ["manual"],
+        provider_ids: [],
+      }]],
+    ]));
+
+    const { GET } = await import("../route");
+    const { request: req,context } = request("test-user@example.com");
+    const response = await GET(req, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockRequireBaselineAdminSurfaceRead).toHaveBeenCalledWith(
+      {
+        sub: "member-sub",
+        user: { email: "member@example.com" },
+      },
+      "stats",
+    );
+    expect(body.data.can_view_conversations).toBe(false);
+    expect(body.data.recent_conversations).toEqual([]);
+    expect(body.data.recent_feedback).toEqual([
+      expect.objectContaining({
+        conversation_id: null,
+        slack_permalink: null,
+      }),
+    ]);
+    // The server does not even fetch conversation titles for scoped viewers.
+    expect(mockFindConversations).not.toHaveBeenCalled();
+    expect(mockCountConversations).toHaveBeenCalledWith({
+      $and: [
+        {
+          owner_id: {
+            $in: expect.arrayContaining([
+              "test-user@example.com",
+              "U123TEST",
+            ]),
+          },
+        },
+        {
+          $or: expect.arrayContaining([
+            expect.objectContaining({
+              $and: expect.any(Array),
+            }),
+            { owner_id: "member@example.com" },
+          ]),
         },
       ],
     });
@@ -187,6 +389,16 @@ describe("GET /api/admin/users/activity/[identity]", () => {
       subjectId: "preview-sub",
     });
     mockSimulationCanManage.mockResolvedValue(false);
+    mockSimulationCanAudit.mockResolvedValue(false);
+    mockCountConversations.mockResolvedValue(0);
+    mockAggregateFeedback
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
+    mockFindFeedback
+      .mockReset()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
     const { GET } = await import("../route");
     const { request: req,context } = request(
       "test-user@example.com",
@@ -196,6 +408,7 @@ describe("GET /api/admin/users/activity/[identity]", () => {
     const response = await GET(req, context);
 
     expect(response.status).toBe(403);
-    expect(mockFindUser).not.toHaveBeenCalled();
+    expect(mockRequireBaselineAdminSurfaceRead).not.toHaveBeenCalled();
+    expect(mockFindConversations).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/api/admin/users/activity/[identity]/route.ts
+++ b/ui/src/app/api/admin/users/activity/[identity]/route.ts
@@ -12,6 +12,7 @@ import {
   simulationSubjectCanAuditOrganization,
   simulationSubjectCanManageAdminSurface,
 } from "@/lib/rbac/admin-simulation-server";
+import { getDirectSharingAccessConversationIds } from "@/lib/rbac/conversation-implicit-authz";
 import { hasOrganizationAdmin } from "@/lib/rbac/platform-admin";
 import {
   requireAdminSurfaceManage,
@@ -22,7 +23,8 @@ import {
   getInsightsActorTeamSlugs,
   getOwnedAgentConversationIds,
   getOwnedAgents,
-  getReadableSlackChannelNames,
+  getReadableConversationIds,
+  getReadableMessagingConversationScope,
   type OwnedAgent,
 } from "@/lib/rbac/user-insights-scope";
 import type { User } from "@/types/mongodb";
@@ -38,16 +40,21 @@ interface ActivityConversation extends Document {
   _id?: unknown;
   channel_id?: string;
   channel_name?: string;
+  channel_type?: string;
   client_type?: string;
   created_at?: Date | string;
   idempotency_key?: string;
   metadata?: {
     channel_id?: string;
     channel_name?: string;
+    channel_type?: string;
     owner_display_name?: string;
     slack_link?: string;
     slack_permalink?: string;
     thread_ts?: string;
+    webex_message_id?: string;
+    webex_room_id?: string;
+    webex_space_id?: string;
     workspace_url?: string;
   };
   slack_meta?: {
@@ -62,6 +69,7 @@ interface ActivityConversation extends Document {
 }
 
 interface ActivityFeedback extends Document {
+  channel_id?: string;
   channel_name?: string;
   comment?: string;
   conversation_id?: string;
@@ -78,9 +86,13 @@ function dateString(value: unknown): string {
 }
 
 function conversationSource(conversation: ActivityConversation): string {
-  return conversation.source === "slack" || conversation.client_type === "slack"
-    ? "slack"
-    : "web";
+  if (conversation.source === "slack" || conversation.client_type === "slack") {
+    return "slack";
+  }
+  if (conversation.source === "webex" || conversation.client_type === "webex") {
+    return "webex";
+  }
+  return "web";
 }
 
 function safeHttpsUrl(value: string | undefined): URL | null {
@@ -130,6 +142,16 @@ function slackConversationPermalink(
   return `https://slack.com/app_redirect?${params.toString()}`;
 }
 
+function webexConversationLink(
+  conversation: ActivityConversation,
+): string | null {
+  if (conversationSource(conversation) !== "webex") return null;
+  const spaceId = conversation.metadata?.webex_space_id;
+  if (!spaceId) return null;
+  const params = new URLSearchParams({ space: spaceId });
+  return `webexteams://im?${params.toString()}`;
+}
+
 function identityMatchesTeamMember(
   member: { user_email?: string; user_subject?: string },
   targetEmails: Set<string>,
@@ -144,26 +166,11 @@ function identityMatchesTeamMember(
 }
 
 function scopedConversationClauses(
-  channelNames: string[],
+  readableConversationClauses: Document[],
   ownerEmail: string,
   ownedAgents: OwnedAgent[],
 ): Document[] {
-  const clauses: Document[] = [];
-  if (channelNames.length > 0) {
-    const names = channelNames.length === 1 ? channelNames[0] : { $in: channelNames };
-    clauses.push({
-      $and: [
-        { $or: [{ source: "slack" }, { client_type: "slack" }] },
-        {
-          $or: [
-            { channel_name: names },
-            { "metadata.channel_name": names },
-            { "slack_meta.channel_name": names },
-          ],
-        },
-      ],
-    });
-  }
+  const clauses: Document[] = [...readableConversationClauses];
   if (ownerEmail) clauses.push({ owner_id: ownerEmail });
 
   const agentIds = ownedAgents.map((agent) => agent.id);
@@ -179,17 +186,86 @@ function scopedConversationClauses(
   return clauses;
 }
 
+/**
+ * Conversation titles and deep links are more sensitive than aggregate
+ * Insights counts. External messaging conversations are visible only through
+ * mapped resources the actor can read. Slack DMs have no valid mapped channel
+ * and are also rejected through their explicit `channel_type`.
+ */
+function readableSlackConversationClause(channelIds: string[]): Document | null {
+  if (channelIds.length === 0) return null;
+  const ids = channelIds.length === 1 ? channelIds[0] : { $in: channelIds };
+  return {
+    $and: [
+      { $or: [{ source: "slack" }, { client_type: "slack" }] },
+      { channel_type: { $ne: "dm" } },
+      { "metadata.channel_type": { $ne: "dm" } },
+      {
+        $or: [
+          { channel_id: ids },
+          { "metadata.channel_id": ids },
+          { "slack_meta.channel_id": ids },
+        ],
+      },
+    ],
+  };
+}
+
+function readableWebexConversationClause(spaceIds: string[]): Document | null {
+  if (spaceIds.length === 0) return null;
+  return {
+    $and: [
+      { $or: [{ source: "webex" }, { client_type: "webex" }] },
+      {
+        "metadata.webex_space_id":
+          spaceIds.length === 1 ? spaceIds[0] : { $in: spaceIds },
+      },
+    ],
+  };
+}
+
+function readableWebConversationClause(
+  ownerEmail: string,
+  ownerSubject: string,
+  explicitConversationIds: string[],
+): Document | null {
+  const accessClauses: Document[] = [];
+  const normalizedEmail = ownerEmail.trim().toLowerCase();
+  if (normalizedEmail) {
+    const emails = ownerEmail === normalizedEmail
+      ? normalizedEmail
+      : { $in: [ownerEmail, normalizedEmail] };
+    accessClauses.push(
+      { owner_id: emails },
+      { "sharing.shared_with": emails },
+    );
+  }
+  if (ownerSubject) accessClauses.push({ owner_subject: ownerSubject });
+  if (explicitConversationIds.length > 0) {
+    accessClauses.push({ _id: { $in: explicitConversationIds } });
+  }
+  if (accessClauses.length === 0) return null;
+
+  return {
+    $and: [
+      { client_type: { $nin: ["slack", "webex"] } },
+      { source: { $nin: ["slack", "webex"] } },
+      { $or: accessClauses },
+    ],
+  };
+}
+
 function scopedMessageClauses(
-  channelNames: string[],
+  channelIds: string[],
   ownerEmail: string,
   ownedAgents: OwnedAgent[],
 ): Document[] {
   const clauses: Document[] = [];
-  if (channelNames.length > 0) {
+  if (channelIds.length > 0) {
     clauses.push({
       "metadata.source": "slack",
-      "metadata.channel_name":
-        channelNames.length === 1 ? channelNames[0] : { $in: channelNames },
+      "metadata.channel_id":
+        channelIds.length === 1 ? channelIds[0] : { $in: channelIds },
     });
   }
   if (ownerEmail) clauses.push({ owner_id: ownerEmail });
@@ -241,7 +317,6 @@ export const GET = withErrorHandler(
           hasOrganizationAdmin(session),
         ]);
     const isFullInsightsScope = canManageAllInsights || canAuditOrganization;
-    const canViewConversations = canAuditOrganization;
 
     // Direct calls from a baseline member still need the same read grant that
     // exposes Admin → Insights. A stats manager/org admin already passed the
@@ -261,44 +336,68 @@ export const GET = withErrorHandler(
       ? identity.toLowerCase()
       : identity;
 
-    let scopedChannelNames: string[] = [];
-    let scopedOwnerEmail = "";
-    let scopedOwnedAgents: OwnedAgent[] = [];
-    let scopedOwnedAgentConversationIds: string[] = [];
-    let scopedTeamSlugs: string[] = [];
-    if (!isFullInsightsScope) {
-      const openfgaUser = simulationScope?.openfgaUser ?? (
-        typeof session.sub === "string" && session.sub.trim()
-          ? `user:${session.sub.trim()}`
-          : ""
-      );
-      scopedOwnerEmail = simulationScope?.ownerEmail ?? (
-        typeof session.user?.email === "string"
-          ? session.user.email.trim()
-          : ""
-      );
-      if (!openfgaUser && !scopedOwnerEmail) {
-        throw new ApiError("Unauthorized", 401, "UNAUTHORIZED");
-      }
+    const openfgaUser = simulationScope?.openfgaUser ?? (
+      typeof session.sub === "string" && session.sub.trim()
+        ? `user:${session.sub.trim()}`
+        : ""
+    );
+    const actorOwnerEmail = simulationScope?.ownerEmail ?? (
+      typeof session.user?.email === "string"
+        ? session.user.email.trim()
+        : ""
+    );
+    if (!isFullInsightsScope && !openfgaUser && !actorOwnerEmail) {
+      throw new ApiError("Unauthorized", 401, "UNAUTHORIZED");
+    }
 
-      [scopedChannelNames,scopedOwnedAgents,scopedTeamSlugs] = await Promise.all([
-        openfgaUser
-          ? getReadableSlackChannelNames(openfgaUser)
+    const actorSubject = openfgaUser.startsWith("user:")
+      ? openfgaUser.slice("user:".length)
+      : "";
+    const scopedOwnerEmail = isFullInsightsScope ? "" : actorOwnerEmail;
+    let scopedOwnedAgentConversationIds: string[] = [];
+    const [
+      messagingConversationScope,
+      openFgaReadableConversationIds,
+      directShareConversationIds,
+      scopedOwnedAgents,
+      scopedTeamSlugs,
+    ] = await Promise.all([
+      !canAuditOrganization && openfgaUser
+        ? getReadableMessagingConversationScope(openfgaUser)
+        : Promise.resolve({
+            slackChannelIds: [],
+            webexSpaceIds: [],
+          }),
+      !canAuditOrganization && openfgaUser
+        ? getReadableConversationIds(openfgaUser)
+        : Promise.resolve([]),
+      !canAuditOrganization && actorOwnerEmail
+        ? getDirectSharingAccessConversationIds(
+            actorOwnerEmail,
+            getCollection,
+          )
+        : Promise.resolve([]),
+      !isFullInsightsScope && openfgaUser
+        ? getOwnedAgents(openfgaUser)
+        : Promise.resolve([]),
+      !isFullInsightsScope && simulationScope?.subjectType === "team"
+        ? Promise.resolve([simulationScope.subjectId])
+        : !isFullInsightsScope && openfgaUser
+          ? getInsightsActorTeamSlugs(openfgaUser)
           : Promise.resolve([]),
-        openfgaUser
-          ? getOwnedAgents(openfgaUser)
-          : Promise.resolve([]),
-        simulationScope?.subjectType === "team"
-          ? Promise.resolve([simulationScope.subjectId])
-          : openfgaUser
-            ? getInsightsActorTeamSlugs(openfgaUser)
-            : Promise.resolve([]),
-      ]);
-      if (scopedOwnedAgents.length > 0) {
-        scopedOwnedAgentConversationIds = (
-          await getOwnedAgentConversationIds(scopedOwnedAgents)
-        ).ids;
-      }
+    ]);
+    const readableWebConversationIds = [
+      ...new Set([
+        ...openFgaReadableConversationIds,
+        ...directShareConversationIds,
+      ]),
+    ];
+    const scopedChannelIds = messagingConversationScope.slackChannelIds;
+    const scopedWebexSpaceIds = messagingConversationScope.webexSpaceIds;
+    if (scopedOwnedAgents.length > 0) {
+      scopedOwnedAgentConversationIds = (
+        await getOwnedAgentConversationIds(scopedOwnedAgents)
+      ).ids;
     }
 
     const users = await getCollection<ActivityUser>("users");
@@ -337,12 +436,26 @@ export const GET = withErrorHandler(
         { user_id: { $in: identities } },
       ],
     };
+    const readableConversationClauses: Document[] = [];
+    const readableSlackScope =
+      readableSlackConversationClause(scopedChannelIds);
+    const readableWebexScope =
+      readableWebexConversationClause(scopedWebexSpaceIds);
+    const readableWebScope = readableWebConversationClause(
+      actorOwnerEmail,
+      actorSubject,
+      readableWebConversationIds,
+    );
+    if (readableSlackScope) readableConversationClauses.push(readableSlackScope);
+    if (readableWebexScope) readableConversationClauses.push(readableWebexScope);
+    if (readableWebScope) readableConversationClauses.push(readableWebScope);
+
     const conversationScope = scopedConversationClauses(
-      scopedChannelNames,
+      readableConversationClauses,
       scopedOwnerEmail,
       scopedOwnedAgents,
     );
-    const conversationFilter: Document = isFullInsightsScope
+    const activityConversationFilter: Document = isFullInsightsScope
       ? targetConversationFilter
       : {
           $and: [
@@ -352,15 +465,27 @@ export const GET = withErrorHandler(
               : { _id: null },
           ],
         };
+    const visibleConversationFilter: Document = canAuditOrganization
+      ? targetConversationFilter
+      : {
+          $and: [
+            targetConversationFilter,
+            readableConversationClauses.length > 0
+              ? { $or: readableConversationClauses }
+              : { _id: null },
+          ],
+        };
+    const canViewConversations =
+      canAuditOrganization || readableConversationClauses.length > 0;
 
     const feedbackScope: Document[] = [];
-    if (scopedChannelNames.length > 0) {
+    if (scopedChannelIds.length > 0) {
       feedbackScope.push({
         source: "slack",
-        channel_name:
-          scopedChannelNames.length === 1
-            ? scopedChannelNames[0]
-            : { $in: scopedChannelNames },
+        channel_id:
+          scopedChannelIds.length === 1
+            ? scopedChannelIds[0]
+            : { $in: scopedChannelIds },
       });
     }
     if (scopedOwnerEmail) {
@@ -369,6 +494,11 @@ export const GET = withErrorHandler(
     if (scopedOwnedAgentConversationIds.length > 0) {
       feedbackScope.push({
         conversation_id: { $in: scopedOwnedAgentConversationIds },
+      });
+    }
+    if (readableWebConversationIds.length > 0) {
+      feedbackScope.push({
+        conversation_id: { $in: readableWebConversationIds },
       });
     }
     const feedbackFilter: Document = isFullInsightsScope
@@ -381,7 +511,7 @@ export const GET = withErrorHandler(
         };
 
     const messageScope = scopedMessageClauses(
-      scopedChannelNames,
+      scopedChannelIds,
       scopedOwnerEmail,
       scopedOwnedAgents,
     );
@@ -429,6 +559,7 @@ export const GET = withErrorHandler(
     const [
       recentConversations,
       totalConversations,
+      visibleConversationCount,
       feedbackStats,
       recentFeedback,
       visibleMessages,
@@ -437,7 +568,7 @@ export const GET = withErrorHandler(
       await Promise.all([
         canViewConversations
           ? conversations
-              .find(conversationFilter, {
+              .find(visibleConversationFilter, {
                 projection: {
                   _id: 1,
                   channel_id: 1,
@@ -451,6 +582,9 @@ export const GET = withErrorHandler(
                   "metadata.slack_link": 1,
                   "metadata.slack_permalink": 1,
                   "metadata.thread_ts": 1,
+                  "metadata.webex_message_id": 1,
+                  "metadata.webex_room_id": 1,
+                  "metadata.webex_space_id": 1,
                   "metadata.workspace_url": 1,
                   slack_meta: 1,
                   source: 1,
@@ -462,7 +596,10 @@ export const GET = withErrorHandler(
               .limit(20)
               .toArray()
           : Promise.resolve([]),
-        conversations.countDocuments(conversationFilter),
+        conversations.countDocuments(activityConversationFilter),
+        canViewConversations
+          ? conversations.countDocuments(visibleConversationFilter)
+          : Promise.resolve(0),
         feedback
           .aggregate([
             { $match: feedbackFilter },
@@ -484,6 +621,7 @@ export const GET = withErrorHandler(
           .find(feedbackFilter, {
             projection: {
               _id: 0,
+              channel_id: 1,
               channel_name: 1,
               comment: 1,
               created_at: 1,
@@ -529,6 +667,12 @@ export const GET = withErrorHandler(
     addTargetEmail(user?.email);
     addTargetSubject(user?.keycloak_sub);
     addTargetSubject(user?.metadata?.keycloak_sub);
+    const actorOwnsTarget =
+      (
+        Boolean(actorOwnerEmail.trim()) &&
+        targetEmails.has(actorOwnerEmail.trim().toLowerCase())
+      ) ||
+      (Boolean(actorSubject) && targetSubjects.has(actorSubject));
     const sharesTeam = [...teamMembersBySlug.values()].some((members) =>
       members.some((member) =>
         identityMatchesTeamMember(member, targetEmails, targetSubjects),
@@ -565,6 +709,15 @@ export const GET = withErrorHandler(
       : /^[UW][A-Z0-9]+$/.test(identity)
         ? "slack"
         : "web";
+    const readableChannelIdSet = new Set(scopedChannelIds);
+    const readableWebConversationIdSet =
+      new Set(readableWebConversationIds);
+    const visibleWebConversationIdSet = new Set(
+      recentConversations
+        .filter((conversation) => conversationSource(conversation) === "web")
+        .map((conversation) => String(conversation._id ?? ""))
+        .filter(Boolean),
+    );
 
     return successResponse({
       can_view_conversations: canViewConversations,
@@ -584,6 +737,7 @@ export const GET = withErrorHandler(
       },
       stats: {
         total_conversations: totalConversations,
+        visible_conversations: visibleConversationCount,
         feedback_given: Number(feedbackSummary.total ?? 0),
         feedback_positive: Number(feedbackSummary.positive ?? 0),
         feedback_negative: Number(feedbackSummary.negative ?? 0),
@@ -596,6 +750,7 @@ export const GET = withErrorHandler(
           conversation.channel_id ??
           conversation.metadata?.channel_id ??
           conversation.slack_meta?.channel_id ??
+          conversation.metadata?.webex_space_id ??
           null,
         channel_name:
           conversation.channel_name ??
@@ -609,22 +764,46 @@ export const GET = withErrorHandler(
             conversation.slack_meta?.channel_id ??
             null,
         ),
+        webex_permalink: webexConversationLink(conversation),
         created_at: dateString(conversation.created_at),
         updated_at: dateString(conversation.updated_at),
       })),
-      recent_feedback: recentFeedback.map((entry) => ({
-        source: entry.source || "web",
-        rating: entry.rating || "",
-        value: entry.value || "",
-        comment: entry.comment ?? null,
-        channel_name: entry.channel_name ?? null,
-        conversation_id:
-          canViewConversations ? entry.conversation_id ?? null : null,
-        slack_permalink: canViewConversations
-          ? safeHttpsUrl(entry.slack_permalink)?.toString() ?? null
-          : null,
-        created_at: dateString(entry.created_at),
-      })),
+      recent_feedback: recentFeedback.map((entry) => {
+        const canOpenSlackThread =
+          canAuditOrganization ||
+          (
+            entry.source === "slack" &&
+            typeof entry.channel_id === "string" &&
+            readableChannelIdSet.has(entry.channel_id)
+          );
+        const canOpenWebConversation =
+          canAuditOrganization ||
+          (
+            entry.source !== "slack" &&
+            entry.source !== "webex" &&
+            typeof entry.conversation_id === "string" &&
+            (
+              actorOwnsTarget ||
+              readableWebConversationIdSet.has(entry.conversation_id) ||
+              visibleWebConversationIdSet.has(entry.conversation_id)
+            )
+          );
+        return {
+          source: entry.source || "web",
+          rating: entry.rating || "",
+          value: entry.value || "",
+          comment: entry.comment ?? null,
+          channel_name: entry.channel_name ?? null,
+          // Scoped viewers receive web ids only for their own/shared chats.
+          // Slack links survive only for feedback in readable channels.
+          conversation_id:
+            canOpenWebConversation ? entry.conversation_id ?? null : null,
+          slack_permalink: canOpenSlackThread
+            ? safeHttpsUrl(entry.slack_permalink)?.toString() ?? null
+            : null,
+          created_at: dateString(entry.created_at),
+        };
+      }),
     });
   }
 );

--- a/ui/src/app/api/admin/users/activity/[identity]/route.ts
+++ b/ui/src/app/api/admin/users/activity/[identity]/route.ts
@@ -3,15 +3,28 @@
 import {
   ApiError,
   getAuthFromBearerOrSession,
-  requireRbacPermission,
   successResponse,
   withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import {
   resolveAuthorizedAdminSimulationScope,
+  simulationSubjectCanAuditOrganization,
   simulationSubjectCanManageAdminSurface,
 } from "@/lib/rbac/admin-simulation-server";
+import { hasOrganizationAdmin } from "@/lib/rbac/platform-admin";
+import {
+  requireAdminSurfaceManage,
+  requireBaselineAdminSurfaceRead,
+} from "@/lib/rbac/require-openfga";
+import { loadTeamMembersForSlugs } from "@/lib/rbac/team-membership-store";
+import {
+  getInsightsActorTeamSlugs,
+  getOwnedAgentConversationIds,
+  getOwnedAgents,
+  getReadableSlackChannelNames,
+  type OwnedAgent,
+} from "@/lib/rbac/user-insights-scope";
 import type { User } from "@/types/mongodb";
 import type { Document,Filter } from "mongodb";
 import { type NextRequest,NextResponse } from "next/server";
@@ -27,14 +40,21 @@ interface ActivityConversation extends Document {
   channel_name?: string;
   client_type?: string;
   created_at?: Date | string;
+  idempotency_key?: string;
   metadata?: {
     channel_id?: string;
     channel_name?: string;
     owner_display_name?: string;
+    slack_link?: string;
+    slack_permalink?: string;
+    thread_ts?: string;
+    workspace_url?: string;
   };
   slack_meta?: {
     channel_id?: string;
     channel_name?: string;
+    thread_ts?: string;
+    workspace_url?: string;
   };
   source?: string;
   title?: string;
@@ -63,6 +83,130 @@ function conversationSource(conversation: ActivityConversation): string {
     : "web";
 }
 
+function safeHttpsUrl(value: string | undefined): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function slackConversationPermalink(
+  conversation: ActivityConversation,
+  channelId: string | null,
+): string | null {
+  if (conversationSource(conversation) !== "slack") return null;
+
+  const persistedLink =
+    conversation.metadata?.slack_permalink ??
+    conversation.metadata?.slack_link;
+  const safePersistedLink = safeHttpsUrl(persistedLink);
+  if (safePersistedLink) return safePersistedLink.toString();
+
+  const threadTs =
+    conversation.metadata?.thread_ts ??
+    conversation.slack_meta?.thread_ts ??
+    conversation.idempotency_key;
+  if (!threadTs || !channelId) return null;
+
+  const workspaceUrl =
+    conversation.metadata?.workspace_url ??
+    conversation.slack_meta?.workspace_url;
+  const safeWorkspaceUrl = safeHttpsUrl(workspaceUrl);
+  if (safeWorkspaceUrl) {
+    safeWorkspaceUrl.pathname =
+      `/archives/${encodeURIComponent(channelId)}/p${encodeURIComponent(threadTs.replaceAll(".", ""))}`;
+    safeWorkspaceUrl.search = "";
+    safeWorkspaceUrl.hash = "";
+    return safeWorkspaceUrl.toString();
+  }
+
+  const params = new URLSearchParams({
+    channel: channelId,
+    message_ts: threadTs,
+  });
+  return `https://slack.com/app_redirect?${params.toString()}`;
+}
+
+function identityMatchesTeamMember(
+  member: { user_email?: string; user_subject?: string },
+  targetEmails: Set<string>,
+  targetSubjects: Set<string>,
+): boolean {
+  const memberEmail = member.user_email?.trim().toLowerCase();
+  const memberSubject = member.user_subject?.trim();
+  return Boolean(
+    (memberEmail && targetEmails.has(memberEmail)) ||
+    (memberSubject && targetSubjects.has(memberSubject)),
+  );
+}
+
+function scopedConversationClauses(
+  channelNames: string[],
+  ownerEmail: string,
+  ownedAgents: OwnedAgent[],
+): Document[] {
+  const clauses: Document[] = [];
+  if (channelNames.length > 0) {
+    const names = channelNames.length === 1 ? channelNames[0] : { $in: channelNames };
+    clauses.push({
+      $and: [
+        { $or: [{ source: "slack" }, { client_type: "slack" }] },
+        {
+          $or: [
+            { channel_name: names },
+            { "metadata.channel_name": names },
+            { "slack_meta.channel_name": names },
+          ],
+        },
+      ],
+    });
+  }
+  if (ownerEmail) clauses.push({ owner_id: ownerEmail });
+
+  const agentIds = ownedAgents.map((agent) => agent.id);
+  if (agentIds.length > 0) {
+    clauses.push({
+      $or: [
+        { "metadata.thread_owner_agent_id": { $in: agentIds } },
+        { participants: { $elemMatch: { type: "agent", id: { $in: agentIds } } } },
+        { agent_id: { $in: agentIds } },
+      ],
+    });
+  }
+  return clauses;
+}
+
+function scopedMessageClauses(
+  channelNames: string[],
+  ownerEmail: string,
+  ownedAgents: OwnedAgent[],
+): Document[] {
+  const clauses: Document[] = [];
+  if (channelNames.length > 0) {
+    clauses.push({
+      "metadata.source": "slack",
+      "metadata.channel_name":
+        channelNames.length === 1 ? channelNames[0] : { $in: channelNames },
+    });
+  }
+  if (ownerEmail) clauses.push({ owner_id: ownerEmail });
+
+  const agentIds = ownedAgents.map((agent) => agent.id);
+  const agentNames = ownedAgents.map((agent) => agent.name);
+  if (agentIds.length > 0) {
+    clauses.push({
+      $or: [
+        { "metadata.agent_id": { $in: agentIds } },
+        { "metadata.agent_name": { $in: agentNames } },
+      ],
+    });
+  }
+  return clauses;
+}
+
 export const GET = withErrorHandler(
   async (
     request: NextRequest,
@@ -84,24 +228,27 @@ export const GET = withErrorHandler(
       request.nextUrl.searchParams,
       session,
     );
-    if (simulationScope) {
-      const canReadAllStats = await simulationSubjectCanManageAdminSurface(
-        simulationScope,
-        "stats",
-      );
-      if (!canReadAllStats) {
-        throw new ApiError(
-          "The selected preview subject cannot view another user's activity.",
-          403,
-          "admin_surface:stats#can_manage",
-          "pdp_denied",
-          "contact_admin",
-        );
-      }
-    } else {
-      // Match the authorization level of the original admin activity drawer:
-      // detailed conversation titles and feedback are organization-audit data.
-      await requireRbacPermission(session, "admin_ui", "view");
+    const [canManageAllInsights,canAuditOrganization] = simulationScope
+      ? await Promise.all([
+          simulationSubjectCanManageAdminSurface(simulationScope, "stats"),
+          simulationSubjectCanAuditOrganization(simulationScope),
+        ])
+      : await Promise.all([
+          requireAdminSurfaceManage(session, "stats").then(
+            () => true,
+            () => false,
+          ),
+          hasOrganizationAdmin(session),
+        ]);
+    const isFullInsightsScope = canManageAllInsights || canAuditOrganization;
+    const canViewConversations = canAuditOrganization;
+
+    // Direct calls from a baseline member still need the same read grant that
+    // exposes Admin → Insights. A stats manager/org admin already passed the
+    // stronger check above. Access-preview requests were authorized when the
+    // simulation scope was resolved and are evaluated as that subject below.
+    if (!simulationScope && !isFullInsightsScope) {
+      await requireBaselineAdminSurfaceRead(session, "stats");
     }
 
     const { identity: rawIdentity } = await context.params;
@@ -113,9 +260,51 @@ export const GET = withErrorHandler(
     const normalizedIdentity = identity.includes("@")
       ? identity.toLowerCase()
       : identity;
+
+    let scopedChannelNames: string[] = [];
+    let scopedOwnerEmail = "";
+    let scopedOwnedAgents: OwnedAgent[] = [];
+    let scopedOwnedAgentConversationIds: string[] = [];
+    let scopedTeamSlugs: string[] = [];
+    if (!isFullInsightsScope) {
+      const openfgaUser = simulationScope?.openfgaUser ?? (
+        typeof session.sub === "string" && session.sub.trim()
+          ? `user:${session.sub.trim()}`
+          : ""
+      );
+      scopedOwnerEmail = simulationScope?.ownerEmail ?? (
+        typeof session.user?.email === "string"
+          ? session.user.email.trim()
+          : ""
+      );
+      if (!openfgaUser && !scopedOwnerEmail) {
+        throw new ApiError("Unauthorized", 401, "UNAUTHORIZED");
+      }
+
+      [scopedChannelNames,scopedOwnedAgents,scopedTeamSlugs] = await Promise.all([
+        openfgaUser
+          ? getReadableSlackChannelNames(openfgaUser)
+          : Promise.resolve([]),
+        openfgaUser
+          ? getOwnedAgents(openfgaUser)
+          : Promise.resolve([]),
+        simulationScope?.subjectType === "team"
+          ? Promise.resolve([simulationScope.subjectId])
+          : openfgaUser
+            ? getInsightsActorTeamSlugs(openfgaUser)
+            : Promise.resolve([]),
+      ]);
+      if (scopedOwnedAgents.length > 0) {
+        scopedOwnedAgentConversationIds = (
+          await getOwnedAgentConversationIds(scopedOwnedAgents)
+        ).ids;
+      }
+    }
+
     const users = await getCollection<ActivityUser>("users");
     const conversations = await getCollection<ActivityConversation>("conversations");
     const feedback = await getCollection<ActivityFeedback>("feedback");
+    const messages = await getCollection<Document>("messages");
 
     const userLookup: Filter<ActivityUser> = {
       $or: [
@@ -139,38 +328,140 @@ export const GET = withErrorHandler(
     addOwnerId(user?.email);
     addOwnerId(user?.slack_user_id);
     const identities = [...ownerIds];
-    const conversationFilter = {
+    const targetConversationFilter: Document = {
       owner_id: identities.length === 1 ? identities[0] : { $in: identities },
     };
-    const feedbackFilter = {
+    const targetFeedbackFilter: Document = {
       $or: [
         { user_email: { $in: identities } },
         { user_id: { $in: identities } },
       ],
     };
+    const conversationScope = scopedConversationClauses(
+      scopedChannelNames,
+      scopedOwnerEmail,
+      scopedOwnedAgents,
+    );
+    const conversationFilter: Document = isFullInsightsScope
+      ? targetConversationFilter
+      : {
+          $and: [
+            targetConversationFilter,
+            conversationScope.length > 0
+              ? { $or: conversationScope }
+              : { _id: null },
+          ],
+        };
 
-    const [recentConversations,totalConversations,feedbackStats,recentFeedback] =
-      await Promise.all([
-        conversations
-          .find(conversationFilter, {
-            projection: {
-              _id: 1,
-              channel_id: 1,
-              channel_name: 1,
-              client_type: 1,
-              created_at: 1,
-              "metadata.channel_id": 1,
-              "metadata.channel_name": 1,
-              "metadata.owner_display_name": 1,
-              slack_meta: 1,
-              source: 1,
-              title: 1,
-              updated_at: 1,
+    const feedbackScope: Document[] = [];
+    if (scopedChannelNames.length > 0) {
+      feedbackScope.push({
+        source: "slack",
+        channel_name:
+          scopedChannelNames.length === 1
+            ? scopedChannelNames[0]
+            : { $in: scopedChannelNames },
+      });
+    }
+    if (scopedOwnerEmail) {
+      feedbackScope.push({ user_email: scopedOwnerEmail });
+    }
+    if (scopedOwnedAgentConversationIds.length > 0) {
+      feedbackScope.push({
+        conversation_id: { $in: scopedOwnedAgentConversationIds },
+      });
+    }
+    const feedbackFilter: Document = isFullInsightsScope
+      ? targetFeedbackFilter
+      : {
+          $and: [
+            targetFeedbackFilter,
+            feedbackScope.length > 0 ? { $or: feedbackScope } : { _id: null },
+          ],
+        };
+
+    const messageScope = scopedMessageClauses(
+      scopedChannelNames,
+      scopedOwnerEmail,
+      scopedOwnedAgents,
+    );
+    const visibleMessagePromise = !isFullInsightsScope && messageScope.length === 0
+      ? Promise.resolve([])
+      : messages
+          .aggregate([
+            {
+              $match: {
+                role: "assistant",
+                ...(!isFullInsightsScope ? { $or: messageScope } : {}),
+              },
             },
-          })
-          .sort({ updated_at: -1 })
-          .limit(20)
-          .toArray(),
+            {
+              $lookup: {
+                from: "conversations",
+                localField: "conversation_id",
+                foreignField: "_id",
+                as: "_conversation",
+              },
+            },
+            {
+              $addFields: {
+                _owner: {
+                  $ifNull: [
+                    "$owner_id",
+                    { $arrayElemAt: ["$_conversation.owner_id", 0] },
+                  ],
+                },
+              },
+            },
+            {
+              $match: {
+                _owner:
+                  identities.length === 1
+                    ? identities[0]
+                    : { $in: identities },
+              },
+            },
+            { $limit: 1 },
+            { $project: { _id: 1 } },
+          ])
+          .toArray();
+
+    const [
+      recentConversations,
+      totalConversations,
+      feedbackStats,
+      recentFeedback,
+      visibleMessages,
+      teamMembersBySlug,
+    ] =
+      await Promise.all([
+        canViewConversations
+          ? conversations
+              .find(conversationFilter, {
+                projection: {
+                  _id: 1,
+                  channel_id: 1,
+                  channel_name: 1,
+                  client_type: 1,
+                  created_at: 1,
+                  idempotency_key: 1,
+                  "metadata.channel_id": 1,
+                  "metadata.channel_name": 1,
+                  "metadata.owner_display_name": 1,
+                  "metadata.slack_link": 1,
+                  "metadata.slack_permalink": 1,
+                  "metadata.thread_ts": 1,
+                  "metadata.workspace_url": 1,
+                  slack_meta: 1,
+                  source: 1,
+                  title: 1,
+                  updated_at: 1,
+                },
+              })
+              .sort({ updated_at: -1 })
+              .limit(20)
+              .toArray()
+          : Promise.resolve([]),
         conversations.countDocuments(conversationFilter),
         feedback
           .aggregate([
@@ -195,17 +486,25 @@ export const GET = withErrorHandler(
               _id: 0,
               channel_name: 1,
               comment: 1,
-              conversation_id: 1,
               created_at: 1,
               rating: 1,
-              slack_permalink: 1,
               source: 1,
               value: 1,
+              ...(canViewConversations
+                ? {
+                    conversation_id: 1,
+                    slack_permalink: 1,
+                  }
+                : {}),
             },
           })
           .sort({ created_at: -1 })
           .limit(10)
           .toArray(),
+        visibleMessagePromise,
+        scopedTeamSlugs.length > 0
+          ? loadTeamMembersForSlugs(scopedTeamSlugs)
+          : Promise.resolve(new Map()),
       ]);
 
     const feedbackSummary = feedbackStats[0] ?? {
@@ -213,7 +512,50 @@ export const GET = withErrorHandler(
       positive: 0,
       negative: 0,
     };
-    if (!user && totalConversations === 0 && feedbackSummary.total === 0) {
+    const targetEmails = new Set<string>();
+    const targetSubjects = new Set<string>();
+    const addTargetEmail = (value: unknown): void => {
+      if (typeof value === "string" && value.trim()) {
+        targetEmails.add(value.trim().toLowerCase());
+      }
+    };
+    const addTargetSubject = (value: unknown): void => {
+      if (typeof value === "string" && value.trim()) {
+        targetSubjects.add(value.trim());
+      }
+    };
+    if (identity.includes("@")) addTargetEmail(identity);
+    else addTargetSubject(identity);
+    addTargetEmail(user?.email);
+    addTargetSubject(user?.keycloak_sub);
+    addTargetSubject(user?.metadata?.keycloak_sub);
+    const sharesTeam = [...teamMembersBySlug.values()].some((members) =>
+      members.some((member) =>
+        identityMatchesTeamMember(member, targetEmails, targetSubjects),
+      ),
+    );
+    const hasVisibleActivity =
+      totalConversations > 0 ||
+      Number(feedbackSummary.total ?? 0) > 0 ||
+      visibleMessages.length > 0;
+
+    if (
+      (!isFullInsightsScope && !sharesTeam && !hasVisibleActivity) ||
+      (isFullInsightsScope &&
+        !user &&
+        totalConversations === 0 &&
+        Number(feedbackSummary.total ?? 0) === 0 &&
+        visibleMessages.length === 0)
+    ) {
+      if (!isFullInsightsScope) {
+        throw new ApiError(
+          "You do not have permission to view this user's Insights activity.",
+          403,
+          "admin_surface:stats#can_read",
+          "pdp_denied",
+          "contact_admin",
+        );
+      }
       throw new ApiError("User not found", 404, "USER_NOT_FOUND");
     }
 
@@ -225,6 +567,7 @@ export const GET = withErrorHandler(
         : "web";
 
     return successResponse({
+      can_view_conversations: canViewConversations,
       profile: {
         email: user?.email ?? (identity.includes("@") ? normalizedIdentity : ""),
         name:
@@ -259,6 +602,13 @@ export const GET = withErrorHandler(
           conversation.metadata?.channel_name ??
           conversation.slack_meta?.channel_name ??
           null,
+        slack_permalink: slackConversationPermalink(
+          conversation,
+          conversation.channel_id ??
+            conversation.metadata?.channel_id ??
+            conversation.slack_meta?.channel_id ??
+            null,
+        ),
         created_at: dateString(conversation.created_at),
         updated_at: dateString(conversation.updated_at),
       })),
@@ -268,8 +618,11 @@ export const GET = withErrorHandler(
         value: entry.value || "",
         comment: entry.comment ?? null,
         channel_name: entry.channel_name ?? null,
-        conversation_id: entry.conversation_id ?? null,
-        slack_permalink: entry.slack_permalink ?? null,
+        conversation_id:
+          canViewConversations ? entry.conversation_id ?? null : null,
+        slack_permalink: canViewConversations
+          ? safeHttpsUrl(entry.slack_permalink)?.toString() ?? null
+          : null,
         created_at: dateString(entry.created_at),
       })),
     });

--- a/ui/src/components/admin/platform/PrometheusCharts.tsx
+++ b/ui/src/components/admin/platform/PrometheusCharts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { CardPagination } from "@/components/admin/shared/CardPagination";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import {
 getLabeledValues,
 getScalarValue,
@@ -695,7 +695,7 @@ export function AgentHealthTable({
   reliabilityState,
   latencyState,
 }: AgentHealthTableProps) {
-  const [page, setPage] = useState(0);
+  const [page, setPage] = useState(1);
   const rows = useMemo(() => {
     const volumes = metricMap(volumeState.data, "agent_name");
     const reliabilities = metricMap(reliabilityState.data, "agent_name");
@@ -715,8 +715,8 @@ export function AgentHealthTable({
   const configured = volumeState.configured && reliabilityState.configured && latencyState.configured;
   const error = volumeState.error || reliabilityState.error || latencyState.error;
   const pageCount = Math.max(1, Math.ceil(rows.length / 10));
-  const safePage = Math.min(page, pageCount - 1);
-  const visibleRows = rows.slice(safePage * 10, safePage * 10 + 10);
+  const safePage = Math.min(page, pageCount);
+  const visibleRows = rows.slice((safePage - 1) * 10, safePage * 10);
 
   return (
     <Card className="relative" aria-busy={loading}>
@@ -763,32 +763,14 @@ export function AgentHealthTable({
             </table>
           </div>
         )}
-        {rows.length > 10 && (
-          <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-            <span>
-              Showing {safePage * 10 + 1}–{Math.min((safePage + 1) * 10, rows.length)} of {rows.length}
-            </span>
-            <div className="flex items-center gap-2">
-              <span>Page {safePage + 1} of {pageCount}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={safePage === 0}
-                onClick={() => setPage((current) => Math.max(0, current - 1))}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={safePage >= pageCount - 1}
-                onClick={() => setPage((current) => Math.min(pageCount - 1, current + 1))}
-              >
-                Next
-              </Button>
-            </div>
-          </div>
-        )}
+        <CardPagination
+          label="agent health"
+          page={safePage}
+          pageSize={10}
+          total={rows.length}
+          disabled={loading}
+          onPageChange={setPage}
+        />
       </CardContent>
       {rows.length > 0 && <RefreshOverlay loading={loading} />}
       {rows.length > 0 && !loading && <RefreshError error={error} />}

--- a/ui/src/components/admin/platform/__tests__/PrometheusCharts.test.tsx
+++ b/ui/src/components/admin/platform/__tests__/PrometheusCharts.test.tsx
@@ -149,10 +149,10 @@ describe("TimeseriesChart", () => {
 });
 
 describe("AgentHealthTable", () => {
-  it("paginates agent comparisons ten rows at a time", () => {
-    const metrics = Array.from({ length: 12 }, (_, index) => ({
+  it("paginates agent comparisons ten rows at a time and accepts a page number", () => {
+    const metrics = Array.from({ length: 25 }, (_, index) => ({
       metric: { agent_name: `agent-${String(index + 1).padStart(2, "0")}` },
-      value: [1000, String(12 - index)] as [number, string],
+      value: [1000, String(25 - index)] as [number, string],
     }));
     mockGetLabeledValues.mockImplementation((data: unknown, labelKey: unknown) => (
       (data as PrometheusMetric[] | null ?? []).map((metric) => ({
@@ -173,13 +173,23 @@ describe("AgentHealthTable", () => {
 
     expect(screen.getByText("agent-01")).toBeInTheDocument();
     expect(screen.queryByText("agent-11")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing 1–10 of 12")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1–10 of 25")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next agent health page" }));
     expect(screen.getByText("agent-11")).toBeInTheDocument();
-    expect(screen.getByText("agent-12")).toBeInTheDocument();
+    expect(screen.getByText("agent-20")).toBeInTheDocument();
     expect(screen.queryByText("agent-01")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing 11–12 of 12")).toBeInTheDocument();
+    expect(screen.getByText("Showing 11–20 of 25")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: "Go to agent health page" }), {
+      target: { value: "3" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Go" }));
+
+    expect(screen.getByText("agent-21")).toBeInTheDocument();
+    expect(screen.getByText("agent-25")).toBeInTheDocument();
+    expect(screen.queryByText("agent-11")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 21–25 of 25")).toBeInTheDocument();
   });
 });
 

--- a/ui/src/components/admin/shared/CardPagination.tsx
+++ b/ui/src/components/admin/shared/CardPagination.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import React from "react";
+
+interface CardPaginationProps {
+  disabled?: boolean;
+  label: string;
+  onPageChange: (page: number) => void;
+  page: number;
+  pageSize: number;
+  total: number;
+  className?: string;
+}
+
+/**
+ * Compact pagination for tables and leaderboards embedded inside admin cards.
+ * Pages are 1-based. The number input supports direct navigation while the
+ * Previous/Next buttons preserve the familiar card pager interaction.
+ */
+export function CardPagination({
+  className,
+  disabled = false,
+  label,
+  onPageChange,
+  page,
+  pageSize,
+  total,
+}: CardPaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (totalPages <= 1) return null;
+
+  const safePage = Math.min(Math.max(1, page), totalPages);
+  const firstItem = (safePage - 1) * pageSize + 1;
+  const lastItem = Math.min(safePage * pageSize, total);
+  const inputId = `${label.replaceAll(/[^a-zA-Z0-9_-]/g, "-")}-page`;
+
+  const goToPage = (requestedPage: number): void => {
+    const nextPage = Math.min(Math.max(1, requestedPage), totalPages);
+    if (nextPage !== safePage) onPageChange(nextPage);
+  };
+
+  return (
+    <div
+      className={cn(
+        "mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <span>
+        Showing {firstItem}–{lastItem} of {total}
+      </span>
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <form
+          className="flex items-center gap-1.5"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            const requestedPage = Number.parseInt(String(form.get("page") ?? ""), 10);
+            if (Number.isFinite(requestedPage)) goToPage(requestedPage);
+          }}
+        >
+          <label htmlFor={inputId}>Page</label>
+          <Input
+            key={safePage}
+            id={inputId}
+            name="page"
+            type="number"
+            min={1}
+            max={totalPages}
+            defaultValue={safePage}
+            disabled={disabled}
+            className="h-8 w-14 px-2 text-center text-xs text-foreground"
+            aria-label={`Go to ${label} page`}
+          />
+          <span>of {totalPages}</span>
+          <Button
+            type="submit"
+            variant="outline"
+            size="sm"
+            className="h-8 px-2"
+            disabled={disabled}
+          >
+            Go
+          </Button>
+        </form>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8"
+          disabled={disabled || safePage <= 1}
+          onClick={() => goToPage(safePage - 1)}
+          aria-label={`Previous ${label} page`}
+        >
+          Previous
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8"
+          disabled={disabled || safePage >= totalPages}
+          onClick={() => goToPage(safePage + 1)}
+          aria-label={`Next ${label} page`}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/admin/teams/UserDetailPanel.tsx
+++ b/ui/src/components/admin/teams/UserDetailPanel.tsx
@@ -89,15 +89,18 @@ const VALUE_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-/** Return the server-validated Slack deep link for a conversation. */
-function getSlackLink(conv: UserConversation): string | null {
-  return conv.source === "slack" ? conv.slack_permalink : null;
-}
-
-/** Get the appropriate link for a conversation */
-function getConvLink(conv: UserConversation): string | null {
-  if (conv.source === "slack") return getSlackLink(conv);
-  if (conv.source === "webex") return conv.webex_permalink;
+/**
+ * Prefer the integration's server-validated deep link. Legacy integration
+ * records without enough native metadata still open through the saved-chat
+ * route, whose API repeats the conversation RBAC check.
+ */
+function getConvLink(conv: UserConversation): string {
+  if (conv.source === "slack" && conv.slack_permalink) {
+    return conv.slack_permalink;
+  }
+  if (conv.source === "webex" && conv.webex_permalink) {
+    return conv.webex_permalink;
+  }
   return `/chat/${conv.id}?from=admin`;
 }
 
@@ -373,7 +376,7 @@ function ConversationsTab({ conversations }: { conversations: UserConversation[]
           <div className="flex items-center gap-2 min-w-0 flex-1">
             {conv.source === "slack" ? (
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
-                {conv.channel_name || "Slack"}
+                Slack
               </Badge>
             ) : conv.source === "webex" ? (
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
@@ -460,7 +463,7 @@ function FeedbackTab({
               </span>
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
                 {fb.source === "slack"
-                  ? `Slack${fb.channel_name ? ` · ${fb.channel_name}` : ""}`
+                  ? "Slack"
                   : fb.source === "webex"
                     ? "Webex"
                     : "Web"}

--- a/ui/src/components/admin/teams/UserDetailPanel.tsx
+++ b/ui/src/components/admin/teams/UserDetailPanel.tsx
@@ -47,6 +47,7 @@ interface UserConversation {
   source: string;
   channel_id: string | null;
   channel_name: string | null;
+  slack_permalink: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -63,6 +64,7 @@ interface UserFeedback {
 }
 
 interface UserDetailData {
+  can_view_conversations: boolean;
   profile: UserProfile;
   stats: UserStats;
   recent_conversations: UserConversation[];
@@ -85,13 +87,9 @@ const VALUE_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-/** Build a Slack deep link from conversation data. Works without knowing the workspace URL. */
+/** Return the server-validated Slack deep link for a conversation. */
 function getSlackLink(conv: UserConversation): string | null {
-  if (conv.source !== "slack" || !conv.channel_id) return null;
-  // _id format is "slack-{thread_ts}", extract thread_ts
-  const threadTs = conv.id.startsWith("slack-") ? conv.id.slice(6) : null;
-  if (!threadTs) return null;
-  return `https://slack.com/app_redirect?channel=${conv.channel_id}&message_ts=${threadTs}`;
+  return conv.source === "slack" ? conv.slack_permalink : null;
 }
 
 /** Get the appropriate link for a conversation */
@@ -148,6 +146,10 @@ export function UserDetailPanel({
 
   if (!email) return null;
 
+  const visibleTabs = data?.can_view_conversations
+    ? (["overview", "conversations", "feedback"] as const)
+    : (["overview", "feedback"] as const);
+
   return (
     <>
       {/* Backdrop */}
@@ -181,7 +183,7 @@ export function UserDetailPanel({
 
         {/* Tabs */}
         <div className="flex border-b border-border shrink-0">
-          {(["overview", "conversations", "feedback"] as const).map((tab) => (
+          {visibleTabs.map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -208,9 +210,21 @@ export function UserDetailPanel({
             </div>
           ) : data ? (
             <>
-              {activeTab === "overview" && <OverviewTab data={data} />}
-              {activeTab === "conversations" && <ConversationsTab conversations={data.recent_conversations} />}
-              {activeTab === "feedback" && <FeedbackTab feedback={data.recent_feedback} />}
+              {activeTab === "overview" && (
+                <OverviewTab
+                  data={data}
+                  canViewConversations={data.can_view_conversations}
+                />
+              )}
+              {activeTab === "conversations" && data.can_view_conversations && (
+                <ConversationsTab conversations={data.recent_conversations} />
+              )}
+              {activeTab === "feedback" && (
+                <FeedbackTab
+                  feedback={data.recent_feedback}
+                  canViewConversations={data.can_view_conversations}
+                />
+              )}
             </>
           ) : null}
         </div>
@@ -219,7 +233,13 @@ export function UserDetailPanel({
   );
 }
 
-function OverviewTab({ data }: { data: UserDetailData }) {
+function OverviewTab({
+  data,
+  canViewConversations,
+}: {
+  data: UserDetailData;
+  canViewConversations: boolean;
+}) {
   const { profile, stats } = data;
   return (
     <div className="space-y-4">
@@ -285,7 +305,7 @@ function OverviewTab({ data }: { data: UserDetailData }) {
       </div>
 
       {/* Recent activity */}
-      {data.recent_conversations.length > 0 && (
+      {canViewConversations && data.recent_conversations.length > 0 && (
         <div>
           <h3 className="text-xs font-medium mb-2">Recent Conversations</h3>
           <div className="space-y-1">
@@ -389,7 +409,13 @@ function ConversationsTab({ conversations }: { conversations: UserConversation[]
   );
 }
 
-function FeedbackTab({ feedback }: { feedback: UserFeedback[] }) {
+function FeedbackTab({
+  feedback,
+  canViewConversations,
+}: {
+  feedback: UserFeedback[];
+  canViewConversations: boolean;
+}) {
   if (feedback.length === 0) {
     return (
       <div className="text-center py-8 text-sm text-muted-foreground">
@@ -428,7 +454,7 @@ function FeedbackTab({ feedback }: { feedback: UserFeedback[] }) {
           {fb.comment && (
             <p className="text-muted-foreground">{fb.comment}</p>
           )}
-          <div className="flex items-center gap-2">
+          {canViewConversations && <div className="flex items-center gap-2">
             {fb.source === "slack" && fb.slack_permalink && (
               <a
                 href={fb.slack_permalink}
@@ -451,7 +477,7 @@ function FeedbackTab({ feedback }: { feedback: UserFeedback[] }) {
                 View chat
               </a>
             )}
-          </div>
+          </div>}
         </div>
       ))}
     </div>

--- a/ui/src/components/admin/teams/UserDetailPanel.tsx
+++ b/ui/src/components/admin/teams/UserDetailPanel.tsx
@@ -36,6 +36,7 @@ interface UserProfile {
 
 interface UserStats {
   total_conversations: number;
+  visible_conversations: number;
   feedback_given: number;
   feedback_positive: number;
   feedback_negative: number;
@@ -48,6 +49,7 @@ interface UserConversation {
   channel_id: string | null;
   channel_name: string | null;
   slack_permalink: string | null;
+  webex_permalink: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +97,7 @@ function getSlackLink(conv: UserConversation): string | null {
 /** Get the appropriate link for a conversation */
 function getConvLink(conv: UserConversation): string | null {
   if (conv.source === "slack") return getSlackLink(conv);
+  if (conv.source === "webex") return conv.webex_permalink;
   return `/chat/${conv.id}?from=admin`;
 }
 
@@ -193,7 +196,7 @@ export function UserDetailPanel({
                   : "border-transparent text-muted-foreground hover:text-foreground"
               }`}
             >
-              {tab === "overview" ? "Overview" : tab === "conversations" ? `Conversations${data ? ` (${data.stats.total_conversations})` : ""}` : `Feedback${data ? ` (${data.stats.feedback_given})` : ""}`}
+              {tab === "overview" ? "Overview" : tab === "conversations" ? `Conversations${data ? ` (${data.stats.visible_conversations})` : ""}` : `Feedback${data ? ` (${data.stats.feedback_given})` : ""}`}
             </button>
           ))}
         </div>
@@ -260,7 +263,11 @@ function OverviewTab({
             <div className="flex items-center gap-2 text-muted-foreground">
               <Globe className="h-3.5 w-3.5" />
               <Badge variant="outline" className="text-[10px]">
-                {profile.source === "slack" ? "Slack" : "Web"}
+                {profile.source === "slack"
+                  ? "Slack"
+                  : profile.source === "webex"
+                    ? "Webex"
+                    : "Web"}
               </Badge>
               {profile.slack_user_id && (
                 <span className="text-[10px] text-muted-foreground">{profile.slack_user_id}</span>
@@ -314,6 +321,8 @@ function OverviewTab({
                 <div className="flex items-center gap-2 min-w-0">
                   {conv.source === "slack" ? (
                     <Hash className="h-3 w-3 text-purple-500 shrink-0" />
+                  ) : conv.source === "webex" ? (
+                    <Globe className="h-3 w-3 text-cyan-500 shrink-0" />
                   ) : (
                     <MessageSquare className="h-3 w-3 text-blue-500 shrink-0" />
                   )}
@@ -365,6 +374,10 @@ function ConversationsTab({ conversations }: { conversations: UserConversation[]
             {conv.source === "slack" ? (
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
                 {conv.channel_name || "Slack"}
+              </Badge>
+            ) : conv.source === "webex" ? (
+              <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+                Webex
               </Badge>
             ) : (
               <Badge variant="outline" className="text-[10px] px-1.5 py-0 shrink-0">
@@ -446,7 +459,11 @@ function FeedbackTab({
                 {VALUE_LABELS[fb.value] || fb.value}
               </span>
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                {fb.source === "slack" ? `Slack${fb.channel_name ? ` · ${fb.channel_name}` : ""}` : "Web"}
+                {fb.source === "slack"
+                  ? `Slack${fb.channel_name ? ` · ${fb.channel_name}` : ""}`
+                  : fb.source === "webex"
+                    ? "Webex"
+                    : "Web"}
               </Badge>
             </div>
             <span className="text-muted-foreground">{formatDate(fb.created_at)}</span>

--- a/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
+++ b/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
@@ -22,6 +22,7 @@ describe("UserDetailPanel", () => {
           },
           stats: {
             total_conversations: 1,
+            visible_conversations: 1,
             feedback_given: 1,
             feedback_positive: 1,
             feedback_negative: 0,
@@ -35,6 +36,7 @@ describe("UserDetailPanel", () => {
               channel_name: "example-channel",
               slack_permalink:
                 "https://example.slack.com/archives/C123TEST/p1775100000123456",
+              webex_permalink: null,
               created_at: "2026-07-20T00:00:00.000Z",
               updated_at: "2026-07-20T01:00:00.000Z",
             },
@@ -91,6 +93,81 @@ describe("UserDetailPanel", () => {
     );
   });
 
+  it("links authorized web and Webex conversations through their native paths", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          can_view_conversations: true,
+          profile: {
+            email: "test-user@example.com",
+            name: "Test User",
+            avatar_url: null,
+            role: "user",
+            source: "web",
+            slack_user_id: null,
+            created_at: "2026-01-01T00:00:00.000Z",
+            last_login: "2026-07-20T00:00:00.000Z",
+          },
+          stats: {
+            total_conversations: 3,
+            visible_conversations: 2,
+            feedback_given: 0,
+            feedback_positive: 0,
+            feedback_negative: 0,
+          },
+          recent_conversations: [
+            {
+              id: "conversation-web",
+              title: "Shared web chat",
+              source: "web",
+              channel_id: null,
+              channel_name: null,
+              slack_permalink: null,
+              webex_permalink: null,
+              created_at: "2026-07-20T00:00:00.000Z",
+              updated_at: "2026-07-20T01:00:00.000Z",
+            },
+            {
+              id: "conversation-webex",
+              title: "Mapped Webex space",
+              source: "webex",
+              channel_id: "space-shared",
+              channel_name: null,
+              slack_permalink: null,
+              webex_permalink: "webexteams://im?space=space-shared",
+              created_at: "2026-07-20T00:00:00.000Z",
+              updated_at: "2026-07-20T01:00:00.000Z",
+            },
+          ],
+          recent_feedback: [],
+        },
+      }),
+    });
+
+    render(
+      <UserDetailPanel
+        email="test-user@example.com"
+        onClose={jest.fn()}
+      />,
+    );
+
+    await screen.findByText("Test User");
+    fireEvent.click(screen.getByRole("button", { name: "Conversations (2)" }));
+
+    expect(screen.getByRole("link", { name: "Shared web chat" })).toHaveAttribute(
+      "href",
+      "/chat/conversation-web?from=admin",
+    );
+    expect(
+      screen.getByRole("link", { name: "Mapped Webex space" }),
+    ).toHaveAttribute(
+      "href",
+      "webexteams://im?space=space-shared",
+    );
+  });
+
   it("hides conversation tabs, titles, and feedback chat links for a scoped viewer", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
@@ -110,6 +187,7 @@ describe("UserDetailPanel", () => {
           },
           stats: {
             total_conversations: 1,
+            visible_conversations: 0,
             feedback_given: 1,
             feedback_positive: 1,
             feedback_negative: 0,
@@ -124,6 +202,7 @@ describe("UserDetailPanel", () => {
               channel_id: null,
               channel_name: null,
               slack_permalink: null,
+              webex_permalink: null,
               created_at: "2026-07-20T00:00:00.000Z",
               updated_at: "2026-07-20T01:00:00.000Z",
             },

--- a/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
+++ b/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render,screen,waitFor } from "@testing-library/react";
+import { fireEvent,render,screen,waitFor } from "@testing-library/react";
 
 import { UserDetailPanel } from "../UserDetailPanel";
 
@@ -9,6 +9,7 @@ describe("UserDetailPanel", () => {
       json: async () => ({
         success: true,
         data: {
+          can_view_conversations: true,
           profile: {
             email: "test-user@example.com",
             name: "Test User",
@@ -21,12 +22,35 @@ describe("UserDetailPanel", () => {
           },
           stats: {
             total_conversations: 1,
-            feedback_given: 0,
-            feedback_positive: 0,
+            feedback_given: 1,
+            feedback_positive: 1,
             feedback_negative: 0,
           },
-          recent_conversations: [],
-          recent_feedback: [],
+          recent_conversations: [
+            {
+              id: "conversation-1",
+              title: "Example Slack thread",
+              source: "slack",
+              channel_id: "C123TEST",
+              channel_name: "example-channel",
+              slack_permalink:
+                "https://example.slack.com/archives/C123TEST/p1775100000123456",
+              created_at: "2026-07-20T00:00:00.000Z",
+              updated_at: "2026-07-20T01:00:00.000Z",
+            },
+          ],
+          recent_feedback: [
+            {
+              source: "web",
+              rating: "positive",
+              value: "thumbs_up",
+              comment: "Helpful",
+              channel_name: null,
+              conversation_id: "conversation-1",
+              slack_permalink: null,
+              created_at: "2026-07-20T01:00:00.000Z",
+            },
+          ],
         },
       }),
     }) as jest.Mock;
@@ -46,5 +70,95 @@ describe("UserDetailPanel", () => {
         "/api/admin/users/activity/test-user%40example.com",
       );
     });
+  });
+
+  it("links an admin's Slack conversation to its persisted thread permalink", async () => {
+    render(
+      <UserDetailPanel
+        email="test-user@example.com"
+        onClose={jest.fn()}
+      />,
+    );
+
+    await screen.findByText("Test User");
+    fireEvent.click(screen.getByRole("button", { name: "Conversations (1)" }));
+
+    expect(
+      screen.getByRole("link", { name: "Example Slack thread" }),
+    ).toHaveAttribute(
+      "href",
+      "https://example.slack.com/archives/C123TEST/p1775100000123456",
+    );
+  });
+
+  it("hides conversation tabs, titles, and feedback chat links for a scoped viewer", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          can_view_conversations: false,
+          profile: {
+            email: "test-user@example.com",
+            name: "Test User",
+            avatar_url: null,
+            role: "user",
+            source: "web",
+            slack_user_id: null,
+            created_at: "2026-01-01T00:00:00.000Z",
+            last_login: "2026-07-20T00:00:00.000Z",
+          },
+          stats: {
+            total_conversations: 1,
+            feedback_given: 1,
+            feedback_positive: 1,
+            feedback_negative: 0,
+          },
+          // Defense in depth: even a malformed response must not render these
+          // rows when the server capability says conversation access is denied.
+          recent_conversations: [
+            {
+              id: "conversation-private",
+              title: "Private conversation title",
+              source: "web",
+              channel_id: null,
+              channel_name: null,
+              slack_permalink: null,
+              created_at: "2026-07-20T00:00:00.000Z",
+              updated_at: "2026-07-20T01:00:00.000Z",
+            },
+          ],
+          recent_feedback: [
+            {
+              source: "web",
+              rating: "positive",
+              value: "thumbs_up",
+              comment: "Helpful",
+              channel_name: null,
+              conversation_id: "conversation-private",
+              slack_permalink: null,
+              created_at: "2026-07-20T01:00:00.000Z",
+            },
+          ],
+        },
+      }),
+    });
+
+    render(
+      <UserDetailPanel
+        email="test-user@example.com"
+        onClose={jest.fn()}
+      />,
+    );
+
+    await screen.findByText("Test User");
+    expect(
+      screen.queryByRole("button", { name: /Conversations/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Private conversation title")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Feedback (1)" }));
+    expect(screen.getByText("Helpful")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "View chat" })).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
+++ b/ui/src/components/admin/teams/__tests__/UserDetailPanel.test.tsx
@@ -33,7 +33,7 @@ describe("UserDetailPanel", () => {
               title: "Example Slack thread",
               source: "slack",
               channel_id: "C123TEST",
-              channel_name: "example-channel",
+              channel_name: "C123TEST",
               slack_permalink:
                 "https://example.slack.com/archives/C123TEST/p1775100000123456",
               webex_permalink: null,
@@ -91,9 +91,11 @@ describe("UserDetailPanel", () => {
       "href",
       "https://example.slack.com/archives/C123TEST/p1775100000123456",
     );
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+    expect(screen.queryByText("C123TEST")).not.toBeInTheDocument();
   });
 
-  it("links authorized web and Webex conversations through their native paths", async () => {
+  it("uses native links when available and a saved-chat fallback for legacy integration rows", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -112,7 +114,7 @@ describe("UserDetailPanel", () => {
           },
           stats: {
             total_conversations: 3,
-            visible_conversations: 2,
+            visible_conversations: 3,
             feedback_given: 0,
             feedback_positive: 0,
             feedback_negative: 0,
@@ -140,6 +142,17 @@ describe("UserDetailPanel", () => {
               created_at: "2026-07-20T00:00:00.000Z",
               updated_at: "2026-07-20T01:00:00.000Z",
             },
+            {
+              id: "conversation-slack-legacy",
+              title: "Internal on-call lookup",
+              source: "slack",
+              channel_id: null,
+              channel_name: null,
+              slack_permalink: null,
+              webex_permalink: null,
+              created_at: "2026-07-20T00:00:00.000Z",
+              updated_at: "2026-07-20T01:00:00.000Z",
+            },
           ],
           recent_feedback: [],
         },
@@ -154,7 +167,7 @@ describe("UserDetailPanel", () => {
     );
 
     await screen.findByText("Test User");
-    fireEvent.click(screen.getByRole("button", { name: "Conversations (2)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Conversations (3)" }));
 
     expect(screen.getByRole("link", { name: "Shared web chat" })).toHaveAttribute(
       "href",
@@ -165,6 +178,12 @@ describe("UserDetailPanel", () => {
     ).toHaveAttribute(
       "href",
       "webexteams://im?space=space-shared",
+    );
+    expect(
+      screen.getByRole("link", { name: "Internal on-call lookup" }),
+    ).toHaveAttribute(
+      "href",
+      "/chat/conversation-slack-legacy?from=admin",
     );
   });
 

--- a/ui/src/lib/rbac/__tests__/user-insights-scope.test.ts
+++ b/ui/src/lib/rbac/__tests__/user-insights-scope.test.ts
@@ -20,6 +20,7 @@ jest.mock('@/lib/rbac/slack-channel-grant-store', () => ({
 import {
   getAgentsByIds,
   getAllAgents,
+  getInsightsActorTeamSlugs,
   getOwnedAgentConversationIds,
   getOwnedAgents,
 } from '../user-insights-scope';
@@ -40,6 +41,32 @@ beforeEach(() => {
   mockListOpenFgaObjects.mockReset();
   mockCheckOpenFgaTuple.mockReset();
   mockGetCollection.mockReset();
+});
+
+describe('getInsightsActorTeamSlugs', () => {
+  it('lists computed team membership and returns unique slugs', async () => {
+    mockListOpenFgaObjects.mockResolvedValue({
+      objects: ['team:primary', 'team:secondary', 'team:primary'],
+    });
+
+    expect(await getInsightsActorTeamSlugs('user:sub-1')).toEqual([
+      'primary',
+      'secondary',
+    ]);
+    expect(mockListOpenFgaObjects).toHaveBeenCalledWith({
+      user: 'user:sub-1',
+      relation: 'member',
+      type: 'team',
+    });
+  });
+
+  it('fails closed for an empty actor or PDP error', async () => {
+    expect(await getInsightsActorTeamSlugs('')).toEqual([]);
+    expect(mockListOpenFgaObjects).not.toHaveBeenCalled();
+
+    mockListOpenFgaObjects.mockRejectedValue(new Error('fga down'));
+    expect(await getInsightsActorTeamSlugs('user:sub-1')).toEqual([]);
+  });
 });
 
 describe('getAgentsByIds', () => {

--- a/ui/src/lib/rbac/__tests__/user-insights-scope.test.ts
+++ b/ui/src/lib/rbac/__tests__/user-insights-scope.test.ts
@@ -17,12 +17,20 @@ jest.mock('@/lib/rbac/slack-channel-grant-store', () => ({
   slackChannelSubjectId: (ws: string, ch: string) => `${ws}:${ch}`,
 }));
 
+jest.mock('@/lib/rbac/webex-space-grant-store', () => ({
+  webexSpaceSubjectId: (ws: string, space: string) => `${ws}:${space}`,
+}));
+
 import {
   getAgentsByIds,
   getAllAgents,
   getInsightsActorTeamSlugs,
   getOwnedAgentConversationIds,
   getOwnedAgents,
+  getReadableConversationIds,
+  getReadableMessagingConversationScope,
+  getReadableSlackChannelNames,
+  getReadableWebexSpaceIds,
 } from '../user-insights-scope';
 
 /** Minimal collection stub keyed by the method a given helper calls. */
@@ -66,6 +74,148 @@ describe('getInsightsActorTeamSlugs', () => {
 
     mockListOpenFgaObjects.mockRejectedValue(new Error('fga down'));
     expect(await getInsightsActorTeamSlugs('user:sub-1')).toEqual([]);
+  });
+});
+
+describe('getReadableSlackChannelNames', () => {
+  it('returns readable mapped channels while excluding direct messages', async () => {
+    mockGetCollection.mockResolvedValue(
+      collectionStub({
+        find: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([
+              {
+                slack_workspace_id: 'T123',
+                slack_channel_id: 'C123',
+                channel_name: 'shared-channel',
+              },
+              {
+                slack_workspace_id: 'T123',
+                slack_channel_id: 'D123',
+                channel_name: 'direct-message',
+              },
+            ]),
+          }),
+        }),
+      }),
+    );
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
+
+    expect(await getReadableSlackChannelNames('user:sub-1')).toEqual([
+      'shared-channel',
+    ]);
+    expect(mockCheckOpenFgaTuple).toHaveBeenCalledTimes(1);
+    expect(mockCheckOpenFgaTuple).toHaveBeenCalledWith({
+      user: 'user:sub-1',
+      relation: 'can_read',
+      object: 'slack_channel:T123:C123',
+    });
+  });
+});
+
+describe('getReadableWebexSpaceIds', () => {
+  it('returns only readable mapped spaces', async () => {
+    mockGetCollection.mockResolvedValue(
+      collectionStub({
+        find: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([
+              {
+                webex_workspace_id: 'WX123',
+                webex_space_id: 'space-readable',
+              },
+              {
+                webex_workspace_id: 'WX123',
+                webex_space_id: 'space-denied',
+              },
+            ]),
+          }),
+        }),
+      }),
+    );
+    mockCheckOpenFgaTuple.mockImplementation(
+      ({ object }: { object: string }) =>
+        Promise.resolve({ allowed: object.endsWith(':space-readable') }),
+    );
+
+    expect(await getReadableWebexSpaceIds('user:sub-1')).toEqual([
+      'space-readable',
+    ]);
+    expect(mockCheckOpenFgaTuple).toHaveBeenCalledWith({
+      user: 'user:sub-1',
+      relation: 'can_read',
+      object: 'webex_space:WX123:space-readable',
+    });
+  });
+});
+
+describe('getReadableMessagingConversationScope', () => {
+  it('combines authorized Slack channel ids with Webex spaces', async () => {
+    const slackMappings = collectionStub({
+      find: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            {
+              slack_workspace_id: 'T123',
+              slack_channel_id: 'C123',
+              channel_name: 'shared-channel',
+            },
+          ]),
+        }),
+      }),
+    });
+    const webexMappings = collectionStub({
+      find: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            {
+              webex_workspace_id: 'WX123',
+              webex_space_id: 'space-readable',
+            },
+          ]),
+        }),
+      }),
+    });
+    mockGetCollection.mockImplementation((name: string) =>
+      Promise.resolve(
+        name === 'channel_team_mappings' ? slackMappings : webexMappings,
+      ),
+    );
+    mockCheckOpenFgaTuple.mockResolvedValue({ allowed: true });
+
+    expect(
+      await getReadableMessagingConversationScope('user:sub-1'),
+    ).toEqual({
+      slackChannelIds: ['C123'],
+      webexSpaceIds: ['space-readable'],
+    });
+  });
+});
+
+describe('getReadableConversationIds', () => {
+  it('lists and normalizes explicit conversation grants', async () => {
+    mockListOpenFgaObjects.mockResolvedValue({
+      objects: [
+        'conversation:conversation-1',
+        'conversation-2',
+        'conversation:conversation-1',
+      ],
+    });
+
+    expect(await getReadableConversationIds('user:sub-1')).toEqual([
+      'conversation-1',
+      'conversation-2',
+    ]);
+    expect(mockListOpenFgaObjects).toHaveBeenCalledWith({
+      user: 'user:sub-1',
+      relation: 'can_read',
+      type: 'conversation',
+    });
+  });
+
+  it('fails closed when conversation grants cannot be listed', async () => {
+    mockListOpenFgaObjects.mockRejectedValue(new Error('fga down'));
+    expect(await getReadableConversationIds('user:sub-1')).toEqual([]);
   });
 });
 

--- a/ui/src/lib/rbac/user-insights-scope.ts
+++ b/ui/src/lib/rbac/user-insights-scope.ts
@@ -1,11 +1,18 @@
 import { getCollection } from '@/lib/mongodb';
 import { checkOpenFgaTuple, listOpenFgaObjects } from '@/lib/rbac/openfga';
 import { slackChannelSubjectId } from '@/lib/rbac/slack-channel-grant-store';
+import { webexSpaceSubjectId } from '@/lib/rbac/webex-space-grant-store';
 
 interface ChannelTeamMappingDoc {
   slack_workspace_id?: string;
   slack_channel_id?: string;
   channel_name?: string;
+  active?: boolean;
+}
+
+interface WebexSpaceTeamMappingDoc {
+  webex_workspace_id?: string;
+  webex_space_id?: string;
   active?: boolean;
 }
 
@@ -16,6 +23,16 @@ interface DynamicAgentDoc {
 
 /** An agent the caller owns, with both the id (Slack conv key) and display name (web message key). */
 export interface OwnedAgent {
+  id: string;
+  name: string;
+}
+
+export interface ReadableMessagingConversationScope {
+  slackChannelIds: string[];
+  webexSpaceIds: string[];
+}
+
+interface ReadableSlackChannel {
   id: string;
   name: string;
 }
@@ -71,11 +88,17 @@ export async function getAgentsByIds(ids: string[]): Promise<OwnedAgent[]> {
 }
 
 /**
- * Returns the channel_names of every Slack channel the given OpenFGA user
- * can can_read. Used to scope Insights (Stats + Feedback) for non-admins.
+ * Returns every mapped Slack channel the given OpenFGA user can read.
+ * Direct-message channel ids are excluded even if a malformed mapping exists:
+ * DMs are never team resources and must not become visible in Insights through
+ * channel-scoped authorization.
+ *
  * Fail-closed: any error returns [].
  */
-export async function getReadableSlackChannelNames(openfgaUser: string): Promise<string[]> {
+async function getReadableSlackChannels(
+  openfgaUser: string,
+): Promise<ReadableSlackChannel[]> {
+  if (!openfgaUser.trim()) return [];
   try {
     const mappings = await getCollection<ChannelTeamMappingDoc>('channel_team_mappings');
     const rows = await mappings
@@ -83,14 +106,111 @@ export async function getReadableSlackChannelNames(openfgaUser: string): Promise
       .limit(500)
       .toArray();
 
-    const names: string[] = [];
+    const channels: ReadableSlackChannel[] = [];
     for (const row of rows) {
-      if (!row.slack_channel_id || !row.channel_name) continue;
+      if (!row.slack_channel_id) continue;
+      if (row.slack_channel_id.startsWith('D')) continue;
       const object = `slack_channel:${slackChannelSubjectId(row.slack_workspace_id ?? '', row.slack_channel_id)}`;
       const result = await checkOpenFgaTuple({ user: openfgaUser, relation: 'can_read', object }).catch(() => ({ allowed: false }));
-      if (result.allowed) names.push(row.channel_name);
+      if (result.allowed) {
+        channels.push({
+          id: row.slack_channel_id,
+          name: row.channel_name?.trim() ?? '',
+        });
+      }
     }
-    return names;
+    return channels.filter(
+      (channel, index) =>
+        channels.findIndex((candidate) => candidate.id === channel.id) === index,
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Channel names are retained for analytics collections keyed by name. */
+export async function getReadableSlackChannelNames(
+  openfgaUser: string,
+): Promise<string[]> {
+  const channels = await getReadableSlackChannels(openfgaUser);
+  return [...new Set(channels.map((channel) => channel.name).filter(Boolean))];
+}
+
+/**
+ * Returns mapped Webex space ids the actor can read. Direct-message spaces do
+ * not have `webex_space_team_mappings` rows, so using that mapping collection
+ * as the candidate set excludes Webex DMs by construction.
+ */
+export async function getReadableWebexSpaceIds(openfgaUser: string): Promise<string[]> {
+  if (!openfgaUser.trim()) return [];
+  try {
+    const mappings = await getCollection<WebexSpaceTeamMappingDoc>(
+      'webex_space_team_mappings',
+    );
+    const rows = await mappings
+      .find({ active: { $ne: false } } as never)
+      .limit(500)
+      .toArray();
+
+    const spaceIds: string[] = [];
+    for (const row of rows) {
+      if (!row.webex_space_id) continue;
+      const object =
+        `webex_space:${webexSpaceSubjectId(row.webex_workspace_id ?? '', row.webex_space_id)}`;
+      const result = await checkOpenFgaTuple({
+        user: openfgaUser,
+        relation: 'can_read',
+        object,
+      }).catch(() => ({ allowed: false }));
+      if (result.allowed) spaceIds.push(row.webex_space_id);
+    }
+    return [...new Set(spaceIds)];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * All external messaging scopes that may expose conversation titles and deep
+ * links in Insights. Keep source-specific mapping details behind this helper
+ * so the drawer consumes one extensible authorization result.
+ */
+export async function getReadableMessagingConversationScope(
+  openfgaUser: string,
+): Promise<ReadableMessagingConversationScope> {
+  const [slackChannels, webexSpaceIds] = await Promise.all([
+    getReadableSlackChannels(openfgaUser),
+    getReadableWebexSpaceIds(openfgaUser),
+  ]);
+  return {
+    slackChannelIds: slackChannels.map((channel) => channel.id),
+    webexSpaceIds,
+  };
+}
+
+/**
+ * Explicitly shared web conversations visible through OpenFGA. Conversation
+ * ownership is also checked against Mongo fields by the drawer because older
+ * owner-created chats do not necessarily have materialized owner tuples.
+ */
+export async function getReadableConversationIds(openfgaUser: string): Promise<string[]> {
+  if (!openfgaUser.trim()) return [];
+  try {
+    const { objects } = await listOpenFgaObjects({
+      user: openfgaUser,
+      relation: 'can_read',
+      type: 'conversation',
+    });
+    return [...new Set(
+      objects
+        .map((object) => (
+          object.startsWith('conversation:')
+            ? object.slice('conversation:'.length)
+            : object
+        ))
+        .map((id) => id.trim())
+        .filter(Boolean),
+    )];
   } catch {
     return [];
   }

--- a/ui/src/lib/rbac/user-insights-scope.ts
+++ b/ui/src/lib/rbac/user-insights-scope.ts
@@ -21,6 +21,34 @@ export interface OwnedAgent {
 }
 
 /**
+ * Return the teams the Insights actor belongs to through OpenFGA's computed
+ * `team#member` relation. Team admins are included because `member` inherits
+ * `admin` in the authorization model. Used only to decide whether a scoped
+ * Insights drawer may show a teammate's profile shell; activity inside the
+ * drawer remains constrained to the actor's resource scope.
+ *
+ * Fail-closed: any PDP error returns [].
+ */
+export async function getInsightsActorTeamSlugs(openfgaUser: string): Promise<string[]> {
+  if (!openfgaUser.trim()) return [];
+  try {
+    const { objects } = await listOpenFgaObjects({
+      user: openfgaUser,
+      relation: 'member',
+      type: 'team',
+    });
+    return [...new Set(
+      objects
+        .map((object) => object.startsWith('team:') ? object.slice('team:'.length) : object)
+        .map((slug) => slug.trim())
+        .filter(Boolean),
+    )];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Resolve display names for a set of agent ids best-effort from the
  * `dynamic_agents` collection (`_id` → `name`). Web message rows are keyed by
  * display name, so callers need the name to match them. Missing docs fall back

--- a/ui/src/types/admin-stats.ts
+++ b/ui/src/types/admin-stats.ts
@@ -15,6 +15,13 @@ export type AdminStatsSection = typeof ADMIN_STATS_SECTIONS[number];
 
 export type AdminStatsOwnerType = 'service_account' | 'slack_bot' | 'linked' | 'unlinked_slack';
 
+export interface AdminStatsPagination {
+  page: number;
+  limit: number;
+  total: number;
+  total_pages: number;
+}
+
 export interface AdminSlackStats {
   channels: {
     total: number;
@@ -75,6 +82,10 @@ export interface AdminStats {
       name?: string;
       owner_type?: AdminStatsOwnerType;
     }>;
+    pagination?: {
+      by_conversations: AdminStatsPagination;
+      by_messages: AdminStatsPagination;
+    };
   };
   top_agents: Array<{ _id: string; count: number }>;
   feedback_summary: {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.60.dev2"
+version = "0.5.60.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fix the Admin → Insights user drawer for scoped viewers while preserving server-side RBAC boundaries, and add pagination to the Top Users cards.

- Allow Insights readers to open users represented in their permitted resource scope or team.
- Keep overview and feedback scoped to readable resources, self-owned activity, and managed agents.
- Show conversation rows only when the viewer can read the underlying resource:
  - mapped Slack channels authorized by channel ID, excluding DMs;
  - owned or explicitly shared web chats through the existing conversation RBAC paths;
  - mapped Webex spaces authorized by space ID.
- Keep organization admins/auditors able to inspect all user conversations.
- Do not let managed-agent aggregate access expose private conversation titles or deep links.
- Label Slack activity consistently as `Slack` instead of exposing channel IDs.
- Link visible Slack conversations to validated thread permalinks and mapped Webex conversations through the native `webexteams://` space link.
- Open legacy integration rows without native-link metadata through the saved chat, where conversation RBAC is checked again.
- Preserve Slack channel/thread metadata on future VictorOps lookup conversations so they navigate back to the originating thread.
- Add independent server-side pagination for Top Users by Conversations and Messages, 10 rows per page.
- Keep pagination loading local to the requested Top Users card.
- Add direct page-number navigation and reuse the shared in-card pager in Agent Health Comparison.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `uv run ruff check ai_platform_engineering/integrations/slack_bot/utils/escalation.py ai_platform_engineering/integrations/slack_bot/tests/test_escalation_victorops_conversation.py`
- 199 targeted Jest tests across the drawer, stats API, admin page, RBAC helpers, and metrics pager
- 2 targeted Slack bot pytest tests
- Production webpack compilation succeeds; final Next route validation remains blocked by a pre-existing non-route export in an unchanged API route module.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable; none)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass
