### PR TITLE
feat(ui): allow chat title edit and open links in a new tab

### DIFF
--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import { AnimatePresence,motion } from "framer-motion";
 import {
 Archive,
 ArchiveRestore,
+Check,
 ChevronLeft,
 ChevronRight,
 Database,
@@ -27,17 +28,25 @@ HardDrive,
 History,
 MessageCircleQuestion,
 MessageSquare,
+Pencil,
 Plus,
 Radio,
 RefreshCw,
 Shield,
 Sparkles,
 TrendingUp,
-Users
+Users,
+X
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useEffect,useState,useTransition } from "react";
+import {
+  useEffect,
+  useState,
+  useTransition,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 
 interface SidebarProps {
   activeTab: "chat" | "gallery" | "knowledge" | "admin";
@@ -78,6 +87,7 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
     setActiveConversation,
     createConversation,
     deleteConversation,
+    updateConversationTitle,
     loadConversationsFromServer,
     loadMessagesFromServer,
     isConversationStreaming,
@@ -92,6 +102,9 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
   const [isResizing, setIsResizing] = useState(false);
   const [isReloading, setIsReloading] = useState(false);
   const [recycleBinOpen, setRecycleBinOpen] = useState(false);
+  const [editingConversationId, setEditingConversationId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState("");
+  const [renameSavingId, setRenameSavingId] = useState<string | null>(null);
   const { toast } = useToast();
 
   // Agent name lookup for dynamic agent conversations
@@ -245,6 +258,42 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
           router.push(`/chat/${conversationId}`);
         });
       }
+    }
+  };
+
+  const beginTitleEdit = (event: ReactMouseEvent, conversation: Conversation) => {
+    event.stopPropagation();
+    setEditingConversationId(conversation.id);
+    setEditingTitle(conversation.title || "");
+  };
+
+  const cancelTitleEdit = (event?: ReactMouseEvent) => {
+    event?.stopPropagation();
+    setEditingConversationId(null);
+    setEditingTitle("");
+    setRenameSavingId(null);
+  };
+
+  const commitTitleEdit = async (
+    event: ReactMouseEvent | ReactKeyboardEvent,
+    conversation: Conversation,
+  ) => {
+    event.stopPropagation();
+    const nextTitle = editingTitle.trim();
+    if (!nextTitle) return;
+
+    if (nextTitle === conversation.title) {
+      cancelTitleEdit();
+      return;
+    }
+
+    setRenameSavingId(conversation.id);
+    try {
+      await updateConversationTitle(conversation.id, nextTitle);
+      setEditingConversationId(null);
+      setEditingTitle("");
+    } finally {
+      setRenameSavingId(null);
     }
   };
 
@@ -408,6 +457,8 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                   const isInputRequired = !isLive && isConversationInputRequired(conv.id);
                   const isUnviewed = !isLive && !isInputRequired && hasUnviewedMessages(conv.id);
                   const scheduleBadge = getScheduleBadge(conv);
+                  const isEditingTitle = editingConversationId === conv.id;
+                  const isSavingTitle = renameSavingId === conv.id;
 
                   return (
                   <div
@@ -491,16 +542,39 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                       <>
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-1 min-w-0">
-                            <p className="text-sm font-medium truncate flex-1" title={conv.title}>
-                              {truncateText(conv.title, sidebarWidth > 350 ? 40 : sidebarWidth > 320 ? 25 : 20)}
-                            </p>
-                            {scheduleBadge && (
-                              <span
-                                className="shrink-0 max-w-[132px] truncate rounded border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.5 text-[10px] font-medium normal-case tracking-normal text-cyan-700 dark:text-cyan-300"
-                                title={scheduleBadge.title}
-                              >
-                                {truncateText(scheduleBadge.label, sidebarWidth > 350 ? 24 : 18)}
-                              </span>
+                            {isEditingTitle ? (
+                              <input
+                                autoFocus
+                                value={editingTitle}
+                                disabled={isSavingTitle}
+                                onClick={(event) => event.stopPropagation()}
+                                onChange={(event) => setEditingTitle(event.target.value)}
+                                onKeyDown={(event) => {
+                                  if (event.key === "Enter") {
+                                    event.preventDefault();
+                                    void commitTitleEdit(event, conv);
+                                  } else if (event.key === "Escape") {
+                                    event.preventDefault();
+                                    cancelTitleEdit();
+                                  }
+                                }}
+                                className="h-6 min-w-0 flex-1 rounded border border-border bg-background px-2 text-sm font-medium outline-none focus:border-primary"
+                                aria-label="Conversation title"
+                              />
+                            ) : (
+                              <>
+                                <p className="text-sm font-medium truncate flex-1" title={conv.title}>
+                                  {truncateText(conv.title, sidebarWidth > 350 ? 40 : sidebarWidth > 320 ? 25 : 20)}
+                                </p>
+                                {scheduleBadge && (
+                                  <span
+                                    className="shrink-0 max-w-[132px] truncate rounded border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.5 text-[10px] font-medium normal-case tracking-normal text-cyan-700 dark:text-cyan-300"
+                                    title={scheduleBadge.title}
+                                  >
+                                    {truncateText(scheduleBadge.label, sidebarWidth > 350 ? 24 : 18)}
+                                  </span>
+                                )}
+                              </>
                             )}
                           </div>
                           <p className={cn(
@@ -528,24 +602,90 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                         </div>
 
                         <div className="flex items-center gap-0.5 shrink-0">
-                          <div
-                            className={cn(
-                              "transition-opacity",
-                              activeConversationId === conv.id || hasSharingConfig || isSharedWithViewer
-                                ? "opacity-100"
-                                : "opacity-0 group-hover:opacity-100",
-                            )}
-                          >
-                            <ShareButton
-                              conversationId={conv.id}
-                              conversationTitle={conv.title}
-                              isOwner={canManageSharing}
-                              isSharedWithViewer={isSharedWithViewer}
-                              sharedBy={sharedByLabel}
-                              sharing={conv.sharing}
-                              accessLevel={conv.accessLevel}
-                            />
-                          </div>
+                          {isEditingTitle ? (
+                            <>
+                              <TooltipProvider delayDuration={200}>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-6 w-6"
+                                      aria-label="Save title"
+                                      disabled={isSavingTitle || !editingTitle.trim()}
+                                      onClick={(event) => void commitTitleEdit(event, conv)}
+                                    >
+                                      <Check className="h-3 w-3" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top" sideOffset={4}>
+                                    <p className="text-xs">Save title</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                              <TooltipProvider delayDuration={200}>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-6 w-6"
+                                      aria-label="Cancel rename"
+                                      disabled={isSavingTitle}
+                                      onClick={cancelTitleEdit}
+                                    >
+                                      <X className="h-3 w-3" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="top" sideOffset={4}>
+                                    <p className="text-xs">Cancel rename</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            </>
+                          ) : (
+                            <>
+                              {canManageSharing && (
+                                <TooltipProvider delayDuration={200}>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                                        aria-label="Rename conversation"
+                                        onClick={(event) => beginTitleEdit(event, conv)}
+                                      >
+                                        <Pencil className="h-3 w-3" />
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top" sideOffset={4}>
+                                      <p className="text-xs">Rename conversation</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
+                              <div
+                                className={cn(
+                                  "transition-opacity",
+                                  activeConversationId === conv.id || hasSharingConfig || isSharedWithViewer
+                                    ? "opacity-100"
+                                    : "opacity-0 group-hover:opacity-100",
+                                )}
+                              >
+                                <ShareButton
+                                  conversationId={conv.id}
+                                  conversationTitle={conv.title}
+                                  isOwner={canManageSharing}
+                                  isSharedWithViewer={isSharedWithViewer}
+                                  sharedBy={sharedByLabel}
+                                  sharing={conv.sharing}
+                                  accessLevel={conv.accessLevel}
+                                />
+                              </div>
+                            </>
+                          )}
+                          {!isEditingTitle && (
                           <TooltipProvider delayDuration={200}>
                           <Tooltip>
                           <TooltipTrigger asChild>
@@ -607,6 +747,7 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                           </TooltipContent>
                           </Tooltip>
                           </TooltipProvider>
+                          )}
                         </div>
                       </>
                     )}

--- a/ui/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/layout/__tests__/Sidebar.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 // ============================================================================
 // Mocks — must be before imports
@@ -54,6 +54,7 @@ let mockActiveConversationId: string | null = null
 const mockSetActiveConversation = jest.fn()
 const mockCreateConversation = jest.fn(() => 'new-conv-id')
 const mockDeleteConversation = jest.fn()
+const mockUpdateConversationTitle = jest.fn().mockResolvedValue(undefined)
 const mockLoadConversationsFromServer = jest.fn().mockResolvedValue(undefined)
 const mockLoadMessagesFromServer = jest.fn().mockResolvedValue(undefined)
 const mockIsConversationStreaming = jest.fn(() => false)
@@ -73,6 +74,7 @@ jest.mock('@/store/chat-store', () => {
       setActiveConversation: mockSetActiveConversation,
       createConversation: mockCreateConversation,
       deleteConversation: mockDeleteConversation,
+      updateConversationTitle: mockUpdateConversationTitle,
       loadConversationsFromServer: mockLoadConversationsFromServer,
       loadMessagesFromServer: mockLoadMessagesFromServer,
       isConversationStreaming: mockIsConversationStreaming,
@@ -97,8 +99,10 @@ jest.mock('lucide-react', () => ({
   Plus: (props: unknown) => <span data-testid="icon-plus" {...props} />,
   Archive: (props: unknown) => <span data-testid="icon-archive" {...props} />,
   ArchiveRestore: (props: unknown) => <span data-testid="icon-archive-restore" {...props} />,
+  Check: (props: unknown) => <span data-testid="icon-check" {...props} />,
   ChevronLeft: (props: unknown) => <span data-testid="icon-chevron-left" {...props} />,
   ChevronRight: (props: unknown) => <span data-testid="icon-chevron-right" {...props} />,
+  Pencil: (props: unknown) => <span data-testid="icon-pencil" {...props} />,
   Sparkles: (props: unknown) => <span data-testid="icon-sparkles" {...props} />,
   Zap: (props: unknown) => <span data-testid="icon-zap" {...props} />,
   Database: (props: unknown) => <span data-testid="icon-database" {...props} />,
@@ -109,6 +113,7 @@ jest.mock('lucide-react', () => ({
   Users: (props: unknown) => <span data-testid="icon-users" {...props} />,
   TrendingUp: (props: unknown) => <span data-testid="icon-trending-up" {...props} />,
   RefreshCw: (props: unknown) => <span data-testid="icon-refresh" {...props} />,
+  X: (props: unknown) => <span data-testid="icon-x" {...props} />,
 }))
 
 jest.mock('@/components/ui/button', () => ({
@@ -614,6 +619,46 @@ describe('Sidebar — Live Status Indicator', () => {
       fireEvent.click(screen.getByText('Clickable Chat'))
 
       expect(mockSetActiveConversation).toHaveBeenCalledWith('conv-click')
+    })
+
+    it('renames a conversation from the action buttons', async () => {
+      mockConversations = [
+        makeConv('conv-rename', 'Original Title', {
+          owner_id: 'test@test.com',
+        }),
+      ]
+
+      render(<Sidebar {...defaultProps} />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Rename conversation' }))
+      const titleInput = screen.getByRole('textbox', { name: 'Conversation title' })
+      fireEvent.change(titleInput, { target: { value: 'Updated Title' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save title' }))
+
+      await waitFor(() => {
+        expect(mockUpdateConversationTitle).toHaveBeenCalledWith('conv-rename', 'Updated Title')
+        expect(screen.queryByRole('textbox', { name: 'Conversation title' })).not.toBeInTheDocument()
+      })
+    })
+
+    it('cancels title editing without saving', () => {
+      mockConversations = [
+        makeConv('conv-rename', 'Original Title', {
+          owner_id: 'test@test.com',
+        }),
+      ]
+
+      render(<Sidebar {...defaultProps} />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Rename conversation' }))
+      fireEvent.change(screen.getByRole('textbox', { name: 'Conversation title' }), {
+        target: { value: 'Discarded Title' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel rename' }))
+
+      expect(screen.queryByRole('textbox', { name: 'Conversation title' })).not.toBeInTheDocument()
+      expect(screen.getByText('Original Title')).toBeInTheDocument()
+      expect(mockUpdateConversationTitle).not.toHaveBeenCalled()
     })
   })
 

--- a/ui/src/components/shared/timeline/MarkdownRenderer.tsx
+++ b/ui/src/components/shared/timeline/MarkdownRenderer.tsx
@@ -91,6 +91,7 @@ function escapeHtml(text: string) {
 
 const purifyConfig = {
   USE_PROFILES: { html: true },
+  ADD_ATTR: ["target", "rel"] as string[],
   FORBID_TAGS: ["style"] as string[],
   FORBID_CONTENTS: ["style", "script"] as string[],
 };
@@ -98,6 +99,14 @@ const purifyConfig = {
 function sanitize(html: string): string {
   if (typeof window === "undefined") return html;
   return DOMPurify.sanitize(html, purifyConfig);
+}
+
+function decorateLinks(root: HTMLDivElement) {
+  const links = root.querySelectorAll("a[href]");
+  for (const link of links) {
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noopener noreferrer");
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -247,6 +256,7 @@ export function MarkdownRenderer({
     // Build temp element, decorate, then morph
     const temp = document.createElement("div");
     temp.innerHTML = html;
+    decorateLinks(temp);
     decorateCopyButtons(temp);
 
     morphdom(container, temp, {

--- a/ui/src/components/shared/timeline/__tests__/MarkdownRenderer.test.tsx
+++ b/ui/src/components/shared/timeline/__tests__/MarkdownRenderer.test.tsx
@@ -1,0 +1,36 @@
+import { render,screen,waitFor } from "@testing-library/react";
+import { MarkdownRenderer } from "../MarkdownRenderer";
+
+jest.mock("remend", () => ({
+  __esModule: true,
+  default: (content: string) => content,
+}), { virtual: true });
+
+jest.mock("marked-shiki", () => ({
+  __esModule: true,
+  default: () => ({}),
+}));
+
+jest.mock("shiki", () => ({
+  bundledLanguages: {},
+  createHighlighter: jest.fn(),
+}));
+
+describe("MarkdownRenderer links", () => {
+  it("opens external and relative links in a new tab", async () => {
+    render(
+      <MarkdownRenderer
+        content="[External](https://example.com/docs) [Internal](/chat/example)"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "External" })).toHaveAttribute("target", "_blank");
+      expect(screen.getByRole("link", { name: "Internal" })).toHaveAttribute("target", "_blank");
+    });
+
+    for (const link of screen.getAllByRole("link")) {
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+});


### PR DESCRIPTION
# Description

Minor UI improvements:
1. Allow users to edit their chat title
2. Links in chat opens in a new tab


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
