### PR TITLE
fix(ui): clarify feedback issue action

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.61 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.62 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.61 -f your-values.yaml'}
+                  {'    --version 0.5.62 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.61 -f your-values.yaml'}
+              {'    --version 0.5.62 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.62"
+version = "0.5.62-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/chat/FeedbackButton.tsx
+++ b/ui/src/components/chat/FeedbackButton.tsx
@@ -53,7 +53,6 @@ export function FeedbackButton({
 
   const reportProblemEnabled = getConfig("reportProblemEnabled");
   const ticketEnabled = getConfig("ticketEnabled");
-  const ticketProvider = getConfig("ticketProvider");
 
   const handleThumbClick = (type: FeedbackType, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -273,7 +272,7 @@ export function FeedbackButton({
               className="w-full gap-2"
             >
               {isSubmittingCombo && <Loader2 className="h-3 w-3 animate-spin" />}
-              Submit &amp; Report {ticketProvider === "jira" ? "Jira" : "GitHub"} Issue
+              Submit &amp; Create Issue
             </Button>
           )}
         </div>

--- a/ui/src/components/chat/__tests__/FeedbackButton.test.tsx
+++ b/ui/src/components/chat/__tests__/FeedbackButton.test.tsx
@@ -50,7 +50,6 @@ jest.mock("lucide-react", () => ({
 
 let mockReportProblemEnabled = false;
 let mockTicketEnabled = false;
-let mockTicketProvider: string | null = null;
 
 jest.mock("@/lib/config", () => ({
   getConfig: (key: string) => {
@@ -59,8 +58,6 @@ jest.mock("@/lib/config", () => ({
         return mockReportProblemEnabled;
       case "ticketEnabled":
         return mockTicketEnabled;
-      case "ticketProvider":
-        return mockTicketProvider;
       default:
         return null;
     }
@@ -484,23 +481,21 @@ describe("FeedbackButton", () => {
     beforeEach(() => {
       mockReportProblemEnabled = true;
       mockTicketEnabled = true;
-      mockTicketProvider = "jira";
     });
 
     afterEach(() => {
       mockReportProblemEnabled = false;
       mockTicketEnabled = false;
-      mockTicketProvider = null;
     });
 
-    it("shows 'Submit & Report Jira Issue' button on dislike", () => {
+    it("shows 'Submit & Create Issue' button on dislike", () => {
       render(
         <FeedbackButton
           messageId="msg-1"
           feedback={{ type: "dislike", reason: "Inaccurate", showFeedbackOptions: true }}
         />
       );
-      expect(screen.getByText(/Submit & Report Jira Issue/)).toBeInTheDocument();
+      expect(screen.getByText("Submit & Create Issue")).toBeInTheDocument();
     });
 
     it("does NOT show combo button on positive feedback", () => {
@@ -510,7 +505,7 @@ describe("FeedbackButton", () => {
           feedback={{ type: "like", reason: "Very Helpful", showFeedbackOptions: true }}
         />
       );
-      expect(screen.queryByText(/Submit & Report/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Submit & Create/)).not.toBeInTheDocument();
     });
 
     it("shows 'Report a Problem' link on dislike", () => {
@@ -543,7 +538,7 @@ describe("FeedbackButton", () => {
         />
       );
 
-      fireEvent.click(screen.getByText(/Submit & Report Jira Issue/));
+      fireEvent.click(screen.getByText("Submit & Create Issue"));
 
       await waitFor(() => {
         expect(mockSubmitFeedback).toHaveBeenCalledWith(
@@ -564,7 +559,6 @@ describe("FeedbackButton", () => {
     beforeEach(() => {
       mockReportProblemEnabled = false;
       mockTicketEnabled = false;
-      mockTicketProvider = null;
     });
 
     it("does not show combo button", () => {
@@ -574,7 +568,7 @@ describe("FeedbackButton", () => {
           feedback={{ type: "dislike", reason: "Inaccurate", showFeedbackOptions: true }}
         />
       );
-      expect(screen.queryByText(/Submit & Report/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Submit & Create/)).not.toBeInTheDocument();
     });
 
     it("does not show 'Report a Problem' link", () => {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.62"
+version = "0.5.62.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Rename the negative-feedback combo action from **Submit & Report Jira Issue** to **Submit & Create Issue**.

The previous wording was confusing because the action first submits feedback and then opens the configured issue-creation dialog. The underlying two-step behavior is unchanged.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- `npm test -- --runInBand src/components/chat/__tests__/FeedbackButton.test.tsx`
- `npx eslint src/components/chat/FeedbackButton.tsx src/components/chat/__tests__/FeedbackButton.test.tsx`

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All focused tests pass
