### PR TITLE
feat(ui): accept Bearer JWT on RAG BFF for CLI access

### DIFF
--- a/docs/docs/knowledge_bases/api-reference.md
+++ b/docs/docs/knowledge_bases/api-reference.md
@@ -24,7 +24,7 @@ When using the UI BFF, omit the leading slash from the RAG path after `/api/rag/
 
 ## Authentication and RBAC
 
-RAG supports OIDC bearer tokens and ingestor credentials. The UI BFF forwards the current NextAuth `accessToken` to the RAG server as a bearer token.
+RAG supports OIDC bearer tokens and ingestor credentials. The UI BFF accepts either a browser NextAuth session or `Authorization: Bearer <OIDC access token>` (for CLI and automation), validates the JWT, enforces RBAC, then forwards the same bearer token to the RAG server.
 
 Role levels are hierarchical:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.61-dev.3"
+version = "0.5.61-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/rag/[...path]/route.ts
+++ b/ui/src/app/api/rag/[...path]/route.ts
@@ -3,8 +3,8 @@ ApiError,
 handleApiError,
 requireRbacPermission,
 } from '@/lib/api-middleware';
-import { authOptions } from '@/lib/auth-config';
-import { getDevAnonymousSession,isDevAnonymousAuthEnabled } from '@/lib/auth/dev-auth-provider';
+import { getDevAnonymousAuthEnabled } from '@/lib/auth/dev-auth-provider';
+import { resolveRagProxySession } from '@/lib/rag-proxy-session';
 import { checkOpenFgaTuple } from '@/lib/rbac/openfga';
 import {
 deleteAllMcpToolRelationshipTuples,
@@ -21,7 +21,6 @@ type ResourcePermissionAction,
 } from '@/lib/rbac/resource-authz';
 import { resolveShareableOwnershipWrite } from '@/lib/rbac/shareable-resource';
 import type { RbacScope } from '@/lib/rbac/types';
-import { getServerSession } from 'next-auth';
 import { NextRequest,NextResponse } from 'next/server';
 
 /**
@@ -32,7 +31,8 @@ import { NextRequest,NextResponse } from 'next/server';
  * checks. Static IdP/AD groups are not consumed by RAG authorization.
  *
  * Authentication:
- * - Authorization: Bearer {access_token} (OIDC JWT access token)
+ * - Authorization: Bearer {access_token} (OIDC JWT — CLI / automation)
+ * - NextAuth session cookie (browser UI)
  *
  * The RAG server uses the access_token to authenticate the caller and
  * derive OpenFGA subjects for resource checks.
@@ -469,12 +469,7 @@ async function getAuthorizedRagContext(
   request: NextRequest,
   body?: unknown,
 ): Promise<AuthorizedRagContext> {
-  const session = await getServerSession(authOptions) ?? (
-    isDevAnonymousAuthEnabled() ? getDevAnonymousSession() : null
-  );
-  if (!session?.user?.email) {
-    throw new ApiError('Unauthorized', 401);
-  }
+  const session = await resolveRagProxySession(request);
   if (!session.accessToken && !isDevAnonymousAuthEnabled()) {
     throw new ApiError('A Keycloak access token is required for RAG access.', 401, 'NOT_SIGNED_IN');
   }

--- a/ui/src/app/api/rag/__tests__/bearer-proxy.test.ts
+++ b/ui/src/app/api/rag/__tests__/bearer-proxy.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ *
+ * Ensures /api/rag/* accepts OIDC Bearer tokens (CLI / automation), not only
+ * browser NextAuth cookies.
+ */
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth-config', () => ({
+  authOptions: {},
+  isBootstrapAdmin: jest.fn().mockReturnValue(false),
+  REQUIRED_ADMIN_GROUP: '',
+}));
+
+jest.mock('@/lib/auth/dev-auth-provider', () => ({
+  getDevAnonymousSession: jest.fn(),
+  isDevAnonymousAuthEnabled: jest.fn().mockReturnValue(false),
+}));
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockRequireRbacPermission = jest.fn();
+
+jest.mock('@/lib/api-middleware', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
+    handleApiError: (error: unknown) =>
+      Response.json(
+        {
+          success: false,
+          error: error instanceof Error ? error.message : 'error',
+        },
+        { status: (error as { statusCode?: number }).statusCode ?? 500 },
+      ),
+  };
+});
+
+jest.mock('@/lib/rbac/resource-authz', () => ({
+  requireResourcePermission: jest.fn(),
+  filterResourcesByPermission: jest.fn(async (_s, r) => r),
+}));
+
+jest.mock('@/lib/rbac/openfga-owned-resources-reconcile', () => ({
+  reconcileKnowledgeBaseRelationships: jest.fn(),
+  reconcileDataSourceRelationships: jest.fn(),
+  reconcileMcpToolRelationships: jest.fn(),
+  deleteAllMcpToolRelationshipTuples: jest.fn(),
+}));
+
+jest.mock('@/lib/rbac/openfga', () => ({
+  checkOpenFgaTuple: jest.fn(),
+}));
+
+import { NextRequest } from 'next/server';
+
+describe('RAG proxy Bearer auth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireRbacPermission.mockResolvedValue(undefined);
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      user: { email: 'cli@example.com', name: 'CLI', role: 'user' },
+      session: {
+        sub: 'sub-cli',
+        org: 'caipe',
+        accessToken: 'kc-token',
+        role: 'user',
+        user: { email: 'cli@example.com', name: 'CLI' },
+      },
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ email: 'cli@example.com', role: 'readonly' }),
+    }) as unknown as typeof fetch;
+  });
+
+  it('GET /api/rag/v1/user/info forwards Bearer token to RAG server', async () => {
+    const { GET } = await import('@/app/api/rag/[...path]/route');
+    const request = new NextRequest('http://localhost:3000/api/rag/v1/user/info', {
+      headers: { Authorization: 'Bearer kc-token' },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ['v1', 'user', 'info'] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockGetAuthFromBearerOrSession).toHaveBeenCalled();
+    expect(mockRequireRbacPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'kc-token', sub: 'sub-cli' }),
+      'rag',
+      'query',
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/user/info'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer kc-token',
+        }),
+      }),
+    );
+  });
+});

--- a/ui/src/app/api/rag/kb/[...path]/route.ts
+++ b/ui/src/app/api/rag/kb/[...path]/route.ts
@@ -1,8 +1,7 @@
 import { handleApiError,requireRbacPermission } from "@/lib/api-middleware";
-import { authOptions } from "@/lib/auth-config";
+import { resolveRagProxySession } from "@/lib/rag-proxy-session";
 import { requireResourcePermission,type ResourcePermissionAction } from "@/lib/rbac/resource-authz";
 import type { RbacScope } from "@/lib/rbac/types";
-import { getServerSession } from "next-auth";
 import { NextRequest,NextResponse } from "next/server";
 
 /**
@@ -71,10 +70,7 @@ async function proxyToRag(
   pathSegments: string[],
   method: string,
 ): Promise<NextResponse> {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const session = await resolveRagProxySession(request);
 
   let body: unknown = undefined;
   if (method === "POST" || method === "PUT" || method === "PATCH") {

--- a/ui/src/lib/__tests__/rag-proxy-session.test.ts
+++ b/ui/src/lib/__tests__/rag-proxy-session.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/dev-auth-provider', () => ({
+  getDevAnonymousSession: jest.fn(),
+  isDevAnonymousAuthEnabled: jest.fn().mockReturnValue(false),
+}));
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+
+jest.mock('@/lib/api-middleware', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+  };
+});
+
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { resolveRagProxySession } from '@/lib/rag-proxy-session';
+
+function makeRequest(headers?: Record<string, string>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/rag/v1/user/info', {
+    headers,
+  });
+}
+
+describe('resolveRagProxySession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses Bearer JWT when Authorization header is present', async () => {
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      user: { email: 'cli@example.com', name: 'CLI', role: 'user' },
+      session: {
+        sub: 'sub-123',
+        org: 'caipe',
+        accessToken: 'kc-access-token',
+        role: 'user',
+      },
+    });
+
+    const session = await resolveRagProxySession(
+      makeRequest({ Authorization: 'Bearer kc-access-token' }),
+    );
+
+    expect(mockGetAuthFromBearerOrSession).toHaveBeenCalled();
+    expect(getServerSession).not.toHaveBeenCalled();
+    expect(session.accessToken).toBe('kc-access-token');
+    expect(session.sub).toBe('sub-123');
+    expect(session.user?.email).toBe('cli@example.com');
+  });
+
+  it('falls back to NextAuth session when no Bearer header', async () => {
+    jest.mocked(getServerSession).mockResolvedValue({
+      sub: 'browser-sub',
+      org: 'caipe',
+      accessToken: 'browser-token',
+      role: 'user',
+      user: { email: 'browser@example.com', name: 'Browser' },
+    } as unknown);
+
+    const session = await resolveRagProxySession(makeRequest());
+
+    expect(mockGetAuthFromBearerOrSession).not.toHaveBeenCalled();
+    expect(session.accessToken).toBe('browser-token');
+    expect(session.user?.email).toBe('browser@example.com');
+  });
+});

--- a/ui/src/lib/rag-proxy-session.ts
+++ b/ui/src/lib/rag-proxy-session.ts
@@ -1,0 +1,55 @@
+import { getServerSession } from 'next-auth';
+import type { NextRequest } from 'next/server';
+import { ApiError, getAuthFromBearerOrSession } from '@/lib/api-middleware';
+import { authOptions } from '@/lib/auth-config';
+import { getDevAnonymousSession, isDevAnonymousAuthEnabled } from '@/lib/auth/dev-auth-provider';
+
+/** Session shape used by /api/rag/* BFF proxies before forwarding to the RAG server. */
+export type RagProxySession = {
+  accessToken?: string;
+  sub?: unknown;
+  org?: string;
+  role?: string;
+  user?: { email?: string | null; name?: string | null };
+};
+
+/**
+ * Resolve the caller for RAG BFF routes.
+ *
+ * - `Authorization: Bearer` → OIDC JWT (CLI, automation, first-party services)
+ * - otherwise → NextAuth cookie session (browser), with dev-anonymous fallback
+ */
+export async function resolveRagProxySession(request: NextRequest): Promise<RagProxySession> {
+  if (request.headers.get('Authorization')?.startsWith('Bearer ')) {
+    const { user, session } = await getAuthFromBearerOrSession(request);
+    const email = session.user?.email ?? user.email;
+    if (!email) {
+      throw new ApiError('Unauthorized', 401);
+    }
+    return {
+      accessToken: session.accessToken,
+      sub: session.sub,
+      org: session.org,
+      role: session.role ?? user.role,
+      user: {
+        email,
+        name: session.user?.name ?? user.name,
+      },
+    };
+  }
+
+  const session = await getServerSession(authOptions) ?? (
+    isDevAnonymousAuthEnabled() ? getDevAnonymousSession() : null
+  );
+  if (!session?.user?.email) {
+    throw new ApiError('Unauthorized', 401);
+  }
+
+  return {
+    accessToken: session.accessToken,
+    sub: session.sub,
+    org: session.org,
+    role: session.role,
+    user: session.user,
+  };
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.61.dev3"
+version = "0.5.61.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- Adds `resolveRagProxySession()` so `/api/rag/*` and `/api/rag/kb/*` accept **`Authorization: Bearer`** OIDC access tokens (e.g. `caipe-cli` / `CAIPE_TOKEN`), matching other BFF routes like `/api/user/accessible-agents`.
- Browser behavior is unchanged: requests without a Bearer header still use NextAuth cookies (and dev-anonymous when enabled).
- Updates RAG API docs to describe dual auth on the BFF.

## Motivation

Scripted KB access (`caipe kb` with `kb.url=https://grid.outshift.io/api/rag`) currently returns **401** because the RAG proxy only called `getServerSession()`. Direct `rag-server:9446` works with the same Keycloak JWT; this closes the gap for Grid without exposing a separate public RAG ingress.

## Test plan

- [x] `npx jest src/lib/__tests__/rag-proxy-session.test.ts src/app/api/rag/__tests__/bearer-proxy.test.ts`
- [ ] After deploy to Grid: `caipe kb --kb-url https://grid.outshift.io/api/rag user info` with `caipe auth login`
- [ ] Smoke: KB UI in browser still loads and queries datasources


Made with [Cursor](https://cursor.com)