### PR TITLE
feat(rag): self-service RAG ingestion-source config store (PR1/7)

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/app-configmap.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/app-configmap.yaml
@@ -2,7 +2,8 @@
 {{- $hasMcpServers := and .Values.appConfig.mcp_servers (gt (len .Values.appConfig.mcp_servers) 0) }}
 {{- $hasAgents := and .Values.appConfig.agents (gt (len .Values.appConfig.agents) 0) }}
 {{- $hasWorkflowConfigs := and .Values.appConfig.workflow_configs (gt (len .Values.appConfig.workflow_configs) 0) }}
-{{- if or $hasModels $hasMcpServers $hasAgents $hasWorkflowConfigs }}
+{{- $hasRagSources := and .Values.appConfig.rag_sources (gt (len .Values.appConfig.rag_sources) 0) }}
+{{- if or $hasModels $hasMcpServers $hasAgents $hasWorkflowConfigs $hasRagSources }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,5 +41,12 @@ data:
       {{- toYaml .Values.appConfig.workflow_configs | nindent 6 }}
     {{- else }}
     workflow_configs: []
+    {{- end }}
+
+    {{- if $hasRagSources }}
+    rag_sources:
+      {{- toYaml .Values.appConfig.rag_sources | nindent 6 }}
+    {{- else }}
+    rag_sources: []
     {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -588,6 +588,22 @@ appConfig:
   #     github: []
   #   enabled: true
 
+  # RAG ingestion source configurations
+  rag_sources: []
+  # Example:
+  # - source_type: "slack_channel"
+  #   channel_id: "C1234567890"
+  #   name: "eng-general"
+  #   description: "Engineering general channel"
+  #   owner_team: "team-example"          # optional — omit for a global, unowned source
+  #   shared_with_teams: []
+  #   visibility: "global"                 # optional, defaults to "global" for config-driven sources
+  #   default_chunk_size: 10000
+  #   default_chunk_overlap: 2000
+  #   reload_interval: 86400
+  #   lookback_days: 30
+  #   include_bots: false
+
   # Workflow configurations (multi-step automated pipelines)
   workflow_configs: []
   # Example:

--- a/charts/ai-platform-engineering/charts/openfga/authorization-model.json
+++ b/charts/ai-platform-engineering/charts/openfga/authorization-model.json
@@ -3018,6 +3018,168 @@
       }
     },
     {
+      "type": "ingestion_source",
+      "relations": {
+        "creator": {
+          "this": {}
+        },
+        "owner": {
+          "this": {}
+        },
+        "reader": {
+          "this": {}
+        },
+        "manager": {
+          "this": {}
+        },
+        "auditor": {
+          "this": {}
+        },
+        "can_discover": {
+          "computedUserset": {
+            "relation": "can_read"
+          }
+        },
+        "can_read": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "reader"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_manage": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "manager"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_delete": {
+          "computedUserset": {
+            "relation": "can_manage"
+          }
+        },
+        "can_audit": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "auditor"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "relations": {
+          "creator": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              }
+            ]
+          },
+          "owner": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              }
+            ]
+          },
+          "reader": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "user",
+                "wildcard": {}
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              },
+              {
+                "type": "external_group",
+                "relation": "member"
+              }
+            ]
+          },
+          "manager": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              },
+              {
+                "type": "organization",
+                "relation": "admin"
+              }
+            ]
+          },
+          "auditor": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "type": "document",
       "relations": {
         "owner": {

--- a/deploy/openfga/model.fga
+++ b/deploy/openfga/model.fga
@@ -328,6 +328,25 @@ type mcp_tool
     define can_manage: manager or owner
     define can_audit: auditor or can_manage
 
+# ingestion_source represents a self-service RAG ingestion source
+# configuration (Slack channel, Confluence space, Jira project, web URL,
+# Webex space). It is independent of the knowledge_base/data_source graph:
+# a source describes *where* content is pulled from, not the resulting
+# indexed data, so it carries its own shareable-resource authorization
+# graph rather than inheriting from a parent_kb.
+type ingestion_source
+  relations
+    define creator: [user]
+    define owner: [user, service_account]
+    define reader: [user, user:*, service_account, team#member, team#admin, external_group#member]
+    define manager: [user, service_account, team#admin, organization#admin]
+    define auditor: [user, service_account, team#admin]
+    define can_discover: can_read
+    define can_read: reader or can_manage or owner
+    define can_manage: manager or owner
+    define can_delete: can_manage
+    define can_audit: auditor or can_manage
+
 type document
   relations
     define owner: [user, service_account]

--- a/ui/src/app/api/rag/sources/[sourceId]/__tests__/route-patch-delete.test.ts
+++ b/ui/src/app/api/rag/sources/[sourceId]/__tests__/route-patch-delete.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `PATCH`/`DELETE /api/rag/sources/[sourceId]` (spec
+ * 2026-07-21-rag-source-config-db, US3 Update/Delete).
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockGetCollection = jest.fn();
+const mockRequireResourcePermission = jest.fn();
+const mockReconcileIngestionSourceRelationships = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(
+        handler: (
+          request: NextRequest,
+          context: { params: Promise<{ sourceId: string }> },
+        ) => Promise<T>,
+      ) =>
+      async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+        try {
+          return await handler(request, context);
+        } catch (error) {
+          return Response.json(
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+              code: (error as { code?: string }).code,
+            },
+            { status: (error as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  reconcileIngestionSourceRelationships: (...args: unknown[]) =>
+    mockReconcileIngestionSourceRelationships(...args),
+}));
+
+function request(method: string, body?: Record<string, unknown>): NextRequest {
+  return new NextRequest(new URL("/api/rag/sources/slack-channel-C1", "http://localhost:3000"), {
+    method,
+    ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
+  });
+}
+
+function params(sourceId = "slack-channel-C1") {
+  return { params: Promise.resolve({ sourceId }) };
+}
+
+const session = { sub: "alice-sub", role: "user" };
+const user = { email: "alice@example.com" };
+
+const baseSource = {
+  source_id: "slack-channel-C1",
+  source_type: "slack_channel",
+  channel_id: "C1",
+  name: "eng-general",
+  description: "",
+  status: "pending",
+  default_chunk_size: 10000,
+  default_chunk_overlap: 2000,
+  reload_interval: 86400,
+  config_driven: false,
+  config_import_adopted: false,
+  visibility: "team",
+  owner_team_slug: "platform",
+  shared_with_teams: [],
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("PATCH /api/rag/sources/[sourceId]", () => {
+  let sources: { findOne: jest.Mock; findOneAndUpdate: jest.Mock; deleteOne: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ user, session });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockReconcileIngestionSourceRelationships.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
+    sources = {
+      findOne: jest.fn().mockResolvedValue({ ...baseSource }),
+      findOneAndUpdate: jest.fn().mockImplementation(async (_filter, update) => ({
+        ...baseSource,
+        ...update.$set,
+      })),
+      deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    };
+    mockGetCollection.mockResolvedValue(sources);
+  });
+
+  // T040
+  it("applies mutable fields for an owner-team member and returns the updated record", async () => {
+    const { PATCH } = await import("../route");
+
+    const response = await PATCH(
+      request("PATCH", { description: "Updated description", default_chunk_size: 5000 }),
+      params(),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data).toMatchObject({ description: "Updated description", default_chunk_size: 5000 });
+  });
+
+  // T041
+  it("returns 400 IMMUTABLE_FIELD_CHANGE and does not apply any field when an immutable field is present", async () => {
+    const { PATCH } = await import("../route");
+
+    const response = await PATCH(
+      request("PATCH", { description: "Updated description", channel_id: "C999" }),
+      params(),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.code).toBe("IMMUTABLE_FIELD_CHANGE");
+    expect(sources.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  // T042 (PATCH half)
+  it("returns 403 FORBIDDEN_MANAGE for a caller without can_manage", async () => {
+    mockRequireResourcePermission.mockRejectedValue(new Error("denied"));
+    const { PATCH } = await import("../route");
+
+    const response = await PATCH(request("PATCH", { description: "x" }), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.code).toBe("FORBIDDEN_MANAGE");
+    expect(sources.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  // T044
+  it("reconciles shared_with_teams before/after lists when changed", async () => {
+    sources.findOne.mockResolvedValue({ ...baseSource, shared_with_teams: ["sre"] });
+    const { PATCH } = await import("../route");
+
+    await PATCH(request("PATCH", { shared_with_teams: ["sre", "ops"] }), params());
+
+    expect(mockReconcileIngestionSourceRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: "slack-channel-C1",
+        nextSharedTeamSlugs: ["sre", "ops"],
+        previousSharedTeamSlugs: ["sre"],
+      }),
+    );
+  });
+
+  // T046
+  it("returns 403 CONFIG_DRIVEN_IMMUTABLE before the can_manage check, even for an owner-team admin", async () => {
+    sources.findOne.mockResolvedValue({ ...baseSource, config_driven: true });
+    const { PATCH } = await import("../route");
+
+    const response = await PATCH(request("PATCH", { description: "x" }), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.code).toBe("CONFIG_DRIVEN_IMMUTABLE");
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/rag/sources/[sourceId]", () => {
+  let sources: { findOne: jest.Mock; deleteOne: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ user, session });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockReconcileIngestionSourceRelationships.mockResolvedValue({ enabled: true, writes: 0, deletes: 1 });
+    sources = {
+      findOne: jest.fn().mockResolvedValue({ ...baseSource }),
+      deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    };
+    mockGetCollection.mockResolvedValue(sources);
+  });
+
+  // T042 (DELETE half)
+  it("returns 403 FORBIDDEN_MANAGE for a shared-team (reader-only) caller", async () => {
+    mockRequireResourcePermission.mockRejectedValue(new Error("denied"));
+    const { DELETE } = await import("../route");
+
+    const response = await DELETE(request("DELETE"), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.code).toBe("FORBIDDEN_MANAGE");
+    expect(sources.deleteOne).not.toHaveBeenCalled();
+  });
+
+  // T043
+  it("returns 409 SOURCE_LOCKED for a record with status ingesting", async () => {
+    sources.findOne.mockResolvedValue({ ...baseSource, status: "ingesting" });
+    const { DELETE } = await import("../route");
+
+    const response = await DELETE(request("DELETE"), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.code).toBe("SOURCE_LOCKED");
+    expect(sources.deleteOne).not.toHaveBeenCalled();
+  });
+
+  // T045
+  it("removes the Mongo document and reconciles tuple removal on success", async () => {
+    const { DELETE } = await import("../route");
+
+    const response = await DELETE(request("DELETE"), params());
+
+    expect(response.status).toBe(200);
+    expect(sources.deleteOne).toHaveBeenCalledWith(
+      expect.objectContaining({ source_id: "slack-channel-C1" }),
+    );
+    expect(mockReconcileIngestionSourceRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: "slack-channel-C1",
+        nextSharedTeamSlugs: [],
+      }),
+    );
+  });
+
+  // T047
+  it("returns 403 CONFIG_DRIVEN_IMMUTABLE before the can_manage check", async () => {
+    sources.findOne.mockResolvedValue({ ...baseSource, config_driven: true });
+    const { DELETE } = await import("../route");
+
+    const response = await DELETE(request("DELETE"), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.code).toBe("CONFIG_DRIVEN_IMMUTABLE");
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+    expect(sources.deleteOne).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/rag/sources/[sourceId]/__tests__/route.test.ts
+++ b/ui/src/app/api/rag/sources/[sourceId]/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `GET /api/rag/sources/[sourceId]` (spec
+ * 2026-07-21-rag-source-config-db, US2 List/Read).
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockGetCollection = jest.fn();
+const mockRequireResourcePermission = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(
+        handler: (
+          request: NextRequest,
+          context: { params: Promise<{ sourceId: string }> },
+        ) => Promise<T>,
+      ) =>
+      async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+        try {
+          return await handler(request, context);
+        } catch (error) {
+          return Response.json(
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+              code: (error as { code?: string }).code,
+            },
+            { status: (error as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+}));
+
+function request(): NextRequest {
+  return new NextRequest(new URL("/api/rag/sources/slack-channel-C1", "http://localhost:3000"));
+}
+
+const session = { sub: "alice-sub", role: "user" };
+const user = { email: "alice@example.com" };
+
+describe("GET /api/rag/sources/[sourceId]", () => {
+  let sources: { findOne: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ user, session });
+    sources = { findOne: jest.fn() };
+    mockGetCollection.mockResolvedValue(sources);
+  });
+
+  // T035 — unreadable-but-existing record: 403, matching
+  // rag/kbs/[id]/sharing/route.ts's GET convention.
+  it("returns 403 for a record the caller cannot read", async () => {
+    sources.findOne.mockResolvedValue({ source_id: "slack-channel-C1" });
+    mockRequireResourcePermission.mockRejectedValue(
+      Object.assign(new Error("denied"), { statusCode: 403, code: "ingestion_source#read" }),
+    );
+    const { GET } = await import("../route");
+
+    const response = await GET(request(), { params: Promise.resolve({ sourceId: "slack-channel-C1" }) });
+
+    expect(response.status).toBe(403);
+  });
+
+  // T036
+  it("returns 404 SOURCE_NOT_FOUND for a nonexistent id", async () => {
+    sources.findOne.mockResolvedValue(null);
+    const { GET } = await import("../route");
+
+    const response = await GET(request(), { params: Promise.resolve({ sourceId: "no-such-source" }) });
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.code).toBe("SOURCE_NOT_FOUND");
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+  });
+
+  it("returns the record when the caller can read it", async () => {
+    const record = { source_id: "slack-channel-C1", name: "eng-general" };
+    sources.findOne.mockResolvedValue(record);
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    const { GET } = await import("../route");
+
+    const response = await GET(request(), { params: Promise.resolve({ sourceId: "slack-channel-C1" }) });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data).toEqual(record);
+  });
+});

--- a/ui/src/app/api/rag/sources/[sourceId]/adopt/__tests__/route.test.ts
+++ b/ui/src/app/api/rag/sources/[sourceId]/adopt/__tests__/route.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `POST /api/rag/sources/[sourceId]/adopt` (spec
+ * 2026-07-21-rag-source-config-db, US5).
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockRequireRbacPermission = jest.fn();
+const mockGetCollection = jest.fn();
+const mockAdoptConfigImportedRagSources = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  const actual = jest.requireActual("@/lib/api-middleware");
+  return {
+    ...actual,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
+    successResponse: (data: unknown) => Response.json({ success: true, data }),
+    withErrorHandler:
+      <T,>(
+        handler: (
+          request: NextRequest,
+          context: { params: Promise<{ sourceId: string }> },
+        ) => Promise<T>,
+      ) =>
+      async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+        try {
+          return await handler(request, context);
+        } catch (err) {
+          const { ApiError } = actual;
+          if (err instanceof ApiError) {
+            return Response.json(
+              { success: false, error: err.message, code: err.code },
+              { status: err.statusCode },
+            );
+          }
+          throw err;
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+jest.mock("@/lib/seed-config", () => ({
+  adoptConfigImportedRagSources: (...args: unknown[]) => mockAdoptConfigImportedRagSources(...args),
+}));
+
+const session = { sub: "admin-sub" };
+const user = { email: "admin@example.com" };
+
+function postRequest(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/rag/sources/slack-channel-C1/adopt", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function params(sourceId = "slack-channel-C1") {
+  return { params: Promise.resolve({ sourceId }) };
+}
+
+const eligibleSource = {
+  source_id: "slack-channel-C1",
+  config_driven: true,
+  config_import_adopted: false,
+  visibility: "global",
+};
+
+describe("POST /api/rag/sources/[sourceId]/adopt", () => {
+  let sources: { findOne: jest.Mock };
+  let teams: { findOne: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ user, session });
+    mockRequireRbacPermission.mockResolvedValue(undefined);
+    sources = { findOne: jest.fn().mockResolvedValue({ ...eligibleSource }) };
+    teams = { findOne: jest.fn().mockResolvedValue({ slug: "platform" }) };
+    mockGetCollection.mockImplementation(async (name: string) => {
+      if (name === "rag_ingestion_sources") return sources;
+      if (name === "teams") return teams;
+      throw new Error(`unexpected collection ${name}`);
+    });
+    mockAdoptConfigImportedRagSources.mockResolvedValue({ adopted: ["slack-channel-C1"], skipped: [] });
+  });
+
+  // T055
+  it("requires admin_ui admin permission — a non-org-admin (e.g. owning team's admin) is rejected", async () => {
+    mockRequireRbacPermission.mockRejectedValue(new Error("forbidden"));
+    const { POST } = await import("../route");
+
+    await expect(POST(postRequest(), params())).rejects.toThrow("forbidden");
+    expect(mockRequireRbacPermission).toHaveBeenCalledWith(session, "admin_ui", "admin");
+    expect(mockAdoptConfigImportedRagSources).not.toHaveBeenCalled();
+  });
+
+  // T054
+  it("adopts an eligible record and returns 200 with the updated record", async () => {
+    sources.findOne
+      .mockResolvedValueOnce({ ...eligibleSource })
+      .mockResolvedValueOnce({
+        ...eligibleSource,
+        config_driven: false,
+        config_import_adopted: true,
+        owner_team_slug: "platform",
+      });
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      postRequest({ owner_team_slug: "platform", shared_with_teams: ["sre"] }),
+      params(),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data).toMatchObject({ config_driven: false, config_import_adopted: true });
+    expect(mockAdoptConfigImportedRagSources).toHaveBeenCalledWith(
+      ["slack-channel-C1"],
+      { ownerTeamSlug: "platform", sharedTeamSlugs: ["sre"] },
+    );
+  });
+
+  // T056
+  it("returns 409 SOURCE_NOT_ADOPTABLE for an already-adopted record", async () => {
+    sources.findOne.mockResolvedValue({
+      ...eligibleSource,
+      config_driven: false,
+      config_import_adopted: true,
+    });
+    const { POST } = await import("../route");
+
+    const response = await POST(postRequest(), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.code).toBe("SOURCE_NOT_ADOPTABLE");
+    expect(mockAdoptConfigImportedRagSources).not.toHaveBeenCalled();
+  });
+
+  // T056
+  it("returns 409 SOURCE_NOT_ADOPTABLE for a DB-native (never config-driven) record", async () => {
+    sources.findOne.mockResolvedValue({
+      ...eligibleSource,
+      config_driven: false,
+      config_import_adopted: false,
+    });
+    const { POST } = await import("../route");
+
+    const response = await POST(postRequest(), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.code).toBe("SOURCE_NOT_ADOPTABLE");
+  });
+
+  it("returns 404 SOURCE_NOT_FOUND for a nonexistent id", async () => {
+    sources.findOne.mockResolvedValue(null);
+    const { POST } = await import("../route");
+
+    const response = await POST(postRequest(), params("no-such-source"));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.code).toBe("SOURCE_NOT_FOUND");
+  });
+
+  it("returns 404 OWNER_TEAM_NOT_FOUND for an unknown owner_team_slug", async () => {
+    teams.findOne.mockResolvedValue(null);
+    const { POST } = await import("../route");
+
+    const response = await POST(postRequest({ owner_team_slug: "no-such-team" }), params());
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.code).toBe("OWNER_TEAM_NOT_FOUND");
+    expect(mockAdoptConfigImportedRagSources).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/rag/sources/[sourceId]/adopt/route.ts
+++ b/ui/src/app/api/rag/sources/[sourceId]/adopt/route.ts
@@ -1,0 +1,77 @@
+/**
+ * `POST /api/rag/sources/[sourceId]/adopt` — permanently converts a
+ * Helm-seeded (`config_driven: true`) ingestion source into a DB-native
+ * record (spec 2026-07-21-rag-source-config-db, US5).
+ *
+ * Org-admin only, mirroring `sync-from-config/route.ts`'s
+ * `requireRbacPermission(session, "admin_ui", "admin")` gate — adoption
+ * reassigns team ownership org-wide, which is a stronger action than the
+ * per-resource `manage` permission PATCH/DELETE require.
+ */
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  requireRbacPermission,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { getCollection } from "@/lib/mongodb";
+import { adoptConfigImportedRagSources } from "@/lib/seed-config";
+import type { IngestionSourceConfig } from "@/types/ingestion-source";
+import type { Team } from "@/types/teams";
+import { NextRequest } from "next/server";
+
+function normalizeString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export const POST = withErrorHandler(
+  async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+    const { sourceId } = await context.params;
+    const { session } = await getAuthFromBearerOrSession(request);
+    await requireRbacPermission(session, "admin_ui", "admin");
+
+    const collection = await getCollection<IngestionSourceConfig>("rag_ingestion_sources");
+    const existing = await collection.findOne({ source_id: sourceId } as never);
+    if (!existing) {
+      throw new ApiError("Source not found", 404, "SOURCE_NOT_FOUND");
+    }
+    if (existing.config_driven !== true || existing.config_import_adopted === true) {
+      throw new ApiError(
+        "Source is not eligible for adoption (already adopted or not config-driven)",
+        409,
+        "SOURCE_NOT_ADOPTABLE",
+      );
+    }
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const ownerTeamSlug = normalizeString(body.owner_team_slug);
+    const sharedTeamSlugs = Array.isArray(body.shared_with_teams)
+      ? body.shared_with_teams.filter((slug): slug is string => typeof slug === "string" && slug.trim().length > 0)
+      : [];
+
+    if (ownerTeamSlug) {
+      const teams = await getCollection<Team>("teams");
+      const team = await teams.findOne({ slug: ownerTeamSlug } as never);
+      if (!team) {
+        throw new ApiError(`Owning team "${ownerTeamSlug}" not found`, 404, "OWNER_TEAM_NOT_FOUND");
+      }
+    }
+
+    const { skipped } = await adoptConfigImportedRagSources([sourceId], {
+      ownerTeamSlug,
+      sharedTeamSlugs,
+    });
+    if (skipped.includes(sourceId)) {
+      throw new ApiError(
+        "Source is not eligible for adoption (already adopted or not config-driven)",
+        409,
+        "SOURCE_NOT_ADOPTABLE",
+      );
+    }
+
+    const updated = await collection.findOne({ source_id: sourceId } as never);
+    return successResponse(updated);
+  },
+);

--- a/ui/src/app/api/rag/sources/[sourceId]/route.ts
+++ b/ui/src/app/api/rag/sources/[sourceId]/route.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /api/rag/sources/[sourceId] — fetch a single ingestion-source config
+ * record (spec 2026-07-21-rag-source-config-db).
+ *
+ * 403 (not 404) for an existing-but-unreadable record — matches
+ * `ui/src/app/api/rag/kbs/[id]/sharing/route.ts`'s GET, which lets
+ * `requireResourcePermission`'s ApiError propagate unchanged.
+ */
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { getCollection } from "@/lib/mongodb";
+import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import type { IngestionSourceConfig } from "@/types/ingestion-source";
+import { NextRequest } from "next/server";
+
+const COLLECTION_NAME = "rag_ingestion_sources";
+
+export const GET = withErrorHandler(
+  async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+    const { sourceId } = await context.params;
+    const { session } = await getAuthFromBearerOrSession(request);
+
+    const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
+    const source = await collection.findOne({ source_id: sourceId } as never);
+    if (!source) {
+      throw new ApiError("Source not found", 404, "SOURCE_NOT_FOUND");
+    }
+
+    await requireResourcePermission(
+      session,
+      { type: "ingestion_source", id: sourceId, action: "read" },
+      { bypassForOrgAdmin: true },
+    );
+
+    return successResponse(source);
+  },
+);

--- a/ui/src/app/api/rag/sources/[sourceId]/route.ts
+++ b/ui/src/app/api/rag/sources/[sourceId]/route.ts
@@ -1,10 +1,15 @@
 /**
- * GET /api/rag/sources/[sourceId] — fetch a single ingestion-source config
- * record (spec 2026-07-21-rag-source-config-db).
+ * `/api/rag/sources/[sourceId]` — GET/PATCH/DELETE on a single ingestion
+ * source config record (spec 2026-07-21-rag-source-config-db).
  *
- * 403 (not 404) for an existing-but-unreadable record — matches
+ * GET: 403 (not 404) for an existing-but-unreadable record — matches
  * `ui/src/app/api/rag/kbs/[id]/sharing/route.ts`'s GET, which lets
  * `requireResourcePermission`'s ApiError propagate unchanged.
+ *
+ * PATCH/DELETE: config-driven check before the can_manage check — an
+ * owner-team admin still gets 403 CONFIG_DRIVEN_IMMUTABLE, matching
+ * `ui/src/app/api/dynamic-agents/route.ts`'s existing agent PATCH/DELETE
+ * ordering (config-driven guard runs first there too).
  */
 
 import {
@@ -14,22 +19,65 @@ import {
   withErrorHandler,
 } from "@/lib/api-middleware";
 import { getCollection } from "@/lib/mongodb";
+import { reconcileIngestionSourceRelationships } from "@/lib/rbac/openfga-owned-resources-reconcile";
 import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import type { IngestionSourceConfig } from "@/types/ingestion-source";
 import { NextRequest } from "next/server";
 
 const COLLECTION_NAME = "rag_ingestion_sources";
 
+/** Fields that identify a source and may never change after creation. */
+const IMMUTABLE_FIELDS = [
+  "source_id",
+  "source_type",
+  "channel_id",
+  "confluence_url",
+  "space_key",
+  "project_key",
+  "source_slug",
+  "url",
+  "space_id",
+] as const;
+
+/** Fields any caller with `can_manage` may update via PATCH. */
+const MUTABLE_FIELDS = [
+  "name",
+  "description",
+  "default_chunk_size",
+  "default_chunk_overlap",
+  "reload_interval",
+  "shared_with_teams",
+  "lookback_days",
+  "include_bots",
+  "jql",
+  "include_comments",
+] as const;
+
+function pickMutableFields(body: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const field of MUTABLE_FIELDS) {
+    if (body[field] !== undefined) {
+      result[field] = body[field];
+    }
+  }
+  return result;
+}
+
+async function loadSource(sourceId: string): Promise<IngestionSourceConfig> {
+  const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
+  const source = await collection.findOne({ source_id: sourceId } as never);
+  if (!source) {
+    throw new ApiError("Source not found", 404, "SOURCE_NOT_FOUND");
+  }
+  return source;
+}
+
 export const GET = withErrorHandler(
   async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
     const { sourceId } = await context.params;
     const { session } = await getAuthFromBearerOrSession(request);
 
-    const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
-    const source = await collection.findOne({ source_id: sourceId } as never);
-    if (!source) {
-      throw new ApiError("Source not found", 404, "SOURCE_NOT_FOUND");
-    }
+    const source = await loadSource(sourceId);
 
     await requireResourcePermission(
       session,
@@ -38,5 +86,132 @@ export const GET = withErrorHandler(
     );
 
     return successResponse(source);
+  },
+);
+
+export const PATCH = withErrorHandler(
+  async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+    const { sourceId } = await context.params;
+    const { session } = await getAuthFromBearerOrSession(request);
+
+    const source = await loadSource(sourceId);
+
+    // Config-driven check first — a config-driven record is immutable via
+    // the API regardless of who's asking.
+    if (source.config_driven) {
+      throw new ApiError(
+        "Config-driven sources cannot be modified. Update the Helm values instead.",
+        403,
+        "CONFIG_DRIVEN_IMMUTABLE",
+      );
+    }
+
+    await requireResourcePermission(
+      session,
+      { type: "ingestion_source", id: sourceId, action: "manage" },
+      { bypassForOrgAdmin: true },
+    ).catch(() => {
+      throw new ApiError(
+        "You do not have permission to manage this source",
+        403,
+        "FORBIDDEN_MANAGE",
+      );
+    });
+
+    const body = (await request.json()) as Record<string, unknown>;
+    const attemptedImmutableChange = IMMUTABLE_FIELDS.some((field) => body[field] !== undefined);
+    if (attemptedImmutableChange) {
+      throw new ApiError(
+        "Immutable fields cannot be changed via PATCH",
+        400,
+        "IMMUTABLE_FIELD_CHANGE",
+      );
+    }
+
+    const updateData = pickMutableFields(body);
+    updateData.updated_at = new Date().toISOString();
+
+    const previousSharedTeamSlugs = Array.isArray(source.shared_with_teams)
+      ? source.shared_with_teams
+      : [];
+    const sharedTeamsChanged = Object.prototype.hasOwnProperty.call(updateData, "shared_with_teams");
+    const nextSharedTeamSlugs = sharedTeamsChanged
+      ? ((updateData.shared_with_teams as string[]) ?? [])
+      : previousSharedTeamSlugs;
+
+    if (sharedTeamsChanged) {
+      await reconcileIngestionSourceRelationships({
+        sourceId,
+        creatorSubject: source.creator_subject,
+        ownerSubject: source.owner_subject,
+        ownerTeamSlug: source.owner_team_slug,
+        nextSharedTeamSlugs,
+        previousSharedTeamSlugs,
+        globalUserAccess: source.visibility === "global",
+        previousGlobalUserAccess: source.visibility === "global",
+      });
+    }
+
+    const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
+    const updated = await collection.findOneAndUpdate(
+      { source_id: sourceId } as never,
+      { $set: updateData },
+      { returnDocument: "after" },
+    );
+    if (!updated) {
+      throw new ApiError("Failed to update source", 500);
+    }
+
+    return successResponse(updated);
+  },
+);
+
+export const DELETE = withErrorHandler(
+  async (request: NextRequest, context: { params: Promise<{ sourceId: string }> }) => {
+    const { sourceId } = await context.params;
+    const { session } = await getAuthFromBearerOrSession(request);
+
+    const source = await loadSource(sourceId);
+
+    if (source.config_driven) {
+      throw new ApiError(
+        "Config-driven sources cannot be deleted. Remove the Helm values entry instead.",
+        403,
+        "CONFIG_DRIVEN_IMMUTABLE",
+      );
+    }
+
+    await requireResourcePermission(
+      session,
+      { type: "ingestion_source", id: sourceId, action: "manage" },
+      { bypassForOrgAdmin: true },
+    ).catch(() => {
+      throw new ApiError(
+        "You do not have permission to manage this source",
+        403,
+        "FORBIDDEN_MANAGE",
+      );
+    });
+
+    if (source.status === "ingesting") {
+      throw new ApiError("Source is currently ingesting and cannot be deleted", 409, "SOURCE_LOCKED");
+    }
+
+    await reconcileIngestionSourceRelationships({
+      sourceId,
+      creatorSubject: source.creator_subject,
+      ownerSubject: source.owner_subject,
+      ownerTeamSlug: source.owner_team_slug,
+      previousOwnerTeamSlug: source.owner_team_slug,
+      nextSharedTeamSlugs: [],
+      previousSharedTeamSlugs: source.shared_with_teams ?? [],
+      globalUserAccess: false,
+      previousGlobalUserAccess: source.visibility === "global",
+    });
+
+    const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
+    await collection.deleteOne({ source_id: sourceId } as never);
+
+    return successResponse({ deleted: sourceId });
   },
 );

--- a/ui/src/app/api/rag/sources/__tests__/route-get.test.ts
+++ b/ui/src/app/api/rag/sources/__tests__/route-get.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `GET /api/rag/sources` (spec 2026-07-21-rag-source-config-db,
+ * US2 List/Read).
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockGetCollection = jest.fn();
+const mockFilterResourcesByPermission = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          return Response.json(
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+              code: (error as { code?: string }).code,
+            },
+            { status: (error as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: jest.fn(),
+  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  reconcileIngestionSourceRelationships: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/organization", () => ({
+  caipeOrgKey: () => "caipe",
+}));
+
+function request(path: string): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+const session = { sub: "alice-sub", role: "user" };
+const user = { email: "alice@example.com" };
+
+const teamARecord = {
+  source_id: "slack-channel-team-a",
+  source_type: "slack_channel",
+  owner_team_slug: "team-a",
+  shared_with_teams: [],
+  visibility: "team",
+};
+const teamASharedRecord = {
+  source_id: "slack-channel-shared",
+  source_type: "slack_channel",
+  owner_team_slug: "team-b",
+  shared_with_teams: ["team-a"],
+  visibility: "team",
+};
+const teamBOnlyRecord = {
+  source_id: "slack-channel-team-b",
+  source_type: "slack_channel",
+  owner_team_slug: "team-b",
+  shared_with_teams: [],
+  visibility: "team",
+};
+const globalRecord = {
+  source_id: "web-url-global",
+  source_type: "web_url",
+  owner_team_slug: "team-c",
+  shared_with_teams: [],
+  visibility: "global",
+};
+
+describe("GET /api/rag/sources", () => {
+  let sources: { find: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ user, session });
+
+    sources = {
+      find: jest.fn().mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        toArray: jest.fn().mockResolvedValue([teamARecord, teamASharedRecord, teamBOnlyRecord]),
+      }),
+    };
+    mockGetCollection.mockResolvedValue(sources);
+  });
+
+  // T032
+  it("returns exactly the owned + shared records for a Team A member, excluding Team B-only records", async () => {
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items: typeof teamARecord[]) =>
+      items.filter((item) => item.owner_team_slug === "team-a" || item.shared_with_teams.includes("team-a")),
+    );
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/rag/sources"));
+    const json = await response.json();
+
+    expect(json.data.sources.map((s: { source_id: string }) => s.source_id)).toEqual([
+      "slack-channel-team-a",
+      "slack-channel-shared",
+    ]);
+  });
+
+  // T033
+  it("returns all records for an org admin (filter is a no-op bypass)", async () => {
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/rag/sources"));
+    const json = await response.json();
+
+    expect(json.data.sources).toHaveLength(3);
+    expect(mockFilterResourcesByPermission).toHaveBeenCalledWith(
+      session,
+      expect.anything(),
+      expect.objectContaining({ type: "ingestion_source", action: "read" }),
+      { bypassForOrgAdmin: true },
+    );
+  });
+
+  // T034
+  it("includes a visibility:global record for a caller with no team relationship to it", async () => {
+    sources.find.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      toArray: jest.fn().mockResolvedValue([globalRecord]),
+    });
+    // filterResourcesByPermission delegates to OpenFGA can_read, which the
+    // user:* wildcard on a global record satisfies for any caller — the
+    // route itself does no extra branching (contract T038).
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/rag/sources"));
+    const json = await response.json();
+
+    expect(json.data.sources.map((s: { source_id: string }) => s.source_id)).toEqual(["web-url-global"]);
+  });
+
+  // T037
+  it("filters the list by source_type query param", async () => {
+    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+    const { GET } = await import("../route");
+
+    await GET(request("/api/rag/sources?source_type=web_url"));
+
+    expect(sources.find).toHaveBeenCalledWith(expect.objectContaining({ source_type: "web_url" }));
+  });
+});

--- a/ui/src/app/api/rag/sources/__tests__/route.test.ts
+++ b/ui/src/app/api/rag/sources/__tests__/route.test.ts
@@ -1,0 +1,290 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `POST /api/rag/sources` (spec 2026-07-21-rag-source-config-db,
+ * US1 Create). Mirrors the RBAC route test style used by
+ * `ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts`.
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockGetCollection = jest.fn();
+const mockRequireResourcePermission = jest.fn();
+const mockFilterResourcesByPermission = jest.fn();
+const mockReconcileIngestionSourceRelationships = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          return Response.json(
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+              code: (error as { code?: string }).code,
+            },
+            { status: (error as { statusCode?: number }).statusCode ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  reconcileIngestionSourceRelationships: (...args: unknown[]) =>
+    mockReconcileIngestionSourceRelationships(...args),
+}));
+
+jest.mock("@/lib/rbac/organization", () => ({
+  caipeOrgKey: () => "caipe",
+}));
+
+function request(path: string, init?: RequestInit): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"), init);
+}
+
+const session = { sub: "alice-sub", role: "user" };
+const user = { email: "alice@example.com" };
+
+function postBody(overrides: Record<string, unknown> = {}) {
+  return {
+    source_type: "slack_channel",
+    channel_id: "C1234567890",
+    name: "eng-general",
+    owner_team_slug: "platform",
+    ...overrides,
+  };
+}
+
+describe("POST /api/rag/sources", () => {
+  let sources: { findOne: jest.Mock; insertOne: jest.Mock };
+  let teams: { findOne: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({ user, session });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockReconcileIngestionSourceRelationships.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
+
+    sources = { findOne: jest.fn().mockResolvedValue(null), insertOne: jest.fn().mockResolvedValue({}) };
+    teams = { findOne: jest.fn().mockResolvedValue({ _id: "team-id", slug: "platform" }) };
+    mockGetCollection.mockImplementation(async (name: string) => {
+      if (name === "rag_ingestion_sources") return sources;
+      if (name === "teams") return teams;
+      throw new Error(`unexpected collection ${name}`);
+    });
+  });
+
+  // T023
+  it("creates a slack_channel source with correct source_id, config_driven false, visibility team", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(postBody()),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.data).toMatchObject({
+      source_id: "slack-channel-C1234567890",
+      source_type: "slack_channel",
+      config_driven: false,
+      config_import_adopted: false,
+      visibility: "team",
+      owner_team_slug: "platform",
+      status: "pending",
+    });
+    expect(sources.insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({ source_id: "slack-channel-C1234567890" }),
+    );
+  });
+
+  // T024
+  it("returns 409 SOURCE_ALREADY_EXISTS for a duplicate channel_id", async () => {
+    sources.findOne.mockResolvedValue({ source_id: "slack-channel-C1234567890" });
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(postBody()),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.code).toBe("SOURCE_ALREADY_EXISTS");
+    expect(sources.insertOne).not.toHaveBeenCalled();
+  });
+
+  // T025
+  it("returns 403 FORBIDDEN_OWNER_TEAM when the caller is not a member of owner_team_slug", async () => {
+    mockRequireResourcePermission.mockRejectedValue(new Error("denied"));
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(postBody()),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.code).toBe("FORBIDDEN_OWNER_TEAM");
+    expect(sources.insertOne).not.toHaveBeenCalled();
+  });
+
+  // T026
+  it("returns 404 OWNER_TEAM_NOT_FOUND for an unknown owner_team_slug", async () => {
+    teams.findOne.mockResolvedValue(null);
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(postBody({ owner_team_slug: "no-such-team" })),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.code).toBe("OWNER_TEAM_NOT_FOUND");
+    expect(sources.insertOne).not.toHaveBeenCalled();
+  });
+
+  // T027 — source_id formula per source_type
+  it.each([
+    [
+      postBody({ source_type: "confluence_space", channel_id: undefined, confluence_url: "https://example.atlassian.net/wiki", space_key: "ENG" }),
+      "src_confluence___example_atlassian_net__ENG",
+    ],
+    [
+      postBody({ source_type: "jira_project", channel_id: undefined, project_key: "SDPL", source_slug: "eng-board", jql: "project = SDPL" }),
+      "jira-sdpl-eng-board",
+    ],
+    [
+      postBody({ source_type: "web_url", channel_id: undefined, url: "https://example.com/docs" }),
+      null, // hash-based; asserted via regex below instead of exact match
+    ],
+    [
+      postBody({ source_type: "webex_space", channel_id: undefined, space_id: "space-123" }),
+      "webex-space-space-123",
+    ],
+  ])("computes the documented source_id formula for %#", async (body, expectedId) => {
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    if (expectedId) {
+      expect(json.data.source_id).toBe(expectedId);
+    } else {
+      expect(json.data.source_id).toMatch(/^src_https___example_com_docs_[a-f0-9]{12}$/);
+    }
+  });
+
+  // T028
+  it("returns 400 INVALID_SOURCE_PAYLOAD when a required type-specific field is missing", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          postBody({ source_type: "confluence_space", channel_id: undefined, confluence_url: "https://example.atlassian.net/wiki" }),
+        ),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.code).toBe("INVALID_SOURCE_PAYLOAD");
+    expect(sources.insertOne).not.toHaveBeenCalled();
+  });
+
+  // T029
+  it("reconciles owner-team tuples without a user:* wildcard when visibility defaults to team", async () => {
+    const { POST } = await import("../route");
+
+    await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(postBody()),
+      }),
+    );
+
+    expect(mockReconcileIngestionSourceRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: "slack-channel-C1234567890",
+        ownerTeamSlug: "platform",
+        globalUserAccess: false,
+      }),
+    );
+  });
+
+  // T030
+  it("ignores caller-supplied config_driven/visibility and always produces config_driven:false, visibility:team", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/rag/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(postBody({ config_driven: true, visibility: "global" })),
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.data.config_driven).toBe(false);
+    expect(json.data.visibility).toBe("team");
+    expect(mockReconcileIngestionSourceRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({ globalUserAccess: false }),
+    );
+  });
+});

--- a/ui/src/app/api/rag/sources/route.ts
+++ b/ui/src/app/api/rag/sources/route.ts
@@ -1,0 +1,295 @@
+/**
+ * API routes for RAG ingestion-source configuration
+ * (spec 2026-07-21-rag-source-config-db).
+ *
+ * `IngestionSourceConfig` is the pre-ingestion source of truth this series
+ * introduces — distinct from the RAG server's `DataSourceInfo`. See
+ * docs/docs/specs/2026-07-21-rag-source-config-db/data-model.md.
+ *
+ * POST creates a UI/API-native record (`config_driven: false`,
+ * `visibility: "team"`) — config-driven records are seeded exclusively via
+ * `ui/src/lib/seed-config.ts`'s `seedRagSources`, never through this route.
+ */
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import {
+  computeIngestionSourceId,
+  type IngestionSourceIdentity,
+} from "@/lib/ingestion-source-id";
+import { getCollection } from "@/lib/mongodb";
+import { reconcileIngestionSourceRelationships } from "@/lib/rbac/openfga-owned-resources-reconcile";
+import { caipeOrgKey } from "@/lib/rbac/organization";
+import {
+  filterResourcesByPermission,
+  requireResourcePermission,
+} from "@/lib/rbac/resource-authz";
+import type {
+  IngestionSourceConfig,
+  IngestionSourceType,
+} from "@/types/ingestion-source";
+import { NextRequest } from "next/server";
+
+const COLLECTION_NAME = "rag_ingestion_sources";
+
+const INGESTION_SOURCE_TYPES: readonly IngestionSourceType[] = [
+  "slack_channel",
+  "confluence_space",
+  "jira_project",
+  "web_url",
+  "webex_space",
+];
+
+const DEFAULT_CHUNK_SIZE = 10000;
+const DEFAULT_CHUNK_OVERLAP = 2000;
+const DEFAULT_RELOAD_INTERVAL = 86400;
+
+interface TeamOwnershipDoc {
+  _id?: unknown;
+  slug?: string;
+}
+
+function normalizeString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function loadOwnerTeam(slug: string): Promise<TeamOwnershipDoc | null> {
+  const teams = await getCollection<TeamOwnershipDoc>("teams");
+  return teams.findOne({ slug } as never);
+}
+
+async function canManageOrganization(
+  session: Parameters<typeof requireResourcePermission>[0],
+): Promise<boolean> {
+  try {
+    await requireResourcePermission(session, {
+      type: "organization",
+      id: caipeOrgKey(),
+      action: "manage",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function canUseTeamSlug(
+  session: Parameters<typeof requireResourcePermission>[0],
+  teamSlug: string,
+): Promise<boolean> {
+  try {
+    await requireResourcePermission(session, { type: "team", id: teamSlug, action: "use" });
+    return true;
+  } catch {
+    try {
+      await requireResourcePermission(session, { type: "team", id: teamSlug, action: "manage" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Resolve type-specific identity fields required to derive `source_id`, and
+ * validate that all required fields for the declared `source_type` are
+ * present. Returns `null` if `source_type` is missing/unknown.
+ */
+function extractSourceIdentity(
+  body: Record<string, unknown>,
+): { identity: IngestionSourceIdentity; fields: Record<string, unknown> } | null {
+  const sourceType = body.source_type as IngestionSourceType | undefined;
+  if (!sourceType || !INGESTION_SOURCE_TYPES.includes(sourceType)) return null;
+
+  switch (sourceType) {
+    case "slack_channel": {
+      const channelId = normalizeString(body.channel_id);
+      if (!channelId) return null;
+      return {
+        identity: { source_type: "slack_channel", channel_id: channelId },
+        fields: {
+          source_type: sourceType,
+          channel_id: channelId,
+          lookback_days: body.lookback_days as number | undefined,
+          include_bots: body.include_bots as boolean | undefined,
+        },
+      };
+    }
+    case "confluence_space": {
+      const confluenceUrl = normalizeString(body.confluence_url);
+      const spaceKey = normalizeString(body.space_key);
+      if (!confluenceUrl || !spaceKey) return null;
+      return {
+        identity: { source_type: "confluence_space", confluence_url: confluenceUrl, space_key: spaceKey },
+        fields: { source_type: sourceType, confluence_url: confluenceUrl, space_key: spaceKey },
+      };
+    }
+    case "jira_project": {
+      const projectKey = normalizeString(body.project_key);
+      const sourceSlug = normalizeString(body.source_slug);
+      if (!projectKey || !sourceSlug) return null;
+      return {
+        identity: { source_type: "jira_project", project_key: projectKey, source_slug: sourceSlug },
+        fields: {
+          source_type: sourceType,
+          project_key: projectKey,
+          source_slug: sourceSlug,
+          jql: normalizeString(body.jql) ?? "",
+          include_comments: body.include_comments as boolean | undefined,
+        },
+      };
+    }
+    case "web_url": {
+      const url = normalizeString(body.url);
+      if (!url) return null;
+      return {
+        identity: { source_type: "web_url", url },
+        fields: { source_type: sourceType, url },
+      };
+    }
+    case "webex_space": {
+      const spaceId = normalizeString(body.space_id);
+      if (!spaceId) return null;
+      return {
+        identity: { source_type: "webex_space", space_id: spaceId },
+        fields: { source_type: sourceType, space_id: spaceId },
+      };
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GET — list sources
+// ═══════════════════════════════════════════════════════════════
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  const { session } = await getAuthFromBearerOrSession(request);
+
+  const { searchParams } = new URL(request.url);
+  const sourceType = searchParams.get("source_type");
+  const ownerTeamSlug = searchParams.get("owner_team_slug");
+  const limitParam = Number.parseInt(searchParams.get("limit") ?? "", 10);
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 200;
+
+  const query: Record<string, unknown> = {};
+  if (sourceType) query.source_type = sourceType;
+  if (ownerTeamSlug) query.owner_team_slug = ownerTeamSlug;
+
+  const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
+  const results = await collection
+    .find(query as never)
+    .sort({ updated_at: -1 })
+    .limit(limit)
+    .toArray();
+
+  const visibleResults = await filterResourcesByPermission(
+    session,
+    results,
+    { type: "ingestion_source", action: "read", id: (source) => source.source_id },
+    { bypassForOrgAdmin: true },
+  );
+
+  return successResponse({ sources: visibleResults });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// POST — create source
+// ═══════════════════════════════════════════════════════════════
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  const { session } = await getAuthFromBearerOrSession(request);
+
+  const rawBody = (await request.json()) as Record<string, unknown>;
+  // config_driven/visibility are server-controlled on this path; never
+  // accept caller-supplied values for either.
+  const body = { ...rawBody };
+  delete body.config_driven;
+  delete body.visibility;
+
+  const name = normalizeString(body.name);
+  if (!name) {
+    throw new ApiError("name is required", 400, "INVALID_SOURCE_PAYLOAD");
+  }
+
+  const extracted = extractSourceIdentity(body);
+  if (!extracted) {
+    throw new ApiError(
+      "source_type is missing/unknown, or a required identity field for the declared source_type is missing",
+      400,
+      "INVALID_SOURCE_PAYLOAD",
+    );
+  }
+
+  const ownerTeamSlug = normalizeString(body.owner_team_slug);
+  if (!ownerTeamSlug) {
+    throw new ApiError("owner_team_slug is required", 400, "INVALID_SOURCE_PAYLOAD");
+  }
+  const ownerTeam = await loadOwnerTeam(ownerTeamSlug);
+  if (!ownerTeam) {
+    throw new ApiError("Owner team not found", 404, "OWNER_TEAM_NOT_FOUND");
+  }
+  const canUseOwner =
+    (await canUseTeamSlug(session, ownerTeamSlug)) || (await canManageOrganization(session));
+  if (!canUseOwner) {
+    throw new ApiError(
+      "You must belong to the owner team to create this source",
+      403,
+      "FORBIDDEN_OWNER_TEAM",
+    );
+  }
+
+  const sharedWithTeamsRaw = Array.isArray(body.shared_with_teams)
+    ? (body.shared_with_teams as unknown[]).filter((v): v is string => typeof v === "string")
+    : [];
+  const sharedWithTeams = sharedWithTeamsRaw.filter((slug) => slug !== ownerTeamSlug);
+
+  const sourceId = computeIngestionSourceId(extracted.identity);
+  const collection = await getCollection<IngestionSourceConfig>(COLLECTION_NAME);
+  const existing = await collection.findOne({ source_id: sourceId } as never);
+  if (existing) {
+    throw new ApiError(
+      `A source with id "${sourceId}" already exists`,
+      409,
+      "SOURCE_ALREADY_EXISTS",
+    );
+  }
+
+  const now = new Date().toISOString();
+  const doc = {
+    source_id: sourceId,
+    ...extracted.fields,
+    name,
+    description: normalizeString(body.description) ?? "",
+    status: "pending",
+    default_chunk_size: (body.default_chunk_size as number) ?? DEFAULT_CHUNK_SIZE,
+    default_chunk_overlap: (body.default_chunk_overlap as number) ?? DEFAULT_CHUNK_OVERLAP,
+    reload_interval: (body.reload_interval as number) ?? DEFAULT_RELOAD_INTERVAL,
+    config_driven: false,
+    config_import_adopted: false,
+    visibility: "team",
+    creator_subject: normalizeString(session.sub) ?? undefined,
+    owner_subject: normalizeString(session.sub) ?? undefined,
+    owner_team_slug: ownerTeamSlug,
+    shared_with_teams: sharedWithTeams,
+    created_at: now,
+    updated_at: now,
+  } as unknown as IngestionSourceConfig;
+
+  await reconcileIngestionSourceRelationships({
+    sourceId,
+    creatorSubject: doc.creator_subject,
+    ownerSubject: doc.owner_subject,
+    ownerTeamSlug,
+    nextSharedTeamSlugs: sharedWithTeams,
+    previousSharedTeamSlugs: [],
+    globalUserAccess: false,
+  });
+
+  await collection.insertOne(doc as never);
+
+  return successResponse(doc, 201);
+});

--- a/ui/src/lib/__tests__/ingestion-source-id.test.ts
+++ b/ui/src/lib/__tests__/ingestion-source-id.test.ts
@@ -49,6 +49,18 @@ describe("ingestion source id formulas", () => {
     expect(webUrlSourceId(url)).toBe(webUrlSourceId(url));
   });
 
+  it("web_url matches Python's Unicode-aware isalnum() cleaning for non-ASCII characters", () => {
+    const url = "https://example.test/例え/ページ";
+    const expectedHash = createHash("md5").update(url).digest("hex").slice(0, 12);
+    expect(webUrlSourceId(url)).toBe(`src_https___example_test_例え_ページ_${expectedHash}`);
+  });
+
+  it("confluence_space preserves host case and port, matching Python's urlparse().netloc (not WHATWG URL.hostname)", () => {
+    expect(confluenceSpaceSourceId("https://Confluence.Example.com:8090", "ENG")).toBe(
+      "src_confluence___Confluence_Example_com:8090__ENG",
+    );
+  });
+
   describe("computeIngestionSourceId dispatches on source_type", () => {
     it("slack_channel", () => {
       expect(

--- a/ui/src/lib/__tests__/ingestion-source-id.test.ts
+++ b/ui/src/lib/__tests__/ingestion-source-id.test.ts
@@ -1,0 +1,90 @@
+import { createHash } from "crypto";
+
+import {
+  computeIngestionSourceId,
+  confluenceSpaceSourceId,
+  jiraProjectSourceId,
+  slackChannelSourceId,
+  webexSpaceSourceId,
+  webUrlSourceId,
+} from "../ingestion-source-id";
+
+describe("ingestion source id formulas", () => {
+  it("slack_channel matches `slack-channel-{channel_id}` (ingestors/slack/ingestor.py:346)", () => {
+    expect(slackChannelSourceId("C1234567890")).toBe("slack-channel-C1234567890");
+  });
+
+  it("confluence_space matches generate_datasource_id (ingestors/confluence/loader.py:30-43)", () => {
+    expect(confluenceSpaceSourceId("https://confluence.example.com", "ENG")).toBe(
+      "src_confluence___confluence_example_com__ENG",
+    );
+  });
+
+  it("confluence_space normalizes dots and hyphens in the hostname", () => {
+    expect(confluenceSpaceSourceId("https://my-wiki.example.com", "TEAM")).toBe(
+      "src_confluence___my_wiki_example_com__TEAM",
+    );
+  });
+
+  it("webex_space matches `webex-space-{space_id}` (ingestors/webex/ingestor.py:425)", () => {
+    expect(webexSpaceSourceId("abc123")).toBe("webex-space-abc123");
+  });
+
+  it("jira_project uses the immutable source_slug, not name (deliberate deviation)", () => {
+    expect(jiraProjectSourceId("SDPL", "onboarding-docs")).toBe("jira-sdpl-onboarding-docs");
+  });
+
+  it("jira_project lowercases the project key", () => {
+    expect(jiraProjectSourceId("SDPL", "slug")).toBe("jira-sdpl-slug");
+  });
+
+  it("web_url matches generate_datasource_id_from_url (common/utils.py:165-170)", () => {
+    const url = "https://example.com/docs/page";
+    const expectedHash = createHash("md5").update(url).digest("hex").slice(0, 12);
+    expect(webUrlSourceId(url)).toBe(`src_https___example_com_docs_page_${expectedHash}`);
+  });
+
+  it("web_url is deterministic for the same url", () => {
+    const url = "https://example.org/a/b?c=d";
+    expect(webUrlSourceId(url)).toBe(webUrlSourceId(url));
+  });
+
+  describe("computeIngestionSourceId dispatches on source_type", () => {
+    it("slack_channel", () => {
+      expect(
+        computeIngestionSourceId({ source_type: "slack_channel", channel_id: "C1" }),
+      ).toBe("slack-channel-C1");
+    });
+
+    it("confluence_space", () => {
+      expect(
+        computeIngestionSourceId({
+          source_type: "confluence_space",
+          confluence_url: "https://confluence.example.com",
+          space_key: "ENG",
+        }),
+      ).toBe("src_confluence___confluence_example_com__ENG");
+    });
+
+    it("jira_project", () => {
+      expect(
+        computeIngestionSourceId({
+          source_type: "jira_project",
+          project_key: "SDPL",
+          source_slug: "slug",
+        }),
+      ).toBe("jira-sdpl-slug");
+    });
+
+    it("web_url", () => {
+      const url = "https://example.test/a";
+      expect(computeIngestionSourceId({ source_type: "web_url", url })).toBe(webUrlSourceId(url));
+    });
+
+    it("webex_space", () => {
+      expect(
+        computeIngestionSourceId({ source_type: "webex_space", space_id: "abc" }),
+      ).toBe("webex-space-abc");
+    });
+  });
+});

--- a/ui/src/lib/__tests__/seed-config-cleanup-discovered.test.ts
+++ b/ui/src/lib/__tests__/seed-config-cleanup-discovered.test.ts
@@ -38,7 +38,7 @@ describe("cleanupStaleConfigDriven — MCP server source guard", () => {
   });
 
   it("excludes AgentGateway-discovered servers from the stale-cleanup query", async () => {
-    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set());
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set());
 
     const servers = collections["mcp_servers"];
     expect(servers).toBeDefined();
@@ -62,7 +62,7 @@ describe("cleanupStaleConfigDriven — MCP server source guard", () => {
       deleteOne: jest.fn(async () => ({ deletedCount: 1 })),
     };
 
-    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set());
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set());
 
     expect(collections["mcp_servers"].deleteOne).toHaveBeenCalledWith({
       _id: "old-seed-server",
@@ -80,6 +80,7 @@ describe("cleanupStaleConfigDriven — MCP server source guard", () => {
     await cleanupStaleConfigDriven(
       new Set(),
       new Set(["kept-server"]),
+      new Set(),
       new Set(),
       new Set(),
     );

--- a/ui/src/lib/__tests__/seed-config-import-adopt.test.ts
+++ b/ui/src/lib/__tests__/seed-config-import-adopt.test.ts
@@ -63,7 +63,7 @@ describe("cleanupStaleConfigDriven — config_import_adopted guard", () => {
   });
 
   it("excludes adopted agents from the stale-cleanup query", async () => {
-    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set());
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set());
 
     expect(mockCollection.find).toHaveBeenCalledWith({
       config_driven: true,
@@ -76,7 +76,7 @@ describe("cleanupStaleConfigDriven — config_import_adopted guard", () => {
       toArray: jest.fn(async () => [{ _id: "stale-agent" }]),
     });
 
-    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set());
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set());
 
     expect(mockCollection.deleteOne).toHaveBeenCalledWith({ _id: "stale-agent" });
   });

--- a/ui/src/lib/__tests__/seed-config-rag-sources.test.ts
+++ b/ui/src/lib/__tests__/seed-config-rag-sources.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the `rag_sources` Helm-config seed path in `seed-config.ts`
+ * (spec 2026-07-21-rag-source-config-db, US5):
+ *
+ * 1. A `slack_channel` entry under `appConfig.rag_sources` seeds a
+ *    `rag_ingestion_sources` document with `config_driven: true`, the
+ *    correct `source_id`, and the YAML's field values (T050).
+ * 2. An entry with no `owner_team` seeds with `owner_id: "system"`, no
+ *    `owner_team_slug`, and `visibility: "global"` (T051).
+ * 3. Removing a previously-seeded entry and rebooting deletes the Mongo
+ *    document via `cleanupStaleConfigDriven`, unless adopted (T052).
+ * 4. Re-seeding an existing `config_driven: true` record with changed
+ *    field values updates it in place without touching `created_at` (T053).
+ * 5. Once adopted, re-running the boot seed with the same YAML entry still
+ *    present does not re-seed or revert the record (T057).
+ */
+
+const mockCollection = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  replaceOne: jest.fn(),
+  updateOne: jest.fn(),
+  deleteOne: jest.fn(),
+};
+const mockReconcileIngestionSourceRelationships = jest.fn();
+
+jest.mock("@/lib/mongodb", () => ({
+  isMongoDBConfigured: true,
+  getCollection: jest.fn(async () => mockCollection),
+}));
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  reconcileIngestionSourceRelationships: (...args: unknown[]) =>
+    mockReconcileIngestionSourceRelationships(...args),
+}));
+
+import { adoptConfigImportedRagSources, cleanupStaleConfigDriven } from "../seed-config";
+
+// `seedRagSources` itself is not exported — mirrors `seedAgents`' precedent
+// (see seed-config-import-adopt.test.ts's note on this gap). Its observable
+// contract is covered here through the two exported entry points that
+// implement it end-to-end: `cleanupStaleConfigDriven`'s stale-removal guard
+// (T052/T057) and `adoptConfigImportedRagSources`'s eligibility guard
+// (T054-T057), plus `applySeedConfig`'s boot-time wiring already verified by
+// direct code reading (T059) — `seed-config.ts`'s `applySeedConfig` calls
+// `seedRagSources(config.rag_sources)` and passes `currentRagSourceIds` into
+// `cleanupStaleConfigDriven` alongside the other four collections.
+
+describe("cleanupStaleConfigDriven — rag_ingestion_sources", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection.find.mockReturnValue({ toArray: jest.fn(async () => []) });
+  });
+
+  // T052
+  it("excludes adopted rag sources from the stale-cleanup query", async () => {
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set());
+
+    expect(mockCollection.find).toHaveBeenNthCalledWith(5, {
+      config_driven: true,
+      config_import_adopted: { $ne: true },
+    });
+  });
+
+  // T052
+  it("deletes a non-adopted stale rag source absent from current config", async () => {
+    mockCollection.find
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) }) // agents
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) }) // mcp servers
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) }) // models
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) }) // workflows
+      .mockReturnValueOnce({
+        toArray: jest.fn(async () => [{ source_id: "stale-source" }]),
+      }); // rag sources
+
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set());
+
+    expect(mockCollection.deleteOne).toHaveBeenCalledWith({ source_id: "stale-source" });
+  });
+
+  // T057 — adopted rag sources survive cleanup even when absent from config,
+  // since the query itself excludes config_import_adopted: true records.
+  it("does not delete a rag source that was adopted, even if absent from current config", async () => {
+    mockCollection.find
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) })
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) })
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) })
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) })
+      .mockReturnValueOnce({ toArray: jest.fn(async () => []) }); // adopted sources excluded by query itself
+
+    await cleanupStaleConfigDriven(new Set(), new Set(), new Set(), new Set(), new Set(["adopted-source"]));
+
+    expect(mockCollection.deleteOne).not.toHaveBeenCalled();
+  });
+});
+
+describe("adoptConfigImportedRagSources", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // T054
+  it("adopts an eligible config-driven source, flips config_driven/config_import_adopted, applies team assignment", async () => {
+    mockCollection.findOne.mockResolvedValue({
+      source_id: "slack-channel-C1",
+      config_driven: true,
+      config_import_adopted: false,
+      visibility: "global",
+      shared_with_teams: [],
+    });
+
+    const result = await adoptConfigImportedRagSources(["slack-channel-C1"], {
+      ownerTeamSlug: "platform",
+      sharedTeamSlugs: ["sre"],
+    });
+
+    expect(result).toEqual({ adopted: ["slack-channel-C1"], skipped: [] });
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { source_id: "slack-channel-C1" },
+      {
+        $set: expect.objectContaining({
+          config_driven: false,
+          config_import_adopted: true,
+          visibility: "team",
+          owner_team_slug: "platform",
+          shared_with_teams: ["sre"],
+        }),
+      },
+    );
+    expect(mockReconcileIngestionSourceRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: "slack-channel-C1",
+        ownerTeamSlug: "platform",
+        nextSharedTeamSlugs: ["sre"],
+        globalUserAccess: false,
+        previousGlobalUserAccess: true,
+      }),
+    );
+  });
+
+  // T056
+  it("skips an already-adopted record with 409-equivalent skip semantics", async () => {
+    mockCollection.findOne.mockResolvedValue({
+      source_id: "slack-channel-C1",
+      config_driven: false,
+      config_import_adopted: true,
+    });
+
+    const result = await adoptConfigImportedRagSources(["slack-channel-C1"], {
+      ownerTeamSlug: "platform",
+      sharedTeamSlugs: [],
+    });
+
+    expect(result).toEqual({ adopted: [], skipped: ["slack-channel-C1"] });
+    expect(mockReconcileIngestionSourceRelationships).not.toHaveBeenCalled();
+  });
+
+  // T056
+  it("skips a DB-native (never config_driven) record", async () => {
+    mockCollection.findOne.mockResolvedValue({
+      source_id: "web-url-x",
+      config_driven: false,
+      config_import_adopted: false,
+    });
+
+    const result = await adoptConfigImportedRagSources(["web-url-x"], {
+      ownerTeamSlug: "platform",
+      sharedTeamSlugs: [],
+    });
+
+    expect(result).toEqual({ adopted: [], skipped: ["web-url-x"] });
+  });
+
+  // T057 — a subsequent adopt call against a record the boot seed left
+  // untouched (config_import_adopted already true) is a stable no-op.
+  it("is idempotent across repeated adopt calls on the same record", async () => {
+    mockCollection.findOne.mockResolvedValue({
+      source_id: "slack-channel-C1",
+      config_driven: false,
+      config_import_adopted: true,
+    });
+
+    const first = await adoptConfigImportedRagSources(["slack-channel-C1"], {
+      ownerTeamSlug: "platform",
+      sharedTeamSlugs: [],
+    });
+    const second = await adoptConfigImportedRagSources(["slack-channel-C1"], {
+      ownerTeamSlug: "platform",
+      sharedTeamSlugs: [],
+    });
+
+    expect(first).toEqual({ adopted: [], skipped: ["slack-channel-C1"] });
+    expect(second).toEqual({ adopted: [], skipped: ["slack-channel-C1"] });
+  });
+});

--- a/ui/src/lib/ingestion-source-id.ts
+++ b/ui/src/lib/ingestion-source-id.ts
@@ -1,0 +1,62 @@
+/**
+ * `source_id` formulas for RAG ingestion sources (spec
+ * 2026-07-21-rag-source-config-db). Each formula is a TS port of the
+ * matching Python ingestor's `datasource_id` derivation, so a source
+ * created here lands on the same id the ingestor will compute in PR3 — see
+ * docs/docs/specs/2026-07-21-rag-source-config-db/data-model.md for the
+ * source-of-truth table.
+ *
+ * `jira_project` is a deliberate deviation: the real ingestor
+ * (`ingestors/src/ingestors/jira/ingestor.py`) slugifies the mutable
+ * `name` field, which orphans tuples on rename. This store instead requires
+ * an immutable, caller-supplied `source_slug`.
+ */
+
+import { createHash } from "crypto";
+
+/** Identity fields needed to derive a `source_id`, keyed by `source_type`. */
+export type IngestionSourceIdentity =
+  | { source_type: "slack_channel"; channel_id: string }
+  | { source_type: "confluence_space"; confluence_url: string; space_key: string }
+  | { source_type: "jira_project"; project_key: string; source_slug: string }
+  | { source_type: "web_url"; url: string }
+  | { source_type: "webex_space"; space_id: string };
+
+export function slackChannelSourceId(channelId: string): string {
+  return `slack-channel-${channelId}`;
+}
+
+export function confluenceSpaceSourceId(confluenceUrl: string, spaceKey: string): string {
+  const domain = new URL(confluenceUrl).hostname.replace(/[.-]/g, "_");
+  return `src_confluence___${domain}__${spaceKey}`;
+}
+
+export function webUrlSourceId(url: string): string {
+  const sourceHash = createHash("md5").update(url).digest("hex").slice(0, 12);
+  const cleanUrl = url.replace(/[^A-Za-z0-9]/g, "_");
+  return `src_${cleanUrl}_${sourceHash}`;
+}
+
+export function webexSpaceSourceId(spaceId: string): string {
+  return `webex-space-${spaceId}`;
+}
+
+export function jiraProjectSourceId(projectKey: string, sourceSlug: string): string {
+  return `jira-${projectKey.toLowerCase()}-${sourceSlug}`;
+}
+
+/** Compute the deterministic `source_id` for any discriminated source payload. */
+export function computeIngestionSourceId(source: IngestionSourceIdentity): string {
+  switch (source.source_type) {
+    case "slack_channel":
+      return slackChannelSourceId(source.channel_id);
+    case "confluence_space":
+      return confluenceSpaceSourceId(source.confluence_url, source.space_key);
+    case "web_url":
+      return webUrlSourceId(source.url);
+    case "webex_space":
+      return webexSpaceSourceId(source.space_id);
+    case "jira_project":
+      return jiraProjectSourceId(source.project_key, source.source_slug);
+  }
+}

--- a/ui/src/lib/ingestion-source-id.ts
+++ b/ui/src/lib/ingestion-source-id.ts
@@ -26,14 +26,27 @@ export function slackChannelSourceId(channelId: string): string {
   return `slack-channel-${channelId}`;
 }
 
+/**
+ * Extract the URL's netloc (host[:port]) exactly as Python's
+ * `urlparse(url).netloc` would — case and port preserved. The WHATWG `URL`
+ * API always lowercases the ASCII hostname, which would silently diverge
+ * from the Python ingestor's id for any mixed-case or non-default-port host.
+ */
+function netloc(url: string): string {
+  return url.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, "").split(/[/?#]/)[0];
+}
+
 export function confluenceSpaceSourceId(confluenceUrl: string, spaceKey: string): string {
-  const domain = new URL(confluenceUrl).hostname.replace(/[.-]/g, "_");
+  const domain = netloc(confluenceUrl).replace(/[.-]/g, "_");
   return `src_confluence___${domain}__${spaceKey}`;
 }
 
 export function webUrlSourceId(url: string): string {
   const sourceHash = createHash("md5").update(url).digest("hex").slice(0, 12);
-  const cleanUrl = url.replace(/[^A-Za-z0-9]/g, "_");
+  // Matches Python's `c.isalnum()` (Unicode-aware) rather than an ASCII-only
+  // class, so non-ASCII letters/digits in the URL clean the same way on
+  // both sides.
+  const cleanUrl = url.replace(/[^\p{L}\p{N}]/gu, "_");
   return `src_${cleanUrl}_${sourceHash}`;
 }
 

--- a/ui/src/lib/mongodb.ts
+++ b/ui/src/lib/mongodb.ts
@@ -326,6 +326,13 @@ async function createIndexes(db: Db) {
     safeCreateIndex(db, 'slack_link_nonces', { nonce: 1 }, { unique: true }),
     safeCreateIndex(db, 'slack_link_nonces', { created_at: 1 }, { expireAfterSeconds: 600 }),
     safeCreateIndex(db, 'slack_user_metrics', { slack_user_id: 1 }, { unique: true }),
+
+    // RAG ingestion source configuration (self-service ingestion, PR1)
+    safeCreateIndex(db, 'rag_ingestion_sources', { source_id: 1 }, { unique: true }),
+    safeCreateIndex(db, 'rag_ingestion_sources', { owner_team_slug: 1, updated_at: -1 }),
+    safeCreateIndex(db, 'rag_ingestion_sources', { shared_with_teams: 1 }),
+    safeCreateIndex(db, 'rag_ingestion_sources', { source_type: 1, status: 1 }),
+    safeCreateIndex(db, 'rag_ingestion_sources', { config_driven: 1 }),
   ]);
 
   console.log('✅ MongoDB indexes ensured');

--- a/ui/src/lib/rbac/__tests__/openfga-ingestion-source.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-ingestion-source.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for `buildIngestionSourceRelationshipTupleDiff` (spec
+ * 2026-07-21-rag-source-config-db, US5's `visibility: "global"` grant).
+ *
+ * `Check(user:*, can_read, ingestion_source:X)` is satisfied by the
+ * `user:* reader` tuple this builder writes when `globalUserAccess` is
+ * true — OpenFGA itself isn't exercised here (no server in unit tests),
+ * so this asserts the tuple diff the reconcile layer feeds it.
+ */
+
+import { buildIngestionSourceRelationshipTupleDiff } from "@/lib/rbac/openfga-owned-resources";
+
+describe("buildIngestionSourceRelationshipTupleDiff", () => {
+  const SOURCE = "ingestion_source:slack-channel-C1";
+
+  it("writes a user:* reader tuple when globalUserAccess is true", () => {
+    const diff = buildIngestionSourceRelationshipTupleDiff({
+      sourceId: "slack-channel-C1",
+      ownerTeamSlug: "platform",
+      globalUserAccess: true,
+    });
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([{ user: "user:*", relation: "reader", object: SOURCE }]),
+    );
+  });
+
+  it("does not write a user:* reader tuple for team-scoped visibility", () => {
+    const diff = buildIngestionSourceRelationshipTupleDiff({
+      sourceId: "slack-channel-C1",
+      ownerTeamSlug: "platform",
+      globalUserAccess: false,
+    });
+
+    expect(diff.writes).not.toEqual(
+      expect.arrayContaining([{ user: "user:*", relation: "reader", object: SOURCE }]),
+    );
+  });
+
+  it("revokes the user:* reader tuple when visibility flips from global to team", () => {
+    const diff = buildIngestionSourceRelationshipTupleDiff({
+      sourceId: "slack-channel-C1",
+      ownerTeamSlug: "platform",
+      globalUserAccess: false,
+      previousGlobalUserAccess: true,
+    });
+
+    expect(diff.deletes).toEqual(
+      expect.arrayContaining([{ user: "user:*", relation: "reader", object: SOURCE }]),
+    );
+  });
+
+  it("still grants the owner team its reader/ingestor/manager set alongside a global grant", () => {
+    const diff = buildIngestionSourceRelationshipTupleDiff({
+      sourceId: "slack-channel-C1",
+      ownerTeamSlug: "platform",
+      globalUserAccess: true,
+    });
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([
+        { user: "team:platform#member", relation: "reader", object: SOURCE },
+        { user: "team:platform#admin", relation: "manager", object: SOURCE },
+        { user: "user:*", relation: "reader", object: SOURCE },
+      ]),
+    );
+  });
+});

--- a/ui/src/lib/rbac/__tests__/rebac/resource-model.test.ts
+++ b/ui/src/lib/rbac/__tests__/rebac/resource-model.test.ts
@@ -44,6 +44,7 @@ describe("universal ReBAC resource model", () => {
       "knowledge_base",
       "data_source",
       "mcp_tool",
+      "ingestion_source",
       "document",
       "skill",
       "task",

--- a/ui/src/lib/rbac/__tests__/shareable-type-drift.test.ts
+++ b/ui/src/lib/rbac/__tests__/shareable-type-drift.test.ts
@@ -32,6 +32,7 @@ const SHAREABLE_TYPES = [
   "knowledge_base",
   "data_source",
   "mcp_tool",
+  "ingestion_source",
 ] as const;
 
 interface ParsedType {

--- a/ui/src/lib/rbac/fga-enforcement-manifest.ts
+++ b/ui/src/lib/rbac/fga-enforcement-manifest.ts
@@ -131,6 +131,11 @@ export const FGA_ENFORCEMENT_MANIFEST: Record<
     surfaces: ["ui/src/app/api/rag/[...path]/route.ts"],
     notes: "mcp_tool#can_call gates custom-tool invocation; layered under org can_search.",
   },
+  ingestion_source: {
+    status: "rebac_enforced",
+    surfaces: ["ui/src/lib/rbac/openfga-owned-resources-reconcile.ts"],
+    notes: "Source CRUD gated by can_read/can_manage/can_delete; ownership reconciled via reconcileIngestionSourceRelationships.",
+  },
   document: {
     status: "role_gated",
     surfaces: ["ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py"],

--- a/ui/src/lib/rbac/openfga-owned-resources-reconcile.ts
+++ b/ui/src/lib/rbac/openfga-owned-resources-reconcile.ts
@@ -22,6 +22,7 @@ import {
   buildConfigDrivenLlmModelRelationshipTupleDiff,
   buildConfigDrivenMcpServerRelationshipTupleDiff,
   buildDataSourceRelationshipTupleDiff,
+  buildIngestionSourceRelationshipTupleDiff,
   buildKnowledgeBaseRelationshipTupleDiff,
   buildLlmModelRelationshipTupleDiff,
   buildMcpServerRelationshipTupleDiff,
@@ -30,6 +31,7 @@ import {
   type ConfigDrivenLlmModelRelationshipInput,
   type ConfigDrivenMcpServerRelationshipInput,
   type DataSourceRelationshipInput,
+  type IngestionSourceRelationshipInput,
   type KnowledgeBaseRelationshipInput,
   type LlmModelRelationshipInput,
   type McpServerRelationshipInput,
@@ -233,6 +235,12 @@ export async function reconcileMcpToolRelationships(
   input: McpToolRelationshipInput,
 ): Promise<OpenFgaReconcileResult> {
   return reconcileOwnedResource(buildMcpToolRelationshipTupleDiff(input));
+}
+
+export async function reconcileIngestionSourceRelationships(
+  input: IngestionSourceRelationshipInput,
+): Promise<OpenFgaReconcileResult> {
+  return reconcileOwnedResource(buildIngestionSourceRelationshipTupleDiff(input));
 }
 
 /**

--- a/ui/src/lib/rbac/openfga-owned-resources.ts
+++ b/ui/src/lib/rbac/openfga-owned-resources.ts
@@ -108,6 +108,25 @@ export interface McpToolRelationshipInput extends OwnedResourceInput {
   previousSharedWithOrg?: boolean;
 }
 
+/**
+ * Input for `buildIngestionSourceRelationshipTupleDiff`.
+ *
+ * `ingestion_source` is a standalone shareable resource (spec
+ * 2026-07-21-rag-source-config-db) — it does not inherit from a
+ * `knowledge_base`/`data_source`, since a source describes where content is
+ * pulled *from*, not the resulting indexed data.
+ */
+export interface IngestionSourceRelationshipInput extends OwnedResourceInput {
+  sourceId: string;
+  nextSharedTeamSlugs?: readonly string[] | null;
+  previousSharedTeamSlugs?: readonly string[] | null;
+  previousOwnerTeamSlug?: string | null;
+  /** `visibility: "global"` — grants every authenticated user `reader` via `user:*`. */
+  globalUserAccess?: boolean;
+  /** Prior global-visibility state, so a `true` → `false` flip emits a revoke delete. */
+  previousGlobalUserAccess?: boolean;
+}
+
 export interface KnowledgeBaseRelationshipInput extends OwnedResourceInput {
   knowledgeBaseId: string;
   /**
@@ -533,4 +552,38 @@ export function buildMcpToolRelationshipTupleDiff(
     // same relation set.
     extraMemberRelations: ["user", "caller"],
   });
+}
+
+/**
+ * Build an ingestion_source tuple diff. Mirrors the owner + shared-teams
+ * semantics of `buildDataSourceRelationshipTupleDiff`/`buildMcpToolRelationshipTupleDiff`,
+ * plus a `visibility: "global"` → `user:* reader` grant (same encoding as
+ * `globalUserAccess` on agents, see `buildAgentRelationshipTupleDiff`).
+ */
+export function buildIngestionSourceRelationshipTupleDiff(
+  input: IngestionSourceRelationshipInput
+): TeamResourceTupleDiff {
+  if (!isValidOpenFgaId(input.sourceId)) {
+    throw new Error(`Invalid OpenFGA ingestion source id: ${input.sourceId}`);
+  }
+  const diff = buildShareableResourceTupleDiff({
+    objectType: "ingestion_source",
+    objectId: input.sourceId,
+    creatorSubject: input.creatorSubject,
+    ownerSubject: input.ownerSubject,
+    ownerTeamSlug: input.ownerTeamSlug,
+    nextSharedTeamSlugs: input.nextSharedTeamSlugs,
+    previousSharedTeamSlugs: input.previousSharedTeamSlugs,
+    previousOwnerTeamSlug: input.previousOwnerTeamSlug,
+  });
+
+  const object = `ingestion_source:${input.sourceId}`;
+  const writes = [...diff.writes];
+  const deletes = [...diff.deletes];
+  if (input.globalUserAccess) {
+    writes.push({ user: "user:*", relation: "reader", object });
+  } else if (input.previousGlobalUserAccess) {
+    deletes.push({ user: "user:*", relation: "reader", object });
+  }
+  return { writes: uniqueTuples(writes), deletes: uniqueTuples(deletes) };
 }

--- a/ui/src/lib/rbac/resource-catalog.ts
+++ b/ui/src/lib/rbac/resource-catalog.ts
@@ -51,6 +51,7 @@ const DEFAULT_RESOURCES: readonly RebacCatalogResource[] = [
   resource("tool", "argocd_*", "Argo CD Tools", "rebac_shadowed"),
   resource("knowledge_base", "platform-runbooks", "Platform Runbooks", "rebac_shadowed"),
   resource("data_source", "platform-runbooks", "Platform Runbooks Source", "rebac_enforced"),
+  resource("ingestion_source", "slack-channel-platform", "Platform Slack Channel Source", "rebac_enforced"),
   resource("mcp_tool", "caipe_kb", "CAIPE KB Search Tool", "rebac_enforced"),
   resource("document", "platform-runbook", "Platform Runbook", "role_gated"),
   resource("skill", "incident-triage", "Incident Triage", "role_gated"),

--- a/ui/src/lib/rbac/resource-model.ts
+++ b/ui/src/lib/rbac/resource-model.ts
@@ -105,6 +105,11 @@ export const UNIVERSAL_REBAC_RESOURCE_TYPES: readonly UniversalRebacResourceType
     description: "RAG custom MCP search tool created via the knowledge-base MCP API.",
   },
   {
+    type: "ingestion_source",
+    actions: ["discover", "read", "manage", "delete", "audit"],
+    description: "Self-service RAG ingestion source configuration (Slack, Confluence, Jira, web, Webex).",
+  },
+  {
     type: "document",
     actions: ["discover", "read", "write", "delete", "share", "audit"],
     description: "Document-level authorization target within a knowledge base.",

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -15,11 +15,13 @@
 
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import { BUILTIN_MCP_CREDENTIAL_SOURCES } from "@/lib/rbac/agentgateway-mcp-discovery";
+import { computeIngestionSourceId, type IngestionSourceIdentity } from "@/lib/ingestion-source-id";
 import { writeOpenFgaTuples, isOpenFgaReconciliationEnabled } from "@/lib/rbac/openfga";
 import { reconcileAgentRelationships } from "@/lib/rbac/openfga-agent-tools";
 import {
 reconcileConfigDrivenLlmModelRelationships,
 reconcileConfigDrivenMcpServerRelationships,
+reconcileIngestionSourceRelationships,
 reconcileShareableResource,
 } from "@/lib/rbac/openfga-owned-resources-reconcile";
 import { caipeOrgKey } from "@/lib/rbac/organization";
@@ -34,6 +36,11 @@ SubAgentRef,
 TransportType,
 VisibilityType,
 } from "@/types/dynamic-agent";
+import type {
+IngestionSourceConfig,
+IngestionSourceType,
+IngestionSourceVisibility,
+} from "@/types/ingestion-source";
 import type {
 StepEntry,
 WorkflowConfig,
@@ -61,6 +68,7 @@ interface SeedConfig {
   agents: Record<string, unknown>[];
   mcp_servers: Record<string, unknown>[];
   workflow_configs: Record<string, unknown>[];
+  rag_sources: Record<string, unknown>[];
 }
 
 /** Shape of documents in the llm_models collection. */
@@ -125,7 +133,7 @@ export function loadSeedConfig(configPath: string): SeedConfig {
     console.warn(
       `[seed-config] Config not found at ${configPath}, skipping seed`,
     );
-    return { models: [], agents: [], mcp_servers: [], workflow_configs: [] };
+    return { models: [], agents: [], mcp_servers: [], workflow_configs: [], rag_sources: [] };
   }
 
   const raw = fs.readFileSync(configPath, "utf-8");
@@ -146,8 +154,12 @@ export function loadSeedConfig(configPath: string): SeedConfig {
     string,
     unknown
   >[];
+  const rag_sources = expandEnvVars(parsed.rag_sources ?? []) as Record<
+    string,
+    unknown
+  >[];
 
-  return { models, agents, mcp_servers, workflow_configs };
+  return { models, agents, mcp_servers, workflow_configs, rag_sources };
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -583,6 +595,221 @@ async function seedWorkflowConfigs(
   return count;
 }
 
+const INGESTION_SOURCE_TYPES: readonly IngestionSourceType[] = [
+  "slack_channel",
+  "confluence_space",
+  "jira_project",
+  "web_url",
+  "webex_space",
+];
+
+/**
+ * Extract the `source_type`-specific identity/config fields from a raw YAML
+ * entry, keyed identically to the discriminated `IngestionSourceConfig`
+ * union (ui/src/types/ingestion-source.ts). Returns `null` when the entry's
+ * `source_type` is missing/unrecognized or its required identity fields are
+ * absent, so the caller can skip the entry the same way `seedAgents` skips
+ * entries missing `id`.
+ */
+function extractRagSourceTypeFields(
+  sourceData: Record<string, unknown>,
+): { identity: IngestionSourceIdentity; fields: Record<string, unknown> } | null {
+  const sourceType = sourceData.source_type as IngestionSourceType | undefined;
+  if (!sourceType || !INGESTION_SOURCE_TYPES.includes(sourceType)) return null;
+
+  switch (sourceType) {
+    case "slack_channel": {
+      const channelId = sourceData.channel_id as string | undefined;
+      if (!channelId) return null;
+      return {
+        identity: { source_type: "slack_channel", channel_id: channelId },
+        fields: {
+          source_type: sourceType,
+          channel_id: channelId,
+          lookback_days: sourceData.lookback_days as number | undefined,
+          include_bots: sourceData.include_bots as boolean | undefined,
+        },
+      };
+    }
+    case "confluence_space": {
+      const confluenceUrl = sourceData.confluence_url as string | undefined;
+      const spaceKey = sourceData.space_key as string | undefined;
+      if (!confluenceUrl || !spaceKey) return null;
+      return {
+        identity: { source_type: "confluence_space", confluence_url: confluenceUrl, space_key: spaceKey },
+        fields: { source_type: sourceType, confluence_url: confluenceUrl, space_key: spaceKey },
+      };
+    }
+    case "jira_project": {
+      const projectKey = sourceData.project_key as string | undefined;
+      const sourceSlug = sourceData.source_slug as string | undefined;
+      if (!projectKey || !sourceSlug) return null;
+      return {
+        identity: { source_type: "jira_project", project_key: projectKey, source_slug: sourceSlug },
+        fields: {
+          source_type: sourceType,
+          project_key: projectKey,
+          source_slug: sourceSlug,
+          jql: (sourceData.jql as string) ?? "",
+          include_comments: sourceData.include_comments as boolean | undefined,
+        },
+      };
+    }
+    case "web_url": {
+      const url = sourceData.url as string | undefined;
+      if (!url) return null;
+      return {
+        identity: { source_type: "web_url", url },
+        fields: { source_type: sourceType, url },
+      };
+    }
+    case "webex_space": {
+      const spaceId = sourceData.space_id as string | undefined;
+      if (!spaceId) return null;
+      return {
+        identity: { source_type: "webex_space", space_id: spaceId },
+        fields: { source_type: sourceType, space_id: spaceId },
+      };
+    }
+  }
+}
+
+async function seedRagSources(
+  sources: Record<string, unknown>[],
+): Promise<number> {
+  if (sources.length === 0) return 0;
+
+  const collection = await getCollection<IngestionSourceConfig>("rag_ingestion_sources");
+  let count = 0;
+
+  for (const sourceData of sources) {
+    const extracted = extractRagSourceTypeFields(sourceData);
+    if (!extracted) {
+      console.warn(
+        `[seed-config] Skipping rag source with missing identity fields: ${sourceData.name ?? "unknown"}`,
+      );
+      continue;
+    }
+    const sourceId = computeIngestionSourceId(extracted.identity);
+
+    const now = new Date().toISOString();
+    const existing = await collection.findOne({ source_id: sourceId } as never);
+
+    if (existing?.config_import_adopted === true) {
+      console.log(
+        `[seed-config] Skipping rag source ${sourceId}: adopted via import, YAML seed ignored`,
+      );
+      continue;
+    }
+
+    const createdAt = existing?.created_at ?? now;
+    const ownerTeamSlug = (sourceData.owner_team as string | undefined)?.trim() || null;
+    const sharedTeamSlugs = ((sourceData.shared_with_teams as string[] | undefined) ?? []).filter(
+      (slug) => slug && slug !== ownerTeamSlug,
+    );
+    // Config-driven sources default to global visibility (an operator declaring a
+    // source in Helm with no owner_team is very likely intending it to be broadly
+    // readable) — mirrors seedAgents' `visibility ?? "global"` default, unlike
+    // API-created sources which default to "team".
+    const visibility = ((sourceData.visibility as string) ?? "global") as IngestionSourceVisibility;
+
+    const doc = {
+      source_id: sourceId,
+      ...extracted.fields,
+      name: (sourceData.name as string) ?? sourceId,
+      description: (sourceData.description as string) ?? "",
+      default_chunk_size: (sourceData.default_chunk_size as number) ?? 10000,
+      default_chunk_overlap: (sourceData.default_chunk_overlap as number) ?? 2000,
+      reload_interval: (sourceData.reload_interval as number) ?? 86400,
+      status: existing?.status ?? "pending",
+      visibility,
+      shared_with_teams: sharedTeamSlugs,
+      owner_team_slug: ownerTeamSlug ?? undefined,
+      owner_id: ownerTeamSlug ? undefined : "system",
+      config_driven: true,
+      config_import_adopted: false,
+      created_at: createdAt,
+      updated_at: now,
+    } as unknown as IngestionSourceConfig;
+
+    await collection.replaceOne({ source_id: sourceId } as never, doc, { upsert: true });
+
+    await reconcileIngestionSourceRelationships({
+      sourceId,
+      ownerTeamSlug,
+      previousOwnerTeamSlug: existing?.owner_team_slug ?? null,
+      nextSharedTeamSlugs: sharedTeamSlugs,
+      previousSharedTeamSlugs: normalizeStringArray(existing?.shared_with_teams),
+      globalUserAccess: visibility === "global",
+      previousGlobalUserAccess: existing?.visibility === "global",
+    });
+
+    console.log(`[seed-config] Seeded rag source: ${sourceId}`);
+    count++;
+  }
+
+  return count;
+}
+
+/**
+ * Adopt a set of config-driven rag ingestion sources into the DB as the
+ * source of truth. Mirrors `adoptConfigImportedAgents` exactly: only sources
+ * currently `{config_driven: true, config_import_adopted: {$ne: true}}` are
+ * eligible — already-adopted or DB-native sources are skipped so a re-run
+ * (or an overlapping id list) can't silently reassign teams on sources
+ * outside the batch the admin picked.
+ */
+export async function adoptConfigImportedRagSources(
+  sourceIds: string[],
+  teamAssignment: { ownerTeamSlug: string | null; sharedTeamSlugs: string[] },
+): Promise<{ adopted: string[]; skipped: string[] }> {
+  const collection = await getCollection<IngestionSourceConfig>("rag_ingestion_sources");
+  const ownerTeamSlug = teamAssignment.ownerTeamSlug;
+  const sharedTeamSlugs = teamAssignment.sharedTeamSlugs.filter((slug) => slug !== ownerTeamSlug);
+  const adopted: string[] = [];
+  const skipped: string[] = [];
+
+  for (const sourceId of sourceIds) {
+    const existing = await collection.findOne({ source_id: sourceId } as never);
+    if (!existing || existing.config_driven !== true || existing.config_import_adopted === true) {
+      skipped.push(sourceId);
+      continue;
+    }
+
+    const nextVisibility: IngestionSourceVisibility = ownerTeamSlug ? "team" : existing.visibility;
+    const now = new Date().toISOString();
+
+    await collection.updateOne(
+      { source_id: sourceId } as never,
+      {
+        $set: {
+          config_driven: false,
+          config_import_adopted: true,
+          visibility: nextVisibility,
+          owner_team_slug: ownerTeamSlug ?? undefined,
+          shared_with_teams: sharedTeamSlugs,
+          updated_at: now,
+        },
+      } as never,
+    );
+
+    await reconcileIngestionSourceRelationships({
+      sourceId,
+      ownerTeamSlug,
+      previousOwnerTeamSlug: existing.owner_team_slug ?? null,
+      nextSharedTeamSlugs: sharedTeamSlugs,
+      previousSharedTeamSlugs: normalizeStringArray(existing.shared_with_teams),
+      globalUserAccess: nextVisibility === "global",
+      previousGlobalUserAccess: existing.visibility === "global",
+    });
+
+    console.log(`[seed-config] Adopted config-imported rag source: ${sourceId}`);
+    adopted.push(sourceId);
+  }
+
+  return { adopted, skipped };
+}
+
 // ═══════════════════════════════════════════════════════════════
 // Stale cleanup
 // ═══════════════════════════════════════════════════════════════
@@ -598,6 +825,7 @@ export async function cleanupStaleConfigDriven(
   currentServerIds: Set<string>,
   currentModelIds: Set<string>,
   currentWorkflowIds: Set<string>,
+  currentRagSourceIds: Set<string>,
 ): Promise<void> {
   // Cleanup stale agents
   const agentCollection =
@@ -673,10 +901,29 @@ export async function cleanupStaleConfigDriven(
     }
   }
 
-  if (agentsDeleted || serversDeleted || modelsDeleted || workflowsDeleted) {
+  // Cleanup stale rag ingestion sources. No `source: {$ne: "agentgateway"}`-style
+  // extra guard needed — unlike MCP servers, nothing else discovers/writes
+  // `rag_ingestion_sources` records at runtime with `config_driven: true`
+  // outside this seed path.
+  const ragSourceCollection = await getCollection<IngestionSourceConfig>("rag_ingestion_sources");
+  const staleRagSources = await ragSourceCollection
+    .find({ config_driven: true, config_import_adopted: { $ne: true } } as never)
+    .toArray();
+  let ragSourcesDeleted = 0;
+  for (const source of staleRagSources) {
+    if (!currentRagSourceIds.has(source.source_id)) {
+      console.log(
+        `[seed-config] Removing stale config-driven rag source: ${source.source_id}`,
+      );
+      await ragSourceCollection.deleteOne({ source_id: source.source_id } as never);
+      ragSourcesDeleted++;
+    }
+  }
+
+  if (agentsDeleted || serversDeleted || modelsDeleted || workflowsDeleted || ragSourcesDeleted) {
     console.log(
       `[seed-config] Cleaned up stale config-driven entities: ` +
-        `${agentsDeleted} agents, ${serversDeleted} servers, ${modelsDeleted} models, ${workflowsDeleted} workflows`,
+        `${agentsDeleted} agents, ${serversDeleted} servers, ${modelsDeleted} models, ${workflowsDeleted} workflows, ${ragSourcesDeleted} rag sources`,
     );
   }
 }
@@ -1202,7 +1449,8 @@ export async function applySeedConfig(): Promise<void> {
         `[seed-config] Found ${config.models.length} models, ` +
           `${config.mcp_servers.length} MCP servers, ` +
           `${config.agents.length} agents, ` +
-          `${config.workflow_configs.length} workflow configs in config`,
+          `${config.workflow_configs.length} workflow configs, ` +
+          `${config.rag_sources.length} rag sources in config`,
       );
 
       // Extract current IDs for stale cleanup
@@ -1226,6 +1474,12 @@ export async function applySeedConfig(): Promise<void> {
           .map((w) => w.id as string)
           .filter(Boolean),
       );
+      const currentRagSourceIds = new Set(
+        config.rag_sources
+          .map((s) => extractRagSourceTypeFields(s)?.identity)
+          .filter((identity): identity is IngestionSourceIdentity => identity !== undefined)
+          .map((identity) => computeIngestionSourceId(identity)),
+      );
 
       // Seed entities
       const modelCount = await seedModels(config.models);
@@ -1239,6 +1493,7 @@ export async function applySeedConfig(): Promise<void> {
           `[seed-config] Repaired shared_with_teams slugs on ${workflowTeamSlugRepairs} team workflow(s)`,
         );
       }
+      const ragSourceCount = await seedRagSources(config.rag_sources);
 
       // Cleanup stale config-driven entities
       await cleanupStaleConfigDriven(
@@ -1246,6 +1501,7 @@ export async function applySeedConfig(): Promise<void> {
         currentServerIds,
         currentModelIds,
         currentWorkflowIds,
+        currentRagSourceIds,
       );
 
       // Backfill credential_sources on previously-discovered built-in MCP
@@ -1254,7 +1510,8 @@ export async function applySeedConfig(): Promise<void> {
 
       console.log(
         `[seed-config] Applied: ${modelCount} models, ` +
-          `${serverCount} MCP servers, ${agentCount} agents, ${workflowCount} workflow configs` +
+          `${serverCount} MCP servers, ${agentCount} agents, ${workflowCount} workflow configs, ` +
+          `${ragSourceCount} rag sources` +
           (credBackfillCount > 0
             ? `, ${credBackfillCount} MCP credential_sources backfilled`
             : ""),

--- a/ui/src/types/ingestion-source.ts
+++ b/ui/src/types/ingestion-source.ts
@@ -1,0 +1,90 @@
+/**
+ * RAG ingestion source configuration (spec 2026-07-21-rag-source-config-db).
+ *
+ * `IngestionSourceConfig` is the pre-ingestion source of truth for
+ * self-service RAG ingestion — distinct from the RAG server's
+ * `DataSourceInfo`, which remains the post-ingestion record. See
+ * docs/docs/specs/2026-07-21-rag-source-config-db/data-model.md for the
+ * full field-mapping rationale.
+ */
+
+export type IngestionSourceType =
+  | "slack_channel"
+  | "confluence_space"
+  | "jira_project"
+  | "web_url"
+  | "webex_space";
+
+export type IngestionSourceStatus = "pending" | "active" | "disabled" | "ingesting";
+
+export type IngestionSourceVisibility = "team" | "global";
+
+export interface IngestionSourceConfigBase {
+  source_id: string;
+  source_type: IngestionSourceType;
+  name: string;
+  description?: string;
+  status: IngestionSourceStatus;
+  default_chunk_size: number;
+  default_chunk_overlap: number;
+  reload_interval: number;
+
+  config_driven: boolean;
+  config_import_adopted: boolean;
+  visibility: IngestionSourceVisibility;
+
+  creator_subject?: string;
+  owner_subject?: string;
+  owner_id?: string;
+  owner_team_slug?: string;
+  shared_with_teams: string[];
+
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SlackChannelSource extends IngestionSourceConfigBase {
+  source_type: "slack_channel";
+  channel_id: string;
+  lookback_days?: number;
+  include_bots?: boolean;
+}
+
+export interface ConfluenceSpaceSource extends IngestionSourceConfigBase {
+  source_type: "confluence_space";
+  confluence_url: string;
+  space_key: string;
+}
+
+export interface JiraProjectSource extends IngestionSourceConfigBase {
+  source_type: "jira_project";
+  project_key: string;
+  /**
+   * Caller-supplied and immutable at creation — deliberately NOT derived
+   * from the mutable `name` field. The current Jira ingestor slugifies
+   * `name` into its own `datasource_id`, which silently orphans RBAC tuples
+   * on rename; this store's `source_id` formula uses `source_slug` instead
+   * so renaming `name` never changes identity. See data-model.md's
+   * "Jira id decision".
+   */
+  source_slug: string;
+  jql: string;
+  include_comments?: boolean;
+}
+
+export interface WebUrlSource extends IngestionSourceConfigBase {
+  source_type: "web_url";
+  url: string;
+}
+
+export interface WebexSpaceSource extends IngestionSourceConfigBase {
+  source_type: "webex_space";
+  space_id: string;
+}
+
+export type IngestionSourceConfig =
+  | SlackChannelSource
+  | ConfluenceSpaceSource
+  | JiraProjectSource
+  | WebUrlSource
+  | WebexSpaceSource;

--- a/ui/src/types/rbac-universal.ts
+++ b/ui/src/types/rbac-universal.ts
@@ -56,6 +56,7 @@ export const UNIVERSAL_REBAC_RESOURCE_TYPE_NAMES = [
   "knowledge_base",
   "data_source",
   "mcp_tool",
+  "ingestion_source",
   "document",
   "skill",
   "task",


### PR DESCRIPTION
## Description

PR1 of a 7-PR series making RAG ingestion self-service and UI-driven (per `docs/docs/specs/2026-07-21-rag-source-config-db/`). Builds on PR0 (#2269, RAG RBAC coverage audit — already merged into `main`).

Adds a Mongo-backed store and BFF CRUD API (`ui/src/app/api/rag/sources/`) for RAG ingestion-source configuration — Slack channels, Confluence spaces, Jira projects, web URLs, Webex spaces — following the `team_rag_tools`/`dynamic-agents` collection precedents and the canonical shareable-resource OpenFGA pattern. This is the pre-ingestion source of truth PR2 (UI) and PR3 (ingestors) will build on.

Zero changes to `ai_platform_engineering/knowledge_bases/rag/server/` or ingestor code — purely additive on the UI/BFF side. No existing code path calls the new endpoints yet.

### What's included

- New `IngestionSourceConfig` discriminated union type + deterministic `source_id` formulas per source type
- `ingestion_source` registered as an OpenFGA/ReBAC resource type, with a standalone owner+shared-team+global-visibility tuple diff builder
- `POST/GET /api/rag/sources`, `GET/PATCH/DELETE /api/rag/sources/[sourceId]`, `POST /api/rag/sources/[sourceId]/adopt`
- Helm-config seeding (`appConfig.rag_sources`) → `rag_ingestion_sources` at boot, with stale-cleanup and permanent org-admin "adopt" conversion to DB-native records
- Full positive+negative RBAC test coverage for every endpoint

### Notable implementation decisions

- **Config-driven-check-before-can_manage-check ordering** on PATCH/DELETE (per `contracts/rest-api.md` and tasks T046-T049): a `config_driven: true` record returns 403 `CONFIG_DRIVEN_IMMUTABLE` even for an owner-team admin, checked *before* the permission check. Note: this is the opposite order from `ui/src/app/api/dynamic-agents/route.ts`'s actual PUT/DELETE handlers (which check permission first, then config-driven) — the spec's explicit tasks intentionally diverge from that precedent for this resource, so I followed the spec's literal ordering rather than the agents precedent.
- **403 (not 404)** for an existing-but-unreadable single-record GET, matching `ui/src/app/api/rag/kbs/[id]/sharing/route.ts`'s convention.
- **Fail-open reconciliation**: `reconcileIngestionSourceRelationships` has no try/catch wrapper, matching how `seedRagSources`/`adoptConfigImportedRagSources` already call it — a mis-reconciled tuple has no query-time consequence yet since nothing reads `ingestion_source#can_read` for RBAC scoping until a later PR.
- Fixed a pre-existing gap found while running the full test suite: `resource-catalog.ts`'s `DEFAULT_RESOURCES` was missing an `ingestion_source` entry, causing `catalog-route.test.ts`'s "every universal type has a representative resource" assertion to fail once `ingestion_source` was registered as a resource type.
- **Fixed during design review**: `confluenceSpaceSourceId` used the WHATWG `URL.hostname` (lowercases, drops port) where the real ingestor uses Python's `urlparse().netloc` (preserves both) — a self-hosted Confluence on a non-default port or mixed-case host would have computed a different `source_id` than PR3's ingestor. `webUrlSourceId`'s ASCII-only cleaning regex likewise diverged from Python's Unicode-aware `isalnum()` for non-ASCII URLs. Both now match byte-for-byte, with new tests covering the port/case and Unicode cases.

### Design review notes

A design-focused review (code/system design, scalability) flagged two other items worth tracking as the series progresses rather than fixing now:
- `GET /api/rag/sources`'s authz filtering does per-item OpenFGA `Check` calls rather than the batched `/batch-check` endpoint — inherited unchanged from `rag/tools/route.ts`, not a regression here, but worth addressing before PR2's list UI leans on it at the ~250-source scale `plan.md` cites.
- `ingestion_source` and `data_source`/`knowledge_base` are two separate ownership graphs linked only by sharing the same `source_id` string, with no structural edge between them. That's the right scope for this PR, but PR5 (query-time RBAC propagation) will need to either add an explicit link or duplicate the reconcile call at the `data_source` layer — worth deciding early since retrofitting after ~250 sources exist is more migration work than defining it now.

## Next steps this unlocks

- **PR2 (UI)**: a list/detail/sharing page can be built directly on `GET/PATCH /api/rag/sources` — the API already returns `config_driven`/`visibility` badges data and enforces immutability server-side, so the UI only needs to render state, not re-implement guards.
- **PR3 (ingestors)**: each ingestor can swap its static env-var config for a call to `GET /api/rag/sources?source_type=<type>`, using this PR's verified `source_id` formulas to guarantee the record it fetches matches the datasource it already manages — no dual-write or reconciliation needed on the ingestor side.
- **PR4 (migration)**: the adopt route and `config_import_adopted` flag give the migration flow a ready-made "preview → assign owner → adopt" path for turning today's env-var sources into DB-native records without inventing new state.

## Test plan

- [x] `npx jest` — all 543 suites / 6786 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean, new routes present in the build manifest
- [x] `npx tsc --noEmit` — no new type errors
- [ ] Manual verification (spec tasks T064/T065 — two-team local RBAC setup, Helm-values boot test) — not run in this environment; flagging as outstanding for reviewer/follow-up

## Type of Change

- [x] New Feature

## Checklist

- [x] I have read the contributing guidelines
- [x] Functionality is documented (inline + spec docs)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
