### PR TITLE
fix(auth): support local no-SSO MCP access

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
@@ -601,6 +601,10 @@ async def resolve_mcp_credential_refs(
             if source.name.lower() == "authorization" and not credential.lower().startswith("bearer "):
                 header_value = f"Bearer {credential}"
             resolved["headers"] = {**resolved.get("headers", {}), source.name: header_value}
+            if source.kind == "caller_token" and "Authorization" not in resolved["headers"]:
+                resolved["headers"]["Authorization"] = (
+                    credential if credential.lower().startswith("bearer ") else f"Bearer {credential}"
+                )
 
     return resolved
 
@@ -623,7 +627,7 @@ async def resolve_mcp_connections_credential_refs(
     from ``connections`` and recorded in ``failures`` with structured reasons.
     """
 
-    if credential_client is None or not _use_impersonation_tokens():
+    if not _use_impersonation_tokens():
         return McpCredentialResolutionResult(connections=dict(connections))
 
     server_map = {server.id: server for server in servers}
@@ -632,6 +636,12 @@ async def resolve_mcp_connections_credential_refs(
     for server_id, config in connections.items():
         server = server_map.get(server_id)
         if server is None:
+            resolved[server_id] = config
+            continue
+        if credential_client is None and not any(
+            source.kind == "caller_token" and source.fallback_client_credentials
+            for source in server.credential_sources
+        ):
             resolved[server_id] = config
             continue
         try:

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_credential_refs.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_credential_refs.py
@@ -273,6 +273,7 @@ async def test_caller_token_falls_back_to_client_credentials(monkeypatch):
         server, config, credential_client=FakeCredentialClient()
     )
 
+    assert resolved["headers"]["Authorization"] == "Bearer service-client-credentials-token"
     assert resolved["headers"]["X-CAIPE-Provider-Token"] == "service-client-credentials-token"
 
 
@@ -294,6 +295,29 @@ async def test_caller_token_no_jwt_no_mint_skips_injection(monkeypatch):
     )
 
     assert "X-CAIPE-Provider-Token" not in resolved.get("headers", {})
+
+
+@pytest.mark.asyncio
+async def test_batch_resolves_caller_token_fallback_without_credential_api_client(monkeypatch):
+    """Local no-SSO has no user bearer, but can still mint the platform token."""
+    monkeypatch.setenv("USE_IMPERSONATION_TOKENS", "true")
+
+    async def _mint():
+        return "service-client-credentials-token"
+
+    monkeypatch.setattr(mcp_client, "mint_service_client_credentials_token", _mint)
+    server = _kb_server()
+    connections = {"knowledge-base": build_mcp_connection_config(server)}
+
+    result = await resolve_mcp_connections_credential_refs(
+        [server],
+        connections,
+        credential_client=None,
+    )
+
+    assert result.connections["knowledge-base"]["headers"]["Authorization"] == (
+        "Bearer service-client-credentials-token"
+    )
 
 
 @pytest.mark.asyncio

--- a/ui/src/app/api/mcp-servers/test-tool/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/test-tool/__tests__/route.test.ts
@@ -17,6 +17,7 @@ const mockRetrieve = jest.fn();
 const mockRefreshConnection = jest.fn();
 const mockListConnections = jest.fn();
 const mockIsCredentialFeatureEnabled = jest.fn();
+const mockIsDevAnonymousAuthEnabled = jest.fn();
 const mockWriteOpenFgaTuples = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
@@ -75,6 +76,10 @@ jest.mock("@/lib/feature-flags/credentials", () => ({
   isCredentialFeatureEnabled: (...args: unknown[]) => mockIsCredentialFeatureEnabled(...args),
 }));
 
+jest.mock("@/lib/auth/dev-auth-provider", () => ({
+  isDevAnonymousAuthEnabled: () => mockIsDevAnonymousAuthEnabled(),
+}));
+
 function request(body: Record<string, unknown>, headers?: HeadersInit): NextRequest {
   return new NextRequest(new URL("/api/mcp-servers/test-tool", "http://localhost:3000"), {
     method: "POST",
@@ -103,6 +108,7 @@ describe("POST /api/mcp-servers/test-tool", () => {
       refreshConnection: mockRefreshConnection,
     });
     mockIsCredentialFeatureEnabled.mockReturnValue(true);
+    mockIsDevAnonymousAuthEnabled.mockReturnValue(false);
     mockListConnections.mockResolvedValue([]);
     mockRetrieve.mockResolvedValue({ credential: "argocd-provider-token" });
     mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 2, deletes: 0 });
@@ -111,6 +117,9 @@ describe("POST /api/mcp-servers/test-tool", () => {
   afterEach(() => {
     delete process.env.AGENT_GATEWAY_URL;
     delete process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET;
+    delete process.env.INGESTOR_OIDC_DISCOVERY_URL;
+    delete process.env.INGESTOR_OIDC_CLIENT_ID;
+    delete process.env.INGESTOR_OIDC_CLIENT_SECRET;
   });
 
   it("sends user auth to AgentGateway and provider auth as X-CAIPE-Provider-Token", async () => {
@@ -209,6 +218,88 @@ describe("POST /api/mcp-servers/test-tool", () => {
           object: "tool:mcp-test-argocd/*",
         }),
       ],
+    });
+  });
+
+  it("grants and revokes test-tool access for the minted local service account", async () => {
+    const serviceToken = `header.${Buffer.from(
+      JSON.stringify({ sub: "service-account-sub" }),
+    ).toString("base64url")}.signature`;
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      session: { sub: "anonymous-local-dev", role: "admin" },
+    });
+    mockIsDevAnonymousAuthEnabled.mockReturnValue(true);
+    process.env.INGESTOR_OIDC_DISCOVERY_URL =
+      "http://keycloak:7080/realms/caipe/.well-known/openid-configuration";
+    process.env.INGESTOR_OIDC_CLIENT_ID = "caipe-platform";
+    process.env.INGESTOR_OIDC_CLIENT_SECRET = "secret";
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "knowledge-base",
+        name: "Knowledge Base",
+        transport: "http",
+        endpoint: "http://agentgateway:4000/mcp/knowledge-base",
+        source: "agentgateway",
+        enabled: true,
+        credential_sources: [],
+      }),
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ access_token: serviceToken, expires_in: 300 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "initialize-1", result: {} }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "mcp-session-id": "mcp-session-1",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: "tools-call-1",
+            result: { content: [{ type: "text", text: "ok" }] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ) as unknown as typeof fetch;
+
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request({ serverId: "knowledge-base", toolName: "search", params: { query: "test" } }),
+    );
+
+    expect(response.status).toBe(200);
+    const diagnosticWrites = [
+      {
+        user: "service_account:service-account-sub",
+        relation: "caller",
+        object: "mcp_gateway:list",
+      },
+      {
+        user: "service_account:service-account-sub",
+        relation: "user",
+        object: expect.stringMatching(/^agent:mcp-test-knowledge-base-/),
+      },
+      {
+        user: expect.stringMatching(/^agent:mcp-test-knowledge-base-/),
+        relation: "caller",
+        object: "tool:knowledge-base/*",
+      },
+    ];
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: diagnosticWrites,
+      deletes: [],
+    });
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: diagnosticWrites,
     });
   });
 

--- a/ui/src/app/api/mcp-servers/test-tool/route.ts
+++ b/ui/src/app/api/mcp-servers/test-tool/route.ts
@@ -18,7 +18,10 @@ import {
   resolveMcpHeaderCredentials,
   isMcpCredentialUnavailableError,
 } from "@/lib/mcp-credential-headers";
-import { writeOpenFgaTuples, type OpenFgaTupleKey } from "@/lib/rbac/openfga";
+import {
+  grantDiagnosticAgentAccess,
+  revokeDiagnosticAgentAccess,
+} from "@/lib/mcp-http-server-client";
 import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import type { MCPServerConfig } from "@/types/dynamic-agent";
 import { NextRequest } from "next/server";
@@ -101,39 +104,6 @@ function isAgentGatewayEndpoint(server: MCPServerConfig): boolean {
   }
 }
 
-function diagnosticOpenFgaTuples(
-  serverId: string,
-  agentId: string,
-  session: Awaited<ReturnType<typeof getAuthFromBearerOrSession>>["session"],
-): OpenFgaTupleKey[] {
-  const subject = typeof session?.sub === "string" ? session.sub.trim() : "";
-  if (!subject) return [];
-  return [
-    { user: `user:${subject}`, relation: "user", object: `agent:${agentId}` },
-    { user: `agent:${agentId}`, relation: "caller", object: `tool:${serverId}/*` },
-  ];
-}
-
-async function grantDiagnosticAgentAccess(
-  serverId: string,
-  agentId: string,
-  session: Awaited<ReturnType<typeof getAuthFromBearerOrSession>>["session"],
-): Promise<OpenFgaTupleKey[]> {
-  const writes = diagnosticOpenFgaTuples(serverId, agentId, session);
-  if (!writes.length) return [];
-  await writeOpenFgaTuples({ writes, deletes: [] });
-  return writes;
-}
-
-async function revokeDiagnosticAgentAccess(tuples: OpenFgaTupleKey[]): Promise<void> {
-  if (!tuples.length) return;
-  try {
-    await writeOpenFgaTuples({ writes: [], deletes: tuples });
-  } catch (error) {
-    console.warn("[mcp-servers/test-tool] failed to remove diagnostic AgentGateway tuples", error);
-  }
-}
-
 async function readJsonOrSse(response: Response): Promise<unknown> {
   const contentType = response.headers.get("content-type") || "";
   if (contentType.includes("application/json")) return response.json();
@@ -197,38 +167,44 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 
   const viaAgentGateway = isAgentGatewayEndpoint(server);
   const diagnosticAgent = diagnosticAgentId(serverId, session);
+
+  let credentialResolution;
+  try {
+    credentialResolution = await resolveMcpHeaderCredentials({
+      request,
+      session,
+      server,
+      viaAgentGateway,
+      retrievalCaller: "mcp-test-tool",
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "MCP_AUTH_REQUIRED") {
+      throw new ApiError(
+        "A signed-in user token is required to test AgentGateway-routed MCP tools",
+        401,
+        "MCP_TEST_AUTH_REQUIRED",
+      );
+    }
+    if (isMcpCredentialUnavailableError(error)) {
+      throw new ApiError(
+        error instanceof Error ? error.message : "MCP provider credential is unavailable",
+        401,
+        "MCP_CREDENTIAL_UNAVAILABLE",
+      );
+    }
+    throw error;
+  }
+
   const diagnosticTuples = viaAgentGateway
-    ? await grantDiagnosticAgentAccess(serverId, diagnosticAgent, session)
+    ? await grantDiagnosticAgentAccess(
+        serverId,
+        diagnosticAgent,
+        session,
+        credentialResolution.authorizationSubject,
+      )
     : [];
 
   try {
-    let credentialResolution;
-    try {
-      credentialResolution = await resolveMcpHeaderCredentials({
-        request,
-        session,
-        server,
-        viaAgentGateway,
-        retrievalCaller: "mcp-test-tool",
-      });
-    } catch (error) {
-      if (error instanceof Error && error.message === "MCP_AUTH_REQUIRED") {
-        throw new ApiError(
-          "A signed-in user token is required to test AgentGateway-routed MCP tools",
-          401,
-          "MCP_TEST_AUTH_REQUIRED",
-        );
-      }
-      if (isMcpCredentialUnavailableError(error)) {
-        throw new ApiError(
-          error instanceof Error ? error.message : "MCP provider credential is unavailable",
-          401,
-          "MCP_CREDENTIAL_UNAVAILABLE",
-        );
-      }
-      throw error;
-    }
-
     const headers = {
       ...credentialResolution.headers,
       ...buildAgentContextHeaders(diagnosticAgent),
@@ -280,6 +256,6 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       ...(errorMessage ? { error: errorMessage } : {}),
     });
   } finally {
-    await revokeDiagnosticAgentAccess(diagnosticTuples);
+    await revokeDiagnosticAgentAccess(diagnosticTuples, "mcp-servers/test-tool");
   }
 });

--- a/ui/src/app/api/rbac/__tests__/ingest-teams.test.ts
+++ b/ui/src/app/api/rbac/__tests__/ingest-teams.test.ts
@@ -18,6 +18,16 @@ jest.mock("@/lib/auth-config", () => ({
   isBootstrapAdmin: jest.fn().mockReturnValue(false),
 }));
 
+const mockIsDevAnonymousAuthEnabled = jest.fn().mockReturnValue(false);
+jest.mock("@/lib/auth/dev-auth-provider", () => ({
+  isDevAnonymousAuthEnabled: () => mockIsDevAnonymousAuthEnabled(),
+  getDevAnonymousSession: () => ({
+    sub: "anonymous-local-dev",
+    role: "admin",
+    user: { email: "anonymous@local", name: "Anonymous Local Admin", role: "admin" },
+  }),
+}));
+
 const mockCheckOpenFgaTuple = jest.fn();
 const mockReadOpenFgaTuples = jest.fn();
 jest.mock("@/lib/rbac/openfga", () => ({
@@ -61,6 +71,7 @@ describe("GET /api/rbac/ingest-teams", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (isBootstrapAdmin as jest.Mock).mockReturnValue(false);
+    mockIsDevAnonymousAuthEnabled.mockReturnValue(false);
     mockCheckOpenFgaTuple.mockResolvedValue({ allowed: false });
     mockReadOpenFgaTuples.mockResolvedValue({ tuples: [] });
     mockIsUserInTeam.mockResolvedValue(false);
@@ -71,6 +82,20 @@ describe("GET /api/rbac/ingest-teams", () => {
     (getServerSession as jest.Mock).mockResolvedValue(null);
     const res = await GET();
     expect(res.status).toBe(401);
+  });
+
+  it("treats the explicit no-SSO development session as an org admin", async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+    mockIsDevAnonymousAuthEnabled.mockReturnValue(true);
+    mockCollections.teams = teamsCollection([
+      { slug: "super-admins", name: "Super Admins" },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.org_admin).toBe(true);
+    expect(body.teams.map((t: { slug: string }) => t.slug)).toEqual(["super-admins"]);
+    expect(mockCheckOpenFgaTuple).not.toHaveBeenCalled();
   });
 
   it("org admin receives all teams", async () => {

--- a/ui/src/app/api/rbac/ingest-teams/route.ts
+++ b/ui/src/app/api/rbac/ingest-teams/route.ts
@@ -1,4 +1,5 @@
 import { authOptions,isBootstrapAdmin } from "@/lib/auth-config";
+import { getDevAnonymousSession,isDevAnonymousAuthEnabled } from "@/lib/auth/dev-auth-provider";
 import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
 import { checkOpenFgaTuple,readOpenFgaTuples } from "@/lib/rbac/openfga";
 import { organizationObjectId } from "@/lib/rbac/organization";
@@ -56,6 +57,7 @@ async function isOrgAdmin(session: {
   accessToken?: string;
   user?: { email?: string | null };
 }): Promise<boolean> {
+  if (isDevAnonymousAuthEnabled()) return true;
   if (isBootstrapAdmin(session.user?.email ?? "")) return true;
   const subject = getSessionSubject(session);
   if (!subject) return false;
@@ -104,7 +106,9 @@ export async function GET() {
     return NextResponse.json({ teams: [] });
   }
 
-  const session = (await getServerSession(authOptions)) as
+  const session = ((await getServerSession(authOptions)) ?? (
+    isDevAnonymousAuthEnabled() ? getDevAnonymousSession() : null
+  )) as
     | {
         accessToken?: string;
         sub?: string;

--- a/ui/src/lib/__tests__/mcp-credential-headers.test.ts
+++ b/ui/src/lib/__tests__/mcp-credential-headers.test.ts
@@ -19,9 +19,14 @@ const mockRefreshConnection = jest.fn();
 const mockListConnections = jest.fn();
 const mockGetConnection = jest.fn();
 const mockIsCredentialFeatureEnabled = jest.fn();
+const mockIsDevAnonymousAuthEnabled = jest.fn();
 
 jest.mock("@/lib/credentials/retrieval-service-factory", () => ({
   getCredentialRetrievalService: (...args: unknown[]) => mockGetCredentialRetrievalService(...args),
+}));
+
+jest.mock("@/lib/auth/dev-auth-provider", () => ({
+  isDevAnonymousAuthEnabled: () => mockIsDevAnonymousAuthEnabled(),
 }));
 
 jest.mock("@/lib/credentials/oauth-service-factory", () => ({
@@ -45,6 +50,10 @@ describe("mcp-credential-headers", () => {
     delete process.env.MCP_SERVICE_OIDC_TOKEN_URL;
     delete process.env.MCP_SERVICE_OIDC_CLIENT_ID;
     delete process.env.MCP_SERVICE_OIDC_CLIENT_SECRET;
+    delete process.env.INGESTOR_OIDC_DISCOVERY_URL;
+    delete process.env.INGESTOR_OIDC_ISSUER;
+    delete process.env.INGESTOR_OIDC_CLIENT_ID;
+    delete process.env.INGESTOR_OIDC_CLIENT_SECRET;
     mockGetCredentialRetrievalService.mockResolvedValue({ retrieve: mockRetrieve });
     mockGetProviderConnectionService.mockResolvedValue({
       listConnections: mockListConnections,
@@ -52,6 +61,7 @@ describe("mcp-credential-headers", () => {
       refreshConnection: mockRefreshConnection,
     });
     mockIsCredentialFeatureEnabled.mockReturnValue(true);
+    mockIsDevAnonymousAuthEnabled.mockReturnValue(false);
     mockRetrieve.mockResolvedValue({ credential: "secret-token" });
     _resetMcpCredentialHeaderTokenCacheForTests();
     mockListConnections.mockResolvedValue([
@@ -70,6 +80,10 @@ describe("mcp-credential-headers", () => {
     delete process.env.MCP_SERVICE_OIDC_TOKEN_URL;
     delete process.env.MCP_SERVICE_OIDC_CLIENT_ID;
     delete process.env.MCP_SERVICE_OIDC_CLIENT_SECRET;
+    delete process.env.INGESTOR_OIDC_DISCOVERY_URL;
+    delete process.env.INGESTOR_OIDC_ISSUER;
+    delete process.env.INGESTOR_OIDC_CLIENT_ID;
+    delete process.env.INGESTOR_OIDC_CLIENT_SECRET;
   });
 
   it("exchanges provider_connection credentials onto X-CAIPE-Provider-Token for AgentGateway", async () => {
@@ -218,6 +232,66 @@ describe("mcp-credential-headers", () => {
         origin: "client_credentials",
       }),
     ]);
+  });
+
+  it("uses the internal discovery endpoint for anonymous local AgentGateway authentication", async () => {
+    process.env.INGESTOR_OIDC_DISCOVERY_URL =
+      "http://keycloak:7080/realms/caipe/.well-known/openid-configuration";
+    process.env.INGESTOR_OIDC_ISSUER = "http://localhost:7080/realms/caipe";
+    process.env.INGESTOR_OIDC_CLIENT_ID = "caipe-platform";
+    process.env.INGESTOR_OIDC_CLIENT_SECRET = "secret";
+    mockIsDevAnonymousAuthEnabled.mockReturnValue(true);
+    const fetchMock = jest.fn().mockResolvedValue(
+      Response.json({
+        access_token: `header.${Buffer.from(JSON.stringify({ sub: "service-account-sub" })).toString("base64url")}.signature`,
+        expires_in: 300,
+      }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const request = new NextRequest("http://localhost:3000/api/mcp-servers/probe", { method: "POST" });
+    const resolution = await resolveMcpHeaderCredentials({
+      request,
+      session: { sub: "anonymous-local-dev" },
+      viaAgentGateway: true,
+      server: {
+        _id: "netutils",
+        id: "netutils",
+        name: "Netutils",
+        transport: "http",
+        enabled: true,
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://keycloak:7080/realms/caipe/protocol/openid-connect/token",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(resolution.headers.Authorization).toMatch(/^Bearer header\./);
+    expect(resolution.sources).toEqual([]);
+    expect(resolution.authorizationSubject).toEqual({
+      type: "service_account",
+      id: "service-account-sub",
+    });
+  });
+
+  it("still requires a user token outside explicit anonymous local mode", async () => {
+    const request = new NextRequest("http://localhost:3000/api/mcp-servers/probe", { method: "POST" });
+
+    await expect(
+      resolveMcpHeaderCredentials({
+        request,
+        session: { sub: "user-sub" },
+        viaAgentGateway: true,
+        server: {
+          _id: "netutils",
+          id: "netutils",
+          name: "Netutils",
+          transport: "http",
+          enabled: true,
+        },
+      }),
+    ).rejects.toThrow("MCP_AUTH_REQUIRED");
   });
 
   it("detects nested application failures in MCP tool payloads", () => {

--- a/ui/src/lib/__tests__/mcp-http-server-client.test.ts
+++ b/ui/src/lib/__tests__/mcp-http-server-client.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ */
+
+import { grantDiagnosticAgentAccess } from "@/lib/mcp-http-server-client";
+
+const mockWriteOpenFgaTuples = jest.fn();
+
+jest.mock("@/lib/rbac/openfga", () => ({
+  writeOpenFgaTuples: (...args: unknown[]) => mockWriteOpenFgaTuples(...args),
+}));
+
+describe("mcp-http-server-client diagnostic grants", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWriteOpenFgaTuples.mockResolvedValue(undefined);
+  });
+
+  it("grants the minted local service account only the temporary scan path", async () => {
+    const writes = await grantDiagnosticAgentAccess(
+      "knowledge-base",
+      "mcp-test-knowledge-base",
+      { sub: "anonymous-local-dev" },
+      { type: "service_account", id: "service-account-sub" },
+    );
+
+    expect(writes).toEqual([
+      {
+        user: "service_account:service-account-sub",
+        relation: "caller",
+        object: "mcp_gateway:list",
+      },
+      {
+        user: "service_account:service-account-sub",
+        relation: "user",
+        object: "agent:mcp-test-knowledge-base",
+      },
+      {
+        user: "agent:mcp-test-knowledge-base",
+        relation: "caller",
+        object: "tool:knowledge-base/*",
+      },
+    ]);
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({ writes, deletes: [] });
+  });
+});

--- a/ui/src/lib/mcp-credential-headers.ts
+++ b/ui/src/lib/mcp-credential-headers.ts
@@ -10,6 +10,7 @@ import {
   isMcpCredentialUnavailableError,
   resolveProviderConnectionCredential,
 } from "@/lib/mcp-credential-resolution";
+import { isDevAnonymousAuthEnabled } from "@/lib/auth/dev-auth-provider";
 import type { MCPCredentialSource, MCPServerConfig } from "@/types/dynamic-agent";
 import type { NextRequest } from "next/server";
 import type { ResourceAuthzSession } from "@/lib/rbac/resource-authz";
@@ -34,6 +35,10 @@ export interface McpCredentialSourceDebug {
 export interface McpCredentialResolution {
   headers: Record<string, string>;
   sources: McpCredentialSourceDebug[];
+  authorizationSubject?: {
+    type: "service_account";
+    id: string;
+  };
 }
 
 interface ServiceTokenCacheEntry {
@@ -97,6 +102,7 @@ function serviceTokenConfig(): { tokenUrl: string; clientId: string; clientSecre
   const tokenUrl =
     process.env.MCP_SERVICE_OIDC_TOKEN_URL?.trim() ||
     process.env.OAUTH2_TOKEN_URL?.trim() ||
+    tokenEndpointFromIssuer(process.env.INGESTOR_OIDC_DISCOVERY_URL) ||
     tokenEndpointFromIssuer(process.env.INGESTOR_OIDC_ISSUER) ||
     tokenEndpointFromIssuer(process.env.OIDC_DISCOVERY_URL) ||
     tokenEndpointFromIssuer(process.env.OIDC_ISSUER) ||
@@ -165,6 +171,18 @@ async function mintServiceClientCredentialsToken(): Promise<string | null> {
 
 function asBearerToken(value: string): string {
   return value.toLowerCase().startsWith("bearer ") ? value : `Bearer ${value}`;
+}
+
+function serviceAccountSubjectFromToken(value: string): string | null {
+  const token = value.replace(/^Bearer\s+/i, "");
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { sub?: unknown };
+    return typeof claims.sub === "string" && claims.sub.trim() ? claims.sub.trim() : null;
+  } catch {
+    return null;
+  }
 }
 
 async function resolveSourceCredential(
@@ -306,6 +324,7 @@ export async function resolveMcpHeaderCredentials(input: {
   const retrievalCaller = input.retrievalCaller ?? "mcp-http-server-client";
   const callerAuthorization = userAuthorizationHeader(input.request, input.session);
   let agentGatewayServiceAuthorization: string | null = null;
+  let agentGatewayServiceSubject: string | null = null;
 
   for (const source of input.server.credential_sources ?? []) {
     const resolved = await resolveSourceCredential(
@@ -332,10 +351,22 @@ export async function resolveMcpHeaderCredentials(input: {
     );
     if (source.kind === "caller_token" && resolved.origin === "client_credentials") {
       agentGatewayServiceAuthorization = asBearerToken(resolved.credential);
+      agentGatewayServiceSubject = serviceAccountSubjectFromToken(resolved.credential);
     }
   }
 
   if (input.viaAgentGateway) {
+    // Local no-SSO mode still exercises AgentGateway's real JWT validation
+    // path. Use the configured platform client only for that explicit dev
+    // mode; production callers must continue to supply their own user token.
+    if (!callerAuthorization && !agentGatewayServiceAuthorization && isDevAnonymousAuthEnabled()) {
+      const minted = await mintServiceClientCredentialsToken();
+      if (minted) {
+        agentGatewayServiceAuthorization = asBearerToken(minted);
+        agentGatewayServiceSubject = serviceAccountSubjectFromToken(minted);
+      }
+    }
+
     const authorization = callerAuthorization ?? agentGatewayServiceAuthorization;
     if (!authorization) {
       throw new Error("MCP_AUTH_REQUIRED");
@@ -343,7 +374,13 @@ export async function resolveMcpHeaderCredentials(input: {
     headers.Authorization = authorization;
   }
 
-  return { headers, sources };
+  return {
+    headers,
+    sources,
+    ...(agentGatewayServiceSubject
+      ? { authorizationSubject: { type: "service_account" as const, id: agentGatewayServiceSubject } }
+      : {}),
+  };
 }
 
 export function _resetMcpCredentialHeaderTokenCacheForTests(): void {

--- a/ui/src/lib/mcp-http-server-client.ts
+++ b/ui/src/lib/mcp-http-server-client.ts
@@ -7,7 +7,10 @@
 import crypto from "crypto";
 
 import { ApiError } from "@/lib/api-middleware";
-import { resolveMcpHeaderCredentials } from "@/lib/mcp-credential-headers";
+import {
+  resolveMcpHeaderCredentials,
+  type McpCredentialResolution,
+} from "@/lib/mcp-credential-headers";
 import { writeOpenFgaTuples, type OpenFgaTupleKey } from "@/lib/rbac/openfga";
 import type { MCPServerConfig, MCPToolInfo } from "@/types/dynamic-agent";
 import type { NextRequest } from "next/server";
@@ -108,21 +111,32 @@ function diagnosticOpenFgaTuples(
   serverId: string,
   agentId: string,
   session: AuthSession,
+  authorizationSubject?: McpCredentialResolution["authorizationSubject"],
 ): OpenFgaTupleKey[] {
-  const subject = typeof session?.sub === "string" ? session.sub.trim() : "";
+  const sessionSubject = typeof session?.sub === "string" ? session.sub.trim() : "";
+  const subject = authorizationSubject
+    ? `service_account:${authorizationSubject.id}`
+    : sessionSubject
+      ? `user:${sessionSubject}`
+      : "";
   if (!subject) return [];
-  return [
-    { user: `user:${subject}`, relation: "user", object: `agent:${agentId}` },
+  const tuples: OpenFgaTupleKey[] = [
+    { user: subject, relation: "user", object: `agent:${agentId}` },
     { user: `agent:${agentId}`, relation: "caller", object: `tool:${serverId}/*` },
   ];
+  if (authorizationSubject) {
+    tuples.unshift({ user: subject, relation: "caller", object: "mcp_gateway:list" });
+  }
+  return tuples;
 }
 
 export async function grantDiagnosticAgentAccess(
   serverId: string,
   agentId: string,
   session: AuthSession,
+  authorizationSubject?: McpCredentialResolution["authorizationSubject"],
 ): Promise<OpenFgaTupleKey[]> {
-  const writes = diagnosticOpenFgaTuples(serverId, agentId, session);
+  const writes = diagnosticOpenFgaTuples(serverId, agentId, session, authorizationSubject);
   if (!writes.length) return [];
   await writeOpenFgaTuples({ writes, deletes: [] });
   return writes;
@@ -226,9 +240,9 @@ async function buildMcpRequestHeaders(input: {
   server: MCPServerConfig;
   viaAgentGateway: boolean;
   serverId: string;
-}): Promise<Record<string, string>> {
+}): Promise<Pick<McpCredentialResolution, "headers" | "authorizationSubject">> {
   try {
-    const { headers } = await resolveMcpHeaderCredentials({
+    const { headers, authorizationSubject } = await resolveMcpHeaderCredentials({
       request: input.request,
       session: input.session,
       server: input.server,
@@ -236,8 +250,11 @@ async function buildMcpRequestHeaders(input: {
       retrievalCaller: "mcp-http-server-client",
     });
     return {
-      ...headers,
-      ...buildAgentContextHeaders(diagnosticAgentId(input.serverId, input.session)),
+      headers: {
+        ...headers,
+        ...buildAgentContextHeaders(diagnosticAgentId(input.serverId, input.session)),
+      },
+      ...(authorizationSubject ? { authorizationSubject } : {}),
     };
   } catch (error) {
     if (error instanceof Error && error.message === "MCP_AUTH_REQUIRED") {
@@ -259,18 +276,24 @@ export async function listHttpMcpTools(input: {
 }): Promise<{ tools: MCPToolInfo[]; sessionId?: string }> {
   const viaAgentGateway = isAgentGatewayEndpoint(input.server);
   const diagnosticAgent = diagnosticAgentId(input.serverId, input.session);
+  const requestCredentials = await buildMcpRequestHeaders({
+    request: input.request,
+    session: input.session,
+    server: input.server,
+    viaAgentGateway,
+    serverId: input.serverId,
+  });
   const diagnosticTuples = viaAgentGateway
-    ? await grantDiagnosticAgentAccess(input.serverId, diagnosticAgent, input.session)
+    ? await grantDiagnosticAgentAccess(
+        input.serverId,
+        diagnosticAgent,
+        input.session,
+        requestCredentials.authorizationSubject,
+      )
     : [];
 
   try {
-    const headers = await buildMcpRequestHeaders({
-      request: input.request,
-      session: input.session,
-      server: input.server,
-      viaAgentGateway,
-      serverId: input.serverId,
-    });
+    const headers = requestCredentials.headers;
 
     const first = await mcpJsonRpc({
       endpoint: input.server.endpoint,


### PR DESCRIPTION
# Description

Fixes #2314.

Related to #1969, which tracks the broader credential model for autonomous agents.

## Problem

The Docker Compose development path supports an explicit anonymous/no-SSO administrator, but three downstream paths still assumed a signed-in user JWT:

1. AgentGateway-routed MCP probes had no bearer token and reported that a signed-in user was required.
2. Dynamic Agents skipped credential resolution when no credential API client existed, even when a `caller_token` source enabled `fallback_client_credentials`.
3. The RAG ingestion team endpoint did not recognize the explicit anonymous development administrator, preventing selection of an owning team.

Together these made the local UI appear healthy while MCP scans were degraded, knowledge-base tools were absent from agent runtimes, and ingestion authoring was blocked.

## Root Cause

The anonymous development session is intentionally synthetic and has no user JWT. The affected paths treated the missing JWT or credential API client as a reason to stop before using the already-configured client-credentials fallback.

## Changes

- Mint the configured platform client-credentials token for AgentGateway probes only when the explicit anonymous development provider is enabled.
- Derive the service-account subject from the minted JWT and grant diagnostic OpenFGA tuples to that subject instead of the synthetic anonymous user.
- Allow Dynamic Agents to resolve `caller_token` client-credentials fallback without a credential API client.
- Use the fallback token as AgentGateway `Authorization` while preserving the configured provider-token header.
- Treat the explicit anonymous development session as an organization administrator for ingestion-team discovery.
- Add regression coverage for all of these paths.

Production behavior remains fail-closed: outside explicit local anonymous mode, AgentGateway-routed probes still require a caller token.

## Impact

With the documented local no-SSO Compose configuration:

- MCP server scans can authenticate through AgentGateway.
- Dynamic agents can load and call assigned Knowledge Base MCP tools.
- Local administrators can select an owning team and ingest RAG sources.

Authenticated deployments continue to use the signed-in user's token.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- [x] UI regression tests: 4 suites and 18 tests passed
- [x] Dynamic Agents credential tests: 15 tests passed
- [x] UI lint: `npm run lint`
- [x] UI production build: `npm run build`
- [x] Python lint: Ruff 0.15.5
- [x] Live Docker Compose verification:
  - connected to one Knowledge Base MCP server
  - loaded all three advertised tools
  - completed `list_datasources_and_entity_types` and `search`
  - observed no 401 or 403 response

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in the issue and code comments
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant tests pass
