### PR TITLE
fix(rag): recurse into sitemap index children instead of scraping them as pages

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -299,7 +299,26 @@ class WorkerSpider(Spider):
 
     # Extract URLs from sitemap
     urls = re.findall(r"<loc>(.*?)</loc>", response.text)
-    self.urls_found_in_sitemap = len(urls)
+
+    # A sitemap *index* (root element <sitemapindex>) lists other sitemaps,
+    # not pages — its <loc> entries point to child sitemap files. Dispatching
+    # those straight to parse_page fetches XML and "successfully" gets a
+    # response, but content extraction finds nothing, silently reporting
+    # N URLs found / 0 scraped. Recurse into each child sitemap instead.
+    if "<sitemapindex" in response.text[:2000]:
+      self._log(logging.INFO, f"Sitemap index at {response.url} references {len(urls)} child sitemap(s); fetching each")
+      for sitemap_url in urls[: self.max_pages]:
+        request = self._safe_request(
+          sitemap_url,
+          callback=self.parse_sitemap,
+          errback=self.handle_sitemap_error,
+          meta=response.meta,
+        )
+        if request:
+          yield request
+      return
+
+    self.urls_found_in_sitemap += len(urls)
 
     self._log(logging.INFO, f"Found {len(urls)} URLs in sitemap")
 
@@ -310,8 +329,10 @@ class WorkerSpider(Spider):
         urls_to_crawl.append(url)
         self.pending_urls.add(url)
 
-    # Set total for progress tracking
-    self.total_pages_to_crawl = len(urls_to_crawl)
+    # Set total for progress tracking. Accumulate rather than overwrite:
+    # a sitemap index fans out to multiple child sitemaps, each reaching
+    # this point once, and the reported total should cover all of them.
+    self.total_pages_to_crawl = (self.total_pages_to_crawl or 0) + len(urls_to_crawl)
 
     self._log(logging.INFO, f"Queued {len(urls_to_crawl)} URLs for crawling. Filtered: {self.urls_filtered_external} external, {self.urls_filtered_pattern} by pattern, {self.urls_filtered_max_pages} over max pages limit")
 

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
@@ -594,6 +594,81 @@ class TestParseSitemapIndex:
     assert spider.total_pages_to_crawl == 4
 
 
+class TestParseSitemapFlatUrlset:
+  """Tests for parse_sitemap against a real, non-indexed sitemap.
+
+  cnoe-io.github.io/ai-platform-engineering/sitemap.xml (this repo's own docs
+  site) is a flat Docusaurus-generated <urlset> with 4200+ entries and the
+  extra xmlns/changefreq/priority attributes real sitemaps carry - the
+  opposite shape from the outshift.cisco.com index above. This guards against
+  the sitemapindex check in parse_sitemap ever misfiring on an ordinary,
+  larger, real-world urlset.
+  """
+
+  # A representative excerpt of the real sitemap, namespaces and per-url tags intact.
+  REAL_FLAT_URLSET = """<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"><url><loc>https://cnoe-io.github.io/ai-platform-engineering/blog</loc><changefreq>weekly</changefreq><priority>0.5</priority></url><url><loc>https://cnoe-io.github.io/ai-platform-engineering/blog/ai-agent-vs-mcp-server</loc><changefreq>weekly</changefreq><priority>0.5</priority></url><url><loc>https://cnoe-io.github.io/ai-platform-engineering/docs/workshop/rag</loc><changefreq>weekly</changefreq><priority>0.5</priority></url><url><loc>https://cnoe-io.github.io/ai-platform-engineering/docs/workshop/tracing</loc><changefreq>weekly</changefreq><priority>0.5</priority></url><url><loc>https://cnoe-io.github.io/ai-platform-engineering/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url></urlset>"""
+
+  def _make_worker_spider(self, max_pages: int = 100):
+    """Create a WorkerSpider instance for testing."""
+    from ingestors.webloader.loader.scrapy_worker import WorkerSpider
+    from ingestors.webloader.loader.worker_types import CrawlRequest
+    from multiprocessing import Queue
+
+    request = CrawlRequest(
+      job_id="test-job",
+      url="https://cnoe-io.github.io/ai-platform-engineering/",
+      datasource_id="test-ds",
+      crawl_mode="sitemap",
+      max_pages=max_pages,
+    )
+    result_queue = Queue()
+
+    return WorkerSpider(request=request, result_queue=result_queue)
+
+  def _make_sitemap_response(self, url: str, text: str):
+    """Create a mock Response for parse_sitemap, with no redirect (response.url == response.request.url)."""
+    mock_response = Mock()
+    mock_response.url = url
+    mock_response.status = 200
+    mock_response.text = text
+    mock_response.meta = {}
+    mock_response.request = Mock()
+    mock_response.request.url = url
+    return mock_response
+
+  def test_real_flat_urlset_is_not_treated_as_an_index(self):
+    """A namespaced Docusaurus <urlset> must dispatch straight to parse_page, not recurse."""
+    from unittest.mock import patch
+
+    spider = self._make_worker_spider()
+    response = self._make_sitemap_response(
+      "https://cnoe-io.github.io/ai-platform-engineering/sitemap.xml", self.REAL_FLAT_URLSET
+    )
+
+    with patch("ingestors.webloader.loader.scrapy_worker.is_publicly_routable_url", return_value=(True, "")):
+      requests = list(spider.parse_sitemap(response))
+
+    assert len(requests) == 5
+    assert all(r.callback == spider.parse_page for r in requests)
+    assert spider.urls_found_in_sitemap == 5
+    assert spider.total_pages_to_crawl == 5
+
+  def test_real_flat_urlset_respects_max_pages_truncation(self):
+    """With 4200+ real URLs in the live sitemap, max_pages must still cap what gets queued."""
+    from unittest.mock import patch
+
+    spider = self._make_worker_spider(max_pages=3)
+    response = self._make_sitemap_response(
+      "https://cnoe-io.github.io/ai-platform-engineering/sitemap.xml", self.REAL_FLAT_URLSET
+    )
+
+    with patch("ingestors.webloader.loader.scrapy_worker.is_publicly_routable_url", return_value=(True, "")):
+      requests = list(spider.parse_sitemap(response))
+
+    assert len(requests) == 3
+    assert spider.total_pages_to_crawl == 3
+
+
 # ============================================================================
 # WorkerSpider Streaming and Cancellation Tests
 # ============================================================================

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
@@ -485,6 +485,116 @@ class TestWorkerSpiderRedirectHandling:
 
 
 # ============================================================================
+# WorkerSpider Sitemap Index Handling Tests
+# ============================================================================
+
+
+class TestParseSitemapIndex:
+  """Tests for WorkerSpider.parse_sitemap distinguishing a sitemap index from a urlset.
+
+  Regression coverage for a real ingestion failure on outshift.cisco.com: its
+  sitemap.xml is a <sitemapindex> listing three child sitemaps, not a page
+  list. parse_sitemap used to extract those child-sitemap <loc> URLs and
+  dispatch them straight to parse_page, which fetched the XML "successfully"
+  but extracted zero content, reporting "3 URLs found in sitemap, 0 scraped".
+  """
+
+  SITEMAP_INDEX = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://outshift.cisco.com/sitemap-pages.xml</loc></sitemap>
+  <sitemap><loc>https://outshift.cisco.com/sitemap-blogs.xml</loc></sitemap>
+  <sitemap><loc>https://outshift.cisco.com/sitemap-events.xml</loc></sitemap>
+</sitemapindex>"""
+
+  PAGES_URLSET = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://outshift.cisco.com/</loc></url>
+  <url><loc>https://outshift.cisco.com/about-us</loc></url>
+  <url><loc>https://outshift.cisco.com/careers</loc></url>
+</urlset>"""
+
+  BLOGS_URLSET = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://outshift.cisco.com/blog/post-1</loc></url>
+</urlset>"""
+
+  def _make_worker_spider(self, max_pages: int = 100):
+    """Create a WorkerSpider instance for testing."""
+    from ingestors.webloader.loader.scrapy_worker import WorkerSpider
+    from ingestors.webloader.loader.worker_types import CrawlRequest
+    from multiprocessing import Queue
+
+    request = CrawlRequest(
+      job_id="test-job",
+      url="https://outshift.cisco.com",
+      datasource_id="test-ds",
+      crawl_mode="sitemap",
+      max_pages=max_pages,
+    )
+    result_queue = Queue()
+
+    return WorkerSpider(request=request, result_queue=result_queue)
+
+  def _make_sitemap_response(self, url: str, text: str):
+    """Create a mock Response for parse_sitemap, with no redirect (response.url == response.request.url)."""
+    mock_response = Mock()
+    mock_response.url = url
+    mock_response.status = 200
+    mock_response.text = text
+    mock_response.meta = {}
+    mock_response.request = Mock()
+    mock_response.request.url = url
+    return mock_response
+
+  def test_sitemap_index_recurses_into_child_sitemaps_instead_of_scraping_them(self):
+    """A <sitemapindex> root should fan out to each child sitemap via parse_sitemap, not parse_page."""
+    from unittest.mock import patch
+
+    spider = self._make_worker_spider()
+    response = self._make_sitemap_response("https://outshift.cisco.com/sitemap.xml", self.SITEMAP_INDEX)
+
+    with patch("ingestors.webloader.loader.scrapy_worker.is_publicly_routable_url", return_value=(True, "")):
+      requests = list(spider.parse_sitemap(response))
+
+    assert len(requests) == 3
+    assert {r.url for r in requests} == {
+      "https://outshift.cisco.com/sitemap-pages.xml",
+      "https://outshift.cisco.com/sitemap-blogs.xml",
+      "https://outshift.cisco.com/sitemap-events.xml",
+    }
+    assert all(r.callback == spider.parse_sitemap for r in requests)
+
+    # The index itself lists no pages - nothing should be counted as crawlable yet.
+    assert spider.urls_found_in_sitemap == 0
+    assert spider.total_pages_to_crawl is None
+
+  def test_child_urlset_dispatches_to_parse_page_and_totals_accumulate_across_children(self):
+    """A <urlset> reached via the index is a real page list; totals must accumulate, not overwrite, across siblings."""
+    from unittest.mock import patch
+
+    spider = self._make_worker_spider()
+
+    with patch("ingestors.webloader.loader.scrapy_worker.is_publicly_routable_url", return_value=(True, "")):
+      index_response = self._make_sitemap_response("https://outshift.cisco.com/sitemap.xml", self.SITEMAP_INDEX)
+      list(spider.parse_sitemap(index_response))
+
+      pages_response = self._make_sitemap_response("https://outshift.cisco.com/sitemap-pages.xml", self.PAGES_URLSET)
+      page_requests = list(spider.parse_sitemap(pages_response))
+
+      assert len(page_requests) == 3
+      assert all(r.callback == spider.parse_page for r in page_requests)
+      assert spider.urls_found_in_sitemap == 3
+      assert spider.total_pages_to_crawl == 3
+
+      # A second child sitemap must add to the running total, not reset it.
+      blogs_response = self._make_sitemap_response("https://outshift.cisco.com/sitemap-blogs.xml", self.BLOGS_URLSET)
+      list(spider.parse_sitemap(blogs_response))
+
+    assert spider.urls_found_in_sitemap == 4
+    assert spider.total_pages_to_crawl == 4
+
+
+# ============================================================================
 # WorkerSpider Streaming and Cancellation Tests
 # ============================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.61-dev.1"
+version = "0.5.61-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.61.dev1"
+version = "0.5.61.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- `WorkerSpider.parse_sitemap()` extracted every `<loc>` URL with a flat regex regardless of whether the document was a `<sitemapindex>` (lists other sitemaps) or a `<urlset>` (lists real pages).
- Any site whose `sitemap.xml` is an index -- e.g. `outshift.cisco.com`, which splits into `sitemap-pages.xml`, `sitemap-blogs.xml`, `sitemap-events.xml` -- had those child sitemap URLs dispatched straight to `parse_page`. Those XML documents fetch fine (HTTP 200) but yield zero extractable content, so ingestion silently reported "N URLs found in sitemap, 0 scraped".
- `parse_sitemap` now detects a `<sitemapindex>` root and recurses into each child sitemap via itself instead of `parse_page`. `total_pages_to_crawl` / `urls_found_in_sitemap` now accumulate instead of overwrite, since an index fans out to multiple children each reaching that code path once.

## Test plan
- [x] Added `TestParseSitemapIndex` in `tests/webloader/test_spiders.py` using the real `outshift.cisco.com` sitemap structure as fixture data: one test asserts the index recurses into its 3 children via `parse_sitemap` (not `parse_page`); the other asserts a child `<urlset>` dispatches to `parse_page` and that totals accumulate correctly across multiple children.
- [x] `uv run pytest tests/webloader/test_spiders.py` -- 40 passed, 3 skipped (optional Playwright deps).
- [x] `uv run pytest` (full ingestors suite) -- same 10 pre-existing failures reproduce identically on a clean `main` checkout (unrelated dependency-version issues in `backstage`/`s3`/`slack`/`readthedocs`/`tls` tests, untouched by this change); no new failures introduced.