### PR TITLE
docs(releases): add release blog posts for 0.5.59-0.5.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.61-dev.3 (2026-07-24)
+## 0.5.62 (2026-07-26)
 
 ### Fix
 
@@ -7,17 +7,7 @@
 - **skills**: isCatalogKey must match user:-prefixed subject
 - **skills**: catalog key returns hub and global agent_skills, not only default
 - **skills**: catalog key and local skills JWT missing sub drops all skills
-
-## 0.5.61-dev.2 (2026-07-24)
-
-### Fix
-
 - **rag**: recurse into sitemap index children instead of scraping them as pages (#2293)
-
-## 0.5.61-dev.1 (2026-07-24)
-
-### Fix
-
 - **CI**: ui
 
 ## 0.5.61 (2026-07-24)

--- a/docs/releases/2026-07-23-release-0-5-59.md
+++ b/docs/releases/2026-07-23-release-0-5-59.md
@@ -1,0 +1,106 @@
+---
+slug: release-0.5.59
+title: "Release 0.5.59 — Remote MCP Catalog"
+date: 2026-07-23
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-23
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.59`
+> Previous release: 0.5.58
+
+## Highlights
+
+0.5.59 adds a remote MCP catalog to the MCP Server Editor — browse and add pre-configured remote MCP providers (Amplitude, Figma, Linear, Notion, ThousandEyes, AWS, PagerDuty, and more) without hand-writing server config. This release also republishes the `mcp-webex` image that was missing from 0.5.58, and fixes a deployment default that broke built-in workflow tools for dynamic agents.
+
+<!-- truncate -->
+
+## What's New
+
+### Remote MCP catalog
+
+- **Catalog dialog in the MCP Server Editor** — browse pre-configured remote MCP providers and add them with prefilled config, gated behind `NEXT_PUBLIC_REMOTE_MCP_CATALOG_ENABLED`. ([#2263](https://github.com/cnoe-io/ai-platform-engineering/pull/2263))
+- **Admin Settings → MCP tab** — manage installed remote MCP catalog entries alongside the existing Agents tab.
+- **Test Connection** — validates a saved credential and triggers OAuth (PKCE/standard) for providers that require it, right from the MCP Server Editor.
+- **Built-in OAuth connectors** for Amplitude, Figma, Linear, and Notion, plus a ThousandEyes catalog entry.
+- **AgentGateway config bridge resilience** — keeps the last-known-good config and retries instead of crashing when the BFF is temporarily unavailable.
+
+## Bug Fixes
+
+- **helm**: dynamic agents now default `CAIPE_API_URL` to the in-cluster CAIPE UI service for the release, fixing built-in workflow tool calls that previously failed with "No scheme supplied" when the value was left unset. ([#2255](https://github.com/cnoe-io/ai-platform-engineering/pull/2255))
+- **ci**: fork pull requests no longer fail CI on unrelated GitHub App token steps that only work for in-org contributors. ([#2281](https://github.com/cnoe-io/ai-platform-engineering/pull/2281))
+
+## Known Issues Resolved
+
+`mcp-webex:0.5.58` was missing from `ghcr.io` due to a CI digest-naming collision (see the [0.5.58 release notes](/blog/releases/release-0.5.58)). The fix landed in the 0.5.58 prereleases and this tag republishes a working `mcp-webex:0.5.59` image — no action needed beyond upgrading past 0.5.58.
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.58.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.58 → 0.5.59
+
+### Overview
+
+Drop-in upgrade — no `values.yaml` edits required.
+
+### Helm Values Changes
+
+Comment-only change: `dynamic-agents.config.CAIPE_API_URL` now documents that leaving it empty defaults to the in-cluster CAIPE UI service (`http://<release-name>-caipe-ui:3000`), and should only be overridden when pointing dynamic agents at an external CAIPE UI/BFF. No key was added, removed, or renamed.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.59 \
+  -f your-values.yaml
+```
+
+#### 2. Try the remote MCP catalog (optional)
+
+Set `NEXT_PUBLIC_REMOTE_MCP_CATALOG_ENABLED=true` in the CAIPE UI environment to enable the catalog dialog in the MCP Server Editor.
+
+#### 3. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If you were hitting `ImagePullBackOff` on `mcp-webex:0.5.58`, confirm it resolves once you're on `0.5.59`.
+
+### Personal Impact Analysis
+
+No `values.yaml` changes required.
+
+### Full Values Diff
+
+<details>
+<summary>Raw diff (0.5.58 → 0.5.59)</summary>
+
+```diff
+--- 0.5.58
++++ 0.5.59
+@@ -1094,7 +1094,9 @@
+     # Connections & Secrets credential exchange client. Disabled by default.
+     CAIPE_CREDENTIALS_ENABLED: "false"
+     CREDENTIAL_API_URL: ""
+-    # CAIPE UI server base URL for built-in workflow tools.
++    # CAIPE UI server base URL for built-in workflow tools. Leave empty to get
++    # the in-cluster default http://<release-name>-caipe-ui:3000; override only
++    # when pointing dynamic-agents at an external CAIPE UI/BFF.
+     CAIPE_API_URL: ""
+     CREDENTIAL_SERVICE_AUDIENCE: "caipe-credential-service"
+     USE_IMPERSONATION_TOKENS: "false"
+```
+
+</details>

--- a/docs/releases/2026-07-23-release-0-5-60.md
+++ b/docs/releases/2026-07-23-release-0-5-60.md
@@ -1,0 +1,68 @@
+---
+slug: release-0.5.60
+title: "Release 0.5.60 — Auto-Create Team Sync Fix"
+date: 2026-07-23
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-23
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.60`
+> Previous release: 0.5.59
+
+## Highlights
+
+0.5.60 is a focused fix for deployments that enable login-time team auto-creation: OIDC group membership now syncs into OpenFGA team tuples even when no explicit group-sync rules are configured, restoring team-scoped resource sharing for non-admin users.
+
+<!-- truncate -->
+
+## Bug Fixes
+
+- **rbac**: when `IDENTITY_SYNC_LOGIN_AUTO_CREATE_TEAMS` is enabled but no `identity_group_sync` rules are configured, login now synthesizes a passthrough rule mapping each OIDC group to a same-named team instead of silently writing zero OpenFGA membership tuples. This was breaking team-scoped resource sharing (for example, the team dropdown in secret sharing) for every non-admin user on affected deployments. Behavior is unchanged if you already configure `identity_group_sync` rules, or if auto-create is off. ([#2282](https://github.com/cnoe-io/ai-platform-engineering/pull/2282))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.59.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.59 → 0.5.60
+
+### Overview
+
+Drop-in upgrade — no `values.yaml` edits required.
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.59 and 0.5.60. Drop-in upgrade.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.60 \
+  -f your-values.yaml
+```
+
+#### 2. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If you run with `IDENTITY_SYNC_LOGIN_AUTO_CREATE_TEAMS=true` and no `identity_group_sync` rules, expect newly logged-in users to start getting team-membership tuples written on next login — this is the intended fix, not a regression.
+
+### Personal Impact Analysis
+
+No `values.yaml` changes required.
+
+### Full Values Diff
+
+No diff — `values.yaml` is identical between 0.5.59 and 0.5.60.

--- a/docs/releases/2026-07-24-release-0-5-61.md
+++ b/docs/releases/2026-07-24-release-0-5-61.md
@@ -1,0 +1,81 @@
+---
+slug: release-0.5.61
+title: "Release 0.5.61 — SSO Idle Timeout Fix & Insights Drill-Down"
+date: 2026-07-24
+authors: [sriaradhyula]
+tags: [release]
+---
+
+> Released: 2026-07-24
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.61`
+> Previous release: 0.5.60
+
+## Highlights
+
+0.5.61 fixes an SSO session bug that was randomly logging out idle users, adds per-user OAuth token support to the Webex and Confluence MCP servers, and lets admins click into a day's feedback directly from the Insights trend chart.
+
+<!-- truncate -->
+
+## What's New
+
+### Feedback trend drill-down
+
+Clicking a point on the Admin → Insights feedback trend chart now opens the Feedback tab pre-filtered to that day, with Back returning you to Statistics. Existing source, user, and simulation filters carry through unchanged. ([#2283](https://github.com/cnoe-io/ai-platform-engineering/pull/2283))
+
+### Insights user drawer for scoped viewers
+
+Insights readers can now open the user drawer for users within their permitted resource scope or team, not just full admins — while server-side RBAC still governs exactly which conversations are visible. Top Users cards are now paginated (10 rows per page) instead of loading everything at once. ([#2285](https://github.com/cnoe-io/ai-platform-engineering/pull/2285))
+
+## Bug Fixes
+
+- **ui**: fixed users being logged out mid-session when their Keycloak SSO idle timer expired while a tab sat open but idle. A 6-hour keepalive now refreshes the session before the 8-hour idle window closes. ([#2288](https://github.com/cnoe-io/ai-platform-engineering/pull/2288))
+- **webex**: the Webex MCP server now uses a connected user's own OAuth token when available, falling back to the shared bot token — enabling per-user impersonation instead of every call running as the bot.
+- **confluence**: the Confluence MCP server now sends per-user Atlassian OAuth tokens as Bearer auth against the correct Atlassian API host, fixing "cannot access Confluence" for users with a connected Atlassian credential. Static bot-token deployments are unaffected.
+- **rag**: closed several RBAC gaps in the RAG server where document/chunk reads, job endpoints, and graph-explore endpoints checked only a coarse role instead of the per-datasource grant already enforced elsewhere — inaccessible datasources are now filtered or denied consistently. ([#2269](https://github.com/cnoe-io/ai-platform-engineering/pull/2269))
+
+## Breaking Changes
+
+No breaking changes. Drop-in upgrade from 0.5.60.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.60 → 0.5.61
+
+### Overview
+
+Drop-in upgrade — no `values.yaml` edits required.
+
+### Helm Values Changes
+
+No Helm values changes between 0.5.60 and 0.5.61. Drop-in upgrade.
+
+### Upgrade Runbook
+
+#### 1. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.61 \
+  -f your-values.yaml
+```
+
+#### 2. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If users on your deployment were reporting random logouts after long idle periods, confirm those stop occurring after this upgrade.
+
+### Personal Impact Analysis
+
+No `values.yaml` changes required.
+
+### Full Values Diff
+
+No diff — `values.yaml` is identical between 0.5.60 and 0.5.61.

--- a/docs/releases/2026-07-26-release-0-5-62.md
+++ b/docs/releases/2026-07-26-release-0-5-62.md
@@ -1,0 +1,131 @@
+---
+slug: release-0.5.62
+title: "Release 0.5.62 — Scheduler Access Control & Skills Catalog Fixes"
+date: 2026-07-26
+authors: [sriaradhyula, suwhang-cisco]
+tags: [release]
+---
+
+> Released: 2026-07-26
+> Chart: `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering:0.5.62`
+> Previous release: 0.5.61
+
+## Highlights
+
+0.5.62 gives admins finer control over who can see and edit the Scheduler agent, fixes several skills-catalog authorization bugs that were dropping skills for API-key and JWT callers, and stops the Webex bot from dropping messages during reconnect storms. It also **changes the default AgentGateway authorization posture for the scheduler MCP server** — see Breaking Changes below.
+
+<!-- truncate -->
+
+## What's New
+
+### Scheduler admin access controls
+
+- Admins can now change the default schedule-editor agent from Admin Settings instead of it being fixed at deploy time.
+- The Scheduler tab correctly hides itself for normal users when admin-only access is enabled — previously it stayed visible even when the underlying access was restricted.
+- Scheduler documentation was updated to match. ([#2292](https://github.com/cnoe-io/ai-platform-engineering/pull/2292))
+
+## Bug Fixes
+
+- **skills**: the skills catalog API key and local skills JWT paths returned a session with no subject, which silently dropped every skill for programmatic callers (`caipe-skills.py`, `install.sh`, `update-caipe-skills`). Both paths now resolve a subject correctly.
+- **skills**: once the subject was fixed, the catalog API key path still filtered out hub and global `agent_skills`, returning only default filesystem skills — it now returns the full set of globally-visible skills.
+- **skills**: the OpenFGA subject-match bypass for the catalog API key compared against the raw subject instead of the `user:`-prefixed value the route handler actually sends, so the bypass never fired — global skills were still filtered out for CLI callers. Fixed and covered by regression tests.
+- **webex-wdm**: the Webex bot now refreshes its WDM device registration on both graceful (`ConnectionClosedOK`) and abnormal (`ConnectionClosedError`) WebSocket closes from Mercury, instead of only the abnormal case — closing a gap where a clean-but-expired `webSocketUrl` caused a drop-reconnect-drop loop and missed messages.
+- **rag**: sitemap ingestion now recurses into sitemap index files (`<sitemapindex>`) instead of treating each child sitemap URL as a page, fixing sites that split their sitemap into multiple files silently ingesting zero content.
+
+## Security
+
+**AgentGateway `restrictedMcpServers` default changed from `[scheduler]` to `[]`.** Caller-level `mcp_server:<id>#can_invoke` authorization is no longer enforced for the scheduler MCP target by default — restricting it is now opt-in via Helm values instead of baked into the chart default. See Breaking Changes for the upgrade action.
+
+## Breaking Changes
+
+**Affected key**: `agentgateway.authz.restrictedMcpServers` (exact path depends on your chart layout — check your rendered values)
+
+**Before (0.5.61)**:
+```yaml
+authz:
+  restrictedMcpServers:
+    - scheduler
+```
+
+**After (0.5.62)**:
+```yaml
+authz:
+  restrictedMcpServers: []
+```
+
+**Action**: If you rely on the scheduler MCP target requiring per-caller `can_invoke` authorization, set `restrictedMcpServers: [scheduler]` explicitly in your `values.yaml` before upgrading. Left unset, any caller with general MCP gateway access can invoke the scheduler MCP target — use the Scheduler admin-only UI toggle (see What's New) as your access control instead, or restore the old Helm-level restriction.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.5.61 → 0.5.62
+
+### Overview
+
+Not a drop-in upgrade if you depend on the previous `restrictedMcpServers: [scheduler]` default — see Breaking Changes. Otherwise no other `values.yaml` edits required.
+
+### Helm Values Changes
+
+#### Breaking Changes
+
+See above: `restrictedMcpServers` default changed from `[scheduler]` to `[]`.
+
+### Upgrade Runbook
+
+#### 1. Update `values.yaml` if needed
+
+```yaml
+authz:
+  restrictedMcpServers:
+    - scheduler
+```
+
+Add this only if you want to keep enforcing caller-level authorization on the scheduler MCP target the way 0.5.61 and earlier did by default.
+
+#### 2. Update chart version
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  --version 0.5.62 \
+  -f your-values.yaml
+```
+
+#### 3. Verify
+
+```bash
+kubectl get pods -n <namespace>
+```
+
+If your Scheduler is set to admin-only access in Admin Settings, confirm the Scheduler tab is now correctly hidden for a non-admin test user.
+
+### Personal Impact Analysis
+
+If your `values.yaml` does not set `restrictedMcpServers` explicitly, scheduler MCP access control now depends entirely on the Scheduler admin-only UI toggle rather than the AgentGateway default — review which one your deployment actually needs before upgrading.
+
+### Full Values Diff
+
+<details>
+<summary>Raw diff (0.5.61 → 0.5.62)</summary>
+
+```diff
+--- 0.5.61
++++ 0.5.62
+@@ -1490,9 +1490,8 @@
+     algorithms:
+       - RS256
+   # Require caller-level `mcp_server:<id>#can_invoke` authorization only for
+-  # these AgentGateway MCP targets.
+-  restrictedMcpServers:
+-    - scheduler
++  # these AgentGateway MCP targets. Empty by default; restrictions are opt-in.
++  restrictedMcpServers: []
+   audit:
+     enabled: true
+     serviceUrl: ""
+```
+
+</details>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.61 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.62 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {


### PR DESCRIPTION
## Description

Backfills four missing release blog posts (`docs/releases/`) and bumps the homepage Helm quickstart version string, which had fallen behind the latest tag.

- `2026-07-23-release-0-5-59.md` — remote MCP catalog, `CAIPE_API_URL` dynamic-agents default fix, fork-PR CI fix
- `2026-07-23-release-0-5-60.md` — OIDC auto-create team sync fix
- `2026-07-24-release-0-5-61.md` — SSO idle-timeout fix, per-user Webex/Confluence OAuth, Insights drill-down + pagination, RAG RBAC audit
- `2026-07-26-release-0-5-62.md` — scheduler admin access controls, skills-catalog auth fixes, Webex WDM reconnect fix, RAG sitemap-index fix, and a breaking Helm default change (`restrictedMcpServers` default flips from `[scheduler]` to `[]`)
- `docs/src/pages/index.tsx` — Helm quickstart `--version` bumped `0.5.61` to `0.5.62`

Content was sourced from `git log <tag>..<tag>` commit ranges and PR bodies rather than the root `CHANGELOG.md`, since that file's auto-generated per-version headers mislabel several commits to the wrong release (confirmed by cross-checking commit dates against tag dates).

## Type of Change

- [x] Documentation

## Checklist

- [x] I have read the contributing guidelines
- [x] Functionality is documented
- [x] All code style checks pass
