### PR TITLE
fix(ui): synchronize token refresh across replicas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.61-dev.3"
+version = "0.5.61-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -931,6 +931,35 @@ describe('getAuthenticatedUser', () => {
     expect(updateOne).toHaveBeenCalledTimes(1);
   });
 
+  it('never serves a cached session beyond the access-token expiry deadline', async () => {
+    process.env.CAIPE_SESSION_AUTH_CACHE_TTL_MS = '10000';
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const payload = Buffer.from(JSON.stringify({ exp: 1007 })).toString('base64url');
+    const accessToken = `header.${payload}.signature`;
+    const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1 });
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'expiring@test.com', name: 'Expiring User' },
+      role: 'user',
+      sub: 'expiring-sub',
+      accessToken,
+    });
+    mockGetCollection.mockResolvedValue({ updateOne });
+
+    const makeRequest = () =>
+      new Request('http://test.com/api/admin/slack/channels', {
+        headers: { cookie: 'next-auth.session-token=expiring-session' },
+      }) as unknown as NextRequest;
+
+    await getAuthenticatedUser(makeRequest());
+    nowSpy.mockReturnValue(1_001_000);
+    await getAuthenticatedUser(makeRequest());
+    nowSpy.mockReturnValue(1_003_000);
+    await getAuthenticatedUser(makeRequest());
+
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+
   it('does not cache session auth when no cookie header is present', async () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: 'nocookie@test.com', name: 'No Cookie' },

--- a/ui/src/lib/__tests__/auth-config.test.ts
+++ b/ui/src/lib/__tests__/auth-config.test.ts
@@ -5,11 +5,28 @@
 
 // Mock the token store so tests don't require a MongoDB/ESM environment.
 // Provides a simple in-memory Map that behaves identically to the real L1 path.
-const _mockTokenStore = new Map<string, import('../auth-token-store').StoredTokens>()
+const _mockTokenStore = new Map<string, import('../auth-token-store').StoredTokenState>()
 jest.mock('../auth-token-store', () => ({
-  getStoredTokens: jest.fn(async (sub: string | undefined) => _mockTokenStore.get(sub ?? '') ?? undefined),
-  storeTokens: jest.fn(async (sub: string | undefined, tokens: import('../auth-token-store').StoredTokens) => {
-    if (sub) _mockTokenStore.set(sub, tokens)
+  getStoredTokens: jest.fn(async (
+    sub: string | undefined,
+    options: import('../auth-token-store').GetStoredTokensOptions = {},
+  ) => {
+    const state = _mockTokenStore.get(sub ?? '')
+    return state && state.version >= (options.minimumVersion ?? 0) ? state : undefined
+  }),
+  storeTokens: jest.fn(async (
+    sub: string | undefined,
+    tokens: import('../auth-token-store').StoredTokens,
+    expectedVersion?: number,
+  ) => {
+    if (!sub) return undefined
+    const current = _mockTokenStore.get(sub)
+    if (current && expectedVersion !== undefined && current.version !== expectedVersion) {
+      return current
+    }
+    const state = { ...tokens, version: (current?.version ?? expectedVersion ?? 0) + 1 }
+    _mockTokenStore.set(sub, state)
+    return state
   }),
   resetTokenStore: jest.fn(() => { _mockTokenStore.clear() }),
 }))
@@ -1368,8 +1385,50 @@ describe('auth-config', () => {
       // Should NOT be logged out — access token is still valid
       expect(result.error).toBeUndefined()
       expect(result.accessToken).toBe('still-valid-at')
-      // Should suppress further refresh attempts until token expires
-      expect(result.refreshSuppressedUntil).toBe(now + 200)
+      // Retry shortly instead of suppressing until the token expires.
+      expect(result.refreshSuppressedUntil).toBe(now + 15)
+    })
+
+    it('adopts a newer token written by another replica after invalid_grant', async () => {
+      const now = Math.floor(Date.now() / 1000)
+      _mockTokenStore.set('shared-user', {
+        accessToken: 'peer-access-token',
+        refreshToken: 'peer-refresh-token',
+        expiresAt: now + 3600,
+        version: 2,
+      })
+      fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async (url) => {
+        if (url.toString().includes('.well-known')) {
+          return {
+            ok: true,
+            json: async () => ({ token_endpoint: 'https://sso.example.com/token' }),
+          } as Response
+        }
+        return {
+          ok: false,
+          headers: { get: () => 'application/json' },
+          json: async () => ({ error: 'invalid_grant', error_description: 'Token already used' }),
+        } as unknown
+      })
+
+      const result = await (authOptions.callbacks!.jwt! as (...args: unknown[]) => Promise<unknown>)({
+        token: {
+          sub: 'shared-user',
+          accessToken: 'stale-access-token',
+          refreshToken: 'consumed-refresh-token',
+          expiresAt: now + 200,
+          tokenStoreVersion: 1,
+        },
+      })
+
+      expect(result).toEqual(expect.objectContaining({
+        accessToken: 'peer-access-token',
+        refreshToken: 'peer-refresh-token',
+        expiresAt: now + 3600,
+        tokenStoreVersion: 2,
+        error: undefined,
+      }))
+      expect(result.refreshSuppressedUntil).toBeUndefined()
     })
 
     it('Safety net 3: suppressed refresh prevents further refresh attempts', async () => {

--- a/ui/src/lib/__tests__/auth-token-store.test.ts
+++ b/ui/src/lib/__tests__/auth-token-store.test.ts
@@ -29,39 +29,143 @@ describe("auth-token-store", () => {
       accessToken: "access-token",
       refreshToken: "refresh-token",
       idToken: "id-token",
+      expiresAt: 2_000_000_000,
     };
+    mockFindOne.mockResolvedValue(null);
+    mockUpdateOne.mockResolvedValue({ upsertedCount: 1 });
 
-    await storeTokens("user-1", tokens);
+    await expect(storeTokens("user-1", tokens)).resolves.toEqual({
+      ...tokens,
+      version: 1,
+    });
 
-    expect(await getStoredTokens("user-1")).toEqual(tokens);
-    expect(mockFindOne).not.toHaveBeenCalled();
+    expect(await getStoredTokens("user-1")).toEqual({ ...tokens, version: 1 });
     expect(mockUpdateOne).toHaveBeenCalledWith(
       { _id: "user-1" },
       expect.objectContaining({
-        $set: expect.objectContaining({
+        $setOnInsert: expect.objectContaining({
           enc: expect.any(String),
+          version: 1,
+          accessTokenExpiresAt: tokens.expiresAt,
           updatedAt: expect.any(Date),
         }),
       }),
       { upsert: true },
     );
 
-    const enc = mockUpdateOne.mock.calls[0][1].$set.enc as string;
+    const enc = mockUpdateOne.mock.calls[0][1].$setOnInsert.enc as string;
     expect(enc).not.toContain("access-token");
     expect(enc).not.toContain("refresh-token");
   });
 
   it("hydrates L1 from MongoDB on cache miss", async () => {
-    const tokens = { accessToken: "l2-access", refreshToken: "l2-refresh" };
+    const tokens = {
+      accessToken: "l2-access",
+      refreshToken: "l2-refresh",
+      expiresAt: 2_000_000_000,
+    };
+    mockFindOne.mockResolvedValue(null);
+    mockUpdateOne.mockResolvedValue({ upsertedCount: 1 });
 
     await storeTokens("user-2", tokens);
-    const enc = mockUpdateOne.mock.calls[0][1].$set.enc as string;
+    const enc = mockUpdateOne.mock.calls[0][1].$setOnInsert.enc as string;
     resetTokenStore();
-    mockFindOne.mockResolvedValue({ _id: "user-2", enc, updatedAt: new Date() });
+    mockFindOne.mockResolvedValue({
+      _id: "user-2",
+      enc,
+      version: 1,
+      accessTokenExpiresAt: tokens.expiresAt,
+      updatedAt: new Date(),
+    });
 
-    await expect(getStoredTokens("user-2")).resolves.toEqual(tokens);
+    await expect(getStoredTokens("user-2")).resolves.toEqual({ ...tokens, version: 1 });
     mockFindOne.mockClear();
-    await expect(getStoredTokens("user-2")).resolves.toEqual(tokens);
+    await expect(getStoredTokens("user-2")).resolves.toEqual({ ...tokens, version: 1 });
     expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it("bypasses a stale L1 entry when the session carries a newer version", async () => {
+    const oldTokens = {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: 2_000_000_000,
+    };
+    mockFindOne.mockResolvedValue(null);
+    mockUpdateOne.mockResolvedValue({ upsertedCount: 1 });
+    await storeTokens("user-3", oldTokens);
+    const oldEnc = mockUpdateOne.mock.calls[0][1].$setOnInsert.enc as string;
+
+    mockFindOne.mockResolvedValue({
+      _id: "user-3",
+      enc: oldEnc,
+      version: 1,
+      accessTokenExpiresAt: oldTokens.expiresAt,
+      updatedAt: new Date(),
+    });
+    mockUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+    const newTokens = {
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: 2_000_003_600,
+    };
+    await storeTokens("user-3", newTokens, 1);
+    const newEnc = mockUpdateOne.mock.calls[1][1].$set.enc as string;
+
+    resetTokenStore();
+    mockFindOne.mockResolvedValueOnce({
+      _id: "user-3",
+      enc: oldEnc,
+      version: 1,
+      accessTokenExpiresAt: oldTokens.expiresAt,
+      updatedAt: new Date(),
+    });
+    await expect(getStoredTokens("user-3")).resolves.toEqual({
+      ...oldTokens,
+      version: 1,
+    });
+
+    mockFindOne.mockResolvedValueOnce({
+      _id: "user-3",
+      enc: newEnc,
+      version: 2,
+      accessTokenExpiresAt: newTokens.expiresAt,
+      updatedAt: new Date(),
+    });
+    await expect(getStoredTokens("user-3", { minimumVersion: 2 })).resolves.toEqual({
+      ...newTokens,
+      version: 2,
+    });
+  });
+
+  it("does not let a stale replica overwrite a newer token record", async () => {
+    const newTokens = {
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: 2_000_003_600,
+    };
+    mockFindOne.mockResolvedValue(null);
+    mockUpdateOne.mockResolvedValue({ upsertedCount: 1 });
+    await storeTokens("user-4", newTokens);
+    const newEnc = mockUpdateOne.mock.calls[0][1].$setOnInsert.enc as string;
+
+    resetTokenStore();
+    mockFindOne.mockResolvedValue({
+      _id: "user-4",
+      enc: newEnc,
+      version: 2,
+      accessTokenExpiresAt: newTokens.expiresAt,
+      updatedAt: new Date(),
+    });
+    mockUpdateOne.mockClear();
+
+    await expect(storeTokens("user-4", {
+      accessToken: "stale-access",
+      refreshToken: "stale-refresh",
+      expiresAt: 2_000_000_000,
+    }, 1)).resolves.toEqual({
+      ...newTokens,
+      version: 2,
+    });
+    expect(mockUpdateOne).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -172,6 +172,7 @@ type SessionAuthCacheEntry = SessionAuthPayload & {
 
 const DEFAULT_SESSION_AUTH_CACHE_TTL_MS = 10_000;
 const MAX_SESSION_AUTH_CACHE_ENTRIES = 500;
+const SESSION_TOKEN_EXPIRY_SKEW_MS = 5_000;
 const sessionAuthCache = new Map<string, SessionAuthCacheEntry>();
 
 function getSessionAuthCacheTtlMs(): number {
@@ -208,6 +209,20 @@ function cloneSessionAuthPayload(value: SessionAuthPayload): SessionAuthPayload 
   };
 }
 
+function sessionAccessTokenDeadlineMs(session: SessionAuthSession): number | null {
+  if (typeof session.accessToken !== 'string' || !session.accessToken.trim()) {
+    return null;
+  }
+  try {
+    const payload = decodeJwtPayloadForAuth(session.accessToken);
+    return typeof payload.exp === 'number'
+      ? payload.exp * 1000 - SESSION_TOKEN_EXPIRY_SKEW_MS
+      : null;
+  } catch {
+    return Date.now();
+  }
+}
+
 // assisted-by Codex Codex-sonnet-4-6
 function readCachedSessionAuth(request: NextRequest): SessionAuthPayload | null {
   const key = getSessionAuthCacheKey(request);
@@ -220,7 +235,9 @@ function readCachedSessionAuth(request: NextRequest): SessionAuthPayload | null 
     return null;
   }
 
-  if (entry.expiresAt <= Date.now()) {
+  const now = Date.now();
+  const tokenDeadline = sessionAccessTokenDeadlineMs(entry.session);
+  if (entry.expiresAt <= now || (tokenDeadline !== null && tokenDeadline <= now)) {
     sessionAuthCache.delete(key);
     return null;
   }
@@ -249,9 +266,17 @@ function writeCachedSessionAuth(request: NextRequest, value: SessionAuthPayload)
     sessionAuthCache.delete(oldestKey);
   }
 
+  const tokenDeadline = sessionAccessTokenDeadlineMs(value.session);
+  const expiresAt = tokenDeadline === null
+    ? Date.now() + ttlMs
+    : Math.min(Date.now() + ttlMs, tokenDeadline);
+  if (expiresAt <= Date.now()) {
+    return;
+  }
+
   sessionAuthCache.set(key, {
     ...cloneSessionAuthPayload(value),
-    expiresAt: Date.now() + ttlMs,
+    expiresAt,
   });
 }
 

--- a/ui/src/lib/auth-config.ts
+++ b/ui/src/lib/auth-config.ts
@@ -336,7 +336,84 @@ const _inflightRefreshes = new Map<string, Promise<ExchangeResult>>();
 //     tokens AES-256-GCM encrypted at rest (key derived from NEXTAUTH_SECRET).
 //
 // See: https://github.com/cnoe-io/ai-platform-engineering/issues/1986
-import { getStoredTokens, storeTokens, resetTokenStore } from './auth-token-store';
+import {
+  getStoredTokens,
+  storeTokens,
+  resetTokenStore,
+  type StoredTokenState,
+} from './auth-token-store';
+
+const PEER_REFRESH_RETRY_DELAYS_MS = [0, 25, 50, 100];
+
+async function readPeerRefreshedTokens(token: {
+  sub?: unknown;
+  tokenStoreVersion?: unknown;
+}): Promise<StoredTokenState | undefined> {
+  const sub = typeof token.sub === "string" ? token.sub : undefined;
+  const version = typeof token.tokenStoreVersion === "number"
+    ? token.tokenStoreVersion
+    : undefined;
+  if (!sub || version === undefined) return undefined;
+
+  for (const delayMs of PEER_REFRESH_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    const state = await getStoredTokens(sub, {
+      bypassL1: true,
+      minimumVersion: version + 1,
+    });
+    if (state) return state;
+  }
+  return undefined;
+}
+
+function exchangeResultFromStoredTokens(
+  state: StoredTokenState,
+): Exclude<ExchangeResult, null> | null {
+  if (!state.accessToken) return null;
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    access_token: state.accessToken,
+    id_token: state.idToken,
+    refresh_token: state.refreshToken,
+    expires_in: state.expiresAt ? Math.max(1, state.expiresAt - now) : undefined,
+  };
+}
+
+async function applyExchangeResult(
+  token: {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    [key: string]: unknown;
+  },
+  result: Exclude<ExchangeResult, null>,
+) {
+  const expiresAt = Math.floor(Date.now() / 1000) + (result.expires_in || 3600);
+  const candidate = {
+    accessToken: result.access_token,
+    idToken: result.id_token,
+    expiresAt,
+    refreshToken: result.refresh_token ?? token.refreshToken,
+  };
+  const sub = typeof token.sub === "string" ? token.sub : undefined;
+  const expectedVersion = typeof token.tokenStoreVersion === "number"
+    ? token.tokenStoreVersion
+    : undefined;
+  const authoritative = await storeTokens(sub, candidate, expectedVersion);
+
+  return {
+    ...token,
+    accessToken: authoritative?.accessToken ?? candidate.accessToken,
+    idToken: authoritative?.idToken ?? candidate.idToken,
+    expiresAt: authoritative?.expiresAt ?? candidate.expiresAt,
+    refreshToken: authoritative?.refreshToken ?? candidate.refreshToken,
+    tokenStoreVersion: authoritative?.version ?? expectedVersion,
+    error: undefined,
+    refreshSuppressedUntil: undefined,
+  };
+}
 
 // Claim groups are only needed for in-process authorization checks and are
 // re-populated on login and every token refresh. They stay in L1 only.
@@ -378,6 +455,8 @@ async function refreshAccessToken(token: {
   accessToken?: string;
   refreshToken?: string;
   expiresAt?: number;
+  sub?: string;
+  tokenStoreVersion?: number;
   [key: string]: unknown;
 }) {
   try {
@@ -416,14 +495,7 @@ async function refreshAccessToken(token: {
         // Another caller already handled the race; current access token is still valid
         return { ...token, error: undefined };
       }
-      return {
-        ...token,
-        accessToken: result.access_token,
-        idToken: result.id_token,
-        expiresAt: Math.floor(Date.now() / 1000) + (result.expires_in || 3600),
-        refreshToken: result.refresh_token ?? currentRefreshToken,
-        error: undefined,
-      };
+      return applyExchangeResult(token, result);
     }
 
     // Inner function that performs the actual HTTP exchange.
@@ -483,6 +555,14 @@ async function refreshAccessToken(token: {
         if (data.error === "invalid_grant") {
           const now = Math.floor(Date.now() / 1000);
           const expiresAt = token.expiresAt as number | undefined;
+          const peerTokens = await readPeerRefreshedTokens(token);
+          const peerResult = peerTokens
+            ? exchangeResultFromStoredTokens(peerTokens)
+            : null;
+          if (peerResult) {
+            console.log("[Auth] Adopted token refresh completed by another replica");
+            return peerResult;
+          }
           if (expiresAt && expiresAt > now) {
             console.warn(
               "[Auth] invalid_grant with valid access token — concurrent refresh race detected, keeping current token"
@@ -514,14 +594,7 @@ async function refreshAccessToken(token: {
       return { ...token, error: undefined };
     }
 
-    return {
-      ...token,
-      accessToken: result.access_token,
-      idToken: result.id_token,
-      expiresAt: Math.floor(Date.now() / 1000) + (result.expires_in || 3600),
-      refreshToken: result.refresh_token ?? currentRefreshToken, // Use new refresh token if provided
-      error: undefined, // Clear any previous errors
-    };
+    return applyExchangeResult(token, result);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (errorMessage === "RefreshTokenExpired") {
@@ -756,7 +829,10 @@ export const authOptions: NextAuthOptions = {
             // an infinite refresh loop.
             if (!refreshedToken.error && refreshedToken.accessToken === token.accessToken) {
               console.log(`[Auth] Refresh suppressed — access token still valid for ${timeUntilExpiry}s, will not retry`);
-              return { ...refreshedToken, refreshSuppressedUntil: expiresAt };
+              return {
+                ...refreshedToken,
+                refreshSuppressedUntil: Math.min(expiresAt, now + 15),
+              };
             }
 
             // Re-evaluate group authorization every 4 hours using claims from
@@ -872,11 +948,19 @@ export const authOptions: NextAuthOptions = {
   jwt: {
     async encode({ token, secret, maxAge }) {
       if (token?.sub) {
-        await storeTokens(token.sub, {
+        const authoritative = await storeTokens(token.sub, {
           accessToken: token.accessToken as string | undefined,
           refreshToken: token.refreshToken as string | undefined,
           idToken: token.idToken as string | undefined,
-        });
+          expiresAt: token.expiresAt as number | undefined,
+        }, token.tokenStoreVersion as number | undefined);
+        if (authoritative) {
+          token.accessToken = authoritative.accessToken;
+          token.refreshToken = authoritative.refreshToken;
+          token.idToken = authoritative.idToken;
+          token.expiresAt = authoritative.expiresAt ?? token.expiresAt;
+          token.tokenStoreVersion = authoritative.version;
+        }
       }
       const slimToken = { ...(token ?? {}) } as Record<string, unknown>;
       delete slimToken.accessToken;
@@ -890,11 +974,17 @@ export const authOptions: NextAuthOptions = {
       const { decode } = await import("next-auth/jwt");
       const decoded = await decode({ token, secret });
       if (decoded?.sub) {
-        const stored = await getStoredTokens(decoded.sub);
+        const stored = await getStoredTokens(decoded.sub, {
+          minimumVersion: typeof decoded.tokenStoreVersion === "number"
+            ? decoded.tokenStoreVersion
+            : 0,
+        });
         if (stored) {
           if (stored.accessToken) decoded.accessToken = stored.accessToken;
           if (stored.refreshToken) decoded.refreshToken = stored.refreshToken;
           if (stored.idToken) decoded.idToken = stored.idToken;
+          if (stored.expiresAt) decoded.expiresAt = stored.expiresAt;
+          decoded.tokenStoreVersion = stored.version;
         }
       }
       return decoded;
@@ -963,6 +1053,7 @@ declare module "next-auth/jwt" {
     canAccessDynamicAgents?: boolean; // Legacy context flag; OpenFGA authorizes agents
     groupsCheckedAt?: number; // Unix timestamp of last group re-evaluation
     refreshSuppressedUntil?: number; // Unix timestamp — skip refresh attempts until this time (set after graceful invalid_grant)
+    tokenStoreVersion?: number; // Monotonic MongoDB token record version for cross-replica cache coherence
     org?: string;           // Tenant identifier from org claim (FR-020)
   }
 }

--- a/ui/src/lib/auth-token-store.ts
+++ b/ui/src/lib/auth-token-store.ts
@@ -7,16 +7,28 @@ export interface StoredTokens {
   accessToken?: string;
   refreshToken?: string;
   idToken?: string;
+  expiresAt?: number;
+}
+
+export interface StoredTokenState extends StoredTokens {
+  version: number;
+}
+
+export interface GetStoredTokensOptions {
+  bypassL1?: boolean;
+  minimumVersion?: number;
 }
 
 interface L1Entry {
-  tokens: StoredTokens;
+  state: StoredTokenState;
   expiresAt: number; // unix seconds
 }
 
 interface TokenStoreDoc {
   _id: string;
   enc: string; // base64(iv[12] || authTag[16] || ciphertext)
+  version?: number;
+  accessTokenExpiresAt?: number;
   updatedAt: Date;
 }
 
@@ -57,32 +69,54 @@ function _decrypt(enc: string): StoredTokens {
   ) as StoredTokens;
 }
 
-function _l1Get(sub: string): StoredTokens | undefined {
+function _l1Get(sub: string, minimumVersion: number): StoredTokenState | undefined {
   const entry = _l1.get(sub);
   if (!entry) return undefined;
   if (Math.floor(Date.now() / 1000) >= entry.expiresAt) {
     _l1.delete(sub);
     return undefined;
   }
-  return entry.tokens;
+  if (entry.state.version < minimumVersion) return undefined;
+  return entry.state;
 }
 
-function _l1Set(sub: string, tokens: StoredTokens): void {
+function _l1Set(sub: string, state: StoredTokenState): void {
   _l1.set(sub, {
-    tokens,
+    state,
     expiresAt: Math.floor(Date.now() / 1000) + L1_TTL_S,
   });
 }
 
+function _stateFromDoc(doc: TokenStoreDoc): StoredTokenState {
+  return {
+    ..._decrypt(doc.enc),
+    version: doc.version ?? 0,
+  };
+}
+
+function _versionFilter(doc: TokenStoreDoc): Record<string, unknown> {
+  return doc.version === undefined
+    ? { version: { $exists: false } }
+    : { version: doc.version };
+}
+
 /**
  * Read stored OAuth tokens for a user.
- * L1 (in-memory, 60s TTL) is checked first; on miss, falls back to MongoDB.
+ * L1 (in-memory, 60s TTL) is checked first when it is at least as new as the
+ * version carried by the session cookie. A newer cookie version forces an L2
+ * read so another replica's refresh becomes visible immediately.
  */
-export async function getStoredTokens(sub: string | undefined): Promise<StoredTokens | undefined> {
+export async function getStoredTokens(
+  sub: string | undefined,
+  options: GetStoredTokensOptions = {},
+): Promise<StoredTokenState | undefined> {
   if (!sub) return undefined;
 
-  const l1 = _l1Get(sub);
-  if (l1) return l1;
+  const minimumVersion = options.minimumVersion ?? 0;
+  if (!options.bypassL1) {
+    const l1 = _l1Get(sub, minimumVersion);
+    if (l1) return l1;
+  }
 
   if (!isMongoDBConfigured) return undefined;
 
@@ -90,9 +124,10 @@ export async function getStoredTokens(sub: string | undefined): Promise<StoredTo
     const col = await getCollection<TokenStoreDoc>(COLLECTION);
     const doc = await col.findOne({ _id: sub } as Parameters<typeof col.findOne>[0]);
     if (!doc) return undefined;
-    const tokens = _decrypt(doc.enc);
-    _l1Set(sub, tokens);
-    return tokens;
+    const state = _stateFromDoc(doc);
+    if (state.version < minimumVersion) return undefined;
+    _l1Set(sub, state);
+    return state;
   } catch (err) {
     console.error('[auth-token-store] MongoDB read error:', err);
     return undefined;
@@ -101,27 +136,109 @@ export async function getStoredTokens(sub: string | undefined): Promise<StoredTo
 
 /**
  * Persist OAuth tokens for a user.
- * Writes to L1 immediately and to MongoDB asynchronously (non-fatal on failure).
- * Tokens are AES-256-GCM encrypted before storage; key derived from NEXTAUTH_SECRET via HKDF.
+ * MongoDB is authoritative when configured. The caller supplies the version it
+ * originally read; a compare-and-swap prevents a stale replica from replacing
+ * a newer refresh. The authoritative state is returned to the caller.
  */
-export async function storeTokens(sub: string | undefined, tokens: StoredTokens): Promise<void> {
-  if (!sub) return;
+export async function storeTokens(
+  sub: string | undefined,
+  tokens: StoredTokens,
+  expectedVersion?: number,
+): Promise<StoredTokenState | undefined> {
+  if (!sub) return undefined;
 
-  _l1Set(sub, tokens);
-
-  if (!isMongoDBConfigured) return;
+  if (!isMongoDBConfigured) {
+    const current = _l1Get(sub, 0);
+    const state = {
+      ...tokens,
+      version: Math.max(current?.version ?? 0, expectedVersion ?? 0) + 1,
+    };
+    _l1Set(sub, state);
+    return state;
+  }
 
   try {
     const enc = _encrypt(tokens);
     const col = await getCollection<TokenStoreDoc>(COLLECTION);
-    await col.updateOne(
-      { _id: sub } as Parameters<typeof col.updateOne>[0],
-      { $set: { enc, updatedAt: new Date() } },
-      { upsert: true },
-    );
+    const current = await col.findOne({ _id: sub } as Parameters<typeof col.findOne>[0]);
+
+    if (!current) {
+      const inserted = await col.updateOne(
+        { _id: sub } as Parameters<typeof col.updateOne>[0],
+        {
+          $setOnInsert: {
+            enc,
+            version: 1,
+            accessTokenExpiresAt: tokens.expiresAt,
+            updatedAt: new Date(),
+          },
+        },
+        { upsert: true },
+      );
+      if (inserted.upsertedCount === 1) {
+        const state = { ...tokens, version: 1 };
+        _l1Set(sub, state);
+        return state;
+      }
+    } else {
+      const currentState = _stateFromDoc(current);
+      const currentExpiry = current.accessTokenExpiresAt ?? currentState.expiresAt ?? 0;
+      const incomingExpiry = tokens.expiresAt ?? 0;
+      const tokensUnchanged =
+        currentState.accessToken === tokens.accessToken &&
+        currentState.refreshToken === tokens.refreshToken &&
+        currentState.idToken === tokens.idToken &&
+        currentState.expiresAt === tokens.expiresAt;
+
+      if (tokensUnchanged) {
+        _l1Set(sub, currentState);
+        return currentState;
+      }
+
+      if (
+        (expectedVersion !== undefined && currentState.version !== expectedVersion) ||
+        currentExpiry > incomingExpiry
+      ) {
+        _l1Set(sub, currentState);
+        return currentState;
+      }
+
+      const nextVersion = currentState.version + 1;
+      const updated = await col.updateOne(
+        {
+          _id: sub,
+          ..._versionFilter(current),
+        } as Parameters<typeof col.updateOne>[0],
+        {
+          $set: {
+            enc,
+            version: nextVersion,
+            accessTokenExpiresAt: tokens.expiresAt,
+            updatedAt: new Date(),
+          },
+        },
+      );
+      if (updated.modifiedCount === 1) {
+        const state = { ...tokens, version: nextVersion };
+        _l1Set(sub, state);
+        return state;
+      }
+    }
+
+    // A peer won the insert/update race. Return its state instead of allowing
+    // this replica's stale tokens to escape into the session.
+    const authoritative = await col.findOne({ _id: sub } as Parameters<typeof col.findOne>[0]);
+    if (authoritative) {
+      const state = _stateFromDoc(authoritative);
+      _l1Set(sub, state);
+      return state;
+    }
+    return undefined;
   } catch (err) {
-    // Non-fatal: L1 still serves this pod; other pods may miss until next refresh
     console.error('[auth-token-store] MongoDB write error:', err);
+    const state = { ...tokens, version: (expectedVersion ?? 0) + 1 };
+    _l1Set(sub, state);
+    return state;
   }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.61.dev3"
+version = "0.5.61.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fix intermittent authentication failures when CAIPE UI runs with multiple replicas.

Each UI process kept access and refresh tokens in an independent L1 cache while MongoDB acted as the shared backing store. After one replica refreshed a rotated token, another replica could continue using its stale cached token or attempt to overwrite the newer shared state. That produced intermittent expired-token and `invalid_grant` failures depending on which replica served the request.

This change:

- versions shared token records and carries the version in the slim session token
- bypasses stale L1 entries when the session requires a newer version
- uses optimistic compare-and-set writes so stale replicas cannot overwrite newer tokens
- adopts a peer replica's successful refresh after a rotated-refresh-token race
- persists successful refreshes immediately
- caps middleware authorization-cache lifetime at the access-token expiry boundary
- includes compatibility handling for existing unversioned MongoDB records

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- `npm test -- --runInBand src/lib/__tests__/auth-token-store.test.ts src/lib/__tests__/auth-config.test.ts src/lib/__tests__/api-middleware.test.ts` — 184 tests passed
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check origin/main...HEAD` — passed

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable; no issue was provided for this fix
- [x] I verified this change is not present in another open pull request
- [x] Functionality is documented in code and tests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] Relevant existing tests pass

Related downstream validation: cisco-eti/ai-platform-engineering-mirror#244