### PR TITLE
fix(ui): add proactive session keepalive to prevent SSO idle timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.60-dev.3"
+version = "0.5.60-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.60-dev.4"
+version = "0.5.60-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/token-expiry-guard.tsx
+++ b/ui/src/components/token-expiry-guard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-// assisted-by Codex Codex-sonnet-4-6
+// assisted-by claude code claude-sonnet-4-6
 
 import { Button } from "@/components/ui/button";
 import { formatTimeUntilExpiry,getTimeUntilExpiry,getWarningTimestamp,isTokenExpired } from "@/lib/auth-utils";
@@ -11,6 +11,10 @@ import { signOut,useSession } from "next-auth/react";
 import { useCallback,useEffect,useRef,useState } from "react";
 
 const LOGIN_REDIRECT_COUNTDOWN_SECONDS = 5;
+// Keepalive fires at 75% of the Keycloak SSO session idle timeout (default 8h → 6h).
+// Each successful token exchange resets the server-side idle timer, preventing
+// users from being silently logged out while the tab is open but idle.
+const SESSION_KEEPALIVE_INTERVAL_MS = 6 * 60 * 60 * 1000;
 // AccessTokenMissing is intentionally absent here — it has its own retry-budget
 // handling above (lines 198-211) and must never fall through to immediate logout.
 const SESSION_CREDENTIAL_ERRORS = new Set([
@@ -57,6 +61,7 @@ export function TokenExpiryGuard() {
   const checkIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const redirectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const keepaliveIntervalRef = useRef<NodeJS.Timeout | null>(null);
   /** Tracks user dismissal — stores the expiresAt timestamp for which the warning was dismissed.
    *  This way, if the token is refreshed (new expiresAt), the warning can show again for the new cycle. */
   const dismissedForExpiryRef = useRef<number | null>(null);
@@ -334,6 +339,33 @@ export function TokenExpiryGuard() {
       }
     };
   }, [status, checkTokenExpiry]);
+
+  // Proactive session keepalive: force-refresh the token on a fixed interval so
+  // the Keycloak SSO session idle timer never reaches its limit while the tab is
+  // open. Without this, a user idle for longer than ssoSessionIdleTimeout (8h)
+  // has their refresh token invalidated server-side, causing the next expiry check
+  // to fail with invalid_token and immediately log them out.
+  useEffect(() => {
+    if (!getConfig('ssoEnabled') || status !== "authenticated" || !session?.hasRefreshToken) {
+      return;
+    }
+
+    keepaliveIntervalRef.current = setInterval(async () => {
+      console.log("[TokenExpiryGuard] Proactive keepalive — refreshing token to reset SSO idle timer");
+      try {
+        await updateSession({ forceRefresh: true });
+      } catch (error) {
+        console.warn("[TokenExpiryGuard] Keepalive refresh failed:", error);
+      }
+    }, SESSION_KEEPALIVE_INTERVAL_MS);
+
+    return () => {
+      if (keepaliveIntervalRef.current) {
+        clearInterval(keepaliveIntervalRef.current);
+        keepaliveIntervalRef.current = null;
+      }
+    };
+  }, [status, session?.hasRefreshToken, updateSession]);
 
   useEffect(() => clearRedirectTimers, [clearRedirectTimers]);
 

--- a/ui/src/components/token-expiry-guard.tsx
+++ b/ui/src/components/token-expiry-guard.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-// assisted-by claude code claude-sonnet-4-6
-
 import { Button } from "@/components/ui/button";
 import { formatTimeUntilExpiry,getTimeUntilExpiry,getWarningTimestamp,isTokenExpired } from "@/lib/auth-utils";
 import { getConfig } from "@/lib/config";

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.60.dev4"
+version = "0.5.60.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.60.dev3"
+version = "0.5.60.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Users were being logged out mid-session when their Keycloak SSO session idle timer expired while the tab was open but idle. Root cause analysis:

- Keycloak `ssoSessionIdleTimeout` defaults to **8h**
- Access token lifespan is **4h** — the UI only calls `updateSession()` within 5 minutes of access token expiry
- A user idle >8h has their refresh token invalidated server-side
- The next token refresh returns `invalid_token` (not `invalid_grant`), which `auth-config.ts` correctly maps to `RefreshTokenExpired` — triggering immediate logout

**Fix:** add a 6h keepalive interval in `TokenExpiryGuard` that calls `updateSession({ forceRefresh: true })`. This triggers the existing `forceRefresh` path in `auth-config.ts` (line 612), performs a real OIDC token exchange with Keycloak, and resets the SSO idle timer before it expires. If a keepalive fails, the next cycle fires 6h later — well within the 8h window.

Evidence from production Keycloak logs: 139 `REFRESH_TOKEN_ERROR` events over 6 days, trending upward as user adoption grows. All with `reason="Token is not active"` and `userId=null` (session already gone server-side).

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)