### PR TITLE
fix(credentials): load caller teams in secret sharing

### DIFF
--- a/ui/e2e/rbac/credential-team-sharing.spec.ts
+++ b/ui/e2e/rbac/credential-team-sharing.spec.ts
@@ -31,6 +31,7 @@ test.describe("RBAC e2e — credential team sharing", () => {
   test("uses inline common team picker and shows the selected shared team", async ({ page }) => {
     const env = rbacEnvOrSkip();
     const pendingShares: PendingShare[] = [];
+    let callerTeamsRequests = 0;
 
     await page.route("**/api/admin/platform-config", async (route) => {
       await fulfillJson(route, {
@@ -39,16 +40,17 @@ test.describe("RBAC e2e — credential team sharing", () => {
       });
     });
 
-    await page.route("**/api/admin/teams", async (route) => {
+    // Credential sharing must use caller-visible teams. The admin-only endpoint
+    // leaves non-admin secret owners with an empty picker.
+    await page.route("**/api/dynamic-agents/teams", async (route) => {
+      callerTeamsRequests += 1;
       await fulfillJson(route, {
         success: true,
-        data: {
-          teams: [
-            { _id: "team-1", slug: "platform-team", name: "Platform Team" },
-            { _id: "team-2", slug: "observability-team", name: "Observability Team" },
-            { _id: "team-3", slug: "security-team", name: "Security Team" },
-          ],
-        },
+        data: [
+          { _id: "team-1", slug: "platform-team", name: "Platform Team" },
+          { _id: "team-2", slug: "observability-team", name: "Observability Team" },
+          { _id: "team-3", slug: "security-team", name: "Security Team" },
+        ],
       });
     });
 
@@ -84,6 +86,7 @@ test.describe("RBAC e2e — credential team sharing", () => {
 
     const panel = page.getByRole("region", { name: /github token team access/i });
     await expect(panel).toBeVisible();
+    await expect.poll(() => callerTeamsRequests).toBe(1);
     await expect(page.getByRole("dialog", { name: /share github token/i })).toHaveCount(0);
     await expect(panel.getByText(/Choose a team that can use this saved secret/)).toBeVisible();
     await expect(panel.getByLabel("Team access")).toContainText("Platform Team");

--- a/ui/src/components/credentials/SecretSharingPanel.tsx
+++ b/ui/src/components/credentials/SecretSharingPanel.tsx
@@ -64,12 +64,12 @@ export function SecretSharingPanel({
   React.useEffect(() => {
     async function loadTeams() {
       try {
-        const response = await fetch("/api/admin/teams");
+        const response = await fetch("/api/dynamic-agents/teams");
         if (!response.ok) {
           throw new Error("Could not load teams");
         }
-        const payload = apiData<{ teams?: TeamOption[] }>(await response.json());
-        setTeamOptions(payload.teams ?? []);
+        const payload = apiData<{ teams?: TeamOption[] } | TeamOption[]>(await response.json());
+        setTeamOptions(Array.isArray(payload) ? payload : payload.teams ?? []);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Could not load teams");
       }

--- a/ui/src/components/credentials/__tests__/SecretSharingPanel.test.tsx
+++ b/ui/src/components/credentials/__tests__/SecretSharingPanel.test.tsx
@@ -10,17 +10,15 @@ import { SecretSharingPanel } from "../SecretSharingPanel";
 describe("SecretSharingPanel", () => {
   beforeEach(() => {
     global.fetch = jest.fn(async (url) => {
-      if (String(url) === "/api/admin/teams") {
+      if (String(url) === "/api/dynamic-agents/teams") {
         return {
           ok: true,
           json: async () => ({
             success: true,
-            data: {
-              teams: [
-                { _id: "team-1", slug: "platform-team", name: "Platform Team" },
-                { _id: "team-2", slug: "security-team", name: "Security Team" },
-              ],
-            },
+            data: [
+              { _id: "team-1", slug: "platform-team", name: "Platform Team" },
+              { _id: "team-2", slug: "security-team", name: "Security Team" },
+            ],
           }),
         } as Response;
       }
@@ -39,6 +37,7 @@ describe("SecretSharingPanel", () => {
     );
 
     await pickTeam(/team access/i, "platform-team");
+    expect(global.fetch).toHaveBeenCalledWith("/api/dynamic-agents/teams");
     await user.click(screen.getByRole("button", { name: /grant access/i }));
 
     expect(global.fetch).toHaveBeenCalledWith(
@@ -113,12 +112,12 @@ describe("SecretSharingPanel", () => {
     const user = userEvent.setup();
     const onSharingChange = jest.fn();
     (global.fetch as jest.Mock).mockImplementation(async (url) => {
-      if (String(url) === "/api/admin/teams") {
+      if (String(url) === "/api/dynamic-agents/teams") {
         return {
           ok: true,
           json: async () => ({
             success: true,
-            data: { teams: [{ _id: "team-1", slug: "platform-team", name: "Platform Team" }] },
+            data: [{ _id: "team-1", slug: "platform-team", name: "Platform Team" }],
           }),
         } as Response;
       }

--- a/ui/src/components/credentials/__tests__/SecretsManager.test.tsx
+++ b/ui/src/components/credentials/__tests__/SecretsManager.test.tsx
@@ -9,17 +9,15 @@ describe("SecretsManager", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = jest.fn(async (url, init) => {
-      if (String(url) === "/api/admin/teams") {
+      if (String(url) === "/api/dynamic-agents/teams") {
         return {
           ok: true,
           json: async () => ({
             success: true,
-            data: {
-              teams: [
-                { _id: "team-1", slug: "platform-team", name: "Platform Team" },
-                { _id: "team-2", slug: "security-team", name: "Security Team" },
-              ],
-            },
+            data: [
+              { _id: "team-1", slug: "platform-team", name: "Platform Team" },
+              { _id: "team-2", slug: "security-team", name: "Security Team" },
+            ],
           }),
         } as Response;
       }


### PR DESCRIPTION
## Summary

- Load credential-sharing candidates from the caller-scoped `/api/dynamic-agents/teams` endpoint.
- Accept that endpoint’s direct-array response shape in the credential sharing panel.
- Add a regression assertion that the panel requests the caller-team endpoint.

## Root cause

The credential sharing panel queried `/api/admin/teams`. In the affected generic-user flow that endpoint returned no candidates, so the picker displayed “No teams available” even though the user had an active membership in `caipe-internal-demo-users`.

## Validation

- `npx jest src/components/credentials/__tests__/SecretSharingPanel.test.tsx --runInBand` (4 passed)
- `npx eslint src/components/credentials/SecretSharingPanel.tsx src/components/credentials/__tests__/SecretSharingPanel.test.tsx`
- `git diff --check`